### PR TITLE
issue/967-site-picker-continue-analytics 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -77,7 +77,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
 
         // -- Site Picker
         SITE_PICKER_STORES_SHOWN(siteless = true),
-        SITE_PICKER_STORE_PICKER_CONTINUE_TAPPED(siteless = true),
+        SITE_PICKER_CONTINUE_TAPPED(siteless = true),
         SITE_PICKER_HELP_BUTTON_TAPPED(siteless = true),
 
         // -- Dashboard

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -221,7 +221,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         }
 
         AnalyticsTracker.track(
-                Stat.SITE_PICKER_STORE_PICKER_CONTINUE_TAPPED,
+                Stat.SITE_PICKER_CONTINUE_TAPPED,
                 mapOf(AnalyticsTracker.KEY_SELECTED_STORE_ID to site.id)
         )
 


### PR DESCRIPTION
Resolves #967 to use the correct event name when tracking the continue button being tapped in the site picker.