### PR TITLE
Issue/740 sales totals dont match calypso

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@ Bugfixes
 - Fixed missing "empty view" in notifications
 - Fixed crash when a review is opened from the notification list
 - Fixed rare crash in login during two-factor authentication
+- Fixed cases where the sales totals for a time period don't match what Calypso and wp-admin report
 
 Improvements
 - Custom order status labels are now supported! Instead of just displaying the order status slug, the custom order

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = '70c69ccbc4a3056e01c85f37e4f3451cf0ccb605'
+    fluxCVersion = '314b09775b5200e16dce9977ab01e2dc55f41e60'
     daggerVersion = '2.11'
     supportLibraryVersion = '27.1.1'
     glideVersion = '4.6.1'

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = '314b09775b5200e16dce9977ab01e2dc55f41e60'
+    fluxCVersion = 'fca18a13a5e2bc81edd10f313a4c4eaa3c004408'
     daggerVersion = '2.11'
     supportLibraryVersion = '27.1.1'
     glideVersion = '4.6.1'


### PR DESCRIPTION
Fixes #740 - the real fix was on the [FluxC side](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1109), this simply updates to the hash containing the fix.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
