### PR TITLE
Feature/792 chrome custom tabs everywhere

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -110,7 +110,7 @@ dependencies {
     implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
     implementation "com.android.support:design:$supportLibraryVersion"
     implementation "com.android.support:cardview-v7:$supportLibraryVersion"
-
+    implementation "com.android.support:customtabs:$supportLibraryVersion"
 
     implementation('org.wordpress:utils:1.22') {
         exclude group: "com.mcxiaoke.volley"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -63,19 +63,22 @@ class HelpActivity : AppCompatActivity() {
         if (savedInstanceState == null && originFromExtras == Origin.ZENDESK_NOTIFICATION) {
             showZendeskTickets()
         }
-
-        ChromeCustomTabUtils.connect(this, FAQ_URL)
-    }
-
-    override fun onDestroy() {
-        ChromeCustomTabUtils.disconnect(this)
-        super.onDestroy()
     }
 
     override fun onResume() {
         super.onResume()
         refreshContactEmailText()
         AnalyticsTracker.trackViewShown(this)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        ChromeCustomTabUtils.connect(this, FAQ_URL)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        ChromeCustomTabUtils.disconnect(this)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -63,14 +63,18 @@ class HelpActivity : AppCompatActivity() {
         if (savedInstanceState == null && originFromExtras == Origin.ZENDESK_NOTIFICATION) {
             showZendeskTickets()
         }
-
-        ChromeCustomTabUtils.preload(this, FAQ_URL)
     }
 
     override fun onResume() {
         super.onResume()
         refreshContactEmailText()
         AnalyticsTracker.trackViewShown(this)
+        ChromeCustomTabUtils.connect(this, FAQ_URL)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        ChromeCustomTabUtils.disconnect(this)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -133,7 +137,7 @@ class HelpActivity : AppCompatActivity() {
 
     private fun showZendeskFaq() {
         AnalyticsTracker.track(Stat.SUPPORT_FAQ_VIEWED)
-        ChromeCustomTabUtils.viewUrl(this, FAQ_URL)
+        ChromeCustomTabUtils.launchUrl(this, FAQ_URL)
         /* TODO: for now we simply link to the online FAQ, but we should show the Zendesk FAQ once it's ready
         zendeskHelper
                 .showZendeskHelpCenter(this, originFromExtras, selectedSiteOrNull(), extraTagsFromExtras)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -63,6 +63,8 @@ class HelpActivity : AppCompatActivity() {
         if (savedInstanceState == null && originFromExtras == Origin.ZENDESK_NOTIFICATION) {
             showZendeskTickets()
         }
+
+        ChromeCustomTabUtils.preload(this, FAQ_URL)
     }
 
     override fun onResume() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -11,7 +11,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.util.ActivityUtils
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import dagger.android.AndroidInjection
 import kotlinx.android.synthetic.main.activity_help.*
 import org.wordpress.android.fluxc.model.SiteModel
@@ -131,7 +131,7 @@ class HelpActivity : AppCompatActivity() {
 
     private fun showZendeskFaq() {
         AnalyticsTracker.track(Stat.SUPPORT_FAQ_VIEWED)
-        ActivityUtils.openUrlExternal(this, FAQ_URL)
+        ChromeCustomTabUtils.viewUrl(this, FAQ_URL)
         /* TODO: for now we simply link to the online FAQ, but we should show the Zendesk FAQ once it's ready
         zendeskHelper
                 .showZendeskHelpCenter(this, originFromExtras, selectedSiteOrNull(), extraTagsFromExtras)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -63,18 +63,19 @@ class HelpActivity : AppCompatActivity() {
         if (savedInstanceState == null && originFromExtras == Origin.ZENDESK_NOTIFICATION) {
             showZendeskTickets()
         }
+
+        ChromeCustomTabUtils.connect(this, FAQ_URL)
+    }
+
+    override fun onDestroy() {
+        ChromeCustomTabUtils.disconnect(this)
+        super.onDestroy()
     }
 
     override fun onResume() {
         super.onResume()
         refreshContactEmailText()
         AnalyticsTracker.trackViewShown(this)
-        ChromeCustomTabUtils.connect(this, FAQ_URL)
-    }
-
-    override fun onPause() {
-        super.onPause()
-        ChromeCustomTabUtils.disconnect(this)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -18,7 +18,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.TopLevelFragmentRouter
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.util.ActivityUtils
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
@@ -115,7 +115,7 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
                 title = getString(R.string.dashboard_plugin_notice_title),
                 message = getString(R.string.dashboard_plugin_notice_message),
                 buttonLabel = getString(R.string.button_update_instructions),
-                buttonAction = { ActivityUtils.openUrlExternal(activity as Context, URL_UPGRADE_WOOCOMMERCE) })
+                buttonAction = { ChromeCustomTabUtils.launchUrl(activity as Context, URL_UPGRADE_WOOCOMMERCE) })
 
         if (isActive) {
             refreshDashboard(forced = this.isRefreshPending)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.ui.login.LoginPrologueFragment.PrologueFinishedListener
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.util.ActivityUtils
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import dagger.android.AndroidInjection
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
@@ -219,7 +220,7 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
 
     override fun forgotPassword(url: String?) {
         loginAnalyticsListener.trackLoginForgotPasswordClicked()
-        ActivityUtils.openUrlExternal(this, url + FORGOT_PASSWORD_URL_SUFFIX)
+        ChromeCustomTabUtils.launchUrl(this, url + FORGOT_PASSWORD_URL_SUFFIX)
     }
 
     override fun needs2fa(email: String?, password: String?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
@@ -9,10 +9,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.woocommerce.android.R
-import kotlinx.android.synthetic.main.fragment_login_prologue.*
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
-import com.woocommerce.android.util.ActivityUtils
+import com.woocommerce.android.util.ChromeCustomTabUtils
+import kotlinx.android.synthetic.main.fragment_login_prologue.*
 import org.wordpress.android.util.DisplayUtils
 
 class LoginPrologueFragment : Fragment() {
@@ -71,7 +71,7 @@ class LoginPrologueFragment : Fragment() {
 
         text_jetpack.setOnClickListener {
             AnalyticsTracker.track(Stat.LOGIN_PROLOGUE_JETPACK_CONFIGURATION_INSTRUCTIONS_LINK_TAPPED)
-            ActivityUtils.openUrlExternal(activity as Context, JETPACK_HELP_URL)
+            ChromeCustomTabUtils.launchUrl(activity as Context, JETPACK_HELP_URL)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/ReviewDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/ReviewDetailFragment.kt
@@ -21,7 +21,7 @@ import com.woocommerce.android.extensions.getRating
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.base.TopLevelFragmentView
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.util.ActivityUtils
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.NOTIFICATIONS
 import com.woocommerce.android.widgets.SkeletonView
@@ -132,7 +132,7 @@ class ReviewDetailFragment : Fragment(), ReviewDetailContract.View {
         note.getProductInfo()?.url?.let { url ->
             review_open_product.setOnClickListener {
                 AnalyticsTracker.track(Stat.REVIEW_DETAIL_OPEN_EXTERNAL_BUTTON_TAPPED)
-                ActivityUtils.openUrlExternal(activity as Context, url)
+                ChromeCustomTabUtils.launchUrl(activity as Context, url)
             }
         }
         productUrl = note.getProductInfo()?.url

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AboutFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AboutFragment.kt
@@ -73,7 +73,12 @@ class AboutFragment : Fragment() {
 
     override fun onStart() {
         super.onStart()
-        val preloadUrlList = mapOf(URL_PRIVACY_POLICY, URL_TOS, URL_AUTOMATTIC)
-        ChromeCustomTabUtils.connect(this, FAQ_URL)
+        val preloadUrlList = arrayOf(URL_PRIVACY_POLICY, URL_TOS)
+        ChromeCustomTabUtils.connect(activity as Context, preloadUrlList)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        ChromeCustomTabUtils.disconnect(activity as Context)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AboutFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AboutFragment.kt
@@ -73,8 +73,7 @@ class AboutFragment : Fragment() {
 
     override fun onStart() {
         super.onStart()
-        val preloadUrlList = arrayOf(URL_PRIVACY_POLICY, URL_TOS)
-        ChromeCustomTabUtils.connect(activity as Context, preloadUrlList)
+        ChromeCustomTabUtils.connect(activity as Context, URL_PRIVACY_POLICY, arrayOf(URL_TOS, URL_AUTOMATTIC))
     }
 
     override fun onStop() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AboutFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AboutFragment.kt
@@ -70,4 +70,10 @@ class AboutFragment : Fragment() {
             it.supportActionBar?.elevation = 0f
         }
     }
+
+    override fun onStart() {
+        super.onStart()
+        val preloadUrlList = mapOf(URL_PRIVACY_POLICY, URL_TOS, URL_AUTOMATTIC)
+        ChromeCustomTabUtils.connect(this, FAQ_URL)
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AboutFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AboutFragment.kt
@@ -10,7 +10,7 @@ import android.view.ViewGroup
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.util.ActivityUtils
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import kotlinx.android.synthetic.main.fragment_about.*
 import org.wordpress.android.util.DisplayUtils
 import java.util.Calendar
@@ -48,15 +48,15 @@ class AboutFragment : Fragment() {
         about_copyright.text = copyright
 
         about_url.setOnClickListener {
-            ActivityUtils.openUrlExternal(activity as Context, URL_AUTOMATTIC)
+            ChromeCustomTabUtils.launchUrl(activity as Context, URL_AUTOMATTIC)
         }
 
         about_privacy.setOnClickListener {
-            ActivityUtils.openUrlExternal(activity as Context, URL_PRIVACY_POLICY)
+            ChromeCustomTabUtils.launchUrl(activity as Context, URL_PRIVACY_POLICY)
         }
 
         about_tos.setOnClickListener {
-            ActivityUtils.openUrlExternal(activity as Context, URL_TOS)
+            ChromeCustomTabUtils.launchUrl(activity as Context, URL_TOS)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsFragment.kt
@@ -86,6 +86,17 @@ class PrivacySettingsFragment : Fragment(), PrivacySettingsContract.View {
         activity?.setTitle(R.string.privacy_settings)
     }
 
+    override fun onStart() {
+        super.onStart()
+        val preloadUrlList = arrayOf(URL_PRIVACY_POLICY, URL_COOKIE_POLICY)
+        ChromeCustomTabUtils.connect(activity as Context, preloadUrlList)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        ChromeCustomTabUtils.disconnect(activity as Context)
+    }
+
     override fun showCookiePolicy() {
         ChromeCustomTabUtils.launchUrl(activity as Context, URL_COOKIE_POLICY)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsFragment.kt
@@ -13,8 +13,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRIVACY_SETTINGS_
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRIVACY_SETTINGS_PRIVACY_POLICY_LINK_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRIVACY_SETTINGS_SHARE_INFO_LINK_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRIVACY_SETTINGS_THIRD_PARTY_TRACKING_INFO_LINK_TAPPED
-import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.AnalyticsUtils
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_settings_privacy.*
 import javax.inject.Inject
@@ -87,10 +87,10 @@ class PrivacySettingsFragment : Fragment(), PrivacySettingsContract.View {
     }
 
     override fun showCookiePolicy() {
-        ActivityUtils.openUrlExternal(activity as Context, URL_COOKIE_POLICY)
+        ChromeCustomTabUtils.launchUrl(activity as Context, URL_COOKIE_POLICY)
     }
 
     override fun showPrivacyPolicy() {
-        ActivityUtils.openUrlExternal(activity as Context, URL_PRIVACY_POLICY)
+        ChromeCustomTabUtils.launchUrl(activity as Context, URL_PRIVACY_POLICY)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsFragment.kt
@@ -88,8 +88,7 @@ class PrivacySettingsFragment : Fragment(), PrivacySettingsContract.View {
 
     override fun onStart() {
         super.onStart()
-        val preloadUrlList = arrayOf(URL_PRIVACY_POLICY, URL_COOKIE_POLICY)
-        ChromeCustomTabUtils.connect(activity as Context, preloadUrlList)
+        ChromeCustomTabUtils.connect(activity as Context, URL_PRIVACY_POLICY, arrayOf(URL_COOKIE_POLICY))
     }
 
     override fun onStop() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/WooUpgradeRequiredDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/WooUpgradeRequiredDialog.kt
@@ -9,7 +9,7 @@ import android.view.ViewGroup
 import android.view.WindowManager
 import android.widget.Button
 import com.woocommerce.android.R
-import com.woocommerce.android.util.ActivityUtils
+import com.woocommerce.android.util.ChromeCustomTabUtils
 
 class WooUpgradeRequiredDialog : DialogFragment() {
     companion object {
@@ -24,7 +24,7 @@ class WooUpgradeRequiredDialog : DialogFragment() {
 
         context?.let { ctx ->
             view.findViewById<Button>(R.id.upgrade_instructions)?.setOnClickListener {
-                ActivityUtils.openUrlExternal(ctx, URL_UPGRADE_WOOCOMMERCE)
+                ChromeCustomTabUtils.launchUrl(ctx, URL_UPGRADE_WOOCOMMERCE)
             }
         }
         view.findViewById<Button>(R.id.upgrade_dismiss)?.setOnClickListener { dialog.dismiss() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ActivityUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ActivityUtils.kt
@@ -37,6 +37,10 @@ object ActivityUtils {
         context.startActivity(intent)
     }
 
+    /**
+     * Use this only when you want to open the external browser - otherwise use
+     * [ChromeCustomTabUtils.launchUrl] to provide a better in-app experience
+     */
     fun openUrlExternal(context: Context, url: String) {
         val uri = Uri.parse(url)
         val intent = Intent(Intent.ACTION_VIEW, uri)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
@@ -22,7 +22,7 @@ object ChromeCustomTabUtils {
                 .setExitAnimations(context, 0, R.anim.activity_slide_out_to_right)
                 .setShowTitle(true)
                 .build()
-
+        intent.intent.putExtra(Intent.EXTRA_REFERRER, Uri.parse("android-app://" + context.getPackageName()))
         intent.launchUrl(context, Uri.parse(url))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
@@ -1,19 +1,52 @@
 package com.woocommerce.android.util
 
+import android.content.ComponentName
 import android.content.Context
+import android.content.Intent
 import android.net.Uri
+import android.support.customtabs.CustomTabsClient
 import android.support.customtabs.CustomTabsIntent
+import android.support.customtabs.CustomTabsServiceConnection
+import android.support.customtabs.CustomTabsSession
 import android.support.v4.content.ContextCompat
 import com.woocommerce.android.R
 
 object ChromeCustomTabUtils {
+    private const val CUSTOM_TAB_PACKAGE_NAME_STABLE = "com.android.chrome"
+    private var session: CustomTabsSession? = null
+
     fun viewUrl(context: Context, url: String) {
-        CustomTabsIntent.Builder()
+        val intent = CustomTabsIntent.Builder(session)
                 .setToolbarColor(ContextCompat.getColor(context, R.color.wc_purple))
                 .setStartAnimations(context, R.anim.activity_slide_in_from_right, 0)
                 .setExitAnimations(context, 0, R.anim.activity_slide_out_to_right)
                 .setShowTitle(true)
                 .build()
-                .launchUrl(context, Uri.parse(url))
+
+        intent.launchUrl(context, Uri.parse(url))
+    }
+
+    fun preload(context: Context, url: String) {
+        // use existing session if available
+        session?.let {
+            it.mayLaunchUrl(Uri.parse(url), null, null)
+            return
+        }
+
+        val connection = object : CustomTabsServiceConnection() {
+            override fun onCustomTabsServiceConnected(name: ComponentName, client: CustomTabsClient) {
+                client.warmup(0)
+                session = client.newSession(null)
+                session?.mayLaunchUrl(Uri.parse(url), null, null)
+            }
+            override fun onServiceDisconnected(name: ComponentName) {
+                session = null
+            }
+        }
+        CustomTabsClient.bindCustomTabsService(context, CUSTOM_TAB_PACKAGE_NAME_STABLE, connection)
+    }
+
+    fun disconnect(context: Context) {
+        session = null
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
@@ -17,7 +17,7 @@ import com.woocommerce.android.R
 /**
  * Simplifies using Chrome Custom Tabs
  *
- *  - Call connect with an optional URL to preload when the activity starts
+ *  - Call connect with an optional URL or list of URLs to preload when the activity starts
  *  - Call launchUrl() to actually display the URL
  *  - Call disconnect when the activity stops
  *
@@ -26,7 +26,8 @@ import com.woocommerce.android.R
  *  - Call launchUrl() by itself to avoid connecting and disconnecting
  *
  *  The latter is recommended when it's not necessary to pre-load the URL (Google recommends
- *  preloading only when there's at least a 50% chance users will visit the URL)
+ *  preloading only when there's at least a 50% chance users will visit the URL). Note that
+ *  when passing a list of URLs, they should be ordered in descending order of priority
  */
 object ChromeCustomTabUtils {
     private const val CUSTOM_TAB_PACKAGE_NAME_STABLE = "com.android.chrome"
@@ -43,9 +44,6 @@ object ChromeCustomTabUtils {
         return ChromeCustomTabUtils.connect(context, preloadUrlList)
     }
 
-    /**
-     * When passing a list of URLs to preload, put them in descending order of priority
-     */
     fun connect(context: Context, preloadUrlArray: Array<String>): Boolean {
         val preloadUrlList = ArrayList<String>()
         for (url in preloadUrlArray) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
@@ -46,18 +46,18 @@ object ChromeCustomTabUtils {
                 client.warmup(0)
                 session = client.newSession(null)
 
-                val otherLikelyBundles = ArrayList<Bundle>()
+                val uriToPreload: Uri? = preloadUrl?.let { Uri.parse(it) }
                 otherLikelyUrls?.let { urlList ->
+                    val otherLikelyBundles = ArrayList<Bundle>()
                     for (url in urlList) {
                         val bundle = Bundle()
                         bundle.putParcelable(KEY_URL, Uri.parse(url))
                         otherLikelyBundles.add(bundle)
                     }
-                }
-
-                val uriToPreload: Uri? = preloadUrl?.let { Uri.parse(it) }
-                session?.mayLaunchUrl(uriToPreload, null, otherLikelyBundles)
+                    session?.mayLaunchUrl(uriToPreload, null, otherLikelyBundles)
+                } ?: session?.mayLaunchUrl(uriToPreload, null, null)
             }
+
             override fun onServiceDisconnected(name: ComponentName) {
                 session = null
                 connection = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
@@ -8,12 +8,12 @@ import com.woocommerce.android.R
 
 object ChromeCustomTabUtils {
     fun viewUrl(context: Context, url: String) {
-        val builder = CustomTabsIntent.Builder()
-        builder.setToolbarColor(ContextCompat.getColor(context, R.color.wc_purple))
-        builder.setStartAnimations(context, R.anim.activity_slide_in_from_right, 0)
-        builder.setExitAnimations(context, 0, R.anim.activity_slide_out_to_right)
-
-        val customTabsIntent = builder.build()
-        customTabsIntent.launchUrl(context, Uri.parse(url))
+        CustomTabsIntent.Builder()
+                .setToolbarColor(ContextCompat.getColor(context, R.color.wc_purple))
+                .setStartAnimations(context, R.anim.activity_slide_in_from_right, 0)
+                .setExitAnimations(context, 0, R.anim.activity_slide_out_to_right)
+                .setShowTitle(true)
+                .build()
+                .launchUrl(context, Uri.parse(url))
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
@@ -3,10 +3,16 @@ package com.woocommerce.android.util
 import android.content.Context
 import android.net.Uri
 import android.support.customtabs.CustomTabsIntent
+import android.support.v4.content.ContextCompat
+import com.woocommerce.android.R
 
 object ChromeCustomTabUtils {
     fun viewUrl(context: Context, url: String) {
         val builder = CustomTabsIntent.Builder()
+        builder.setToolbarColor(ContextCompat.getColor(context, R.color.wc_purple))
+        builder.setStartAnimations(context, R.anim.activity_slide_in_from_right, 0)
+        builder.setExitAnimations(context, 0, R.anim.activity_slide_out_to_right)
+
         val customTabsIntent = builder.build()
         customTabsIntent.launchUrl(context, Uri.parse(url))
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
@@ -43,6 +43,17 @@ object ChromeCustomTabUtils {
         return ChromeCustomTabUtils.connect(context, preloadUrlList)
     }
 
+    /**
+     * When passing a list of URLs to preload, put them in descending order of priority
+     */
+    fun connect(context: Context, preloadUrlArray: Array<String>): Boolean {
+        val preloadUrlList = ArrayList<String>()
+        for (url in preloadUrlArray) {
+            preloadUrlList.add(url)
+        }
+        return connect(context, preloadUrlList)
+    }
+
     fun connect(context: Context, preloadUrlList: ArrayList<String>): Boolean {
         if (!canUseCustomTabs(context)) {
             return false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.util
+
+import android.content.Context
+import android.net.Uri
+import android.support.customtabs.CustomTabsIntent
+
+object ChromeCustomTabUtils {
+    fun viewUrl(context: Context, url: String) {
+        val builder = CustomTabsIntent.Builder()
+        val customTabsIntent = builder.build()
+        customTabsIntent.launchUrl(context, Uri.parse(url))
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
@@ -4,68 +4,96 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.os.Bundle
-import android.support.customtabs.CustomTabsCallback
 import android.support.customtabs.CustomTabsClient
 import android.support.customtabs.CustomTabsIntent
+import android.support.customtabs.CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION
 import android.support.customtabs.CustomTabsServiceConnection
 import android.support.customtabs.CustomTabsSession
 import android.support.v4.content.ContextCompat
 import com.woocommerce.android.R
-import java.lang.ref.WeakReference
 
 object ChromeCustomTabUtils {
     private const val CUSTOM_TAB_PACKAGE_NAME_STABLE = "com.android.chrome"
+
     private var session: CustomTabsSession? = null
     private var connection: CustomTabsServiceConnection? = null
 
-    fun viewUrl(context: Context, url: String) {
+    fun launchUrl(context: Context, url: String) {
+        // if there's no connection then the device doesn't support custom tabs (or the caller neglected to connect)
+        if (connection == null) {
+            ActivityUtils.openUrlExternal(context, url)
+            return
+        }
+
         val intent = CustomTabsIntent.Builder(session)
                 .setToolbarColor(ContextCompat.getColor(context, R.color.wc_purple))
                 .setStartAnimations(context, R.anim.activity_slide_in_from_right, 0)
                 .setExitAnimations(context, 0, R.anim.activity_slide_out_to_right)
                 .setShowTitle(true)
                 .build()
-        intent.intent.putExtra(Intent.EXTRA_REFERRER, Uri.parse("android-app://" + context.getPackageName()))
+        intent.intent.putExtra(Intent.EXTRA_REFERRER, Uri.parse("android-app://" + context.packageName))
         intent.launchUrl(context, Uri.parse(url))
     }
 
-    fun preload(context: Context, url: String) {
-        // use existing session if available
-        session?.let {
-            it.mayLaunchUrl(Uri.parse(url), null, null)
-            return
+    /**
+     * Call this when the activity/fragment starts to create a custom tab connection and optionally
+     * preload a url
+     */
+    fun connect(context: Context, preloadUrl: String? = null): Boolean {
+        if (!canUseCustomTabs(context)) {
+            return false
         }
 
-        val weakContext = WeakReference(context)
         connection = object : CustomTabsServiceConnection() {
             override fun onCustomTabsServiceConnected(name: ComponentName, client: CustomTabsClient) {
                 client.warmup(0)
-                val callback = object: CustomTabsCallback() {
-                    override fun onNavigationEvent(navigationEvent: Int, extras: Bundle) {
-                        if (navigationEvent == NAVIGATION_ABORTED || navigationEvent == TAB_HIDDEN) {
-                            disconnect(weakContext.get())
-                        }
-                    }
+                session = client.newSession(null)
+                preloadUrl?.let { url ->
+                    session?.mayLaunchUrl(Uri.parse(url), null, null)
                 }
-                session = client.newSession(callback)
-                session?.mayLaunchUrl(Uri.parse(url), null, null)
             }
             override fun onServiceDisconnected(name: ComponentName) {
+                session = null
                 connection = null
             }
         }
         CustomTabsClient.bindCustomTabsService(context, CUSTOM_TAB_PACKAGE_NAME_STABLE, connection)
+        return true
     }
 
-    private fun disconnect(context: Context?) {
-        if (connection == null) return
-
-        try {
-            session = null
-            context?.unbindService(connection!!)
-        } catch (e: IllegalArgumentException) {
-            WooLog.e(WooLog.T.SUPPORT, e)
+    /**
+     * Call this when the activity/fragment ends to close the connection
+     */
+    fun disconnect(context: Context) {
+        if (connection != null) {
+            try {
+                context.unbindService(connection!!)
+            } catch (e: IllegalArgumentException) {
+                WooLog.e(WooLog.T.SUPPORT, e)
+            }
         }
+
+        session = null
+        connection = null
+    }
+
+    /**
+     * From https://github.com/GoogleChrome/custom-tabs-client/blob/master/shared/src/main/java/org/chromium/
+     * customtabsclient/shared/CustomTabsHelper.java
+     */
+    private fun canUseCustomTabs(context: Context): Boolean {
+        val pm = context.packageManager
+        val activityIntent = Intent(Intent.ACTION_VIEW, Uri.parse("http://www.example.com"))
+        val resolvedActivityList = pm.queryIntentActivities(activityIntent, 0)
+        for (info in resolvedActivityList) {
+            val serviceIntent = Intent()
+            serviceIntent.action = ACTION_CUSTOM_TABS_CONNECTION
+            serviceIntent.setPackage(info.activityInfo.packageName)
+            if (pm.resolveService(serviceIntent, 0) != null) {
+                return true
+            }
+        }
+
+        return false
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
@@ -69,9 +69,8 @@ object ChromeCustomTabUtils {
         }
 
         val intent = CustomTabsIntent.Builder(session)
+                .addDefaultShareMenuItem()
                 .setToolbarColor(ContextCompat.getColor(context, R.color.wc_purple))
-                .setStartAnimations(context, R.anim.activity_slide_in_from_right, 0)
-                .setExitAnimations(context, 0, R.anim.activity_slide_out_to_right)
                 .setShowTitle(true)
                 .build()
         intent.intent.putExtra(Intent.EXTRA_REFERRER, Uri.parse("android-app://" + context.packageName))


### PR DESCRIPTION
Closes #792 = adds a utility class which enables us to easily use Chrome Custom Tabs. I originally intended to use it only when showing the support FAQ but decided to use it everywhere we shell out to the external browser.

Update release notes:

* [x]  If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.