### PR TITLE
Feature/add release tooling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: bdaaef3307fab209a55ca136f3419060f1238d70
-  ref: bdaaef3307fab209a55ca136f3419060f1238d70
+  revision: 7a0767867690390d4322de7a86e4c2f9a9aa70b9
+  tag: 0.2.1
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.1.9)
+    fastlane-plugin-wpmreleasetoolkit (0.2.1)
       diffy
       git
       nokogiri
@@ -121,7 +121,7 @@ GEM
     naturally (2.2.0)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
-    octokit (4.13.0)
+    octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     os (1.0.0)
     plist (3.5.0)
@@ -133,9 +133,9 @@ GEM
     retriable (3.1.2)
     rouge (2.0.7)
     rubyzip (1.2.2)
-    sawyer (0.8.1)
-      addressable (>= 2.3.5, < 2.6)
-      faraday (~> 0.8, < 1.0)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
     security (0.1.3)
     signet (0.11.0)
       addressable (~> 2.3)
@@ -179,4 +179,4 @@ DEPENDENCIES
   nokogiri!
 
 BUNDLED WITH
-   1.17.2
+   2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: a7f414b31dc383075d3489b3d9d4ec039529ef67
-  tag: 0.1.9
+  revision: bdaaef3307fab209a55ca136f3419060f1238d70
+  ref: bdaaef3307fab209a55ca136f3419060f1238d70
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.1.9)
       diffy

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -7,10 +7,37 @@ platform :android do
 ########################################################################
 Dotenv.load('~/.wcandroid-env.default')
 ENV[GHHELPER_REPO="woocommerce/woocommerce-android"]
+ENV["PROJECT_NAME"]="WooCommerce"
+ENV["PROJECT_ROOT_FOLDER"]="./"
+ENV["validate_translations"]="buildVanillaRelease"
 
 ########################################################################
 # Release Lanes
 ########################################################################  
+  #####################################################################################
+  # code_freeze
+  # -----------------------------------------------------------------------------------
+  # This lane executes the steps planned on code freeze
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane code_freeze codefreeze_version:<version> [update_release_branch_version:<update flag>] [skip_confirm:<skip confirm>]
+  #
+  # Example:
+  # bundle exec fastlane code_freeze codefreeze_version:11.2
+  # bundle exec fastlane code_freeze codefreeze_version:11.2 skip_confirm:true
+  #####################################################################################
+  desc "Creates a new release branch from the current develop"
+  lane :code_freeze do | options |
+    options.merge!(update_release_branch_version: false)
+    old_version = android_codefreeze(options)
+   
+    localize_libs()
+    setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{options[:codefreeze_version]}")
+    setfrozentag(repository:GHHELPER_REPO, milestone: options[:codefreeze_version])
+
+    get_prs_list(repository:GHHELPER_REPO, start_tag:"#{old_version}", report_path:"#{File.expand_path('~')}/wcandroid_prs_list_#{old_version}_#{options[:codefreeze_version]}.txt")
+  end
+
 #####################################################################################
 # update_appstore_strings 
 # -----------------------------------------------------------------------------------
@@ -48,6 +75,24 @@ lane :update_appstore_strings do |options|
     release_version: options[:version])
 end 
 
+  #####################################################################################
+  # finalize_release
+  # -----------------------------------------------------------------------------------
+  # This lane finalize a release: updates store metadata and runs the release checks
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane finalize_release [skip_confirm:<skip confirm>] 
+  #
+  # Example:
+  # bundle exec fastlane finalize_release 
+  # bundle exec fastlane finalize_release skip_confirm:true 
+  #####################################################################################
+  desc "Updates store metadata and runs the release checks"
+  lane :finalize_release do | options |
+    android_finalize_prechecks(options)
+    android_update_metadata(options) unless android_current_branch_is_hotfix
+  end
+  
 #####################################################################################
 # localize_libs 
 # -----------------------------------------------------------------------------------

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.1.9'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: 'bdaaef3307fab209a55ca136f3419060f1238d70'

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: 'bdaaef3307fab209a55ca136f3419060f1238d70'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.2.1'

