### PR TITLE
Issue/699 login epilogue help

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -76,6 +76,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         LOGIN_PROLOGUE_JETPACK_CONFIGURATION_INSTRUCTIONS_LINK_TAPPED(siteless = true),
         LOGIN_EPILOGUE_STORES_SHOWN(siteless = true),
         LOGIN_EPILOGUE_STORE_PICKER_CONTINUE_TAPPED(siteless = true),
+        LOGIN_EPILOGUE_HELP_BUTTON_TAPPED(siteless = true),
 
         // -- Dashboard
         DASHBOARD_PULLED_TO_REFRESH,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -154,6 +154,7 @@ class HelpActivity : AppCompatActivity() {
         LOGIN_SITE_ADDRESS("origin:login-site-address"),
         LOGIN_SOCIAL("origin:login-social"),
         LOGIN_USERNAME_PASSWORD("origin:login-username-password"),
+        LOGIN_EPILOGUE("origin:login-epilogue"),
         SIGNUP_EMAIL("origin:signup-email"),
         SIGNUP_MAGIC_LINK("origin:signup-magic-link");
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
@@ -8,6 +8,8 @@ import android.support.v7.app.AppCompatActivity
 import android.support.v7.content.res.AppCompatResources
 import android.support.v7.widget.LinearLayoutManager
 import android.text.TextUtils
+import android.view.Menu
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import com.woocommerce.android.R
@@ -15,6 +17,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.di.GlideApp
 import com.woocommerce.android.push.FCMRegistrationIntentService
+import com.woocommerce.android.support.HelpActivity
+import com.woocommerce.android.support.HelpActivity.Origin
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.adapter.SiteListAdapter
 import com.woocommerce.android.ui.login.adapter.SiteListAdapter.OnSiteClickListener
@@ -89,6 +93,20 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
         AnalyticsTracker.trackBackPressed(this)
 
         finish()
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        menuInflater.inflate(R.menu.menu_help, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem?): Boolean {
+        if (item!!.itemId == R.id.menu_help) {
+            startActivity(HelpActivity.createIntent(this, Origin.LOGIN_EPILOGUE, null))
+            return true
+        } else {
+            return super.onOptionsItemSelected(item)
+        }
     }
 
     override fun showUserInfo() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
@@ -8,8 +8,6 @@ import android.support.v7.app.AppCompatActivity
 import android.support.v7.content.res.AppCompatResources
 import android.support.v7.widget.LinearLayoutManager
 import android.text.TextUtils
-import android.view.Menu
-import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import com.woocommerce.android.R
@@ -69,6 +67,11 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
                     Stat.LOGIN_EPILOGUE_STORES_SHOWN,
                     mapOf(AnalyticsTracker.KEY_NUMBER_OF_STORES to presenter.getWooCommerceSites().size))
         }
+
+        button_help.setOnClickListener {
+            startActivity(HelpActivity.createIntent(this, Origin.LOGIN_EPILOGUE, null))
+            AnalyticsTracker.track(Stat.MAIN_MENU_CONTACT_SUPPORT_TAPPED)
+        }
     }
 
     override fun onResume() {
@@ -93,20 +96,6 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
         AnalyticsTracker.trackBackPressed(this)
 
         finish()
-    }
-
-    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
-        menuInflater.inflate(R.menu.menu_help, menu)
-        return true
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem?): Boolean {
-        if (item!!.itemId == R.id.menu_help) {
-            startActivity(HelpActivity.createIntent(this, Origin.LOGIN_EPILOGUE, null))
-            return true
-        } else {
-            return super.onOptionsItemSelected(item)
-        }
     }
 
     override fun showUserInfo() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginEpilogueActivity.kt
@@ -70,7 +70,7 @@ class LoginEpilogueActivity : AppCompatActivity(), LoginEpilogueContract.View, O
 
         button_help.setOnClickListener {
             startActivity(HelpActivity.createIntent(this, Origin.LOGIN_EPILOGUE, null))
-            AnalyticsTracker.track(Stat.MAIN_MENU_CONTACT_SUPPORT_TAPPED)
+            AnalyticsTracker.track(Stat.LOGIN_EPILOGUE_HELP_BUTTON_TAPPED)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -10,7 +10,6 @@ import android.support.v7.app.AppCompatDelegate
 import android.support.v7.widget.Toolbar
 import android.view.Menu
 import android.view.MenuItem
-import android.view.View
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -42,7 +41,6 @@ import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.support.HasSupportFragmentInjector
 import kotlinx.android.synthetic.main.activity_main.*
-import kotlinx.android.synthetic.main.notification_badge_view.*
 import org.wordpress.android.login.LoginAnalyticsListener
 import org.wordpress.android.login.LoginMode
 import org.wordpress.android.util.NetworkUtils
@@ -113,6 +111,7 @@ class MainActivity : AppCompatActivity(),
         }
 
         initFragment(savedInstanceState)
+        showLoginEpilogueScreen() // TODO: remove
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -111,7 +111,6 @@ class MainActivity : AppCompatActivity(),
         }
 
         initFragment(savedInstanceState)
-        showLoginEpilogueScreen() // TODO: remove
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {

--- a/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
+++ b/WooCommerce/src/main/res/layout/activity_login_epilogue.xml
@@ -8,6 +8,15 @@
     android:layout_height="match_parent"
     android:background="@color/wc_grey_light">
 
+    <Button
+        android:id="@+id/button_help"
+        style="@style/Woo.Button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/help"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
     <ImageView
         android:id="@+id/image_avatar"
         android:layout_width="@dimen/login_avatar_size"

--- a/WooCommerce/src/main/res/menu/menu_help.xml
+++ b/WooCommerce/src/main/res/menu/menu_help.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:app="http://schemas.android.com/apk/res-auto">
-
-    <item
-        android:id="@+id/menu_help"
-        android:title="@string/help"
-        app:showAsAction="always"/>
-</menu>

--- a/WooCommerce/src/main/res/menu/menu_help.xml
+++ b/WooCommerce/src/main/res/menu/menu_help.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/menu_help"
+        android:title="@string/help"
+        app:showAsAction="always"/>
+</menu>


### PR DESCRIPTION
Resolves #699 - adds a Help button to the login epilogue

![screenshot_1548760948](https://user-images.githubusercontent.com/3903757/51905594-a0685b80-238f-11e9-8152-5b5cbf436a40.png)

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
