### PR TITLE
Update Jetpack login track event to match iOS

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -72,7 +72,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         SIGNUP_SOCIAL_TO_LOGIN(siteless = true),
         ADDED_SELF_HOSTED_SITE(siteless = true),
         CREATED_ACCOUNT(siteless = true),
-        LOGIN_PROLOGUE_JETPACK_BUTTON_TAPPED(siteless = true),
+        LOGIN_PROLOGUE_JETPACK_LOGIN_BUTTON_TAPPED(siteless = true),
         LOGIN_PROLOGUE_JETPACK_CONFIGURATION_INSTRUCTIONS_LINK_TAPPED(siteless = true),
 
         // -- Site Picker

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
@@ -57,7 +57,7 @@ class LoginPrologueFragment : Fragment() {
         super.onActivityCreated(savedInstanceState)
         button_login_jetpack.setOnClickListener {
             prologueFinishedListener?.onPrologueFinished()
-            AnalyticsTracker.track(Stat.LOGIN_PROLOGUE_JETPACK_BUTTON_TAPPED)
+            AnalyticsTracker.track(Stat.LOGIN_PROLOGUE_JETPACK_LOGIN_BUTTON_TAPPED)
         }
 
         val separator = if (DisplayUtils.isLandscape(activity)) " " else "<br>"


### PR DESCRIPTION
This PR fixes #949 by updating the track event sent after the user clicks the "Login with Jetpack" button to match the event iOS is sending.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
