### PR TITLE
Add override for a login library string

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -334,7 +334,7 @@
     <string name="invalid_verification_code">Invalid verification code</string>
     <string name="send_link">Send link</string>
     <string name="enter_your_password_instead">Enter your password instead</string>
-    <string name="username">WordPress.com username</string>
+    <string name="username" content_override="true">WordPress.com username</string>
     <string name="password">Password</string>
     <string name="log_in">Log In</string>
     <string name="login_promo_text_onthego">Publish from the park. Blog from the bus. Comment from the café. WordPress goes where you go.</string>


### PR DESCRIPTION
This PR only adds the `content_override`  tag to the `username` string in order to avoid that it's replaced by the original string in the library during the code freeze.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
