### PR TITLE
Issue/452 update button style

### DIFF
--- a/WooCommerce/src/main/res/layout-land/fragment_login_prologue.xml
+++ b/WooCommerce/src/main/res/layout-land/fragment_login_prologue.xml
@@ -72,9 +72,9 @@
         android:orientation="horizontal"
         android:padding="@dimen/login_prologue_padding">
 
-        <Button
+        <android.support.v7.widget.AppCompatButton
             android:id="@+id/button_login_jetpack"
-            style="@style/Woo.Button.White"
+            android:theme="@style/Woo.Button.White"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"

--- a/WooCommerce/src/main/res/layout-land/fragment_login_prologue.xml
+++ b/WooCommerce/src/main/res/layout-land/fragment_login_prologue.xml
@@ -64,6 +64,7 @@
         app:srcCompat="@drawable/img_slanted_rectangle_landscape"/>
 
     <LinearLayout
+        android:clipToPadding="false"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"

--- a/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
+++ b/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
@@ -100,6 +100,7 @@
 
     <FrameLayout
         android:id="@+id/frame_bottom"
+        android:clipToPadding="false"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"

--- a/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
+++ b/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
@@ -107,7 +107,7 @@
         android:background="@color/white"
         android:padding="@dimen/margin_extra_large">
 
-        <Button
+        <android.support.v7.widget.AppCompatButton
             android:id="@+id/button_continue"
             style="@style/Woo.Button.Purple"
             android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/layout/dashboard_unfilled_orders.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_unfilled_orders.xml
@@ -28,7 +28,7 @@
             android:text="@string/dashboard_fulfill_orders_msg"/>
 
         <!-- Action Button -->
-        <Button
+        <android.support.v7.widget.AppCompatButton
             android:id="@+id/alertAction_action"
             style="@style/Woo.Button"
             android:layout_width="wrap_content"

--- a/WooCommerce/src/main/res/layout/fragment_dashboard.xml
+++ b/WooCommerce/src/main/res/layout/fragment_dashboard.xml
@@ -79,7 +79,7 @@
             android:layout_marginTop="@dimen/margin_large"
             android:text="@string/dashboard_no_orders"/>
 
-        <Button
+        <android.support.v7.widget.AppCompatButton
             android:id="@+id/no_orders_share_button"
             style="@style/Woo.Button.Purple"
             android:layout_width="wrap_content"

--- a/WooCommerce/src/main/res/layout/fragment_login_prologue.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_prologue.xml
@@ -45,6 +45,7 @@
         app:srcCompat="@drawable/img_slanted_rectangle"/>
 
     <LinearLayout
+        android:clipToPadding="false"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"

--- a/WooCommerce/src/main/res/layout/fragment_login_prologue.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_prologue.xml
@@ -62,9 +62,9 @@
             android:textColor="@color/white"
             android:textColorLink="@color/white"/>
 
-        <Button
+        <android.support.v7.widget.AppCompatButton
             android:id="@+id/button_login_jetpack"
-            style="@style/Woo.Button.White"
+            android:theme="@style/Woo.Button.White"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_extra_large"

--- a/WooCommerce/src/main/res/layout/fragment_order_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_detail.xml
@@ -23,6 +23,7 @@
         <!-- Product List -->
         <com.woocommerce.android.ui.orders.OrderDetailProductListView
             android:id="@+id/orderDetail_productList"
+            android:clipToPadding="false"
             style="@style/Woo.Card.List"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/layout/fragment_order_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_list.xml
@@ -52,7 +52,7 @@
                 android:layout_marginTop="@dimen/margin_large"
                 android:text="@string/dashboard_no_orders"/>
 
-            <Button
+            <android.support.v7.widget.AppCompatButton
                 android:id="@+id/no_orders_share_button"
                 style="@style/Woo.Button.Purple"
                 android:layout_width="wrap_content"

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -48,7 +48,7 @@
 
     </LinearLayout>
 
