### PR TITLE
Analytics: Track Jetpack tunnel timeouts

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -21,6 +21,8 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.ApplicationLifecycleMonitor
 import com.woocommerce.android.util.ApplicationLifecycleMonitor.ApplicationLifecycleListener
 import com.woocommerce.android.util.CrashlyticsUtils
+import com.woocommerce.android.util.REGEX_API_JETPACK_TUNNEL_METHOD
+import com.woocommerce.android.util.REGEX_API_NUMERIC_PARAM
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import com.yarolegovich.wellsql.WellSql
@@ -202,8 +204,8 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
     fun onJetpackTimeoutError(event: OnJetpackTimeoutError) {
         with(event) {
             // Replace numeric IDs with a placeholder so events can be aggregated
-            val genericPath = apiPath.replace(Regex("/[0-9]*/"), "/ID/")
-            val protocol = Regex("_method=([a-z]*)").find(apiPath)?.groups?.get(1)?.value ?: ""
+            val genericPath = apiPath.replace(REGEX_API_NUMERIC_PARAM, "/ID/")
+            val protocol = REGEX_API_JETPACK_TUNNEL_METHOD.find(apiPath)?.groups?.get(1)?.value ?: ""
 
             val properties = mapOf(
                     "path" to genericPath,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -201,10 +201,12 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onJetpackTimeoutError(event: OnJetpackTimeoutError) {
         with(event) {
+            // Replace numeric IDs with a placeholder so events can be aggregated
+            val genericPath = apiPath.replace(Regex("/[0-9]*/"), "/ID/")
             val protocol = Regex("_method=([a-z]*)").find(apiPath)?.groups?.get(1)?.value ?: ""
 
             val properties = mapOf(
-                    "path" to apiPath,
+                    "path" to genericPath,
                     "protocol" to protocol,
                     "times_retried" to timesRetried.toString()
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -181,7 +181,10 @@ class AnalyticsTracker private constructor(private val context: Context) {
         REVIEW_DETAIL_APPROVE_BUTTON_TAPPED,
         REVIEW_DETAIL_OPEN_EXTERNAL_BUTTON_TAPPED,
         REVIEW_DETAIL_SPAM_BUTTON_TAPPED,
-        REVIEW_DETAIL_TRASH_BUTTON_TAPPED
+        REVIEW_DETAIL_TRASH_BUTTON_TAPPED,
+
+        // -- Errors
+        JETPACK_TUNNEL_TIMEOUT
     }
     // endregion
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/Regex.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/Regex.kt
@@ -1,0 +1,4 @@
+package com.woocommerce.android.util
+
+val REGEX_API_JETPACK_TUNNEL_METHOD = Regex("_method=([a-z]*)")
+val REGEX_API_NUMERIC_PARAM = Regex("/[0-9]*/")

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = '6de913c6cab8ff845a068e20097d59002c08aea5'
+    fluxCVersion = 'c63caa365307deaaeda6f04fa46d4331699dcd31'
     daggerVersion = '2.11'
     supportLibraryVersion = '27.1.1'
     glideVersion = '4.6.1'

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -13,6 +13,9 @@
     <module name="BeforeExecutionExclusionFileFilter">
         <property name="fileNamePattern" value="[/\\]gen[/\\]"/>
     </module>
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="Regex.kt"/>
+    </module>
 
     <!-- Checks whether files end with a new line.                        -->
     <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->


### PR DESCRIPTION
Closes #526. Dispatches a tracks event whenever a Jetpack tunnel timeout occurs.

Relies on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1063, which should be reviewed and merged before this PR.

I added a few properties to the existing `jetpack_tunnel_timeout` stat iOS is using, so we can filter by path, by protocol, and by how many retries have been made.

### To test

Following the same setup outlined in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1063, toggle fake timeouts on and off and check the logs for:

```
🔵 Tracked: jetpack_tunnel_timeout, Properties: {"path":"\/wc\/v3\/orders\/ID\/notes\/&_method=get","protocol":"get","times_retried":"0","blog_id":.....,"is_wpcom_store":false}
```