### PR TITLE
Refresh site and account periodically

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -37,11 +37,13 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.AccountAction
+import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.generated.WCCoreActionBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.OnJetpackTimeoutError
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.utils.ErrorUtils.OnUnexpectedError
 import org.wordpress.android.util.PackageUtils
@@ -55,6 +57,7 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
 
     @Inject lateinit var dispatcher: Dispatcher
     @Inject lateinit var accountStore: AccountStore
+    @Inject lateinit var siteStore: SiteStore // Required to ensure the SiteStore is initialized
     @Inject lateinit var wooCommerceStore: WooCommerceStore // Required to ensure the WooCommerceStore is initialized
 
     @Inject lateinit var selectedSite: SelectedSite
@@ -77,12 +80,15 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
     }
 
     /**
-     * Update WooCommerce site settings in a background task.
+     * Update WP.com and WooCommerce site settings in a background task.
      */
     private val updateSelectedSite: RateLimitedTask = object : RateLimitedTask(SECONDS_BETWEEN_SITE_UPDATE) {
         override fun run(): Boolean {
             if (selectedSite.exists()) {
-                dispatcher.dispatch(WCCoreActionBuilder.newFetchSiteSettingsAction(selectedSite.get()))
+                selectedSite.get().let {
+                    dispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(it))
+                    dispatcher.dispatch(WCCoreActionBuilder.newFetchSiteSettingsAction(it))
+                }
             }
             return true
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -85,11 +85,9 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
      */
     private val updateSelectedSite: RateLimitedTask = object : RateLimitedTask(SECONDS_BETWEEN_SITE_UPDATE) {
         override fun run(): Boolean {
-            if (selectedSite.exists()) {
-                selectedSite.get().let {
-                    dispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(it))
-                    dispatcher.dispatch(WCCoreActionBuilder.newFetchSiteSettingsAction(it))
-                }
+            selectedSite.getIfExists()?.let {
+                dispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(it))
+                dispatcher.dispatch(WCCoreActionBuilder.newFetchSiteSettingsAction(it))
             }
             return true
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -37,6 +37,7 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.AccountAction
+import org.wordpress.android.fluxc.generated.AccountActionBuilder
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.generated.WCCoreActionBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.OnJetpackTimeoutError
@@ -143,6 +144,14 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
 
         if (networkStatus.isConnected()) {
             updateSelectedSite.runIfNotLimited()
+        }
+    }
+
+    override fun onFirstActivityResumed() {
+        // Update the WP.com account details and settings every time the app is completely restarted
+        if (networkStatus.isConnected()) {
+            dispatcher.dispatch(AccountActionBuilder.newFetchAccountAction())
+            dispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction())
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
@@ -47,6 +47,8 @@ class SelectedSite(private var context: Context, private var siteStore: SiteStor
         return siteModel != null
     }
 
+    fun getIfExists(): SiteModel? = if (exists()) get() else null
+
     fun reset() {
         selectedSite = null
         getPreferences().edit().remove(SELECTED_SITE_LOCAL_ID).apply()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ApplicationLifecycleMonitor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ApplicationLifecycleMonitor.kt
@@ -10,6 +10,7 @@ class ApplicationLifecycleMonitor(private val lifecycleListener: ApplicationLife
     : Application.ActivityLifecycleCallbacks, ComponentCallbacks2 {
     interface ApplicationLifecycleListener {
         fun onAppComesFromBackground()
+        fun onFirstActivityResumed()
         fun onAppGoesToBackground()
     }
 
@@ -18,6 +19,7 @@ class ApplicationLifecycleMonitor(private val lifecycleListener: ApplicationLife
     }
 
     private var lastState = LastApplicationState.BACKGROUND
+    private var firstActivityResumed = true
 
     override fun onActivityPaused(activity: Activity?) {}
 
@@ -25,6 +27,11 @@ class ApplicationLifecycleMonitor(private val lifecycleListener: ApplicationLife
         if (lastState == LastApplicationState.BACKGROUND) {
             lastState = LastApplicationState.FOREGROUND
             lifecycleListener.onAppComesFromBackground()
+        }
+
+        if (firstActivityResumed) {
+            firstActivityResumed = false
+            lifecycleListener.onFirstActivityResumed()
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainPresenterTest.kt
@@ -68,6 +68,9 @@ class MainPresenterTest {
     @Test
     fun `Triggers a selected site update after site info fetch`() {
         // Magic link login requires the presenter to fetch account and site info
+        // Trigger the beginning of magic link flow to put the presenter in 'magic link' mode
+        mainPresenter.storeMagicLinkToken("a-token")
+
         // Check that the final OnSiteChanged triggers a site update
         mainPresenter.onSiteChanged(OnSiteChanged(6))
         verify(mainContractView).updateSelectedSite()


### PR DESCRIPTION
Resolves #276. In addition to the WooCommerce-specific site settings (added in https://github.com/woocommerce/woocommerce-android/pull/708), the general WP.com site settings (from the `/sites/$site/` endpoint) will also now be fetched whenever the app is brought to the foreground (as long as it's been at least an hour since the last fetch).

Also, the WP.com account settings for the user (`/me/` and `/me/settings/`) will be fetched periodically - once per clean launch of the app.

The behavior of site and account refreshes is following the same rules used for WPAndroid - we can probably adjust them if needed in future.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

### To test

A few cases to try:

1. If the app is completely stopped and launched, you should see `SiteAction-FETCH_SITE`, `AccountAction-FETCH_ACCOUNT`, and `AccountAction-FETCH_SETTINGS` actions dispatched in the logs (in addition to `WCCoreAction-FETCH_SITE_SETTINGS`).
2. If the app is backgrounded and foregrounded without being stopped:
    * No `FETCH_ACCOUNT` or `FETCH_SETTINGS` should be dispatched
    * If an hour has passed since the last one, a `FETCH_SITE_SETTINGS` should be dispatched (I advise tweaking the delay for this one for testing 😀)
3. Also test signin via magic link, since I had to make some changes to prevent multiple account/site fetches happening at the same time. Once logged in, backgrounding and foregrounding the app shouldn't trigger any site or account fetches.