### PR TITLE
issue/957-order-id-must-not-be-null

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@ Bugfixes
 * Fixed bug that led to incorrect stats bar heights
 * Fixed rare crash opening order detail when it's already showing
 * Fixed rare crash in order detail while loading product images
+* Fixed rare crash when showing order note
 
 Improvements
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderNoteActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderNoteActivity.kt
@@ -29,6 +29,7 @@ class AddOrderNoteActivity : AppCompatActivity(), AddOrderNoteContract.View {
         const val FIELD_NOTE_TEXT = "note_text"
         const val FIELD_IS_CUSTOMER_NOTE = "is_customer_note"
         const val FIELD_IS_CONFIRMING_DISCARD = "is_confirming_discard"
+        const val RESULT_INVALID_ORDER = Activity.RESULT_FIRST_USER
     }
 
     @Inject lateinit var presenter: AddOrderNoteContract.Presenter
@@ -49,15 +50,21 @@ class AddOrderNoteActivity : AppCompatActivity(), AddOrderNoteContract.View {
         supportActionBar?.setHomeAsUpIndicator(R.drawable.ic_gridicons_cross_white_24dp)
 
         if (savedInstanceState == null) {
-            orderId = intent.getStringExtra(FIELD_ORDER_IDENTIFIER)
-            orderNumber = intent.getStringExtra(FIELD_ORDER_NUMBER)
+            orderId = intent.getStringExtra(FIELD_ORDER_IDENTIFIER) ?: ""
+            orderNumber = intent.getStringExtra(FIELD_ORDER_NUMBER) ?: ""
         } else {
-            orderId = savedInstanceState.getString(FIELD_ORDER_IDENTIFIER)
-            orderNumber = savedInstanceState.getString(FIELD_ORDER_NUMBER)
+            orderId = savedInstanceState.getString(FIELD_ORDER_IDENTIFIER) ?: ""
+            orderNumber = savedInstanceState.getString(FIELD_ORDER_NUMBER) ?: ""
             addNote_switch.isChecked = savedInstanceState.getBoolean(FIELD_IS_CUSTOMER_NOTE)
             if (savedInstanceState.getBoolean(FIELD_IS_CONFIRMING_DISCARD)) {
                 confirmDiscard()
             }
+        }
+
+        if (orderId.isEmpty() || orderNumber.isEmpty()) {
+            setResult(RESULT_INVALID_ORDER)
+            finish()
+            return
         }
 
         if (presenter.hasBillingEmail(orderId)) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -17,12 +17,12 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SNACK_ORDER_MARKE
 import com.woocommerce.android.extensions.onScrollDown
 import com.woocommerce.android.extensions.onScrollUp
 import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.orders.AddOrderNoteActivity.Companion.FIELD_IS_CUSTOMER_NOTE
 import com.woocommerce.android.ui.orders.AddOrderNoteActivity.Companion.FIELD_NOTE_TEXT
 import com.woocommerce.android.ui.orders.OrderDetailOrderNoteListView.OrderDetailNoteListener
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.widgets.AppRatingDialog
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_order_detail.*
@@ -127,12 +127,16 @@ class OrderDetailFragment : Fragment(), OrderDetailContract.View, OrderDetailNot
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        if (requestCode == REQUEST_CODE_ADD_NOTE && resultCode == RESULT_OK && data != null) {
-            val noteText = data.getStringExtra(FIELD_NOTE_TEXT)
-            val isCustomerNote = data.getBooleanExtra(FIELD_IS_CUSTOMER_NOTE, false)
-            orderDetail_noteList.addTransientNote(noteText, isCustomerNote)
-            presenter.pushOrderNote(noteText, isCustomerNote)
-            AppRatingDialog.incrementInteractions()
+        if (requestCode == REQUEST_CODE_ADD_NOTE) {
+            if (resultCode == RESULT_OK && data != null) {
+                val noteText = data.getStringExtra(FIELD_NOTE_TEXT)
+                val isCustomerNote = data.getBooleanExtra(FIELD_IS_CUSTOMER_NOTE, false)
+                orderDetail_noteList.addTransientNote(noteText, isCustomerNote)
+                presenter.pushOrderNote(noteText, isCustomerNote)
+                AppRatingDialog.incrementInteractions()
+            } else if (resultCode == AddOrderNoteActivity.RESULT_INVALID_ORDER) {
+                uiMessageResolver.showSnack(R.string.add_order_note_invalid_order)
+            }
         }
         super.onActivityResult(requestCode, resultCode, data)
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -207,6 +207,7 @@
     <string name="add_order_note_added">Order note added</string>
     <string name="add_order_note_error">Unable to add note</string>
     <string name="add_order_note_confirm_discard">Discard this note?</string>
+    <string name="add_order_note_invalid_order">Invalid order</string>
     <!--
         Order Status Labels
     -->


### PR DESCRIPTION
Resolves #957 (again). The underlying crash is a puzzler. The app log shows the user went through the login flow and it failed, so why the "add order note" screen was being shown is a mystery.

At any rate, the actual crash was due to two not nullable variables being set to null when read from the intent's extras. You can repro the crash by commenting out [this line](https://github.com/woocommerce/woocommerce-android/blob/c8eef7286c4cd0f81b465ff15eac415eed43b2b0/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt#L359) which sets the order id.

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
