### PR TITLE
Use the asynchronous method to pop the childfFragmentManagers backstack

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -410,7 +410,6 @@ class MainActivity : AppCompatActivity(),
                 // Remove the active fragment and replace with this newly selected one
                 hideParentFragment(activeFragment)
                 showTopLevelFragment(frag, navPosition.getTag())
-                supportFragmentManager.executePendingTransactions()
                 activeNavPosition = navPosition
                 return true
             }
@@ -425,9 +424,9 @@ class MainActivity : AppCompatActivity(),
      */
     private fun showTopLevelFragment(fragment: TopLevelFragment, tag: String) {
         if (fragment.isHidden) {
-            supportFragmentManager.beginTransaction().show(fragment).commit()
+            supportFragmentManager.beginTransaction().show(fragment).commitAllowingStateLoss()
         } else {
-            supportFragmentManager.beginTransaction().add(R.id.container, fragment, tag).commit()
+            supportFragmentManager.beginTransaction().add(R.id.container, fragment, tag).commitAllowingStateLoss()
         }
     }
 
@@ -438,11 +437,7 @@ class MainActivity : AppCompatActivity(),
     private fun hideParentFragment(fragment: Fragment?) {
         fragment?.let {
             with(supportFragmentManager) {
-                if (isStateSaved) {
-                    // fragmentManager state already saved, no changes to state allowed
-                    return
-                }
-                beginTransaction().hide(it).commit()
+                beginTransaction().hide(it).commitAllowingStateLoss()
             }
         }
     }
@@ -454,14 +449,9 @@ class MainActivity : AppCompatActivity(),
     private fun clearFragmentBackStack(fragment: Fragment?): Boolean {
         fragment?.let {
             with(it.childFragmentManager) {
-                // If the fragment manager's state has already been saved,
-                // exit to avoid the IllegalStateException
-                if (isStateSaved) {
-                    return true
-                }
-
                 if (backStackEntryCount > 0) {
-                    popBackStackImmediate(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+                    val firstEntry = getBackStackEntryAt(0)
+                    popBackStack(firstEntry.id, FragmentManager.POP_BACK_STACK_INCLUSIVE)
                     return true
                 }
             }


### PR DESCRIPTION
Fixes #644, #646, #648 

The previously used `popBackStackImmediate()` method will throw an `IllegalStateException` if called after `onSaveInstanceState`. To avoid this issue, call the asynchronous `popBackStack()` alternative that waits for the state to be restored before processing the request. Since this method does not return anything to indicate success, I now first check if there are any fragments in the backstack before requesting to pop the back stack.

Use `commitAllowStateLoss()` for displaying top level fragments. This is safe because in the event the fragmentManager has already been saved and cannot be updated during `onSaveInstanceState`, the proper state will be rebuild by the MainActivity.