### PR TITLE
issue/922-onbackpressed-exception

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -175,7 +175,7 @@ class MainActivity : AppCompatActivity(),
     override fun onBackPressed() {
         AnalyticsTracker.trackBackPressed(this)
 
-        with (bottomNavView.activeFragment) {
+        with(bottomNavView.activeFragment) {
             if (isAdded && childFragmentManager.backStackEntryCount > 0) {
                 childFragmentManager.popBackStack()
                 return

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -175,14 +175,14 @@ class MainActivity : AppCompatActivity(),
     override fun onBackPressed() {
         AnalyticsTracker.trackBackPressed(this)
 
-        val fragment = bottomNavView.activeFragment
-        with(fragment.childFragmentManager) {
-            if (backStackEntryCount > 0) {
-                popBackStack()
-            } else {
-                super.onBackPressed()
+        with (bottomNavView.activeFragment) {
+            if (isAdded && childFragmentManager.backStackEntryCount > 0) {
+                childFragmentManager.popBackStack()
+                return
             }
         }
+
+        super.onBackPressed()
     }
 
     override fun onOptionsItemSelected(item: MenuItem?): Boolean {


### PR DESCRIPTION
Resolves #922 by checking whether the fragment has been added before accessing its childFragmentManager.
