### PR TITLE
issue/910-app-rating-init 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -28,6 +28,7 @@ import com.woocommerce.android.util.REGEX_API_JETPACK_TUNNEL_METHOD
 import com.woocommerce.android.util.REGEX_API_NUMERIC_PARAM
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
+import com.woocommerce.android.widgets.AppRatingDialog
 import com.yarolegovich.wellsql.WellSql
 import dagger.MembersInjector
 import dagger.android.AndroidInjector
@@ -112,6 +113,7 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
         dispatcher.register(this)
 
         AppPrefs.init(this)
+        AppRatingDialog.init(this)
 
         initAnalytics()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -121,7 +121,6 @@ class MainActivity : AppCompatActivity(),
         val promoShown = presenter.hasMultipleStores() && WCPromoDialog.showIfNeeded(this, PromoType.SITE_PICKER)
 
         // show the app rating dialog if it's time and we didn't just show the promo
-        AppRatingDialog.init(this)
         if (!promoShown) {
             AppRatingDialog.showIfNeeded(this)
         }


### PR DESCRIPTION
Closes #910 - Initializes the app rating dialog in the app class rather than the main activity to avoid potential problems down the road (such as [this crash](https://github.com/wordpress-mobile/WordPress-Android/issues/9416) in WPAndroid).