### PR TITLE
issue/846-review-notifs-2lines

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,5 +5,6 @@ Bugfixes
 * Fixed bug that could cause review detail not to appear after tapping a review notification
 
 Improvements
+* In the notification list, only the first two lines of a review are now shown
 
 New Features

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
@@ -341,9 +341,11 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
             when (notif.getWooType()) {
                 NEW_ORDER -> {
                     itemHolder.icon.setImageResource(R.drawable.ic_cart)
+                    itemHolder.desc.maxLines = Int.MAX_VALUE
                 }
                 PRODUCT_REVIEW -> {
                     itemHolder.icon.setImageResource(R.drawable.ic_comment)
+                    itemHolder.desc.maxLines = 2
 
                     notif.getRating()?.let {
                         itemHolder.rating.rating = it

--- a/WooCommerce/src/main/res/layout/notifs_list_item.xml
+++ b/WooCommerce/src/main/res/layout/notifs_list_item.xml
@@ -37,6 +37,7 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
         android:layout_marginTop="8dp"
+        android:ellipsize="end"
         app:layout_constraintBottom_toTopOf="@+id/notif_rating"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@+id/notif_title"


### PR DESCRIPTION
Closes #846 - limits review notifs to two lines, as per i7 designs.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

![screenshot_1551386104](https://user-images.githubusercontent.com/3903757/53596839-b4f66a00-3b6e-11e9-83d1-a2c016ab4976.png)
