### PR TITLE
issue/291-order-notelist-position

### DIFF
--- a/WooCommerce/src/main/res/layout/order_detail_note_list.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_note_list.xml
@@ -19,6 +19,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/white"
+        android:descendantFocusability="blocksDescendants"
         android:minHeight="@dimen/list_item_height"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
Fixes #291 - prior to this change, tapping "Add Note" in order detail and then hitting the back button would cause the note list to be scrolled down. The simple fix was to add `descendantFocusability="blocksDescendants"`.

cc: @AmandaRiu 