### PR TITLE
Drop unneeded last-active-plugin-version from shared Checkstyle config

### DIFF
--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -6,7 +6,6 @@
         <entry key="active-configuration" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:a8c Style" />
         <entry key="checkstyle-version" value="8.2" />
         <entry key="copy-libs" value="false" />
-        <entry key="last-active-plugin-version" value="5.17.0" />
         <entry key="location-0" value="BUNDLED:(bundled):Sun Checks" />
         <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
         <entry key="location-2" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:a8c Style" />


### PR DESCRIPTION
Version `5.16.3` of the Checkstyle-IDEA plugin also added a "last active plugin version" config:

```
<entry key="last-active-plugin-version" value="5.17.0" />
```

This would've been problematic since we'd have to update the config file for every plugin update, but thankfully this has been moved to `workspace.xml` (which is not tracked in Git) since version `5.17.1`. So, we can drop that field from the shared config file.

(If `last-active-plugin-version` is appearing in your diffs, update to the latest Checkstyle-IDEA plugin version, restart AS, and revert the change to `checkstyle-idea.xml` - it should stay gone.)