### PR TITLE
Add Violations plugin to comment on GH PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,19 @@ jobs:
       - <<: *copy_gradle_properties
       - run:
           name: Checkstyle & klint
-          command: ./gradlew --stacktrace checkstyle ktlint
+          command: ./gradlew --stacktrace checkstyle ciktlint
       - run:
           name: Lint
           command: ./gradlew --stacktrace lintVanillaRelease
+       - run:
+          name: Violations
+          when: on_fail
+          command: |
+            if [ -n "$GITHUB_API_TOKEN" ]; then
+              $GRADLEW violationCommentsToGitHub -DGITHUB_PULLREQUESTID=${CIRCLE_PULL_REQUEST##*/} -DGITHUB_OAUTH2TOKEN=$GITHUB_API_TOKEN
+            else
+              echo "Not posting lint errors to Github because \$GITHUB_API_TOKEN is not found"
+            fi 
       - android/save-gradle-cache:
           cache-prefix: lint-cache-v1
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           when: on_fail
           command: |
             if [ -n "$GITHUB_API_TOKEN" ]; then
-              $GRADLEW violationCommentsToGitHub -DGITHUB_PULLREQUESTID=${CIRCLE_PULL_REQUEST##*/} -DGITHUB_OAUTH2TOKEN=$GITHUB_API_TOKEN
+              ./gradlew violationCommentsToGitHub -DGITHUB_PULLREQUESTID=${CIRCLE_PULL_REQUEST##*/} -DGITHUB_OAUTH2TOKEN=$GITHUB_API_TOKEN
             else
               echo "Not posting lint errors to Github because \$GITHUB_API_TOKEN is not found"
             fi 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run:
           name: Lint
           command: ./gradlew --stacktrace lintVanillaRelease
-       - run:
+      - run:
           name: Violations
           when: on_fail
           command: |

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -235,7 +235,7 @@ android.buildTypes.all { buildType ->
 
 task violationCommentsToGitHub(type: se.bjurr.violations.comments.github.plugin.gradle.ViolationCommentsToGitHubTask) {
    repositoryOwner = "woocommerce";
-   repositoryName = "woocommerce-Android"
+   repositoryName = "woocommerce-android"
    pullRequestId = System.properties['GITHUB_PULLREQUESTID']
    username = System.properties['GITHUB_USERNAME']
    password = System.properties['GITHUB_PASSWORD']

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -2,10 +2,12 @@ buildscript {
     repositories {
         jcenter()
         maven { url 'https://maven.fabric.io/public' }
+        maven { url 'https://plugins.gradle.org/m2/' }
     }
     dependencies {
         classpath 'io.fabric.tools:gradle:1.25.4'
         classpath 'com.google.gms:google-services:3.2.0'
+        classpath 'se.bjurr.violations:violation-comments-to-github-gradle-plugin:1.51'
     }
 }
 
@@ -15,6 +17,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-allopen'
 apply plugin: 'io.fabric'
+apply plugin: 'se.bjurr.violations.violation-comments-to-github-gradle-plugin'
 
 repositories {
     maven { url 'https://maven.fabric.io/public' }
@@ -228,6 +231,31 @@ android.buildTypes.all { buildType ->
     if ((file("google-services.json").text) == (file("google-services.json-example").text)) {
         println("WARNING: You're using the example google-services.json file. Google login will fail.")
     }
+}
+
+task violationCommentsToGitHub(type: se.bjurr.violations.comments.github.plugin.gradle.ViolationCommentsToGitHubTask) {
+   repositoryOwner = "woocommerce";
+   repositoryName = "woocommerce-Android"
+   pullRequestId = System.properties['GITHUB_PULLREQUESTID']
+   username = System.properties['GITHUB_USERNAME']
+   password = System.properties['GITHUB_PASSWORD']
+   oAuth2Token = System.properties['GITHUB_OAUTH2TOKEN']
+   gitHubUrl = "https://api.github.com/"
+   createCommentWithAllSingleFileComments = false
+   createSingleFileComments = true
+   commentOnlyChangedContent = true
+   minSeverity = se.bjurr.violations.lib.model.SEVERITY.INFO //ERROR, INFO, WARN
+   commentTemplate = """
+**Reporter**: {{violation.reporter}}{{#violation.rule}}\n
+**Rule**: {{violation.rule}}{{/violation.rule}}
+**Severity**: {{violation.severity}}
+**File**: {{violation.file}} L{{violation.startLine}}{{#violation.source}}
+**Source**: {{violation.source}}{{/violation.source}}
+{{violation.message}}
+"""
+   violations = [
+    ["CHECKSTYLE", ".", ".*/build/.*\\.xml\$", "Checkstyle"]
+   ]
 }
 
 def checkGradlePropertiesFile() {

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,12 @@ subprojects {
         classpath = configurations.ktlint
         args "-F", "src/**/*.kt"
     }
+
+    task ciktlint(type: JavaExec) {
+        main = "com.github.shyiko.ktlint.Main"
+        classpath = configurations.ktlint
+        args "src/**/*.kt", "--reporter=checkstyle,output=${buildDir}/ktlint.xml"
+    }
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
This PR adds the Violations plugin that will comment on PRs to show the line and error when linter errors are found.

An example of how it works is here: https://github.com/woocommerce/woocommerce-android/pull/880

To test, you can create a new branch, add a linting error, push it and open a PR.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
