### PR TITLE
Convert order dates to UTC date objects for TimeGrouping

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailOrderStatusView.kt
@@ -35,7 +35,7 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(ctx: Context, attrs: 
     }
 
     private fun getFriendlyDateString(rawDate: String): String {
-        val date = DateTimeUtils.dateFromIso8601(rawDate) ?: Date()
+        val date = DateTimeUtils.dateUTCFromIso8601(rawDate) ?: Date()
         val timeGroup = TimeGroup.getTimeGroupForDate(date)
         val dateLabel = when (timeGroup) {
             TimeGroup.GROUP_TODAY -> {


### PR DESCRIPTION
Fixes #191, correctly displaying the human-friendly date in the order status card on the order detail screen.

cc @AmandaRiu 