### PR TITLE
issue/746-resource-exception-login-2fa

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,3 +8,4 @@ Bugfixes
 - Scheduled orders with a future creation date are now hidden from the order list
 - Fixed crash in order detail when the "add order note" button is tapped before the order has been downloaded
 - Fixed crash when a review is opened from the notification list
+- Fixed rare crash in login during two-factor authentication

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
@@ -82,7 +82,9 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
 
     private WPLoginInputRow m2FaInput;
 
-    private @StringRes int mInProgressMessageId;
+    private static final @StringRes int DEFAULT_PROGRESS_MESSAGE_ID = R.string.logging_in;
+    private @StringRes int mInProgressMessageId = DEFAULT_PROGRESS_MESSAGE_ID;
+
     ArrayList<Integer> mOldSitesIDs;
 
     private Button mSecondaryButton;
@@ -241,7 +243,7 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
         // retrieve mInProgressMessageId before super.onActivityCreated() so the string will be available to the
         //  progress bar helper if in progress
         if (savedInstanceState != null) {
-            mInProgressMessageId = savedInstanceState.getInt(KEY_IN_PROGRESS_MESSAGE_ID, 0);
+            mInProgressMessageId = savedInstanceState.getInt(KEY_IN_PROGRESS_MESSAGE_ID, DEFAULT_PROGRESS_MESSAGE_ID);
             mOldSitesIDs = savedInstanceState.getIntegerArrayList(KEY_OLD_SITES_IDS);
         } else {
             mAnalyticsListener.trackTwoFactorFormViewed();
@@ -370,7 +372,7 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
     @Override
     protected void endProgress() {
         super.endProgress();
-        mInProgressMessageId = 0;
+        mInProgressMessageId = DEFAULT_PROGRESS_MESSAGE_ID;
     }
 
     private void handleAuthError(AuthenticationErrorType error, String errorMessage) {


### PR DESCRIPTION
Fixes #746 - Uses a default progress message to avoid resources not found exception. I wasn't able to repro the problem, but looking at the code it was obvious there would be situations where the string resource `mInProgressMessageId` would be 0, which would result in a `Resources.NotFoundException`.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
