### PR TITLE
Add event tracking for order notes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -116,6 +116,13 @@ class AnalyticsTracker private constructor(private val context: Context) {
         ORDER_DETAIL_FULFILL_ORDER_BUTTON_TAPPED,
         ORDER_DETAIL_PRODUCT_DETAIL_BUTTON_TAPPED,
 
+        // -- Order Notes
+        ADD_ORDER_NOTE_ADD_BUTTON_TAPPED,
+        ADD_ORDER_NOTE_EMAIL_NOTE_TO_CUSTOMER_TOGGLED,
+        ORDER_NOTE_ADD,
+        ORDER_NOTE_ADD_FAILED,
+        ORDER_NOTE_ADD_SUCCESS,
+
         // -- Order Fulfillment
         FULFILLED_ORDER,
 
@@ -259,8 +266,10 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_IS_WPCOM_STORE = "is_wpcom_store"
         const val KEY_NAME = "name"
         const val KEY_NUMBER_OF_STORES = "number_of_stores"
+        const val KEY_PARENT_ID = "parent_id"
         const val KEY_RANGE = "range"
         const val KEY_SELECTED_STORE_ID = "selected_store_id"
+        const val KEY_STATE = "state"
         const val KEY_STATUS = "status"
         const val KEY_TO = "to"
         const val KEY_TYPE = "type"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderNoteActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderNoteActivity.kt
@@ -12,8 +12,11 @@ import android.view.MenuItem
 import android.view.View
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ADD_ORDER_NOTE_ADD_BUTTON_TAPPED
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ADD_ORDER_NOTE_EMAIL_NOTE_TO_CUSTOMER_TOGGLED
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.util.AnalyticsUtils
 import dagger.android.AndroidInjection
 import kotlinx.android.synthetic.main.activity_add_order_note.*
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
@@ -58,7 +61,11 @@ class AddOrderNoteActivity : AppCompatActivity(), AddOrderNoteContract.View {
         }
 
         if (presenter.hasBillingEmail(orderId)) {
-            addNote_switch.setOnCheckedChangeListener { buttonView, isChecked ->
+            addNote_switch.setOnCheckedChangeListener { _, isChecked ->
+                AnalyticsTracker.track(
+                        ADD_ORDER_NOTE_EMAIL_NOTE_TO_CUSTOMER_TOGGLED,
+                        mapOf(AnalyticsTracker.KEY_STATE to AnalyticsUtils.getToggleStateLabel(isChecked)))
+
                 val drawableId = if (isChecked) R.drawable.ic_note_public else R.drawable.ic_note_private
                 addNote_icon.setImageDrawable(ContextCompat.getDrawable(this, drawableId))
             }
@@ -105,6 +112,8 @@ class AddOrderNoteActivity : AppCompatActivity(), AddOrderNoteContract.View {
                 true
             }
             R.id.menu_add -> {
+                AnalyticsTracker.track(ADD_ORDER_NOTE_ADD_BUTTON_TAPPED)
+
                 if (!networkStatus.isConnected()) {
                     uiMessageResolver.showOfflineSnack()
                 } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -2,6 +2,9 @@ package com.woocommerce.android.ui.orders
 
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_NOTE_ADD
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_NOTE_ADD_FAILED
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_NOTE_ADD_SUCCESS
 import com.woocommerce.android.network.ConnectionChangeReceiver
 import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
 import com.woocommerce.android.tools.NetworkStatus
@@ -106,6 +109,8 @@ class OrderDetailPresenter @Inject constructor(
     }
 
     override fun pushOrderNote(noteText: String, isCustomerNote: Boolean) {
+        AnalyticsTracker.track(ORDER_NOTE_ADD, mapOf(AnalyticsTracker.KEY_PARENT_ID to orderModel!!.remoteOrderId))
+
         if (!networkStatus.isConnected()) {
             // Device is not connected. Display generic message and exit. Technically we shouldn't get this far, but
             // just in case...
@@ -166,9 +171,18 @@ class OrderDetailPresenter @Inject constructor(
             }
         } else if (event.causeOfChange == POST_ORDER_NOTE) {
             if (event.isError) {
+                AnalyticsTracker.track(
+                        ORDER_NOTE_ADD_FAILED,
+                        this::class.java.simpleName,
+                        event.error.type.toString(),
+                        event.error.message)
+
                 WooLog.e(T.ORDERS, "$TAG - Error posting order note : ${event.error.message}")
                 orderView?.showAddOrderNoteErrorSnack()
+            } else {
+                AnalyticsTracker.track(ORDER_NOTE_ADD_SUCCESS)
             }
+
             // note that we refresh even on error to make sure the transient note is removed
             // from the note list
             fetchAndLoadNotesFromDb()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/AnalyticsUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/AnalyticsUtils.kt
@@ -1,0 +1,14 @@
+package com.woocommerce.android.util
+
+object AnalyticsUtils {
+    /**
+     * Returns the proper label for a toggle state property
+     * on a track event.
+     */
+    fun getToggleStateLabel(isSelected: Boolean): String {
+        return when (isSelected) {
+            true -> "on"
+            false -> "off"
+        }
+    }
+}


### PR DESCRIPTION
Fixes #386 

Adds event tracking for order note actions and view interactions with the Order Notes Activity:
- ADD_ORDER_NOTE_ADD_BUTTON_TAPPED
- ADD_ORDER_NOTE_EMAIL_NOTE_TO_CUSTOMER_TOGGLED
- ORDER_NOTE_ADD
- ORDER_NOTE_ADD_FAILED
- ORDER_NOTE_ADD_SUCCESS
