### PR TITLE
Fix Kotlin JRE7 deprecation warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.automattic.android:fetchstyle:1.1'
         classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlinVersion"

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
     }
 }
 


### PR DESCRIPTION
Updates the FluxC dependency to the latest version of the orders working branch, which contains the changes made in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/799. This updates away from the deprecated `stdlib-jre7` Kotlin libraries, so we no longer see a bunch of compiler warnings when building the Woo app:

> kotlin-stdlib-jre7 is deprecated. Please use kotlin-stdlib-jdk7 instead

Also updates Kotlin and the Gradle to the latest.