### PR TITLE
V3 API: Update WooCommerce version warning card copy

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -130,7 +130,7 @@
     <string name="dashboard_no_orders_contentdesc">Waiting for customers image</string>
 
     <string name="dashboard_plugin_notice_title">Update to WooCommerce 3.5 to keep using this app</string>
-    <string name="dashboard_plugin_notice_message">This app requires that you install WooCommerce 3.5 on your server, and won\'t work properly without it. Update as soon as possible to continue using this app.</string>
+    <string name="dashboard_plugin_notice_message">This app requires that you install WooCommerce 3.5 on your server. Update as soon as possible to continue using this app.</string>
     <string name="dashboard_plugin_notice_button_label">Update instructions</string>
     <!--
         Order List View


### PR DESCRIPTION
Updates the dashboard card warning about upgrading to WooCommerce 3.5. We would be showing this in the release after next, where we've already upgraded to the V3 API and parts of the app are now broken for users who didn't upgrade.

**Relies on #523 and should be merged after that one.**

![woo-3 5-warning](https://user-images.githubusercontent.com/9613966/49031348-af584500-f177-11e8-828f-393386e3c719.png)

We could force logout but I'm not sure that's a better experience - the dashboard stats and notifications will continue to work even without updating the WooCommerce plugin, and after upgrading everything would work without needing to log out and back in.

cc @kyleaparker 