### PR TITLE
Force stats refresh on manual action

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContract.kt
@@ -7,7 +7,7 @@ import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 
 interface DashboardContract {
     interface Presenter : BasePresenter<View> {
-        fun loadStats(period: StatsTimeframe)
+        fun loadStats(period: StatsTimeframe, forced: Boolean = false)
         fun getStatsCurrency(): String?
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -50,7 +50,7 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View {
                 }
                 setOnRefreshListener {
                     setLoadingIndicator(true)
-                    presenter.loadStats(dashboard_stats.getActiveTimeframe())
+                    presenter.loadStats(dashboard_stats.getActiveTimeframe(), forced = true)
                 }
             }
         }
@@ -119,7 +119,7 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View {
     override fun refreshFragmentState() {
         if (isActive) {
             setLoadingIndicator(true)
-            presenter.loadStats(dashboard_stats.getActiveTimeframe())
+            presenter.loadStats(dashboard_stats.getActiveTimeframe(), forced = true)
         } else {
             loadDataPending = true
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardPresenter.kt
@@ -29,7 +29,7 @@ class DashboardPresenter @Inject constructor(
         dispatcher.unregister(this)
     }
 
-    override fun loadStats(period: StatsTimeframe) {
+    override fun loadStats(period: StatsTimeframe, forced: Boolean) {
         val granularity = when (period) {
             StatsTimeframe.THIS_WEEK -> StatsGranularity.DAYS
             StatsTimeframe.THIS_MONTH -> StatsGranularity.DAYS
@@ -37,7 +37,7 @@ class DashboardPresenter @Inject constructor(
             StatsTimeframe.YEARS -> StatsGranularity.YEARS
         }
 
-        val payload = FetchOrderStatsPayload(selectedSite.get(), granularity)
+        val payload = FetchOrderStatsPayload(selectedSite.get(), granularity, forced)
         dispatcher.dispatch(WCStatsActionBuilder.newFetchOrderStatsAction(payload))
     }
 


### PR DESCRIPTION
#258 imported the stats caching changes from FluxC into the project, but it didn't include handling forced refresh. This PR adds that in.

There seem like two situations in which we want to ignore the cache and force a network refresh: when pulling to refresh, and when reselecting the Dashboard button on the nav bar.