### PR TITLE
Show app launcher icon badge for unread notifs

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
@@ -326,7 +326,9 @@ class NotificationHandler @Inject constructor(
 
             // create the channel since it doesn't already exist
             val channelName = getChannelTitleForNoteType(context, noteType)
-            val channel = NotificationChannel(channelId, channelName, IMPORTANCE_DEFAULT)
+            val channel = NotificationChannel(channelId, channelName, IMPORTANCE_DEFAULT).apply {
+                setShowBadge(true)
+            }
 
             // add cha-ching sound to new order notifications
             if (noteType == NEW_ORDER) {


### PR DESCRIPTION
Fixes #629 by adding the logic to enable displaying an unread notifications indicator (app launcher icon badge). 

Note: testing on emulators was hit and miss for some reason that I can't figure out. I was able to get it working on physical devices however. I believe that since a channel cannot be changed once it has been created, you will need to first **uninstall the app to test.** 

<img src="https://user-images.githubusercontent.com/5810477/50494759-2ee56800-09f3-11e9-8cf6-962eea17d9ce.jpg" width="300">  <img src="https://user-images.githubusercontent.com/5810477/50494752-2b51e100-09f3-11e9-941b-7470859a2ab2.jpg" width="300">
