### PR TITLE
Update to latest FluxC hash to include the stats refresh fix

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@ Bugfixes
 * Fixed bug that could cause review detail not to appear after tapping a review notification
 * Fixed bug that could cause an "Update to WooCommerce 3.5" message to appear in your dashboard
 * Fixed a very rare crash during logging
+* Fixed an issue where stats would stop updating
 
 Improvements
 * Product images are now shown in review detail and order detail

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = '77ce6d4864682d383fe30bde3fb7f3ea1c7b68a0'
+    fluxCVersion = 'c799bea3d76a9044b63a69f7e50509112763fb2c'
     daggerVersion = '2.11'
     supportLibraryVersion = '28.0.0'
     glideVersion = '4.6.1'

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = 'c799bea3d76a9044b63a69f7e50509112763fb2c'
+    fluxCVersion = 'd70d82dcc2d74922bdc53301595d5d06d7dbfc91'
     daggerVersion = '2.11'
     supportLibraryVersion = '28.0.0'
     glideVersion = '4.6.1'


### PR DESCRIPTION
Fixes #894 by updating the hash to point to the fluxC Fix in this [PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1154). **The FluxC PR should be merged and the new hash updated in this PR before merging**

## To Test
1. Manually set the device date to 2 days before today.
2. Install a fresh copy of the app from the `develop` branch.
3. Verify stats loaded in the My Store tab.
4. Manually change device date one day ahead (yesterday).
5. pull to force stats refresh...notice no data (you can also use stethos to verify that now there are two rows in the `WCOrderStatsModel` table -- which is the bug)
6. Change to this branch, build and run. Verify now that the stats table only has a single row.
7. Manually change device date to today. Verify stats for today populates.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
