### PR TITLE
Issue/766 inflate exception top earners

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 Features
 - Prices now conform to the WooCommerce store's currency display settings
+
 Bugfixes
 - Issue with order notes not saving properly during activity restore (low memory situations) resolved
 - Fixed bug that caused the support menu to be hidden when the device has no email client
@@ -11,6 +12,7 @@ Bugfixes
 - Fixed crash when a review is opened from the notification list
 - Fixed rare crash in login during two-factor authentication
 - Fixed cases where the sales totals for a time period don't match what Calypso and wp-admin report
+- Fixed rare crash loading product images in top earners 
 
 Improvements
 - Custom order status labels are now supported! Instead of just displaying the order status slug, the custom order

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardTopEarnersView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardTopEarnersView.kt
@@ -169,7 +169,6 @@ class DashboardTopEarnersView @JvmOverloads constructor(ctx: Context, attrs: Att
             holder.totalSpendText.text = total
             holder.divider.visibility = if (position < itemCount - 1) View.VISIBLE else View.GONE
 
-            // strip the image query params and add a width param that matches our desired size
             val imageUrl = PhotonUtils.getPhotonImageUrl(topEarner.image, imageSize, 0)
             GlideApp.with(holder.itemView.context)
                     .load(imageUrl)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardTopEarnersView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardTopEarnersView.kt
@@ -27,7 +27,7 @@ import org.apache.commons.text.StringEscapeUtils
 import org.wordpress.android.fluxc.model.WCTopEarnerModel
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.util.FormatUtils
-import org.wordpress.android.util.UrlUtils
+import org.wordpress.android.util.PhotonUtils
 
 class DashboardTopEarnersView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
     : LinearLayout(ctx, attrs) {
@@ -170,7 +170,7 @@ class DashboardTopEarnersView @JvmOverloads constructor(ctx: Context, attrs: Att
             holder.divider.visibility = if (position < itemCount - 1) View.VISIBLE else View.GONE
 
             // strip the image query params and add a width param that matches our desired size
-            val imageUrl = UrlUtils.removeQuery(topEarner.image) + "?w=$imageSize"
+            val imageUrl = PhotonUtils.getPhotonImageUrl(topEarner.image, imageSize, 0)
             GlideApp.with(holder.itemView.context)
                     .load(imageUrl)
                     .placeholder(R.drawable.ic_product)


### PR DESCRIPTION
Resolves #766 - I wasn't able to reproduce the inflate exception, but I'm fairly confident this PR fixes it. A common cause of these exceptions is running out of memory loading images, and it turns out the way we were attempting to reduce the size of top earner images doesn't work with all sites.

This PR corrects this by using Photon to request images at the exact size needed.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
