### PR TITLE
Add RELEASE-NOTES.txt file to encourage adding release notes iteratively

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+
+Update release notes:
+
+- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.


### PR DESCRIPTION
This PR adds a RELEASE-NOTES.txt file to encourage adding release notes iteratively. It also modifies the standard PR template adding a related reminder.