### PR TITLE
issue/953-remove-site-switcher-promo 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -37,7 +37,6 @@ import com.woocommerce.android.util.WooAnimUtils.Duration
 import com.woocommerce.android.widgets.AppRatingDialog
 import com.woocommerce.android.widgets.WCPromoDialog
 import com.woocommerce.android.widgets.WCPromoDialog.PromoButton
-import com.woocommerce.android.widgets.WCPromoDialog.PromoType
 import com.woocommerce.android.widgets.WCPromoTooltip
 import com.woocommerce.android.widgets.WCPromoTooltip.Feature
 import dagger.android.AndroidInjection
@@ -116,13 +115,8 @@ class MainActivity : AppCompatActivity(),
 
         initFragment(savedInstanceState)
 
-        // show the site picker promo if it hasn't been shown and the user has multiple stores
-        val promoShown = presenter.hasMultipleStores() && WCPromoDialog.showIfNeeded(this, PromoType.SITE_PICKER)
-
-        // show the app rating dialog if it's time and we didn't just show the promo
-        if (!promoShown) {
-            AppRatingDialog.showIfNeeded(this)
-        }
+        // show the app rating dialog if it's time
+        AppRatingDialog.showIfNeeded(this)
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCPromoDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCPromoDialog.kt
@@ -15,7 +15,8 @@ import com.woocommerce.android.widgets.WCPromoDialog.PromoButton.SITE_PICKER_TRY
 import org.wordpress.android.util.DisplayUtils
 
 /**
- * Used to advertise a new feature with a single-shot dialog
+ * Used to advertise a new feature with a single-shot dialog. This was initially added to promote the ability to
+ * switch sites but is no longer used. Code is being left here for possible future use.
  */
 class WCPromoDialog : DialogFragment() {
     companion object {


### PR DESCRIPTION
Resolves #953 -Changed the main activity so we don't show the site picker promo at startup. Even though the promo dialog is no longer used, I decided not to delete it since we'll likely use it down the road to promote some other feature.