### PR TITLE
issue/381-illegal-argument-login-take2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -339,10 +339,14 @@ class AnalyticsTracker private constructor(private val context: Context) {
          * @param errorType The type of error.
          * @param errorDescription The error text or other description.
          */
-        fun track(stat: Stat, errorContext: String, errorType: String, errorDescription: String?) {
+        fun track(stat: Stat, errorContext: String?, errorType: String?, errorDescription: String?) {
             val props = HashMap<String, String>()
-            props[KEY_ERROR_CONTEXT] = errorContext
-            props[KEY_ERROR_TYPE] = errorType
+            errorContext?.let {
+                props[KEY_ERROR_CONTEXT] = it
+            }
+            errorType?.let {
+                props[KEY_ERROR_TYPE] = it
+            }
             errorDescription?.let {
                 props[KEY_ERROR_DESC] = it
             }


### PR DESCRIPTION
Fixes #381 - this is the second PR to address this issue. In the first one I handled a null `errorDescription` parameter, which was the source of the original problem. But another, similar crash report shows a null `errorContext`. So in this PR I null check all the string parameters.