### PR TITLE
origin/issue/720-runtime-exception-addordernote

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,4 @@
 Bugfixes
 - Issue with order notes not saving properly during activity restore (low memory situations) resolved
 - Fixed bug that caused the support menu to be hidden when the device has no email client
+- Fixed crash in order detail when the "add order note" button is tapped before the order has been downloaded

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
@@ -226,7 +226,7 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
         }
 
         // position not found, fail fast
-        throw IndexOutOfBoundsException("Unable to find matching position in section")
+        throw IndexOutOfBoundsException("Unable to find matching position $position in section")
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
@@ -251,7 +251,7 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
         }
 
         // position not found, fail fast
-        throw IndexOutOfBoundsException("Unable to find matching position in section")
+        throw IndexOutOfBoundsException("Unable to find matching section at position $position")
     }
     // endregion
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
@@ -16,7 +16,6 @@ import com.woocommerce.android.extensions.getTitleSnippet
 import com.woocommerce.android.extensions.getWooType
 import com.woocommerce.android.model.TimeGroup
 import com.woocommerce.android.util.WooLog
-import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.util.WooLog.T.NOTIFICATIONS
 import com.woocommerce.android.util.applyTransform
 import com.woocommerce.android.widgets.Section
@@ -138,10 +137,6 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
         notifsList.firstOrNull { it.remoteNoteId == remoteNoteId }?.let { notif ->
             // get the index
             val pos = notifsList.indexOfFirst { it == notif }
-            if (pos == -1) {
-                WooLog.w(T.NOTIFICATIONS, "Unable to hide notification with remoteId $remoteNoteId")
-                return
-            }
 
             // remove from the list
             val section = getSectionForListItemPosition(pos) as NotifsListSection
@@ -226,7 +221,7 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
         }
 
         // position not found, fail fast
-        throw IndexOutOfBoundsException("Unable to find matching position $position in section")
+        throw IndexOutOfBoundsException("Unable to find matching position in section")
     }
 
     /**
@@ -251,7 +246,7 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
         }
 
         // position not found, fail fast
-        throw IndexOutOfBoundsException("Unable to find matching section at position $position")
+        throw IndexOutOfBoundsException("Unable to find matching position in section")
     }
     // endregion
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.extensions.getTitleSnippet
 import com.woocommerce.android.extensions.getWooType
 import com.woocommerce.android.model.TimeGroup
 import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.util.WooLog.T.NOTIFICATIONS
 import com.woocommerce.android.util.applyTransform
 import com.woocommerce.android.widgets.Section
@@ -137,6 +138,10 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
         notifsList.firstOrNull { it.remoteNoteId == remoteNoteId }?.let { notif ->
             // get the index
             val pos = notifsList.indexOfFirst { it == notif }
+            if (pos == -1) {
+                WooLog.w(T.NOTIFICATIONS, "Unable to hide notification with remoteId $remoteNoteId")
+                return
+            }
 
             // remove from the list
             val section = getSectionForListItemPosition(pos) as NotifsListSection

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -310,10 +310,12 @@ class OrderDetailFragment : Fragment(), OrderDetailContract.View, OrderDetailNot
     }
 
     override fun showAddOrderNoteScreen() {
-        val intent = Intent(activity, AddOrderNoteActivity::class.java)
-        intent.putExtra(AddOrderNoteActivity.FIELD_ORDER_IDENTIFIER, presenter.orderModel?.getIdentifier())
-        intent.putExtra(AddOrderNoteActivity.FIELD_ORDER_NUMBER, presenter.orderModel?.number)
-        startActivityForResult(intent, REQUEST_CODE_ADD_NOTE)
+        presenter.orderModel?.let {
+            val intent = Intent(activity, AddOrderNoteActivity::class.java)
+            intent.putExtra(AddOrderNoteActivity.FIELD_ORDER_IDENTIFIER, it.getIdentifier())
+            intent.putExtra(AddOrderNoteActivity.FIELD_ORDER_NUMBER, it.number)
+            startActivityForResult(intent, REQUEST_CODE_ADD_NOTE)
+        }
     }
 
     override fun showAddOrderNoteSnack() {


### PR DESCRIPTION
Addresses #720 - I'm not 100% certain this fixes the issue because I couldn't repro it, but I believe this is what's happening:

* User taps an order notif for an order that hasn't been loaded yet
* Order detail appears and the order is requested
* User taps to add a note before the order request completes
* Crash because there's no order ID or number yet

If this is the cause of the crash, then this PR fixes the problem by ensuring we have an order before showing the add order note screen.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
