### PR TITLE
issue/733-illegal-state-review-detail

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,3 +6,4 @@ Bugfixes
 - Fixed bug that caused a crash when switching tabs while an order search was active
 - Scheduled orders with a future creation date are now hidden from the order list
 - Fixed crash in order detail when the "add order note" button is tapped before the order has been downloaded
+- Fixed crash when a review is opened from the notification list

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/ReviewDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/ReviewDetailFragment.kt
@@ -83,6 +83,10 @@ class ReviewDetailFragment : Fragment(), ReviewDetailContract.View {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         presenter.takeView(this)
+    }
+
+    override fun onViewStateRestored(savedInstanceState: Bundle?) {
+        super.onViewStateRestored(savedInstanceState)
 
         arguments?.let {
             remoteNoteId = it.getLong(FIELD_REMOTE_NOTIF_ID)


### PR DESCRIPTION
Potentially fixes #733 - I wasn't able to repro this crash, but it seems clear from the stack trace that what's happening is the moderate button's `OnCheckedChangeListener` is being triggered when the fragment's view state is restored. When the moderate button is checked (or unchecked) the fragment is closed, which could lead to the crash since it's being closed before it has been fully restored.

If that's the case, this PR should fix the problem by loading the notif in `onViewStateRestored` instead of `onActivityCreated`. This way the check listener isn't assigned until after the view state is restored.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
