### PR TITLE
issue/715-illegal-state-noordersview

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,3 +2,4 @@ Bugfixes
 - Issue with order notes not saving properly during activity restore (low memory situations) resolved
 - Fixed bug that caused the support menu to be hidden when the device has no email client
 - Fixed bug that caused a crash when switching tabs while an order search was active
+- Fixed crash in order detail when the "add order note" button is tapped before the order has been downloaded

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,4 +2,5 @@ Bugfixes
 - Issue with order notes not saving properly during activity restore (low memory situations) resolved
 - Fixed bug that caused the support menu to be hidden when the device has no email client
 - Fixed bug that caused a crash when switching tabs while an order search was active
+- Scheduled orders with a future creation date are now hidden from the order list
 - Fixed crash in order detail when the "add order note" button is tapped before the order has been downloaded

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,4 @@
 Bugfixes
 - Issue with order notes not saving properly during activity restore (low memory situations) resolved
 - Fixed bug that caused the support menu to be hidden when the device has no email client
+- Fixed bug that caused a crash when switching tabs while an order search was active

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -294,6 +294,7 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View, OrderStatu
     }
 
     override fun onDestroyView() {
+        disableSearchListeners()
         presenter.dropView()
         filterMenuItem = null
         searchView = null


### PR DESCRIPTION
Resolves #715 by disabling the order search listeners when the order fragment's view is destroyed.

To test:
* Run `develop`
* Perform a search on the orders list
* Switch to the notifs tab
* BOOM!
* Run this branch, observe no boom :)

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
