### PR TITLE
issue/374-illegal-state-selected-site

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
@@ -39,6 +39,12 @@ class SelectedSite(private var context: Context, private var siteStore: SiteStor
 
     fun isSet() = PreferenceUtils.getInt(getPreferences(), SELECTED_SITE_LOCAL_ID, -1) != -1
 
+    fun exists(): Boolean {
+        val localSiteId = PreferenceUtils.getInt(getPreferences(), SELECTED_SITE_LOCAL_ID, -1)
+        val siteModel = siteStore.getSiteByLocalId(localSiteId)
+        return siteModel != null
+    }
+
     fun reset() {
         selectedSite = null
         getPreferences().edit().remove(SELECTED_SITE_LOCAL_ID).apply()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -89,7 +89,7 @@ class MainActivity : AppCompatActivity(),
             return
         }
 
-        if (!selectedSite.isSet()) {
+        if (!selectedSite.exists()) {
             updateSelectedSite()
             return
         }
@@ -219,7 +219,7 @@ class MainActivity : AppCompatActivity(),
     override fun updateSelectedSite() {
         loginProgressDialog?.apply { if (isShowing) { cancel() } }
 
-        if (!selectedSite.isSet()) {
+        if (!selectedSite.exists()) {
             showLoginEpilogueScreen()
             return
         }


### PR DESCRIPTION
Fixes #374 - I wasn't able to reproduce the problem, but my assumption is that the previously selected site is no longer valid for some reason.

Right now [we send the user to the epilogue](https://github.com/woocommerce/woocommerce-android/blob/develop/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt#L92) if there's no siteId in preferences, but we don't verify that it points to an actual site. This PR corrects this.