### PR TITLE
Added `kotlin-android-extensions` as a dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.automattic.android:fetchstyle:1.1'
         classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlinVersion"
+        classpath "org.jetbrains.kotlin:kotlin-android-extensions:$kotlinVersion"
     }
 }
 
@@ -17,7 +18,6 @@ apply plugin: 'com.automattic.android.fetchstyle'
 
 allprojects {
     apply plugin: 'checkstyle'
-    apply plugin: 'kotlin-android-extensions'
 
     repositories {
         google()


### PR DESCRIPTION
Fixes #248 - according to [this source](https://youtrack.jetbrains.com/issue/KT-10336), our problem with synthetic properties is due to not including `kotlin-android-extensions` as a dependency. This PR corrects that.