### PR TITLE
Update logout button text

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -236,7 +236,7 @@
     -->
     <string name="settings">Settings</string>
     <string name="privacy_settings">Privacy settings</string>
-    <string name="settings_signout">Logout account</string>
+    <string name="settings_signout">Log out account</string>
     <string name="settings_confirm_logout">Are you sure you want to logout from the account %s?</string>
     <string name="settings_send_stats">Collect information</string>
     <string name="settings_send_stats_detail">Share information with our analytics tool about your use of services while logged in to your WordPress account</string>


### PR DESCRIPTION
Fixes #678, updating the text of the logout button.

![device-2019-01-14-114458](https://user-images.githubusercontent.com/9613966/51126822-15655e00-17f2-11e9-8a02-836a1a3c81fb.png)
