### PR TITLE
issue/765-illegalstateexception-filterdialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -479,8 +479,10 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View, OrderStatu
     // region Filtering
     private fun showFilterDialog() {
         val orderStatusOptions = presenter.getOrderStatusOptions()
-        OrderStatusFilterDialog.newInstance(orderStatusOptions, orderStatusFilter, listener = this)
-                .show(fragmentManager, OrderStatusFilterDialog.TAG)
+        val dialog = OrderStatusFilterDialog.newInstance(orderStatusOptions, orderStatusFilter, listener = this)
+        fragmentManager?.beginTransaction()
+                ?.add(dialog, OrderStatusFilterDialog.TAG)
+                ?.commitAllowingStateLoss()
     }
 
     override fun onFilterSelected(orderStatus: String?) {


### PR DESCRIPTION
Fixes #765 - Uses commitAllowingStateLoss when showing order filter dialog to avoid the IllegalStateException.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
