### PR TITLE
Support multiline product names

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
@@ -25,6 +25,7 @@ class OrderDetailProductItemView @JvmOverloads constructor(ctx: Context, attrs: 
         productInfo_productTotal.visibility = viewMode
         productInfo_totalTax.visibility = viewMode
         productInfo_lblTax.visibility = viewMode
+        productInfo_name.setSingleLine(!expanded)
 
         if (item.sku.isNullOrEmpty() || !expanded) {
             productInfo_lblSku.visibility = View.GONE

--- a/WooCommerce/src/main/res/layout/order_detail_product_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_product_item.xml
@@ -23,15 +23,17 @@
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/card_item_padding_intra_h"
         android:layout_marginStart="12dp"
+        android:ellipsize="end"
         android:paddingBottom="@dimen/card_item_padding_intra_v"
         android:paddingEnd="8dp"
         android:paddingStart="0dp"
+        android:singleLine="true"
         android:textAppearance="@style/Woo.OrderDetail.TextAppearance.Heading"
+        app:layout_constrainedWidth="true"
         app:layout_constraintBaseline_toBaselineOf="@+id/productInfo_qty"
         app:layout_constraintEnd_toStartOf="@+id/productInfo_qty"
-        app:layout_constraintStart_toEndOf="@+id/productInfo_icon"
-        app:layout_constrainedWidth="true"
         app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toEndOf="@+id/productInfo_icon"
         tools:text="Candle"/>
 
     <TextView
@@ -80,11 +82,11 @@
         android:layout_marginEnd="@dimen/card_item_padding_intra_h"
         android:layout_marginTop="@dimen/card_item_padding_intra_v"
         android:textAppearance="@style/Woo.OrderDetail.TextAppearance.Content"
+        app:layout_constrainedWidth="true"
         app:layout_constraintEnd_toStartOf="@+id/productInfo_qty"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toEndOf="@+id/productInfo_lblTax"
         app:layout_constraintTop_toBottomOf="@+id/productInfo_productTotal"
-        app:layout_constrainedWidth="true"
         tools:text="$0.75"
         tools:visibility="visible"/>
 
@@ -109,11 +111,11 @@
         android:layout_marginEnd="@dimen/card_item_padding_intra_h"
         android:layout_marginTop="@dimen/card_item_padding_intra_v"
         android:textAppearance="@style/Woo.OrderDetail.TextAppearance.Content"
+        app:layout_constrainedWidth="true"
         app:layout_constraintEnd_toStartOf="@+id/productInfo_qty"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toEndOf="@+id/productInfo_lblSku"
         app:layout_constraintTop_toBottomOf="@+id/productInfo_lblTax"
-        app:layout_constrainedWidth="true"
         tools:text="T3124"
         tools:visibility="visible"/>
 </merge>


### PR DESCRIPTION
Fixes #432 - removed the `singleLine` setting for the product name in order detail so multiple lines are shown.

![screenshot_1540323349](https://user-images.githubusercontent.com/3903757/47387061-4a26b500-d6dc-11e8-9508-227f1367a71e.png)
