### PR TITLE
issue/892-update-fluxc-hash-for-top-earners-fix

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@ Bugfixes
 * Fixed bug that could cause review detail not to appear after tapping a review notification
 * Fixed bug that could cause an "Update to WooCommerce 3.5" message to appear in your dashboard
 * Fixed a very rare crash during logging
+* Fixed a bug that could prevent Top Performers from appearing
 
 Improvements
 * Product images are now shown in review detail and order detail

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardTopEarnersView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardTopEarnersView.kt
@@ -153,6 +153,10 @@ class DashboardTopEarnersView @JvmOverloads constructor(ctx: Context, attrs: Att
 
         override fun getItemCount() = topEarnerList.size
 
+        override fun getItemId(position: Int): Long {
+            return topEarnerList[position].id
+        }
+
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TopEarnersViewHolder {
             val view = LayoutInflater.from(parent.context)
                     .inflate(R.layout.top_earner_list_item, parent, false)

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = '77ce6d4864682d383fe30bde3fb7f3ea1c7b68a0'
+    fluxCVersion = '9427b0bc352a506a8ab3ece1dc859b8f00f130be'
     daggerVersion = '2.11'
     supportLibraryVersion = '28.0.0'
     glideVersion = '4.6.1'

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = '9427b0bc352a506a8ab3ece1dc859b8f00f130be'
+    fluxCVersion = 'cbdc24cbb46708bfb1d101c4d3e664011f97a0d3'
     daggerVersion = '2.11'
     supportLibraryVersion = '28.0.0'
     glideVersion = '4.6.1'


### PR DESCRIPTION
Fixes #892 - updates the FluxC hash to the one with [this fix](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1152). The problem was caused by the top earner model using an `Int` for its ID, when sometimes it was a `Long` in the response.

I also implemented the top earner adapter's `getItemId()` after noticing it was missing, which it shouldn't be for adapters with stable IDs.

**The FluxC PR should be merged and the new hash updated in this PR before merging**

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.