### PR TITLE
issue/548-landscape-epilogue

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
@@ -7,6 +7,7 @@ import android.support.v7.app.AppCompatActivity
 import android.support.v7.content.res.AppCompatResources
 import android.support.v7.widget.LinearLayoutManager
 import android.view.View
+import android.widget.LinearLayout
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
@@ -72,6 +73,11 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
             AnalyticsTracker.track(
                     Stat.LOGIN_EPILOGUE_STORES_SHOWN,
                     mapOf(AnalyticsTracker.KEY_NUMBER_OF_STORES to presenter.getWooCommerceSites().size))
+        }
+
+        // show buttons side-by-side in landscape
+        if (DisplayUtils.isLandscape(this)) {
+            frame_bottom.orientation = LinearLayout.HORIZONTAL
         }
     }
 

--- a/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
+++ b/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
@@ -152,11 +152,11 @@
 
     <LinearLayout
         android:id="@+id/frame_bottom"
-        android:clipToPadding="false"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:background="@color/white"
+        android:clipToPadding="false"
         android:orientation="vertical"
         android:padding="@dimen/margin_extra_large">
 
@@ -166,6 +166,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/margin_medium"
+            android:layout_weight="1"
             android:text="@string/button_update_instructions"
             android:visibility="gone"
             tools:visibility="visible"/>
@@ -175,6 +176,7 @@
             style="@style/Woo.Button.Purple"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:text="@string/continue_button"/>
     </LinearLayout>
 </RelativeLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = '2a5fb2db71ba1deb81b5c9e12fa2c1c7c8051345'
+    fluxCVersion = '1c00bf68bb52cb2c37d4784c91309745e5a316a5'
     daggerVersion = '2.11'
     supportLibraryVersion = '27.1.1'
     glideVersion = '4.6.1'


### PR DESCRIPTION
Changes the login epilogue to show the buttons side-by-side in landscape. Before and after shots below.

Note: to make this easier to test, reverse the order of the params passed [here](https://github.com/woocommerce/woocommerce-android/blob/feature/v3-api/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpiloguePresenter.kt#L94) to make all sites show up as unsupported.

![before](https://user-images.githubusercontent.com/3903757/49450525-2ced0800-f7ab-11e8-90bc-a3b7cc2e4122.png)


