### PR TITLE
Fix MultiDex crashes on Android 4.x versions

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -45,6 +45,11 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 
+    // Support library
+    implementation "com.android.support:support-v4:$supportLibraryVersion"
+    implementation "com.android.support.constraint:constraint-layout:$constraintLayoutVersion"
+    implementation "com.android.support:recyclerview-v7:$supportLibraryVersion"
+    implementation "com.android.support:multidex:$multidexVersion"
     implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
 
     implementation('org.wordpress:utils:1.19.0') {
@@ -74,11 +79,6 @@ dependencies {
     implementation "com.github.bumptech.glide:glide:$glideVersion"
     kapt "com.github.bumptech.glide:compiler:$glideVersion"
     implementation "com.github.bumptech.glide:volley-integration:$glideVersion@aar"
-
-    // Support library
-    implementation "com.android.support:support-v4:$supportLibraryVersion"
-    implementation "com.android.support.constraint:constraint-layout:$constraintLayoutVersion"
-    implementation "com.android.support:recyclerview-v7:$supportLibraryVersion"
 
     // Debug dependencies
     debugImplementation 'com.facebook.stetho:stetho:1.5.0'

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -1,8 +1,8 @@
 package com.woocommerce.android
 
 import android.app.Activity
-import android.app.Application
 import android.app.Service
+import android.support.multidex.MultiDexApplication
 import com.woocommerce.android.di.AppComponent
 import com.woocommerce.android.di.DaggerAppComponent
 import com.woocommerce.android.di.WooCommerceGlideModule
@@ -15,7 +15,7 @@ import dagger.android.HasServiceInjector
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import javax.inject.Inject
 
-open class WooCommerce : Application(), HasActivityInjector, HasServiceInjector {
+open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceInjector {
     @Inject lateinit var activityInjector: DispatchingAndroidInjector<Activity>
     @Inject lateinit var serviceInjector: DispatchingAndroidInjector<Service>
 

--- a/build.gradle
+++ b/build.gradle
@@ -81,4 +81,5 @@ ext {
     testRunnerVersion = '1.0.0'
     espressoVersion = '3.0.0'
     constraintLayoutVersion = '1.0.2'
+    multidexVersion = '1.0.2'
 }


### PR DESCRIPTION
Fixed an issue where the app was crashing on devices running 4.x:
> E/dalvikvm: Could not find class 'com.woocommerce.android.di.DaggerAppComponentDebug$Builder', referenced from method com.woocommerce.android.di.DaggerAppComponentDebug.builder

It turned out to be a multidex issue. Added proper Multidex support for pre-lollipop.