### PR TITLE
Show exact count of orders in 'Orders to fulfill' card

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContract.kt
@@ -29,7 +29,7 @@ interface DashboardContract {
         fun showVisitorStatsError(granularity: StatsGranularity)
         fun showErrorSnack()
         fun hideUnfilledOrdersCard()
-        fun showUnfilledOrdersCard(count: Int, canLoadMore: Boolean)
+        fun showUnfilledOrdersCard(count: Int)
         fun showPluginVersionNoticeCard()
         fun hidePluginVersionNoticeCard()
         fun showNoOrdersView(show: Boolean)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -266,8 +266,8 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
         }
     }
 
-    override fun showUnfilledOrdersCard(count: Int, canLoadMore: Boolean) {
-        dashboard_unfilled_orders.updateOrdersCount(count, canLoadMore)
+    override fun showUnfilledOrdersCard(count: Int) {
+        dashboard_unfilled_orders.updateOrdersCount(count)
         if (dashboard_unfilled_orders.visibility != View.VISIBLE) {
             WooAnimUtils.scaleIn(dashboard_unfilled_orders, Duration.MEDIUM)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardPresenter.kt
@@ -237,7 +237,7 @@ class DashboardPresenter @Inject constructor(
                         mapOf(AnalyticsTracker.KEY_HAS_UNFULFILLED_ORDERS to (event.rowsAffected > 0)))
 
                 event.rowsAffected.takeIf { it > 0 }?.let { count ->
-                    dashboardView?.showUnfilledOrdersCard(count, event.canLoadMore)
+                    dashboardView?.showUnfilledOrdersCard(count)
                 } ?: dashboardView?.hideUnfilledOrdersCard()
             }
             else -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardUnfilledOrdersCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardUnfilledOrdersCard.kt
@@ -47,19 +47,14 @@ class DashboardUnfilledOrdersCard @JvmOverloads constructor(ctx: Context, attrs:
     /**
      * Updates the title of the unfilled orders dashboard card using strings that match the
      * quantity of the order count.
-     *
-     * NOTE: The title text is not using the [StringUtils.getQuantityString] method because it
-     * temporarily requires a way of displaying a "+" sign if [canLoadMore] is true. Once we
-     * have an API endpoint that can deliver a total for all orders this can be removed.
      */
-    fun updateOrdersCount(count: Int, canLoadMore: Boolean) {
-        alertAction_title.text = when {
-            count == 1 -> resources.getString(R.string.dashboard_fulfill_order_title)
-            canLoadMore -> resources.getString(R.string.dashboard_fulfill_orders_title, count, "+")
-            else -> resources.getString(R.string.dashboard_fulfill_orders_title, count, "")
-        }
+    fun updateOrdersCount(count: Int) {
+        alertAction_title.text = StringUtils.getQuantityString(context, count,
+                default = R.string.dashboard_fulfill_order_title_multiple,
+                one = R.string.dashboard_fulfill_order_title_single)
 
-        alertAction_action.text = StringUtils.getQuantityString(
-                context, count, R.string.dashboard_action_view_orders, one = R.string.dashboard_action_view_order)
+        alertAction_action.text = StringUtils.getQuantityString(context, count,
+                default = R.string.dashboard_action_view_orders,
+                one = R.string.dashboard_action_view_order)
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -132,8 +132,8 @@
 
     <string name="dashboard_action_view_order">View Order</string>
     <string name="dashboard_action_view_orders">View Orders</string>
-    <string name="dashboard_fulfill_order_title">You have 1 order to fulfill</string>
-    <string name="dashboard_fulfill_orders_title">You have %1$d%2$s orders to fulfill</string>
+    <string name="dashboard_fulfill_order_title_single">You have 1 order to fulfill</string>
+    <string name="dashboard_fulfill_order_title_multiple">You have %1$d orders to fulfill</string>
     <string name="dashboard_fulfill_orders_msg">Review, prepare, and ship these pending orders</string>
 
     <string name="dashboard_no_orders">Waiting for customers</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardPresenterTest.kt
@@ -131,7 +131,7 @@ class DashboardPresenterTest {
             canLoadMore = true
         })
 
-        verify(dashboardView).showUnfilledOrdersCard(totalOrders, true)
+        verify(dashboardView).showUnfilledOrdersCard(totalOrders)
     }
 
     @Test
@@ -171,7 +171,7 @@ class DashboardPresenterTest {
 
         // Simulate onOrderChanged event: FETCH-ORDERS - Dashboard should refresh
         presenter.onOrderChanged(OnOrderChanged(0).apply { causeOfChange = FETCH_ORDERS })
-        verify(dashboardView, times(0)).showUnfilledOrdersCard(any(), any())
+        verify(dashboardView, times(0)).showUnfilledOrdersCard(any())
         verify(dashboardView, times(0)).hideUnfilledOrdersCard()
         verify(dashboardView, times(1)).refreshDashboard(forced = any())
     }
@@ -182,7 +182,7 @@ class DashboardPresenterTest {
 
         // Simulate onOrderChanged event: UPDATE-ORDER-STATUS - Dashboard should refresh
         presenter.onOrderChanged(OnOrderChanged(0).apply { causeOfChange = UPDATE_ORDER_STATUS })
-        verify(dashboardView, times(0)).showUnfilledOrdersCard(any(), any())
+        verify(dashboardView, times(0)).showUnfilledOrdersCard(any())
         verify(dashboardView, times(0)).hideUnfilledOrdersCard()
         verify(dashboardView, times(1)).refreshDashboard(forced = any())
     }
@@ -193,7 +193,7 @@ class DashboardPresenterTest {
 
         // Simulate onOrderChanged event: FETCH-ORDER-NOTES - Dashboard should ignore
         presenter.onOrderChanged(OnOrderChanged(0).apply { causeOfChange = FETCH_ORDER_NOTES })
-        verify(dashboardView, times(0)).showUnfilledOrdersCard(any(), any())
+        verify(dashboardView, times(0)).showUnfilledOrdersCard(any())
         verify(dashboardView, times(0)).hideUnfilledOrdersCard()
         verify(dashboardView, times(0)).refreshDashboard(forced = true)
     }
@@ -207,7 +207,7 @@ class DashboardPresenterTest {
             causeOfChange = FETCH_ORDERS
             error = OrderError()
         })
-        verify(dashboardView, times(0)).showUnfilledOrdersCard(any(), any())
+        verify(dashboardView, times(0)).showUnfilledOrdersCard(any())
         verify(dashboardView, times(0)).hideUnfilledOrdersCard()
         verify(dashboardView, times(0)).refreshDashboard(forced = any())
     }

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = 'c63caa365307deaaeda6f04fa46d4331699dcd31'
+    fluxCVersion = 'e2139f89c864f41376eb686324efc5df256d1415'
     daggerVersion = '2.11'
     supportLibraryVersion = '27.1.1'
     glideVersion = '4.6.1'


### PR DESCRIPTION
Closes #536. Since we're now using the V3 API, we can use the `/reports/` endpoint to get an exact number of unfulfilled orders and do away with the '25+' logic we've had to use until now.

![device-2019-01-14-113837](https://user-images.githubusercontent.com/9613966/51126384-fd410f00-17f0-11e9-8cb1-cb6d06dd6891.png)

_Relies on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1068, which should be reviewed and merged first._