### PR TITLE
Fix invalid package errors in MockedActivityBindingModule

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockedActivityBindingModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockedActivityBindingModule.kt
@@ -4,8 +4,8 @@ import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.MagicLinkInterceptActivity
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MockedMainModule
-import com.woocommerce.android.ui.order.OrderDetailModule
-import com.woocommerce.android.ui.orderlist.OrderListModule
+import com.woocommerce.android.ui.orders.OrderDetailModule
+import com.woocommerce.android.ui.orders.OrderListModule
 import dagger.Module
 import dagger.android.ContributesAndroidInjector
 import org.wordpress.android.login.di.LoginFragmentModule


### PR DESCRIPTION
I'm not sure how this snuck bug snuck in since the `order` and `orderlist` directory haven't existed for quite a while. I'm guessing it's likely due to a merge. This PR fixes those invalid imports.

cc: @aforcier 