### PR TITLE
Fix automated navigation tests by adding missing di modules

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockedActivityBindingModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockedActivityBindingModule.kt
@@ -7,8 +7,12 @@ import com.woocommerce.android.ui.login.LoginEpilogueModule
 import com.woocommerce.android.ui.login.MagicLinkInterceptActivity
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MockedMainModule
+import com.woocommerce.android.ui.notifications.NotifsListModule
+import com.woocommerce.android.ui.notifications.ReviewDetailModule
 import com.woocommerce.android.ui.orders.OrderDetailModule
+import com.woocommerce.android.ui.orders.OrderFulfillmentModule
 import com.woocommerce.android.ui.orders.OrderListModule
+import com.woocommerce.android.ui.orders.OrderProductListModule
 import dagger.Module
 import dagger.android.ContributesAndroidInjector
 import org.wordpress.android.login.di.LoginFragmentModule
@@ -20,7 +24,11 @@ abstract class MockedActivityBindingModule {
             MockedMainModule::class,
             DashboardModule::class,
             OrderListModule::class,
-            OrderDetailModule::class))
+            OrderDetailModule::class,
+            OrderProductListModule::class,
+            OrderFulfillmentModule::class,
+            NotifsListModule::class,
+            ReviewDetailModule::class))
     abstract fun provideMainActivityInjector(): MainActivity
 
     @ActivityScope

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/MainNavigationTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/MainNavigationTest.kt
@@ -50,6 +50,9 @@ class MainNavigationTest : TestBase() {
 
     @Test
     fun appDisplaysDashboardOnLaunch() {
+        // Make sure the bottom navigation view is showing
+        activityTestRule.activity.showBottomNav()
+
         // The Dashboard tab should be active if the app is launched
         onView(withId(R.id.bottom_nav)).check { view, noMatchException ->
             view?.let {
@@ -65,6 +68,9 @@ class MainNavigationTest : TestBase() {
 
     @Test
     fun ordersMenuOptionDisplaysOrdersView() {
+        // Make sure the bottom navigation view is showing
+        activityTestRule.activity.showBottomNav()
+
         // Select the orders bottom menu option
         onView(withId(R.id.orders)).perform(click())
 
@@ -75,6 +81,9 @@ class MainNavigationTest : TestBase() {
 
     @Test
     fun notificationsMenuOptionDisplaysNotificationsView() {
+        // Make sure the bottom navigation view is showing
+        activityTestRule.activity.showBottomNav()
+
         // Select the notifications bottom bar option
         onView(withId(R.id.notifications)).perform(click())
 
@@ -85,6 +94,9 @@ class MainNavigationTest : TestBase() {
 
     @Test
     fun dashboardMenuOptionDisplaysDashboardView() {
+        // Make sure the bottom navigation view is showing
+        activityTestRule.activity.showBottomNav()
+
         // Switch away from the default selected dashboard option
         onView(withId(R.id.notifications)).perform(click())
 


### PR DESCRIPTION
A handful of the tests in `MainNavigationTest` were failing due to some missing dagger modules. Added those. Also made a code to make sure the bottom bar is visible before attempting to click on one of the options. 