### PR TITLE
issue/381-login-illegal-argument

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -220,11 +220,13 @@ class AnalyticsTracker private constructor(private val context: Context) {
          * @param errorType The type of error.
          * @param errorDescription The error text or other description.
          */
-        fun track(stat: Stat, errorContext: String, errorType: String, errorDescription: String) {
+        fun track(stat: Stat, errorContext: String, errorType: String, errorDescription: String?) {
             val props = HashMap<String, String>()
             props["error_context"] = errorContext
             props["error_type"] = errorType
-            props["error_description"] = errorDescription
+            errorDescription?.let {
+                props["error_description"] = it
+            }
             track(stat, props)
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginAnalyticsTracker.kt
@@ -43,7 +43,7 @@ class LoginAnalyticsTracker : LoginAnalyticsListener {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_AUTOFILL_CREDENTIALS_UPDATED)
     }
 
-    override fun trackLoginFailed(errorContext: String, errorType: String, errorDescription: String) {
+    override fun trackLoginFailed(errorContext: String, errorType: String, errorDescription: String?) {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_FAILED, errorContext, errorType, errorDescription)
     }
 


### PR DESCRIPTION
Fixes #381 - the error log showed that the crash was due to a null `errorDescription`. This PR resolves it by allowed for that parameter to be null.