### PR TITLE
Issue/748 orderlist invalid section

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,3 +9,4 @@ Bugfixes
 - Fixed crash in order detail when the "add order note" button is tapped before the order has been downloaded
 - Fixed crash when a review is opened from the notification list
 - Fixed rare crash in login during two-factor authentication
+- Fixed rare crash after undoing a review moderation

--- a/WooCommerce/src/main/java/com/woocommerce/android/widgets/SectionedRecyclerViewAdapter.java
+++ b/WooCommerce/src/main/java/com/woocommerce/android/widgets/SectionedRecyclerViewAdapter.java
@@ -7,6 +7,9 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
+
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -435,6 +438,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
             currentPos += sectionTotal;
         }
 
+        AppLog.w(T.NOTIFS, "Invalid section " + section.toString());
         return INVALID_POSITION;
     }
 
@@ -470,7 +474,11 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @return position of the item in the adapter
      */
     public int getPositionInAdapter(Section section, int position) {
-        return getSectionPosition(section) + (section.mHasHeader ? 1 : 0) + position;
+        int sectionPos = getSectionPosition(section);
+        if (sectionPos == INVALID_POSITION) {
+            return INVALID_POSITION;
+        }
+        return sectionPos + (section.mHasHeader ? 1 : 0) + position;
     }
 
     /**
@@ -522,7 +530,11 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
             throw new IllegalStateException("Section doesn't have a footer");
         }
 
-        return getSectionPosition(section) + section.getSectionItemsTotal() - 1;
+        int sectionPos = getSectionPosition(section);
+        if (sectionPos == INVALID_POSITION) {
+            return INVALID_POSITION;
+        }
+        return sectionPos + section.getSectionItemsTotal() - 1;
     }
 
     /**
@@ -1006,8 +1018,9 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      */
     public void notifyHeaderRemovedFromSection(Section section) {
         int position = getSectionPosition(section);
-
-        callSuperNotifyItemRemoved(position);
+        if (position != INVALID_POSITION) {
+            callSuperNotifyItemRemoved(position);
+        }
     }
 
     /**
@@ -1031,9 +1044,11 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param section a mVisible section of this adapter
      */
     public void notifyFooterRemovedFromSection(Section section) {
-        int position = getSectionPosition(section) + section.getSectionItemsTotal();
-
-        callSuperNotifyItemRemoved(position);
+        int sectionPos = getSectionPosition(section);
+        if (sectionPos != INVALID_POSITION) {
+            int position = sectionPos + section.getSectionItemsTotal();
+            callSuperNotifyItemRemoved(position);
+        }
     }
 
     /**
@@ -1061,11 +1076,11 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
             throw new IllegalStateException("This section is not mVisible.");
         }
 
-        int sectionPosition = getSectionPosition(section);
-
-        int sectionItemsTotal = section.getSectionItemsTotal();
-
-        callSuperNotifyItemRangeInserted(sectionPosition, sectionItemsTotal);
+        int sectionPos = getSectionPosition(section);
+        if (sectionPos != INVALID_POSITION) {
+            int sectionItemsTotal = section.getSectionItemsTotal();
+            callSuperNotifyItemRangeInserted(sectionPos, sectionItemsTotal);
+        }
     }
 
     /**

--- a/WooCommerce/src/main/java/com/woocommerce/android/widgets/SectionedRecyclerViewAdapter.java
+++ b/WooCommerce/src/main/java/com/woocommerce/android/widgets/SectionedRecyclerViewAdapter.java
@@ -33,7 +33,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
     private static final int VIEW_TYPE_FAILED = 4;
     private static final int VIEW_TYPE_EMPTY = 5;
 
-    static final int INVALID_POSITION = -1;
+    public static final int INVALID_POSITION = -1;
 
     private final LinkedHashMap<String, Section> mSections;
     private final HashMap<String, Integer> mSectionViewTypeNumbers;

--- a/WooCommerce/src/main/java/com/woocommerce/android/widgets/SectionedRecyclerViewAdapter.java
+++ b/WooCommerce/src/main/java/com/woocommerce/android/widgets/SectionedRecyclerViewAdapter.java
@@ -30,6 +30,8 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
     private static final int VIEW_TYPE_FAILED = 4;
     private static final int VIEW_TYPE_EMPTY = 5;
 
+    static final int INVALID_POSITION = -1;
+
     private final LinkedHashMap<String, Section> mSections;
     private final HashMap<String, Integer> mSectionViewTypeNumbers;
     private int mViewTypeCount = 0;
@@ -433,7 +435,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
             currentPos += sectionTotal;
         }
 
-        throw new IllegalArgumentException("Invalid section");
+        return INVALID_POSITION;
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
@@ -171,7 +171,9 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
         if (section.list.size == 0) {
             val sectionPos = getSectionPosition(section)
             section.isVisible = false
-            notifySectionChangedToInvisible(section, sectionPos)
+            if (sectionPos != SectionedRecyclerViewAdapter.INVALID_POSITION) {
+                notifySectionChangedToInvisible(section, sectionPos)
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #748 - resolves a rare (two users) crash that could occur after undoing a review moderation. The exception was being thrown in `SectionedRecyclerViewAdapter` due to a section position not being found. After discussing with @AmandaRiu we agreed that the recycler should simply return `-1` in this situation, which is in line with what other similar routines normally do.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
