### PR TITLE
Retry GET requests silently on 5-second timeout

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = '713aedca3b5a5ed555236f74f3870afd816e123b'
+    fluxCVersion = '802fd4e0edc14f95a220c572fb70519cb4872eec'
     daggerVersion = '2.11'
     supportLibraryVersion = '27.1.1'
     glideVersion = '4.6.1'


### PR DESCRIPTION
Brings in the FluxC change added in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/846. Jetpack timeout errors will be silently retried twice before actually reporting an error (for GET requests).

(Some more background: https://github.com/woocommerce/woocommerce-android/issues/204)