### PR TITLE
issue/598-licenses-wont-scroll

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/LicensesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/LicensesFragment.kt
@@ -6,9 +6,9 @@ import android.support.v7.app.AppCompatActivity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.webkit.WebView
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import kotlinx.android.synthetic.main.fragment_licenses.*
 
 class LicensesFragment : Fragment() {
     companion object {
@@ -20,9 +20,12 @@ class LicensesFragment : Fragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        val webView = WebView(context)
+        return inflater.inflate(R.layout.fragment_licenses, container, false)
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
         webView.loadUrl("file:///android_asset/licenses.html")
-        return webView
     }
 
     override fun onResume() {

--- a/WooCommerce/src/main/res/layout/fragment_licenses.xml
+++ b/WooCommerce/src/main/res/layout/fragment_licenses.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white">
+
+    <WebView
+        android:id="@+id/webView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+</FrameLayout>


### PR DESCRIPTION
Fixes #598 - previously the webView in the OS licenses fragment wasn't scrollable. This PR fixes it.