### PR TITLE
issue/942-cant-fulfill-order

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragment.kt
@@ -95,6 +95,8 @@ class OrderFulfillmentFragment : Fragment(), OrderFulfillmentContract.View, View
 
         // Populate the Customer Information Card
         orderFulfill_customerInfo.initView(order, true)
+
+        orderFulfill_btnComplete.setOnClickListener(this)
     }
 
     override fun onClick(v: View?) {


### PR DESCRIPTION
Fixes #942 - a previous commit accidentally removed the click listener for the "Mark order complete" button. This PR restores it.

**Note:** This is a hotfix for v1.5.