### PR TITLE
Amanda/608 shipment tracking

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,3 +10,4 @@ Bugfixes
 Improvements
 
 New Features
+* New support for the Shipment Tracking plugin. Read-only Shipment tracking information will now be displayed on a completed order and packages may be tracked directly from the order detail screen. Support for adding shipment tracking information is coming in a future release, so stay tuned!

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -120,6 +120,8 @@ class AnalyticsTracker private constructor(private val context: Context) {
         ORDER_DETAIL_FULFILL_ORDER_BUTTON_TAPPED,
         ORDER_DETAIL_ORDER_STATUS_EDIT_BUTTON_TAPPED,
         ORDER_DETAIL_PRODUCT_DETAIL_BUTTON_TAPPED,
+        ORDER_DETAIL_TRACK_PACKAGE_BUTTON_TAPPED,
+        ORDER_TRACKING_LOADED,
 
         // -- Order Notes
         ADD_ORDER_NOTE_ADD_BUTTON_TAPPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/ProductImageMap.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/ProductImageMap.kt
@@ -39,7 +39,7 @@ class ProductImageMap @Inject constructor(
 
         // product isn't in our map so get it from the database
         selectedSite.getIfExists()?.let { site ->
-            productStore.getProductByRemoteId(site, remoteProductId)?.getFirstImage()?.let { imageUrl ->
+            productStore.getProductByRemoteId(site, remoteProductId)?.getFirstImageUrl()?.let { imageUrl ->
                 map[remoteProductId] = imageUrl
                 pendingRequestIds.remove(remoteProductId)
                 return imageUrl

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailContract.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.ui.base.BasePresenter
 import com.woocommerce.android.ui.base.BaseView
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
+import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 
@@ -13,9 +14,11 @@ interface OrderDetailContract {
         var orderModel: WCOrderModel?
         var orderIdentifier: OrderIdentifier?
         var isUsingCachedNotes: Boolean
+        var isUsingCachedShipmentTrackings: Boolean
         fun fetchOrder(remoteOrderId: Long)
         fun loadOrderDetail(orderIdentifier: OrderIdentifier, markComplete: Boolean)
         fun loadOrderNotes()
+        fun loadOrderShipmentTrackings()
         fun doChangeOrderStatus(newStatus: String)
         fun pushOrderNote(noteText: String, isCustomerNote: Boolean)
         fun markOrderNotificationRead(context: Context, remoteNoteId: Long)
@@ -30,6 +33,7 @@ interface OrderDetailContract {
         fun showOrderNotesSkeleton(show: Boolean)
         fun showAddOrderNoteScreen()
         fun updateOrderNotes(notes: List<WCOrderNoteModel>)
+        fun showOrderShipmentTrackings(trackings: List<WCOrderShipmentTrackingModel>)
         fun setOrderStatus(newStatus: String)
         fun showChangeOrderStatusSnackbar(newStatus: String)
         fun showNotesErrorSnack()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -23,6 +23,7 @@ import com.woocommerce.android.ui.orders.AddOrderNoteActivity.Companion.FIELD_IS
 import com.woocommerce.android.ui.orders.AddOrderNoteActivity.Companion.FIELD_NOTE_TEXT
 import com.woocommerce.android.ui.orders.OrderDetailOrderNoteListView.OrderDetailNoteListener
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.widgets.AppRatingDialog
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_order_detail.*
@@ -216,10 +217,14 @@ class OrderDetailFragment : Fragment(), OrderDetailContract.View, OrderDetailNot
 
     override fun showOrderShipmentTrackings(trackings: List<WCOrderShipmentTrackingModel>) {
         if (trackings.isNotEmpty()) {
-            orderDetail_shipmentList.visibility = View.VISIBLE
             orderDetail_shipmentList.initView(trackings, uiMessageResolver)
+            if (orderDetail_shipmentList.visibility != View.VISIBLE) {
+                WooAnimUtils.scaleIn(orderDetail_shipmentList, WooAnimUtils.Duration.MEDIUM)
+            }
         } else {
-            orderDetail_shipmentList.visibility = View.GONE
+            if (orderDetail_shipmentList.visibility == View.VISIBLE) {
+                WooAnimUtils.scaleOut(orderDetail_shipmentList, WooAnimUtils.Duration.MEDIUM)
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -28,6 +28,7 @@ import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_order_detail.*
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
+import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import javax.inject.Inject
@@ -211,6 +212,15 @@ class OrderDetailFragment : Fragment(), OrderDetailContract.View, OrderDetailNot
     override fun showOrderNotes(notes: List<WCOrderNoteModel>) {
         // Populate order notes card
         orderDetail_noteList.initView(notes, this)
+    }
+
+    override fun showOrderShipmentTrackings(trackings: List<WCOrderShipmentTrackingModel>) {
+        if (trackings.isNotEmpty()) {
+            orderDetail_shipmentList.visibility = View.VISIBLE
+            orderDetail_shipmentList.initView(trackings)
+        } else {
+            orderDetail_shipmentList.visibility = View.GONE
+        }
     }
 
     override fun showOrderNotesSkeleton(show: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -217,7 +217,7 @@ class OrderDetailFragment : Fragment(), OrderDetailContract.View, OrderDetailNot
     override fun showOrderShipmentTrackings(trackings: List<WCOrderShipmentTrackingModel>) {
         if (trackings.isNotEmpty()) {
             orderDetail_shipmentList.visibility = View.VISIBLE
-            orderDetail_shipmentList.initView(trackings)
+            orderDetail_shipmentList.initView(trackings, uiMessageResolver)
         } else {
             orderDetail_shipmentList.visibility = View.GONE
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -101,7 +101,7 @@ class OrderDetailPresenter @Inject constructor(
         orderView?.showOrderNotesSkeleton(true)
         orderModel?.let { order ->
             // Preload order notes from database if available
-            fetchAndLoadNotesFromDb()
+            loadNotesFromDb()
 
             if (networkStatus.isConnected()) {
                 // Attempt to refresh notes from api in the background
@@ -116,7 +116,7 @@ class OrderDetailPresenter @Inject constructor(
     override fun loadOrderShipmentTrackings() {
         orderModel?.let { order ->
             // Preload trackings from the db is available
-            fetchAndLoadShipmentTrackingsFromDb()
+            loadShipmentTrackingsFromDb()
 
             if (networkStatus.isConnected()) {
                 // Attempt to refresh trackings from api in the background
@@ -296,14 +296,14 @@ class OrderDetailPresenter @Inject constructor(
 
             // note that we refresh even on error to make sure the transient note is removed
             // from the note list
-            fetchAndLoadNotesFromDb()
+            loadNotesFromDb()
         }
     }
 
     /**
      * Fetch the order notes from the device database.
      */
-    fun fetchAndLoadNotesFromDb() {
+    fun loadNotesFromDb() {
         orderModel?.let { order ->
             val notes = orderStore.getOrderNotesForOrder(order)
             if (isNotesInit) {
@@ -318,7 +318,7 @@ class OrderDetailPresenter @Inject constructor(
     /**
      * Fetch the order shipment tracking records from the device db.
      */
-    fun fetchAndLoadShipmentTrackingsFromDb() {
+    fun loadShipmentTrackingsFromDb() {
         orderModel?.let { order ->
             val trackings = orderStore.getShipmentTrackingsForOrder(order)
             orderView?.showOrderShipmentTrackings(trackings)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -253,8 +253,7 @@ class OrderDetailPresenter @Inject constructor(
                             mapOf(AnalyticsTracker.KEY_ID to order.remoteOrderId))
 
                     isUsingCachedShipmentTrackings = false
-                    val trackings = orderStore.getShipmentTrackingsForOrder(order)
-                    orderView?.showOrderShipmentTrackings(trackings)
+                    loadShipmentTrackingsFromDb()
                 }
             }
         } else if (event.causeOfChange == UPDATE_ORDER_STATUS) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -248,7 +248,9 @@ class OrderDetailPresenter @Inject constructor(
                 WooLog.e(T.ORDERS, "$TAG - Error fetching order shipment tracking info: ${event.error.message}")
             } else {
                 orderModel?.let { order ->
-                    // TODO track success
+                    AnalyticsTracker.track(
+                            Stat.ORDER_TRACKING_LOADED,
+                            mapOf(AnalyticsTracker.KEY_ID to order.remoteOrderId))
 
                     isUsingCachedShipmentTrackings = false
                     val trackings = orderStore.getShipmentTrackingsForOrder(order)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -38,6 +38,7 @@ import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationsRead
 import org.wordpress.android.fluxc.store.NotificationStore.OnNotificationChanged
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderStatusOptionsChanged
@@ -62,6 +63,7 @@ class OrderDetailPresenter @Inject constructor(
     override var orderModel: WCOrderModel? = null
     override var orderIdentifier: OrderIdentifier? = null
     override var isUsingCachedNotes = false
+    override var isUsingCachedShipmentTrackings = false
     private var pendingRemoteOrderId: Long? = null
     private var pendingMarkReadNotification: NotificationModel? = null
 
@@ -90,6 +92,7 @@ class OrderDetailPresenter @Inject constructor(
                 orderView?.showOrderDetail(order)
                 if (markComplete) orderView?.showChangeOrderStatusSnackbar(CoreOrderStatus.COMPLETED.value)
                 loadOrderNotes()
+                loadOrderShipmentTrackings()
             } ?: fetchOrder(orderIdentifier.toIdSet().remoteOrderId)
         }
     }
@@ -106,6 +109,21 @@ class OrderDetailPresenter @Inject constructor(
             } else {
                 // Track so when the device is connected notes can be refreshed
                 isUsingCachedNotes = true
+            }
+        }
+    }
+
+    override fun loadOrderShipmentTrackings() {
+        orderModel?.let { order ->
+            // Preload trackings from the db is available
+            fetchAndLoadShipmentTrackingsFromDb()
+
+            if (networkStatus.isConnected()) {
+                // Attempt to refresh trackings from api in the background
+                requestShipmentTrackingsFromApi(order)
+            } else {
+                // Track so when the device is connected shipment trackings can be refreshed
+                isUsingCachedShipmentTrackings = true
             }
         }
     }
@@ -225,6 +243,18 @@ class OrderDetailPresenter @Inject constructor(
                     orderView?.updateOrderNotes(notes)
                 }
             }
+        } else if (event.causeOfChange == WCOrderAction.FETCH_ORDER_SHIPMENT_TRACKINGS) {
+            if (event.isError) {
+                WooLog.e(T.ORDERS, "$TAG - Error fetching order shipment tracking info: ${event.error.message}")
+            } else {
+                orderModel?.let { order ->
+                    // TODO track success
+
+                    isUsingCachedShipmentTrackings = false
+                    val trackings = orderStore.getShipmentTrackingsForOrder(order)
+                    orderView?.showOrderShipmentTrackings(trackings)
+                }
+            }
         } else if (event.causeOfChange == UPDATE_ORDER_STATUS) {
             if (event.isError) {
                 WooLog.e(T.ORDERS, "$TAG - Error updating order status : ${event.error.message}")
@@ -284,11 +314,29 @@ class OrderDetailPresenter @Inject constructor(
     }
 
     /**
+     * Fetch the order shipment tracking records from the device db.
+     */
+    fun fetchAndLoadShipmentTrackingsFromDb() {
+        orderModel?.let { order ->
+            val trackings = orderStore.getShipmentTrackingsForOrder(order)
+            orderView?.showOrderShipmentTrackings(trackings)
+        }
+    }
+
+    /**
      * Request a fresh copy of order notes from the api.
      */
     fun requestOrderNotesFromApi(order: WCOrderModel) {
         val payload = FetchOrderNotesPayload(order, selectedSite.get())
         dispatcher.dispatch(WCOrderActionBuilder.newFetchOrderNotesAction(payload))
+    }
+
+    /**
+     * Request a fresh copy of order shipment tracking records from the api.
+     */
+    fun requestShipmentTrackingsFromApi(order: WCOrderModel) {
+        val payload = FetchOrderShipmentTrackingsPayload(selectedSite.get(), order)
+        dispatcher.dispatch(WCOrderActionBuilder.newFetchOrderShipmentTrackingsAction(payload))
     }
 
     @Suppress("unused")
@@ -299,6 +347,10 @@ class OrderDetailPresenter @Inject constructor(
             orderModel?.let { order ->
                 if (isUsingCachedNotes) {
                     requestOrderNotesFromApi(order)
+                }
+
+                if (isUsingCachedShipmentTrackings) {
+                    requestShipmentTrackingsFromApi(order)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingItemView.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.WooLog
 import kotlinx.android.synthetic.main.order_detail_shipment_tracking_item.view.*
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
@@ -26,13 +27,16 @@ class OrderDetailShipmentTrackingItemView @JvmOverloads constructor(
     fun initView(item: WCOrderShipmentTrackingModel, uiMessageResolver: UIMessageResolver) {
         tracking_type.text = item.trackingProvider
         tracking_number.text = item.trackingNumber
+        tracking_dateShipped.text = context.getString(
+                R.string.order_shipment_tracking_shipped_date,
+                DateUtils.getFullDateString(item.dateShipped))
 
         tracking_copyNumber.setOnClickListener {
             try {
                 val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
                 clipboard.primaryClip = ClipData.newPlainText(
                         context.getString(R.string.order_shipment_tracking_number),
-                        context.getString(R.string.order_shipment_tracking_number_clipboard))
+                        item.trackingNumber)
                 uiMessageResolver.showSnack(R.string.order_shipment_tracking_number_clipboard)
             } catch (e: Exception) {
                 WooLog.e(WooLog.T.UTILS, e)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingItemView.kt
@@ -1,0 +1,31 @@
+package com.woocommerce.android.ui.orders
+
+import android.content.Context
+import android.support.constraint.ConstraintLayout
+import android.util.AttributeSet
+import android.view.View
+import com.woocommerce.android.R
+import com.woocommerce.android.util.ChromeCustomTabUtils
+import kotlinx.android.synthetic.main.order_detail_shipment_tracking_item.view.*
+import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
+
+class OrderDetailShipmentTrackingItemView @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null
+) : ConstraintLayout(ctx, attrs) {
+    init {
+        View.inflate(context, R.layout.order_detail_shipment_tracking_item, this)
+    }
+
+    fun initView(item: WCOrderShipmentTrackingModel) {
+        tracking_type.text = item.trackingProvider
+        tracking_number.text = item.trackingNumber
+
+        if (item.trackingLink.isNotEmpty()) {
+            tracking_btnTrack.setOnClickListener {
+                // TODO tracks analytics
+                ChromeCustomTabUtils.launchUrl(context, item.trackingLink)
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingItemView.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.orders
 
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import android.support.constraint.ConstraintLayout
 import android.util.AttributeSet
@@ -7,7 +9,9 @@ import android.view.View
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.WooLog
 import kotlinx.android.synthetic.main.order_detail_shipment_tracking_item.view.*
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 
@@ -19,12 +23,21 @@ class OrderDetailShipmentTrackingItemView @JvmOverloads constructor(
         View.inflate(context, R.layout.order_detail_shipment_tracking_item, this)
     }
 
-    fun initView(item: WCOrderShipmentTrackingModel) {
+    fun initView(item: WCOrderShipmentTrackingModel, uiMessageResolver: UIMessageResolver) {
         tracking_type.text = item.trackingProvider
         tracking_number.text = item.trackingNumber
 
         tracking_copyNumber.setOnClickListener {
-            // TODO copy number
+            try {
+                val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                clipboard.primaryClip = ClipData.newPlainText(
+                        context.getString(R.string.order_shipment_tracking_number),
+                        context.getString(R.string.order_shipment_tracking_number_clipboard))
+                uiMessageResolver.showSnack(R.string.order_shipment_tracking_number_clipboard)
+            } catch (e: Exception) {
+                WooLog.e(WooLog.T.UTILS, e)
+                uiMessageResolver.showSnack(R.string.error_copy_to_clipboard)
+            }
         }
 
         if (item.trackingLink.isNotEmpty()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingItemView.kt
@@ -23,6 +23,10 @@ class OrderDetailShipmentTrackingItemView @JvmOverloads constructor(
         tracking_type.text = item.trackingProvider
         tracking_number.text = item.trackingNumber
 
+        tracking_copyNumber.setOnClickListener {
+            // TODO copy number
+        }
+
         if (item.trackingLink.isNotEmpty()) {
             tracking_btnTrack.setOnClickListener {
                 AnalyticsTracker.track(Stat.ORDER_DETAIL_TRACK_PACKAGE_BUTTON_TAPPED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingItemView.kt
@@ -5,6 +5,8 @@ import android.support.constraint.ConstraintLayout
 import android.util.AttributeSet
 import android.view.View
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import kotlinx.android.synthetic.main.order_detail_shipment_tracking_item.view.*
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
@@ -23,7 +25,7 @@ class OrderDetailShipmentTrackingItemView @JvmOverloads constructor(
 
         if (item.trackingLink.isNotEmpty()) {
             tracking_btnTrack.setOnClickListener {
-                // TODO tracks analytics
+                AnalyticsTracker.track(Stat.ORDER_DETAIL_TRACK_PACKAGE_BUTTON_TAPPED)
                 ChromeCustomTabUtils.launchUrl(context, item.trackingLink)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingListView.kt
@@ -1,0 +1,57 @@
+package com.woocommerce.android.ui.orders
+
+import android.content.Context
+import android.support.constraint.ConstraintLayout
+import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.RecyclerView
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.woocommerce.android.R
+import kotlinx.android.synthetic.main.order_detail_shipment_tracking_list.view.*
+import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
+
+class OrderDetailShipmentTrackingListView @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null
+) : ConstraintLayout(ctx, attrs) {
+    init {
+        View.inflate(context, R.layout.order_detail_shipment_tracking_list, this)
+    }
+
+    fun initView(trackings: List<WCOrderShipmentTrackingModel>) {
+        val viewManager = LinearLayoutManager(context)
+        val viewAdapter = ShipmentTrackingListAdapter(trackings)
+
+        shipmentTrack_items.apply {
+            setHasFixedSize(true)
+            layoutManager = viewManager
+            adapter = viewAdapter
+        }
+    }
+
+    class ShipmentTrackingListAdapter(
+        private val trackings: List<WCOrderShipmentTrackingModel>
+    ) : RecyclerView.Adapter<ShipmentTrackingListAdapter.ViewHolder>() {
+        class ViewHolder(val view: OrderDetailShipmentTrackingItemView) : RecyclerView.ViewHolder(view)
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+            val view: OrderDetailShipmentTrackingItemView = LayoutInflater.from(parent.context)
+                    .inflate(R.layout.order_detail_product_list_item, parent, false)
+                    as OrderDetailShipmentTrackingItemView
+            return ViewHolder(view)
+        }
+
+        override fun onBindViewHolder(p0: ViewHolder, p1: Int) {
+            // TODO why is this required?
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun onBindViewHolder(holder: ViewHolder, position: Int, payloads: MutableList<Any>) {
+            holder.view.initView(trackings[position])
+        }
+
+        override fun getItemCount() = trackings.size
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingListView.kt
@@ -11,6 +11,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.base.UIMessageResolver
 import kotlinx.android.synthetic.main.order_detail_shipment_tracking_list.view.*
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 
@@ -22,9 +23,9 @@ class OrderDetailShipmentTrackingListView @JvmOverloads constructor(
         View.inflate(context, R.layout.order_detail_shipment_tracking_list, this)
     }
 
-    fun initView(trackings: List<WCOrderShipmentTrackingModel>) {
+    fun initView(trackings: List<WCOrderShipmentTrackingModel>, uiMessageResolver: UIMessageResolver) {
         val viewManager = LinearLayoutManager(context)
-        val viewAdapter = ShipmentTrackingListAdapter(trackings)
+        val viewAdapter = ShipmentTrackingListAdapter(trackings, uiMessageResolver)
 
         shipmentTrack_items.apply {
             setHasFixedSize(true)
@@ -36,7 +37,8 @@ class OrderDetailShipmentTrackingListView @JvmOverloads constructor(
     }
 
     class ShipmentTrackingListAdapter(
-        private val trackings: List<WCOrderShipmentTrackingModel>
+        private val trackings: List<WCOrderShipmentTrackingModel>,
+        private val uiMessageResolver: UIMessageResolver
     ) : RecyclerView.Adapter<ShipmentTrackingListAdapter.ViewHolder>() {
         class ViewHolder(val view: OrderDetailShipmentTrackingItemView) : RecyclerView.ViewHolder(view)
 
@@ -48,7 +50,7 @@ class OrderDetailShipmentTrackingListView @JvmOverloads constructor(
         }
 
         override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-            holder.view.initView(trackings[position])
+            holder.view.initView(trackings[position], uiMessageResolver)
         }
 
         override fun getItemCount() = trackings.size

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingListView.kt
@@ -38,7 +38,7 @@ class OrderDetailShipmentTrackingListView @JvmOverloads constructor(
 
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
             val view: OrderDetailShipmentTrackingItemView = LayoutInflater.from(parent.context)
-                    .inflate(R.layout.order_detail_product_list_item, parent, false)
+                    .inflate(R.layout.order_detail_shipment_tracking_list_item, parent, false)
                     as OrderDetailShipmentTrackingItemView
             return ViewHolder(view)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingListView.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.ui.orders
 
 import android.content.Context
 import android.support.constraint.ConstraintLayout
+import android.support.v7.widget.DefaultItemAnimator
+import android.support.v7.widget.DividerItemDecoration
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
 import android.util.AttributeSet
@@ -27,6 +29,8 @@ class OrderDetailShipmentTrackingListView @JvmOverloads constructor(
         shipmentTrack_items.apply {
             setHasFixedSize(true)
             layoutManager = viewManager
+            itemAnimator = DefaultItemAnimator()
+            addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
             adapter = viewAdapter
         }
     }
@@ -43,12 +47,7 @@ class OrderDetailShipmentTrackingListView @JvmOverloads constructor(
             return ViewHolder(view)
         }
 
-        override fun onBindViewHolder(p0: ViewHolder, p1: Int) {
-            // TODO why is this required?
-            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-        }
-
-        override fun onBindViewHolder(holder: ViewHolder, position: Int, payloads: MutableList<Any>) {
+        override fun onBindViewHolder(holder: ViewHolder, position: Int) {
             holder.view.initView(trackings[position])
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -14,6 +14,7 @@ import java.util.Locale
 
 object DateUtils {
     val friendlyMonthDayFormat by lazy { SimpleDateFormat("MMM d", Locale.getDefault()) }
+    val friendlyFullDateFormat by lazy { SimpleDateFormat("MMMM d, YYYY", Locale.getDefault()) }
     private val weekOfYearStartingMondayFormat by lazy {
         SimpleDateFormat("yyyy-'W'ww", Locale.getDefault()).apply {
             calendar = Calendar.getInstance().apply {
@@ -96,6 +97,24 @@ object DateUtils {
             val (year, month, day) = iso8601Date.split("-")
             val date = GregorianCalendar(year.toInt(), month.toInt() - 1, day.toInt()).time
             friendlyMonthDayFormat.format(date)
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Date string argument is not of format YYYY-MM-DD: $iso8601Date")
+        }
+    }
+
+    /**
+     * Given an ISO8601 date of format YYYY-MM-DD, returns the stirng in the full format of ("MMM d, YYYY".
+     *
+     * For example, given 2018-07-03 returns "July 3, 2018".
+     *
+     * @throws IllegalArgumentException if the argument is not a valid iso8601 date string.
+     */
+    @Throws(IllegalArgumentException::class)
+    fun getFullDateString(iso8601Date: String): String {
+        return try {
+            val (year, month, day) = iso8601Date.split("-")
+            val date = GregorianCalendar(year.toInt(), month.toInt() - 1, day.toInt()).time
+            friendlyFullDateFormat.format(date)
         } catch (e: Exception) {
             throw IllegalArgumentException("Date string argument is not of format YYYY-MM-DD: $iso8601Date")
         }

--- a/WooCommerce/src/main/res/layout/fragment_order_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_detail.xml
@@ -40,6 +40,16 @@
                 android:clipToPadding="false"
                 android:contentDescription="@string/products"/>
 
+            <!-- Shipment Tracking -->
+            <com.woocommerce.android.ui.orders.OrderDetailShipmentTrackingListView
+                android:id="@+id/orderDetail_shipmentList"
+                style="@style/Woo.Card.List"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:clipToPadding="false"
+                android:contentDescription="@string/order_shipment_tracking_section_cd"
+                android:visibility="gone"/>
+
             <!-- Customer Note -->
             <com.woocommerce.android.ui.orders.OrderDetailCustomerNoteView
                 android:id="@+id/orderDetail_customerNote"

--- a/WooCommerce/src/main/res/layout/fragment_order_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_detail.xml
@@ -47,6 +47,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:clipToPadding="false"
+                android:paddingBottom="0dp"
                 android:contentDescription="@string/order_shipment_tracking_section_cd"
                 android:visibility="gone"/>
 

--- a/WooCommerce/src/main/res/layout/fragment_order_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_detail.xml
@@ -54,6 +54,15 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"/>
 
+            <!-- Payments -->
+            <com.woocommerce.android.ui.orders.OrderDetailPaymentView
+                android:id="@+id/orderDetail_paymentInfo"
+                style="@style/Woo.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:animateLayoutChanges="true"
+                android:focusable="true"/>
+
             <!-- Shipment Tracking -->
             <com.woocommerce.android.ui.orders.OrderDetailShipmentTrackingListView
                 android:id="@+id/orderDetail_shipmentList"
@@ -63,16 +72,8 @@
                 android:clipToPadding="false"
                 android:paddingBottom="0dp"
                 android:contentDescription="@string/order_shipment_tracking_section_cd"
-                android:visibility="gone"/>
-
-            <!-- Payments -->
-            <com.woocommerce.android.ui.orders.OrderDetailPaymentView
-                android:id="@+id/orderDetail_paymentInfo"
-                style="@style/Woo.Card"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:animateLayoutChanges="true"
-                android:focusable="true"/>
+                android:visibility="gone"
+                tools:visibility="visible"/>
 
             <!-- Order Notes -->
             <com.woocommerce.android.ui.orders.OrderDetailOrderNoteListView

--- a/WooCommerce/src/main/res/layout/fragment_order_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_detail.xml
@@ -40,17 +40,6 @@
                 android:clipToPadding="false"
                 android:contentDescription="@string/products"/>
 
-            <!-- Shipment Tracking -->
-            <com.woocommerce.android.ui.orders.OrderDetailShipmentTrackingListView
-                android:id="@+id/orderDetail_shipmentList"
-                style="@style/Woo.Card.List"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:clipToPadding="false"
-                android:paddingBottom="0dp"
-                android:contentDescription="@string/order_shipment_tracking_section_cd"
-                android:visibility="gone"/>
-
             <!-- Customer Note -->
             <com.woocommerce.android.ui.orders.OrderDetailCustomerNoteView
                 android:id="@+id/orderDetail_customerNote"
@@ -64,6 +53,17 @@
                 style="@style/Woo.Card.Expandable"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"/>
+
+            <!-- Shipment Tracking -->
+            <com.woocommerce.android.ui.orders.OrderDetailShipmentTrackingListView
+                android:id="@+id/orderDetail_shipmentList"
+                style="@style/Woo.Card.List"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:clipToPadding="false"
+                android:paddingBottom="0dp"
+                android:contentDescription="@string/order_shipment_tracking_section_cd"
+                android:visibility="gone"/>
 
             <!-- Payments -->
             <com.woocommerce.android.ui.orders.OrderDetailPaymentView

--- a/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_item.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/tracking_type"
+        style="@style/Woo.TextView.Title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="USPS"/>
+
+    <TextView
+        android:id="@+id/tracking_number"
+        style="@style/Woo.TextView.Title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tracking_type"
+        tools:text="111222 3334 4444Z"/>
+
+    <Button
+        android:id="@+id/tracking_btnTrack"
+        style="@style/Woo.Button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:text="@string/order_shipment_tracking_button"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tracking_number"/>
+
+</merge>

--- a/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_item.xml
@@ -14,7 +14,12 @@
         android:clickable="true"
         android:focusable="true"
         android:background="?android:attr/selectableItemBackground"
-        app:layout_constraintEnd_toStartOf="@+id/guideline6"
+        android:contentDescription="@string/order_shipment_tracking_copy_to_clipboard"
+        android:paddingStart="@dimen/list_item_padding_start"
+        android:paddingEnd="@dimen/list_item_padding_end"
+        android:paddingTop="@dimen/list_divider_padding_top"
+        android:paddingBottom="@dimen/list_divider_padding_bottom"
+        app:layout_constraintEnd_toStartOf="@+id/tracking_btnTrack"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
@@ -23,28 +28,28 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingTop="@dimen/list_item_padding_top"
-            android:textAppearance="@style/Woo.TextAppearance.ListItem.Title.Bold"
+            android:textAppearance="@style/Woo.TextAppearance.Medium"
             tools:text="USPS"/>
 
         <TextView
             android:id="@+id/tracking_number"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textAppearance="@style/Woo.TextAppearance.ListItem"
+            android:textAppearance="@style/Woo.OrderDetail.TextAppearance.Content"
             tools:text="111222 3334 4444Z"/>
     </LinearLayout>
 
     <FrameLayout
         android:id="@+id/tracking_btnTrack"
-        android:layout_width="0dp"
+        android:layout_width="40dp"
         android:layout_height="0dp"
-        android:clickable="true"
-        android:focusable="true"
         android:background="?android:attr/selectableItemBackground"
         android:contentDescription="@string/order_shipment_tracking_button"
+        android:clickable="true"
+        android:focusable="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@+id/guideline6"
+        app:layout_constraintStart_toEndOf="@+id/tracking_copyNumber"
         app:layout_constraintTop_toTopOf="parent">
 
         <ImageView
@@ -55,12 +60,4 @@
             android:tint="@color/wc_purple"
             app:srcCompat="@drawable/ic_external"/>
     </FrameLayout>
-
-    <android.support.constraint.Guideline
-        android:id="@+id/guideline6"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_end="54dp"/>
-
 </android.support.constraint.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_item.xml
@@ -8,9 +8,10 @@
 
     <TextView
         android:id="@+id/tracking_type"
-        style="@style/Woo.TextView.Title"
+        android:textAppearance="@style/Woo.TextAppearance.ListItem.Title.Bold"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:paddingTop="@dimen/list_item_padding_top"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
@@ -18,7 +19,7 @@
 
     <TextView
         android:id="@+id/tracking_number"
-        style="@style/Woo.TextView.Title"
+        android:textAppearance="@style/Woo.TextAppearance.ListItem"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
@@ -26,13 +27,11 @@
         app:layout_constraintTop_toBottomOf="@+id/tracking_type"
         tools:text="111222 3334 4444Z"/>
 
-    <Button
+    <android.support.v7.widget.AppCompatButton
         android:id="@+id/tracking_btnTrack"
         style="@style/Woo.Button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:layout_marginEnd="8dp"
         android:text="@string/order_shipment_tracking_button"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_item.xml
@@ -27,7 +27,7 @@
             android:id="@+id/tracking_type"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingTop="@dimen/list_item_padding_top"
+            android:paddingTop="@dimen/card_item_padding_intra_v"
             android:textAppearance="@style/Woo.TextAppearance.Medium"
             tools:text="USPS"/>
 
@@ -35,13 +35,23 @@
             android:id="@+id/tracking_number"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textAppearance="@style/Woo.OrderDetail.TextAppearance.Content"
+            android:paddingTop="@dimen/card_item_padding_intra_v"
+            android:paddingBottom="@dimen/card_item_padding_intra_v"
+            android:textAppearance="@style/Woo.TextAppearance.Medium.Bold"
             tools:text="111222 3334 4444Z"/>
+
+        <TextView
+            android:id="@+id/tracking_dateShipped"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="@dimen/card_item_padding_intra_v"
+            android:textAppearance="@style/Woo.OrderDetail.TextAppearance.Content"
+            tools:text="Shipped February 27, 2019"/>
     </LinearLayout>
 
     <FrameLayout
         android:id="@+id/tracking_btnTrack"
-        android:layout_width="40dp"
+        android:layout_width="50dp"
         android:layout_height="0dp"
         android:background="?android:attr/selectableItemBackground"
         android:contentDescription="@string/order_shipment_tracking_button"

--- a/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_item.xml
@@ -1,40 +1,66 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge
+<android.support.constraint.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <TextView
-        android:id="@+id/tracking_type"
-        android:textAppearance="@style/Woo.TextAppearance.ListItem.Title.Bold"
+    <LinearLayout
+        android:id="@+id/tracking_copyNumber"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:paddingTop="@dimen/list_item_padding_top"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:orientation="vertical"
+        android:clickable="true"
+        android:focusable="true"
+        android:background="?android:attr/selectableItemBackground"
+        app:layout_constraintEnd_toStartOf="@+id/guideline6"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="USPS"/>
+        app:layout_constraintTop_toTopOf="parent">
 
-    <TextView
-        android:id="@+id/tracking_number"
-        android:textAppearance="@style/Woo.TextAppearance.ListItem"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/tracking_type"
-        tools:text="111222 3334 4444Z"/>
+        <TextView
+            android:id="@+id/tracking_type"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="@dimen/list_item_padding_top"
+            android:textAppearance="@style/Woo.TextAppearance.ListItem.Title.Bold"
+            tools:text="USPS"/>
 
-    <android.support.v7.widget.AppCompatButton
+        <TextView
+            android:id="@+id/tracking_number"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/Woo.TextAppearance.ListItem"
+            tools:text="111222 3334 4444Z"/>
+    </LinearLayout>
+
+    <FrameLayout
         android:id="@+id/tracking_btnTrack"
-        style="@style/Woo.Button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/order_shipment_tracking_button"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:clickable="true"
+        android:focusable="true"
+        android:background="?android:attr/selectableItemBackground"
+        android:contentDescription="@string/order_shipment_tracking_button"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/tracking_number"/>
+        app:layout_constraintStart_toStartOf="@+id/guideline6"
+        app:layout_constraintTop_toTopOf="parent">
 
-</merge>
+        <ImageView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:importantForAccessibility="no"
+            android:scaleType="center"
+            android:tint="@color/wc_purple"
+            app:srcCompat="@drawable/ic_external"/>
+    </FrameLayout>
+
+    <android.support.constraint.Guideline
+        android:id="@+id/guideline6"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_end="54dp"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_list.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_list.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/shipmentTrack_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/order_shipment_tracking"
+        style="@style/Woo.TextView.Title.Purple"
+        android:paddingBottom="@dimen/card_section_padding_h"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <!-- List: Order Shipment Trackings -->
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/shipmentTrack_items"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:nestedScrollingEnabled="false"
+        android:paddingTop="@dimen/card_section_padding_h"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/shipmentTrack_label"
+        tools:itemCount="3"
+        tools:listitem="@layout/order_detail_shipment_tracking_list_item"
+        tools:targetApi="lollipop">
+
+    </android.support.v7.widget.RecyclerView>
+</merge>

--- a/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_list.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_list.xml
@@ -12,7 +12,6 @@
         android:layout_height="wrap_content"
         android:text="@string/order_shipment_tracking"
         style="@style/Woo.TextView.Title.Purple"
-        android:paddingBottom="@dimen/card_section_padding_h"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"/>
 
@@ -22,7 +21,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:nestedScrollingEnabled="false"
-        android:paddingTop="@dimen/card_section_padding_h"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/shipmentTrack_label"

--- a/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_list_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_list_item.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.woocommerce.android.ui.orders.OrderDetailShipmentTrackingItemView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"/>

--- a/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_list_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_list_item.xml
@@ -2,8 +2,4 @@
 <com.woocommerce.android.ui.orders.OrderDetailShipmentTrackingItemView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:paddingEnd="0dp"
-    android:paddingStart="@dimen/list_item_padding_start"
-    android:paddingTop="@dimen/list_item_padding_top"
-    android:paddingBottom="@dimen/list_item_padding_bottom"/>
+    android:layout_height="wrap_content"/>

--- a/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_list_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_list_item.xml
@@ -2,4 +2,8 @@
 <com.woocommerce.android.ui.orders.OrderDetailShipmentTrackingItemView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"/>
+    android:layout_height="wrap_content"
+    android:paddingEnd="0dp"
+    android:paddingStart="@dimen/list_item_padding_start"
+    android:paddingTop="@dimen/list_item_padding_top"
+    android:paddingBottom="@dimen/list_item_padding_bottom"/>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -60,7 +60,7 @@
     <string name="button_update_instructions">Update instructions</string>
     <string name="dismiss">Dismiss</string>
     <string name="apply">Apply</string>
-
+    <string name="error_copy_to_clipboard">Error copying to clipboard</string>
     <!--
         Date/Time Labels
     -->
@@ -199,8 +199,11 @@
     <string name="order_error_update_general">Error changing order</string>
     <string name="order_error_fetch_generic">Error fetching order</string>
     <string name="order_shipment_tracking">Tracking</string>
+    <string name="order_shipment_tracking_number">Tracking Number</string>
+    <string name="order_shipment_tracking_number_clipboard">Tracking number copied to the clipboard</string>
     <string name="order_shipment_tracking_button">Track package</string>
     <string name="order_shipment_tracking_section_cd">Shipment tracking</string>
+    <string name="order_shipment_tracking_copy_to_clipboard">Copy tracking number to clipboard</string>
     <!--
         Add Order Note
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -198,6 +198,9 @@
     <string name="order_error_fetch_notes_generic">Error fetching error notes</string>
     <string name="order_error_update_general">Error changing order</string>
     <string name="order_error_fetch_generic">Error fetching order</string>
+    <string name="order_shipment_tracking">Tracking</string>
+    <string name="order_shipment_tracking_button">Track package</string>
+    <string name="order_shipment_tracking_section_cd">Shipment tracking</string>
     <!--
         Add Order Note
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -204,6 +204,7 @@
     <string name="order_shipment_tracking_button">Track package</string>
     <string name="order_shipment_tracking_section_cd">Shipment tracking</string>
     <string name="order_shipment_tracking_copy_to_clipboard">Copy tracking number to clipboard</string>
+    <string name="order_shipment_tracking_shipped_date">Shipped %s</string>
     <!--
         Add Order Note
     -->

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -260,6 +260,10 @@
     <style name="Woo.TextAppearance.ListItem.Title">
         <item name="android:textColor">@color/list_item_text_title</item>
     </style>
+
+    <style name="Woo.TextAppearance.ListItem.Title.Bold">
+        <item name="android:textStyle">bold</item>
+    </style>
     <!--
         Default List Item Header Styles
     -->

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -103,6 +103,10 @@
         <item name="android:fontFamily">@font/roboto_medium</item>
     </style>
 
+    <style name="Woo.TextAppearance.Medium.Bold">
+        <item name="android:textStyle">bold</item>
+    </style>
+
     <style name="Woo.TextAppearance.Large">
         <item name="android:textColor">@color/default_text_title_color</item>
         <item name="android:textSize">@dimen/text_large</item>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenterTest.kt
@@ -78,7 +78,9 @@ class OrderDetailPresenterTest {
         presenter.takeView(orderDetailView)
         doReturn(order).whenever(orderStore).getOrderByIdentifier(any())
         presenter.loadOrderDetail(orderIdentifier, false)
-        verify(dispatcher, times(1)).dispatch(any<Action<FetchOrderNotesPayload>>())
+
+        // Fetch notes and fetch order shipment trackings
+        verify(dispatcher, times(2)).dispatch(any<Action<*>>())
 
         // OnOrderChanged callback from FluxC should trigger the appropriate UI update
         doReturn(orderNotes).whenever(orderStore).getOrderNotesForOrder(any())
@@ -91,7 +93,9 @@ class OrderDetailPresenterTest {
         presenter.takeView(orderDetailView)
         doReturn(order).whenever(orderStore).getOrderByIdentifier(any())
         presenter.loadOrderDetail(orderIdentifier, false)
-        verify(dispatcher, times(1)).dispatch(any<Action<FetchOrderNotesPayload>>())
+
+        // Fetch notes and fetch order shipment trackings
+        verify(dispatcher, times(2)).dispatch(any<Action<*>>())
 
         // OnOrderChanged callback from FluxC with error should trigger error message
         presenter.onOrderChanged(OnOrderChanged(0).apply {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenterTest.kt
@@ -197,7 +197,7 @@ class OrderDetailPresenterTest {
         // we also want to verify that notes are loaded even on error because the UI adds
         // a transient note while the note is pushed and it won't be removed from the
         // note list until notes are loaded
-        verify(presenter, times(1)).fetchAndLoadNotesFromDb()
+        verify(presenter, times(1)).loadNotesFromDb()
     }
 
     @Test
@@ -207,7 +207,7 @@ class OrderDetailPresenterTest {
 
         presenter.doChangeOrderStatus(CoreOrderStatus.COMPLETED.value)
         verify(uiMessageResolver, times(1)).showOfflineSnack()
-        verify(presenter, times(0)).fetchAndLoadNotesFromDb()
+        verify(presenter, times(0)).loadNotesFromDb()
     }
 
     @Test
@@ -217,7 +217,7 @@ class OrderDetailPresenterTest {
         doReturn(false).whenever(networkStatus).isConnected()
 
         presenter.loadOrderNotes()
-        verify(presenter, times(1)).fetchAndLoadNotesFromDb()
+        verify(presenter, times(1)).loadNotesFromDb()
         verify(presenter, times(0)).requestOrderNotesFromApi(any())
     }
 
@@ -261,7 +261,7 @@ class OrderDetailPresenterTest {
         presenter.takeView(orderDetailView)
 
         presenter.loadOrderDetail(orderIdentifier, false)
-        verify(presenter, times(1)).fetchAndLoadShipmentTrackingsFromDb()
+        verify(presenter, times(1)).loadShipmentTrackingsFromDb()
         verify(presenter, times(1)).requestShipmentTrackingsFromApi(any())
     }
 
@@ -272,7 +272,7 @@ class OrderDetailPresenterTest {
         presenter.takeView(orderDetailView)
 
         presenter.loadOrderDetail(orderIdentifier, false)
-        verify(presenter, times(1)).fetchAndLoadShipmentTrackingsFromDb()
+        verify(presenter, times(1)).loadShipmentTrackingsFromDb()
         verify(presenter, times(0)).requestShipmentTrackingsFromApi(any())
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = '4fd7e7418b33207d1a6a0564a7f3edab2842f6c1'
+    fluxCVersion = '2526f3919165a82be86ba66854b4dfae984c4e7e'
     daggerVersion = '2.11'
     supportLibraryVersion = '28.0.0'
     glideVersion = '4.6.1'


### PR DESCRIPTION
Fixes #608 by adding read-only support for the Shipment Tracking plugin. If tracking information is available for an order, that information will be printed to the screen, along with a button to track the package. Some highlights:
- Multiple shipment tracking records supported
- If no shipment tracking items, the card will not be displayed
- Loading skeleton not needed since we only show the card after we have data
- Unit tests have been added

<img src="https://user-images.githubusercontent.com/5810477/55442044-a1299380-5572-11e9-96dc-4a6a21d599ca.gif" width="300"/>


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
