### PR TITLE
Added cha-ching credit to licenses

### DIFF
--- a/WooCommerce/src/main/assets/licenses.html
+++ b/WooCommerce/src/main/assets/licenses.html
@@ -34,5 +34,10 @@
         <li><a href="https://github.com/facebook/shimmer-android">Shimmer</a>: Copyright 2015, Facebook, Inc.</li>
     </ul>
 
+    <p>Additional credits:</p>
+    <ul>
+      <li><a href="https://freesound.org/people/Zott820/sounds/209578/">Cash register sound</a> ("cha-ching") by CapsLok remixed for extra depth by Zott820</li>
+    </ul>
+
   </body>
 </html>


### PR DESCRIPTION
Resolves #596 - adds credit for the "cha-ching" sound to our licenses.

![screenshot_1545140538](https://user-images.githubusercontent.com/3903757/50158066-1497e580-02a1-11e9-828b-129b98a9a61a.png)
