### PR TITLE
ssue/719-illegal-state-mainnav

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
@@ -121,7 +121,10 @@ class MainNavigationView @JvmOverloads constructor(
         // Close any child fragments if open
         clearFragmentBackStack(fragment)
 
-        fragmentManager.beginTransaction().replace(R.id.container, fragment, navPos.getTag()).commitNow()
+        fragmentManager
+                .beginTransaction()
+                .replace(R.id.container, fragment, navPos.getTag())
+                .commitAllowingStateLoss()
     }
 
     private fun assignNavigationListeners(assign: Boolean) {


### PR DESCRIPTION
Fixes #719 by using `commitAllowingStateLoss` when updating the navbar position to avoid IllegalStateException.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
