### PR TITLE
Feature/792 chrome custom tabs

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -110,7 +110,7 @@ dependencies {
     implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
     implementation "com.android.support:design:$supportLibraryVersion"
     implementation "com.android.support:cardview-v7:$supportLibraryVersion"
-
+    implementation "com.android.support:customtabs:$supportLibraryVersion"
 
     implementation('org.wordpress:utils:1.22') {
         exclude group: "com.mcxiaoke.volley"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -63,14 +63,18 @@ class HelpActivity : AppCompatActivity() {
         if (savedInstanceState == null && originFromExtras == Origin.ZENDESK_NOTIFICATION) {
             showZendeskTickets()
         }
-
-        ChromeCustomTabUtils.preload(this, FAQ_URL)
     }
 
     override fun onResume() {
         super.onResume()
         refreshContactEmailText()
         AnalyticsTracker.trackViewShown(this)
+        ChromeCustomTabUtils.connect(this, FAQ_URL)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        ChromeCustomTabUtils.disconnect(this)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -133,7 +137,7 @@ class HelpActivity : AppCompatActivity() {
 
     private fun showZendeskFaq() {
         AnalyticsTracker.track(Stat.SUPPORT_FAQ_VIEWED)
-        ChromeCustomTabUtils.viewUrl(this, FAQ_URL)
+        ChromeCustomTabUtils.launchUrl(this, FAQ_URL)
         /* TODO: for now we simply link to the online FAQ, but we should show the Zendesk FAQ once it's ready
         zendeskHelper
                 .showZendeskHelpCenter(this, originFromExtras, selectedSiteOrNull(), extraTagsFromExtras)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -63,6 +63,8 @@ class HelpActivity : AppCompatActivity() {
         if (savedInstanceState == null && originFromExtras == Origin.ZENDESK_NOTIFICATION) {
             showZendeskTickets()
         }
+
+        ChromeCustomTabUtils.preload(this, FAQ_URL)
     }
 
     override fun onResume() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -11,7 +11,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.util.ActivityUtils
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import dagger.android.AndroidInjection
 import kotlinx.android.synthetic.main.activity_help.*
 import org.wordpress.android.fluxc.model.SiteModel
@@ -131,7 +131,7 @@ class HelpActivity : AppCompatActivity() {
 
     private fun showZendeskFaq() {
         AnalyticsTracker.track(Stat.SUPPORT_FAQ_VIEWED)
-        ActivityUtils.openUrlExternal(this, FAQ_URL)
+        ChromeCustomTabUtils.viewUrl(this, FAQ_URL)
         /* TODO: for now we simply link to the online FAQ, but we should show the Zendesk FAQ once it's ready
         zendeskHelper
                 .showZendeskHelpCenter(this, originFromExtras, selectedSiteOrNull(), extraTagsFromExtras)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -63,18 +63,19 @@ class HelpActivity : AppCompatActivity() {
         if (savedInstanceState == null && originFromExtras == Origin.ZENDESK_NOTIFICATION) {
             showZendeskTickets()
         }
+
+        ChromeCustomTabUtils.connect(this, FAQ_URL)
+    }
+
+    override fun onDestroy() {
+        ChromeCustomTabUtils.disconnect(this)
+        super.onDestroy()
     }
 
     override fun onResume() {
         super.onResume()
         refreshContactEmailText()
         AnalyticsTracker.trackViewShown(this)
-        ChromeCustomTabUtils.connect(this, FAQ_URL)
-    }
-
-    override fun onPause() {
-        super.onPause()
-        ChromeCustomTabUtils.disconnect(this)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
@@ -22,7 +22,7 @@ object ChromeCustomTabUtils {
                 .setExitAnimations(context, 0, R.anim.activity_slide_out_to_right)
                 .setShowTitle(true)
                 .build()
-
+        intent.intent.putExtra(Intent.EXTRA_REFERRER, Uri.parse("android-app://" + context.getPackageName()))
         intent.launchUrl(context, Uri.parse(url))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
@@ -1,19 +1,52 @@
 package com.woocommerce.android.util
 
+import android.content.ComponentName
 import android.content.Context
+import android.content.Intent
 import android.net.Uri
+import android.support.customtabs.CustomTabsClient
 import android.support.customtabs.CustomTabsIntent
+import android.support.customtabs.CustomTabsServiceConnection
+import android.support.customtabs.CustomTabsSession
 import android.support.v4.content.ContextCompat
 import com.woocommerce.android.R
 
 object ChromeCustomTabUtils {
+    private const val CUSTOM_TAB_PACKAGE_NAME_STABLE = "com.android.chrome"
+    private var session: CustomTabsSession? = null
+
     fun viewUrl(context: Context, url: String) {
-        CustomTabsIntent.Builder()
+        val intent = CustomTabsIntent.Builder(session)
                 .setToolbarColor(ContextCompat.getColor(context, R.color.wc_purple))
                 .setStartAnimations(context, R.anim.activity_slide_in_from_right, 0)
                 .setExitAnimations(context, 0, R.anim.activity_slide_out_to_right)
                 .setShowTitle(true)
                 .build()
-                .launchUrl(context, Uri.parse(url))
+
+        intent.launchUrl(context, Uri.parse(url))
+    }
+
+    fun preload(context: Context, url: String) {
+        // use existing session if available
+        session?.let {
+            it.mayLaunchUrl(Uri.parse(url), null, null)
+            return
+        }
+
+        val connection = object : CustomTabsServiceConnection() {
+            override fun onCustomTabsServiceConnected(name: ComponentName, client: CustomTabsClient) {
+                client.warmup(0)
+                session = client.newSession(null)
+                session?.mayLaunchUrl(Uri.parse(url), null, null)
+            }
+            override fun onServiceDisconnected(name: ComponentName) {
+                session = null
+            }
+        }
+        CustomTabsClient.bindCustomTabsService(context, CUSTOM_TAB_PACKAGE_NAME_STABLE, connection)
+    }
+
+    fun disconnect(context: Context) {
+        session = null
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
@@ -8,12 +8,12 @@ import com.woocommerce.android.R
 
 object ChromeCustomTabUtils {
     fun viewUrl(context: Context, url: String) {
-        val builder = CustomTabsIntent.Builder()
-        builder.setToolbarColor(ContextCompat.getColor(context, R.color.wc_purple))
-        builder.setStartAnimations(context, R.anim.activity_slide_in_from_right, 0)
-        builder.setExitAnimations(context, 0, R.anim.activity_slide_out_to_right)
-
-        val customTabsIntent = builder.build()
-        customTabsIntent.launchUrl(context, Uri.parse(url))
+        CustomTabsIntent.Builder()
+                .setToolbarColor(ContextCompat.getColor(context, R.color.wc_purple))
+                .setStartAnimations(context, R.anim.activity_slide_in_from_right, 0)
+                .setExitAnimations(context, 0, R.anim.activity_slide_out_to_right)
+                .setShowTitle(true)
+                .build()
+                .launchUrl(context, Uri.parse(url))
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
@@ -3,10 +3,16 @@ package com.woocommerce.android.util
 import android.content.Context
 import android.net.Uri
 import android.support.customtabs.CustomTabsIntent
+import android.support.v4.content.ContextCompat
+import com.woocommerce.android.R
 
 object ChromeCustomTabUtils {
     fun viewUrl(context: Context, url: String) {
         val builder = CustomTabsIntent.Builder()
+        builder.setToolbarColor(ContextCompat.getColor(context, R.color.wc_purple))
+        builder.setStartAnimations(context, R.anim.activity_slide_in_from_right, 0)
+        builder.setExitAnimations(context, 0, R.anim.activity_slide_out_to_right)
+
         val customTabsIntent = builder.build()
         customTabsIntent.launchUrl(context, Uri.parse(url))
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.util
+
+import android.content.Context
+import android.net.Uri
+import android.support.customtabs.CustomTabsIntent
+
+object ChromeCustomTabUtils {
+    fun viewUrl(context: Context, url: String) {
+        val builder = CustomTabsIntent.Builder()
+        val customTabsIntent = builder.build()
+        customTabsIntent.launchUrl(context, Uri.parse(url))
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
@@ -4,68 +4,96 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.os.Bundle
-import android.support.customtabs.CustomTabsCallback
 import android.support.customtabs.CustomTabsClient
 import android.support.customtabs.CustomTabsIntent
+import android.support.customtabs.CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION
 import android.support.customtabs.CustomTabsServiceConnection
 import android.support.customtabs.CustomTabsSession
 import android.support.v4.content.ContextCompat
 import com.woocommerce.android.R
-import java.lang.ref.WeakReference
 
 object ChromeCustomTabUtils {
     private const val CUSTOM_TAB_PACKAGE_NAME_STABLE = "com.android.chrome"
+
     private var session: CustomTabsSession? = null
     private var connection: CustomTabsServiceConnection? = null
 
-    fun viewUrl(context: Context, url: String) {
+    fun launchUrl(context: Context, url: String) {
+        // if there's no connection then the device doesn't support custom tabs (or the caller neglected to connect)
+        if (connection == null) {
+            ActivityUtils.openUrlExternal(context, url)
+            return
+        }
+
         val intent = CustomTabsIntent.Builder(session)
                 .setToolbarColor(ContextCompat.getColor(context, R.color.wc_purple))
                 .setStartAnimations(context, R.anim.activity_slide_in_from_right, 0)
                 .setExitAnimations(context, 0, R.anim.activity_slide_out_to_right)
                 .setShowTitle(true)
                 .build()
-        intent.intent.putExtra(Intent.EXTRA_REFERRER, Uri.parse("android-app://" + context.getPackageName()))
+        intent.intent.putExtra(Intent.EXTRA_REFERRER, Uri.parse("android-app://" + context.packageName))
         intent.launchUrl(context, Uri.parse(url))
     }
 
-    fun preload(context: Context, url: String) {
-        // use existing session if available
-        session?.let {
-            it.mayLaunchUrl(Uri.parse(url), null, null)
-            return
+    /**
+     * Call this when the activity/fragment starts to create a custom tab connection and optionally
+     * preload a url
+     */
+    fun connect(context: Context, preloadUrl: String? = null): Boolean {
+        if (!canUseCustomTabs(context)) {
+            return false
         }
 
-        val weakContext = WeakReference(context)
         connection = object : CustomTabsServiceConnection() {
             override fun onCustomTabsServiceConnected(name: ComponentName, client: CustomTabsClient) {
                 client.warmup(0)
-                val callback = object: CustomTabsCallback() {
-                    override fun onNavigationEvent(navigationEvent: Int, extras: Bundle) {
-                        if (navigationEvent == NAVIGATION_ABORTED || navigationEvent == TAB_HIDDEN) {
-                            disconnect(weakContext.get())
-                        }
-                    }
+                session = client.newSession(null)
+                preloadUrl?.let { url ->
+                    session?.mayLaunchUrl(Uri.parse(url), null, null)
                 }
-                session = client.newSession(callback)
-                session?.mayLaunchUrl(Uri.parse(url), null, null)
             }
             override fun onServiceDisconnected(name: ComponentName) {
+                session = null
                 connection = null
             }
         }
         CustomTabsClient.bindCustomTabsService(context, CUSTOM_TAB_PACKAGE_NAME_STABLE, connection)
+        return true
     }
 
-    private fun disconnect(context: Context?) {
-        if (connection == null) return
-
-        try {
-            session = null
-            context?.unbindService(connection!!)
-        } catch (e: IllegalArgumentException) {
-            WooLog.e(WooLog.T.SUPPORT, e)
+    /**
+     * Call this when the activity/fragment ends to close the connection
+     */
+    fun disconnect(context: Context) {
+        if (connection != null) {
+            try {
+                context.unbindService(connection!!)
+            } catch (e: IllegalArgumentException) {
+                WooLog.e(WooLog.T.SUPPORT, e)
+            }
         }
+
+        session = null
+        connection = null
+    }
+
+    /**
+     * From https://github.com/GoogleChrome/custom-tabs-client/blob/master/shared/src/main/java/org/chromium/
+     * customtabsclient/shared/CustomTabsHelper.java
+     */
+    private fun canUseCustomTabs(context: Context): Boolean {
+        val pm = context.packageManager
+        val activityIntent = Intent(Intent.ACTION_VIEW, Uri.parse("http://www.example.com"))
+        val resolvedActivityList = pm.queryIntentActivities(activityIntent, 0)
+        for (info in resolvedActivityList) {
+            val serviceIntent = Intent()
+            serviceIntent.action = ACTION_CUSTOM_TABS_CONNECTION
+            serviceIntent.setPackage(info.activityInfo.packageName)
+            if (pm.resolveService(serviceIntent, 0) != null) {
+                return true
+            }
+        }
+
+        return false
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
@@ -69,9 +69,8 @@ object ChromeCustomTabUtils {
         }
 
         val intent = CustomTabsIntent.Builder(session)
+                .addDefaultShareMenuItem()
                 .setToolbarColor(ContextCompat.getColor(context, R.color.wc_purple))
-                .setStartAnimations(context, R.anim.activity_slide_in_from_right, 0)
-                .setExitAnimations(context, 0, R.anim.activity_slide_out_to_right)
                 .setShowTitle(true)
                 .build()
         intent.intent.putExtra(Intent.EXTRA_REFERRER, Uri.parse("android-app://" + context.packageName))


### PR DESCRIPTION
Resolves #792 - adds a utility class which enables us to easily use Chrome Custom Tabs. For now it's only used when showing the support FAQ but can be used anywhere we need to show web content in the future (a separate PR will tackle that).

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
