### PR TITLE
Site Selector: Switch to on-demand api version verification design like iOS

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
@@ -48,9 +48,9 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
         ActivityUtils.setStatusBarColor(this, R.color.wc_grey_mid)
         presenter.takeView(this)
 
-        supported_recycler.layoutManager = LinearLayoutManager(this)
+        sites_recycler.layoutManager = LinearLayoutManager(this)
         siteAdapter = SiteListAdapter(this, this)
-        supported_recycler.adapter = siteAdapter
+        sites_recycler.adapter = siteAdapter
 
         showUserInfo()
 
@@ -58,7 +58,7 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
             val sites = presenter.getSitesForLocalIds(bundle.getIntArray(STATE_KEY_SITE_ID_LIST))
             showStoreList(sites)
         } ?: run {
-            supported_frame_list_container.visibility = View.GONE
+            site_list_container.visibility = View.GONE
             presenter.loadSites()
 
             AnalyticsTracker.track(
@@ -110,8 +110,8 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
             return
         }
 
-        supported_frame_list_container.visibility = View.VISIBLE
-        supported_text_list_label.text = if (wcSites.size == 1)
+        site_list_container.visibility = View.VISIBLE
+        site_list_label.text = if (wcSites.size == 1)
             getString(R.string.login_connected_store)
         else
             getString(R.string.login_pick_store)
@@ -174,7 +174,7 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
     }
 
     private fun showNoStoresView() {
-        supported_frame_list_container.visibility = View.GONE
+        site_list_container.visibility = View.GONE
         no_stores_view.visibility = View.VISIBLE
 
         val noStoresImage =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
@@ -129,6 +129,9 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
         button_continue.setOnClickListener { _ ->
             val site = presenter.getSiteBySiteId(siteAdapter.selectedSiteId)
             site?.let { it ->
+                AnalyticsTracker.track(
+                        Stat.LOGIN_EPILOGUE_STORE_PICKER_CONTINUE_TAPPED,
+                        mapOf(AnalyticsTracker.KEY_SELECTED_STORE_ID to site.id))
                 loginProgressDialog = ProgressDialog.show(this, null, getString(R.string.login_verifying_site))
                 presenter.verifySiteApiVersion(it)
             }
@@ -143,9 +146,6 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
         loginProgressDialog?.dismiss()
         selectedSite.set(site)
         CrashlyticsUtils.initSite(site)
-        AnalyticsTracker.track(
-                Stat.LOGIN_EPILOGUE_STORE_PICKER_CONTINUE_TAPPED,
-                mapOf(AnalyticsTracker.KEY_SELECTED_STORE_ID to site.id))
         finishEpilogue()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
@@ -38,6 +38,7 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
 
     private lateinit var siteAdapter: SiteListAdapter
 
+
     private var loginProgressDialog: ProgressDialog? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
@@ -38,7 +38,6 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
 
     private lateinit var siteAdapter: SiteListAdapter
 
-
     private var loginProgressDialog: ProgressDialog? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
@@ -153,6 +153,7 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
         loginProgressDialog?.dismiss()
 
         siteAdapter.selectedSiteId = 0
+        button_continue.isEnabled = false
 
         val ft = supportFragmentManager.beginTransaction()
         val prev = supportFragmentManager.findFragmentByTag(WooUpgradeRequiredDialog.TAG)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
@@ -3,10 +3,12 @@ package com.woocommerce.android.ui.login
 import android.app.ProgressDialog
 import android.content.Intent
 import android.os.Bundle
+import android.support.design.widget.Snackbar
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.content.res.AppCompatResources
 import android.support.v7.widget.LinearLayoutManager
 import android.view.View
+import android.view.ViewGroup
 import android.widget.LinearLayout
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -179,6 +181,14 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
     override fun onSiteClick(siteId: Long) {
         val site = presenter.getSiteBySiteId(siteId)
         site?.let { selectedSite.set(it) }
+    }
+
+    override fun errorVerifyingSites() {
+        Snackbar.make(
+                login_root as ViewGroup,
+                R.string.login_verifying_sites_error,
+                Snackbar.LENGTH_LONG
+        ).show()
     }
 
     private fun showNoStoresView() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
@@ -7,9 +7,9 @@ import android.support.design.widget.Snackbar
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.content.res.AppCompatResources
 import android.support.v7.widget.LinearLayoutManager
+import android.text.TextUtils
 import android.view.View
 import android.view.ViewGroup
-import android.widget.LinearLayout
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
@@ -18,7 +18,6 @@ import com.woocommerce.android.push.FCMRegistrationIntentService
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.adapter.SiteListAdapter
 import com.woocommerce.android.ui.login.adapter.SiteListAdapter.OnSiteClickListener
-import com.woocommerce.android.ui.login.adapter.SiteListUnsupportedAdapter
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.CrashlyticsUtils
@@ -31,17 +30,13 @@ import javax.inject.Inject
 
 class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, OnSiteClickListener {
     companion object {
-        private const val STATE_KEY_SUPPORTED_SITE_ID_LIST = "key-supported-site-id-list"
-        private const val STATE_KEY_UNSUPPORTED_SITE_ID_LIST = "key-unsupported-site-id-list"
-
-        private const val URL_UPGRADE_WOOCOMMERCE = "https://docs.woocommerce.com/document/how-to-update-woocommerce/"
+        private const val STATE_KEY_SITE_ID_LIST = "key-supported-site-id-list"
     }
 
     @Inject lateinit var presenter: LoginEpilogueContract.Presenter
     @Inject lateinit var selectedSite: SelectedSite
 
     private lateinit var siteAdapter: SiteListAdapter
-    private lateinit var unsupportedSiteAdapter: SiteListUnsupportedAdapter
 
     private var loginProgressDialog: ProgressDialog? = null
 
@@ -57,29 +52,18 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
         siteAdapter = SiteListAdapter(this, this)
         supported_recycler.adapter = siteAdapter
 
-        unsupported_recycler.layoutManager = LinearLayoutManager(this)
-        unsupportedSiteAdapter = SiteListUnsupportedAdapter(this)
-        unsupported_recycler.adapter = unsupportedSiteAdapter
-
         showUserInfo()
 
         savedInstanceState?.let { bundle ->
-            val supportedSites = presenter.getSitesForLocalIds(bundle.getIntArray(STATE_KEY_SUPPORTED_SITE_ID_LIST))
-            val unsupportedSites = presenter.getSitesForLocalIds(bundle.getIntArray(STATE_KEY_UNSUPPORTED_SITE_ID_LIST))
-            showStoreList(supportedSites, unsupportedSites)
+            val sites = presenter.getSitesForLocalIds(bundle.getIntArray(STATE_KEY_SITE_ID_LIST))
+            showStoreList(sites)
         } ?: run {
-            loginProgressDialog = ProgressDialog.show(this, null, getString(R.string.login_verifying_sites))
             supported_frame_list_container.visibility = View.GONE
-            presenter.checkWCVersionsForAllSites()
+            presenter.loadSites()
 
             AnalyticsTracker.track(
                     Stat.LOGIN_EPILOGUE_STORES_SHOWN,
                     mapOf(AnalyticsTracker.KEY_NUMBER_OF_STORES to presenter.getWooCommerceSites().size))
-        }
-
-        // show buttons side-by-side in landscape
-        if (DisplayUtils.isLandscape(this)) {
-            frame_bottom.orientation = LinearLayout.HORIZONTAL
         }
     }
 
@@ -96,11 +80,9 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
     public override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
 
-        val supportedSiteIdList = siteAdapter.siteList.map { it.id }
-        val unsupportedSiteIdList = unsupportedSiteAdapter.siteList.map { it.id }
+        val sitesList = siteAdapter.siteList.map { it.id }
 
-        outState.putIntArray(STATE_KEY_SUPPORTED_SITE_ID_LIST, supportedSiteIdList.toIntArray())
-        outState.putIntArray(STATE_KEY_UNSUPPORTED_SITE_ID_LIST, unsupportedSiteIdList.toIntArray())
+        outState.putIntArray(STATE_KEY_SITE_ID_LIST, sitesList.toIntArray())
     }
 
     override fun onBackPressed() {
@@ -120,80 +102,79 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
                 .into(image_avatar)
     }
 
-    override fun showStoreList(supportedWCSites: List<SiteModel>, unsupportedWCSites: List<SiteModel>) {
+    override fun showStoreList(wcSites: List<SiteModel>) {
         loginProgressDialog?.takeIf { it.isShowing }?.dismiss()
 
-        if (supportedWCSites.isEmpty() && unsupportedWCSites.isEmpty()) {
+        if (wcSites.isEmpty()) {
             showNoStoresView()
             return
         }
 
-        if (supportedWCSites.isNotEmpty()) {
-            supported_frame_list_container.visibility = View.VISIBLE
-            button_update_instructions.visibility = View.GONE
+        supported_frame_list_container.visibility = View.VISIBLE
+        supported_text_list_label.text = if (wcSites.size == 1)
+            getString(R.string.login_connected_store)
+        else
+            getString(R.string.login_pick_store)
 
-            supported_text_list_label.text = if (supportedWCSites.size == 1)
-                getString(R.string.login_connected_store)
-            else
-                getString(R.string.login_pick_store)
+        siteAdapter.siteList = wcSites
 
-            if (selectedSite.exists()) {
-                siteAdapter.selectedSiteId = selectedSite.get().siteId
-            } else {
-                siteAdapter.selectedSiteId = supportedWCSites[0].siteId
+        button_continue.text = getString(R.string.continue_button)
+        button_continue.isEnabled = false
+        button_continue.setOnClickListener { _ ->
+            val site = presenter.getSiteBySiteId(siteAdapter.selectedSiteId)
+            site?.let { it ->
+                selectedSite.set(it)
+                CrashlyticsUtils.initSite(it)
+                AnalyticsTracker.track(
+                        Stat.LOGIN_EPILOGUE_STORE_PICKER_CONTINUE_TAPPED,
+                        mapOf(AnalyticsTracker.KEY_SELECTED_STORE_ID to it.id))
+                finishEpilogue()
             }
-
-            siteAdapter.siteList = supportedWCSites
-
-            button_continue.text = getString(R.string.continue_button)
-            button_continue.setOnClickListener { _ ->
-                val site = presenter.getSiteBySiteId(siteAdapter.selectedSiteId)
-                site?.let { it ->
-                    selectedSite.set(it)
-                    CrashlyticsUtils.initSite(it)
-                    AnalyticsTracker.track(
-                            Stat.LOGIN_EPILOGUE_STORE_PICKER_CONTINUE_TAPPED,
-                            mapOf(AnalyticsTracker.KEY_SELECTED_STORE_ID to it.id))
-                    finishEpilogue()
-                }
-            }
-        } else {
-            // Show 'Update instructions' button, and replace 'Continue' button with 'Refresh'
-            button_update_instructions.visibility = View.VISIBLE
-            button_update_instructions.setOnClickListener {
-                ActivityUtils.openUrlExternal(this, URL_UPGRADE_WOOCOMMERCE)
-            }
-
-            button_continue.text = getString(R.string.refresh_button)
-            button_continue.setOnClickListener {
-                loginProgressDialog = ProgressDialog.show(this, null, getString(R.string.login_verifying_sites))
-                presenter.checkWCVersionsForAllSites()
-            }
-            supported_frame_list_container.visibility = View.GONE
-        }
-
-        if (unsupportedWCSites.isNotEmpty()) {
-            unsupported_frame_list_container.visibility = View.VISIBLE
-            unsupportedSiteAdapter.siteList = unsupportedWCSites
         }
     }
 
     override fun onSiteClick(siteId: Long) {
-        val site = presenter.getSiteBySiteId(siteId)
-        site?.let { selectedSite.set(it) }
+        button_continue.isEnabled = false
+        presenter.getSiteBySiteId(siteId)?.let { site ->
+            loginProgressDialog = ProgressDialog.show(this, null, getString(R.string.login_verifying_site))
+            presenter.verifySiteApiVersion(site)
+        }
     }
 
-    override fun errorVerifyingSites() {
+    override fun siteVerificationPassed(site: SiteModel) {
+        loginProgressDialog?.dismiss()
+
+        button_continue.isEnabled = true
+    }
+
+    override fun siteVerificationFailed(site: SiteModel) {
+        loginProgressDialog?.dismiss()
+
+        siteAdapter.selectedSiteId = 0
+
+        val ft = supportFragmentManager.beginTransaction()
+        val prev = supportFragmentManager.findFragmentByTag(WooUpgradeRequiredDialog.TAG)
+        if (prev != null) {
+            ft.remove(prev)
+        }
+        ft.addToBackStack(null)
+        val dialogFragment = WooUpgradeRequiredDialog()
+        dialogFragment.show(ft, WooUpgradeRequiredDialog.TAG)
+    }
+
+    override fun siteVerificationError(site: SiteModel) {
+        loginProgressDialog?.dismiss()
+
+        val siteName = if (!TextUtils.isEmpty(site.name)) site.name else getString(R.string.untitled)
         Snackbar.make(
                 login_root as ViewGroup,
-                R.string.login_verifying_sites_error,
+                getString(R.string.login_verifying_site_error, siteName),
                 Snackbar.LENGTH_LONG
         ).show()
     }
 
     private fun showNoStoresView() {
         supported_frame_list_container.visibility = View.GONE
-        unsupported_frame_list_container.visibility = View.GONE
         no_stores_view.visibility = View.VISIBLE
 
         val noStoresImage =
@@ -202,6 +183,7 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
         no_stores_view.setCompoundDrawablesWithIntrinsicBounds(null, noStoresImage, null, null)
 
         button_continue.text = getString(R.string.login_with_a_different_account)
+        button_continue.isEnabled = true
         button_continue.setOnClickListener {
             presenter.logout()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueContract.kt
@@ -13,14 +13,17 @@ interface LoginEpilogueContract {
         fun getUserDisplayName(): String?
         fun logout()
         fun userIsLoggedIn(): Boolean
-        fun checkWCVersionsForAllSites()
+        fun loadSites()
         fun getSitesForLocalIds(siteIdList: IntArray): List<SiteModel>
+        fun verifySiteApiVersion(site: SiteModel)
     }
 
     interface View : BaseView<Presenter> {
         fun showUserInfo()
-        fun showStoreList(supportedWCSites: List<SiteModel>, unsupportedWCSites: List<SiteModel>)
+        fun showStoreList(wcSites: List<SiteModel>)
         fun cancel()
-        fun errorVerifyingSites()
+        fun siteVerificationPassed(site: SiteModel)
+        fun siteVerificationFailed(site: SiteModel)
+        fun siteVerificationError(site: SiteModel)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueContract.kt
@@ -21,5 +21,6 @@ interface LoginEpilogueContract {
         fun showUserInfo()
         fun showStoreList(supportedWCSites: List<SiteModel>, unsupportedWCSites: List<SiteModel>)
         fun cancel()
+        fun errorVerifyingSites()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpiloguePresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpiloguePresenter.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.login
 
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -83,6 +85,20 @@ class LoginEpiloguePresenter @Inject constructor(
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onApiVersionFetched(event: OnApiVersionFetched) {
+        if (event.isError) {
+            WooLog.e(T.LOGIN, "Error fetching apiVersion for site [${event.site.siteId} : ${event.site.name}]! " +
+                    "${event.error?.message}")
+            loginEpilogueView?.errorVerifyingSites()
+            return
+        }
+
+        // Check for empty API version as well (which may not result in an error from the api)
+        if (event.apiVersion.isBlank()) {
+            WooLog.e(T.LOGIN, "Empty apiVersion for site [${event.site.siteId} : ${event.site.name}]!")
+            loginEpilogueView?.errorVerifyingSites()
+            return
+        }
+
         if (event.apiVersion == WooCommerceStore.WOO_API_NAMESPACE_V3) {
             supportedWCSites.add(event.site)
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WooUpgradeRequiredDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WooUpgradeRequiredDialog.kt
@@ -1,0 +1,42 @@
+package com.woocommerce.android.ui.login
+
+import android.os.Bundle
+import android.support.v4.app.DialogFragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import com.woocommerce.android.R
+import com.woocommerce.android.util.ActivityUtils
+import android.view.WindowManager
+
+class WooUpgradeRequiredDialog : DialogFragment() {
+    companion object {
+        const val TAG = "WooUpgradeRequiredDialog"
+        private const val URL_UPGRADE_WOOCOMMERCE = "https://docs.woocommerce.com/document/how-to-update-woocommerce/"
+
+        fun newInstance() = WooUpgradeRequiredDialog()
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        val view = inflater.inflate(R.layout.dialog_version_upgrade_required, container, false)
+
+        context?.let { ctx ->
+            view.findViewById<Button>(R.id.upgrade_instructions)?.setOnClickListener {
+                ActivityUtils.openUrlExternal(ctx, URL_UPGRADE_WOOCOMMERCE)
+            }
+        }
+        view.findViewById<Button>(R.id.upgrade_dismiss)?.setOnClickListener { dialog.dismiss() }
+
+        return view
+    }
+
+    override fun onResume() {
+        dialog.window?.attributes?.let { params ->
+            params.width = WindowManager.LayoutParams.MATCH_PARENT
+            params.height = WindowManager.LayoutParams.WRAP_CONTENT
+            dialog.window?.attributes = params
+        }
+        super.onResume()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -29,7 +29,8 @@ object WooLog {
         DEVICE,
         SUPPORT,
         WP,
-        NOTIFICATIONS
+        NOTIFICATIONS,
+        LOGIN
     }
 
     // Breaking convention to be consistent with org.wordpress.android.util.AppLog

--- a/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
+++ b/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
@@ -3,9 +3,9 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/login_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:id="@+id/login_root"
     android:background="@color/wc_grey_light">
 
     <ImageView
@@ -129,7 +129,6 @@
             style="@style/Woo.Button.Purple"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/continue_button"
-            android:enabled="false"/>
+            android:text="@string/continue_button"/>
     </FrameLayout>
 </android.support.constraint.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
+++ b/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
@@ -1,149 +1,94 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:app="http://schemas.android.com/apk/res-auto"
-                xmlns:tools="http://schemas.android.com/tools"
-                android:id="@+id/login_root"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:background="@color/wc_grey_light"
-                android:orientation="vertical">
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:id="@+id/login_root"
+    android:background="@color/wc_grey_light">
 
     <ImageView
         android:id="@+id/image_avatar"
         android:layout_width="@dimen/login_avatar_size"
         android:layout_height="@dimen/login_avatar_size"
-        android:layout_centerHorizontal="true"
         android:layout_marginTop="40dp"
         android:contentDescription="@string/login_avatar_content_description"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         tools:srcCompat="@drawable/ic_placeholder_gravatar_grey_lighten_20_100dp"/>
 
     <TextView
         android:id="@+id/text_displayname"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/image_avatar"
-        android:layout_centerHorizontal="true"
         android:layout_marginTop="@dimen/margin_large"
         android:textColor="@color/grey_dark"
         android:textSize="@dimen/text_extra_large"
-        tools:text="text_username"/>
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/image_avatar"
+        tools:text="droidtester2018"/>
 
     <TextView
         android:id="@+id/text_username"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/text_displayname"
-        android:layout_centerHorizontal="true"
         android:textColor="@color/grey_dark"
         android:textSize="@dimen/text_large"
-        tools:text="text_displayname"/>
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/text_displayname"
+        tools:text="\@droidtester2018"/>
 
-    <android.support.v4.widget.NestedScrollView
+    <android.support.v7.widget.CardView
+        android:id="@+id/supported_frame_list_container"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_above="@+id/frame_bottom"
-        android:layout_below="@+id/text_username">
+        android:layout_height="0dp"
+        android:layout_marginBottom="8dp"
+        android:layout_marginTop="@dimen/margin_extra_extra_medium_large"
+        app:cardElevation="@dimen/card_elevation"
+        app:layout_constraintBottom_toTopOf="@+id/view6"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/text_username"
+        app:layout_constraintVertical_bias="0.0"
+        tools:visibility="visible">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <FrameLayout
-                android:id="@+id/supported_frame_list_container"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+            <TextView
+                android:id="@+id/supported_text_list_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingEnd="@dimen/margin_extra_large"
+                android:paddingStart="@dimen/margin_extra_large"
+                android:paddingTop="@dimen/margin_extra_large"
+                android:text="@string/login_pick_store"
+                android:textColor="@color/wc_purple"
+                android:textSize="@dimen/text_large"
+                android:textStyle="bold"/>
 
-                <android.support.v7.widget.CardView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/margin_extra_small"
-                    android:layout_marginTop="@dimen/margin_extra_extra_medium_large"
-                    app:cardElevation="@dimen/card_elevation">
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:id="@+id/supported_text_list_label"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:paddingEnd="@dimen/margin_extra_large"
-                            android:paddingStart="@dimen/margin_extra_large"
-                            android:paddingTop="@dimen/margin_extra_large"
-                            android:text="@string/login_pick_store"
-                            android:textColor="@color/wc_purple"
-                            android:textSize="@dimen/text_large"
-                            android:textStyle="bold"/>
-
-                        <android.support.v7.widget.RecyclerView
-                            android:id="@+id/supported_recycler"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:clipChildren="false"
-                            android:clipToPadding="false"
-                            android:paddingBottom="@dimen/margin_extra_large"
-                            android:paddingEnd="@dimen/margin_extra_large"
-                            android:paddingStart="@dimen/margin_extra_large"/>
-                    </LinearLayout>
-                </android.support.v7.widget.CardView>
-            </FrameLayout>
-
-            <FrameLayout
-                android:id="@+id/unsupported_frame_list_container"
+            <android.support.v7.widget.RecyclerView
+                android:id="@+id/supported_recycler"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:visibility="gone"
-                tools:visibility="visible">
-
-                <android.support.v7.widget.CardView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/margin_extra_small"
-                    android:layout_marginTop="@dimen/margin_extra_extra_medium_large"
-                    app:cardElevation="@dimen/card_elevation">
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:id="@+id/unsupported_text_list_label"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:paddingEnd="@dimen/margin_extra_large"
-                            android:paddingStart="@dimen/margin_extra_large"
-                            android:paddingTop="@dimen/margin_extra_large"
-                            android:text="@string/login_site_list_update_required"
-                            android:textColor="@color/wc_purple"
-                            android:textSize="@dimen/text_large"
-                            android:textStyle="bold"/>
-
-                        <android.support.v7.widget.RecyclerView
-                            android:id="@+id/unsupported_recycler"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:clipChildren="false"
-                            android:clipToPadding="false"
-                            android:paddingBottom="@dimen/margin_extra_large"
-                            android:paddingEnd="@dimen/margin_extra_large"
-                            android:paddingStart="@dimen/margin_extra_large"/>
-                    </LinearLayout>
-                </android.support.v7.widget.CardView>
-            </FrameLayout>
+                android:clipChildren="false"
+                android:clipToPadding="false"
+                android:paddingBottom="@dimen/margin_extra_large"
+                android:paddingEnd="@dimen/margin_extra_large"
+                android:paddingStart="@dimen/margin_extra_large"/>
         </LinearLayout>
-    </android.support.v4.widget.NestedScrollView>
+    </android.support.v7.widget.CardView>
 
     <TextView
         android:id="@+id/no_stores_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/text_username"
-        android:layout_centerHorizontal="true"
-        android:layout_marginEnd="@dimen/margin_extra_large"
-        android:layout_marginStart="@dimen/margin_extra_large"
         android:layout_marginTop="@dimen/margin_extra_extra_large"
         android:gravity="center_horizontal"
         android:orientation="vertical"
@@ -152,42 +97,39 @@
         android:textSize="@dimen/text_large"
         android:textStyle="bold"
         android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/text_username"
         tools:drawableTop="@drawable/ic_woo_no_store"
-        tools:visibility="visible"/>
+        tools:visibility="gone"/>
 
     <View
+        android:id="@+id/view6"
         android:layout_width="match_parent"
         android:layout_height="@dimen/appbar_elevation"
-        android:layout_above="@+id/frame_bottom"
-        android:background="@drawable/shadow_top"/>
+        android:background="@drawable/shadow_top"
+        app:layout_constraintBottom_toTopOf="@+id/frame_bottom"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"/>
 
-    <LinearLayout
+    <FrameLayout
         android:id="@+id/frame_bottom"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:background="@color/white"
         android:clipToPadding="false"
-        android:orientation="vertical"
-        android:padding="@dimen/margin_extra_large">
-
-        <android.support.v7.widget.AppCompatButton
-            android:id="@+id/button_update_instructions"
-            style="@style/Woo.Button.Grey"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/margin_medium"
-            android:layout_weight="1"
-            android:text="@string/button_update_instructions"
-            android:visibility="gone"
-            tools:visibility="visible"/>
+        android:padding="@dimen/margin_extra_large"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
 
         <android.support.v7.widget.AppCompatButton
             android:id="@+id/button_continue"
             style="@style/Woo.Button.Purple"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="@string/continue_button"/>
-    </LinearLayout>
-</RelativeLayout>
+            android:text="@string/continue_button"
+            android:enabled="false"/>
+    </FrameLayout>
+</android.support.constraint.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
+++ b/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
@@ -43,7 +43,7 @@
         tools:text="\@droidtester2018"/>
 
     <android.support.v7.widget.CardView
-        android:id="@+id/supported_frame_list_container"
+        android:id="@+id/site_list_container"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_marginBottom="8dp"
@@ -62,7 +62,7 @@
             android:orientation="vertical">
 
             <TextView
-                android:id="@+id/supported_text_list_label"
+                android:id="@+id/site_list_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingEnd="@dimen/margin_extra_large"
@@ -74,7 +74,7 @@
                 android:textStyle="bold"/>
 
             <android.support.v7.widget.RecyclerView
-                android:id="@+id/supported_recycler"
+                android:id="@+id/sites_recycler"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:clipChildren="false"

--- a/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
+++ b/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
@@ -1,6 +1,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
                 xmlns:app="http://schemas.android.com/apk/res-auto"
                 xmlns:tools="http://schemas.android.com/tools"
+                android:id="@+id/login_root"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:background="@color/wc_grey_light"

--- a/WooCommerce/src/main/res/layout/dialog_version_upgrade_required.xml
+++ b/WooCommerce/src/main/res/layout/dialog_version_upgrade_required.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:padding="@dimen/default_padding"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/login_update_required_title"
+        android:textAppearance="@style/Woo.TextAppearance.Title"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <TextView
+        android:id="@+id/textView2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/login_update_required_desc"
+        android:textAppearance="@style/Woo.TextAppearance.Medium"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView"/>
+
+    <android.support.v7.widget.AppCompatButton
+        android:id="@+id/upgrade_instructions"
+        style="@style/Woo.Button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end"
+        android:layout_marginBottom="8dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/button_update_instructions"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView2"/>
+
+    <android.support.v7.widget.AppCompatButton
+        android:id="@+id/upgrade_dismiss"
+        style="@style/Woo.Button.Purple"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/dismiss"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toEndOf="@+id/upgrade_instructions"
+        app:layout_constraintTop_toBottomOf="@+id/textView2"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -96,6 +96,7 @@
     <string name="login_pick_store">Pick store</string>
     <string name="login_connected_store">Connected store</string>
     <string name="login_verifying_sites">Verifying sites…</string>
+    <string name="login_verifying_sites_error">Error verifying sites</string>
     <string name="login_site_list_update_required">Update to WooCommerce 3.5 required</string>
     <string name="login_avatar_content_description">Your profile photo</string>
     <string name="login_nostores_content_description">No WooCommerce stores</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -99,8 +99,7 @@
     <string name="login_verifying_site">Verifying site…</string>
     <string name="login_verifying_site_error">Cannot connect to %s</string>
     <string name="login_update_required_title">Update Store to WooCommerce 3.5</string>
-    <string name="login_update_required_desc">This app requires WooCommerce 3.5 on your server. To continue using this app, please update your site.</string>
-    <string name="login_site_list_update_required">Update to WooCommerce 3.5 required</string>
+    <string name="login_update_required_desc">This app requires WooCommerce 3.5 on your server. To continue using this app, please update your store.</string>
     <string name="login_avatar_content_description">Your profile photo</string>
     <string name="login_nostores_content_description">No WooCommerce stores</string>
     <string name="login_with_a_different_account">Login with a different account</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -99,7 +99,7 @@
     <string name="login_verifying_site">Verifying site…</string>
     <string name="login_verifying_site_error">Cannot connect to %s</string>
     <string name="login_update_required_title">Update Store to WooCommerce 3.5</string>
-    <string name="login_update_required_desc">This app requires that you install WooCommerce 3.5 on your server, and won\'t work properly without it. Update as soon as possible to continue using this app.</string>
+    <string name="login_update_required_desc">This app requires WooCommerce 3.5 on your server. To continue using this app, please update your site.</string>
     <string name="login_site_list_update_required">Update to WooCommerce 3.5 required</string>
     <string name="login_avatar_content_description">Your profile photo</string>
     <string name="login_nostores_content_description">No WooCommerce stores</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -58,6 +58,7 @@
     <string name="search">Search</string>
     <string name="back">Back</string>
     <string name="button_update_instructions">Update instructions</string>
+    <string name="dismiss">Dismiss</string>
 
     <!--
         Date/Time Labels
@@ -95,8 +96,10 @@
     <string name="login_configure_link">Read the %sconfiguration instructions%s.</string>
     <string name="login_pick_store">Pick store</string>
     <string name="login_connected_store">Connected store</string>
-    <string name="login_verifying_sites">Verifying sites…</string>
-    <string name="login_verifying_sites_error">Error verifying sites</string>
+    <string name="login_verifying_site">Verifying site…</string>
+    <string name="login_verifying_site_error">Cannot connect to %s</string>
+    <string name="login_update_required_title">Update Store to WooCommerce 3.5</string>
+    <string name="login_update_required_desc">This app requires that you install WooCommerce 3.5 on your server, and won\'t work properly without it. Update as soon as possible to continue using this app.</string>
     <string name="login_site_list_update_required">Update to WooCommerce 3.5 required</string>
     <string name="login_avatar_content_description">Your profile photo</string>
     <string name="login_nostores_content_description">No WooCommerce stores</string>


### PR DESCRIPTION
This PR fixes #691 and changes the design of the site selector to more closely match the iOS version.

The former design validated all stores up front and then displayed stores that did not meet the minimum api version requirements in a separate section. The problem was that if the store could not be validated for one reason or another, they would automatically show up in the "Update required" section, even though they _may_ be running the correct version of WooCommerce. A couple ideas were thrown around to address this like creating a separate section for the stores that could not be verified, but in the end we decided to match the iOS design since it allows more flexibility on how to handle the validation response at the individual site level.

The new design will show all Woo stores in a single list and then validation will happen when the user _**selects a store**_. There are three possible outcomes of this validation:
1. The store passes -> the **continue** button will enable
2. The store's api version does not meet the minimum requirements (failed) -> a dialog will be shown advising the user to upgrade their WooCommerce plugin.
3. The store cannot be verified for some reason (error) -> display a snack error message

<img src="https://user-images.githubusercontent.com/5810477/51356345-3ba42b80-1a88-11e9-9a43-07eecf33b264.gif" width="300">
