### PR TITLE
Account for nullability

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@ Bugfixes
 * Fixed rare crash opening order detail when it's already showing
 * Fixed rare crash in order detail while loading product images
 * Fixed rare crash when showing order note
+* Fixed a very rare crash when showing the filter menu options button
 
 Improvements
 * Dashboard no longer reloads every time you return to it

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -154,7 +154,8 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
 
     private fun shouldShowFilterMenuItem(): Boolean {
         return when {
-            (isShowingAllOrders() && empty_view?.visibility == View.VISIBLE) -> false
+            !isAdded -> false
+            (isShowingAllOrders() && empty_view.visibility == View.VISIBLE) -> false
             (childFragmentManager.backStackEntryCount > 0) -> false
             else -> true
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -154,7 +154,7 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
 
     private fun shouldShowFilterMenuItem(): Boolean {
         return when {
-            (isShowingAllOrders() && empty_view.visibility == View.VISIBLE) -> false
+            (isShowingAllOrders() && empty_view?.visibility == View.VISIBLE) -> false
             (childFragmentManager.backStackEntryCount > 0) -> false
             else -> true
         }


### PR DESCRIPTION
Fixes #956 by checking if the view is empty before accessing its `visibility` property. I'm not sure why this is happening since the view should be instantiated at the point of building the options menu, but I've added it to cover the null pointer exception. This crash had only happened one time for a single user.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
