### PR TITLE
Added user name, email and ID to Crashlytics

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -68,7 +68,7 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
         AppPrefs.init(this)
 
         initAnalytics()
-        CrashlyticsUtils.initCrashlytics(this)
+        CrashlyticsUtils.initCrashlytics(this, accountStore.account)
 
         createNotificationChannelsOnSdk26()
 
@@ -152,6 +152,7 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
             // Reset analytics
             AnalyticsTracker.flush()
             AnalyticsTracker.clearAllData()
+            CrashlyticsUtils.resetAccount()
 
             // Wipe user-specific preferences
             AppPrefs.reset()
@@ -161,6 +162,7 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
             if (hasUserOptedOut != accountStore.account.tracksOptOut) {
                 AnalyticsTracker.sendUsageStats = !accountStore.account.tracksOptOut
             }
+            CrashlyticsUtils.initAccount(accountStore.account)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CrashlyticsUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CrashlyticsUtils.kt
@@ -5,8 +5,8 @@ import com.crashlytics.android.Crashlytics
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.util.WooLog.T
-
 import io.fabric.sdk.android.Fabric
+import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.util.AppLog as WordPressAppLog
 
 object CrashlyticsUtils {
@@ -17,10 +17,11 @@ object CrashlyticsUtils {
         return AnalyticsTracker.sendUsageStats && !BuildConfig.DEBUG
     }
 
-    fun initCrashlytics(context: Context) {
+    fun initCrashlytics(context: Context, account: AccountModel?) {
         if (!isCrashlyticsAllowed()) { return }
 
         Fabric.with(context, Crashlytics())
+        initAccount(account)
 
         // Send logs for app events through to Crashlytics
         WooLog.addListener { tag, logLevel, message ->
@@ -31,6 +32,18 @@ object CrashlyticsUtils {
         WordPressAppLog.addListener { tag, logLevel, message ->
             CrashlyticsUtils.log("$logLevel/${WordPressAppLog.TAG}-$tag: $message")
         }
+    }
+
+    fun initAccount(account: AccountModel?) {
+        if (!isCrashlyticsAllowed()) { return }
+
+        Crashlytics.setUserName(account?.userName)
+        Crashlytics.setUserEmail(account?.email)
+        Crashlytics.setUserIdentifier(account?.userId.toString())
+    }
+
+    fun resetAccount() {
+        initAccount(null)
     }
 
     fun logException(tr: Throwable, tag: T? = null, message: String? = null) {


### PR DESCRIPTION
Resolves #227 by adding user information to Crashlytics, similar to how it's done [on iOS](https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/Tools/Fabric/FabricManager.swift#L34).

Note to reviewer: Crashlytics is disabled in debug builds, so you'll want to change [this function](https://github.com/woocommerce/woocommerce-android/blob/a97bc282132eb9997c324ff5c0b1ca45c72a0fac/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CrashlyticsUtils.kt#L16) to always return true while testing.