### PR TITLE
issue/628-npe-toplevelfragment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -129,11 +129,11 @@ abstract class TopLevelFragment : Fragment(), TopLevelFragmentView {
     private fun updateParentViewState(childActive: Boolean) {
         val mainActivity: AppCompatActivity? = activity as? AppCompatActivity
         if (childActive) {
-            container.getChildAt(0).visibility = View.GONE
+            container?.getChildAt(0)?.visibility = View.GONE
             mainActivity?.supportActionBar?.setDisplayHomeAsUpEnabled(true)
             mainActivity?.supportActionBar?.setDisplayShowHomeEnabled(true)
         } else {
-            container.getChildAt(0).visibility = View.VISIBLE
+            container?.getChildAt(0)?.visibility = View.VISIBLE
             mainActivity?.supportActionBar?.setDisplayHomeAsUpEnabled(false)
             mainActivity?.supportActionBar?.setDisplayShowHomeEnabled(false)
             mainActivity?.title = getFragmentTitle()


### PR DESCRIPTION
Fixes #628 - I wasn't able to repro this, but I think my description in the issue is accurate:

> I think what's happening is this occurs when the app is started from a notification, and this function is being called before the view has been created. Notifications were added in the last release, so this makes sense.

This PR addresses the crash by sprinkling a few `?` in the code where views are accessed.