### PR TITLE
Update string variable used in UI tests

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/MainNavigationTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/MainNavigationTest.kt
@@ -58,9 +58,9 @@ class MainNavigationTest : TestBase() {
             } ?: throw noMatchException
         }
 
-        // Verify the toolbar title is Dashboard
+        // Verify the toolbar title is 'My Store'
         onView(withId(R.id.toolbar)).check(matches(
-                WCMatchers.withToolbarTitle(equalToIgnoringCase(appContext.getString(R.string.dashboard)))))
+                WCMatchers.withToolbarTitle(equalToIgnoringCase(appContext.getString(R.string.my_store)))))
     }
 
     @Test
@@ -91,9 +91,9 @@ class MainNavigationTest : TestBase() {
         // Select the dashboard bottom bar option
         onView(withId(R.id.dashboard)).perform(click())
 
-        // Verify the toolbar title has changed to Dashboard
+        // Verify the toolbar title has changed to 'My Store'
         onView(withId(R.id.toolbar)).check(matches(
-                WCMatchers.withToolbarTitle(equalToIgnoringCase(appContext.getString(R.string.dashboard)))))
+                WCMatchers.withToolbarTitle(equalToIgnoringCase(appContext.getString(R.string.my_store)))))
     }
 
     private fun assertPressingBackExitsApp() {


### PR DESCRIPTION
The UI tests from https://github.com/woocommerce/woocommerce-android/pull/316 were merged just after https://github.com/woocommerce/woocommerce-android/pull/313, which changed a string resource name the tests use. This updates the tests so they pass again.