### PR TITLE
Handle OnUnexpectedError events and forward to Crashlytics

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
+import org.wordpress.android.fluxc.utils.ErrorUtils.OnUnexpectedError
 import org.wordpress.android.util.PackageUtils
 import javax.inject.Inject
 
@@ -125,6 +126,14 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
 
             // Wipe user-specific preferences
             AppPrefs.reset()
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onUnexpectedError(event: OnUnexpectedError) {
+        with (event) {
+            CrashlyticsUtils.logException(exception, message = "FluxC: ${exception.message}: $description")
         }
     }
 


### PR DESCRIPTION
Creates a 'non-fatal' issue in Crashlytics each time an OnUnexpectedError is created in FluxC.

~#214 should be reviewed and merged before this one~ - this PR doesn't strictly rely on it, but this handling was added to record the case where a required field from the stats endpoint is missing (https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/804#discussion_r190784314).

To view the created crash report in Crashlytics, make sure you're looking at 'Non-Fatals' from the drop-down and open the report. From there you need to click on 'View all sessions' to view session-by-session rather than aggregate data. You should see something like this for each session:

<img width="796" alt="crashlytics-nonfatal" src="https://user-images.githubusercontent.com/9613966/40719958-2c564ee4-63e3-11e8-9cf2-463bf1882083.png">

(I tested this by spoofing the stats endpoint server reply to be missing one of the fields we need in Charles.)