### PR TITLE
Fix LoginEmailFragment NPE crash in onActivityResult()

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -445,6 +445,11 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
         super.onActivityResult(requestCode, resultCode, data);
 
         if (requestCode == EMAIL_CREDENTIALS_REQUEST_CODE) {
+            if (mEmailInput == null) {
+                // Activity result received before the fragments onCreateView(), disregard result.
+                return;
+            }
+
             if (resultCode == RESULT_OK) {
                 Credential credential = data.getParcelableExtra(Credential.EXTRA_KEY);
                 mEmailInput.getEditText().setText(credential.getId());


### PR DESCRIPTION
Fixes #408 

## The Issue
The crash is around the email address hint functionality on the email field for login. A NPE is thrown in the `onActiivtyResult()` method of the `LoginEmailFragment`. The `mEmailInput` variable is null and the code is attempting to call a method on this variable in `onActivityResult()`:

```@Override
public void onActivityResult(int requestCode, int resultCode, Intent data) {
    super.onActivityResult(requestCode, resultCode, data);

    if (requestCode == EMAIL_CREDENTIALS_REQUEST_CODE) {
        if (resultCode == RESULT_OK) {
            Credential credential = data.getParcelableExtra(Credential.EXTRA_KEY);
            mEmailInput.getEditText().setText(credential.getId());
            next(getCleanedEmail());
        } else {
            mHasDismissedEmailHints = true;
            mEmailInput.getEditText().postDelayed(new Runnable() { <------ CRASHES HERE -----|
                @Override
                public void run() {
                    if (isAdded()) {
                        ActivityUtils.showKeyboard(mEmailInput.getEditText());
                    }
                }
            }, getResources().getInteger(android.R.integer.config_mediumAnimTime));
        }

        mIsDisplayingEmailHints = false;
    }
}
```


`mEmailInput` gets initialized in the `setupContent()` method which is called during `onCreateView()` in the base Fragment class. So knowing this I'm assuming that somehow `LoginEmailFragment`'s `onActivityResult()` is being called before `onCreateView()`. I've tried to replicate this crash by enabling "Don't keep activities" and trying to somehow hit that sweet spot where I activate the TextInput and then put the app in the background before the hint results are returned. No luck. 

## The Fix
Verify `mEmailInput` is not null before attempting to access it. There is no side effect of this fix since when `setupContent()` is finally called and `mEmailInput` is initialized, the email hint code will be called again.