### PR TITLE
Update Kotlin, Gradle, and build tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ android:
     - extra-android-support
     - platform-tools
     - tools
-    - build-tools-27.0.3
+    - build-tools-28.0.3
     - android-27
 
 env:

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -37,7 +37,7 @@ androidExtensions {
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "com.woocommerce.android"

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = '1.2.71'
+    ext.kotlinVersion = '1.3.11'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.automattic.android:fetchstyle:1.1'
         classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlinVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ subprojects {
     }
 
     dependencies {
-        ktlint 'com.github.shyiko:ktlint:0.28.0'
+        ktlint 'com.github.shyiko:ktlint:0.29.0'
     }
 
     task ktlint(type: JavaExec) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Oct 12 12:11:51 EEST 2017
+#Wed Jan 16 10:48:55 EST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -18,7 +18,7 @@ repositories {
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 16

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 


### PR DESCRIPTION
Updates Kotlin and `ktlint` to latest. Also updates the gradle plugin to `3.2.1` and the build tools to `28.0.3`.

Note: There's a more recent version of the gradle plugin, `3.3.0`. However that one triggers build warnings (`WARNING: API 'variant.getExternalNativeBuildTasks()' is obsolete`). The cause is the Fabric gradle plugin, which needs to be updated to support gradle plugin `3.3.0`. I'll file a ticket to watch out for that and update our version.