### PR TITLE
Prevent fragment startup when no Woo sites are found on login

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -186,6 +186,7 @@ class MainActivity : AppCompatActivity(),
             0 -> {
                 ToastUtils.showToast(this, R.string.no_woocommerce_sites, Duration.LONG)
                 presenter.logout()
+                return
             }
             1 -> selectedSite.set(wcSites[0])
             else -> {


### PR DESCRIPTION
Found a bug when testing logging into a WP.com account with no WooCommerce sites from the #214 branch. The `MainActivity` logs the user out, but the `onUpdated()` call that sets up the bottom nav and initializes the dashboard fragment was still getting run, causing a crash (since the `SelectedSite` was being accessed before it was set up).

The crash doesn't happen in `develop`, but instead just verifying that the `DashboardFragment` is never initialized when logged into a WooCommerce-less WP.com account covers the same case.