### PR TITLE
Use woocommerce scheme for magic links

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -45,7 +45,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data
                     android:host="magic-login"
-                    android:scheme="wordpress" />
+                    android:scheme="woocommerce" />
             </intent-filter>
         </activity>
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -16,6 +16,7 @@ import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.support.HasSupportFragmentInjector
 import org.wordpress.android.fluxc.network.MemorizingTrustManager
+import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayloadScheme
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.login.GoogleFragment.GoogleListener
 import org.wordpress.android.login.Login2FaFragment
@@ -147,7 +148,8 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
 
     override fun gotWpcomEmail(email: String?) {
         if (getLoginMode() != LoginMode.WPCOM_LOGIN_DEEPLINK && getLoginMode() != LoginMode.SHARE_INTENT) {
-            val loginMagicLinkRequestFragment = LoginMagicLinkRequestFragment.newInstance(email, false, null)
+            val loginMagicLinkRequestFragment = LoginMagicLinkRequestFragment.newInstance(email,
+                    AuthEmailPayloadScheme.WOOCOMMERCE, false, null)
             slideInFragment(loginMagicLinkRequestFragment, true, LoginMagicLinkRequestFragment.TAG)
         } else {
             val loginEmailPasswordFragment = LoginEmailPasswordFragment.newInstance(email, null, null, null, false)

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = '6b658f1889841ca1470a104c9aa15e9f984957fa'
+    fluxCVersion = 'f5cba3cb50d0804ba224b6b380885845faa5e9b2'
     daggerVersion = '2.11'
     supportLibraryVersion = '27.1.1'
     glideVersion = '4.6.1'

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkRequestFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkRequestFragment.java
@@ -32,6 +32,7 @@ import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayload;
+import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayloadScheme;
 import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayloadSource;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthEmailSent;
 import org.wordpress.android.util.AppLog;
@@ -51,6 +52,7 @@ public class LoginMagicLinkRequestFragment extends Fragment {
     private static final String KEY_IN_PROGRESS = "KEY_IN_PROGRESS";
     private static final String KEY_GRAVATAR_IN_PROGRESS = "KEY_GRAVATAR_IN_PROGRESS";
     private static final String ARG_EMAIL_ADDRESS = "ARG_EMAIL_ADDRESS";
+    private static final String ARG_MAGIC_LINK_SCHEME = "ARG_MAGIC_LINK_SCHEME";
     private static final String ARG_IS_JETPACK_CONNECT = "ARG_IS_JETPACK_CONNECT";
     private static final String ARG_JETPACK_CONNECT_SOURCE = "ARG_JETPACK_CONNECT_SOURCE";
 
@@ -59,6 +61,7 @@ public class LoginMagicLinkRequestFragment extends Fragment {
     private LoginListener mLoginListener;
 
     private String mEmail;
+    private AuthEmailPayloadScheme mMagicLinkScheme;
     private String mJetpackConnectSource;
 
     private View mAvatarProgressBar;
@@ -71,12 +74,12 @@ public class LoginMagicLinkRequestFragment extends Fragment {
     @Inject protected Dispatcher mDispatcher;
 
     @Inject protected LoginAnalyticsListener mAnalyticsListener;
-
-    public static LoginMagicLinkRequestFragment newInstance(String email, boolean isJetpackConnect,
-                                                            String jetpackConnectSource) {
+    public static LoginMagicLinkRequestFragment newInstance(String email, AuthEmailPayloadScheme scheme,
+                                                            boolean isJetpackConnect, String jetpackConnectSource) {
         LoginMagicLinkRequestFragment fragment = new LoginMagicLinkRequestFragment();
         Bundle args = new Bundle();
         args.putString(ARG_EMAIL_ADDRESS, email);
+        args.putSerializable(ARG_MAGIC_LINK_SCHEME, scheme);
         args.putBoolean(ARG_IS_JETPACK_CONNECT, isJetpackConnect);
         args.putString(ARG_JETPACK_CONNECT_SOURCE, jetpackConnectSource);
         fragment.setArguments(args);
@@ -100,6 +103,7 @@ public class LoginMagicLinkRequestFragment extends Fragment {
 
         if (getArguments() != null) {
             mEmail = getArguments().getString(ARG_EMAIL_ADDRESS);
+            mMagicLinkScheme = (AuthEmailPayloadScheme) getArguments().getSerializable(ARG_MAGIC_LINK_SCHEME);
             mIsJetpackConnect = getArguments().getBoolean(ARG_IS_JETPACK_CONNECT);
             mJetpackConnectSource = getArguments().getString(ARG_JETPACK_CONNECT_SOURCE);
         }
@@ -119,7 +123,8 @@ public class LoginMagicLinkRequestFragment extends Fragment {
                         showMagicLinkRequestProgressDialog();
                         AuthEmailPayloadSource source = getAuthEmailPayloadSource();
                         AuthEmailPayload authEmailPayload = new AuthEmailPayload(mEmail, false,
-                                mIsJetpackConnect ? AccountStore.AuthEmailPayloadFlow.JETPACK : null, source);
+                                mIsJetpackConnect ? AccountStore.AuthEmailPayloadFlow.JETPACK : null,
+                                source, mMagicLinkScheme);
                         mDispatcher.dispatch(AuthenticationActionBuilder.newSendAuthEmailAction(authEmailPayload));
                     }
                 }


### PR DESCRIPTION
Closes #218. Creates magic links with scheme `woocommerce://` (instead of the default `wordpress://`).

**Relies on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/880 - that PR should be reviewed and merged before this one is merged.**

This PR allows the magic link (from the received email) to launch the WooCommerce app directly instead of popping up a system 'choose app for this action' dialog (this will happen if the WordPress app is already installed).

**To test:**
1. First, build current `develop`, and make sure the WordPress app is also installed
2. Go through the login flow and request a magic link
3. Tap the link in the magic link email
4. The link should popup a system dialog, offering a choice between the WooCommerce and the WordPress app (possibly up to two of each if you have release and dev versions installed at the same time) - unless you've already chosen 'always' before, in which case you'll need to remove that default app setting so you can get the dialog again
5. Now build this branch and go through steps 2-3
6. The link should launch the Woo app right away, and log you in (you can observe the difference using Stetho - a `scheme: "woocommerce"` parameter is added to the magic link request sent by the app)

Please also test the WordPress app with this same FluxC branch (no code changes are needed in the WordPress app).