### PR TITLE
Site Selector: Switch to on-demand api version verification design like iOS

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueContract.kt
@@ -13,13 +13,17 @@ interface LoginEpilogueContract {
         fun getUserDisplayName(): String?
         fun logout()
         fun userIsLoggedIn(): Boolean
-        fun checkWCVersionsForAllSites()
+        fun loadSites()
         fun getSitesForLocalIds(siteIdList: IntArray): List<SiteModel>
+        fun verifySiteApiVersion(site: SiteModel)
     }
 
     interface View : BaseView<Presenter> {
         fun showUserInfo()
-        fun showStoreList(supportedWCSites: List<SiteModel>, unsupportedWCSites: List<SiteModel>)
+        fun showStoreList(wcSites: List<SiteModel>)
         fun cancel()
+        fun siteVerificationPassed(site: SiteModel)
+        fun siteVerificationFailed(site: SiteModel)
+        fun siteVerificationError(site: SiteModel)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpiloguePresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpiloguePresenter.kt
@@ -79,7 +79,7 @@ class LoginEpiloguePresenter @Inject constructor(
     fun onApiVersionFetched(event: OnApiVersionFetched) {
         if (event.isError) {
             WooLog.e(T.LOGIN, "Error fetching apiVersion for site [${event.site.siteId} : ${event.site.name}]! " +
-                    "${event.error?.message}")
+                    "${event.error?.type} - ${event.error?.message}")
             loginEpilogueView?.siteVerificationError(event.site)
             return
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpiloguePresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpiloguePresenter.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.login
 
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -21,9 +23,6 @@ class LoginEpiloguePresenter @Inject constructor(
     private val wooCommerceStore: WooCommerceStore
 ) : LoginEpilogueContract.Presenter {
     private var loginEpilogueView: LoginEpilogueContract.View? = null
-
-    private var supportedWCSites = mutableListOf<SiteModel>()
-    private var unsupportedWCSites = mutableListOf<SiteModel>()
 
     override fun takeView(view: LoginEpilogueContract.View) {
         dispatcher.register(this)
@@ -54,18 +53,13 @@ class LoginEpiloguePresenter @Inject constructor(
         return accountStore.hasAccessToken()
     }
 
-    override fun checkWCVersionsForAllSites() {
-        supportedWCSites.clear()
-        unsupportedWCSites.clear()
+    override fun loadSites() {
         val wcSites = wooCommerceStore.getWooCommerceSites()
-        if (wcSites.isEmpty()) {
-            loginEpilogueView?.showStoreList(emptyList(), emptyList())
-            return
-        }
+        loginEpilogueView?.showStoreList(wcSites)
+    }
 
-        for (site in wcSites) {
-            dispatcher.dispatch(WCCoreActionBuilder.newFetchSiteApiVersionAction(site))
-        }
+    override fun verifySiteApiVersion(site: SiteModel) {
+        dispatcher.dispatch(WCCoreActionBuilder.newFetchSiteApiVersionAction(site))
     }
 
     override fun getSitesForLocalIds(siteIdList: IntArray): List<SiteModel> {
@@ -83,15 +77,24 @@ class LoginEpiloguePresenter @Inject constructor(
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onApiVersionFetched(event: OnApiVersionFetched) {
-        if (event.apiVersion == WooCommerceStore.WOO_API_NAMESPACE_V3) {
-            supportedWCSites.add(event.site)
-        } else {
-            unsupportedWCSites.add(event.site)
+        if (event.isError) {
+            WooLog.e(T.LOGIN, "Error fetching apiVersion for site [${event.site.siteId} : ${event.site.name}]! " +
+                    "${event.error?.message}")
+            loginEpilogueView?.siteVerificationError(event.site)
+            return
         }
 
-        val totalSitesChecked = supportedWCSites.size + unsupportedWCSites.size
-        if (totalSitesChecked == wooCommerceStore.getWooCommerceSites().size) {
-            loginEpilogueView?.showStoreList(supportedWCSites, unsupportedWCSites)
+        // Check for empty API version as well (which may not result in an error from the api)
+        if (event.apiVersion.isBlank()) {
+            WooLog.e(T.LOGIN, "Empty apiVersion for site [${event.site.siteId} : ${event.site.name}]!")
+            loginEpilogueView?.siteVerificationError(event.site)
+            return
+        }
+
+        if (event.apiVersion == WooCommerceStore.WOO_API_NAMESPACE_V3) {
+            loginEpilogueView?.siteVerificationPassed(event.site)
+        } else {
+            loginEpilogueView?.siteVerificationFailed(event.site)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WooUpgradeRequiredDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WooUpgradeRequiredDialog.kt
@@ -1,0 +1,42 @@
+package com.woocommerce.android.ui.login
+
+import android.os.Bundle
+import android.support.v4.app.DialogFragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import com.woocommerce.android.R
+import com.woocommerce.android.util.ActivityUtils
+import android.view.WindowManager
+
+class WooUpgradeRequiredDialog : DialogFragment() {
+    companion object {
+        const val TAG = "WooUpgradeRequiredDialog"
+        private const val URL_UPGRADE_WOOCOMMERCE = "https://docs.woocommerce.com/document/how-to-update-woocommerce/"
+
+        fun newInstance() = WooUpgradeRequiredDialog()
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        val view = inflater.inflate(R.layout.dialog_version_upgrade_required, container, false)
+
+        context?.let { ctx ->
+            view.findViewById<Button>(R.id.upgrade_instructions)?.setOnClickListener {
+                ActivityUtils.openUrlExternal(ctx, URL_UPGRADE_WOOCOMMERCE)
+            }
+        }
+        view.findViewById<Button>(R.id.upgrade_dismiss)?.setOnClickListener { dialog.dismiss() }
+
+        return view
+    }
+
+    override fun onResume() {
+        dialog.window?.attributes?.let { params ->
+            params.width = WindowManager.LayoutParams.MATCH_PARENT
+            params.height = WindowManager.LayoutParams.WRAP_CONTENT
+            dialog.window?.attributes = params
+        }
+        super.onResume()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -29,7 +29,8 @@ object WooLog {
         DEVICE,
         SUPPORT,
         WP,
-        NOTIFICATIONS
+        NOTIFICATIONS,
+        LOGIN
     }
 
     // Breaking convention to be consistent with org.wordpress.android.util.AppLog

--- a/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
+++ b/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
@@ -1,148 +1,94 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:app="http://schemas.android.com/apk/res-auto"
-                xmlns:tools="http://schemas.android.com/tools"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:background="@color/wc_grey_light"
-                android:orientation="vertical">
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/login_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/wc_grey_light">
 
     <ImageView
         android:id="@+id/image_avatar"
         android:layout_width="@dimen/login_avatar_size"
         android:layout_height="@dimen/login_avatar_size"
-        android:layout_centerHorizontal="true"
         android:layout_marginTop="40dp"
         android:contentDescription="@string/login_avatar_content_description"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         tools:srcCompat="@drawable/ic_placeholder_gravatar_grey_lighten_20_100dp"/>
 
     <TextView
         android:id="@+id/text_displayname"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/image_avatar"
-        android:layout_centerHorizontal="true"
         android:layout_marginTop="@dimen/margin_large"
         android:textColor="@color/grey_dark"
         android:textSize="@dimen/text_extra_large"
-        tools:text="text_username"/>
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/image_avatar"
+        tools:text="droidtester2018"/>
 
     <TextView
         android:id="@+id/text_username"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/text_displayname"
-        android:layout_centerHorizontal="true"
         android:textColor="@color/grey_dark"
         android:textSize="@dimen/text_large"
-        tools:text="text_displayname"/>
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/text_displayname"
+        tools:text="\@droidtester2018"/>
 
-    <android.support.v4.widget.NestedScrollView
+    <android.support.v7.widget.CardView
+        android:id="@+id/site_list_container"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_above="@+id/frame_bottom"
-        android:layout_below="@+id/text_username">
+        android:layout_height="0dp"
+        android:layout_marginBottom="8dp"
+        android:layout_marginTop="@dimen/margin_extra_extra_medium_large"
+        app:cardElevation="@dimen/card_elevation"
+        app:layout_constraintBottom_toTopOf="@+id/view6"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/text_username"
+        app:layout_constraintVertical_bias="0.0"
+        tools:visibility="visible">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <FrameLayout
-                android:id="@+id/supported_frame_list_container"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+            <TextView
+                android:id="@+id/site_list_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingEnd="@dimen/margin_extra_large"
+                android:paddingStart="@dimen/margin_extra_large"
+                android:paddingTop="@dimen/margin_extra_large"
+                android:text="@string/login_pick_store"
+                android:textColor="@color/wc_purple"
+                android:textSize="@dimen/text_large"
+                android:textStyle="bold"/>
 
-                <android.support.v7.widget.CardView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/margin_extra_small"
-                    android:layout_marginTop="@dimen/margin_extra_extra_medium_large"
-                    app:cardElevation="@dimen/card_elevation">
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:id="@+id/supported_text_list_label"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:paddingEnd="@dimen/margin_extra_large"
-                            android:paddingStart="@dimen/margin_extra_large"
-                            android:paddingTop="@dimen/margin_extra_large"
-                            android:text="@string/login_pick_store"
-                            android:textColor="@color/wc_purple"
-                            android:textSize="@dimen/text_large"
-                            android:textStyle="bold"/>
-
-                        <android.support.v7.widget.RecyclerView
-                            android:id="@+id/supported_recycler"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:clipChildren="false"
-                            android:clipToPadding="false"
-                            android:paddingBottom="@dimen/margin_extra_large"
-                            android:paddingEnd="@dimen/margin_extra_large"
-                            android:paddingStart="@dimen/margin_extra_large"/>
-                    </LinearLayout>
-                </android.support.v7.widget.CardView>
-            </FrameLayout>
-
-            <FrameLayout
-                android:id="@+id/unsupported_frame_list_container"
+            <android.support.v7.widget.RecyclerView
+                android:id="@+id/sites_recycler"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:visibility="gone"
-                tools:visibility="visible">
-
-                <android.support.v7.widget.CardView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/margin_extra_small"
-                    android:layout_marginTop="@dimen/margin_extra_extra_medium_large"
-                    app:cardElevation="@dimen/card_elevation">
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:id="@+id/unsupported_text_list_label"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:paddingEnd="@dimen/margin_extra_large"
-                            android:paddingStart="@dimen/margin_extra_large"
-                            android:paddingTop="@dimen/margin_extra_large"
-                            android:text="@string/login_site_list_update_required"
-                            android:textColor="@color/wc_purple"
-                            android:textSize="@dimen/text_large"
-                            android:textStyle="bold"/>
-
-                        <android.support.v7.widget.RecyclerView
-                            android:id="@+id/unsupported_recycler"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:clipChildren="false"
-                            android:clipToPadding="false"
-                            android:paddingBottom="@dimen/margin_extra_large"
-                            android:paddingEnd="@dimen/margin_extra_large"
-                            android:paddingStart="@dimen/margin_extra_large"/>
-                    </LinearLayout>
-                </android.support.v7.widget.CardView>
-            </FrameLayout>
+                android:clipChildren="false"
+                android:clipToPadding="false"
+                android:paddingBottom="@dimen/margin_extra_large"
+                android:paddingEnd="@dimen/margin_extra_large"
+                android:paddingStart="@dimen/margin_extra_large"/>
         </LinearLayout>
-    </android.support.v4.widget.NestedScrollView>
+    </android.support.v7.widget.CardView>
 
     <TextView
         android:id="@+id/no_stores_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/text_username"
-        android:layout_centerHorizontal="true"
-        android:layout_marginEnd="@dimen/margin_extra_large"
-        android:layout_marginStart="@dimen/margin_extra_large"
         android:layout_marginTop="@dimen/margin_extra_extra_large"
         android:gravity="center_horizontal"
         android:orientation="vertical"
@@ -151,42 +97,38 @@
         android:textSize="@dimen/text_large"
         android:textStyle="bold"
         android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/text_username"
         tools:drawableTop="@drawable/ic_woo_no_store"
-        tools:visibility="visible"/>
+        tools:visibility="gone"/>
 
     <View
+        android:id="@+id/view6"
         android:layout_width="match_parent"
         android:layout_height="@dimen/appbar_elevation"
-        android:layout_above="@+id/frame_bottom"
-        android:background="@drawable/shadow_top"/>
+        android:background="@drawable/shadow_top"
+        app:layout_constraintBottom_toTopOf="@+id/frame_bottom"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"/>
 
-    <LinearLayout
+    <FrameLayout
         android:id="@+id/frame_bottom"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:background="@color/white"
         android:clipToPadding="false"
-        android:orientation="vertical"
-        android:padding="@dimen/margin_extra_large">
-
-        <android.support.v7.widget.AppCompatButton
-            android:id="@+id/button_update_instructions"
-            style="@style/Woo.Button.Grey"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/margin_medium"
-            android:layout_weight="1"
-            android:text="@string/button_update_instructions"
-            android:visibility="gone"
-            tools:visibility="visible"/>
+        android:padding="@dimen/margin_extra_large"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
 
         <android.support.v7.widget.AppCompatButton
             android:id="@+id/button_continue"
             style="@style/Woo.Button.Purple"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
             android:text="@string/continue_button"/>
-    </LinearLayout>
-</RelativeLayout>
+    </FrameLayout>
+</android.support.constraint.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/dialog_version_upgrade_required.xml
+++ b/WooCommerce/src/main/res/layout/dialog_version_upgrade_required.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:padding="@dimen/default_padding"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/login_update_required_title"
+        android:textAppearance="@style/Woo.TextAppearance.Title"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <TextView
+        android:id="@+id/textView2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/login_update_required_desc"
+        android:textAppearance="@style/Woo.TextAppearance.Medium"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView"/>
+
+    <android.support.v7.widget.AppCompatButton
+        android:id="@+id/upgrade_instructions"
+        style="@style/Woo.Button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end"
+        android:layout_marginBottom="8dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/button_update_instructions"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView2"/>
+
+    <android.support.v7.widget.AppCompatButton
+        android:id="@+id/upgrade_dismiss"
+        style="@style/Woo.Button.Purple"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/dismiss"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toEndOf="@+id/upgrade_instructions"
+        app:layout_constraintTop_toBottomOf="@+id/textView2"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -58,6 +58,7 @@
     <string name="search">Search</string>
     <string name="back">Back</string>
     <string name="button_update_instructions">Update instructions</string>
+    <string name="dismiss">Dismiss</string>
 
     <!--
         Date/Time Labels
@@ -95,8 +96,10 @@
     <string name="login_configure_link">Read the %sconfiguration instructions%s.</string>
     <string name="login_pick_store">Pick store</string>
     <string name="login_connected_store">Connected store</string>
-    <string name="login_verifying_sites">Verifying sites…</string>
-    <string name="login_site_list_update_required">Update to WooCommerce 3.5 required</string>
+    <string name="login_verifying_site">Verifying site…</string>
+    <string name="login_verifying_site_error">Cannot connect to %s</string>
+    <string name="login_update_required_title">Update Store to WooCommerce 3.5</string>
+    <string name="login_update_required_desc">This app requires WooCommerce 3.5 on your server. To continue using this app, please update your store.</string>
     <string name="login_avatar_content_description">Your profile photo</string>
     <string name="login_nostores_content_description">No WooCommerce stores</string>
     <string name="login_with_a_different_account">Login with a different account</string>


### PR DESCRIPTION
This PR fixes #691 and changes the design of the site selector to more closely match the iOS version.

The former design validated all stores up front and then displayed stores that did not meet the minimum api version requirements in a separate section. The problem was that if the store could not be validated for one reason or another, they would automatically show up in the "Update required" section, even though they _may_ be running the correct version of WooCommerce. A couple ideas were thrown around to address this like creating a separate section for the stores that could not be verified, but in the end we decided to match the iOS design since it allows more flexibility on how to handle the validation response at the individual site level.

The new design will show all Woo stores in a single list and then validation will happen when the user _**selects a store**_. There are three possible outcomes of this validation:
1. The store passes -> the **continue** button will enable
2. The store's api version does not meet the minimum requirements (failed) -> a dialog will be shown advising the user to upgrade their WooCommerce plugin.
3. The store cannot be verified for some reason (error) -> display a snack error message

<img src="https://user-images.githubusercontent.com/5810477/51491827-989c2c00-1d7d-11e9-9caa-91bf965862c0.gif" width="300">
