### PR TITLE
Verify fragment is not null before attempting to cast

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -372,8 +372,7 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
     //  -- BEGIN: GoogleListener implementation methods
 
     override fun onGoogleEmailSelected(email: String?) {
-        val loginEmailFragment = supportFragmentManager.findFragmentByTag(LoginEmailFragment.TAG) as LoginEmailFragment
-        loginEmailFragment.setGoogleEmail(email)
+        (supportFragmentManager.findFragmentByTag(LoginEmailFragment.TAG) as? LoginEmailFragment)?.setGoogleEmail(email)
     }
 
     override fun onGoogleLoginFinished() {


### PR DESCRIPTION
Fixes #647 by verifying the fragment is not null before attempting to cast it and use it as an `EmailLoginFragment`