### PR TITLE
Issue/748 orderlist invalid section kotlin

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@ Bugfixes
 - Fixed missing "empty view" in notifications
 - Fixed crash when a review is opened from the notification list
 - Fixed rare crash in login during two-factor authentication
+- Fixed rare crash after undoing a review moderation
 
 Improvements
 - Custom order status labels are now supported! Instead of just displaying the order status slug, the custom order

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
@@ -171,7 +171,9 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
         if (section.list.size == 0) {
             val sectionPos = getSectionPosition(section)
             section.isVisible = false
-            notifySectionChangedToInvisible(section, sectionPos)
+            if (sectionPos != SectionedRecyclerViewAdapter.INVALID_POSITION) {
+                notifySectionChangedToInvisible(section, sectionPos)
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/sectionedrecyclerview/SectionedRecyclerViewAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/sectionedrecyclerview/SectionedRecyclerViewAdapter.kt
@@ -386,7 +386,7 @@ open class SectionedRecyclerViewAdapter : RecyclerView.Adapter<RecyclerView.View
         }
 
         WooLog.w(T.NOTIFICATIONS, "Invalid section " + section.toString())
-        throw IllegalArgumentException("Invalid section")
+        return INVALID_POSITION
     }
 
     /**
@@ -412,7 +412,10 @@ open class SectionedRecyclerViewAdapter : RecyclerView.Adapter<RecyclerView.View
      * @return position of the item in the adapter
      */
     fun getPositionInAdapter(section: Section, position: Int): Int {
-        return getSectionPosition(section) + (if (section.hasHeader) 1 else 0) + position
+        val sectionPos = getSectionPosition(section)
+        return if (sectionPos == INVALID_POSITION) {
+            INVALID_POSITION
+        } else sectionPos + (if (section.hasHeader) 1 else 0) + position
     }
 
     /**
@@ -463,8 +466,10 @@ open class SectionedRecyclerViewAdapter : RecyclerView.Adapter<RecyclerView.View
         if (!section.hasFooter) {
             throw IllegalStateException("Section doesn't have a footer")
         }
-
-        return getSectionPosition(section) + section.sectionItemsTotal - 1
+        val sectionPos = getSectionPosition(section)
+        return if (sectionPos == INVALID_POSITION) {
+            INVALID_POSITION
+        } else sectionPos + section.sectionItemsTotal - 1
     }
 
     /**
@@ -955,8 +960,9 @@ open class SectionedRecyclerViewAdapter : RecyclerView.Adapter<RecyclerView.View
      */
     fun notifyHeaderRemovedFromSection(section: Section) {
         val position = getSectionPosition(section)
-
-        callSuperNotifyItemRemoved(position)
+        if (position != INVALID_POSITION) {
+            callSuperNotifyItemRemoved(position)
+        }
     }
 
     /**
@@ -980,9 +986,11 @@ open class SectionedRecyclerViewAdapter : RecyclerView.Adapter<RecyclerView.View
      * @param section a mVisible section of this adapter
      */
     fun notifyFooterRemovedFromSection(section: Section) {
-        val position = getSectionPosition(section) + section.sectionItemsTotal
-
-        callSuperNotifyItemRemoved(position)
+        val sectionPos = getSectionPosition(section)
+        if (sectionPos != INVALID_POSITION) {
+            val position = sectionPos + section.sectionItemsTotal
+            callSuperNotifyItemRemoved(position)
+        }
     }
 
     /**
@@ -1008,11 +1016,10 @@ open class SectionedRecyclerViewAdapter : RecyclerView.Adapter<RecyclerView.View
             throw IllegalStateException("This section is not mVisible.")
         }
 
-        val sectionPosition = getSectionPosition(section)
-
-        val sectionItemsTotal = section.sectionItemsTotal
-
-        callSuperNotifyItemRangeInserted(sectionPosition, sectionItemsTotal)
+        val sectionPos = getSectionPosition(section)
+        if (sectionPos != INVALID_POSITION) {
+            callSuperNotifyItemRangeInserted(sectionPos, section.sectionItemsTotal)
+        }
     }
 
     /**
@@ -1064,5 +1071,7 @@ open class SectionedRecyclerViewAdapter : RecyclerView.Adapter<RecyclerView.View
         private const val VIEW_TYPE_FAILED = 4
         private const val VIEW_TYPE_EMPTY = 5
         private const val VIEW_TYPE_QTY = 6
+
+        const val INVALID_POSITION = -1
     }
 }


### PR DESCRIPTION
Fixes #748 - resolves a rare (two users) crash that could occur after undoing a review moderation. The exception was being thrown in `SectionedRecyclerViewAdapter` due to a section position not being found. After discussing with @AmandaRiu we agreed that the recycler should simply return `-1` in this situation, which is in line with what other similar routines normally do.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
