### PR TITLE
issue/753-login-illegal-argument-exception

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -68,7 +68,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     public static final String TAG = "login_email_fragment_tag";
     public static final int MAX_EMAIL_LENGTH = 100;
 
-    private ArrayList<Integer> mOldSitesIDs;
+    private ArrayList<Integer> mOldSitesIDs = new ArrayList<>();
     private GoogleApiClient mGoogleApiClient;
     private String mGoogleEmail;
     private String mRequestedEmail;


### PR DESCRIPTION
Fixes #753 - I wasn't able to repro the problem, but the crash log below makes it clear the problem was due to the list of old site IDs being null. This PR should resolve the problem by ensuring the list is created.

```
Caused by java.lang.IllegalArgumentException: Parameter specified as non-null is null:
method kotlin.jvm.internal.Intrinsics.checkParameterIsNotNull, parameter oldSitesIds
```

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
