### PR TITLE
Only call onBackPressed if the fragment is not savedState = true

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -76,6 +76,7 @@ class OrderDetailFragment : Fragment(), OrderDetailContract.View, OrderDetailNot
     private var previousOrderStatus: String? = null
     private var notesSnack: Snackbar? = null
     private var pendingNotesError = false
+    private var runOnStartFunc: (() -> Unit)? = null
 
     override fun onAttach(context: Context?) {
         AndroidSupportInjection.inject(this)
@@ -125,6 +126,15 @@ class OrderDetailFragment : Fragment(), OrderDetailContract.View, OrderDetailNot
             presenter.pushOrderNote(noteText, isCustomerNote)
         }
         super.onActivityResult(requestCode, resultCode, data)
+    }
+
+    override fun onStart() {
+        super.onStart()
+
+        runOnStartFunc?.let {
+            it.invoke()
+            runOnStartFunc = null
+        }
     }
 
     override fun onStop() {
@@ -279,7 +289,12 @@ class OrderDetailFragment : Fragment(), OrderDetailContract.View, OrderDetailNot
     override fun showLoadOrderError() {
         loadingProgress.visibility = View.GONE
         uiMessageResolver.showSnack(R.string.order_error_fetch_generic)
-        activity?.onBackPressed()
+
+        if (isStateSaved) {
+            runOnStartFunc = { activity?.onBackPressed() }
+        } else {
+            activity?.onBackPressed()
+        }
     }
 
     override fun onRequestAddNote() {


### PR DESCRIPTION
Fixes #662

The crash, "IllegalStateException: can not perform after onSaveInstanceState" can happen under very difficult to reproduce circumstances, but I was able to reproduce it using a hacky test that I've turned into a patch file. See the testing section below. 

The problem is that if an error is encountered while loading the detail of an order, we show an error to the user and then _close the fragment_. Since fetching the order is asynchronous, the state of the fragment may not be ready to process the close request when a response is received from the API. To get around this, I now check the state of the fragment and if it's not ready to process this type of request, I save it as a function to be run in the `onResume` method of the fragment. 

### Testing
Apply [this patch](https://github.com/woocommerce/woocommerce-android/files/2747713/TESTINGCRASH.patch.zip) to the source code to reproduce the error using the `develop` branch, then:
1. Open a **new order** notification, wait for the progress spinner to be shown
2. minimize the app and wait. The app will crash.

Apply the same patch on this PRs branch and retest to ensure it no longer happens. 
