### PR TITLE
issue/496-drop-disableShiftMode

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/BottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/BottomNavigationView.kt
@@ -1,42 +1,6 @@
 package com.woocommerce.android.extensions
 
-import android.annotation.SuppressLint
-import android.support.design.internal.BottomNavigationItemView
-import android.support.design.internal.BottomNavigationMenuView
 import android.support.design.widget.BottomNavigationView
-import com.woocommerce.android.util.WooLog
-import com.woocommerce.android.util.WooLog.T
-
-/**
- * "Shift-mode" removes the labels for every option in the bottom bar except for the selected
- * option. When enabled, the bottom bar "shifts" the icons to accommodate the adding of a label.
- * this mode is enabled automatically when more than 3 options are added to the bottom bar which
- * is really annoying. Currently, there is no straight-forward way to disable this so below we
- * have this little hack.
- *
- * [Google is aware of this](https://issuetracker.google.com/issues/37125827)
- */
-@SuppressLint("RestrictedApi")
-fun BottomNavigationView.disableShiftMode() {
-    val menuView = getChildAt(0) as BottomNavigationMenuView
-    try {
-        menuView.javaClass.getDeclaredField("mShiftingMode").also { shiftMode ->
-            shiftMode.isAccessible = true
-            shiftMode.setBoolean(menuView, false)
-            shiftMode.isAccessible = false
-        }
-        for (i in 0 until menuView.childCount) {
-            (menuView.getChildAt(i) as BottomNavigationItemView).also { item ->
-                item.setShiftingMode(false)
-                item.setChecked(item.itemData.isChecked)
-            }
-        }
-    } catch (e: NoSuchFieldException) {
-        WooLog.e(T.UTILS, "BottomNavigationHelper: Unable to get shift mode field", e)
-    } catch (e: IllegalAccessException) {
-        WooLog.e(T.UTILS, "BottomNavigationHelper: Unable to change value of shift mode", e)
-    }
-}
 
 fun BottomNavigationView.active(position: Int) {
     menu.getItem(position).isChecked = true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -18,7 +18,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.extensions.active
-import com.woocommerce.android.extensions.disableShiftMode
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin.MAIN_ACTIVITY
 import com.woocommerce.android.tools.SelectedSite
@@ -256,7 +255,6 @@ class MainActivity : AppCompatActivity(),
 
     // region Bottom Navigation
     private fun setupBottomNavigation() {
-        bottom_nav.disableShiftMode()
         bottom_nav.active(activeNavPosition.position)
         bottom_nav.setOnNavigationItemSelectedListener(this)
         bottom_nav.setOnNavigationItemReselectedListener(this)


### PR DESCRIPTION
Resolves #496 - drops `disableShiftMode()` from the bottom navigation view. It was unnecessary since we have three tabs and that call only impacts when there are four or more tabs.

If we ever add another tab, we can rely on the recently-added [LabelVisibilityMode](https://developer.android.com/reference/com/google/android/material/bottomnavigation/LabelVisibilityMode) to ensure all labels are visible.