### PR TITLE
Update to new FluxC interceptor usage for Stetho

### DIFF
--- a/WooCommerce/src/debug/kotlin/com.woocommerce.android/di/InterceptorModule.kt
+++ b/WooCommerce/src/debug/kotlin/com.woocommerce.android/di/InterceptorModule.kt
@@ -4,12 +4,12 @@ import com.facebook.stetho.okhttp3.StethoInterceptor
 
 import dagger.Module
 import dagger.Provides
+import dagger.multibindings.IntoSet
 import okhttp3.Interceptor
+import javax.inject.Named
 
 @Module
 class InterceptorModule {
-    @Provides
-    fun provideNetworkInterceptor(): Interceptor {
-        return StethoInterceptor()
-    }
+    @Provides @IntoSet @Named("network-interceptors")
+    fun provideNetworkInterceptor(): Interceptor = StethoInterceptor()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = 'cbdc24cbb46708bfb1d101c4d3e664011f97a0d3'
+    fluxCVersion = 'cfafbfec81e337e7fdfb97dc985d25095effaea9'
     daggerVersion = '2.11'
     supportLibraryVersion = '28.0.0'
     glideVersion = '4.6.1'


### PR DESCRIPTION
Updates our usage of Stetho to follow the injection style added to FluxC in
wordpress-mobile/WordPress-FluxC-Android#1155 - that PR should be reviewed and merged before this one.

## To test:

There should be no behavior changes. To test Stetho is still working:

1. With the app running this branch, open chrome://inspect from your computer and open the appropriate instance of the app on the device.
2. Visit the Network tab and make sure you're seeing networking traffic

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
