### PR TITLE
Allow errorDescription to be nullable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginAnalyticsTracker.kt
@@ -171,7 +171,7 @@ class LoginAnalyticsTracker : LoginAnalyticsListener {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_SOCIAL_ERROR_UNKNOWN_USER)
     }
 
-    override fun trackSocialFailure(errorContext: String, errorType: String, errorDescription: String) {
+    override fun trackSocialFailure(errorContext: String, errorType: String, errorDescription: String?) {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_SOCIAL_FAILURE, errorContext, errorType, errorDescription)
     }
 


### PR DESCRIPTION
Fixes #381 by allowing the `errorDescription` parameter of the `trackSocialFailure` method to be null