### PR TITLE
Crash fix: Init bottomNavView before authentication checks

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -92,6 +92,7 @@ class MainActivity : AppCompatActivity(),
         setSupportActionBar(toolbar as Toolbar)
 
         presenter.takeView(this)
+        bottomNavView = bottom_nav.also { it.init(supportFragmentManager, this) }
 
         // Verify authenticated session
         if (!presenter.userIsLoggedIn()) {
@@ -111,7 +112,6 @@ class MainActivity : AppCompatActivity(),
             return
         }
 
-        bottomNavView = bottom_nav.also { it.init(supportFragmentManager, this) }
         initFragment(savedInstanceState)
     }
 


### PR DESCRIPTION
Fixes #681. The problem was that `bottomNavView` was being initialized too late in `onCreate`, after logic which exits the function if we're not logged in yet. Calls to `onResume` in this state would cause the `UninitializedPropertyAccessException`.

### To test

To reproduce the crash in `develop`, enter the login flow, background the app, and resume.

(The most common situation this crash would occur in is during the magic link flow - leave the app to open your e-mail, and it'll crash on resume.)

Then, verify that this branch is crash-free.