### PR TITLE
Removed "last updated" callback when stats view is detached

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -99,14 +99,13 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
         }
     }
 
-    override fun onAttachedToWindow() {
-        super.onAttachedToWindow()
-        updateRecencyMessage()
-    }
-
-    override fun onDetachedFromWindow() {
-        lastUpdatedHandler.removeCallbacks(lastUpdatedRunnable)
-        super.onDetachedFromWindow()
+    override fun onVisibilityChanged(changedView: View?, visibility: Int) {
+        super.onVisibilityChanged(changedView, visibility)
+        if (visibility == View.VISIBLE) {
+            updateRecencyMessage()
+        } else {
+            lastUpdatedHandler.removeCallbacks(lastUpdatedRunnable)
+        }
     }
 
     fun clearLabelValues() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -98,6 +98,16 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
         }
     }
 
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        updateRecencyMessage()
+    }
+
+    override fun onDetachedFromWindow() {
+        lastUpdatedHandler.removeCallbacks(lastUpdatedRunnable)
+        super.onDetachedFromWindow()
+    }
+
     fun clearLabelValues() {
         visitors_value.text = ""
         revenue_value.text = ""


### PR DESCRIPTION
Fixes #322 - @AmandaRiu I wasn't wild about having the fragment tell the stats view to cancel its callback, nor did I want to move the handler/runnable to the fragment. To me it's cleaner to keep stats more self-contained.

So I decided to simply have the stats view override `onDetachedFromWindow()` and cancel the callback there. Does that address the problem?