### PR TITLE
Issue/552 epilogue scrolling

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
@@ -7,6 +7,7 @@ import android.support.v7.app.AppCompatActivity
 import android.support.v7.content.res.AppCompatResources
 import android.support.v7.widget.LinearLayoutManager
 import android.view.View
+import android.widget.LinearLayout
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
@@ -72,6 +73,11 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
             AnalyticsTracker.track(
                     Stat.LOGIN_EPILOGUE_STORES_SHOWN,
                     mapOf(AnalyticsTracker.KEY_NUMBER_OF_STORES to presenter.getWooCommerceSites().size))
+        }
+
+        // show buttons side-by-side in landscape
+        if (DisplayUtils.isLandscape(this)) {
+            frame_bottom.orientation = LinearLayout.HORIZONTAL
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpiloguePresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpiloguePresenter.kt
@@ -91,7 +91,7 @@ class LoginEpiloguePresenter @Inject constructor(
 
         val totalSitesChecked = supportedWCSites.size + unsupportedWCSites.size
         if (totalSitesChecked == wooCommerceStore.getWooCommerceSites().size) {
-            loginEpilogueView?.showStoreList(supportedWCSites, unsupportedWCSites)
+            loginEpilogueView?.showStoreList(unsupportedWCSites, supportedWCSites)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpiloguePresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpiloguePresenter.kt
@@ -91,7 +91,7 @@ class LoginEpiloguePresenter @Inject constructor(
 
         val totalSitesChecked = supportedWCSites.size + unsupportedWCSites.size
         if (totalSitesChecked == wooCommerceStore.getWooCommerceSites().size) {
-            loginEpilogueView?.showStoreList(unsupportedWCSites, supportedWCSites)
+            loginEpilogueView?.showStoreList(supportedWCSites, unsupportedWCSites)
         }
     }
 }

--- a/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
+++ b/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
@@ -36,94 +36,104 @@
         android:textSize="@dimen/text_large"
         tools:text="text_displayname"/>
 
-    <FrameLayout
-        android:id="@+id/supported_frame_list_container"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/text_username">
-
-        <android.support.v7.widget.CardView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/margin_extra_small"
-            android:layout_marginTop="@dimen/margin_extra_extra_medium_large"
-            app:cardElevation="@dimen/card_elevation">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
-
-                <TextView
-                    android:id="@+id/supported_text_list_label"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:paddingEnd="@dimen/margin_extra_large"
-                    android:paddingStart="@dimen/margin_extra_large"
-                    android:paddingTop="@dimen/margin_extra_large"
-                    android:text="@string/login_pick_store"
-                    android:textColor="@color/wc_purple"
-                    android:textSize="@dimen/text_large"
-                    android:textStyle="bold"/>
-
-                <android.support.v7.widget.RecyclerView
-                    android:id="@+id/supported_recycler"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:clipChildren="false"
-                    android:clipToPadding="false"
-                    android:paddingBottom="@dimen/margin_extra_large"
-                    android:paddingEnd="@dimen/margin_extra_large"
-                    android:paddingStart="@dimen/margin_extra_large"/>
-            </LinearLayout>
-        </android.support.v7.widget.CardView>
-    </FrameLayout>
-
-    <FrameLayout
-        android:id="@+id/unsupported_frame_list_container"
+    <android.support.v4.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_above="@+id/frame_bottom"
-        android:layout_below="@+id/supported_frame_list_container"
-        android:visibility="gone"
-        tools:visibility="visible">
+        android:layout_below="@+id/text_username">
 
-        <android.support.v7.widget.CardView
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/margin_extra_small"
-            android:layout_marginTop="@dimen/margin_extra_extra_medium_large"
-            app:cardElevation="@dimen/card_elevation">
+            android:orientation="vertical">
 
-            <LinearLayout
+            <FrameLayout
+                android:id="@+id/supported_frame_list_container"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:layout_height="wrap_content">
 
-                <TextView
-                    android:id="@+id/unsupported_text_list_label"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:paddingEnd="@dimen/margin_extra_large"
-                    android:paddingStart="@dimen/margin_extra_large"
-                    android:paddingTop="@dimen/margin_extra_large"
-                    android:text="@string/login_site_list_update_required"
-                    android:textColor="@color/wc_purple"
-                    android:textSize="@dimen/text_large"
-                    android:textStyle="bold"/>
-
-                <android.support.v7.widget.RecyclerView
-                    android:id="@+id/unsupported_recycler"
+                <android.support.v7.widget.CardView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:clipChildren="false"
-                    android:clipToPadding="false"
-                    android:paddingBottom="@dimen/margin_extra_large"
-                    android:paddingEnd="@dimen/margin_extra_large"
-                    android:paddingStart="@dimen/margin_extra_large"/>
-            </LinearLayout>
-        </android.support.v7.widget.CardView>
-    </FrameLayout>
+                    android:layout_marginBottom="@dimen/margin_extra_small"
+                    android:layout_marginTop="@dimen/margin_extra_extra_medium_large"
+                    app:cardElevation="@dimen/card_elevation">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:id="@+id/supported_text_list_label"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:paddingEnd="@dimen/margin_extra_large"
+                            android:paddingStart="@dimen/margin_extra_large"
+                            android:paddingTop="@dimen/margin_extra_large"
+                            android:text="@string/login_pick_store"
+                            android:textColor="@color/wc_purple"
+                            android:textSize="@dimen/text_large"
+                            android:textStyle="bold"/>
+
+                        <android.support.v7.widget.RecyclerView
+                            android:id="@+id/supported_recycler"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:clipChildren="false"
+                            android:clipToPadding="false"
+                            android:paddingBottom="@dimen/margin_extra_large"
+                            android:paddingEnd="@dimen/margin_extra_large"
+                            android:paddingStart="@dimen/margin_extra_large"/>
+                    </LinearLayout>
+                </android.support.v7.widget.CardView>
+            </FrameLayout>
+
+            <FrameLayout
+                android:id="@+id/unsupported_frame_list_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <android.support.v7.widget.CardView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/margin_extra_small"
+                    android:layout_marginTop="@dimen/margin_extra_extra_medium_large"
+                    app:cardElevation="@dimen/card_elevation">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:id="@+id/unsupported_text_list_label"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:paddingEnd="@dimen/margin_extra_large"
+                            android:paddingStart="@dimen/margin_extra_large"
+                            android:paddingTop="@dimen/margin_extra_large"
+                            android:text="@string/login_site_list_update_required"
+                            android:textColor="@color/wc_purple"
+                            android:textSize="@dimen/text_large"
+                            android:textStyle="bold"/>
+
+                        <android.support.v7.widget.RecyclerView
+                            android:id="@+id/unsupported_recycler"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:clipChildren="false"
+                            android:clipToPadding="false"
+                            android:paddingBottom="@dimen/margin_extra_large"
+                            android:paddingEnd="@dimen/margin_extra_large"
+                            android:paddingStart="@dimen/margin_extra_large"/>
+                    </LinearLayout>
+                </android.support.v7.widget.CardView>
+            </FrameLayout>
+        </LinearLayout>
+    </android.support.v4.widget.NestedScrollView>
 
     <TextView
         android:id="@+id/no_stores_view"

--- a/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
+++ b/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
@@ -152,11 +152,11 @@
 
     <LinearLayout
         android:id="@+id/frame_bottom"
-        android:clipToPadding="false"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:background="@color/white"
+        android:clipToPadding="false"
         android:orientation="vertical"
         android:padding="@dimen/margin_extra_large">
 
@@ -166,6 +166,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/margin_medium"
+            android:layout_weight="1"
             android:text="@string/button_update_instructions"
             android:visibility="gone"
             tools:visibility="visible"/>
@@ -175,6 +176,7 @@
             style="@style/Woo.Button.Purple"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:text="@string/continue_button"/>
     </LinearLayout>
 </RelativeLayout>


### PR DESCRIPTION
Fixes #552 - wrapped the login epilogue's supported / unsupported site lists in a single nested scroll view so both views scroll together.

Note that this also includes the simple changes from #549 because an error on my part caused it not to be merged into `develop`.