### PR TITLE
issue/374-selected-site-get-exception

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -23,7 +23,11 @@ class MainSettingsPresenter @Inject constructor(
 
     override fun getUserDisplayName(): String = accountStore.account.displayName
 
-    override fun getStoreDomainName(): String = StringUtils.getSiteDomainAndPath(selectedSite.get())
+    override fun getStoreDomainName(): String {
+        return selectedSite.getIfExists()?.let { site ->
+            StringUtils.getSiteDomainAndPath(site)
+        } ?: ""
+    }
 
     override fun hasMultipleStores() = wooCommerceStore.getWooCommerceSites().size > 1
 }


### PR DESCRIPTION
Closes #374 (again) - the crash was due to accessing `selectedSite.get()` when there is no selected site. Fix was to use `selectedSite.getIfExists()` instead.

Of course, I'm left wondering how the user got to settings without a selected site, but this at least corrects it.