### PR TITLE
Remember selected bottom bar tab across activity recreation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -362,7 +362,7 @@ class MainActivity : AppCompatActivity(),
                 }
             }
         } else {
-            switchFragment(BottomNavigationPosition.DASHBOARD)
+            switchFragment(activeNavPosition)
         }
     }
 


### PR DESCRIPTION
Fixes #650  by using the saved selected navigation position to restore the bottom bar state.