### PR TITLE
Disable Volley debug logging on release builds

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@ Bugfixes
 * Fixed bug that could cause an empty review detail to appear if the review couldn't be loaded
 * Fixed bug that could cause review detail not to appear after tapping a review notification
 * Fixed bug that could cause an "Update to WooCommerce 3.5" message to appear in your dashboard
+* Fixed a very rare crash during logging
 
 Improvements
 * Product images are now shown in review detail and order detail

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.IntentFilter
 import android.net.ConnectivityManager
 import android.support.multidex.MultiDexApplication
+import com.android.volley.VolleyLog
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -97,6 +98,11 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
 
     override fun onCreate() {
         super.onCreate()
+
+        // Disables Volley debug logging on release build and prevents the "Marker added to finished log" crash
+        if (!BuildConfig.DEBUG) {
+            VolleyLog.DEBUG = false
+        }
 
         val wellSqlConfig = WellSqlConfig(applicationContext, WellSqlConfig.ADDON_WOOCOMMERCE)
         WellSql.init(wellSqlConfig)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -100,6 +100,7 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
         super.onCreate()
 
         // Disables Volley debug logging on release build and prevents the "Marker added to finished log" crash
+        // https://github.com/woocommerce/woocommerce-android/issues/817
         if (!BuildConfig.DEBUG) {
             VolleyLog.DEBUG = false
         }


### PR DESCRIPTION
Fixes #817 

This is a crash that is happening when Volley attempts to write to a finished log. We are seeing this crash only for a single user, and so far just 5 times. Some [StackOverflow](https://stackoverflow.com/questions/26350035/volley-bug-repeating-a-request-when-verbose-logging-is-enabled-fails/28110821#28110821) comments are recommending just setting `VolleyLog.DEBUG = false`. Looking at Volley's [VolleyLog](https://android.googlesource.com/platform/frameworks/volley/+/android-5.1.1_r13/src/com/android/volley/VolleyLog.java#127) code, they use `Log.isLoggable("Volley", VERBOSE)` to see if they should be logging. That method should return false since the default logging level for any tag is `INFO` unless a system property is explicitly set. I've run `adb shell getprop | grep log.tag` and nothing is forcing it to be set on my test devices. However, device manufacturers have been known to set their own system properties so I'm guessing this is either something the user is manually forcing by running `adb shell setprop tag.log.Volley VERBOSE`, or the device manufacturer (Proline tablet) has it set. If this is done by the device manufacturer then this PR will override that setting.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
