### PR TITLE
issue/829-top-performers-total

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -129,7 +129,7 @@
     <string name="dashboard_top_earners_title">Top performers</string>
     <string name="dashboard_top_earners_description">Gain insights into how products are performing on your store</string>
     <string name="dashboard_top_earners_total_spend">Total spend</string>
-    <string name="dashboard_top_earners_total_orders">Total product order: %s</string>
+    <string name="dashboard_top_earners_total_orders">Total orders: %s</string>
     <string name="dashboard_top_earners_content_description">Product image</string>
     <string name="dashboard_top_earners_empty">No activity this period</string>
 


### PR DESCRIPTION
Closes #829 - As per the i7 designs, the top performers list now says "Total orders" rather than "Total product order."

![before](https://user-images.githubusercontent.com/3903757/53245353-7f87e300-367b-11e9-9684-9b2e6bc89eeb.png)
