### PR TITLE
Remove Danger: Dangerfile, gem and CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ copy_gradle_properties: &copy_gradle_properties
 
 orbs:
   android: wordpress-mobile/android@0.0.20
-  danger: wordpress-mobile/danger@0.0.20
 
 version: 2.1
 jobs:
@@ -50,5 +49,3 @@ workflows:
     jobs:
       - Lint
       - Test
-      - danger/danger-ruby:
-          name: Danger

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,9 +1,0 @@
-# A PR should have at least one label
-warn("PR is missing at least one label.") if github.pr_labels.empty?
-
-# Warn when there is a big PR
-warn("PR has more than 500 lines of code changing. Consider splitting into smaller PRs if possible.") if git.lines_of_code > 500
-
-# PRs should have a milestone attached
-has_milestone = github.pr_json["milestone"] != nil
-warn("PR is not assigned to a milestone.", sticky: false) unless has_milestone

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "https://rubygems.org" do 
-  gem 'danger'
   gem 'nokogiri'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,28 +15,10 @@ GEM
     atomos (0.1.3)
     babosa (1.0.2)
     claide (1.0.2)
-    claide-plugins (0.9.2)
-      cork
-      nap
-      open4 (~> 1.3)
     colored (1.2)
     colored2 (3.1.2)
     commander-fastlane (4.4.6)
       highline (~> 1.7.2)
-    cork (0.3.0)
-      colored2 (~> 3.1)
-    danger (5.6.2)
-      claide (~> 1.0)
-      claide-plugins (>= 0.9.2)
-      colored2 (~> 3.1)
-      cork (~> 0.1)
-      faraday (~> 0.9)
-      faraday-http-cache (~> 1.0)
-      git (~> 1)
-      kramdown (~> 1.5)
-      no_proxy_fix
-      octokit (~> 4.7)
-      terminal-table (~> 1)
     declarative (0.0.10)
     declarative-option (0.1.0)
     diffy (3.3.0)
@@ -50,8 +32,6 @@ GEM
     faraday-cookie_jar (0.0.6)
       faraday (>= 0.7.4)
       http-cookie (~> 1.0.0)
-    faraday-http-cache (1.3.1)
-      faraday (~> 0.8)
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     fastimage (2.1.4)
@@ -92,7 +72,6 @@ GEM
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
     gh_inspector (1.1.3)
-    git (1.4.0)
     google-api-client (0.23.9)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.5, < 0.7.0)
@@ -114,7 +93,6 @@ GEM
     httpclient (2.8.3)
     json (2.1.0)
     jwt (2.1.0)
-    kramdown (1.17.0)
     memoist (0.16.0)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
@@ -125,14 +103,9 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nanaimo (0.2.6)
-    nap (1.1.0)
     naturally (2.2.0)
-    no_proxy_fix (0.1.2)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
-    octokit (4.9.0)
-      sawyer (~> 0.8.0, >= 0.5.3)
-    open4 (1.3.4)
     os (1.0.0)
     plist (3.4.0)
     public_suffix (2.0.5)
@@ -143,9 +116,6 @@ GEM
     retriable (3.1.2)
     rouge (2.0.7)
     rubyzip (1.2.2)
-    sawyer (0.8.1)
-      addressable (>= 2.3.5, < 2.6)
-      faraday (~> 0.8, < 1.0)
     security (0.1.3)
     signet (0.11.0)
       addressable (~> 2.3)
@@ -184,7 +154,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  danger!
   fastlane
   fastlane-plugin-wpmreleasetoolkit!
   nokogiri!


### PR DESCRIPTION
Danger has now been replaced with its self-hosted equivalent, [Peril](https://github.com/danger/peril).

All existing rules from the `Dangerfile` have been added to our new Peril settings repo: https://github.com/wordpress-mobile/peril-settings. This will allow us to share rules across projects and platforms.

You can see an example of Peril failing here: https://github.com/woocommerce/woocommerce-android/pull/852#issuecomment-467819249

To test:

- See that there is a new Peril status on this PR, and there is no Danger check.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.