### PR TITLE
verify fragment mgr state before attempting to modify it

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -365,7 +365,7 @@ class MainActivity : AppCompatActivity(),
      */
     private fun clearFragmentBackStack(fragment: Fragment?): Boolean {
         fragment?.let {
-            with (it.childFragmentManager) {
+            with(it.childFragmentManager) {
                 // If the fragment manager's state has already been saved,
                 // exit to avoid the IllegalStateException
                 if (isStateSaved) {


### PR DESCRIPTION
Fixes #409 

This fixes the `IllegalStateException` crash that happens when attempting to clear the fragment backstack after `onSaveInstanceState()` has already been called. 