### PR TITLE
Issue/zendesk update tag

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -488,7 +488,7 @@ private object ZendeskConstants {
     const val noneValue = "none"
     // We rely on this platform tag to filter tickets in Zendesk, so should be kept separate from the `articleLabel`
     const val platformTag = "Android"
-    const val sourcePlatform = "Mobile - Woo Android"
+    const val sourcePlatform = "Mobile_-_Woo_Android"
     const val ticketSubject = "WooCommerce for Android Support"
     const val wpComTag = "wpcom"
     const val unknownValue = "unknown"


### PR DESCRIPTION
Resolves #484 - changes the Zendesk source platform tag as per support's request. I've verified that the updated tag is being shown our Zendesk portal.

<img width="303" alt="screen shot 2018-11-09 at 3 42 47 pm" src="https://user-images.githubusercontent.com/3903757/48287259-43b36f80-e436-11e8-9653-76e926909ca1.png">
