### PR TITLE
issue/244-unnecessary-fetch-orders-take2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -316,9 +316,7 @@ class MainActivity : AppCompatActivity(),
     private fun clearFragmentBackStack(fragment: Fragment?): Boolean {
         fragment?.let {
             if (it.childFragmentManager.backStackEntryCount > 0) {
-                while (it.childFragmentManager.backStackEntryCount > 0) {
-                    it.childFragmentManager.popBackStackImmediate()
-                }
+                it.childFragmentManager.popBackStackImmediate(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
                 return true
             }
         }


### PR DESCRIPTION
Fixes #244 - prior to this fix, an unnecessary `FETCH_ORDERS` happened after tapping an order to view the order detail then tapping the Dashboard nav item.

This was due to use popping the child fragments individually, which caused the order fragment's `onActivityCreated()` to be triggered, which is where orders are loaded.

The simple fix was to use `FragmentManager.POP_BACK_STACK_INCLUSIVE` when clearing the child fragment backstack, which avoids unnecessary recreation of the child fragments.