### PR TITLE
Issue/891 stats bar size

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 
 Bugfixes
+* Fixed bug that led to incorrect stats bar heights
 
 Improvements
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -193,8 +193,6 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
                 gridColor = ContextCompat.getColor(context, R.color.wc_border_color)
                 setLabelCount(3, true)
 
-                axisMinimum = 0F
-
                 valueFormatter = IAxisValueFormatter { value, _ ->
                     // Only use non-zero values for the axis
                     value.toDouble().takeIf { it > 0 }?.let {
@@ -285,6 +283,8 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
         val duration = context.resources.getInteger(android.R.integer.config_shortAnimTime)
 
         with(chart) {
+            axisLeft.axisMinimum = 0f
+            axisRight.axisMinimum = 0f
             data = BarData(dataSet)
             animateY(duration)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -273,14 +273,6 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
             barColors.add(normalColor)
         }
 
-        // determine the min revenue so we can determine the min value for the x-axis, which should be zero
-        // unless the stats contain any negative revenue
-        var minRevenue = 0f
-        for (entry in revenueStats) {
-            val value = entry.value.toFloat()
-            if (value < minRevenue) minRevenue = value
-        }
-
         val dataSet = generateBarDataSet(revenueStats).apply {
             colors = barColors
             setDrawValues(false)
@@ -288,9 +280,17 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
             highLightColor = ContextCompat.getColor(context, R.color.graph_highlight_color)
         }
 
+        // determine the min revenue so we can set the min value for the left axis, which should be zero unless
+        // the stats contain any negative revenue
+        var minRevenue = 0f
+        for (value in dataSet.values) {
+            if (value.y < minRevenue) minRevenue = value.y
+        }
+
         val duration = context.resources.getInteger(android.R.integer.config_shortAnimTime)
         with(chart) {
             axisLeft.axisMinimum = minRevenue
+            axisRight.axisMinimum = 0f
             data = BarData(dataSet)
             animateY(duration)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -273,6 +273,14 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
             barColors.add(normalColor)
         }
 
+        // determine the min revenue so we can determine the min value for the x-axis, which should be zero
+        // unless the stats contain any negative revenue
+        var minRevenue = 0f
+        for (entry in revenueStats) {
+            val value = entry.value.toFloat()
+            if (value < minRevenue) minRevenue = value
+        }
+
         val dataSet = generateBarDataSet(revenueStats).apply {
             colors = barColors
             setDrawValues(false)
@@ -281,10 +289,8 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
         }
 
         val duration = context.resources.getInteger(android.R.integer.config_shortAnimTime)
-
         with(chart) {
-            axisLeft.axisMinimum = 0f
-            axisRight.axisMinimum = 0f
+            axisLeft.axisMinimum = minRevenue
             data = BarData(dataSet)
             animateY(duration)
         }


### PR DESCRIPTION
Fixes #891 - resolves the bug that caused some stats bars to be far shorter than they should be. The problem was we weren't setting the minimum value for the axis, so it defaulted to the lowest value in the dataset.

This can easily be reproduced by viewing Years in the Bananza World test site. Before and after shots are below.

![before](https://user-images.githubusercontent.com/3903757/54995195-8cf6fc80-4f9c-11e9-9e4a-d67135bb3dc7.png)

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
