### PR TITLE
Manual order status change support

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -26,3 +26,6 @@ Improvements
 status label will now be fetched from the server and properly displayed.
 - Filtering by custom order status now supported!
 - The name of the active store is now shown at the top of the "My store" tab
+
+New Features
+- Added support for manually changing the status of an order! Click the pencil icon next to the order status in the order detail view to open a list of available order status options for selection. Custom order statuses are also supported.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -118,6 +118,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         ORDER_DETAIL_CUSTOMER_INFO_PHONE_MENU_PHONE_TAPPED,
         ORDER_DETAIL_CUSTOMER_INFO_PHONE_MENU_SMS_TAPPED,
         ORDER_DETAIL_FULFILL_ORDER_BUTTON_TAPPED,
+        ORDER_DETAIL_ORDER_STATUS_EDIT_BUTTON_TAPPED,
         ORDER_DETAIL_PRODUCT_DETAIL_BUTTON_TAPPED,
 
         // -- Order Notes
@@ -189,7 +190,10 @@ class AnalyticsTracker private constructor(private val context: Context) {
         REVIEW_DETAIL_TRASH_BUTTON_TAPPED,
 
         // -- Errors
-        JETPACK_TUNNEL_TIMEOUT
+        JETPACK_TUNNEL_TIMEOUT,
+
+        // -- Order status changes
+        SET_ORDER_STATUS_DIALOG_APPLY_BUTTON_TAPPED
     }
     // endregion
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardPresenter.kt
@@ -80,11 +80,11 @@ class DashboardPresenter @Inject constructor(
             statsForceRefresh[granularity.ordinal] = false
             dashboardView?.showChartSkeleton(true)
         }
-        val statsPayload = FetchOrderStatsPayload(selectedSite.get(), granularity, forceRefresh)
+        val statsPayload = FetchOrderStatsPayload(selectedSite.get(), granularity, forced = forceRefresh)
         dispatcher.dispatch(WCStatsActionBuilder.newFetchOrderStatsAction(statsPayload))
 
         // fetch visitor stats
-        val visitsPayload = FetchVisitorStatsPayload(selectedSite.get(), granularity, forceRefresh)
+        val visitsPayload = FetchVisitorStatsPayload(selectedSite.get(), granularity, forced = forceRefresh)
         dispatcher.dispatch(WCStatsActionBuilder.newFetchVisitorStatsAction(visitsPayload))
     }
 
@@ -100,7 +100,8 @@ class DashboardPresenter @Inject constructor(
             dashboardView?.showTopEarnersSkeleton(true)
         }
 
-        val payload = FetchTopEarnersStatsPayload(selectedSite.get(), granularity, NUM_TOP_EARNERS, forceRefresh)
+        val payload = FetchTopEarnersStatsPayload(
+                selectedSite.get(), granularity, NUM_TOP_EARNERS, forced = forceRefresh)
         dispatcher.dispatch(WCStatsActionBuilder.newFetchTopEarnersStatsAction(payload))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -376,7 +376,7 @@ class MainActivity : AppCompatActivity(),
         bottomNavView.updatePositionAndDeferInit(ORDERS)
 
         val fragment = bottomNavView.getFragment(ORDERS)
-        (fragment as OrderListFragment).onFilterSelected(orderStatusFilter)
+        (fragment as OrderListFragment).onOrderStatusSelected(orderStatusFilter)
     }
 
     override fun showNotificationDetail(remoteNoteId: Long) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailContract.kt
@@ -20,6 +20,8 @@ interface OrderDetailContract {
         fun pushOrderNote(noteText: String, isCustomerNote: Boolean)
         fun markOrderNotificationRead(context: Context, remoteNoteId: Long)
         fun getOrderStatusForStatusKey(key: String): WCOrderStatusModel
+        fun getOrderStatusOptions(): Map<String, WCOrderStatusModel>
+        fun refreshOrderStatusOptions()
     }
 
     interface View : BaseView<Presenter>, OrderActionListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -32,7 +32,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import javax.inject.Inject
 
 class OrderDetailFragment : Fragment(), OrderDetailContract.View, OrderDetailNoteListener,
