### PR TITLE
Fail Fast - throw IllegalArgumentException if string argument not an iso date string

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -68,7 +68,10 @@ object DateUtils {
 
     /**
      * Given an ISO8601 date of format YYYY-MM-DD, returns the number of days in the given month.
+     *
+     * @throws IllegalArgumentException if the argument is not a valid iso8601 date string.
      */
+    @Throws(IllegalArgumentException::class)
     fun getNumberOfDaysInMonth(iso8601Date: String): Int {
         try {
             val (year, month) = iso8601Date.split("-")
@@ -76,7 +79,7 @@ object DateUtils {
             val calendar = GregorianCalendar(year.toInt(), month.toInt() - 1, 1)
             return calendar.getActualMaximum(Calendar.DAY_OF_MONTH)
         } catch (e: IndexOutOfBoundsException) {
-            throw IllegalArgumentException("Date string is not of format YYYY-MM-DD: $iso8601Date")
+            throw IllegalArgumentException("Date string argument is not of format YYYY-MM-DD: $iso8601Date")
         }
     }
 
@@ -84,11 +87,18 @@ object DateUtils {
      * Given an ISO8601 date of format YYYY-MM-DD, returns the String in short month ("MMM d") format.
      *
      * For example, given 2018-07-03 returns "Jul 3", and given 2018-07-28 returns "Jul 28".
+     *
+     * @throws IllegalArgumentException if the argument is not a valid iso8601 date string.
      */
+    @Throws(IllegalArgumentException::class)
     fun getShortMonthDayString(iso8601Date: String): String {
-        val (year, month, day) = iso8601Date.split("-")
-        val date = GregorianCalendar(year.toInt(), month.toInt() - 1, day.toInt()).time
-        return friendlyMonthDayFormat.format(date)
+        return try {
+            val (year, month, day) = iso8601Date.split("-")
+            val date = GregorianCalendar(year.toInt(), month.toInt() - 1, day.toInt()).time
+            friendlyMonthDayFormat.format(date)
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Date string argument is not of format YYYY-MM-DD: $iso8601Date")
+        }
     }
 
     /**
@@ -96,29 +106,50 @@ object DateUtils {
      * with the day being the first day of that week (a Monday, by ISO8601 convention).
      *
      * For example, given 2018-W11, returns "Mar 12".
+     *
+     * @throws IllegalArgumentException if the argument is not a valid iso8601 date string.
      */
+    @Throws(IllegalArgumentException::class)
     fun getShortMonthDayStringForWeek(iso8601Week: String): String {
-        val date = weekOfYearStartingMondayFormat.parse(iso8601Week)
-        return friendlyMonthDayFormat.format(date)
+        return try {
+            val date = weekOfYearStartingMondayFormat.parse(iso8601Week)
+            friendlyMonthDayFormat.format(date)
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Date string argument is not of format YYYY-'W'WW: $iso8601Week")
+        }
     }
 
     /**
      * Given a date of format YYYY-MM, returns the corresponding short month format.
      *
      * For example, given 2018-07, returns "Jul".
+     *
+     * @throws IllegalArgumentException if the argument is not a valid iso8601 date string.
      */
+    @Throws(IllegalArgumentException::class)
     fun getShortMonthString(iso8601Month: String): String {
         val month = iso8601Month.split("-").last()
-        return shortMonths[month.toInt() - 1]
+        return try {
+            shortMonths[month.toInt() - 1]
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Date string argument is not of format YYYY-MM: $iso8601Month")
+        }
     }
 
     /**
-    * Given a date of format YYYY-MM, returns whether it's on a weekend
-    */
+     * Given a date of format YYYY-MM, returns whether it's on a weekend
+     *
+     * @throws IllegalArgumentException if the argument is not a valid iso8601 date string.
+     */
+    @Throws(IllegalArgumentException::class)
     fun isWeekend(iso8601Date: String): Boolean {
-        val (year, month, day) = iso8601Date.split("-")
-        val date = GregorianCalendar(year.toInt(), month.toInt() - 1, day.toInt())
-        val dayOfWeek = date.get(Calendar.DAY_OF_WEEK)
-        return (dayOfWeek == Calendar.SATURDAY || dayOfWeek == Calendar.SUNDAY)
+        return try {
+            val (year, month, day) = iso8601Date.split("-")
+            val date = GregorianCalendar(year.toInt(), month.toInt() - 1, day.toInt())
+            val dayOfWeek = date.get(Calendar.DAY_OF_WEEK)
+            (dayOfWeek == Calendar.SATURDAY || dayOfWeek == Calendar.SUNDAY)
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Date string argument is not of format YYYY-MM: $iso8601Date")
+        }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.util
 
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class DateUtilsTest {
     @Test
@@ -28,6 +29,23 @@ class DateUtilsTest {
     fun `getShortMonthDayString() returns correct values`() {
         assertEquals("Jul 3", DateUtils.getShortMonthDayString("2018-07-03"))
         assertEquals("Jul 28", DateUtils.getShortMonthDayString("2018-07-28"))
+
+        // Test for invalid value handling
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortMonthDayString("22")
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortMonthDayString("2018-22")
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortMonthDayString("-07-41")
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortMonthDayString("")
+        }
     }
 
     @Test
@@ -37,11 +55,45 @@ class DateUtilsTest {
         // the first day of the year
         assertEquals("Jan 1", DateUtils.getShortMonthDayStringForWeek("2018-W1"))
         assertEquals("Jan 2", DateUtils.getShortMonthDayStringForWeek("2017-W1"))
+
+        // Test for invalid value handling
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortMonthDayString("22")
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortMonthDayString("2018-22")
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortMonthDayString("-07-41")
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortMonthDayString("")
+        }
     }
 
     @Test
     fun `getShortMonthString() returns correct values`() {
         assertEquals("Jul", DateUtils.getShortMonthString("2018-07"))
         assertEquals("Jan", DateUtils.getShortMonthString("2017-01"))
+
+        // Test for invalid value handling
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortMonthDayString("22")
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortMonthDayString("2018-22")
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortMonthDayString("-07-41")
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortMonthDayString("")
+        }
     }
 }


### PR DESCRIPTION
Partially addresses #373 

Allows us to 'fail fast' and provide more data in the stacktrace. The stacktrace will now include a formatted message of what was expected, and what the argument value was.