### PR TITLE
issue/806-toolbar-back-arrow-nav

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,6 +16,7 @@ Bugfixes
 - Fixed a rare crash when recreating the order filter during activity restore (low memory situations)
 - Fixed a crash that occasionally happened while attempting to load the app from a woocommerce notification alert
 - Fixed a crash that occasionally happened while attempting to load the app from a woocommerce notification alert
+- Fixed bug that could cause the back arrow to appear in the toolbar when it shouldn't
 
 
 Improvements

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -289,6 +289,8 @@ class MainActivity : AppCompatActivity(),
         }
         AnalyticsTracker.track(stat)
 
+        supportActionBar?.setDisplayHomeAsUpEnabled(false)
+
         // Update the unseen notifications badge visiblility
         if (navPos == NOTIFICATIONS) {
             NotificationHandler.removeAllNotificationsFromSystemBar(this)


### PR DESCRIPTION
Fixes #806 - ensures that the back arrow doesn't appear in the toolbar in the following situation:

* Switch to the Orders tab
* Open an order detail
* Tap My store

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
