### PR TITLE
issue/782-illegal-state-main-clearbackstack 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,6 +16,6 @@ Bugfixes
 - Fixed a rare crash when recreating the order filter during activity restore (low memory situations)
 - Fixed a crash that occasionally happened while attempting to load the app from a woocommerce notification alert
 - Fixed a crash that occasionally happened while attempting to load the app from a woocommerce notification alert
-
+- Fixed rare crash when the current tab is reselected
 
 Improvements

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
@@ -144,7 +144,7 @@ class MainNavigationView @JvmOverloads constructor(
             with(it.childFragmentManager) {
                 if (backStackEntryCount > 0) {
                     val firstEntry = getBackStackEntryAt(0)
-                    popBackStack(firstEntry.id, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+                    popBackStackImmediate(firstEntry.id, FragmentManager.POP_BACK_STACK_INCLUSIVE)
                     return true
                 }
             }


### PR DESCRIPTION
Closes #782 - Uses popBackStackImmediate rather than popBackStack so there's no delay when clearing the backstack.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
