### PR TITLE
Issue/854 api upgrade notice

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 Bugfixes
 * Fixed bug that could cause review detail not to appear after tapping a review notification
+* Fixed bug that could cause an "Update to WooCommerce 3.5" message to appear in your dashboard
 
 Improvements
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContract.kt
@@ -13,7 +13,6 @@ interface DashboardContract {
         fun getStatsCurrency(): String?
         fun fetchUnfilledOrderCount(forced: Boolean = false)
         fun fetchHasOrders()
-        fun checkApiVersion()
     }
 
     interface View : BaseView<Presenter> {
@@ -30,8 +29,6 @@ interface DashboardContract {
         fun showErrorSnack()
         fun hideUnfilledOrdersCard()
         fun showUnfilledOrdersCard(count: Int)
-        fun showPluginVersionNoticeCard()
-        fun hidePluginVersionNoticeCard()
         fun showEmptyView(show: Boolean)
 
         fun showChartSkeleton(show: Boolean)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -8,7 +8,6 @@ import android.support.v4.widget.NestedScrollView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
@@ -18,7 +17,6 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.TopLevelFragmentRouter
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
@@ -36,8 +34,6 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
         fun newInstance() = DashboardFragment()
 
         val DEFAULT_STATS_GRANULARITY = StatsGranularity.DAYS
-
-        private const val URL_UPGRADE_WOOCOMMERCE = "https://docs.woocommerce.com/document/how-to-update-woocommerce/"
     }
 
     @Inject lateinit var presenter: DashboardContract.Presenter
@@ -110,12 +106,6 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
             v: NestedScrollView?, scrollX: Int, scrollY: Int, oldScrollX: Int, oldScrollY: Int ->
             if (scrollY > oldScrollY) onScrollDown() else if (scrollY < oldScrollY) onScrollUp()
         }
-
-        dashboard_plugin_version_notice.initView(
-                title = getString(R.string.dashboard_plugin_notice_title),
-                message = getString(R.string.dashboard_plugin_notice_message),
-                buttonLabel = getString(R.string.button_update_instructions),
-                buttonAction = { ChromeCustomTabUtils.launchUrl(activity as Context, URL_UPGRADE_WOOCOMMERCE) })
 
         if (isActive) {
             refreshDashboard(forced = this.isRefreshPending)
@@ -235,9 +225,6 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
                 presenter.loadTopEarnerStats(dashboard_top_earners.activeGranularity, forced)
                 presenter.fetchUnfilledOrderCount(forced)
                 presenter.fetchHasOrders()
-                if (!AppPrefs.isUsingV3Api()) {
-                    presenter.checkApiVersion()
-                }
             }
             else -> isRefreshPending = true
         }
@@ -276,16 +263,6 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
         if (dashboard_unfilled_orders.visibility != View.VISIBLE) {
             WooAnimUtils.scaleIn(dashboard_unfilled_orders, Duration.MEDIUM)
         }
