### PR TITLE
Removed findViewById from settings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
@@ -14,6 +14,7 @@ import dagger.android.AndroidInjection
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.support.HasSupportFragmentInjector
+import kotlinx.android.synthetic.main.activity_app_settings.*
 import javax.inject.Inject
 
 class AppSettingsActivity : AppCompatActivity(),
@@ -30,9 +31,7 @@ class AppSettingsActivity : AppCompatActivity(),
         setContentView(R.layout.activity_app_settings)
         presenter.takeView(this)
 
-        // TODO: replace with synthetics once Kotlin plugin bug is fixed
-        val toolbar = findViewById<Toolbar>(R.id.toolbar)
-        setSupportActionBar(toolbar)
+        setSupportActionBar(toolbar as Toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         if (savedInstanceState == null) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -6,10 +6,9 @@ import android.support.v4.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Button
-import android.widget.TextView
 import com.woocommerce.android.R
 import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.fragment_settings_main.*
 import javax.inject.Inject
 
 class MainSettingsFragment : Fragment(), MainSettingsContract.View {
@@ -47,12 +46,6 @@ class MainSettingsFragment : Fragment(), MainSettingsContract.View {
         } else {
             throw ClassCastException(context.toString() + " must implement AppSettingsListener")
         }
-
-        // TODO: replace with synthetics once Kotlin plugin bug is fixed
-        val textPrimaryStoreDomain = view!!.findViewById<TextView>(R.id.textPrimaryStoreDomain)
-        val textPrimaryStoreUsername = view!!.findViewById<TextView>(R.id.textPrimaryStoreUsername)
-        val textPrivacySettings = view!!.findViewById<TextView>(R.id.textPrivacySettings)
-        val buttonLogout = view!!.findViewById<Button>(R.id.buttonLogout)
 
         textPrimaryStoreDomain.text = presenter.getStoreDomainName()
         textPrimaryStoreUsername.text = presenter.getUserDisplayName()


### PR DESCRIPTION
Closes #270 - this PR removes the calls to `findViewById()` I added while working on settings as a workaround for that awful Kotlin synthetics bugs I was experiencing.