### PR TITLE
Verify the TopLevelFragment is attached before attempting to call chi…

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,6 +16,7 @@ Bugfixes
 - Fixed cases where the sales totals for a time period don't match what Calypso and wp-admin report
 - Fixed rare crash loading product images in top earners 
 - Fixed a rare crash when recreating the order filter during activity restore (low memory situations)
+- Fixed a crash that occasionally happened while attempting to load the app from a woocommerce notification alert
 
 Improvements
 - Custom order status labels are now supported! Instead of just displaying the order status slug, the custom order

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.base
 
+import android.content.Context
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.support.v7.app.AppCompatActivity
@@ -28,6 +29,7 @@ abstract class TopLevelFragment : Fragment(), TopLevelFragmentView {
      * normal initialization until manually requested.
      */
     var deferInit: Boolean = false
+    private var runOnResumeFunc: (() -> Unit)? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -53,6 +55,15 @@ abstract class TopLevelFragment : Fragment(), TopLevelFragmentView {
 
         // Set activity title
         activity?.title = getFragmentTitle()
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        runOnResumeFunc?.let { frag ->
+            frag.invoke()
+            runOnResumeFunc = null
+        }
     }
 
     override fun onHiddenChanged(hidden: Boolean) {
@@ -94,6 +105,8 @@ abstract class TopLevelFragment : Fragment(), TopLevelFragmentView {
                     .replace(R.id.container, fragment, tag)
                     .addToBackStack(tag)
                     .commitAllowingStateLoss()
+        } else {
+            runOnResumeFunc = { loadChildFragment(fragment, tag) }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -81,18 +81,20 @@ abstract class TopLevelFragment : Fragment(), TopLevelFragmentView {
     }
 
     override fun loadChildFragment(fragment: Fragment, tag: String) {
-        // before changing the custom animation, please read this PR:
-        // https://github.com/woocommerce/woocommerce-android/pull/554
-        childFragmentManager.beginTransaction()
-                .setCustomAnimations(
-                        R.anim.activity_fade_in,
-                        R.anim.activity_fade_out,
-                        R.anim.activity_fade_in,
-                        0
-                )
-                .replace(R.id.container, fragment, tag)
-                .addToBackStack(tag)
-                .commitAllowingStateLoss()
+        if (isAdded) {
+            // before changing the custom animation, please read this PR:
+            // https://github.com/woocommerce/woocommerce-android/pull/554
+            childFragmentManager.beginTransaction()
+                    .setCustomAnimations(
+                            R.anim.activity_fade_in,
+                            R.anim.activity_fade_out,
+                            R.anim.activity_fade_in,
+                            0
+                    )
+                    .replace(R.id.container, fragment, tag)
+                    .addToBackStack(tag)
+                    .commitAllowingStateLoss()
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.base
 
-import android.content.Context
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.support.v7.app.AppCompatActivity


### PR DESCRIPTION
Fixes #659 

This fixes a crash that happens when we attempt to load a child fragment in a `TopLevelFragment` that has not yet been attached to the `MainActivity`. This will happen in two scenarios:
- The user clicks on a woo notification alert when the app **is not open**
- The user clicks on a woo notification alert when the app is in the background and memory issues have caused the `MainActivity` to be destroyed

The fix is to check if the `TopLevelFragment` has been added to the `MainActivity`, and if it hasn't, to defer calling the `loadChildFragment()` method until the `TopLevelFragment` resumes. I chose a design that is flexible enough to be reused for any similar scenarios in the future.

Release Notes:
- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
