### PR TITLE
Issue/951 dashboard refreshes too often

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,5 +7,6 @@ Bugfixes
 * Fixed rare crash in order detail while loading product images
 
 Improvements
+* Dashboard no longer reloads every time you return to it
 
 New Features

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -1,36 +1,16 @@
 package com.woocommerce.android.extensions
 
 import android.support.v4.app.Fragment
-import android.support.v4.widget.SwipeRefreshLayout
 
 interface FragmentScrollListener {
     fun onFragmentScrollUp()
     fun onFragmentScrollDown()
 }
 
-fun Fragment.onScrollUp(refreshLayout: SwipeRefreshLayout? = null) {
-    enableSwipeRefresh(refreshLayout, true)
+fun Fragment.onScrollUp() {
     (activity as? FragmentScrollListener)?.onFragmentScrollUp()
 }
 
-fun Fragment.onScrollDown(refreshLayout: SwipeRefreshLayout? = null) {
-    enableSwipeRefresh(refreshLayout, false)
+fun Fragment.onScrollDown() {
     (activity as? FragmentScrollListener)?.onFragmentScrollDown()
-}
-
-/**
- * This function was added to allow the enable and disable of the [SwipeRefreshLayout] isEnabled property.
- * When the gesture for refresh operation is enabled (isEnabled property is true), this interfere with the
- * overScrollMode of an eventual scrollable view that is inside (ie NestedScrollView or RecyclerView).
- *
- * This function should be used to set to false the SwipeRefreshLayout.isEnabled when scrolling down (so to
- * allow the overScrollMode to do its job) and to set to true the SwipeRefreshLayout.isEnabled when scrolling up (so
- * to allow the SwipeRefreshLayout to refresh the view)
- *
- * @param refreshLayout The SwipeRefreshLayout to manage
- * @param enable Set to true to enable, false to disable
- *
- */
-private fun enableSwipeRefresh(refreshLayout: SwipeRefreshLayout?, enable: Boolean) {
-    if (refreshLayout?.isEnabled != enable) refreshLayout?.isEnabled = enable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -21,6 +21,10 @@ abstract class TopLevelFragment : Fragment(), TopLevelFragmentView {
         // If the value associated with this label is true, then this
         // fragment is currently hosting a child fragment (drilled in).
         const val CHILD_FRAGMENT_ACTIVE = "child-fragment-active"
+
+        // auto-refresh after five minutes
+        const val AUTO_REFRESH_MS = 5 // * 1000
+        var lastRefreshTimestamp = 0L
     }
 
     /**
@@ -29,6 +33,9 @@ abstract class TopLevelFragment : Fragment(), TopLevelFragmentView {
      */
     var deferInit: Boolean = false
     private var runOnResumeFunc: (() -> Unit)? = null
+
+    override var isActive: Boolean = false
+        get() = childFragmentManager.backStackEntryCount == 0 && !isHidden
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -73,6 +80,16 @@ abstract class TopLevelFragment : Fragment(), TopLevelFragmentView {
     override fun onDestroyView() {
         container.removeAllViews()
         super.onDestroyView()
+    }
+
+    override fun isTimeToAutoRefresh(): Boolean {
+        val currentTimestamp = System.currentTimeMillis()
+        if (currentTimestamp - lastRefreshTimestamp >= AUTO_REFRESH_MS) {
+            lastRefreshTimestamp = currentTimestamp
+            return true
+        } else {
+            return false
+        }
     }
 
     override fun getFragmentFromBackStack(tag: String): Fragment? {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -35,7 +35,7 @@ abstract class TopLevelFragment : Fragment(), TopLevelFragmentView {
     private var runOnResumeFunc: (() -> Unit)? = null
 
     override var isActive: Boolean = false
-        get() = childFragmentManager.backStackEntryCount == 0 && !isHidden
+        get() = host != null && childFragmentManager.backStackEntryCount == 0 && !isHidden
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -21,10 +21,6 @@ abstract class TopLevelFragment : Fragment(), TopLevelFragmentView {
         // If the value associated with this label is true, then this
         // fragment is currently hosting a child fragment (drilled in).
         const val CHILD_FRAGMENT_ACTIVE = "child-fragment-active"
-
-        // auto-refresh after five minutes
-        const val AUTO_REFRESH_MS = 5 // * 1000
-        var lastRefreshTimestamp = 0L
     }
 
     /**
@@ -80,16 +76,6 @@ abstract class TopLevelFragment : Fragment(), TopLevelFragmentView {
     override fun onDestroyView() {
         container.removeAllViews()
         super.onDestroyView()
-    }
-
-    override fun isTimeToAutoRefresh(): Boolean {
-        val currentTimestamp = System.currentTimeMillis()
-        if (currentTimestamp - lastRefreshTimestamp >= AUTO_REFRESH_MS) {
-            lastRefreshTimestamp = currentTimestamp
-            return true
-        } else {
-            return false
-        }
     }
 
     override fun getFragmentFromBackStack(tag: String): Fragment? {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragmentView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragmentView.kt
@@ -18,6 +18,8 @@ import org.wordpress.android.fluxc.model.WCOrderModel
  * fragments and their associated back stack.
  */
 interface TopLevelFragmentView : FragmentManager.OnBackStackChangedListener, OrdersViewRouter {
+    var isActive: Boolean
+
     /**
      * Load the provided fragment into the current view and disable the main
      * underlying fragment view.
@@ -73,6 +75,11 @@ interface TopLevelFragmentView : FragmentManager.OnBackStackChangedListener, Ord
      * @return The fragment matching the provided tag, or null if not found.
      */
     fun getFragmentFromBackStack(tag: String): Fragment?
+
+    /**
+     * Determines whether it's time to auto-refresh the fragments data
+     */
+    fun isTimeToAutoRefresh(): Boolean
 
     /**
      * Only open the order detail if the list is not actively being refreshed.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragmentView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragmentView.kt
@@ -77,11 +77,6 @@ interface TopLevelFragmentView : FragmentManager.OnBackStackChangedListener, Ord
     fun getFragmentFromBackStack(tag: String): Fragment?
 
     /**
-     * Determines whether it's time to auto-refresh the fragments data
-     */
-    fun isTimeToAutoRefresh(): Boolean
-
-    /**
      * Only open the order detail if the list is not actively being refreshed.
      */
     override fun openOrderDetail(order: WCOrderModel, markOrderComplete: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContract.kt
@@ -15,7 +15,6 @@ interface DashboardContract {
     }
 
     interface View : BaseView<Presenter> {
-        var isActive: Boolean
         var isRefreshPending: Boolean
 
         fun refreshDashboard(forced: Boolean = false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContract.kt
@@ -9,7 +9,6 @@ interface DashboardContract {
     interface Presenter : BasePresenter<View> {
         fun loadStats(granularity: StatsGranularity, forced: Boolean = false)
         fun loadTopEarnerStats(granularity: StatsGranularity, forced: Boolean = false)
-        fun resetForceRefresh()
         fun getStatsCurrency(): String?
         fun fetchUnfilledOrderCount(forced: Boolean = false)
         fun fetchHasOrders()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -111,10 +111,8 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
             }
         }
 
-        if (isActive) {
+        if (isActive && !deferInit) {
             refreshDashboard(forced = this.isRefreshPending)
-        } else {
-            isRefreshPending = true
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -71,7 +71,7 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
                     // Track the user gesture
                     AnalyticsTracker.track(Stat.DASHBOARD_PULLED_TO_REFRESH)
 
-                    presenter.resetForceRefresh()
+                    DashboardPresenter.resetForceRefresh()
                     dashboard_refresh_layout.isRefreshing = false
                     refreshDashboard(forced = true)
                 }
@@ -214,7 +214,7 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
     }
 
     override fun refreshFragmentState() {
-        presenter.resetForceRefresh()
+        DashboardPresenter.resetForceRefresh()
         refreshDashboard(forced = false)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -123,7 +123,7 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
 
         // If this fragment is now visible and we've deferred loading data due to it not
         // being visible - go ahead and load the data.
-        if (isActive && isRefreshPending) {
+        if (!isHidden) {
             refreshDashboard(forced = false)
         }
     }
@@ -219,7 +219,10 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
         when {
             isActive -> {
                 isRefreshPending = false
-                dashboard_stats.clearLabelValues()
+                if (forced) {
+                    dashboard_stats.clearLabelValues()
+                    dashboard_stats.clearChartData()
+                }
                 presenter.loadStats(dashboard_stats.activeGranularity, forced)
                 presenter.loadTopEarnerStats(dashboard_top_earners.activeGranularity, forced)
                 presenter.fetchUnfilledOrderCount(forced)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -44,9 +44,6 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
     override var isRefreshPending: Boolean = false // If true, the fragment will refresh its data when it's visible
     private var errorSnackbar: Snackbar? = null
 
-    override var isActive: Boolean = false
-        get() = childFragmentManager.backStackEntryCount == 0 && !isHidden
-
     override fun onAttach(context: Context?) {
         AndroidSupportInjection.inject(this)
         super.onAttach(context)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -102,9 +102,9 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
         scroll_view.setOnScrollChangeListener {
             v: NestedScrollView?, scrollX: Int, scrollY: Int, oldScrollX: Int, oldScrollY: Int ->
             if (scrollY > oldScrollY) {
-                onScrollDown(dashboard_refresh_layout)
+                onScrollDown()
             } else if (scrollY < oldScrollY) {
-                onScrollUp(dashboard_refresh_layout)
+                onScrollUp()
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -121,8 +121,7 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
     override fun onHiddenChanged(hidden: Boolean) {
         super.onHiddenChanged(hidden)
 
-        // If this fragment is now visible and we've deferred loading data due to it not
-        // being visible - go ahead and load the data.
+        // silently refresh if this fragment is no longer hidden
         if (!isHidden) {
             refreshDashboard(forced = false)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardPresenter.kt
@@ -48,7 +48,7 @@ class DashboardPresenter @Inject constructor(
         private val topEarnersForceRefresh = BooleanArray(StatsGranularity.values().size)
 
         init {
-             resetForceRefresh()
+            resetForceRefresh()
         }
 
         /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardPresenter.kt
@@ -44,15 +44,28 @@ class DashboardPresenter @Inject constructor(
     companion object {
         private val TAG = DashboardPresenter::class.java
         private const val NUM_TOP_EARNERS = 3
+        private val statsForceRefresh = BooleanArray(StatsGranularity.values().size)
+        private val topEarnersForceRefresh = BooleanArray(StatsGranularity.values().size)
+
+        init {
+             resetForceRefresh()
+        }
+
+        /**
+         * this tells the presenter to force a refresh for all granularities on the next request - this is
+         * used after a swipe-to-refresh on the dashboard to ensure we don't get cached data
+         */
+        fun resetForceRefresh() {
+            for (i in 0 until statsForceRefresh.size) {
+                statsForceRefresh[i] = true
+            }
+            for (i in 0 until topEarnersForceRefresh.size) {
+                topEarnersForceRefresh[i] = true
+            }
+        }
     }
 
     private var dashboardView: DashboardContract.View? = null
-    private val statsForceRefresh = BooleanArray(StatsGranularity.values().size)
-    private val topEarnersForceRefresh = BooleanArray(StatsGranularity.values().size)
-
-    init {
-        resetForceRefresh()
-    }
 
     override fun takeView(view: DashboardContract.View) {
         dashboardView = view
@@ -100,19 +113,6 @@ class DashboardPresenter @Inject constructor(
         val payload = FetchTopEarnersStatsPayload(
                 selectedSite.get(), granularity, NUM_TOP_EARNERS, forced = forceRefresh)
         dispatcher.dispatch(WCStatsActionBuilder.newFetchTopEarnersStatsAction(payload))
-    }
-
-    /**
-     * this tells the presenter to force a refresh for all granularities on the next request - this is
-     * used after a swipe-to-refresh on the dashboard to ensure we don't get cached data
-     */
-    override fun resetForceRefresh() {
-        for (i in 0 until statsForceRefresh.size) {
-            statsForceRefresh[i] = true
-        }
-        for (i in 0 until topEarnersForceRefresh.size) {
-            topEarnersForceRefresh[i] = true
-        }
     }
 
     override fun getStatsCurrency() = wcStatsStore.getStatsCurrencyForSite(selectedSite.get())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -256,6 +256,8 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
     fun updateView(revenueStats: Map<String, Double>, orderStats: Map<String, Int>, currencyCode: String?) {
         chartCurrencyCode = currencyCode
 
+        val wasEmpty = chart.barData?.let { it.dataSetCount == 0 } ?: true
+
         val revenue = formatCurrencyForDisplay(revenueStats.values.sum(), currencyCode.orEmpty())
         val orders = orderStats.values.sum().toString()
         fadeInLabelValue(revenue_value, revenue)
@@ -292,7 +294,9 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
             axisLeft.axisMinimum = minRevenue
             axisRight.axisMinimum = 0f
             data = BarData(dataSet)
-            animateY(duration)
+            if (wasEmpty) {
+                animateY(duration)
+            }
         }
 
         hideMarker()
@@ -323,6 +327,10 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
         visitors_value.setText(R.string.emdash)
         revenue_value.setText(R.string.emdash)
         orders_value.setText(R.string.emdash)
+    }
+
+    fun clearChartData() {
+        chart.data.clearValues()
     }
 
     private fun fadeInLabelValue(view: TextView, value: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -334,6 +334,11 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
     }
 
     private fun fadeInLabelValue(view: TextView, value: String) {
+        // do nothing if value hasn't changed
+        if (view.text.toString().equals(value)) {
+            return
+        }
+
         // fade out the current value
         val duration = Duration.SHORT
         WooAnimUtils.fadeOut(view, duration, View.INVISIBLE)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
@@ -146,11 +146,6 @@ class MainNavigationView @JvmOverloads constructor(
                         .show(fragment)
                         .commitAllowingStateLoss()
             }
-
-            // refresh the incoming fragment's data if it's due
-            if (fragment.isTimeToAutoRefresh()) {
-                fragment.refreshFragmentState()
-            }
         }
 
         previousNavPos = navPos

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
@@ -123,6 +123,8 @@ class MainNavigationView @JvmOverloads constructor(
         // Close any child fragments if open
         clearFragmentBackStack(fragment)
 
+        // add the fregment if it hasn't been added yet, otherwise hide the previously active
+        // fragment and show the incoming one
         val tag = navPos.getTag()
         if (fragmentManager.findFragmentByTag(tag) == null) {
             fragmentManager
@@ -143,6 +145,11 @@ class MainNavigationView @JvmOverloads constructor(
                         .beginTransaction()
                         .show(fragment)
                         .commitAllowingStateLoss()
+            }
+
+            // refresh the incoming fragment's data if it's due
+            if (fragment.isTimeToAutoRefresh()) {
+                fragment.refreshFragmentState()
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
@@ -31,6 +31,8 @@ class MainNavigationView @JvmOverloads constructor(
     private lateinit var listener: MainNavigationListener
     private lateinit var badgeView: View
 
+    private var previousNavPos: BottomNavigationPosition? = null
+
     interface MainNavigationListener {
         fun onNavItemSelected(navPos: BottomNavigationPosition)
 
@@ -121,10 +123,30 @@ class MainNavigationView @JvmOverloads constructor(
         // Close any child fragments if open
         clearFragmentBackStack(fragment)
 
-        fragmentManager
-                .beginTransaction()
-                .replace(R.id.container, fragment, navPos.getTag())
-                .commitAllowingStateLoss()
+        val tag = navPos.getTag()
+        if (fragmentManager.findFragmentByTag(tag) == null) {
+            fragmentManager
+                    .beginTransaction()
+                    .add(R.id.container, fragment, tag)
+                    .commitAllowingStateLoss()
+        } else {
+            var shouldHidePrev = previousNavPos?.position != navPos.position ?: false
+            if (shouldHidePrev) {
+                val prevFragment = navAdapter.getFragment(previousNavPos!!)
+                fragmentManager
+                        .beginTransaction()
+                        .hide(prevFragment)
+                        .show(fragment)
+                        .commitAllowingStateLoss()
+            } else {
+                fragmentManager
+                        .beginTransaction()
+                        .show(fragment)
+                        .commitAllowingStateLoss()
+            }
+        }
+
+        previousNavPos = navPos
     }
 
     private fun assignNavigationListeners(assign: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
@@ -31,7 +31,9 @@ class MainNavigationView @JvmOverloads constructor(
     private lateinit var listener: MainNavigationListener
     private lateinit var badgeView: View
 
-    private var previousNavPos: BottomNavigationPosition? = null
+    companion object {
+        private var previousNavPos: BottomNavigationPosition? = null
+    }
 
     interface MainNavigationListener {
         fun onNavItemSelected(navPos: BottomNavigationPosition)
@@ -123,7 +125,7 @@ class MainNavigationView @JvmOverloads constructor(
         // Close any child fragments if open
         clearFragmentBackStack(fragment)
 
-        // add the fregment if it hasn't been added yet, otherwise hide the previously active
+        // add the fragment if it hasn't been added yet, otherwise hide the previously active
         // fragment and show the incoming one
         val tag = navPos.getTag()
         if (fragmentManager.findFragmentByTag(tag) == null) {
@@ -132,7 +134,9 @@ class MainNavigationView @JvmOverloads constructor(
                     .add(R.id.container, fragment, tag)
                     .commitAllowingStateLoss()
         } else {
-            var shouldHidePrev = previousNavPos?.position != navPos.position ?: false
+            val shouldHidePrev = previousNavPos?.let {
+                it.position != navPos.position
+            } ?: false
             if (shouldHidePrev) {
                 val prevFragment = navAdapter.getFragment(previousNavPos!!)
                 fragmentManager

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListContract.kt
@@ -16,7 +16,6 @@ interface NotifsListContract {
     }
 
     interface View : BaseView<Presenter>, ReviewActionListener {
-        var isActive: Boolean
         var isRefreshPending: Boolean
 
         fun showNotifications(notifsList: List<NotificationModel>, isFreshData: Boolean)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
@@ -157,9 +157,9 @@ class NotifsListFragment : TopLevelFragment(),
             addOnScrollListener(object : RecyclerView.OnScrollListener() {
                 override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                     if (dy > 0) {
-                        onScrollDown(this@NotifsListFragment.notifsRefreshLayout)
+                        onScrollDown()
                     } else if (dy < 0) {
-                        onScrollUp(this@NotifsListFragment.notifsRefreshLayout)
+                        onScrollUp()
                     }
                 }
             })

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
@@ -72,9 +72,6 @@ class NotifsListFragment : TopLevelFragment(),
     private var pendingModerationNewStatus: String? = null
     private var pendingModerationRemoteNoteId: Long? = null
 
-    override var isActive: Boolean = false
-        get() = childFragmentManager.backStackEntryCount == 0 && !isHidden
-
     override var isRefreshPending = true
     private var listState: Parcelable? = null // Save the state of the recycler view
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
@@ -222,9 +222,13 @@ class NotifsListFragment : TopLevelFragment(),
     override fun onHiddenChanged(hidden: Boolean) {
         super.onHiddenChanged(hidden)
 
-        // If this fragment is no longer visible, dismiss the pending notification
-        // moderation so it can be processed immediately.
-        changeCommentStatusSnackbar?.dismiss()
+        // If this fragment is no longer visible dismiss the pending notification moderation
+        // so it can be processed immediately, otherwise silently refresh
+        if (hidden) {
+            changeCommentStatusSnackbar?.dismiss()
+        } else {
+            presenter.fetchAndLoadNotifsFromDb(false)
+        }
     }
 
     override fun onStop() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListContract.kt
@@ -20,7 +20,6 @@ interface OrderListContract {
     }
 
     interface View : BaseView<Presenter>, OrdersViewRouter {
-        var isActive: Boolean
         var isRefreshPending: Boolean
         var isSearching: Boolean
         var isRefreshing: Boolean

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -306,7 +306,11 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
 
         // silently refresh if this fragment is no longer hidden
         if (!hidden) {
-            presenter.fetchAndLoadOrdersFromDb(orderStatusFilter, isForceRefresh = false)
+            if (isSearching) {
+                presenter.searchOrders(searchQuery)
+            } else {
+                presenter.fetchAndLoadOrdersFromDb(orderStatusFilter, isForceRefresh = false)
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -237,9 +237,9 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
             addOnScrollListener(object : RecyclerView.OnScrollListener() {
                 override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                     if (dy > 0) {
-                        onScrollDown(this@OrderListFragment.orderRefreshLayout)
+                        onScrollDown()
                     } else if (dy < 0) {
-                        onScrollUp(this@OrderListFragment.orderRefreshLayout)
+                        onScrollUp()
                     }
                 }
             })

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -301,6 +301,15 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
         super.onDestroyView()
     }
 
+    override fun onHiddenChanged(hidden: Boolean) {
+        super.onHiddenChanged(hidden)
+
+        // silently refresh if this fragment is no longer hidden
+        if (!hidden) {
+            presenter.fetchAndLoadOrdersFromDb(orderStatusFilter, isForceRefresh = false)
+        }
+    }
+
     override fun setLoadingMoreIndicator(active: Boolean) {
         load_more_progressbar.visibility = if (active) View.VISIBLE else View.GONE
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -81,9 +81,6 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
 
     private val skeletonView = SkeletonView()
 
-    override var isActive: Boolean = false
-        get() = childFragmentManager.backStackEntryCount == 0 && !isHidden
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)


### PR DESCRIPTION
This PR includes two changes aimed at preventing the dashboard from refreshing every time the user returns to it:

* Moved the variables that determine whether it's time to refresh to the presenter's companion object [here](https://github.com/woocommerce/woocommerce-android/compare/issue/951-dashboard-refreshes-too-often#diff-2dfb5e57dd5d6c055a61dfc62cbf11b2R58). We previously had these in the presenter itself, which caused them to be reset when the view is attached.

* Changed the way fragments are added to the bottom navigation. Previously tapping a navigation tab would use `replace` to swap in the new fragment, which meant the incoming fragment would be recreated from scratch. This PR changes things so fragments are added rather than replaced, and we use [findFragmentByTag](https://github.com/woocommerce/woocommerce-android/compare/issue/951-dashboard-refreshes-too-often#diff-2f7e6d3438b16dbacd86d72696f06119R131) to locate previously added fragments.

Note: as part of this PR I moved `isActive` to the `TopLevelFragment` [here](https://github.com/woocommerce/woocommerce-android/blob/4702efbb76147bb06f915ec7d27c8915827ceb4c/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt#L33). Previously we had the same code is each fragment.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
