### PR TITLE
Add event tracking for order fulfillment screens

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -117,7 +117,8 @@ class AnalyticsTracker private constructor(private val context: Context) {
         ORDER_DETAIL_PRODUCT_DETAIL_BUTTON_TAPPED,
 
         // -- Order Fulfillment
-        FULFILLED_ORDER,
+        SNACK_ORDER_MARKED_COMPLETE_UNDO_BUTTON_TAPPED,
+        ORDER_FULFILLMENT_MARK_ORDER_COMPLETE_BUTTON_TAPPED,
 
         // -- Top-level navigation
         MAIN_MENU_SETTINGS_TAPPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -12,6 +12,7 @@ import android.view.ViewGroup
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SNACK_ORDER_MARKED_COMPLETE_UNDO_BUTTON_TAPPED
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.orders.AddOrderNoteActivity.Companion.FIELD_IS_CUSTOMER_NOTE
@@ -21,6 +22,7 @@ import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_order_detail.*
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import javax.inject.Inject
 
 class OrderDetailFragment : Fragment(), OrderDetailContract.View, OrderDetailNoteListener {
@@ -199,6 +201,12 @@ class OrderDetailFragment : Fragment(), OrderDetailContract.View, OrderDetailNot
                 AnalyticsTracker.track(
                         Stat.ORDER_STATUS_CHANGE_UNDO,
                         mapOf(AnalyticsTracker.KEY_ID to order.remoteOrderId))
+
+                when (newStatus) {
+                    CoreOrderStatus.COMPLETED.value ->
+                        AnalyticsTracker.track(SNACK_ORDER_MARKED_COMPLETE_UNDO_BUTTON_TAPPED)
+                    else -> {}
+                }
 
                 // User canceled the action to change the order status
                 changeOrderStatusCanceled = true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -93,12 +93,6 @@ class OrderDetailPresenter @Inject constructor(
             return
         }
 
-        when (newStatus) {
-            CoreOrderStatus.COMPLETED.value -> {
-                AnalyticsTracker.track(Stat.FULFILLED_ORDER)
-            }
-        }
-
         orderModel?.let { order ->
             val payload = UpdateOrderStatusPayload(order, selectedSite.get(), newStatus)
             dispatcher.dispatch(WCOrderActionBuilder.newUpdateOrderStatusAction(payload))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragment.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import com.woocommerce.android.R
 import com.woocommerce.android.R.layout
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_FULFILLMENT_MARK_ORDER_COMPLETE_BUTTON_TAPPED
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_order_fulfillment.*
 import org.wordpress.android.fluxc.model.WCOrderModel
@@ -88,6 +89,8 @@ class OrderFulfillmentFragment : Fragment(), OrderFulfillmentContract.View, View
     override fun onClick(v: View?) {
         // User has clicked the button to mark this order complete.
         context?.let {
+            AnalyticsTracker.track(ORDER_FULFILLMENT_MARK_ORDER_COMPLETE_BUTTON_TAPPED)
+
             presenter.orderModel?.let {
                 presenter.markOrderComplete()
             }


### PR DESCRIPTION
Fixes #387 

Adds the following view interaction events:
- SNACK_ORDER_MARKED_COMPLETE_UNDO_BUTTON_TAPPED
-  ORDER_FULFILLMENT_MARK_ORDER_COMPLETE_BUTTON_TAPPED

Removes defunct event:
- ORDER_FULFILLED (this is now tracked using `order_status_change` event)