### PR TITLE
issue/update-selected-site-exception

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
@@ -30,7 +30,8 @@ class SelectedSite(private var context: Context, private var siteStore: SiteStor
             return it
         }
 
-        throw IllegalStateException("SelectedSite was accessed before being initialized - siteId $localSiteId")
+        throw IllegalStateException("SelectedSite.get() was accessed before being initialized - siteId $localSiteId." +
+                "\nConsider calling selectedSite.exists() to ensure site exists prior to calling selectedSite.get().")
     }
 
     fun set(siteModel: SiteModel) {


### PR DESCRIPTION
This PR updates the `selectedSite.get()` exception message as discussed on Slack. The existing message is too similar to Kotlin's `UninitializedPropertyAccessException`, which has lead to confusion when debugging these exceptions.