### PR TITLE
issue/750-clarify-login-username 

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -331,7 +331,7 @@
     <string name="invalid_verification_code">Invalid verification code</string>
     <string name="send_link">Send link</string>
     <string name="enter_your_password_instead">Enter your password instead</string>
-    <string name="username">Username</string>
+    <string name="username">WordPress.com username</string>
     <string name="password">Password</string>
     <string name="log_in">Log In</string>
     <string name="login_promo_text_onthego">Publish from the park. Blog from the bus. Comment from the café. WordPress goes where you go.</string>


### PR DESCRIPTION
Fixes #750 - when logging in using a site address, the login screen's user name label now reads "WordPress.com username" to clarify that a wp.com username/password is being requested.

![screenshot_1550576226](https://user-images.githubusercontent.com/3903757/53012531-33d20100-3411-11e9-8fa5-2bd6b475f7a8.png)