### PR TITLE
Do not overwrite saved fragment states while restoring bottom nav state

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,0 +1,2 @@
+Bugfixes
+- Issue with order notes not saving properly during activity restore (low memory situations) resolved

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -153,7 +153,7 @@ class MainActivity : AppCompatActivity(),
         // Restore the current navigation position
         savedInstanceState?.also {
             val id = it.getInt(STATE_KEY_POSITION, BottomNavigationPosition.DASHBOARD.id)
-            bottomNavView.currentPosition = findNavigationPositionById(id)
+            bottomNavView.restoreSelectedItemState(id)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
@@ -69,6 +69,16 @@ class MainNavigationView @JvmOverloads constructor(
         updateCurrentPosition(navPos, true)
     }
 
+    /**
+     * For use when restoring the navigation bar after the host activity
+     * state has been restored.
+     */
+    fun restoreSelectedItemState(itemId: Int) {
+        assignNavigationListeners(false)
+        selectedItemId = itemId
+        assignNavigationListeners(true)
+    }
+
     fun showNotificationBadge(show: Boolean) {
         with(badgeView) {
             if (show && visibility != View.VISIBLE) {


### PR DESCRIPTION
This PR fixes #666 which started out as an issue causing crashes while adding notes in situations where `MainActivity` had to be restored (low memory or intentionally not keeping activities scenarios). After the top level fragment fixes in the last main release, this downgraded itself to just a bug fix as the crash was not happening anymore. In actuality, that fix fixed the bug causing the crash, but introduced a new bug with pretty much the same end result -> the order note was not saved.

Update release notes:
- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

## The Problem
Restoring the `MainActivity` state was forcing the bottom navigation bar to completely clear the fragment backstack and start from scratch. This meant that if a child fragment, like `OrderDetailFragment`, was open it would no longer be open once restored. Since adding an order note opens a new activity, the previous activity would be destroyed in low memory situations and since the restore wasn't restoring the `OrderDetailFragment`, the request to save an order note was just dying in transit.

## To Test
Make sure to set `Don't Keep Activities` to ON in the test device's Developer options.

To recreate the issue:
1. build and open the app from the `develop` branch
2. open an order from the orders list view
3. click the option to add a note
4. type in note text and click **add**
The view will close, the user will be routed back to the order list, and the note **will not** be saved.

To test the fix:
1. build and open the app from this branch
2. follow steps 2-4 above
The note should save as expected.
