### PR TITLE
Issue/425 hide future orders

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,3 +2,4 @@ Bugfixes
 - Issue with order notes not saving properly during activity restore (low memory situations) resolved
 - Fixed bug that caused the support menu to be hidden when the device has no email client
 - Scheduled orders with a future creation date are now hidden from the order list
+- Fixed crash in order detail when the "add order note" button is tapped before the order has been downloaded

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,4 @@
 Bugfixes
 - Issue with order notes not saving properly during activity restore (low memory situations) resolved
 - Fixed bug that caused the support menu to be hidden when the device has no email client
+- Scheduled orders with a future creation date are now hidden from the order list

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,2 +1,3 @@
 Bugfixes
 - Issue with order notes not saving properly during activity restore (low memory situations) resolved
+- Scheduled orders with a future creation date are now hidden from the order list

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListPresenter.kt
@@ -20,6 +20,8 @@ import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrdersSearched
 import org.wordpress.android.fluxc.store.WCOrderStore.SearchOrdersPayload
+import org.wordpress.android.util.DateTimeUtils
+import java.util.Date
 import javax.inject.Inject
 
 class OrderListPresenter @Inject constructor(
@@ -197,12 +199,13 @@ class OrderListPresenter @Inject constructor(
             orderStore.getOrdersForSite(selectedSite.get(), it)
         } ?: orderStore.getOrdersForSite(selectedSite.get())
         orderView?.let { view ->
-            if (orders.count() > 0) {
+            val filteredOrders = removeFutureOrders(orders)
+            if (filteredOrders.count() > 0) {
                 view.showNoOrdersView(false)
-                view.showOrders(orders, orderStatusFilter, isForceRefresh)
+                view.showOrders(filteredOrders, orderStatusFilter, isForceRefresh)
             } else {
                 if (!networkStatus.isConnected()) {
-                    // if the device if offline with no cached orders to display, show the loading
+                    // if the device is offline with no cached orders to display, show the loading
                     // indicator until a successful online refresh.
                     view.showSkeleton(true)
                 } else {
@@ -210,6 +213,24 @@ class OrderListPresenter @Inject constructor(
                 }
             }
         }
+    }
+
+    /**
+     * Removes orders with a future creation date so we don't show them in the order list
+     * https://github.com/woocommerce/woocommerce-android/issues/425
+     */
+    private fun removeFutureOrders(orders: List<WCOrderModel>): List<WCOrderModel> {
+        val now = DateTimeUtils.nowUTC()
+        val filteredOrders = ArrayList<WCOrderModel>()
+        orders.forEach() {
+            val orderDate = DateTimeUtils.dateUTCFromIso8601(it.dateCreated) ?: Date()
+            if (DateTimeUtils.daysBetween(now, orderDate) >= 0) {
+                filteredOrders.add(it)
+            } else {
+                WooLog.w(T.ORDERS, "Hiding future order ${it.dateCreated}")
+            }
+        }
+        return filteredOrders
     }
 
     @Suppress("unused")


### PR DESCRIPTION
Resolves #425 - mimicking the [iOS app](https://github.com/woocommerce/woocommerce-ios/pull/616), this PR hides orders with a future creation date unless it's today.

A simple way to test this is to change [this line](https://github.com/woocommerce/woocommerce-android/blob/c0a06dec915c2a0a68f3b42455d05e896dd6cc9b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListPresenter.kt#L223) to the following and verify that orders in the past 30 days are hidden:

```
val calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
calendar.add(Calendar.DAY_OF_YEAR, -30)
val now = calendar.time
```

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
