### PR TITLE
issue/816-notifs-index-out-of-bounds

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 
 Bugfixes
+* Fixed rare crash after moderating a product review
 
 Improvements
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
@@ -248,7 +248,7 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
 
             notifyItemInsertedInSection(section, pos)
             getPositionInAdapter(section, pos)
-        }.also { pendingRemovalNotification = null } ?: 0
+        }.also { pendingRemovalNotification = null } ?: INVALID_POSITION
     }
 
     /**
@@ -403,31 +403,32 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
         }
 
         override fun onDrawOver(canvas: Canvas, parent: RecyclerView, state: RecyclerView.State) {
-            for (i in 0 until parent.childCount) {
+            for (i in 0 until parent.childCount - 1) {
                 val child = parent.getChildAt(i)
-                val position = parent.getChildAdapterPosition(child)
-                val itemType = decorListener?.getItemTypeAtPosition(position) ?: ItemType.READ_NOTIF
+                val position = child?.let { parent.getChildAdapterPosition(it) } ?: INVALID_POSITION
+                if (position != INVALID_POSITION) {
+                    val itemType = decorListener?.getItemTypeAtPosition(position) ?: ItemType.READ_NOTIF
+                    /*
+                     * note that we have to draw the indicator for all items rather than just unread notifs
+                     * in order to paint over recycled cells that have a previously-drawn indicator
+                     */
+                    val colorId = when (itemType) {
+                        ItemType.HEADER -> R.color.list_header_bg
+                        ItemType.UNREAD_NOTIF -> R.color.wc_green
+                        else -> R.color.list_item_bg
+                    }
 
-                /*
-                 * note that we have to draw the indicator for all items rather than just unread notifs
-                 * in order to paint over recycled cells that have a previously-drawn indicator
-                 */
-                val colorId = when (itemType) {
-                    ItemType.HEADER -> R.color.list_header_bg
-                    ItemType.UNREAD_NOTIF -> R.color.wc_green
-                    else -> R.color.list_item_bg
+                    val paint = Paint()
+                    paint.color = ContextCompat.getColor(parent.context, colorId)
+
+                    parent.getDecoratedBoundsWithMargins(child, bounds)
+                    val top = bounds.top.toFloat()
+                    val bottom = (bounds.bottom + Math.round(child.translationY)).toFloat()
+                    val left = bounds.left.toFloat()
+                    val right = left + dividerWidth
+
+                    canvas.drawRect(left, top, right, bottom, paint)
                 }
-
-                val paint = Paint()
-                paint.color = ContextCompat.getColor(parent.context, colorId)
-
-                parent.getDecoratedBoundsWithMargins(child, bounds)
-                val top = bounds.top.toFloat()
-                val bottom = (bounds.bottom + Math.round(child.translationY)).toFloat()
-                val left = bounds.left.toFloat()
-                val right = left + dividerWidth
-
-                canvas.drawRect(left, top, right, bottom, paint)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
@@ -171,7 +171,7 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
         if (section.list.size == 0) {
             val sectionPos = getSectionPosition(section)
             section.isVisible = false
-            if (sectionPos != SectionedRecyclerViewAdapter.INVALID_POSITION) {
+            if (sectionPos != INVALID_POSITION) {
                 notifySectionChangedToInvisible(section, sectionPos)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
@@ -45,6 +45,8 @@ import org.wordpress.android.fluxc.model.CommentStatus
 import org.wordpress.android.fluxc.model.CommentStatus.SPAM
 import org.wordpress.android.fluxc.model.CommentStatus.TRASH
 import org.wordpress.android.fluxc.model.notification.NotificationModel
+import com.woocommerce.android.widgets.sectionedrecyclerview.SectionedRecyclerViewAdapter
+import com.woocommerce.android.widgets.sectionedrecyclerview.SectionedRecyclerViewAdapter.Companion.INVALID_POSITION
 import javax.inject.Inject
 
 class NotifsListFragment : TopLevelFragment(),
@@ -430,7 +432,9 @@ class NotifsListFragment : TopLevelFragment(),
         AnalyticsTracker.track(Stat.REVIEW_ACTION_UNDO)
 
         val itemPosition = notifsAdapter.revertHiddenNotificationAndReturnPos()
-        notifsList.smoothScrollToPosition(itemPosition)
+        if (itemPosition != INVALID_POSITION) {
+            notifsList.smoothScrollToPosition(itemPosition)
+        }
         resetPendingModerationVariables()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
@@ -37,6 +37,7 @@ import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.NOTIFICATIONS
 import com.woocommerce.android.widgets.AppRatingDialog
 import com.woocommerce.android.widgets.SkeletonView
+import com.woocommerce.android.widgets.sectionedrecyclerview.SectionedRecyclerViewAdapter.Companion.INVALID_POSITION
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_notifs_list.*
 import kotlinx.android.synthetic.main.fragment_notifs_list.view.*
@@ -45,8 +46,6 @@ import org.wordpress.android.fluxc.model.CommentStatus
 import org.wordpress.android.fluxc.model.CommentStatus.SPAM
 import org.wordpress.android.fluxc.model.CommentStatus.TRASH
 import org.wordpress.android.fluxc.model.notification.NotificationModel
-import com.woocommerce.android.widgets.sectionedrecyclerview.SectionedRecyclerViewAdapter
-import com.woocommerce.android.widgets.sectionedrecyclerview.SectionedRecyclerViewAdapter.Companion.INVALID_POSITION
 import javax.inject.Inject
 
 class NotifsListFragment : TopLevelFragment(),


### PR DESCRIPTION
Closes #816 - I wasn't able to repro the crash, but looking at the user's logs I was seeing lots of entries like this:

```
w/WooCommerce-NOTIFICATIONS: Failed to get item type at recycler position -1
```

That log entry is added when we fail to determine the item type at a specific position in the notification list, and that's only used by the unread item decoration. Digging into the item decoration code I saw [this](https://github.com/woocommerce/woocommerce-android/blob/develop/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt#L406):

```
for (i in 0 until parent.childCount) {
     val child = parent.getChildAt(i)
```

The `for` loop _should_ have used `childCount -1`, resulting in a null child being accessed and triggering that log entry. I fixed that mistake, and also added checks for invalid child views and positions.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
