### PR TITLE
Merge Fabric fix into 1.4

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -41,8 +41,8 @@ android {
 
     defaultConfig {
         applicationId "com.woocommerce.android"
-        versionName "1.3.1"
-        versionCode 40
+        versionName "1.3.2"
+        versionCode 42
 
         minSdkVersion 21
         targetSdkVersion 27

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -41,8 +41,8 @@ android {
 
     defaultConfig {
         applicationId "com.woocommerce.android"
-        versionName "1.3"
-        versionCode 39
+        versionName "1.3.1"
+        versionCode 40
 
         minSdkVersion 21
         targetSdkVersion 27

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = '0616e9766d6275dab16cfc237e21f041ca643b38'
+    fluxCVersion = 'cfafbfec81e337e7fdfb97dc985d25095effaea9'
     daggerVersion = '2.11'
     supportLibraryVersion = '28.0.0'
     glideVersion = '4.6.1'


### PR DESCRIPTION
This PR merges the fix outlined in #911  into the 1.4 release branch. 

### To test
1. Sync gradle, and ensure you don't see any warnings (you can check against current `develop` to see what the warnings look like)
2. Since we're updating the Fabric plugin, it's worth testing that crash reports are still going through:

You can create a test crash by building a release build of the app and adding a `throw RuntimeException("...")` somewhere - the crash will appear in the Fabric console within 10 minutes or so (you may need to restart the app after the crash for this to work).
