### PR TITLE
issue/582-notif-rating-bar-style

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_review_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_review_detail.xml
@@ -105,7 +105,7 @@
             android:layout_marginTop="@dimen/margin_extra_large"
             android:isIndicator="true"
             android:numStars="5"
-            android:progressTint="@color/grey_darken_30"
+            android:progressTint="@color/alert_yellow"
             android:visibility="gone"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/review_gravatar"


### PR DESCRIPTION
Resolves #582 - updates the review rating bars to match design. Previously they were yellow, this changes them to dark grey.

![screenshot_1545056568](https://user-images.githubusercontent.com/3903757/50093061-b0f8b400-01dd-11e9-976c-2ec464e30b46.png)


