### PR TITLE
issue/notifications_ui_badge

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -4,14 +4,19 @@ import android.app.Activity
 import android.app.ProgressDialog
 import android.content.Intent
 import android.os.Bundle
+import android.os.Handler
+import android.support.design.internal.BottomNavigationItemView
+import android.support.design.internal.BottomNavigationMenuView
 import android.support.design.widget.BottomNavigationView
 import android.support.v4.app.Fragment
 import android.support.v4.app.FragmentManager
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.app.AppCompatDelegate
 import android.support.v7.widget.Toolbar
+import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
@@ -35,6 +40,7 @@ import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.support.HasSupportFragmentInjector
 import kotlinx.android.synthetic.main.activity_main.*
+import kotlinx.android.synthetic.main.notification_badge_view.*
 import org.wordpress.android.login.LoginAnalyticsListener
 import org.wordpress.android.login.LoginMode
 import org.wordpress.android.util.NetworkUtils
@@ -252,6 +258,21 @@ class MainActivity : AppCompatActivity(),
         bottom_nav.active(activeNavPosition.position)
         bottom_nav.setOnNavigationItemSelectedListener(this)
         bottom_nav.setOnNavigationItemReselectedListener(this)
+
+        // add the badge to the notifications item
+        val menuView = bottom_nav.getChildAt(0) as BottomNavigationMenuView
+        val itemView = menuView.getChildAt(BottomNavigationPosition.NOTIFICATIONS.position) as BottomNavigationItemView
+        val badgeView = LayoutInflater.from(this).inflate(R.layout.notification_badge_view, menuView, false)
+        itemView.addView(badgeView)
+    }
+
+    // TODO: add logic to show badge when there are unseen store notifications
+    override fun showNotificationBadge(show: Boolean) {
+        if (show && badge.visibility != View.VISIBLE) {
+            WooAnimUtils.fadeIn(badge, Duration.MEDIUM)
+        } else if (!show && badge.visibility == View.VISIBLE) {
+            WooAnimUtils.fadeOut(badge, Duration.MEDIUM)
+        }
     }
 
     override fun onNavigationItemSelected(item: MenuItem): Boolean {
@@ -263,6 +284,12 @@ class MainActivity : AppCompatActivity(),
             BottomNavigationPosition.NOTIFICATIONS -> AnalyticsTracker.Stat.MAIN_TAB_NOTIFICATIONS_SELECTED
         }
         AnalyticsTracker.track(stat)
+
+        // TODO: remove this test code before merging
+        showNotificationBadge(true)
+        Handler().postDelayed({
+            showNotificationBadge(false)
+        }, 1500)
 
         return switchFragment(navPosition)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainContract.kt
@@ -20,5 +20,6 @@ interface MainContract {
         fun updateOfflineStatusBar(isConnected: Boolean)
         fun hideBottomNav()
         fun showBottomNav()
+        fun showNotificationBadge(show: Boolean)
     }
 }

--- a/WooCommerce/src/main/res/drawable/notification_badge.xml
+++ b/WooCommerce/src/main/res/drawable/notification_badge.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+       android:shape="oval">
+    <solid android:color="@color/wc_green"/>
+    <stroke
+        android:width="1dp"
+        android:color="@color/white"/>
+</shape>

--- a/WooCommerce/src/main/res/layout/notification_badge_view.xml
+++ b/WooCommerce/src/main/res/layout/notification_badge_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/badge"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:visibility="gone"
+    tools:visibility="visible">
+
+    <ImageView
+        android:layout_width="@dimen/notification_badge_sz"
+        android:layout_height="@dimen/notification_badge_sz"
+        android:layout_gravity="top|center_horizontal"
+        android:layout_marginEnd="@dimen/notification_badge_offset"
+        android:layout_marginTop="@dimen/notification_badge_offset"
+        android:importantForAccessibility="no"
+        app:srcCompat="@drawable/notification_badge"/>
+</FrameLayout>

--- a/WooCommerce/src/main/res/values/dimens.xml
+++ b/WooCommerce/src/main/res/values/dimens.xml
@@ -133,6 +133,12 @@
     <dimen name="order_note_icon">26dp</dimen>
 
     <!--
+        Notifications
+    -->
+    <dimen name="notification_badge_sz">12dp</dimen>
+    <dimen name="notification_badge_offset">6dp</dimen>
+
+    <!--
         Skeletons
     -->
     <dimen name="skeleton_bar_chart_padding">30dp</dimen>


### PR DESCRIPTION
This PR adds a badge to the notification navigation item. Note there is **no** logic to determine whether to show the badge - this simply adds the badge view and provides a way to animate it in and out.

To make this easier to test, I've added code to show and hide the badge when you switch between navigation items. This test code should be removed before merging.

![screenshot_1544880025](https://user-images.githubusercontent.com/3903757/50043599-28471000-0045-11e9-91d3-d191e34fb1c1.png)


