### PR TITLE
Fix push notifications for API<24

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/FCMMessageService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/FCMMessageService.kt
@@ -29,7 +29,7 @@ class FCMMessageService : FirebaseMessagingService() {
 
     private fun convertMapToBundle(data: Map<String, String>): Bundle {
         return Bundle().apply {
-            data.forEach { key, value -> putString(key, value) }
+            data.forEach { (key, value) -> putString(key, value) }
         }
     }
 }


### PR DESCRIPTION
It turns out I accidentally used the Java 8 `Map.forEach` instead of the Kotlin extension function of the same name. This works fine on API 24+, but is unsupported on older APIs, causing a crash whenever a push notification was received.

**To test**

1. Build this branch on an API 23 or lower device (emulators with Google APIs should work too)
2. Login and select a site
3. Trigger a non-order notification for that site (commenting on a post is a good idea) from another account
4. Observe that you receive a push notification

If you run into trouble, you can instead follow the steps from https://github.com/woocommerce/woocommerce-android/pull/398 to change registration to pretend to be the WordPress app.