--- a/tools/release-checks.sh
+++ b/tools/release-checks.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+RESDIR=WooCommerce/src/main/res/
+BUILDFILE=WooCommerce/build.gradle
+
+function pOk() {
+  echo "[$(tput setaf 2)OK$(tput sgr0)]"
+}
+
+function pFail() {
+  echo "[$(tput setaf 1)KO$(tput sgr0)]"
+}
+
+function checkENStrings() {
+  if [[ -n $(git status --porcelain|grep "M res") ]]; then
+    /bin/echo -n "Unstagged changes detected in $RESDIR - can't continue..."
+    pFail
+    exit 3
+  fi
+  # save local changes
+  git stash | grep "No local changes to save" > /dev/null
+  needpop=$?
+
+  rm -f $RESDIR/values-??/strings.xml $RESDIR/values-??-r??/strings.xml
+  /bin/echo -n "Check for missing strings (slow)..."
+  ./gradlew buildVanillaRelease > /dev/null 2>&1 && pOk || (pFail; ./gradlew buildVanillaRelease)
+  ./gradlew clean > /dev/null 2>&1
+  git checkout -- $RESDIR/
+
+  # restore local changes
+  if [ $needpop -eq 1 ]; then
+    git stash pop > /dev/null
+  fi
+}
+
+function printVersion() {
+  gradle_version=$(grep -E 'versionName' $BUILDFILE | sed s/versionName// | grep -Eo "[a-zA-Z0-9.-]+" )
+  echo "$BUILDFILE version $gradle_version"
+}
+
+function checkThatConfigurationFilesAreUpToDate() {
+  bundle exec fastlane run configure_validate
+  pOk
+}
+
+checkENStrings
+checkThatConfigurationFilesAreUpToDate
+printVersion

--- a/tools/update-name-core.sh
+++ b/tools/update-name-core.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# This script defines some shared functions that are used by the update-name* set.
+
+function check_version_code() {
+    echo "Done."
+}
+
+function edit_build_file_commit() {
+    echo "Editing $BUILD_FILE - name: $2 code: $1"
+    perl -pi -e "s/versionCode.*$/versionCode $1/" $BUILD_FILE
+    perl -pi -e "s/versionName.*$/versionName \"$2\"/" $BUILD_FILE
+    echo "Adding to git"
+    git add $BUILD_FILE >> $LOGFILE 2>> $LOGFILE
+    git commit -m "$2 / $1 version bump" >> $LOGFILE 2>> $LOGFILE
+}
+
+function switch_branch_pull() {
+    echo "Switching and pulling: $1"
+    git checkout $1 >> $LOGFILE 2>> $LOGFILE
+    git pull origin $1 >> $LOGFILE 2>> $LOGFILE
+}

--- a/tools/update-release-names.sh
+++ b/tools/update-release-names.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+if [ x"$2" == x ]; then
+  echo "This script updates the version name and code"
+  echo "Usage:   $0 version-code beta-version"
+  echo "Example: $0 31 1.1"
+  exit 1
+fi
+
+source ./tools/update-name-core.sh
+
+BETA_VERSION_CODE=$1
+BETA_VERSION=$2
+
+if [ x"$3" == x ]; then
+    BETA_BRANCH=release/`echo $BETA_VERSION | cut -d- -f1`
+else
+    BETA_BRANCH=$3
+fi
+
+BUILD_FILE=WooCommerce/build.gradle
+LOGFILE=/tmp/update-release-names.log
+echo > $LOGFILE
+
+check_version_code
+
+switch_branch_pull $BETA_BRANCH
+edit_build_file_commit $BETA_VERSION_CODE $BETA_VERSION

--- a/tools/update-translations.sh
+++ b/tools/update-translations.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-LANG_FILE=../tools/exported-language-codes.csv
-RESDIR=../WooCommerce/src/main/res/
+LANG_FILE=./tools/exported-language-codes.csv
+RESDIR=./WooCommerce/src/main/res/
 
 # Language definitions resource file
 HEADER=\<?xml\ version=\"1.0\"\ encoding=\"UTF-8\"?\>\\n\<!--Warning:\ Auto-generated\ file,\ don\'t\ edit\ it.--\>\\n\<resources\>\\n\<string-array\ name=\"available_languages\"\ translatable=\"false\"\>


### PR DESCRIPTION
This PR adds some Fastlane lanes that help the release of the app.
In order to share the same code, all the actions in the WordPress Android repository have been extracted and added to the release-toolkit.

# To Test
Testing is not trivial and should be done paying great attention, especially for the code_freeze lane because the test is done on the main repository.

In order to make the steps clearer, I'm referring to defined release numbers, instead of saying this version or next version. Note that these numbers works as of today, when 1.4 is the version in beta testing. If you test this PR later, you have to change the number consequently.

### code_freeze lane
This lanes executes the steps to code freeze a new version of the app.
Please, be super careful with this and make sure to revert all the changes that the script does.

1. Tag a fake version 1.4 in your local repository: `git checkout develop` && `git tag 1.4`. You don't need push it to origin.
2. Checkout this branch and run `bundle exec fastlane code_freeze codefreeze_version:1.5`.
3. Verify that a new 1.5 branch has been created.
4. Verify that the version has been updated in build.gradle.
5. Verify that the 1.5 milestone has marked with the snowflake icon.
6. Verify that the branch protection has been set for the release/1.5 branch.
7. Verify that the change log file has been created in your home.

Clean up
1. Remove the branch protection for the release/1.5 branch on GitHub.
2. Delete the release/1.5 branch on GitHub.
3. Remove the snowflake icon from the 1.5 milestone.
4. Remove the 1.4 tag from your local repository.
5. Remove the release/1.5 branch from your local repository.

### finalize_release lane
This lane downloads the translations and runs some final checks.
The simpler way to test this lane is to use a fake release branch.

1. Checkout a fake release/1.4.1 branch from the one in this PR, push it to origin and set it as upstream.
2. Run `bundle exec fastlane finalize_release`.
3. Verify that the app translations have been downloaded.
4. Verify that the test build and checks pass.
5. Verify that all the files have been committed and pushed.

Clean up
1. Remove the fake release/1.4.1 branch from GitHub.
2. Remove the fake release/1.4.1 branch from your local repository.