### PR TITLE
Add strings from promo screenshots

### DIFF
--- a/WooCommerce/metadata/PlayStoreStrings.pot
+++ b/WooCommerce/metadata/PlayStoreStrings.pot
@@ -57,3 +57,70 @@ msgctxt "play_store_app_title"
 msgid "WooCommerce"
 msgstr ""
 
+#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
+#. No specified characters limit here, but try to keep as short as the source one. 
+msgctxt "app_store_screenshot-1"
+msgid ""
+"Your Store\n"
+"in Your Pocket"
+msgstr ""
+
+#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
+#. No specified characters limit here, but try to keep as short as the source one. 
+msgctxt "app_store_screenshot-1_b"
+msgid ""
+"Made with\n"
+"at Automattic"
+msgstr ""
+
+#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
+#. No specified characters limit here, but try to keep as short as the source one. 
+msgctxt "app_store_screenshot-2"
+msgid "View and manage orders"
+msgstr ""
+
+#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
+#. No specified characters limit here, but try to keep as short as the source one. 
+msgctxt "app_store_screenshot-3"
+msgid "Get real-time order alerts"
+msgstr ""
+
+#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
+#. No specified characters limit here, but try to keep as short as the source one. 
+msgctxt "app_store_screenshot-4"
+msgid "Track order status"
+msgstr ""
+
+#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
+#. No specified characters limit here, but try to keep as short as the source one. 
+msgctxt "app_store_screenshot-5"
+msgid ""
+"Scroll through, filter,\n"
+"or look up specific orders"
+msgstr ""
+
+#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
+#. No specified characters limit here, but try to keep as short as the source one. 
+msgctxt "app_store_screenshot-6"
+msgid ""
+"View store data by week,\n"
+"month, and year"
+msgstr ""
+
+#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
+#. No specified characters limit here, but try to keep as short as the source one. 
+msgctxt "app_store_screenshot-7"
+msgid ""
+"Check which products are\n"
+"performing best"
+msgstr ""
+
+#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
+#. No specified characters limit here, but try to keep as short as the source one. 
+msgctxt "app_store_screenshot-8"
+msgid ""
+"Get notified about new\n"
+"customer reviews"
+msgstr ""
+
+

--- a/WooCommerce/metadata/promo_screenshot_1.txt
+++ b/WooCommerce/metadata/promo_screenshot_1.txt
@@ -1,0 +1,2 @@
+Your Store
+in Your Pocket

--- a/WooCommerce/metadata/promo_screenshot_1_b.txt
+++ b/WooCommerce/metadata/promo_screenshot_1_b.txt
@@ -1,0 +1,2 @@
+Made with
+at Automattic

--- a/WooCommerce/metadata/promo_screenshot_2.txt
+++ b/WooCommerce/metadata/promo_screenshot_2.txt
@@ -1,0 +1,1 @@
+View and manage orders

--- a/WooCommerce/metadata/promo_screenshot_3.txt
+++ b/WooCommerce/metadata/promo_screenshot_3.txt
@@ -1,0 +1,1 @@
+Get real-time order alerts

--- a/WooCommerce/metadata/promo_screenshot_4.txt
+++ b/WooCommerce/metadata/promo_screenshot_4.txt
@@ -1,0 +1,1 @@
+Track order status

--- a/WooCommerce/metadata/promo_screenshot_5.txt
+++ b/WooCommerce/metadata/promo_screenshot_5.txt
@@ -1,0 +1,2 @@
+Scroll through, filter,
+or look up specific orders

--- a/WooCommerce/metadata/promo_screenshot_6.txt
+++ b/WooCommerce/metadata/promo_screenshot_6.txt
@@ -1,0 +1,2 @@
+View store data by week,
+month, and year

--- a/WooCommerce/metadata/promo_screenshot_7.txt
+++ b/WooCommerce/metadata/promo_screenshot_7.txt
@@ -1,0 +1,2 @@
+Check which products are
+performing best

--- a/WooCommerce/metadata/promo_screenshot_8.txt
+++ b/WooCommerce/metadata/promo_screenshot_8.txt
@@ -1,0 +1,2 @@
+Get notified about new
+customer reviews

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -31,7 +31,16 @@ lane :update_ps_strings do |options|
     release_note: prj_folder + "/WooCommerce/metadata/release_notes.txt",
     play_store_promo: prj_folder + "/WooCommerce/metadata/short_description.txt",
     play_store_desc: prj_folder + "/WooCommerce/metadata/full_description.txt",
-    play_store_app_title: prj_folder + "/WooCommerce/metadata/title.txt"
+    play_store_app_title: prj_folder + "/WooCommerce/metadata/title.txt",
+    play_store_screenshot_1: prj_folder + "/WooCommerce/metadata/promo_screenshot_1.txt",
+    play_store_screenshot_1_b: prj_folder + "/WooCommerce/metadata/promo_screenshot_1_b.txt",
+    play_store_screenshot_2: prj_folder + "/WooCommerce/metadata/promo_screenshot_2.txt",
+    play_store_screenshot_3: prj_folder + "/WooCommerce/metadata/promo_screenshot_3.txt",
+    play_store_screenshot_4: prj_folder + "/WooCommerce/metadata/promo_screenshot_4.txt",
+    play_store_screenshot_5: prj_folder + "/WooCommerce/metadata/promo_screenshot_5.txt",
+    play_store_screenshot_6: prj_folder + "/WooCommerce/metadata/promo_screenshot_6.txt",
+    play_store_screenshot_7: prj_folder + "/WooCommerce/metadata/promo_screenshot_7.txt",
+    play_store_screenshot_8: prj_folder + "/WooCommerce/metadata/promo_screenshot_8.txt"
   }
 
   android_update_metadata_source(po_file_path: prj_folder + "/WooCommerce/metadata/PlayStoreStrings.pot", 


### PR DESCRIPTION
This PR adds the strings used as promotional messages in the screenshots to the set of strings to send to translators.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
