### PR TITLE
issue/828-logout-button-text 

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -244,7 +244,7 @@
     -->
     <string name="settings">Settings</string>
     <string name="privacy_settings">Privacy settings</string>
-    <string name="settings_signout">Log out account</string>
+    <string name="settings_signout">Log out</string>
     <string name="settings_confirm_logout">Are you sure you want to logout from the account %s?</string>
     <string name="settings_send_stats">Collect information</string>
     <string name="settings_send_stats_detail">Share information with our analytics tool about your use of services while logged in to your WordPress account</string>


### PR DESCRIPTION
Fixes #828 - changes the logout button from "Log out account" to simply "Log out," as per the i7 designs.