### PR TITLE
Issue/474 toolbar touch feedback

### DIFF
--- a/WooCommerce/src/main/res/layout/view_toolbar.xml
+++ b/WooCommerce/src/main/res/layout/view_toolbar.xml
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v7.widget.Toolbar
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="?attr/actionBarSize"
     android:background="?attr/colorPrimary"
     android:elevation="@dimen/appbar_elevation"
-    app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-    app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
     style="@style/ToolbarTheme"/>

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -49,6 +49,10 @@
         <!-- Ripple effect when clicking items -->
         <item name="selectableItemBackground">?android:selectableItemBackground</item>
         <item name="selectableItemBackgroundBorderless">?android:selectableItemBackground</item>
+        <!-- Light touch feedback for actions -->
+        <item name="android:theme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
+        <!-- Light background for menus -->
+        <item name="popupTheme">@style/ThemeOverlay.AppCompat.Light</item>
     </style>
 
     <style name="Woo"/>


### PR DESCRIPTION
### Fix
Update the toolbar view layout theme and style attributes to show touch feedback as described in https://github.com/woocommerce/woocommerce-android/issues/474.  See the screenshots below for illustration.

![toolbar_touch_feedback](https://user-images.githubusercontent.com/3827611/48104375-e2528d00-e1f8-11e8-8b62-60e2625f0db5.png)

### Test
1. Go to ***My Store*** tab.
2. Long-press overflow menu action.
3. Notice touch feedback is shown.
4. Go to ***Orders*** tab.
5. Long-press ***Filter*** action.
6. Notice touch feedback is shown.
7. Tap overflow menu action.
8. Tap ***Settings*** item in menu.
9. Long-press back arrow in toolbar.
10. Notice touch feedback is shown.

### Review
Only one developer is required to review these changes, but anyone can perform the review.