### PR TITLE
Issue/350 round currencies

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CurrencyUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CurrencyUtils.kt
@@ -8,6 +8,7 @@ import java.text.NumberFormat
 import java.util.Currency
 import java.util.Locale
 import kotlin.math.absoluteValue
+import kotlin.math.roundToInt
 
 /**
  * Since the WooCommerce platform supports some unconventional ways of displaying currency,
@@ -86,7 +87,7 @@ object CurrencyUtils {
      * @param currencyCode The ISO 4217 currency code (ex: USD)
      */
     fun currencyStringRounded(context: Context, rawValue: Double, currencyCode: String): String {
-        val roundedValue = rawValue * ONE_THOUSAND // rawValue.roundToInt().toDouble()
+        val roundedValue = rawValue.roundToInt().toDouble()
         if (roundedValue.absoluteValue >= ONE_MILLION) {
             return getCurrencySymbol(currencyCode) + currencyFormatterRounded.format(roundedValue / ONE_MILLION) + "m"
         } else if (roundedValue.absoluteValue >= ONE_THOUSAND) {


### PR DESCRIPTION
Addresses #350 - rounds currency values >= 1000 to the nearest tenth and formats them using a "k" value. Similarly, we show currency values >= 1,000,000 suffixed with an "m".

![screenshot_1542055750](https://user-images.githubusercontent.com/3903757/48374702-a8b7d100-e693-11e8-8889-4489537df2f9.png)
