### PR TITLE
Add scroll listener to notifs list to hide/show bottom bar on scroll

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
@@ -8,6 +8,7 @@ import android.support.v4.content.ContextCompat
 import android.support.v7.widget.DefaultItemAnimator
 import android.support.v7.widget.DividerItemDecoration
 import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -19,6 +20,8 @@ import com.woocommerce.android.extensions.WooNotificationType.PRODUCT_REVIEW
 import com.woocommerce.android.extensions.WooNotificationType.UNKNOWN
 import com.woocommerce.android.extensions.getRemoteOrderId
 import com.woocommerce.android.extensions.getWooType
+import com.woocommerce.android.extensions.onScrollDown
+import com.woocommerce.android.extensions.onScrollUp
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
@@ -131,6 +134,11 @@ class NotifsListFragment : TopLevelFragment(), NotifsListContract.View, NotifsLi
             setHasFixedSize(false)
             addItemDecoration(dividerDecoration)
             adapter = notifsAdapter
+            addOnScrollListener(object : RecyclerView.OnScrollListener() {
+                override fun onScrolled(recyclerView: RecyclerView?, dx: Int, dy: Int) {
+                    if (dy > 0) onScrollDown() else if (dy < 0) onScrollUp()
+                }
+            })
         }
 
         presenter.takeView(this)


### PR DESCRIPTION
Added the missing logic to fix #625 Notifications list will now hide/show the bottom bar when scrolling.

<img src="https://user-images.githubusercontent.com/5810477/50455404-d42d0d00-091b-11e9-93d2-e8428ac7908d.gif" width="300">
