### PR TITLE
Fix Gradle plugin 3.3.+ deprecation warnings

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'io.fabric.tools:gradle:1.25.4'
+        classpath 'io.fabric.tools:gradle:1.28.0'
         classpath 'com.google.gms:google-services:3.2.0'
     }
 }

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -201,7 +201,9 @@ task copyGoogleServicesExampleFile(type: Copy) {
 
 // Add generateCrashlyticsConfig to all generateBuildConfig tasks (all variants)
 android.applicationVariants.all { variant ->
-    variant.generateBuildConfig.dependsOn(generateCrashlyticsConfig)
+    variant.generateBuildConfigProvider.configure {
+        dependsOn(generateCrashlyticsConfig)
+    }
 }
 
 // Add properties named "wc.xxx" to our BuildConfig

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.automattic.android:fetchstyle:1.1'
         classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlinVersion"


### PR DESCRIPTION
**EDIT:** It turns out this PR also fixes an issue where the apps haven't been using Fabric since version `1.3`. The problem appears to have started with the update to Gradle in https://github.com/woocommerce/woocommerce-android/pull/825.

It seems that in addition to generating a Gradle compiler warning, the version of the Fabric plugin we've been using was incompatible with Android Gradle plugin `3.3.+`. When building the app in current `develop` or `release/1.3` and inducing a crash, I see this in the logs:

> 2019-03-19 08:21:28.374 30861-30861/? I/CrashlyticsCore: Initializing Crashlytics 2.6.2.24
> 2019-03-19 08:21:28.382 30861-30861/? I/CrashlyticsInitProvider: CrashlyticsInitProvider initialization successful
> 2019-03-19 08:21:28.870 30861-30877/? E/Fabric: Failed to retrieve settings from https://settings.crashlytics.com/spi/v2/platforms/android/apps/com.woocommerce.android/settings
> 2019-03-19 08:21:28.873 30861-30886/? W/CrashlyticsCore: Received null settings, skipping report submission!

So I've updated this PR to be branched off `release/1.3` instead of `develop` and changed the target branch, so we can release a `1.3.2` hotfix including this fix.

Testing steps for this PR are the same as outlined in the original description below, but you can also confirm that Fabric reports aren't currently working by also inducing a crash in `release/1.3` before switching to this branch.

<hr>

Closes #694. Fabric just released an update to their plugin resolving their use of Gradle APIs now marked obsolete (we were also using one obsolete API, which I updated).

### To test
1. Sync gradle, and ensure you don't see any warnings (you can check against current `develop` to see what the warnings look like)
2. Since we're updating the Fabric plugin, it's worth testing that crash reports are still going through:

You can create a test crash by building a release build of the app and adding a `throw RuntimeException("...")` somewhere - the crash will appear in the Fabric console within 10 minutes or so (you may need to restart the app after the crash for this to work).

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.