### PR TITLE
issue/920-dead-system-exception

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/FCMMessageService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/FCMMessageService.kt
@@ -24,7 +24,11 @@ class FCMMessageService : FirebaseMessagingService() {
         if (!accountStore.hasAccessToken()) return
 
         message?.data?.let {
-            notificationHandler.buildAndShowNotificationFromNoteData(this.applicationContext, convertMapToBundle(it), accountStore.account)
+            notificationHandler.buildAndShowNotificationFromNoteData(
+                    this.applicationContext,
+                    convertMapToBundle(it),
+                    accountStore.account
+            )
         } ?: WooLog.d(T.NOTIFS, "No notification message content received. Aborting.")
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/FCMMessageService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/FCMMessageService.kt
@@ -24,7 +24,7 @@ class FCMMessageService : FirebaseMessagingService() {
         if (!accountStore.hasAccessToken()) return
 
         message?.data?.let {
-            notificationHandler.buildAndShowNotificationFromNoteData(this, convertMapToBundle(it), accountStore.account)
+            notificationHandler.buildAndShowNotificationFromNoteData(this.applicationContext, convertMapToBundle(it), accountStore.account)
         } ?: WooLog.d(T.NOTIFS, "No notification message content received. Aborting.")
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
@@ -12,6 +12,7 @@ import android.media.AudioAttributes
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.os.RemoteException
 import android.preference.PreferenceManager
 import android.support.v4.app.NotificationCompat
 import android.support.v4.app.NotificationManagerCompat
@@ -527,10 +528,17 @@ class NotificationHandler @Inject constructor(
 
         builder.setCategory(NotificationCompat.CATEGORY_SOCIAL)
 
-        val pendingIntent = PendingIntent.getActivity(context, pushId, resultIntent,
-                PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_UPDATE_CURRENT)
-        builder.setContentIntent(pendingIntent)
-        val notificationManager = NotificationManagerCompat.from(context)
-        notificationManager.notify(pushId, builder.build())
+        try {
+            val pendingIntent = PendingIntent.getActivity(
+                    context, pushId, resultIntent,
+                    PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_UPDATE_CURRENT
+            )
+            builder.setContentIntent(pendingIntent)
+            val notificationManager = NotificationManagerCompat.from(context)
+            notificationManager.notify(pushId, builder.build())
+        } catch (e: RemoteException) {
+            // see https://github.com/woocommerce/woocommerce-android/issues/920
+            WooLog.e(T.NOTIFS, e)
+        }
     }
 }


### PR DESCRIPTION
Closes #920 - Catches and ignores the `DeadSystemException` when showing a notification. As noted in the issue, the system is restarting so we should simply ignore this error.

Note that I chose to catch `RemoteException` because `DeadSystemException` wasn't added until API 24, but `RemoteException` is its parent.