### PR TITLE
Dismiss the open filter dialog in onPause

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -14,6 +14,7 @@ Bugfixes
 - Fixed rare crash after undoing a review moderation
 - Fixed cases where the sales totals for a time period don't match what Calypso and wp-admin report
 - Fixed rare crash loading product images in top earners 
+- Fixed a rare crash when recreating the order filter during activity restore (low memory situations)
 
 Improvements
 - Custom order status labels are now supported! Instead of just displaying the order status slug, the custom order

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -65,6 +65,7 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View, OrderStatu
     @Inject lateinit var selectedSite: SelectedSite
 
     private lateinit var ordersDividerDecoration: DividerItemDecoration
+    private var orderFilterDialog: OrderStatusFilterDialog? = null
 
     override var isRefreshPending = true // If true, the fragment will refresh its orders when its visible
     override var isRefreshing: Boolean
@@ -212,6 +213,14 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View, OrderStatu
             }
         }
         return view
+    }
+
+    override fun onPause() {
+        super.onPause()
+
+        // If the order filter dialog is visible, close it
+        orderFilterDialog?.dismiss()
+        orderFilterDialog = null
     }
 
     override fun onResume() {
@@ -479,8 +488,9 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View, OrderStatu
     // region Filtering
     private fun showFilterDialog() {
         val orderStatusOptions = presenter.getOrderStatusOptions()
-        OrderStatusFilterDialog.newInstance(orderStatusOptions, orderStatusFilter, listener = this)
-                .show(fragmentManager, OrderStatusFilterDialog.TAG)
+        orderFilterDialog = OrderStatusFilterDialog
+                .newInstance(orderStatusOptions, orderStatusFilter, listener = this)
+                .also { it.show(fragmentManager, OrderStatusFilterDialog.TAG) }
     }
 
     override fun onFilterSelected(orderStatus: String?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusFilterDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusFilterDialog.kt
@@ -72,7 +72,7 @@ class OrderStatusFilterDialog : DialogFragment() {
                         // If 'All' is selected filter, pass null to signal a filterless refresh
                         listener?.onFilterSelected(selectedFilter.takeUnless { it == ALL_FILTER_ID })
                     }
-                    dialog.cancel()
+                    dialog.dismiss()
                 }.create()
     }
 


### PR DESCRIPTION
Fixes #769 This happens just before onSaveInstanceState. Closing the dialog after onSaveInstanceState causes a crash.

Update release notes:
- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.


