### PR TITLE
Add WCAndroid field to GH issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -7,5 +7,5 @@
 ### Steps to reproduce the behavior
 
 
-##### Tested on [device], Android [version]
+##### Tested on [device], Android [version], WCAndroid [version]
 


### PR DESCRIPTION
Updates the GitHub issue template to include a placeholder for the version of the WCAndroid app the issue was discovered in.