### PR TITLE
Issue/notifs moderation issues

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,8 @@
 -----
 
 Bugfixes
+* Fixed a crash that could occur when undo-ing a review moderation
+* Fixed a UI issue that could show an apparent duplicate review when trashing the last review notification
 
 Improvements
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
@@ -46,10 +46,9 @@ import javax.inject.Singleton
 @Singleton
 class NotificationHandler @Inject constructor(
     private val siteStore: SiteStore,
+    private val notificationStore: NotificationStore, // Required to ensure instantiated when app started from a push
     private val dispatcher: Dispatcher
 ) {
-    @Inject lateinit var notificationStore: NotificationStore
-
     companion object {
         private val ACTIVE_NOTIFICATIONS_MAP = mutableMapOf<Int, Bundle>()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
@@ -159,13 +159,10 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
             return
         }
 
-        // extract this notif and remove it from the list
-        val notif = notifsList.removeAt(posInList)
-
         getSectionForListItemPosition(posInList)?.let {
             val section = it as NotifsListSection
             val posInSection = getPositionInSectionByListPos(posInList)
-            pendingRemovalNotification = Triple(notif, section, posInSection)
+            pendingRemovalNotification = Triple(notifsList[posInList], section, posInSection)
 
             // remove from the section list
             section.list.removeAt(posInSection)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
@@ -152,20 +152,22 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
      * by reverting the action, or by loading a fresh list of notifications.
      */
     fun hideNotificationWithId(remoteNoteId: Long) {
-        val pos = notifsList.indexOfFirst { it.remoteNoteId == remoteNoteId }
-        if (pos == -1) {
+        val posInList = notifsList.indexOfFirst { it.remoteNoteId == remoteNoteId }
+        if (posInList == -1) {
             WooLog.w(T.NOTIFICATIONS, "Unable to hide notification, position is -1")
             pendingRemovalNotification = null
             return
         }
 
-        val notif = notifsList[pos]
-        getSectionForListItemPosition(pos)?.let {
+        // extract this notif and remove it from the list
+        val notif = notifsList.removeAt(posInList)
+
+        getSectionForListItemPosition(posInList)?.let {
             val section = it as NotifsListSection
-            val posInSection = getPositionInSectionByListPos(pos)
+            val posInSection = getPositionInSectionByListPos(posInList)
             pendingRemovalNotification = Triple(notif, section, posInSection)
 
-            // remove from the list
+            // remove from the section list
             section.list.removeAt(posInSection)
             notifyItemRemovedFromSection(section, posInSection)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
@@ -269,6 +269,8 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
 
         setNotifications(newList)
     }
+
+    fun isEmpty() = notifsList.isEmpty()
     // endregion
 
     // region Private methods

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
@@ -160,19 +160,21 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
         }
 
         val notif = notifsList[pos]
-        val section = getSectionForListItemPosition(pos) as NotifsListSection
-        val posInSection = getPositionInSectionByListPos(pos)
-        pendingRemovalNotification = Triple(notif, section, posInSection)
+        getSectionForListItemPosition(pos)?.let {
+            val section = it as NotifsListSection
+            val posInSection = getPositionInSectionByListPos(pos)
+            pendingRemovalNotification = Triple(notif, section, posInSection)
 
-        // remove from the list
-        section.list.removeAt(posInSection)
-        notifyItemRemovedFromSection(section, posInSection)
+            // remove from the list
+            section.list.removeAt(posInSection)
+            notifyItemRemovedFromSection(section, posInSection)
 
-        if (section.list.size == 0) {
-            val sectionPos = getSectionPosition(section)
-            section.isVisible = false
-            if (sectionPos != SectionedRecyclerViewAdapter.INVALID_POSITION) {
-                notifySectionChangedToInvisible(section, sectionPos)
+            if (section.list.size == 0) {
+                val sectionPos = getSectionPosition(section)
+                section.isVisible = false
+                if (sectionPos != SectionedRecyclerViewAdapter.INVALID_POSITION) {
+                    notifySectionChangedToInvisible(section, sectionPos)
+                }
             }
         }
     }
@@ -303,9 +305,9 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
      * Returns the Section object for a position in the backing list.
      *
      * @param position position in the original list
-     * @return Section object for that position
+     * @return Section object for that position or null if not found
      */
-    private fun getSectionForListItemPosition(position: Int): Section {
+    private fun getSectionForListItemPosition(position: Int): Section? {
         var currentPos = 0
 
         sectionsMap.entries.forEach {
@@ -321,7 +323,8 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
         }
 
         // position not found, fail fast
-        throw IndexOutOfBoundsException("Unable to find matching sectionfor position $position")
+        WooLog.w(T.NOTIFS, "Unable to find matching sectionfor position $position")
+        return null
     }
     // endregion
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
@@ -234,17 +234,17 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
      */
     fun revertHiddenNotificationAndReturnPos(): Int {
         return pendingRemovalNotification?.let { (notif, section, pos) ->
-            with(section) {
-                if (pos < list.size) {
-                    list.add(pos, notif)
-                } else {
-                    list.add(notif)
-                }
-            }
-
             if (!section.isVisible) {
                 section.isVisible = true
                 notifySectionChangedToVisible(section)
+            }
+
+            with(section.list) {
+                if (pos < size) {
+                    add(pos, notif)
+                } else {
+                    add(notif)
+                }
             }
 
             notifyItemInsertedInSection(section, pos)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
@@ -249,7 +249,7 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
 
             notifyItemInsertedInSection(section, pos)
             getPositionInAdapter(section, pos)
-        }.also { pendingRemovalNotification = null } ?: 0
+        }.also { pendingRemovalNotification = null } ?: INVALID_POSITION
     }
 
     /**
@@ -322,7 +322,7 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
         }
 
         // position not found, fail fast
-        WooLog.w(T.NOTIFS, "Unable to find matching sectionfor position $position")
+        WooLog.w(T.NOTIFS, "Unable to find matching section for position $position")
         return null
     }
     // endregion

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
@@ -345,9 +345,11 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
             when (notif.getWooType()) {
                 NEW_ORDER -> {
                     itemHolder.icon.setImageResource(R.drawable.ic_cart)
+                    itemHolder.desc.maxLines = Int.MAX_VALUE
                 }
                 PRODUCT_REVIEW -> {
                     itemHolder.icon.setImageResource(R.drawable.ic_comment)
+                    itemHolder.desc.maxLines = 2
 
                     notif.getRating()?.let {
                         itemHolder.rating.rating = it
@@ -407,31 +409,32 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
         }
 
         override fun onDrawOver(canvas: Canvas, parent: RecyclerView, state: RecyclerView.State) {
-            for (i in 0 until parent.childCount) {
+            for (i in 0 until parent.childCount - 1) {
                 val child = parent.getChildAt(i)
-                val position = parent.getChildAdapterPosition(child)
-                val itemType = decorListener?.getItemTypeAtPosition(position) ?: ItemType.READ_NOTIF
+                val position = child?.let { parent.getChildAdapterPosition(it) } ?: INVALID_POSITION
+                if (position != INVALID_POSITION) {
+                    val itemType = decorListener?.getItemTypeAtPosition(position) ?: ItemType.READ_NOTIF
+                    /*
+                     * note that we have to draw the indicator for all items rather than just unread notifs
+                     * in order to paint over recycled cells that have a previously-drawn indicator
+                     */
+                    val colorId = when (itemType) {
+                        ItemType.HEADER -> R.color.list_header_bg
+                        ItemType.UNREAD_NOTIF -> R.color.wc_green
+                        else -> R.color.list_item_bg
+                    }
 
-                /*
-                 * note that we have to draw the indicator for all items rather than just unread notifs
-                 * in order to paint over recycled cells that have a previously-drawn indicator
-                 */
-                val colorId = when (itemType) {
-                    ItemType.HEADER -> R.color.list_header_bg
-                    ItemType.UNREAD_NOTIF -> R.color.wc_green
-                    else -> R.color.list_item_bg
+                    val paint = Paint()
+                    paint.color = ContextCompat.getColor(parent.context, colorId)
+
+                    parent.getDecoratedBoundsWithMargins(child, bounds)
+                    val top = bounds.top.toFloat()
+                    val bottom = (bounds.bottom + Math.round(child.translationY)).toFloat()
+                    val left = bounds.left.toFloat()
+                    val right = left + dividerWidth
+
+                    canvas.drawRect(left, top, right, bottom, paint)
                 }
-
-                val paint = Paint()
-                paint.color = ContextCompat.getColor(parent.context, colorId)
-
-                parent.getDecoratedBoundsWithMargins(child, bounds)
-                val top = bounds.top.toFloat()
-                val bottom = (bounds.bottom + Math.round(child.translationY)).toFloat()
-                val left = bounds.left.toFloat()
-                val right = left + dividerWidth
-
-                canvas.drawRect(left, top, right, bottom, paint)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
@@ -292,7 +292,7 @@ class NotifsListFragment : TopLevelFragment(),
     private fun isModerationSnackShowing() = changeCommentStatusSnackbar?.isShown ?: false
 
     override fun openReviewDetail(notification: NotificationModel) {
-        // don't show detail if the moderation snack is still showing TODO: not sure about this
+        // don't show detail if the moderation snack is still showing
         if (isModerationSnackShowing()) {
             return
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
@@ -366,7 +366,7 @@ class NotifsListFragment : TopLevelFragment(),
             val callback = object : Snackbar.Callback() {
                 override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
                     super.onDismissed(transientBottomBar, event)
-
+                    resetPendingModerationVariables()
                     if (!changeCommentStatusCanceled) {
                         comment.status = newStatus.toString()
                         presenter.pushUpdatedComment(comment)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
@@ -289,7 +289,14 @@ class NotifsListFragment : TopLevelFragment(),
         AppRatingDialog.incrementInteractions()
     }
 
+    private fun isModerationSnackShowing() = changeCommentStatusSnackbar?.isShown ?: false
+
     override fun openReviewDetail(notification: NotificationModel) {
+        // don't show detail if the moderation snack is still showing TODO: not sure about this
+        if (isModerationSnackShowing()) {
+            return
+        }
+
         AnalyticsTracker.track(Stat.NOTIFICATION_OPEN, mapOf(
                 AnalyticsTracker.KEY_TYPE to AnalyticsTracker.VALUE_REVIEW,
                 AnalyticsTracker.KEY_ALREADY_READ to notification.read))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
@@ -37,6 +37,7 @@ import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.NOTIFICATIONS
 import com.woocommerce.android.widgets.AppRatingDialog
 import com.woocommerce.android.widgets.SkeletonView
+import com.woocommerce.android.widgets.sectionedrecyclerview.SectionedRecyclerViewAdapter.Companion.INVALID_POSITION
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_notifs_list.*
 import kotlinx.android.synthetic.main.fragment_notifs_list.view.*
@@ -430,7 +431,9 @@ class NotifsListFragment : TopLevelFragment(),
         AnalyticsTracker.track(Stat.REVIEW_ACTION_UNDO)
 
         val itemPosition = notifsAdapter.revertHiddenNotificationAndReturnPos()
-        notifsList.smoothScrollToPosition(itemPosition)
+        if (itemPosition != INVALID_POSITION && !notifsAdapter.isEmpty()) {
+            notifsList.smoothScrollToPosition(itemPosition)
+        }
         resetPendingModerationVariables()
     }
 


### PR DESCRIPTION
Fixes #856 and fixes #845 - these were related issues so I tackled them together. Note that as part of this I added [this check](https://github.com/woocommerce/woocommerce-android/blob/1e6eedb78106269c7f299a97d3e1924f527d5bfd/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt#L296) to prevent opening a review when the undo snackbar is showing. This is to prevent the problems described in #859 until we can fix them properly.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
