### PR TITLE
Issue/476 privacy settings color

### DIFF
--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -351,6 +351,7 @@
     <style name="Woo.Settings.LabelWithDetail" parent="Woo.Settings.LabelWithButton"/>
 
     <style name="Woo.Settings.Label.Detail" parent="Woo.TextAppearance">
+        <item name="android:textColor">@color/wc_grey_darker</item>
         <item name="android:textSize">@dimen/text_medium</item>
         <item name="android:paddingStart">@dimen/settings_padding</item>
         <item name="android:paddingEnd">@dimen/settings_padding</item>


### PR DESCRIPTION
### Fix
Update the icons and text on the ***Privacy Settings*** screen follow the app style by having the `wc_grey_dark` (`#3c3c3c`) color as described in https://github.com/woocommerce/woocommerce-android/issues/476.  The username text on the ***Settings*** screen was updated to `wc_grey_darker` (`#787878`) also.  See the screenshots below for illustration.

![privacy_settings](https://user-images.githubusercontent.com/3827611/48304858-c1cf4f00-e4e6-11e8-9ec5-cb0d77701666.png)

### Test
1. Tap overflow menu action.
2. Tap ***Settings*** item in overflow menu.
3. Notice username text is `#787878`.
4. Tap ***Privacy Settings*** button.
5. Notice icons and text are `#3c3c3c`.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.