### PR TITLE
Issue/735 nosuchelement notification ext

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NotificationModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NotificationModelExt.kt
@@ -181,7 +181,6 @@ fun NotificationModel.isApproved(): Boolean {
 fun NotificationModel.canMarkAsSpam() = NotificationHelper
         .getCommentBlockFromBody(this)?.actions?.containsKey(ReviewActionKeys.ACTION_KEY_SPAM) ?: false
 
-
 /**
  * There is an action option for trash, but in the interest of consistent notification UX
  * between WPAndroid and WCAndroid, following WPAndroid.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NotificationModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NotificationModelExt.kt
@@ -165,7 +165,7 @@ fun NotificationModel.canModerate() = NotificationHelper
 /**
  * If the notification has been approved, return true, else false
  */
-fun NotificationModel.isApproved(): Boolean{
+fun NotificationModel.isApproved(): Boolean {
     NotificationHelper.getCommentBlockFromBody(this)?.actions?.let {
         return if (it.containsKey(ReviewActionKeys.ACTION_KEY_APPROVE)) {
             it.getValue(ReviewActionKeys.ACTION_KEY_APPROVE)
@@ -178,7 +178,7 @@ fun NotificationModel.isApproved(): Boolean{
 /**
  * If true, user can mark this notification as spam.
  */
-fun NotificationModel.canMarkAsSpam(): Boolean{
+fun NotificationModel.canMarkAsSpam(): Boolean {
     NotificationHelper.getCommentBlockFromBody(this)?.actions?.let {
         return if (it.containsKey(ReviewActionKeys.ACTION_KEY_SPAM)) {
             it.getValue(ReviewActionKeys.ACTION_KEY_SPAM)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NotificationModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NotificationModelExt.kt
@@ -178,8 +178,15 @@ fun NotificationModel.isApproved(): Boolean{
 /**
  * If true, user can mark this notification as spam.
  */
-fun NotificationModel.canMarkAsSpam() = NotificationHelper
-        .getCommentBlockFromBody(this)?.actions?.containsKey(ReviewActionKeys.ACTION_KEY_SPAM) ?: false
+fun NotificationModel.canMarkAsSpam(): Boolean{
+    NotificationHelper.getCommentBlockFromBody(this)?.actions?.let {
+        return if (it.containsKey(ReviewActionKeys.ACTION_KEY_SPAM)) {
+            it.getValue(ReviewActionKeys.ACTION_KEY_SPAM)
+        } else {
+            false
+        }
+    } ?: return false
+}
 
 /**
  * There is an action option for trash, but in the interest of consistent notification UX

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NotificationModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NotificationModelExt.kt
@@ -8,8 +8,8 @@ import com.woocommerce.android.extensions.WooNotificationType.UNKNOWN
 import com.woocommerce.android.ui.notifications.NotificationHelper
 import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.fluxc.model.CommentModel
-import org.wordpress.android.fluxc.model.CommentStatus.UNAPPROVED
 import org.wordpress.android.fluxc.model.CommentStatus.APPROVED
+import org.wordpress.android.fluxc.model.CommentStatus.UNAPPROVED
 import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.util.DateTimeUtils
 
@@ -165,8 +165,15 @@ fun NotificationModel.canModerate() = NotificationHelper
 /**
  * If the notification has been approved, return true, else false
  */
-fun NotificationModel.isApproved() = NotificationHelper
-        .getCommentBlockFromBody(this)?.actions?.getValue(ReviewActionKeys.ACTION_KEY_APPROVE) ?: false
+fun NotificationModel.isApproved(): Boolean{
+    NotificationHelper.getCommentBlockFromBody(this)?.actions?.let {
+        return if (it.containsKey(ReviewActionKeys.ACTION_KEY_APPROVE)) {
+            it.getValue(ReviewActionKeys.ACTION_KEY_APPROVE)
+        } else {
+            false
+        }
+    } ?: return false
+}
 
 /**
  * If true, user can mark this notification as spam.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NotificationModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NotificationModelExt.kt
@@ -178,15 +178,9 @@ fun NotificationModel.isApproved(): Boolean {
 /**
  * If true, user can mark this notification as spam.
  */
-fun NotificationModel.canMarkAsSpam(): Boolean {
-    NotificationHelper.getCommentBlockFromBody(this)?.actions?.let {
-        return if (it.containsKey(ReviewActionKeys.ACTION_KEY_SPAM)) {
-            it.getValue(ReviewActionKeys.ACTION_KEY_SPAM)
-        } else {
-            false
-        }
-    } ?: return false
-}
+fun NotificationModel.canMarkAsSpam() = NotificationHelper
+        .getCommentBlockFromBody(this)?.actions?.containsKey(ReviewActionKeys.ACTION_KEY_SPAM) ?: false
+
 
 /**
  * There is an action option for trash, but in the interest of consistent notification UX


### PR DESCRIPTION
Fixes #735 - fixes the `NoSuchElement` exception caused when reading the `ACTION_KEY_APPROVE` value when that key doesn't exist by first checking whether it exists. A similar change was made to the `ACTION_KEY_SPAM` reading, as that suffered the same problem.


<img width="751" alt="screen shot 2019-02-01 at 7 51 30 am" src="https://user-images.githubusercontent.com/3903757/52124247-a3b15080-25f6-11e9-8ca9-bea126f81d25.png">


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
