### PR TITLE
issue/787-state-loss-google-login-fragment 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,6 +16,6 @@ Bugfixes
 - Fixed a rare crash when recreating the order filter during activity restore (low memory situations)
 - Fixed a crash that occasionally happened while attempting to load the app from a woocommerce notification alert
 - Fixed a crash that occasionally happened while attempting to load the app from a woocommerce notification alert
-
+- Fixed a rare crash when showing the Google login screen
 
 Improvements

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -307,7 +307,7 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
             retainInstance = true
         }
         fragmentTransaction.add(loginGoogleFragment, LoginGoogleFragment.TAG)
-        fragmentTransaction.commit()
+        fragmentTransaction.commitAllowingStateLoss()
     }
 
     override fun helpMagicLinkRequest(email: String?) {


### PR DESCRIPTION
Fixes #787 - Uses commitAllowingStateLoss when adding the Google login fragment to avoid the dreaded "cannot commit after onSaveInstanceState" exception.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
