### PR TITLE
verify fragment mgr state before attempting to modify it

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -355,7 +355,7 @@ class MainActivity : AppCompatActivity(),
      */
     private fun hideParentFragment(fragment: Fragment?) {
         fragment?.let {
-            with (supportFragmentManager) {
+            with(supportFragmentManager) {
                 if (isStateSaved) {
                     // fragmentManager state already saved, no changes to state allowed
                     return


### PR DESCRIPTION
Fixes #407 

Any modification to the fragment managers state after it has been saved results in an `IllegalStateException`. This fixes the `IllegalStateException` crash that happens when attempting hide a fragment after `onSaveInstanceState()` has already been called. 