### PR TITLE
issue/888-order-detail-already-active 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 Bugfixes
 * Fixed bug that led to incorrect stats bar heights
+* Fixed rare crash opening order detail when it's already showing
 
 Improvements
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragmentView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragmentView.kt
@@ -95,7 +95,9 @@ interface TopLevelFragmentView : FragmentManager.OnBackStackChangedListener, Ord
 
     override fun openOrderDetail(localSiteId: Int, remoteOrderId: Long, remoteNotificationId: Long?) {
         val tag = OrderDetailFragment.TAG
-        loadChildFragment(OrderDetailFragment.newInstance(localSiteId, remoteOrderId, remoteNotificationId), tag)
+        if (!popToState(tag)) {
+            loadChildFragment(OrderDetailFragment.newInstance(localSiteId, remoteOrderId, remoteNotificationId), tag)
+        }
     }
 
     override fun openOrderFulfillment(order: WCOrderModel) {


### PR DESCRIPTION
Fixes #888 by popping to existing order detail fragment before creating new one

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
