### PR TITLE
Fix issue where the radio button for multiple sites could be selected

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/SiteListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/SiteListAdapter.kt
@@ -71,5 +71,9 @@ class SiteListAdapter(private val context: Context, private val listener: OnSite
         val radio: RadioButton = view.radio
         val txtSiteName: TextView = view.text_site_name
         val txtSiteDomain: TextView = view.text_site_domain
+
+        init {
+            radio.isClickable = false
+        }
     }
 }


### PR DESCRIPTION
Fixes #422 

The user was able to select multiple sites if the radio button was directly clicked. The click listener is configured for view that displays the individual site option so if the user clicked on anywhere else on the view, all would work fine, but if the user clicked directly on the radio button, the radio would check, but no action would happen. Since radios are single choice, clicking again would not unselect the radio.

The fix was to just make it so the radio element in the view was not individually clickable. This transfers the click event to the parent where the listener is registered to take action.