### PR TITLE
Issue/450 filter action visibility

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -82,8 +82,8 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View, OrderStatu
     }
 
     override fun onPrepareOptionsMenu(menu: Menu?) {
-        // hide the filter menu item when we're showing all orders and there aren't any
-        val hideFilterMenu = noOrdersView.visibility == View.VISIBLE && isShowingAllOrders()
+        // Hide filter menu item when we're showing all orders and there aren't any or we're showing order detail.
+        val hideFilterMenu = (isShowingAllOrders() && noOrdersView.visibility == View.VISIBLE) || isShowingOrderDetail()
         menu?.findItem(R.id.menu_filter)?.isVisible = !hideFilterMenu
         super.onPrepareOptionsMenu(menu)
     }


### PR DESCRIPTION
### Fix
Update the ***Filter*** action visibility conditions on the ***Order Details*** screen as described in https://github.com/woocommerce/woocommerce-android/issues/450.

### Test
1. Go to ***Orders*** tab.
2. Select order from list.
3. Notice ***Filter*** action is hidden.
4. Tap menu overflow action.
5. Tap outside popup menu.
6. Notice ***Filter*** action is shown.
7. Tap ***Filter*** action.
8. Select filter in dialog.
9. Tap ***Apply Filter*** button.
10. Notice screen doesn't change.

### Review
Only one developer is required to review these changes, but anyone can perform the review.