### PR TITLE
Change link to support documentation and update the name of the button

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,8 @@
 1.7
 -----
+
+Improvements
+* Changed FAQ button in help section to "Help Center". The button now routes to WooCommerce mobile documentation.
  
 1.6
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -73,7 +73,7 @@ class HelpActivity : AppCompatActivity() {
 
     override fun onStart() {
         super.onStart()
-        ChromeCustomTabUtils.connect(this, FAQ_URL)
+        ChromeCustomTabUtils.connect(this, HELP_CENTER_URL)
     }
 
     override fun onStop() {
@@ -140,9 +140,10 @@ class HelpActivity : AppCompatActivity() {
     }
 
     private fun showZendeskFaq() {
-        AnalyticsTracker.track(Stat.SUPPORT_FAQ_VIEWED)
-        ChromeCustomTabUtils.launchUrl(this, FAQ_URL)
-        /* TODO: for now we simply link to the online FAQ, but we should show the Zendesk FAQ once it's ready
+        AnalyticsTracker.track(Stat.SUPPORT_HELP_CENTER_VIEWED)
+        ChromeCustomTabUtils.launchUrl(this, HELP_CENTER_URL)
+        /* TODO: for now we simply link to the online woo mobile support documentation, but we should show the
+        Zendesk FAQ once it's ready
         zendeskHelper
                 .showZendeskHelpCenter(this, originFromExtras, selectedSiteOrNull(), extraTagsFromExtras)
         */
@@ -176,7 +177,7 @@ class HelpActivity : AppCompatActivity() {
     companion object {
         private const val ORIGIN_KEY = "ORIGIN_KEY"
         private const val EXTRA_TAGS_KEY = "EXTRA_TAGS_KEY"
-        private const val FAQ_URL = "https://docs.woocommerce.com/document/frequently-asked-questions/"
+        private const val HELP_CENTER_URL = "https://docs.woocommerce.com/document/android/"
 
         @JvmStatic
         fun createIntent(

--- a/WooCommerce/src/main/res/layout/activity_help.xml
+++ b/WooCommerce/src/main/res/layout/activity_help.xml
@@ -43,7 +43,7 @@
                         style="@style/Woo.Settings.LabelWithDetail"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="@string/support_faq"/>
+                        android:text="@string/support_help_center"/>
 
                     <TextView
                         style="@style/Woo.Settings.Label.Detail"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -327,7 +327,7 @@
     <string name="support_identity_input_dialog_email_label">Email</string>
     <string name="support_identity_input_dialog_name_label">Name</string>
     <string name="support_subtitle">How can we help?</string>
-    <string name="support_faq">Browse our FAQ</string>
+    <string name="support_help_center">Help Center</string>
     <string name="support_faq_detail">Get answers to questions you have</string>
     <string name="support_contact">Contact support</string>
     <string name="support_contact_detail">Reach our happiness engineers who can help answer tough questions</string>


### PR DESCRIPTION
Fixes #964  by renaming the FAQ button and changing its destination. Note that the Track event has also been updated to the one already established for "Help Center". 

<img src="https://user-images.githubusercontent.com/5810477/55763901-ac773600-5a2e-11e9-853c-5af7f98a433a.gif" width="300"/>

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
