### PR TITLE
Issue/261 order stats styling

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -154,7 +154,7 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
                 setDrawZeroLine(false)
                 setDrawAxisLine(false)
                 setDrawGridLines(true)
-                gridColor = ContextCompat.getColor(context, R.color.gray)
+                gridColor = ContextCompat.getColor(context, R.color.wc_border_color)
                 setLabelCount(3, true)
 
                 axisMinimum = 0F

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -165,7 +165,19 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
                 }
             }
 
-            axisRight.isEnabled = false
+            with (axisRight) {
+                setDrawZeroLine(false)
+                setDrawAxisLine(false)
+                setDrawGridLines(true)
+                setLabelCount(3, true)
+
+                axisMinimum = 0F
+
+                valueFormatter = IAxisValueFormatter { value, _ ->
+                    formatAmountForDisplay(context, value.toDouble(), chartCurrencyCode, allowZero = false)
+                }
+            }
+
             description.isEnabled = false
             legend.isEnabled = false
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -154,6 +154,7 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
                 setDrawZeroLine(false)
                 setDrawAxisLine(false)
                 setDrawGridLines(true)
+                gridColor = ContextCompat.getColor(context, R.color.gray)
                 setLabelCount(3, true)
 
                 axisMinimum = 0F

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -27,6 +27,7 @@ import kotlinx.android.synthetic.main.dashboard_stats.view.*
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.fluxc.utils.SiteUtils
 import org.wordpress.android.util.DateTimeUtils
+import java.util.ArrayList
 import java.util.Date
 
 class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
@@ -202,8 +203,19 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
             return
         }
 
+        val barColors = ArrayList<Int>()
+        val normalColor = ContextCompat.getColor(context, R.color.graph_data_color)
+        val weekendColor = ContextCompat.getColor(context, R.color.graph_data_color_weekend)
+        for (entry in revenueStats) {
+            if (activeGranularity == StatsGranularity.DAYS && DateUtils.isWeekend(entry.key)) {
+                barColors.add(weekendColor)
+            } else {
+                barColors.add(normalColor)
+            }
+        }
+
         val dataSet = generateBarDataSet(revenueStats).apply {
-            color = ContextCompat.getColor(context, R.color.graph_data_color)
+            colors = barColors
             setDrawValues(false)
             isHighlightEnabled = false
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -220,10 +220,11 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
             isHighlightEnabled = false
         }
 
+        val duration = context.resources.getInteger(android.R.integer.config_shortAnimTime)
+
         with (chart) {
             data = BarData(dataSet)
-
-            invalidate() // Draw/redraw the graph
+            animateY(duration)
         }
 
         resetLastUpdated()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -148,23 +148,7 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
                 valueFormatter = StartEndDateAxisFormatter()
             }
 
-            with (axisLeft) {
-                setDrawAxisLine(false)
-
-                setDrawGridLines(true)
-                enableGridDashedLine(10F, 10F, 0F)
-                gridColor = ContextCompat.getColor(context, R.color.graph_grid_color)
-
-                setDrawZeroLine(true)
-                zeroLineWidth = 1F
-                zeroLineColor = ContextCompat.getColor(context, R.color.graph_grid_color)
-
-                axisMinimum = 0F
-
-                valueFormatter = IAxisValueFormatter { value, _ ->
-                    formatAmountForDisplay(context, value.toDouble(), chartCurrencyCode, allowZero = false)
-                }
-            }
+            axisLeft.isEnabled = false
 
             with (axisRight) {
                 setDrawZeroLine(false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -111,4 +111,14 @@ object DateUtils {
         val month = iso8601Month.split("-").last()
         return shortMonths[month.toInt() - 1]
     }
+
+    /**
+    * Given a date of format YYYY-MM, returns whether it's on a weekend
+    */
+    fun isWeekend(iso8601Date: String): Boolean {
+        val (year, month, day) = iso8601Date.split("-")
+        val date = GregorianCalendar(year.toInt(), month.toInt() - 1, day.toInt())
+        val dayOfWeek = date.get(Calendar.DAY_OF_WEEK)
+        return (dayOfWeek == Calendar.SATURDAY || dayOfWeek == Calendar.SUNDAY)
+    }
 }

--- a/WooCommerce/src/main/res/values/colors.xml
+++ b/WooCommerce/src/main/res/values/colors.xml
@@ -84,6 +84,7 @@
     -->
     <color name="graph_no_data_text_color">@color/default_text_color</color>
     <color name="graph_data_color">@color/wc_purple</color>
+    <color name="graph_data_color_weekend">@color/wc_grey_medium</color>
     <color name="graph_grid_color">@color/wc_border_color</color>
     <!--
         Order: status tag background colors


### PR DESCRIPTION
Addresses two of the issues mentioned in #261:

- Replace y-axis with two currency limit lines
- In Days view, color weekend days gray

While I was at it, I also added bar chart animation similar to the iOS app.

![screenshot_1536091288](https://user-images.githubusercontent.com/3903757/45054735-d5c88180-b05b-11e8-8e54-fabf66261cf7.png)
