### PR TITLE
Analytics: exclude site information for some tracks events

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -310,11 +310,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
             sendUsageStats = prefs.getBoolean(PREFKEY_SEND_USAGE_STATS, true)
         }
 
-        fun track(stat: Stat) {
-            track(stat, emptyMap<String, String>())
-        }
-
-        fun track(stat: Stat, properties: Map<String, *>) {
+        fun track(stat: Stat, properties: Map<String, *> = emptyMap<String, String>()) {
             if (sendUsageStats) {
                 instance?.track(stat, properties)
             }


### PR DESCRIPTION
This PR fixes #419 by allowing Tracks stats to be marked as 'siteless' or not. Siteless events won't have the `blog_id` or `is_wpcom_store` properties attached to the event.

This PR also corrects the id being sent (it was previously sending the local, database id, instead of the remote WP.com site ID), and attaches the `blog_id` and `is_wpcom_store` properties to the event instead of setting them globally as a user property. This is because Tracks expects to see a `blog_id` as an event property in order to consider events as 'blogful', and values set as user props actually get prefixed with `user_info_` when sent.

## Testing

(Photos shamelessly stolen from @bummytime's counterpart WooiOS PR, https://github.com/woocommerce/woocommerce-ios/pull/365 - ignore the part where it shows `woocommerceios_*` 😛)

1. Build and run the app
2. Log out of the app if you are logged in.
3. Log into the app, open and close the app, and tap around the UI once logged in. 
4. Wait a few minutes and then in the tracks live view, search for event names with `woocommerceandroid_%` and your username.
5. Verify that events with `siteless = true` _do not include_ the `blogid` or `is_wpcom_store` props:

<img width="372" alt="napkin 102 10-18-18 11 47 49 am copy_resized" src="https://user-images.githubusercontent.com/154014/47170472-b87a0a80-d2cb-11e8-8726-daab1e8447d2.png">

(also in the same event, check out `eventprops` and verify `is_wpcom_store` is not included)

6. Verify that other events _include_ `blogid` and `is_wpcom_store`:

<img width="372" alt="napkin 102 10-18-18 11 52 41 am copy_resized" src="https://user-images.githubusercontent.com/154014/47170737-65548780-d2cc-11e8-810c-6ce47ceaa76f.png">

cc @bummytime 