### PR TITLE
Issue/contact email summary

### DIFF
--- a/WooCommerce/src/main/res/layout/activity_help.xml
+++ b/WooCommerce/src/main/res/layout/activity_help.xml
@@ -113,8 +113,7 @@
                         style="@style/Woo.Settings.Label.Detail"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="@string/support_contact_email_not_set"
-                        android:textColor="@color/grey_darken_10"/>
+                        android:text="@string/support_contact_email_not_set"/>
 
                 </LinearLayout>
 


### PR DESCRIPTION
### Fix
Remove the `android:textColor` attribute from the contact email summary view to fall back to the `Woo.Settings.Label.Detail` style for consistency with other views on the ***Help & Support*** screen.  See the screenshots below for illustration.

![email_summary](https://user-images.githubusercontent.com/3827611/48307296-8301bf00-e50f-11e8-9e08-614896e63c31.png)

### Test
1. Tap overflow menu action.
2. Tap ***Contact support*** item from menu.
3. Notice contact email summary text color.

### Review
Only one developer is required to review these changes, but anyone can perform the review.