### PR TITLE
issue/738-illegal-state-order-detail

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -92,7 +92,7 @@ abstract class TopLevelFragment : Fragment(), TopLevelFragmentView {
                 )
                 .replace(R.id.container, fragment, tag)
                 .addToBackStack(tag)
-                .commit()
+                .commitAllowingStateLoss()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {


### PR DESCRIPTION
Fixes #738 by using `commitAllowingStateLoss` when loading child fragment to avoid `IllegalStateException`.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
