### PR TITLE
Issue/site picker clipping

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -92,8 +92,8 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             button_help.visibility = View.GONE
             site_list_label.visibility = View.GONE
             site_list_container.cardElevation = 0f
-            (site_list_container.layoutParams as MarginLayoutParams).topMargin =
-                    resources.getDimensionPixelSize(R.dimen.margin_large)
+            (site_list_container.layoutParams as MarginLayoutParams).topMargin = 0
+            (site_list_container.layoutParams as MarginLayoutParams).bottomMargin = 0
         }
 
         presenter.takeView(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -94,6 +94,11 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             site_list_container.cardElevation = 0f
             (site_list_container.layoutParams as MarginLayoutParams).topMargin = 0
             (site_list_container.layoutParams as MarginLayoutParams).bottomMargin = 0
+            sites_recycler.setPadding(
+                    resources.getDimensionPixelSize(R.dimen.margin_extra_large),
+                    resources.getDimensionPixelSize(R.dimen.margin_large),
+                    resources.getDimensionPixelSize(R.dimen.margin_extra_large),
+                    resources.getDimensionPixelSize(R.dimen.margin_large))
         }
 
         presenter.takeView(this)

--- a/WooCommerce/src/main/res/layout/activity_site_picker.xml
+++ b/WooCommerce/src/main/res/layout/activity_site_picker.xml
@@ -62,7 +62,7 @@
         android:layout_marginBottom="8dp"
         android:layout_marginTop="@dimen/margin_extra_extra_medium_large"
         app:cardElevation="@dimen/card_elevation"
-        app:layout_constraintBottom_toTopOf="@+id/view6"
+        app:layout_constraintBottom_toBottomOf="@+id/view6"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/text_username"


### PR DESCRIPTION
### Fix
Update the site picker list container view margin and list view padding when not coming from login to avoid clipping.  The layout was also updated to constrain the bottom of the list container view to the bottom of the shadow view so that the list would appear behind the shadow rather than clipped to the top.  See the screenshots below for illustration.

![site_picker_clipping](https://user-images.githubusercontent.com/3827611/54007838-0b404b80-4121-11e9-8e30-d33bf4a8ebcf.png)

#### Note
Ignore the repeated sites in the list.  That is intentional to illustrate the scrolling list behavior.  Also, the margin and padding changes only affect the layout when not coming from login.  The layout of the site picker during the login flow is unchanged.

### Test
0. Use account with eight or more stores.
1. Tap ***More Options*** action button.
2. Tap ***Settings*** option in menu.
3. Tap selected store.
4. Scroll list up/down.
5. Notice list is not clipped by top or bottom padding.
6. Notice list is shown behind top and bottom shadows.

### Review
Only one developer is required to review these changes, but anyone can perform the review.