### PR TITLE
Issue/786 update tracks

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -117,7 +117,7 @@ dependencies {
         exclude group: "com.android.support"
     }
 
-    implementation 'com.automattic:tracks:1.1.5'
+    implementation 'com.automattic:tracks:1.1.6'
 
     implementation("com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:$fluxCVersion") {
         exclude group: "com.android.support"

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -117,7 +117,7 @@ dependencies {
         exclude group: "com.android.support"
     }
 
-    implementation 'com.automattic:tracks:1.1.4'
+    implementation 'com.automattic:tracks:1.1.5'
 
     implementation("com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:$fluxCVersion") {
         exclude group: "com.android.support"


### PR DESCRIPTION
Fixes #786 - this PR simply updates to the latest version of Tracks, which fixed the reported crash in [this commit](https://github.com/Automattic/Automattic-Tracks-Android/commit/fa57c64f2363f87a4f41fc18cf96b18dddaa2dd2#diff-1718aa6474e6bc8491113e238aa9e95a) by checking for a null display.