### PR TITLE
Hide button to open external tracking page when link not available

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 Improvements
 * Changed FAQ button in help section to "Help Center". The button now routes to WooCommerce mobile documentation.
+* Hide the external link button on shipment tracking views if no external link available
  
 1.6
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingItemView.kt
@@ -49,6 +49,8 @@ class OrderDetailShipmentTrackingItemView @JvmOverloads constructor(
                 AnalyticsTracker.track(Stat.ORDER_DETAIL_TRACK_PACKAGE_BUTTON_TAPPED)
                 ChromeCustomTabUtils.launchUrl(context, item.trackingLink)
             }
+        } else {
+            tracking_btnTrack.visibility = View.GONE
         }
     }
 }


### PR DESCRIPTION
Fixe #975 by hiding the the button to open the external shipment tracking details if no link is available.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
