### PR TITLE
Remove extra FrameLayout container that should be a merge tag.

### DIFF
--- a/WooCommerce/src/main/res/layout/dashboard_unfilled_orders.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_unfilled_orders.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
+<merge
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     style="@style/Woo.Card"
@@ -38,4 +38,4 @@
             tools:text="@string/dashboard_action_view_orders"/>
     </LinearLayout>
 
-</FrameLayout>
+</merge>


### PR DESCRIPTION
Removes an extra container layout that was erroneously added during merge conflict resolution

**Before**
<img width="481" alt="screen shot 2018-09-04 at 3 41 34 pm" src="https://user-images.githubusercontent.com/5810477/45053840-32766d00-b059-11e8-9513-df01b5f2435c.png">

**After**
<img width="477" alt="screen shot 2018-09-04 at 3 41 58 pm" src="https://user-images.githubusercontent.com/5810477/45053831-2c808c00-b059-11e8-9ff0-d5d9c23ae09d.png">

