### PR TITLE
Login Epilogue: Require WooCommerce 3.5+

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -106,7 +106,7 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
         dashboard_plugin_version_notice.initView(
                 title = getString(R.string.dashboard_plugin_notice_title),
                 message = getString(R.string.dashboard_plugin_notice_message),
-                buttonLabel = getString(R.string.dashboard_plugin_notice_button_label),
+                buttonLabel = getString(R.string.button_update_instructions),
                 buttonAction = { ActivityUtils.openUrlExternal(activity as Context, URL_UPGRADE_WOOCOMMERCE) })
 
         if (isActive) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
@@ -133,6 +133,7 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
 
             siteAdapter.siteList = supportedWCSites
 
+            button_continue.text = getString(R.string.continue_button)
             button_continue.setOnClickListener { _ ->
                 val site = presenter.getSiteBySiteId(siteAdapter.selectedSiteId)
                 site?.let { it ->
@@ -145,7 +146,11 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
                 }
             }
         } else {
-            button_continue.isEnabled = false
+            button_continue.text = getString(R.string.refresh_button)
+            button_continue.setOnClickListener {
+                loginProgressDialog = ProgressDialog.show(this, null, getString(R.string.login_verifying_sites))
+                presenter.checkWCVersionsForAllSites()
+            }
             supported_frame_list_container.visibility = View.GONE
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
@@ -54,6 +54,7 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
         showUserInfo()
 
         loginProgressDialog = ProgressDialog.show(this, null, getString(R.string.login_verifying_sites))
+        supported_frame_list_container.visibility = View.GONE
         presenter.checkWCVersionsForAllSites()
 
         if (savedInstanceState == null) {
@@ -99,6 +100,7 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
         }
 
         if (supportedWCSites.isNotEmpty()) {
+            supported_frame_list_container.visibility = View.VISIBLE
             supported_text_list_label.text = if (supportedWCSites.size == 1)
                 getString(R.string.login_connected_store)
             else

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
@@ -123,6 +123,9 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
                     finishEpilogue()
                 }
             }
