### PR TITLE
Upgrade gradle distribution to 4.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.3-all.zip


### PR DESCRIPTION
Upgrades the gradle distributionUrl from 4.0-all to 4.3-all to get around those pesky `Could not determine java version from '9.0.1'` gradle build errors.