### PR TITLE
Use the correct ID for the WP.com blogId in Tracks

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -227,7 +227,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         }
 
         site?.let {
-            val properties = mapOf(KEY_BLOG_ID to it.id, KEY_IS_WPCOM_STORE to it.isWpComStore)
+            val properties = mapOf(KEY_BLOG_ID to it.siteId, KEY_IS_WPCOM_STORE to it.isWpComStore)
             val props = JSONObject(properties)
             tracksClient?.registerUserProperties(props)
         }


### PR DESCRIPTION
Looks like we were sending the wrong id to Tracks as `blogId` metadata. `SiteModel.id` refers to the unique key of that site in the local (app) database, while `SiteModel.siteId` is the WP.com site ID that we want.