+        } else {
+            button_continue.isEnabled = false
+            supported_frame_list_container.visibility = View.GONE
         }
 
         if (unsupportedWCSites.isNotEmpty()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
@@ -141,6 +141,7 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
 
     private fun showNoStoresView() {
         supported_frame_list_container.visibility = View.GONE
+        unsupported_frame_list_container.visibility = View.GONE
         no_stores_view.visibility = View.VISIBLE
 
         val noStoresImage =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
@@ -12,7 +12,9 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.di.GlideApp
 import com.woocommerce.android.push.FCMRegistrationIntentService
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.login.SiteListAdapter.OnSiteClickListener
+import com.woocommerce.android.ui.login.adapter.SiteListAdapter
+import com.woocommerce.android.ui.login.adapter.SiteListAdapter.OnSiteClickListener
+import com.woocommerce.android.ui.login.adapter.SiteListUnsupportedAdapter
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.CrashlyticsUtils
@@ -27,6 +29,7 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
     @Inject lateinit var selectedSite: SelectedSite
 
     private lateinit var siteAdapter: SiteListAdapter
+    private lateinit var unsupportedSiteAdapter: SiteListUnsupportedAdapter
 
     override fun onCreate(savedInstanceState: Bundle?) {
         AndroidInjection.inject(this)
@@ -39,6 +42,10 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
         supported_recycler.layoutManager = LinearLayoutManager(this)
         siteAdapter = SiteListAdapter(this, this)
         supported_recycler.adapter = siteAdapter
+
+        unsupported_recycler.layoutManager = LinearLayoutManager(this)
+        unsupportedSiteAdapter = SiteListUnsupportedAdapter(this)
+        unsupported_recycler.adapter = unsupportedSiteAdapter
 
         showUserInfo()
         showStoreList()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
@@ -30,6 +30,8 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
     companion object {
         private const val STATE_KEY_SUPPORTED_SITE_ID_LIST = "key-supported-site-id-list"
         private const val STATE_KEY_UNSUPPORTED_SITE_ID_LIST = "key-unsupported-site-id-list"
+
+        private const val URL_UPGRADE_WOOCOMMERCE = "https://docs.woocommerce.com/document/how-to-update-woocommerce/"
     }
 
     @Inject lateinit var presenter: LoginEpilogueContract.Presenter
@@ -120,6 +122,8 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
 
         if (supportedWCSites.isNotEmpty()) {
             supported_frame_list_container.visibility = View.VISIBLE
+            button_update_instructions.visibility = View.GONE
+
             supported_text_list_label.text = if (supportedWCSites.size == 1)
                 getString(R.string.login_connected_store)
             else
@@ -146,6 +150,12 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
                 }
             }
         } else {
+            // Show 'Update instructions' button, and replace 'Continue' button with 'Refresh'
+            button_update_instructions.visibility = View.VISIBLE
+            button_update_instructions.setOnClickListener {
+                ActivityUtils.openUrlExternal(this, URL_UPGRADE_WOOCOMMERCE)
+            }
+
             button_continue.text = getString(R.string.refresh_button)
             button_continue.setOnClickListener {
                 loginProgressDialog = ProgressDialog.show(this, null, getString(R.string.login_verifying_sites))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
@@ -36,9 +36,9 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
         ActivityUtils.setStatusBarColor(this, R.color.wc_grey_mid)
         presenter.takeView(this)
 
-        recycler.layoutManager = LinearLayoutManager(this)
+        supported_recycler.layoutManager = LinearLayoutManager(this)
         siteAdapter = SiteListAdapter(this, this)
-        recycler.adapter = siteAdapter
+        supported_recycler.adapter = siteAdapter
 
         showUserInfo()
         showStoreList()
@@ -84,7 +84,7 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
             return
         }
 
-        text_list_label.text = if (wcSites.size == 1)
+        supported_text_list_label.text = if (wcSites.size == 1)
             getString(R.string.login_connected_store)
         else
             getString(R.string.login_pick_store)
@@ -116,7 +116,7 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
     }
 
     private fun showNoStoresView() {
-        frame_list_container.visibility = View.GONE
+        supported_frame_list_container.visibility = View.GONE
         no_stores_view.visibility = View.VISIBLE
 
         val noStoresImage =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.login
 
+import android.app.ProgressDialog
 import android.content.Intent
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
@@ -31,6 +32,8 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
     private lateinit var siteAdapter: SiteListAdapter
     private lateinit var unsupportedSiteAdapter: SiteListUnsupportedAdapter
 
+    private var loginProgressDialog: ProgressDialog? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         AndroidInjection.inject(this)
         super.onCreate(savedInstanceState)
@@ -48,7 +51,9 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
         unsupported_recycler.adapter = unsupportedSiteAdapter
 
         showUserInfo()
-        showStoreList()
+
+        loginProgressDialog = ProgressDialog.show(this, null, getString(R.string.login_verifying_sites))
+        presenter.checkWCVersionsForAllSites()
 
         if (savedInstanceState == null) {
             AnalyticsTracker.track(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueContract.kt
@@ -18,7 +18,7 @@ interface LoginEpilogueContract {
 
     interface View : BaseView<Presenter> {
         fun showUserInfo()
-        fun showStoreList()
+        fun showStoreList(supportedWCSites: List<SiteModel>, unsupportedWCSites: List<SiteModel>)
         fun cancel()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueContract.kt
@@ -14,6 +14,7 @@ interface LoginEpilogueContract {
         fun logout()
         fun userIsLoggedIn(): Boolean
         fun checkWCVersionsForAllSites()
+        fun getSitesForLocalIds(siteIdList: IntArray): List<SiteModel>
     }
 
     interface View : BaseView<Presenter> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueContract.kt
@@ -13,6 +13,7 @@ interface LoginEpilogueContract {
         fun getUserDisplayName(): String?
         fun logout()
         fun userIsLoggedIn(): Boolean
+        fun checkWCVersionsForAllSites()
     }
 
     interface View : BaseView<Presenter> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpiloguePresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpiloguePresenter.kt
@@ -55,6 +55,8 @@ class LoginEpiloguePresenter @Inject constructor(
     }
 
     override fun checkWCVersionsForAllSites() {
+        supportedWCSites.clear()
+        unsupportedWCSites.clear()
         val wcSites = wooCommerceStore.getWooCommerceSites()
         if (wcSites.isEmpty()) {
             loginEpilogueView?.showStoreList(emptyList(), emptyList())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpiloguePresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpiloguePresenter.kt
@@ -57,7 +57,7 @@ class LoginEpiloguePresenter @Inject constructor(
     override fun checkWCVersionsForAllSites() {
         val wcSites = wooCommerceStore.getWooCommerceSites()
         if (wcSites.isEmpty()) {
-            // TODO Show no stores view
+            loginEpilogueView?.showStoreList(emptyList(), emptyList())
             return
         }
 
@@ -85,7 +85,7 @@ class LoginEpiloguePresenter @Inject constructor(
 
         val totalSitesChecked = supportedWCSites.size + unsupportedWCSites.size
         if (totalSitesChecked == wooCommerceStore.getWooCommerceSites().size) {
-            // TODO Show store list
+            loginEpilogueView?.showStoreList(supportedWCSites, unsupportedWCSites)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpiloguePresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpiloguePresenter.kt
@@ -66,6 +66,10 @@ class LoginEpiloguePresenter @Inject constructor(
         }
     }
 
+    override fun getSitesForLocalIds(siteIdList: IntArray): List<SiteModel> {
+        return siteIdList.map { siteStore.getSiteByLocalId(it) }
+    }
+
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onAccountChanged(event: OnAccountChanged) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/adapter/SiteListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/adapter/SiteListAdapter.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.login
+package com.woocommerce.android.ui.login.adapter
 
 import android.content.Context
 import android.support.v7.widget.RecyclerView
@@ -9,7 +9,7 @@ import android.view.ViewGroup
 import android.widget.RadioButton
 import android.widget.TextView
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.login.SiteListAdapter.SiteViewHolder
+import com.woocommerce.android.ui.login.adapter.SiteListAdapter.SiteViewHolder
 import com.woocommerce.android.util.StringUtils
 import kotlinx.android.synthetic.main.site_list_item.view.*
 import org.wordpress.android.fluxc.model.SiteModel

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/adapter/SiteListUnsupportedAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/adapter/SiteListUnsupportedAdapter.kt
@@ -1,0 +1,52 @@
+package com.woocommerce.android.ui.login.adapter
+
+import android.content.Context
+import android.support.v7.widget.RecyclerView
+import android.text.TextUtils
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.login.adapter.SiteListUnsupportedAdapter.SiteViewUnsupportedHolder
+import com.woocommerce.android.util.StringUtils
+import kotlinx.android.synthetic.main.site_list_unsupported_item.view.*
+import org.wordpress.android.fluxc.model.SiteModel
+
+class SiteListUnsupportedAdapter(private val context: Context) :
+        RecyclerView.Adapter<SiteViewUnsupportedHolder>() {
+    var siteList: List<SiteModel> = ArrayList()
+        set(value) {
+            field = value
+            notifyDataSetChanged()
+        }
+
+    init {
+        setHasStableIds(true)
+    }
+
+    override fun getItemId(position: Int): Long {
+        return siteList[position].siteId
+    }
+
+    override fun getItemCount(): Int {
+        return siteList.size
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SiteViewUnsupportedHolder {
+        return SiteViewUnsupportedHolder(
+                LayoutInflater.from(context).inflate(R.layout.site_list_unsupported_item, parent, false))
+    }
+
+    override fun onBindViewHolder(holder: SiteViewUnsupportedHolder, position: Int) {
+        val site = siteList[position]
+        holder.txtSiteName.text = if (!TextUtils.isEmpty(site.name)) site.name else context.getString(R.string.untitled)
+        holder.txtSiteDomain.text = StringUtils.getSiteDomainAndPath(site)
+        holder.itemView.setOnClickListener(null)
+    }
+
+    class SiteViewUnsupportedHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val txtSiteName: TextView = view.text_site_name
+        val txtSiteDomain: TextView = view.text_site_domain
+    }
+}

--- a/WooCommerce/src/main/res/drawable/ic_block.xml
+++ b/WooCommerce/src/main/res/drawable/ic_block.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M12,2C6.477,2 2,6.477 2,12c0,5.523 4.477,10 10,10c5.523,0 10,-4.477 10,-10C22,6.477 17.523,2 12,2zM4,12c0,-4.418 3.582,-8 8,-8c1.848,0 3.545,0.633 4.9,1.686L5.686,16.9C4.633,15.545 4,13.848 4,12zM12,20c-1.848,0 -3.546,-0.633 -4.9,-1.686L18.314,7.1C19.367,8.455 20,10.152 20,12C20,16.418 16.418,20 12,20z"/>
+</vector>

--- a/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
+++ b/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
@@ -107,7 +107,7 @@
                     android:paddingEnd="@dimen/margin_extra_large"
                     android:paddingStart="@dimen/margin_extra_large"
                     android:paddingTop="@dimen/margin_extra_large"
-                    android:text="@string/login_site_list_upgrade_required"
+                    android:text="@string/login_site_list_update_required"
                     android:textColor="@color/wc_purple"
                     android:textSize="@dimen/text_large"
                     android:textStyle="bold"/>

--- a/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
+++ b/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
@@ -37,10 +37,9 @@
         tools:text="text_displayname"/>
 
     <FrameLayout
-        android:id="@+id/frame_list_container"
+        android:id="@+id/supported_frame_list_container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_above="@+id/frame_bottom"
+        android:layout_height="wrap_content"
         android:layout_below="@+id/text_username">
 
         <android.support.v7.widget.CardView
@@ -56,7 +55,7 @@
                 android:orientation="vertical">
 
                 <TextView
-                    android:id="@+id/text_list_label"
+                    android:id="@+id/supported_text_list_label"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:paddingEnd="@dimen/margin_extra_large"
@@ -68,7 +67,53 @@
                     android:textStyle="bold"/>
 
                 <android.support.v7.widget.RecyclerView
-                    android:id="@+id/recycler"
+                    android:id="@+id/supported_recycler"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:clipChildren="false"
+                    android:clipToPadding="false"
+                    android:paddingBottom="@dimen/margin_extra_large"
+                    android:paddingEnd="@dimen/margin_extra_large"
+                    android:paddingStart="@dimen/margin_extra_large"/>
+            </LinearLayout>
+        </android.support.v7.widget.CardView>
+    </FrameLayout>
+
+    <FrameLayout
+        android:id="@+id/unsupported_frame_list_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/frame_bottom"
+        android:layout_below="@+id/supported_frame_list_container"
+        android:visibility="gone"
+        tools:visibility="visible">
+
+        <android.support.v7.widget.CardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_extra_small"
+            android:layout_marginTop="@dimen/margin_extra_extra_medium_large"
+            app:cardElevation="@dimen/card_elevation">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/unsupported_text_list_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingEnd="@dimen/margin_extra_large"
+                    android:paddingStart="@dimen/margin_extra_large"
+                    android:paddingTop="@dimen/margin_extra_large"
+                    android:text="@string/login_site_list_upgrade_required"
+                    android:textColor="@color/wc_purple"
+                    android:textSize="@dimen/text_large"
+                    android:textStyle="bold"/>
+
+                <android.support.v7.widget.RecyclerView
+                    android:id="@+id/unsupported_recycler"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:clipChildren="false"

--- a/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
+++ b/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
@@ -150,21 +150,31 @@
         android:layout_above="@+id/frame_bottom"
         android:background="@drawable/shadow_top"/>
 
-    <FrameLayout
+    <LinearLayout
         android:id="@+id/frame_bottom"
         android:clipToPadding="false"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:background="@color/white"
+        android:orientation="vertical"
         android:padding="@dimen/margin_extra_large">
+
+        <android.support.v7.widget.AppCompatButton
+            android:id="@+id/button_update_instructions"
+            style="@style/Woo.Button.Grey"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_medium"
+            android:text="@string/button_update_instructions"
+            android:visibility="gone"
+            tools:visibility="visible"/>
 
         <android.support.v7.widget.AppCompatButton
             android:id="@+id/button_continue"
             style="@style/Woo.Button.Purple"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
             android:text="@string/continue_button"/>
-    </FrameLayout>
+    </LinearLayout>
 </RelativeLayout>

--- a/WooCommerce/src/main/res/layout/site_list_unsupported_item.xml
+++ b/WooCommerce/src/main/res/layout/site_list_unsupported_item.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:tools="http://schemas.android.com/tools"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                xmlns:app="http://schemas.android.com/apk/res-auto"
+                android:paddingBottom="@dimen/margin_large"
+                android:paddingTop="@dimen/margin_large">
+
+    <ImageView
+        android:id="@+id/bullet_image"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerVertical="true"
+        android:layout_marginEnd="@dimen/margin_large"
+        app:srcCompat="@drawable/ic_block"/>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerVertical="true"
+        android:layout_toEndOf="@+id/bullet_image"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/text_site_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/grey_dark"
+            android:textSize="@dimen/text_large"
+            tools:text="text_site_name"/>
+
+        <TextView
+            android:id="@+id/text_site_domain"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/grey_dark"
+            android:textSize="@dimen/text_medium"
+            tools:text="text_site_domain"/>
+    </LinearLayout>
+
+</RelativeLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -51,6 +51,7 @@
     <string name="no_orders_share_store_title">Share your store\'s URL</string>
     <string name="emdash" translatable="false">\u2014</string>
     <string name="share">Share</string>
+    <string name="button_update_instructions">Update instructions</string>
 
     <!--
         Date/Time Labels
@@ -135,7 +136,6 @@
 
     <string name="dashboard_plugin_notice_title">Update to WooCommerce 3.5 to keep using this app</string>
     <string name="dashboard_plugin_notice_message">This app requires that you install WooCommerce 3.5 on your server. Update as soon as possible to continue using this app.</string>
-    <string name="dashboard_plugin_notice_button_label">Update instructions</string>
     <!--
         Order List View
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -89,7 +89,7 @@
     <string name="login_pick_store">Pick store</string>
     <string name="login_connected_store">Connected store</string>
     <string name="login_verifying_sites">Verifying sites…</string>
-    <string name="login_site_list_upgrade_required">Upgrade to WooCommerce 3.5 required</string>
+    <string name="login_site_list_update_required">Update to WooCommerce 3.5 required</string>
     <string name="login_avatar_content_description">Your profile photo</string>
     <string name="login_nostores_content_description">No WooCommerce stores</string>
     <string name="login_with_a_different_account">Login with a different account</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     <string name="retry">Retry</string>
     <string name="undo">Undo</string>
     <string name="continue_button">Continue</string>
+    <string name="refresh_button">Refresh</string>
     <string name="untitled">Untitled</string>
     <string name="cancel">Cancel</string>
     <string name="learn_more">Learn More</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -87,6 +87,7 @@
     <string name="login_configure_link">Read the %sconfiguration instructions%s.</string>
     <string name="login_pick_store">Pick store</string>
     <string name="login_connected_store">Connected store</string>
+    <string name="login_site_list_upgrade_required">Upgrade to WooCommerce 3.5 required</string>
     <string name="login_avatar_content_description">Your profile photo</string>
     <string name="login_nostores_content_description">No WooCommerce stores</string>
     <string name="login_with_a_different_account">Login with a different account</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -87,6 +87,7 @@
     <string name="login_configure_link">Read the %sconfiguration instructions%s.</string>
     <string name="login_pick_store">Pick store</string>
     <string name="login_connected_store">Connected store</string>
+    <string name="login_verifying_sites">Verifying sites…</string>
     <string name="login_site_list_upgrade_required">Upgrade to WooCommerce 3.5 required</string>
     <string name="login_avatar_content_description">Your profile photo</string>
     <string name="login_nostores_content_description">No WooCommerce stores</string>

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -146,6 +146,12 @@
         <item name="colorButtonNormal">@color/white</item>
     </style>
 
+    <style name="Woo.Button.Grey" parent="Widget.AppCompat.Button.Colored">
+        <item name="android:textColor">@color/wc_purple</item>
+        <item name="colorButtonNormal">@color/wc_grey_light</item>
+        <item name="android:backgroundTint">@color/wc_grey_light</item>
+    </style>
+
     <!--
         Default TagView Style
     -->


### PR DESCRIPTION
Closes #469, and #414, finishing up the migration to the WooCommerce V3 API.

After login but before the epilogue screen is displayed, the max supported version of the Woo API is checked for each detected WooCommerce site, and any sites without V3 API support (this means sites running WooCommerce older than `3.5`) are grouped in a new section of the epilogue site picker:

![woo-login-v3-check-some-supported](https://user-images.githubusercontent.com/9613966/49307759-2a856800-f4a4-11e8-9a07-4155299b7ff8.png)

If all sites found are up to date, we fall back to normal behavior:

![woo-login-v3-check-all-supported](https://user-images.githubusercontent.com/9613966/49307786-3cffa180-f4a4-11e8-83a5-2bf6388cda8c.png)

If all the WooCommerce sites found are out of date, the screen looks like this (the continue button is disabled):

![woo-login-v3-check-none-supported](https://user-images.githubusercontent.com/9613966/49307896-9d8ede80-f4a4-11e8-99a8-3ebb88a9a998.png)

I'm open to other suggestions for what to do here. When we find no WooCommerce sites at all, the "Continue" button becomes "Login with a different account" (see https://github.com/woocommerce/woocommerce-android/pull/240). We could do that in this case too (though as-is currently, if the user dismisses the app, updates WooCommerce on a site, and re-opens the app, they'd get the site picker with that site available, without having to log out and back in). We could maybe have 'Refresh' to trigger a reload right away, as well. cc @kyleaparker 

### Implementation details

I ended up going with checking all the sites at once. The calls are parallelized (FluxC supports up to 10 parallel network requests, and the app shouldn't be making any other network calls at this point), and from my tests takes very little time for my account with 4 connected WooCommerce sites.

Also, from looking at overall figures, around 85% of users who successfully log in have 2 or fewer WooCommerce sites connected to that Jetpack account (over 95% have 5 or less).

cc @bummytime who's likely working on the Woo iOS implementation of this.