### PR TITLE
issue/659-illegal-state-fragment-again

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -19,6 +19,7 @@ Bugfixes
 - Fixed a crash that occasionally happened while attempting to load the app from a woocommerce notification alert
 - Fixed a rare crash when showing the Google login screen
 - Fixed bug that could cause the back arrow to appear in the toolbar when it shouldn't
+- Fixed crash when opening app from a notification
 
 Improvements
 - Custom order status labels are now supported! Instead of just displaying the order status slug, the custom order

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -76,7 +76,11 @@ abstract class TopLevelFragment : Fragment(), TopLevelFragmentView {
     }
 
     override fun getFragmentFromBackStack(tag: String): Fragment? {
-        return childFragmentManager.findFragmentByTag(tag)
+        return if (isAdded) {
+            childFragmentManager.findFragmentByTag(tag)
+        } else {
+            null
+        }
     }
 
     override fun popToState(tag: String): Boolean {


### PR DESCRIPTION
Fixes #659 (finally!). To repro the crash in `develop`:

* Make sure "Don't get activities" is enabled
* Send the app to the background
* Generate a push notification
* Tap the notification
* BOOM!

Then perform the same steps with this branch and notice no more boom :)

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
