### PR TITLE
Issue/722 index out of bounds notifs

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
@@ -221,7 +221,7 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
         }
 
         // position not found, fail fast
-        throw IndexOutOfBoundsException("Unable to find matching position in section")
+        throw IndexOutOfBoundsException("Unable to find matching position $position in section")
     }
 
     /**
@@ -246,7 +246,7 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
         }
 
         // position not found, fail fast
-        throw IndexOutOfBoundsException("Unable to find matching position in section")
+        throw IndexOutOfBoundsException("Unable to find matching sectionfor position $position")
     }
     // endregion
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.extensions.getTitleSnippet
 import com.woocommerce.android.extensions.getWooType
 import com.woocommerce.android.model.TimeGroup
 import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.util.WooLog.T.NOTIFICATIONS
 import com.woocommerce.android.util.applyTransform
 import com.woocommerce.android.widgets.Section
@@ -134,23 +135,26 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
      * by reverting the action, or by loading a fresh list of notifications.
      */
     fun hideNotificationWithId(remoteNoteId: Long) {
-        notifsList.firstOrNull { it.remoteNoteId == remoteNoteId }?.let { notif ->
-            // get the index
-            val pos = notifsList.indexOfFirst { it == notif }
+        val pos = notifsList.indexOfFirst { it.remoteNoteId == remoteNoteId }
+        if (pos == -1) {
+            WooLog.w(T.NOTIFICATIONS, "Unable to hide notification, position is -1")
+            pendingRemovalNotification = null
+            return
+        }
 
-            // remove from the list
-            val section = getSectionForListItemPosition(pos) as NotifsListSection
-            val posInSection = getPositionInSectionByListPos(pos)
-            pendingRemovalNotification = Triple(notif, section, posInSection)
+        val notif = notifsList[pos]
+        val section = getSectionForListItemPosition(pos) as NotifsListSection
+        val posInSection = getPositionInSectionByListPos(pos)
+        pendingRemovalNotification = Triple(notif, section, posInSection)
 
-            section.list.removeAt(posInSection)
-            notifyItemRemovedFromSection(section, posInSection)
+        // remove from the list
+        section.list.removeAt(posInSection)
+        notifyItemRemovedFromSection(section, posInSection)
 
-            if (section.list.size == 0) {
-                val sectionPos = getSectionPosition(section)
-                section.isVisible = false
-                notifySectionChangedToInvisible(section, sectionPos)
-            }
+        if (section.list.size == 0) {
+            val sectionPos = getSectionPosition(section)
+            section.isVisible = false
+            notifySectionChangedToInvisible(section, sectionPos)
         }
     }
 


### PR DESCRIPTION
Potentially fixes #722 - the only way I could see the crash happening is if [this](https://github.com/woocommerce/woocommerce-android/blob/develop/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt#L139) returns -1, so I added a check for an invalid position [here](https://github.com/woocommerce/woocommerce-android/commit/5b3090c7c48f761eeb7443ef7dc6fdfb48619415#diff-57d252b4d4579f879de8c38c83b147cfR140).

I also changed the exception messages to include the passed position, to help us debug this if it continues to happen.

@AmandaRiu I'm requesting your review on this because you're very familiar with this code.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
