### PR TITLE
Add CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,54 @@
+copy_gradle_properties: &copy_gradle_properties
+  run:
+    name: Setup gradle.properties
+    command: cp gradle.properties-example gradle.properties
+
+orbs:
+  android: wordpress-mobile/android@0.0.20
+  danger: wordpress-mobile/danger@0.0.20
+
+version: 2.1
+jobs:
+  Lint:
+    executor: 
+      name: android/default
+      api-version: "28"
+    steps:
+      - checkout
+      - android/restore-gradle-cache:
+          cache-prefix: lint-cache-v1
+      - <<: *copy_gradle_properties
+      - run:
+          name: Checkstyle & klint
+          command: ./gradlew --stacktrace checkstyle ktlint
+      - run:
+          name: Lint
+          command: ./gradlew --stacktrace lintVanillaRelease
+      - android/save-gradle-cache:
+          cache-prefix: lint-cache-v1
+      - store_artifacts:
+          path: WooCommerce/build/reports
+          destination: reports
+  Test:
+    executor: 
+      name: android/default
+      api-version: "28"
+    steps:
+      - checkout
+      - android/restore-gradle-cache:
+          cache-prefix: tests-cache-v1
+      - <<: *copy_gradle_properties
+      - run:
+          name: Unit tests
+          command: ./gradlew --stacktrace testVanillaRelease
+      - android/save-gradle-cache:
+          cache-prefix: tests-cache-v1
+      - android/save-test-results
+
+workflows:
+  "WooCommerce Android":
+    jobs:
+      - Lint
+      - Test
+      - danger/danger-ruby:
+          name: Danger


### PR DESCRIPTION
Adding a CircleCI config for this repo. It re-uses the configuration from https://github.com/wordpress-mobile/circleci-orbs.

To test:

- CircleCI checks are ✅ 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.