-    }
-
-    override fun showPluginVersionNoticeCard() {
-        if (dashboard_plugin_version_notice.visibility != View.VISIBLE) {
-            WooAnimUtils.scaleIn(dashboard_plugin_version_notice, Duration.MEDIUM)
-        }
-    }
-
-    override fun hidePluginVersionNoticeCard() {
-        dashboard_plugin_version_notice.visibility = View.GONE
     }
 
     override fun showEmptyView(show: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardPresenter.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.dashboard
 
-import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.network.ConnectionChangeReceiver
@@ -17,7 +16,6 @@ import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_HAS_ORDERS
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS_COUNT
 import org.wordpress.android.fluxc.action.WCStatsAction.FETCH_ORDER_STATS
 import org.wordpress.android.fluxc.action.WCStatsAction.FETCH_VISITOR_STATS
-import org.wordpress.android.fluxc.generated.WCCoreActionBuilder
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.generated.WCStatsActionBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus.PROCESSING
@@ -33,7 +31,6 @@ import org.wordpress.android.fluxc.store.WCStatsStore.OnWCStatsChanged
 import org.wordpress.android.fluxc.store.WCStatsStore.OnWCTopEarnersChanged
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.fluxc.store.WooCommerceStore
-import org.wordpress.android.fluxc.store.WooCommerceStore.OnApiVersionFetched
 import javax.inject.Inject
 
 class DashboardPresenter @Inject constructor(
@@ -139,23 +136,6 @@ class DashboardPresenter @Inject constructor(
     override fun fetchHasOrders() {
         val payload = FetchHasOrdersPayload(selectedSite.get())
         dispatcher.dispatch(WCOrderActionBuilder.newFetchHasOrdersAction(payload))
-    }
-
-    override fun checkApiVersion() {
-        dispatcher.dispatch(WCCoreActionBuilder.newFetchSiteApiVersionAction(selectedSite.get()))
-    }
-
-    @Suppress("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onApiVersionFetched(event: OnApiVersionFetched) {
-        if (!event.isError) {
-            if (event.apiVersion == WooCommerceStore.WOO_API_NAMESPACE_V3) {
-                dashboardView?.hidePluginVersionNoticeCard()
-                AppPrefs.setIsUsingV3Api()
-            } else {
-                dashboardView?.showPluginVersionNoticeCard()
-            }
-        }
     }
 
     @Suppress("unused")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -61,11 +61,14 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
 
     private var progressDialog: ProgressDialog? = null
     private var calledFromLogin: Boolean = false
+    private var currentSite: SiteModel? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         AndroidInjection.inject(this)
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_site_picker)
+
+        currentSite = selectedSite.getIfExists()
 
         calledFromLogin = savedInstanceState?.getBoolean(KEY_CALLED_FROM_LOGIN)
                 ?: intent.getBooleanExtra(KEY_CALLED_FROM_LOGIN, false)
@@ -209,8 +212,8 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
 
     override fun siteSelected(site: SiteModel) {
         // finish if user simply selected the current site
-        selectedSite.getIfExists()?.let { currentSite ->
-            if (site.siteId == currentSite.siteId) {
+        currentSite?.let {
+            if (site.siteId == it.siteId) {
                 setResult(Activity.RESULT_CANCELED)
                 finish()
                 return

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -255,8 +255,9 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
     override fun siteVerificationFailed(site: SiteModel) {
         progressDialog?.dismiss()
 
-        siteAdapter.selectedSiteId = 0
-        button_continue.isEnabled = false
+        // re-select the previous site, if there was one
+        siteAdapter.selectedSiteId = currentSite?.siteId ?: 0L
+        button_continue.isEnabled = siteAdapter.selectedSiteId != 0L
 
         WooUpgradeRequiredDialog().show(supportFragmentManager)
     }

--- a/WooCommerce/src/main/res/layout/fragment_dashboard.xml
+++ b/WooCommerce/src/main/res/layout/fragment_dashboard.xml
@@ -23,15 +23,6 @@
                 android:descendantFocusability="blocksDescendants"
                 android:orientation="vertical">
 
-                <!-- Update API version warning -->
-                <com.woocommerce.android.ui.dashboard.DashboardNoticeCard
-                    android:id="@+id/dashboard_plugin_version_notice"
-                    style="@style/Woo.Card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:visibility="gone"/>
-
                 <!-- Order stats -->
                 <com.woocommerce.android.ui.dashboard.DashboardStatsView
                     android:id="@+id/dashboard_stats"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -100,7 +100,7 @@
     <string name="login_verifying_site">Verifying site…</string>
     <string name="login_verifying_site_error">Cannot connect to %s</string>
     <string name="login_update_required_title">Update Store to WooCommerce 3.5</string>
-    <string name="login_update_required_desc">This app requires WooCommerce 3.5 on your server. To continue using this app, please update your store.</string>
+    <string name="login_update_required_desc">This store uses an older version of WooCommerce. Please upgrade your store to WooCommerce 3.5 or greater to use it with this app.</string>
     <string name="login_avatar_content_description">Your profile photo</string>
     <string name="login_nostores_content_description">No WooCommerce stores</string>
     <string name="login_with_a_different_account">Login with a different account</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -140,8 +140,6 @@
     <string name="dashboard_fulfill_order_title_multiple">You have %1$d orders to fulfill</string>
     <string name="dashboard_fulfill_orders_msg">Review, prepare, and ship these pending orders</string>
 
-    <string name="dashboard_plugin_notice_title">Update to WooCommerce 3.5 to keep using this app</string>
-    <string name="dashboard_plugin_notice_message">This app requires that you install WooCommerce 3.5 on your server. Update as soon as possible to continue using this app.</string>
     <!--
         Order List View
     -->


### PR DESCRIPTION
Closes #854 - the problem was that the dashboard would intercept the `onApiVersionFetched` triggered from the site picker. That code, along with the related dashboard card, has been removed since it's no longer necessary.

While I was at it, I made two other changes:

* When the API version check fails, the previously selected site is reselected
* Updated the message text to be more appropriate with the site picker

![screenshot_1551380580](https://user-images.githubusercontent.com/3903757/53591878-10baf600-3b63-11e9-8ccb-258b077b8385.png)


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
