### PR TITLE
issue/793-bar-chart-colors

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -271,13 +271,8 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
 
         val barColors = ArrayList<Int>()
         val normalColor = ContextCompat.getColor(context, R.color.graph_data_color)
-        val weekendColor = ContextCompat.getColor(context, R.color.graph_data_color_weekend)
         for (entry in revenueStats) {
-            if (activeGranularity == StatsGranularity.DAYS && DateUtils.isWeekend(entry.key)) {
-                barColors.add(weekendColor)
-            } else {
-                barColors.add(normalColor)
-            }
+            barColors.add(normalColor)
         }
 
         val dataSet = generateBarDataSet(revenueStats).apply {

--- a/WooCommerce/src/main/res/values/colors.xml
+++ b/WooCommerce/src/main/res/values/colors.xml
@@ -94,10 +94,9 @@
         Default graph colors
     -->
     <color name="graph_no_data_text_color">@color/default_text_color</color>
-    <color name="graph_data_color">@color/wc_purple</color>
-    <color name="graph_data_color_weekend">@color/wc_grey_medium</color>
+    <color name="graph_data_color">@color/wc_grey_mid</color>
     <color name="graph_grid_color">@color/wc_border_color</color>
-    <color name="graph_highlight_color">@color/wc_green</color>
+    <color name="graph_highlight_color">@color/wc_purple</color>
     <!--
         Order: status tag background colors
     -->


### PR DESCRIPTION
Resolves #793 - Updates the bar chart colors to drop the weekend color, use Woo Grey Mid (#969696) as the normal bar color, and use Woo Primary (#96588a) as the highlight color. This is to match [this iOS PR](https://github.com/woocommerce/woocommerce-ios/pull/680).

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
