### PR TITLE
Update Woo site settings during login and periodically

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -17,6 +17,8 @@ import com.woocommerce.android.network.ConnectionChangeReceiver
 import com.woocommerce.android.push.FCMRegistrationIntentService
 import com.woocommerce.android.push.NotificationHandler
 import com.woocommerce.android.support.ZendeskHelper
+import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.tools.RateLimitedTask
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.ApplicationLifecycleMonitor
 import com.woocommerce.android.util.ApplicationLifecycleMonitor.ApplicationLifecycleListener
@@ -35,10 +37,12 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.AccountAction
+import org.wordpress.android.fluxc.generated.WCCoreActionBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.OnJetpackTimeoutError
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
+import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.utils.ErrorUtils.OnUnexpectedError
 import org.wordpress.android.util.PackageUtils
 import javax.inject.Inject
@@ -51,8 +55,10 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
 
     @Inject lateinit var dispatcher: Dispatcher
     @Inject lateinit var accountStore: AccountStore
+    @Inject lateinit var wooCommerceStore: WooCommerceStore // Required to ensure the WooCommerceStore is initialized
 
     @Inject lateinit var selectedSite: SelectedSite
+    @Inject lateinit var networkStatus: NetworkStatus
     @Inject lateinit var zendeskHelper: ZendeskHelper
     @Inject lateinit var notificationHandler: NotificationHandler
 
@@ -64,6 +70,22 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
         DaggerAppComponent.builder()
                 .application(this)
                 .build()
+    }
+
+    companion object {
+        private const val SECONDS_BETWEEN_SITE_UPDATE = 60 * 60 // 1 hour
+    }
+
+    /**
+     * Update WooCommerce site settings in a background task.
+     */
+    private val updateSelectedSite: RateLimitedTask = object : RateLimitedTask(SECONDS_BETWEEN_SITE_UPDATE) {
+        override fun run(): Boolean {
+            if (selectedSite.exists()) {
+                dispatcher.dispatch(WCCoreActionBuilder.newFetchSiteSettingsAction(selectedSite.get()))
+            }
+            return true
+        }
     }
 
     override fun onCreate() {
@@ -111,6 +133,10 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
         if (isGooglePlayServicesAvailable(applicationContext)) {
             // Register for Cloud messaging
             FCMRegistrationIntentService.enqueueWork(this)
+        }
+
+        if (networkStatus.isConnected()) {
+            updateSelectedSite.runIfNotLimited()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/RateLimitedTask.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/RateLimitedTask.kt
@@ -1,0 +1,29 @@
+package com.woocommerce.android.tools
+
+import org.wordpress.android.util.DateTimeUtils
+import java.util.Date
+
+abstract class RateLimitedTask(private val minRateInSeconds: Int) {
+    private var lastUpdate: Date? = null
+
+    @Synchronized fun forceRun(): Boolean {
+        if (run()) {
+            lastUpdate = Date()
+            return true
+        }
+        return false
+    }
+
+    @Synchronized fun runIfNotLimited(): Boolean {
+        val now = Date()
+        if (lastUpdate == null || DateTimeUtils.secondsBetween(now, lastUpdate) >= minRateInSeconds) {
+            if (run()) {
+                lastUpdate = now
+                return true
+            }
+        }
+        return false
+    }
+
+    protected abstract fun run(): Boolean
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
@@ -134,6 +134,8 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
                         mapOf(AnalyticsTracker.KEY_SELECTED_STORE_ID to site.id))
                 loginProgressDialog = ProgressDialog.show(this, null, getString(R.string.login_verifying_site))
                 presenter.verifySiteApiVersion(it)
+                // Preemptively also update the site settings so we have them available sooner
+                presenter.updateWooSiteSettings(it)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueContract.kt
@@ -16,6 +16,7 @@ interface LoginEpilogueContract {
         fun loadSites()
         fun getSitesForLocalIds(siteIdList: IntArray): List<SiteModel>
         fun verifySiteApiVersion(site: SiteModel)
+        fun updateWooSiteSettings(site: SiteModel)
     }
 
     interface View : BaseView<Presenter> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpiloguePresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpiloguePresenter.kt
@@ -62,6 +62,10 @@ class LoginEpiloguePresenter @Inject constructor(
         dispatcher.dispatch(WCCoreActionBuilder.newFetchSiteApiVersionAction(site))
     }
 
+    override fun updateWooSiteSettings(site: SiteModel) {
+        dispatcher.dispatch(WCCoreActionBuilder.newFetchSiteSettingsAction(site))
+    }
+
     override fun getSitesForLocalIds(siteIdList: IntArray): List<SiteModel> {
         return siteIdList.map { siteStore.getSiteByLocalId(it) }
     }


### PR DESCRIPTION
Precursor to #148. In order to format currencies for display based on the WooCommerce site's settings, we need to have the settings fetched and stored. Actual using the site settings to format currency for display will come in a follow-up PR.

This PR is making use of this already reviewed and merged FluxC PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1093.

This PR makes two changes:

#### 1. Background sync

When the app is resumed, the site settings will be fetched and refreshed in the background. This is rate-limited to no more frequently than once an hour.

The logic here is based on how we keep basic WordPress.com site settings up to date [in the WordPress app](https://github.com/wordpress-mobile/WordPress-Android/blob/5bef5bd881f92345bee86c97e6ddedc59fd21d34/WordPress/src/main/java/org/wordpress/android/WordPress.java#L826).

Note that apart from WooCommerce site settings, we should also update the WordPress.com site and account settings (and one day the entire WordPress.com site list when we support site switching). This is already tracked in https://github.com/woocommerce/woocommerce-android/issues/276 - I think I'll pick this up and add it in a separate PR.

#### 2. Fetch on login

We also need the settings available once login is completed. I tried something a bit sneaky here, and added a background fetch of the settings at the same time as the WooCommerce API version supported by the site is checked. This seemed better than holding up the flow at the very end to update the settings, and should mean the settings are fetched and available by the time the initial dashboard data is available to be formatted.

### To test

Migration path:
1. Build current `develop`, and login
2. Build this branch
3. When the app runs, confirm that you see a `Dispatching action: WCCoreAction-FETCH_SITE_SETTINGS` log message
4. You can check that the site settings have been synced by inspecting the `WCSettingsModel` table via Stetho
5. Background and restore the app
6. Ensure you don't see a new `FETCH_SITE_SETTINGS` action

Login path:
1. Build this branch and run a clean install
2. Ensure you see a `Dispatching action: WCCoreAction-FETCH_SITE_SETTINGS` log message when attempting to continue with a selected site in the login epilogue screen
3. Ensure you don't see a second `FETCH_SITE_SETTINGS` (from the background task)

### Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.