### PR TITLE
Issue/promo dialog clipped

### DIFF
--- a/WooCommerce/src/main/res/layout/dialog_promo.xml
+++ b/WooCommerce/src/main/res/layout/dialog_promo.xml
@@ -5,6 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@color/white"
+    android:clipToPadding="false"
     android:paddingBottom="@dimen/margin_extra_large">
 
     <FrameLayout


### PR DESCRIPTION
### Fix
Add the `clipToPadding` attribute to the `dialog_promo` layout to avoid clipping the bottom button shadow.  See the screenshots below for illustration.

![dialog](https://user-images.githubusercontent.com/3827611/54629873-b9a79300-4a35-11e9-9cbb-f26eb3f065f2.png)

### Test
0. Use account with multiple sites and hasn't seen site picker promo dialog.
1. Launch app.
2. Long-press ***Try It Now*** button.
3. Notice button shadow is not clipped.

### Review
Only one developer is required to review these changes, but anyone can perform the review.