### PR TITLE
Issue/454 basic currency formatting

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CurrencyUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CurrencyUtils.kt
@@ -40,6 +40,20 @@ object CurrencyUtils {
      * @param currencyCode The ISO 4217 currency code (ex: USD)
      */
     fun currencyString(context: Context, rawValue: Double, currencyCode: String): String {
+        // if the passed currency code is the same as the currency code of the current locale, format
+        // the currency using the locale's currency formatter
+        val locale = Locale.getDefault()
+        try {
+            if (Currency.getInstance(locale)?.currencyCode.equals(currencyCode)) {
+                val formatter = NumberFormat.getCurrencyInstance(locale)
+                return formatter.format(rawValue)
+            }
+        } catch (e: IllegalArgumentException) {
+            WooLog.e(T.UTILS, "Error finding valid currency instance for currency code [$currencyCode]", e)
+        }
+
+        // store must be using a currency that's different than that of the current locale so fall
+        // back to our default currency format
         val symbol = getCurrencySymbol(currencyCode)
         return if (rawValue < 0) {
             context.getString(
@@ -61,28 +75,8 @@ object CurrencyUtils {
      * @param currencyCode The ISO 4217 currency code (ex: USD)
      */
     fun currencyStringRounded(context: Context, rawValue: Double, currencyCode: String): String {
-        val symbol = getCurrencySymbol(currencyCode)
-        val roundedValue = rawValue.roundToInt()
-
-        // if the passed currency code is the same as the currency code of the current locale, format
-        // the currency using the locale's currency formatter
-        val locale = Locale.getDefault()
-        try {
-            if (Currency.getInstance(locale)?.currencyCode.equals(currencyCode)) {
-                val formatter = NumberFormat.getCurrencyInstance(locale)
-                return formatter.format(roundedValue).removeSuffix(".00")
-            }
-        } catch (e: IllegalArgumentException) {
-            WooLog.e(T.UTILS, "Error finding valid currency instance for currency code [$currencyCode]", e)
-        }
-
-        // store must be using a currency that's different than that of the current locale so fall
-        // back to our default currency format
-        return if (rawValue < 0) {
-            context.getString(R.string.currency_total_negative, symbol, roundedValue.absoluteValue.toString())
-        } else {
-            context.getString(R.string.currency_total, symbol, roundedValue.toString())
-        }
+        val roundedValue = rawValue.roundToInt().toDouble()
+        return currencyString(context, roundedValue, currencyCode).removeSuffix(".00")
     }
 
     /**


### PR DESCRIPTION
Resolves #454 - relies on the current locale's currency formatter when we're reasonably sure the current locale is the same as that used by the store. Before and after shots below.

![before-and-after](https://user-images.githubusercontent.com/3903757/47857180-5dfaa700-ddbf-11e8-8376-00afa7d11159.png)

@aforcier @AmandaRiu It would be good to have you both eyeball this as I know you did a lot of currency work before I joined and I want to be sure this is a solid approach.