### PR TITLE
Handle exception from number formatter

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/PhoneUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/PhoneUtils.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.util
 
 import android.os.Build
 import android.telephony.PhoneNumberUtils
+import com.woocommerce.android.util.WooLog.T
 import java.util.Locale
 
 object PhoneUtils {
@@ -9,11 +10,16 @@ object PhoneUtils {
      * Formats a phone number based on the users locale.
      */
     fun formatPhone(number: String): String {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            PhoneNumberUtils.formatNumber(number, Locale.getDefault().country)
-        } else {
-            @Suppress("DEPRECATION")
-            PhoneNumberUtils.formatNumber(number)
+        return try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                PhoneNumberUtils.formatNumber(number, Locale.getDefault().country)
+            } else {
+                @Suppress("DEPRECATION")
+                PhoneNumberUtils.formatNumber(number)
+            }
+        } catch (e: IllegalStateException) {
+            WooLog.d(T.UTILS, "Unable to format phone number: $number")
+            number
         }
     }
 }


### PR DESCRIPTION
Fixes #228. Certain (invalid) phone numbers can cause Android's `PhoneNumberUtils` to throw an `IllegalStateException`. If that happens, log the error and return the original string.

#### To test

Open order details for an order with phone number `123121231231asdas12313`.

cc @AmandaRiu 