### PR TITLE
Fix 'no such file or directory' build error

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -205,7 +205,7 @@ android.buildTypes.all { buildType ->
     }
 
     // Print warning message if example Google services file is used.
-    if ((new File('WooCommerce/google-services.json').text) == (new File('WooCommerce/google-services.json-example').text)) {
+    if ((file("google-services.json").text) == (file("google-services.json-example").text)) {
         println("WARNING: You're using the example google-services.json file. Google login will fail.")
     }
 }


### PR DESCRIPTION
This PR fixes a minor build error that only seems to be noticeable when running a build task directly in the WooCommerce module. Example of the error:
```
8:46:37 AM: Executing task 'sourceSets'...

Executing tasks: [sourceSets]

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/amandariu/development/a8c/woocommerce-android/WooCommerce/build.gradle' line: 208

* What went wrong:
A problem occurred evaluating project ':WooCommerce'.
> WooCommerce/google-services.json (No such file or directory)

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 0s
8:46:38 AM: Task execution finished 'sourceSets'.

```

Error is due to the build script running inside the WooCommerce/ directory and then searching for a WooCommerce/ subdirectory which does not exist. 

cc: @nbradbury  @aforcier 