### PR TITLE
Update FluxC hash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = '35149e532a8982e150810337c298b93fba84847f'
+    fluxCVersion = '0616e9766d6275dab16cfc237e21f041ca643b38'
     daggerVersion = '2.11'
     supportLibraryVersion = '28.0.0'
     glideVersion = '4.6.1'


### PR DESCRIPTION
This hash points to a special FluxC hotfix branch that contains only the subset 4 commits needed to ensure the fix for multiple stats rows is fixed. Those 4 commits are the commits from the original FluxC PR to [implement the fix](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1154). 

## To Test
1. Manually set the device date to a date in the past when you last had orders (example, last friday)
2. Build and run this app
3. Verify stats loaded in the My Store tab.
4. Manually change device date to today. Verify stats for today populates.