### PR TITLE
Issue/374 selected site exception take2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/FCMRegistrationIntentService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/FCMRegistrationIntentService.kt
@@ -69,7 +69,7 @@ class FCMRegistrationIntentService : JobIntentService() {
     }
 
     private fun sendRegistrationToken(fcmToken: String) {
-        if (accountStore.hasAccessToken() && selectedSite.isSet()) {
+        if (accountStore.hasAccessToken() && selectedSite.exists()) {
             // Register for WordPress.com notifications
             WooLog.i(T.NOTIFS, "Sending FCM token to our remote services: $fcmToken")
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -117,7 +117,7 @@ class HelpActivity : AppCompatActivity() {
      * Help activity may have been called during the login flow before the selected site has been set
      */
     private fun selectedSiteOrNull(): SiteModel? {
-        return if (selectedSite.isSet()) {
+        return if (selectedSite.exists()) {
             selectedSite.get()
         } else {
             null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
@@ -41,8 +41,6 @@ class SelectedSite(private var context: Context, private var siteStore: SiteStor
         AnalyticsTracker.refreshSiteMetadata(siteModel)
     }
 
-    fun isSet() = PreferenceUtils.getInt(getPreferences(), SELECTED_SITE_LOCAL_ID, -1) != -1
-
     fun exists(): Boolean {
         val localSiteId = PreferenceUtils.getInt(getPreferences(), SELECTED_SITE_LOCAL_ID, -1)
         val siteModel = siteStore.getSiteByLocalId(localSiteId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
@@ -135,7 +135,7 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
             else
                 getString(R.string.login_pick_store)
 
-            if (selectedSite.isSet()) {
+            if (selectedSite.exists()) {
                 siteAdapter.selectedSiteId = selectedSite.get().siteId
             } else {
                 siteAdapter.selectedSiteId = supportedWCSites[0].siteId


### PR DESCRIPTION
Fixes #374 - this PR replaces all calls to `selectedSite.isSet()` with `selectedSite.exists()`. The former only checked whether there was a siteId stored in the app preferences without verifying whether it was a valid siteId, leading to crashes when the siteId wasn't valid.