### PR TITLE
issue/939-orderproductlist-access-exception

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 Bugfixes
 * Fixed bug that led to incorrect stats bar heights
+* Fixed rare crash in order detail while loading product images
 
 Improvements
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductListView.kt
@@ -119,7 +119,9 @@ class OrderDetailProductListView @JvmOverloads constructor(ctx: Context, attrs: 
 
     // called when a product is fetched to ensure we show the correct product image
     fun refreshProductImages() {
-        viewAdapter.notifyDataSetChanged()
+        if (::viewAdapter.isInitialized) {
+            viewAdapter.notifyDataSetChanged()
+        }
     }
 
     private fun hideButtons() {


### PR DESCRIPTION
Fixes #939 by checking whether viewAdapter is initialized before accessing it

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
