### PR TITLE
Add PlayStoreStrings file

### DIFF
--- a/WooCommerce/metadata/PlayStoreStrings.pot
+++ b/WooCommerce/metadata/PlayStoreStrings.pot
@@ -1,0 +1,49 @@
+# Translation of Release Notes & Play Store Descriptions in English (US)
+# This file is distributed under the same license as the Release Notes & Play Store Descriptions package.
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2019-01-03 11:49:24+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: VsCode\n"
+"Project-Id-Version: Release Notes & Play Store Descriptions\n"
+
+msgctxt "release_note_010"
+msgid ""
+"1.0:\n"
+"First public release\n"
+msgstr ""
+
+#. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!
+msgctxt "play_store_promo"
+msgid "Manage orders, get sales notifications, and view key metrics — wherever you are."
+msgstr ""
+
+#. translators: Multi-paragraph text used to display in the Play Store.
+msgctxt "play_store_desc"
+msgid ""
+"Run your WooCommerce store wherever you are. \n"
+"\n"
+"Manage orders, track sales, and monitor store activity with real-time order alerts.\n"
+"\n"
+"VIEW AND MANAGE ORDERS\n"
+"Scroll through, filter, or look up specific orders. Tap to view order information – including product(s), value, customer data, shipping details, and notes.\n"
+"\n"
+"TRACK YOUR STORE\n"
+"See which products are performing best. Check your overall revenue and view order and visitor data by week, month, and year.\n"
+"\n"
+"REAL-TIME ORDER ALERTS\n"
+"Get notifications about store activity – including new orders and product reviews.\n"
+"\n"
+"WooCommerce is the most customizable eCommerce platform for building your online business. Built on WordPress, it is integrated with the world’s best content management tools. From coffee subscriptions to Spanish lessons to gym memberships to complex enterprise-level eCommerce – visit WooCommerce.com/start to launch a new store and ship your idea.\n"
+"\n"
+"Requirements: WooCommerce v3.5+, the Jetpack plugin.\n"
+msgstr ""
+
+#. translators: Title to be displayed in the Play Store. Limit to 50 characters including spaces and commas!
+msgctxt "play_store_app_title"
+msgid "WooCommerce"
+msgstr ""
+


### PR DESCRIPTION
This PR adds the `PlayStoreStrings.po` file that is used to upload the release notes and other store listing strings to GlotPress.