### PR TITLE
issue/494-child-fragment-transition

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.base
 
 import android.os.Bundle
 import android.support.v4.app.Fragment
+import android.support.v4.app.FragmentTransaction.TRANSIT_FRAGMENT_FADE
 import android.support.v7.app.AppCompatActivity
 import android.view.LayoutInflater
 import android.view.View
@@ -79,6 +80,7 @@ abstract class TopLevelFragment : Fragment(), TopLevelFragmentView {
         childFragmentManager.beginTransaction()
                 .replace(R.id.container, fragment, tag)
                 .addToBackStack(tag)
+                .setTransition(TRANSIT_FRAGMENT_FADE)
                 .commit()
     }
 


### PR DESCRIPTION
Resolves #494 - adds a `TRANSIT_FRAGMENT_FADE` transition when opening child fragments (such as order detail).