### PR TITLE
Update to use FluxC hash that turns line item to float

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.util.CurrencyUtils
 import kotlinx.android.synthetic.main.order_detail_product_item.view.*
 import org.wordpress.android.fluxc.model.WCOrderModel
+import java.text.NumberFormat
 
 class OrderDetailProductItemView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
     : ConstraintLayout(ctx, attrs) {
@@ -17,7 +18,11 @@ class OrderDetailProductItemView @JvmOverloads constructor(ctx: Context, attrs: 
 
     fun initView(item: WCOrderModel.LineItem, currencyCode: String, expanded: Boolean) {
         productInfo_name.text = item.name
-        productInfo_qty.text = item.quantity.toString()
+
+        val numberFormatter = NumberFormat.getNumberInstance().apply {
+            maximumFractionDigits = 2
+        }
+        productInfo_qty.text = numberFormatter.format(item.quantity)
 
         // Modify views for expanded or collapsed mode
         val viewMode = if (expanded) View.VISIBLE else View.GONE

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = '9466baaa5d0bc264c081b28ae94e627dcc553b43'
+    fluxCVersion = '910ed96e93eab5a4a8fc8c4b9852baec329a8815'
     daggerVersion = '2.11'
     supportLibraryVersion = '27.1.1'
     glideVersion = '4.6.1'


### PR DESCRIPTION
There was a [bug ticket opened on the FluxC](https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/972) side that required changing `WCOrderModel.LineItem.quantity` from an Int to a Float to avoid crashes due to cast exceptions. This PR updates the FluxC hash to use this change, and also updated the formatting for the product quantity line item so if there isn't a fractional value, we still only show a whole number w/no decimals.

Note: [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1056) should be merged first, then the "not ready for merge" label can be removed and this PR merged.