### PR TITLE
Update to use index of provided string instead of `.last()`

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -128,7 +128,7 @@ object DateUtils {
      */
     @Throws(IllegalArgumentException::class)
     fun getShortMonthString(iso8601Month: String): String {
-        val month = iso8601Month.split("-").last()
+        val month = iso8601Month.split("-")[1]
         return try {
             shortMonths[month.toInt() - 1]
         } catch (e: Exception) {


### PR DESCRIPTION
Fixes #392 

Method `DateUtils.getShortMonthString(...)` will no longer crash if it gets `YYYY-MM-DD` instead of `YYYY-MM`