### PR TITLE
Install dependencies in the project, not globally

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "vendor/bundle"

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ google-services.json
 # Fastlane
 fastlane/README.md
 fastlane/report.xml
+
+# Ruby Dependencies
+/vendor


### PR DESCRIPTION
We do the same on other projects, namely https://github.com/wordpress-mobile/WordPress-Android/tree/develop/.bundle