### PR TITLE
Issue/470 login epilogue layout

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.util.CrashlyticsUtils
 import dagger.android.AndroidInjection
 import kotlinx.android.synthetic.main.activity_login_epilogue.*
 import org.wordpress.android.login.LoginMode
+import org.wordpress.android.util.DisplayUtils
 import javax.inject.Inject
 
 class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, OnSiteClickListener {
@@ -119,7 +120,9 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
         frame_list_container.visibility = View.GONE
         no_stores_view.visibility = View.VISIBLE
 
-        val noStoresImage = AppCompatResources.getDrawable(this, R.drawable.ic_woo_no_store)
+        val noStoresImage =
+                if (DisplayUtils.isLandscape(this)) null
+                else AppCompatResources.getDrawable(this, R.drawable.ic_woo_no_store)
         no_stores_view.setCompoundDrawablesWithIntrinsicBounds(null, noStoresImage, null, null)
 
         button_continue.text = getString(R.string.login_with_a_different_account)

--- a/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
+++ b/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
@@ -53,13 +53,15 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:padding="@dimen/margin_extra_large">
+                android:orientation="vertical">
 
                 <TextView
                     android:id="@+id/text_list_label"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:paddingEnd="@dimen/margin_extra_large"
+                    android:paddingStart="@dimen/margin_extra_large"
+                    android:paddingTop="@dimen/margin_extra_large"
                     android:text="@string/login_pick_store"
                     android:textColor="@color/wc_purple"
                     android:textSize="@dimen/text_large"
@@ -68,7 +70,12 @@
                 <android.support.v7.widget.RecyclerView
                     android:id="@+id/recycler"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"/>
+                    android:layout_height="wrap_content"
+                    android:clipChildren="false"
+                    android:clipToPadding="false"
+                    android:paddingBottom="@dimen/margin_extra_large"
+                    android:paddingEnd="@dimen/margin_extra_large"
+                    android:paddingStart="@dimen/margin_extra_large"/>
             </LinearLayout>
         </android.support.v7.widget.CardView>
     </FrameLayout>

--- a/WooCommerce/src/main/res/layout/site_list_item.xml
+++ b/WooCommerce/src/main/res/layout/site_list_item.xml
@@ -3,7 +3,6 @@
                 xmlns:tools="http://schemas.android.com/tools"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="?android:attr/selectableItemBackground"
                 android:paddingBottom="@dimen/margin_large"
                 android:paddingTop="@dimen/margin_large">
 


### PR DESCRIPTION
### Fix
Update the login epilogue screen text to hide the image in landscape orientation when no stores are connected, remove touch feedback from the list when only a single store is connected, and remove clipping from the list touch feedback when multiple stores are connected as described in https://github.com/woocommerce/woocommerce-android/issues/470.  Also, the overscroll feedback was extended to the full width of the list.  See the screenshots below for illustration.

![login_epilogue_landscape](https://user-images.githubusercontent.com/3827611/48098686-13c05e00-e1e3-11e8-8f37-20e01b94b094.png)

![login_epilogue_list](https://user-images.githubusercontent.com/3827611/48098697-191da880-e1e3-11e8-8c8f-b25f3e5fb27e.png)

### Test
#### No Stores Connected
0. Go through login until epilogue.
1. Notice image is shown in portrait orientation.
2. Rotate device into landscape orientation.
3. Notice image is not shown in landscape orientation.

#### Single Store Connected
0. Go through login until epilogue.
1. Long-press store in list.
2. Notice no touch feedback.
3. Scroll up/down in list.
4. Notice overscroll feedback is full-width.

#### Multiple Stores Connected
0. Go through login until epilogue.
1. Long-press store in list.
2. Notice touch feedback is not clipped.
3. Scroll up/down in list.
4. Notice overscroll feedback is full-width.

### Review
Only one developer is required to review these changes, but anyone can perform the review.