-        OrderStatusSelectorDialog.OrderListFilterListener {
+        OrderStatusSelectorDialog.OrderStatusDialogListener {
     companion object {
         const val TAG = "OrderDetailFragment"
         const val FIELD_ORDER_IDENTIFIER = "order-identifier"
@@ -389,7 +389,7 @@ class OrderDetailFragment : Fragment(), OrderDetailContract.View, OrderDetailNot
         previousOrderStatus = null
     }
 
-    override fun onFilterSelected(orderStatus: String?) {
+    override fun onOrderStatusSelected(orderStatus: String?) {
         orderStatus?.let {
             showChangeOrderStatusSnackbar(it)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -403,7 +403,7 @@ class OrderDetailFragment : Fragment(), OrderDetailContract.View, OrderDetailNot
                     .newInstance(
                             orderStatusOptions,
                             orderStatus,
-                            getString(R.string.orderstatus_select_status),
+                            false,
                             listener = this)
                     .also { it.show(fragmentManager, OrderStatusSelectorDialog.TAG) }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -114,7 +114,7 @@ class OrderDetailFragment : Fragment(), OrderDetailContract.View, OrderDetailNot
         }
 
         scrollView.setOnScrollChangeListener {
-            v: NestedScrollView?, scrollX: Int, scrollY: Int, oldScrollX: Int, oldScrollY: Int ->
+            _: NestedScrollView?, _: Int, scrollY: Int, _: Int, oldScrollY: Int ->
             if (scrollY > oldScrollY) onScrollDown() else if (scrollY < oldScrollY) onScrollUp()
         }
     }
@@ -269,7 +269,9 @@ class OrderDetailFragment : Fragment(), OrderDetailContract.View, OrderDetailNot
                 when (newStatus) {
                     CoreOrderStatus.COMPLETED.value ->
                         AnalyticsTracker.track(SNACK_ORDER_MARKED_COMPLETE_UNDO_BUTTON_TAPPED)
-                    else -> {}
+                    else -> {
+                        // TODO add tracks for manual order status change
+                    }
                 }
 
                 // User canceled the action to change the order status
@@ -298,9 +300,13 @@ class OrderDetailFragment : Fragment(), OrderDetailContract.View, OrderDetailNot
                 }
             }
 
-            // TODO: for now this assumes orders marked complete, this needs to change when we handle other statuses
+            // Select the appropriate snack message based on the new status
+            val snackMsg = when (newStatus) {
+                CoreOrderStatus.COMPLETED.value -> R.string.order_fulfill_marked_complete
+                else -> R.string.order_status_changed_to
+            }
             changeOrderStatusSnackbar = uiMessageResolver
-                    .getUndoSnack(R.string.order_fulfill_marked_complete, actionListener = actionListener)
+                    .getUndoSnack(snackMsg, newStatus, actionListener = actionListener)
                     .also {
                         it.addCallback(callback)
                         it.show()
@@ -384,9 +390,9 @@ class OrderDetailFragment : Fragment(), OrderDetailContract.View, OrderDetailNot
     }
 
     override fun onFilterSelected(orderStatus: String?) {
-        // TODO update the view
-        // TODO display a snack for UNDO
-        // TODO process the change to the status
+        orderStatus?.let {
+            showChangeOrderStatusSnackbar(it)
+        }
     }
 
     private fun showOrderStatusSelector() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -269,9 +269,7 @@ class OrderDetailFragment : Fragment(), OrderDetailContract.View, OrderDetailNot
                 when (newStatus) {
                     CoreOrderStatus.COMPLETED.value ->
                         AnalyticsTracker.track(SNACK_ORDER_MARKED_COMPLETE_UNDO_BUTTON_TAPPED)
-                    else -> {
-                        // TODO add tracks for manual order status change
-                    }
+                    else -> {}
                 }
 
                 // User canceled the action to change the order status

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -32,7 +32,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import javax.inject.Inject
 
 class OrderDetailFragment : Fragment(), OrderDetailContract.View, OrderDetailNoteListener,
-        OrderStatusFilterDialog.OrderListFilterListener {
+        OrderStatusSelectorDialog.OrderListFilterListener {
     companion object {
         const val TAG = "OrderDetailFragment"
         const val FIELD_ORDER_IDENTIFIER = "order-identifier"
@@ -82,7 +82,7 @@ class OrderDetailFragment : Fragment(), OrderDetailContract.View, OrderDetailNot
     private var pendingNotesError = false
     private var runOnStartFunc: (() -> Unit)? = null
 
-    private var orderStatusSelector: OrderStatusFilterDialog? = null
+    private var orderStatusSelector: OrderStatusSelectorDialog? = null
 
     override fun onAttach(context: Context?) {
         AndroidSupportInjection.inject(this)
@@ -399,9 +399,13 @@ class OrderDetailFragment : Fragment(), OrderDetailContract.View, OrderDetailNot
         presenter.orderModel?.let { order ->
             val orderStatusOptions = presenter.getOrderStatusOptions()
             val orderStatus = order.status
-            orderStatusSelector = OrderStatusFilterDialog
-                    .newInstance(orderStatusOptions, orderStatus, listener = this)
-                    .also { it.show(fragmentManager, OrderStatusFilterDialog.TAG) }
+            orderStatusSelector = OrderStatusSelectorDialog
+                    .newInstance(
+                            orderStatusOptions,
+                            orderStatus,
+                            getString(R.string.orderstatus_select_status),
+                            listener = this)
+                    .also { it.show(fragmentManager, OrderStatusSelectorDialog.TAG) }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailOrderStatusView.kt
@@ -6,6 +6,8 @@ import android.util.AttributeSet
 import android.view.View
 import android.widget.RelativeLayout
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.widgets.tags.TagView
 import kotlinx.android.synthetic.main.order_detail_order_status.view.*
@@ -32,6 +34,8 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(ctx: Context, attrs: 
         orderStatus_orderTags.addView(getTagView(orderStatus))
 
         orderStatus_edit.setOnClickListener {
+            AnalyticsTracker.track(
+                    Stat.ORDER_DETAIL_ORDER_STATUS_EDIT_BUTTON_TAPPED, mapOf("status" to orderModel.status))
             listener.openOrderStatusSelector()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailOrderStatusView.kt
@@ -18,7 +18,11 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(ctx: Context, attrs: 
         View.inflate(context, R.layout.order_detail_order_status, this)
     }
 
-    fun initView(orderModel: WCOrderModel, orderStatus: WCOrderStatusModel) {
+    interface OrderStatusListener {
+        fun openOrderStatusSelector()
+    }
+
+    fun initView(orderModel: WCOrderModel, orderStatus: WCOrderStatusModel, listener: OrderStatusListener) {
         orderStatus_orderNum.text = context.getString(
                 R.string.orderdetail_orderstatus_heading,
                 orderModel.number, orderModel.billingFirstName, orderModel.billingLastName)
@@ -26,6 +30,10 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(ctx: Context, attrs: 
         orderStatus_created.text = context.getString(R.string.orderdetail_orderstatus_created, dateStr)
         orderStatus_orderTags.removeAllViews()
         orderStatus_orderTags.addView(getTagView(orderStatus))
+
+        orderStatus_edit.setOnClickListener {
+            listener.openOrderStatusSelector()
+        }
     }
 
     fun updateStatus(orderStatus: WCOrderStatusModel) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListContract.kt
@@ -31,7 +31,6 @@ interface OrderListContract {
         fun refreshFragmentState()
         fun showLoadOrdersError()
         fun showNoConnectionError()
-        fun onFilterSelected(orderStatus: String?)
 
         fun submitSearch(query: String)
         fun submitSearchDelayed(query: String)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -489,7 +489,7 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View, OrderStatu
     private fun showFilterDialog() {
         val orderStatusOptions = presenter.getOrderStatusOptions()
         orderFilterDialog = OrderStatusSelectorDialog
-                .newInstance(orderStatusOptions, orderStatusFilter, listener = this)
+                .newInstance(orderStatusOptions, orderStatusFilter, true, listener = this)
                 .also { it.show(fragmentManager, OrderStatusSelectorDialog.TAG) }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -40,7 +40,7 @@ import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 
-class OrderListFragment : TopLevelFragment(), OrderListContract.View, OrderStatusSelectorDialog.OrderListFilterListener,
+class OrderListFragment : TopLevelFragment(), OrderListContract.View, OrderStatusSelectorDialog.OrderStatusDialogListener,
         OnQueryTextListener, OnActionExpandListener, OnLoadMoreListener {
     companion object {
         val TAG: String = OrderListFragment::class.java.simpleName
@@ -121,7 +121,7 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View, OrderStatu
     override fun onViewStateRestored(savedInstanceState: Bundle?) {
         super.onViewStateRestored(savedInstanceState)
         if (orderStatusFilter != null && orderStatusFilter != ordersAdapter.orderStatusFilter) {
-            onFilterSelected(orderStatusFilter)
+            onOrderStatusSelected(orderStatusFilter)
         }
     }
 
@@ -493,7 +493,7 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View, OrderStatu
                 .also { it.show(fragmentManager, OrderStatusSelectorDialog.TAG) }
     }
 
-    override fun onFilterSelected(orderStatus: String?) {
+    override fun onOrderStatusSelected(orderStatus: String?) {
         orderStatusFilter = orderStatus
 
         if (isAdded) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -40,8 +40,9 @@ import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 
-class OrderListFragment : TopLevelFragment(), OrderListContract.View, OrderStatusSelectorDialog.OrderStatusDialogListener,
-        OnQueryTextListener, OnActionExpandListener, OnLoadMoreListener {
+class OrderListFragment : TopLevelFragment(), OrderListContract.View,
+        OrderStatusSelectorDialog.OrderStatusDialogListener, OnQueryTextListener, OnActionExpandListener,
+        OnLoadMoreListener {
     companion object {
         val TAG: String = OrderListFragment::class.java.simpleName
         const val STATE_KEY_LIST = "list-state"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -40,7 +40,7 @@ import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 
-class OrderListFragment : TopLevelFragment(), OrderListContract.View, OrderStatusFilterDialog.OrderListFilterListener,
+class OrderListFragment : TopLevelFragment(), OrderListContract.View, OrderStatusSelectorDialog.OrderListFilterListener,
         OnQueryTextListener, OnActionExpandListener, OnLoadMoreListener {
     companion object {
         val TAG: String = OrderListFragment::class.java.simpleName
@@ -65,7 +65,7 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View, OrderStatu
     @Inject lateinit var selectedSite: SelectedSite
 
     private lateinit var ordersDividerDecoration: DividerItemDecoration
-    private var orderFilterDialog: OrderStatusFilterDialog? = null
+    private var orderFilterDialog: OrderStatusSelectorDialog? = null
 
     override var isRefreshPending = true // If true, the fragment will refresh its orders when its visible
     override var isRefreshing: Boolean
@@ -488,9 +488,9 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View, OrderStatu
     // region Filtering
     private fun showFilterDialog() {
         val orderStatusOptions = presenter.getOrderStatusOptions()
-        orderFilterDialog = OrderStatusFilterDialog
+        orderFilterDialog = OrderStatusSelectorDialog
                 .newInstance(orderStatusOptions, orderStatusFilter, listener = this)
-                .also { it.show(fragmentManager, OrderStatusFilterDialog.TAG) }
+                .also { it.show(fragmentManager, OrderStatusSelectorDialog.TAG) }
     }
 
     override fun onFilterSelected(orderStatus: String?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListPresenter.kt
@@ -134,9 +134,13 @@ class OrderListPresenter @Inject constructor(
 
     override fun refreshOrderStatusOptions() {
         // Refresh the order status options from the API
-        isRefreshingOrderStatusOptions = true
-        dispatcher.dispatch(WCOrderActionBuilder
-                .newFetchOrderStatusOptionsAction(FetchOrderStatusOptionsPayload(selectedSite.get())))
+        if (!isRefreshingOrderStatusOptions) {
+            isRefreshingOrderStatusOptions = true
+            dispatcher.dispatch(
+                    WCOrderActionBuilder
+                            .newFetchOrderStatusOptionsAction(FetchOrderStatusOptionsPayload(selectedSite.get()))
+            )
+        }
     }
 
     @Suppress("unused")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusSelectorDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusSelectorDialog.kt
@@ -12,12 +12,12 @@ import org.wordpress.android.fluxc.model.WCOrderStatusModel
 /**
  * Dialog displays a list of order statuses and allows for selecting a single order status to filter by.
  *
- * This fragment should be instantiated using the [OrderStatusFilterDialog.newInstance] method. Calling classes
+ * This fragment should be instantiated using the [OrderStatusSelectorDialog.newInstance] method. Calling classes
  * can obtain the results of selection through the [OrderListFilterListener].
  */
-class OrderStatusFilterDialog : DialogFragment() {
+class OrderStatusSelectorDialog : DialogFragment() {
     companion object {
-        const val TAG: String = "OrderStatusFilterDialog"
+        const val TAG: String = "OrderStatusSelectorDialog"
 
         private const val ALL_FILTER_ID: String = "all"
 
@@ -25,8 +25,8 @@ class OrderStatusFilterDialog : DialogFragment() {
             orderStatusOptions: Map<String, WCOrderStatusModel>,
             currentFilter: String?,
             listener: OrderListFilterListener
-        ): OrderStatusFilterDialog {
-            val fragment = OrderStatusFilterDialog()
+        ): OrderStatusSelectorDialog {
+            val fragment = OrderStatusSelectorDialog()
             fragment.orderStatusOptions = orderStatusOptions
             fragment.listener = listener
             fragment.selectedFilter = currentFilter ?: ALL_FILTER_ID

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusSelectorDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusSelectorDialog.kt
@@ -24,13 +24,13 @@ class OrderStatusSelectorDialog : DialogFragment() {
         fun newInstance(
             orderStatusOptions: Map<String, WCOrderStatusModel>,
             currentFilter: String?,
-            title: String? = null,
+            isFilter: Boolean,
             listener: OrderListFilterListener
         ): OrderStatusSelectorDialog {
             val fragment = OrderStatusSelectorDialog()
             fragment.orderStatusOptions = orderStatusOptions
+            fragment.isFilter = isFilter
             fragment.listener = listener
-            fragment.dialogTitle = title
             fragment.selectedFilter = currentFilter ?: ALL_FILTER_ID
             return fragment
         }
@@ -41,14 +41,18 @@ class OrderStatusSelectorDialog : DialogFragment() {
     }
 
     private val filterMap: Map<String, String> by lazy {
-        mapOf(ALL_FILTER_ID to getString(R.string.all)).plus(
-                orderStatusOptions.values.associate { it.statusKey to it.label }
-        )
+        if (isFilter) {
+            mapOf(ALL_FILTER_ID to getString(R.string.all)).plus(
+                    orderStatusOptions.values.associate { it.statusKey to it.label }
+            )
+        } else {
+            orderStatusOptions.values.associate { it.statusKey to it.label }
+        }
     }
 
     var listener: OrderListFilterListener? = null
-    var dialogTitle: String? = null
     var selectedFilter: String? = null
+    var isFilter: Boolean = false
     lateinit var orderStatusOptions: Map<String, WCOrderStatusModel>
 
     private fun getCurrentOrderStatusIndex(): Int {
@@ -58,7 +62,11 @@ class OrderStatusSelectorDialog : DialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val selectedIndex = getCurrentOrderStatusIndex()
 
-        val title = dialogTitle ?: resources.getString(R.string.orderlist_filter_by)
+        val title = if (isFilter) {
+            resources.getString(R.string.orderlist_filter_by)
+        } else {
+            resources.getString(R.string.orderstatus_select_status)
+        }
         return AlertDialog.Builder(context)
                 .setTitle(title)
                 .setCancelable(true)
@@ -77,7 +85,11 @@ class OrderStatusSelectorDialog : DialogFragment() {
                         listener?.onFilterSelected(selectedFilter.takeUnless { it == ALL_FILTER_ID })
                     }
                     dialog.dismiss()
-                }.create()
+                }
+                .setNegativeButton(R.string.cancel) { dialog, _ ->
+                    dialog.dismiss()
+                }
+                .create()
     }
 
     override fun onResume() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusSelectorDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusSelectorDialog.kt
@@ -24,11 +24,13 @@ class OrderStatusSelectorDialog : DialogFragment() {
         fun newInstance(
             orderStatusOptions: Map<String, WCOrderStatusModel>,
             currentFilter: String?,
+            title: String? = null,
             listener: OrderListFilterListener
         ): OrderStatusSelectorDialog {
             val fragment = OrderStatusSelectorDialog()
             fragment.orderStatusOptions = orderStatusOptions
             fragment.listener = listener
+            fragment.dialogTitle = title
             fragment.selectedFilter = currentFilter ?: ALL_FILTER_ID
             return fragment
         }
@@ -45,6 +47,7 @@ class OrderStatusSelectorDialog : DialogFragment() {
     }
 
     var listener: OrderListFilterListener? = null
+    var dialogTitle: String? = null
     var selectedFilter: String? = null
     lateinit var orderStatusOptions: Map<String, WCOrderStatusModel>
 
@@ -55,8 +58,9 @@ class OrderStatusSelectorDialog : DialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val selectedIndex = getCurrentOrderStatusIndex()
 
+        val title = dialogTitle ?: resources.getString(R.string.orderlist_filter_by)
         return AlertDialog.Builder(context)
-                .setTitle(resources.getString(R.string.orderlist_filter_by))
+                .setTitle(title)
                 .setCancelable(true)
                 .setSingleChoiceItems(filterMap.values.toTypedArray(), selectedIndex) { _, which ->
                     selectedFilter = filterMap.keys.toTypedArray()[which]
@@ -64,7 +68,7 @@ class OrderStatusSelectorDialog : DialogFragment() {
                     AnalyticsTracker.track(Stat.FILTER_ORDERS_BY_STATUS_DIALOG_OPTION_SELECTED,
                             mapOf("status" to selectedFilter))
                 }
-                .setPositiveButton(R.string.orderlist_filter_apply) { dialog, _ ->
+                .setPositiveButton(R.string.apply) { dialog, _ ->
                     AnalyticsTracker.track(Stat.FILTER_ORDERS_BY_STATUS_DIALOG_APPLY_FILTER_BUTTON_TAPPED)
 
                     val newSelectedIndex = getCurrentOrderStatusIndex()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusSelectorDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusSelectorDialog.kt
@@ -83,7 +83,13 @@ class OrderStatusSelectorDialog : DialogFragment() {
                     // If in filter mode and 'All' is selected, pass null to signal a filterless refresh
                     val selectedItem = selectedOrderStatus.takeUnless { it == ALL_FILTER_ID }
 
-                    AnalyticsTracker.track(Stat.FILTER_ORDERS_BY_STATUS_DIALOG_APPLY_FILTER_BUTTON_TAPPED)
+                    if (isFilter) {
+                        AnalyticsTracker.track(Stat.FILTER_ORDERS_BY_STATUS_DIALOG_APPLY_FILTER_BUTTON_TAPPED)
+                    } else {
+                        AnalyticsTracker.track(
+                                Stat.SET_ORDER_STATUS_DIALOG_APPLY_BUTTON_TAPPED,
+                                mapOf("status" to selectedItem.orEmpty()))
+                    }
 
                     if (newSelectedIndex != selectedIndex) {
                         listener?.onOrderStatusSelected(selectedItem)

--- a/WooCommerce/src/main/res/drawable/ic_edit_pencil.xml
+++ b/WooCommerce/src/main/res/drawable/ic_edit_pencil.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="@color/wc_purple"
+        android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z"/>
+</vector>

--- a/WooCommerce/src/main/res/layout/order_detail_order_status.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_order_status.xml
@@ -23,11 +23,32 @@
         android:textAppearance="@style/Woo.OrderDetail.TextAppearance"
         tools:text="Created today at 9:51 AM"/>
 
-    <com.woocommerce.android.widgets.FlowLayout
-        android:id="@+id/orderStatus_orderTags"
-        android:layout_below="@+id/orderStatus_created"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:id="@+id/orderStatus_edit"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:contentDescription="@string/orderstatus_contentDesc"/>
+        android:orientation="horizontal"
+        android:layout_below="@+id/orderStatus_created"
+        android:focusable="true"
+        android:clickable="true"
+        android:padding="4dp"
+        android:contentDescription="@string/orderdetail_change_order_status"
+        android:background="?attr/selectableItemBackground">
+
+        <com.woocommerce.android.widgets.FlowLayout
+            android:id="@+id/orderStatus_orderTags"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:contentDescription="@string/orderstatus_contentDesc"/>
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:focusable="false"
+            android:clickable="false"
+            android:importantForAccessibility="no"
+            android:background="@drawable/ic_edit_pencil"/>
+    </LinearLayout>
 </merge>
 

--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -261,7 +261,7 @@ Language: ar
     <string name="customer_full_name">%1$s %2$s</string>
     <string name="customer_information">معلومات العميل</string>
     <string name="orderlist_filter">عامل التصفية</string>
-    <string name="orderlist_filter_apply">تطبيق عامل التصفية</string>
+    <string name="apply">تطبيق عامل التصفية</string>
     <string name="orderlist_filter_by">تصفية الطلبات حسب</string>
     <string name="orderlist_error_fetch_generic">حدث خطأ أثناء إحضار الطلبات</string>
     <string name="orderlist_item_order_name">%1$s %2$s</string>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -261,7 +261,7 @@ Language: de
     <string name="customer_full_name">%1$s %2$s</string>
     <string name="customer_information">Kundeninformationen</string>
     <string name="orderlist_filter">Filter</string>
-    <string name="orderlist_filter_apply">Filter anwenden</string>
+    <string name="apply">Filter anwenden</string>
     <string name="orderlist_filter_by">Bestellungen filtern nach</string>
     <string name="orderlist_error_fetch_generic">Fehler beim Abrufen der Bestellungen</string>
     <string name="orderlist_item_order_name">%1$s %2$s</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -261,7 +261,7 @@ Language: es
     <string name="customer_full_name">%1$s %2$s</string>
     <string name="customer_information">Información del cliente</string>
     <string name="orderlist_filter">Filtro</string>
-    <string name="orderlist_filter_apply">Aplicar filtro</string>
+    <string name="apply">Aplicar filtro</string>
     <string name="orderlist_filter_by">Filtrar pedidos por</string>
     <string name="orderlist_error_fetch_generic">Se ha producido un error al obtener los pedidos</string>
     <string name="orderlist_item_order_name">%1$s %2$s</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -260,7 +260,7 @@ Language: fr
     <string name="customer_full_name">%2$s %1$s</string>
     <string name="customer_information">Informations sur le client</string>
     <string name="orderlist_filter">Filtrer</string>
-    <string name="orderlist_filter_apply">Appliquer le filtre</string>
+    <string name="apply">Appliquer le filtre</string>
     <string name="orderlist_filter_by">Filtrer les commandes par</string>
     <string name="orderlist_error_fetch_generic">Erreur lors de l’extraction des commandes</string>
     <string name="orderlist_item_order_name">%2$s %1$s</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -264,7 +264,7 @@ Language: he_IL
     <string name="customer_full_name">%1$s %2$s</string>
     <string name="customer_information">פרטי לקוח</string>
     <string name="orderlist_filter">מסנן</string>
-    <string name="orderlist_filter_apply">החלת מסנן</string>
+    <string name="apply">החלת מסנן</string>
     <string name="orderlist_filter_by">סינון הזמנות לפי</string>
     <string name="orderlist_error_fetch_generic">שגיאה בעת אחזור הזמנות</string>
     <string name="orderlist_item_order_name">%1$s %2$s</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -264,7 +264,7 @@ Language: id
     <string name="customer_full_name">%1$s %2$s</string>
     <string name="customer_information">Informasi Pelanggan</string>
     <string name="orderlist_filter">Penyaring</string>
-    <string name="orderlist_filter_apply">Terapkan Penyaring</string>
+    <string name="apply">Terapkan Penyaring</string>
     <string name="orderlist_filter_by">Saring pesanan menurut</string>
     <string name="orderlist_error_fetch_generic">Error saat mengambil pesanan</string>
     <string name="orderlist_item_order_name">%1$s %2$s</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -261,7 +261,7 @@ Language: it
     <string name="customer_full_name">%1$s %2$s</string>
     <string name="customer_information">Informazioni cliente</string>
     <string name="orderlist_filter">Filtro</string>
-    <string name="orderlist_filter_apply">Applica filtro</string>
+    <string name="apply">Applica filtro</string>
     <string name="orderlist_filter_by">Filtra ordini per</string>
     <string name="orderlist_error_fetch_generic">Errore durante il recupero degli ordini</string>
     <string name="orderlist_item_order_name">%1$s %2$s</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -261,7 +261,7 @@ Language: ja_JP
     <string name="customer_full_name">%1$s %2$s</string>
     <string name="customer_information">顧客情報</string>
     <string name="orderlist_filter">フィルター</string>
-    <string name="orderlist_filter_apply">フィルターを適用</string>
+    <string name="apply">フィルターを適用</string>
     <string name="orderlist_filter_by">注文の絞り込み基準</string>
     <string name="orderlist_error_fetch_generic">注文を取得する際にエラーが発生しました</string>
     <string name="orderlist_item_order_name">%1$s %2$s</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -261,7 +261,7 @@ Language: ko_KR
     <string name="customer_full_name">%1$s %2$s</string>
     <string name="customer_information">고객 정보</string>
     <string name="orderlist_filter">필터</string>
-    <string name="orderlist_filter_apply">필터 적용</string>
+    <string name="apply">필터 적용</string>
     <string name="orderlist_filter_by">주문 필터 적용 기준</string>
     <string name="orderlist_error_fetch_generic">주문을 가져오는 중 오류 발생</string>
     <string name="orderlist_item_order_name">%1$s %2$s</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -261,7 +261,7 @@ Language: nl
     <string name="customer_full_name">%1$s %2$s</string>
     <string name="customer_information">Klantgegevens</string>
     <string name="orderlist_filter">Filter</string>
-    <string name="orderlist_filter_apply">Filter toepassen</string>
+    <string name="apply">Filter toepassen</string>
     <string name="orderlist_filter_by">Bestellingen filteren op</string>
     <string name="orderlist_error_fetch_generic">Fout bij ophalen bestellingen</string>
     <string name="orderlist_item_order_name">%1$s %2$s</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -261,7 +261,7 @@ Language: pt_BR
     <string name="customer_full_name">%1$s %2$s</string>
     <string name="customer_information">Informações do cliente</string>
     <string name="orderlist_filter">Filtrar</string>
-    <string name="orderlist_filter_apply">Aplicar filtro</string>
+    <string name="apply">Aplicar filtro</string>
     <string name="orderlist_filter_by">Filtrar pedidos por</string>
     <string name="orderlist_error_fetch_generic">Erro ao buscar pedidos</string>
     <string name="orderlist_item_order_name">%1$s %2$s</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -254,7 +254,7 @@ Language: ru
     <string name="customer_full_name">%1$s %2$s</string>
     <string name="customer_information">Информация о клиенте</string>
     <string name="orderlist_filter">Фильтр</string>
-    <string name="orderlist_filter_apply">Применить фильтр</string>
+    <string name="apply">Применить фильтр</string>
     <string name="orderlist_filter_by">Фильтровать заказы по</string>
     <string name="orderlist_error_fetch_generic">Ошибка при загрузке заказов</string>
     <string name="orderlist_item_order_name">%1$s %2$s</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -253,7 +253,7 @@ Language: sv_SE
     <string name="customer_full_name"> %1$s %2$s</string>
     <string name="customer_information">Kundinformation</string>
     <string name="orderlist_filter">Filtrera</string>
-    <string name="orderlist_filter_apply">Använd filter</string>
+    <string name="apply">Använd filter</string>
     <string name="orderlist_filter_by">Filtrera ordrar efter</string>
     <string name="orderlist_error_fetch_generic">Det gick inte att hämta ordrar</string>
     <string name="orderlist_item_order_name">%1$s %2$s</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -261,7 +261,7 @@ Language: tr
     <string name="customer_full_name">%1$s %2$s</string>
     <string name="customer_information">Müşteri Bilgileri</string>
     <string name="orderlist_filter">Filtreleme</string>
-    <string name="orderlist_filter_apply">Filtreyi Uygulayın</string>
+    <string name="apply">Filtreyi Uygulayın</string>
     <string name="orderlist_filter_by">Siparişleri şuna göre filtreleyin:</string>
     <string name="orderlist_error_fetch_generic">Sipariş alınırken hata</string>
     <string name="orderlist_item_order_name">%1$s %2$s</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -256,7 +256,7 @@ Language: zh_CN
     <string name="customer_full_name">%1$s %2$s</string>
     <string name="customer_information">客户信息</string>
     <string name="orderlist_filter">过滤器</string>
-    <string name="orderlist_filter_apply">应用过滤器</string>
+    <string name="apply">应用过滤器</string>
     <string name="orderlist_filter_by">过滤订单的条件</string>
     <string name="orderlist_error_fetch_generic">抓取订单时出错</string>
     <string name="orderlist_item_order_name">%1$s %2$s</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -256,7 +256,7 @@ Language: zh_TW
     <string name="customer_full_name">%1$s %2$s</string>
     <string name="customer_information">顧客資料</string>
     <string name="orderlist_filter">篩選</string>
-    <string name="orderlist_filter_apply">套用篩選條件</string>
+    <string name="apply">套用篩選條件</string>
     <string name="orderlist_filter_by">訂單篩選條件</string>
     <string name="orderlist_error_fetch_generic">擷取訂單時發生錯誤</string>
     <string name="orderlist_item_order_name">%1$s %2$s</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -192,6 +192,7 @@
     <string name="orderdetail_hide_billing">Hide Billing</string>
     <string name="orderdetail_add_note">Add a note</string>
     <string name="orderdetail_addnote_contentdesc">Add an order note</string>
+    <string name="orderdetail_change_order_status">Click to change order status</string>
     <string name="order_fulfill_order">Fulfill Order</string>
     <string name="order_fulfill_mark_complete">Mark Order Complete</string>
     <string name="order_fulfill_marked_complete">Order Marked Complete</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -59,6 +59,7 @@
     <string name="back">Back</string>
     <string name="button_update_instructions">Update instructions</string>
     <string name="dismiss">Dismiss</string>
+    <string name="apply">Apply</string>
 
     <!--
         Date/Time Labels
@@ -149,7 +150,6 @@
     <string name="orderlist_item_order_name">%1$s %2$s</string>
     <string name="orderlist_error_fetch_generic">Error fetching orders</string>
     <string name="orderlist_filter_by">Filter orders by</string>
-    <string name="orderlist_filter_apply">Apply Filter</string>
     <string name="orderlist_filter">Filter</string>
     <string name="orderlist_filtered" translatable="false">: %1$s</string>
     <!--

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -212,6 +212,7 @@
     <!--
         Order Status Labels
     -->
+    <string name="orderstatus_select_status">Choose order status</string>
     <string name="orderstatus_processing">Processing</string>
     <string name="orderstatus_pending">Pending Payment</string>
     <string name="orderstatus_failed">Failed</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -196,6 +196,7 @@
     <string name="order_fulfill_order">Fulfill Order</string>
     <string name="order_fulfill_mark_complete">Mark Order Complete</string>
     <string name="order_fulfill_marked_complete">Order Marked Complete</string>
+    <string name="order_status_changed_to">Order status changed to %s</string>
     <string name="order_error_fetch_notes_generic">Error fetching error notes</string>
     <string name="order_error_update_general">Error changing order</string>
     <string name="order_error_fetch_generic">Error fetching order</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -212,7 +212,7 @@
     <!--
         Order Status Labels
     -->
-    <string name="orderstatus_select_status">Choose order status</string>
+    <string name="orderstatus_select_status">Change order status</string>
     <string name="orderstatus_processing">Processing</string>
     <string name="orderstatus_pending">Pending Payment</string>
     <string name="orderstatus_failed">Failed</string>

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = 'fca18a13a5e2bc81edd10f313a4c4eaa3c004408'
+    fluxCVersion = '8e637e77ab08b93a73586aed4b9f54305204cecb'
     daggerVersion = '2.11'
     supportLibraryVersion = '28.0.0'
     glideVersion = '4.6.1'


### PR DESCRIPTION
Fixes #22 by adding the ability to allow the user to manually change the status of an order. 

<img src="https://user-images.githubusercontent.com/5810477/53200929-66822200-35e8-11e9-901a-f6db0a1c166e.gif" width="300"/>

This feature re-uses the order status filter dialog so a few changes were made to support this:
- The dialog was renamed
- The `Apply Filter` button was renamed to just `Apply`
- Per feedback from @kyleaparker - added a `Cancel` button as well

Here is a screenshot that shows the difference between the filter and order status change versions:
<img width="1221" alt="screen shot 2019-02-21 at 2 47 43 pm" src="https://user-images.githubusercontent.com/5810477/53200920-6124d780-35e8-11e9-9677-b8fe0e660f87.png">

**New tracks events:**
- set_order_status_dialog_apply_button_tapped [status:$selected-status-name]
- order_detail_order_status_edit_button_tapped [status:$current-status-name]

Update release notes:
- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
