### PR TITLE
Issue/401 subfolder urls

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/SiteListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/SiteListAdapter.kt
@@ -54,7 +54,7 @@ class SiteListAdapter(private val context: Context, private val listener: OnSite
         holder.radio.visibility = if (siteList.size > 1) View.VISIBLE else View.GONE
         holder.radio.isChecked = site.siteId == selectedSiteId
         holder.txtSiteName.text = if (!TextUtils.isEmpty(site.name)) site.name else context.getString(R.string.untitled)
-        holder.txtSiteDomain.text = StringUtils.getHostAndPath(site.url)
+        holder.txtSiteDomain.text = StringUtils.getSiteDomainAndPath(site)
         if (itemCount > 1) {
             holder.itemView.setOnClickListener {
                 if (selectedSiteId != site.siteId) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/SiteListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/SiteListAdapter.kt
@@ -10,9 +10,9 @@ import android.widget.RadioButton
 import android.widget.TextView
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.login.SiteListAdapter.SiteViewHolder
+import com.woocommerce.android.util.StringUtils
 import kotlinx.android.synthetic.main.site_list_item.view.*
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.util.UrlUtils
 
 class SiteListAdapter(private val context: Context, private val listener: OnSiteClickListener) :
         RecyclerView.Adapter<SiteViewHolder>() {
@@ -54,7 +54,7 @@ class SiteListAdapter(private val context: Context, private val listener: OnSite
         holder.radio.visibility = if (siteList.size > 1) View.VISIBLE else View.GONE
         holder.radio.isChecked = site.siteId == selectedSiteId
         holder.txtSiteName.text = if (!TextUtils.isEmpty(site.name)) site.name else context.getString(R.string.untitled)
-        holder.txtSiteDomain.text = UrlUtils.getHost(site.url)
+        holder.txtSiteDomain.text = StringUtils.getHostAndPath(site.url)
         if (itemCount > 1) {
             holder.itemView.setOnClickListener {
                 if (selectedSiteId != site.siteId) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -20,5 +20,5 @@ class MainSettingsPresenter @Inject constructor(
     }
 
     override fun getUserDisplayName(): String = accountStore.account.displayName
-    override fun getStoreDomainName(): String = StringUtils.getHostAndPath(selectedSite.get().url)
+    override fun getStoreDomainName(): String = StringUtils.getSiteDomainAndPath(selectedSite.get())
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -1,8 +1,8 @@
 package com.woocommerce.android.ui.prefs
 
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.StringUtils
 import org.wordpress.android.fluxc.store.AccountStore
-import org.wordpress.android.util.UrlUtils
 import javax.inject.Inject
 
 class MainSettingsPresenter @Inject constructor(
@@ -20,5 +20,5 @@ class MainSettingsPresenter @Inject constructor(
     }
 
     override fun getUserDisplayName(): String = accountStore.account.displayName
-    override fun getStoreDomainName(): String = UrlUtils.getHost(selectedSite.get().url)
+    override fun getStoreDomainName(): String = StringUtils.getHostAndPath(selectedSite.get().url)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
@@ -42,7 +42,7 @@ object StringUtils {
      */
     fun getSiteDomainAndPath(site: SiteModel): String {
         site.url?.let {
-            val uri = Uri.parse("http://www.nickbradbury.com/wp/wp2#")
+            val uri = Uri.parse(it)
             return uri.host.orEmpty() + uri.path.orEmpty()
         } ?: return ""
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
@@ -39,11 +39,10 @@ object StringUtils {
      *      https://baseurl.com -> baseurl.com
      *      https://baseurl.com/mysite -> baseurl.com/mysite
      */
-    fun getHostAndPath(urlString: String): String {
-        val uri = Uri.parse(urlString)
-        uri.host?.let {
-            return it + uri.path
-        }
-        return ""
+    fun getHostAndPath(urlString: String?): String {
+        urlString?.let {
+            val uri = Uri.parse(it)
+            return uri.host.orEmpty() + uri.path.orEmpty()
+        } ?: return ""
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.util
 import android.content.Context
 import android.net.Uri
 import android.support.annotation.StringRes
+import org.wordpress.android.fluxc.model.SiteModel
 
 object StringUtils {
     /**
@@ -39,9 +40,9 @@ object StringUtils {
      *      https://baseurl.com -> baseurl.com
      *      https://baseurl.com/mysite -> baseurl.com/mysite
      */
-    fun getHostAndPath(urlString: String?): String {
-        urlString?.let {
-            val uri = Uri.parse(it)
+    fun getSiteDomainAndPath(site: SiteModel): String {
+        site.url?.let {
+            val uri = Uri.parse("http://www.nickbradbury.com/wp/wp2#")
             return uri.host.orEmpty() + uri.path.orEmpty()
         } ?: return ""
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.util
 
 import android.content.Context
+import android.net.Uri
 import android.support.annotation.StringRes
 
 object StringUtils {
@@ -29,5 +30,20 @@ object StringUtils {
             1 -> context.getString(one ?: default, quantity)
             else -> context.getString(default, quantity)
         }
+    }
+
+    /**
+     * Similar to UrlUtils.getHost() except that it includes the path (subfolder)
+     *
+     * Ex:
+     *      https://baseurl.com -> baseurl.com
+     *      https://baseurl.com/mysite -> baseurl.com/mysite
+     */
+    fun getHostAndPath(urlString: String): String {
+        val uri = Uri.parse(urlString)
+        uri.host?.let {
+            return it + uri.path
+        }
+        return ""
     }
 }


### PR DESCRIPTION
Fixes #401 - Prior to this PR we relied on `getHost()` when displaying a site domain in the epilogue and settings screens, which fails to support sites installed in a subfolder. This PR corrects this by adding the path.

![screenshot_1539261637](https://user-images.githubusercontent.com/3903757/46808024-57858c00-cd39-11e8-8f73-8145542cd273.png)
