### PR TITLE
Issue/640 notifs markread snack

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -37,7 +37,9 @@ object AppPrefs {
         // Enable notifications for new reviews
         NOTIFS_REVIEWS_ENABLED,
         // Play cha-ching sound on new order notifications
-        NOTIFS_ORDERS_CHA_CHING_ENABLED
+        NOTIFS_ORDERS_CHA_CHING_ENABLED,
+        // Number of times the "mark all notifications read" icon was tapped
+        NUM_TIMES_MARK_ALL_NOTIFS_READ_SNACK_SHOWN
     }
 
     fun init(context: Context) {
@@ -114,6 +116,14 @@ object AppPrefs {
 
     fun setHasUnseenNotifs(hasUnseen: Boolean) {
         setBoolean(DeletablePrefKey.HAS_UNSEEN_NOTIFS, hasUnseen)
+    }
+
+    fun getNumTimesMarkAllReadSnackShown(): Int =
+            getInt(UndeletablePrefKey.NUM_TIMES_MARK_ALL_NOTIFS_READ_SNACK_SHOWN, 0)
+
+    fun incNumTimesMarkAllReadSnackShown() {
+        val numTimesShown = getNumTimesMarkAllReadSnackShown() + 1
+        setInt(UndeletablePrefKey.NUM_TIMES_MARK_ALL_NOTIFS_READ_SNACK_SHOWN, numTimesShown)
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListContract.kt
@@ -28,5 +28,6 @@ interface NotifsListContract {
         fun openReviewDetail(notification: NotificationModel)
         fun visuallyMarkNotificationsAsRead()
         fun showMarkAllNotificationsReadError()
+        fun showMarkAllNotificationsReadSuccess()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListContract.kt
@@ -29,5 +29,6 @@ interface NotifsListContract {
         fun visuallyMarkNotificationsAsRead()
         fun showMarkAllNotificationsReadError()
         fun showMarkAllNotificationsReadSuccess()
+        fun showMarkAllNotificationsReadNone()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
@@ -397,8 +397,12 @@ class NotifsListFragment : TopLevelFragment(), NotifsListContract.View, NotifsLi
         notifsAdapter.markAllNotifsAsRead()
     }
 
-    override fun showMarkAllNotificationsReadError() {
+    override fun showMarkAllNotificationsReadSuccess() {
         uiMessageResolver.showSnack(R.string.wc_mark_all_read_error)
+    }
+
+    override fun showMarkAllNotificationsReadError() {
+        uiMessageResolver.showSnack(R.string.wc_mark_all_read_success)
     }
 
     private fun revertPendingModeratedNotifState() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
@@ -402,9 +402,9 @@ class NotifsListFragment : TopLevelFragment(), NotifsListContract.View, NotifsLi
     }
 
     /*
-     * TODO: this snack is shown when the user taps to marks all notifs as read and there
+     * TODO: this snack is shown when the user taps to mark all notifs as read and there
      * are no unread notifs - this is temporary, there is a separate issue filed to hide
-     * the mark all read option when there are no unread notfs
+     * the mark all read option when there are no unread notifs
      */
     override fun showMarkAllNotificationsReadNone() {
         uiMessageResolver.showSnack(R.string.wc_mark_all_read_none)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
@@ -398,11 +398,20 @@ class NotifsListFragment : TopLevelFragment(), NotifsListContract.View, NotifsLi
     }
 
     override fun showMarkAllNotificationsReadSuccess() {
-        uiMessageResolver.showSnack(R.string.wc_mark_all_read_error)
+        uiMessageResolver.showSnack(R.string.wc_mark_all_read_success)
+    }
+
+    /*
+     * TODO: this snack is shown when the user taps to marks all notifs as read and there
+     * are no unread notifs - this is temporary, there is a separate issue filed to hide
+     * the mark all read option when there are no unread notfs
+     */
+    override fun showMarkAllNotificationsReadNone() {
+        uiMessageResolver.showSnack(R.string.wc_mark_all_read_none)
     }
 
     override fun showMarkAllNotificationsReadError() {
-        uiMessageResolver.showSnack(R.string.wc_mark_all_read_success)
+        uiMessageResolver.showSnack(R.string.wc_mark_all_read_error)
     }
 
     private fun revertPendingModeratedNotifState() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListPresenter.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.notifications
 
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.network.ConnectionChangeReceiver
@@ -108,7 +109,13 @@ class NotifsListPresenter @Inject constructor(
                 // Optimistic design - update the UI immediately to show all notifs are now
                 // marked as read. If this fails, the list will be reloaded by the database.
                 view?.visuallyMarkNotificationsAsRead()
-                view?.showMarkAllNotificationsReadSuccess()
+
+                // we only show this snackbar twice to avoid annoying the user
+                val numTimesShown = AppPrefs.getNumTimesMarkAllReadSnackShown()
+                if (numTimesShown < 2) {
+                    AppPrefs.incNumTimesMarkAllReadSnackShown()
+                    view?.showMarkAllNotificationsReadSuccess()
+                }
             } else {
                 view?.showMarkAllNotificationsReadNone()
                 WooLog.d(NOTIFICATIONS, "Mark all as read: No unread notifications found. Exiting.")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListPresenter.kt
@@ -108,6 +108,7 @@ class NotifsListPresenter @Inject constructor(
                 // Optimistic design - update the UI immediately to show all notifs are now
                 // marked as read. If this fails, the list will be reloaded by the database.
                 view?.visuallyMarkNotificationsAsRead()
+                view?.showMarkAllNotificationsReadSuccess()
             } else {
                 WooLog.d(NOTIFICATIONS, "Mark all as read: No unread notifications found. Exiting.")
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListPresenter.kt
@@ -110,6 +110,7 @@ class NotifsListPresenter @Inject constructor(
                 view?.visuallyMarkNotificationsAsRead()
                 view?.showMarkAllNotificationsReadSuccess()
             } else {
+                view?.showMarkAllNotificationsReadNone()
                 WooLog.d(NOTIFICATIONS, "Mark all as read: No unread notifications found. Exiting.")
             }
         }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -319,6 +319,7 @@
     <string name="wc_mark_all_read">Mark all as read</string>
     <string name="wc_mark_all_read_success">All notifications marked as read</string>
     <string name="wc_mark_all_read_error">Error marking all notifications as read</string>
+    <string name="wc_mark_all_read_none">No unread notifications</string>
     <!--
         Login Library Imported Strings
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -317,6 +317,7 @@
         Notifications List
     -->
     <string name="wc_mark_all_read">Mark all as read</string>
+    <string name="wc_mark_all_read_success">All notifications marked as read</string>
     <string name="wc_mark_all_read_error">Error marking all notifications as read</string>
     <!--
         Login Library Imported Strings


### PR DESCRIPTION
Resolves #640 - adds a snackbar after the user taps to mark all notifications as read. As per the issue, the snackbar should only be displayed the first 2 times the user clicks the menu option.