### PR TITLE
issue/834-notification-review-detail

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 
 Bugfixes
+* Fixed bug that could cause review detail not to appear after tapping a review notification
 
 Improvements
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
@@ -32,6 +32,7 @@ import org.greenrobot.eventbus.EventBus
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.NotificationActionBuilder
 import org.wordpress.android.fluxc.model.AccountModel
+import org.wordpress.android.fluxc.store.NotificationStore
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationPayload
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.util.ImageUtils
@@ -47,6 +48,8 @@ class NotificationHandler @Inject constructor(
     private val siteStore: SiteStore,
     private val dispatcher: Dispatcher
 ) {
+    @Inject lateinit var notificationStore: NotificationStore
+
     companion object {
         private val ACTIVE_NOTIFICATIONS_MAP = mutableMapOf<Int, Bundle>()
 


### PR DESCRIPTION
Fixes #834 - Injects the notification store so it's available when notification is received while app isn't loaded. Hat tip to @aforcier for the solution!

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