-    <Button
+    <android.support.v7.widget.AppCompatButton
         android:id="@+id/buttonLogout"
         style="@style/Woo.Button.Purple"
         android:layout_width="wrap_content"

--- a/WooCommerce/src/main/res/layout/order_detail_product_list.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_product_list.xml
@@ -38,7 +38,7 @@
         tools:targetApi="lollipop"/>
 
     <!-- Button: Details -->
-    <Button
+    <android.support.v7.widget.AppCompatButton
         android:id="@+id/productList_btnDetails"
         android:layout_width="wrap_content"
         android:layout_height="37dp"

--- a/WooCommerce/src/main/res/layout/order_detail_product_list.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_product_list.xml
@@ -49,7 +49,7 @@
         app:layout_constraintTop_toBottomOf="@+id/productList_products"/>
 
     <!-- Button: Fulfill Order-->
-    <Button
+    <android.support.v7.widget.AppCompatButton
         android:id="@+id/productList_btnFulfill"
         style="@style/Woo.Button.Purple"
         android:layout_width="0dp"

--- a/WooCommerce/src/main/res/layout/order_detail_product_list.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_product_list.xml
@@ -41,7 +41,7 @@
     <android.support.v7.widget.AppCompatButton
         android:id="@+id/productList_btnDetails"
         android:layout_width="wrap_content"
-        android:layout_height="37dp"
+        android:layout_height="40dp"
         android:layout_marginTop="8dp"
         android:text="@string/details"
         style="@style/Woo.Button"

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -137,9 +137,9 @@
         <item name="android:background">@drawable/button_purple_bg</item>
     </style>
 
-    <style name="Woo.Button.White">
-        <item name="android:textColor">@color/grey_dark</item>
-        <item name="android:background">@drawable/button_white_bg</item>
+    <style name="Woo.Button.White" parent="Widget.AppCompat.Button.Colored">
+        <item name="android:textColor">@color/wc_purple</item>
+        <item name="colorButtonNormal">@color/white</item>
     </style>
 
     <!--

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -123,9 +123,8 @@
     <!--
         Button Styles
     -->
-    <style name="Woo.Button" parent="android:Widget.DeviceDefault.Button.Borderless">
-        <item name="android:textColor">@color/button_purple_bg_color</item>
-        <item name="android:background">@null</item>
+    <style name="Woo.Button" parent="Widget.AppCompat.Button.Borderless">
+        <item name="android:textColor">@color/wc_purple</item>
         <item name="android:textAllCaps">true</item>
         <item name="android:paddingStart">16dp</item>
         <item name="android:paddingEnd">16dp</item>

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -132,9 +132,9 @@
         <item name="android:textSize">@dimen/text_large</item>
     </style>
 
-    <style name="Woo.Button.Purple">
+    <style name="Woo.Button.Purple" parent="Widget.AppCompat.Button.Colored">
         <item name="android:textColor">@color/white</item>
-        <item name="android:background">@drawable/button_purple_bg</item>
+        <item name="colorButtonNormal">@color/button_purple_bg_color</item>
     </style>
 
     <style name="Woo.Button.White" parent="Widget.AppCompat.Button.Colored">


### PR DESCRIPTION
### Fix
Update all button styles across the app to follow the [Contained Button](https://material.io/design/components/buttons.html#contained-button) style including elevation, shadow, fade, and ripple as described in https://github.com/woocommerce/woocommerce-android/issues/452.  See the screenshots below for illustration.

![login_prologue_button](https://user-images.githubusercontent.com/3827611/47833608-1f8acb00-dd72-11e8-8aff-ebb4df977259.png)

### Test
1. Go to the following screens and buttons:
  a. Login Prologue > Log In with Jetpack
  b. Login Epilogue > Continue
  c. My Store > View Orders
  d. Orders > Processing Order > Fulfill Order
  e. Orders > Processing Order > Details
  f. Settings > Logout Account
  g. My Store > Share Your Store
  h. Orders > Share Your Store
2. Notice buttons follow style guidelines.

### Review
Only one developer is required to review these changes, but anyone can perform the review.