### PR TITLE
Fix crash in popToState

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -31,7 +31,7 @@ abstract class TopLevelFragment : Fragment(), TopLevelFragmentView {
     private var runOnResumeFunc: (() -> Unit)? = null
 
     override var isActive: Boolean = false
-        get() = host != null && childFragmentManager.backStackEntryCount == 0 && !isHidden
+        get() = isAdded && childFragmentManager.backStackEntryCount == 0 && !isHidden
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -87,11 +87,15 @@ abstract class TopLevelFragment : Fragment(), TopLevelFragmentView {
     }
 
     override fun popToState(tag: String): Boolean {
-        return childFragmentManager.popBackStackImmediate(tag, 0)
+        return if (isAdded) {
+            childFragmentManager.popBackStackImmediate(tag, 0)
+        } else {
+            false
+        }
     }
 
     override fun closeCurrentChildFragment() {
-        childFragmentManager.popBackStackImmediate()
+        if (isAdded) childFragmentManager.popBackStackImmediate()
     }
 
     override fun loadChildFragment(fragment: Fragment, tag: String) {


### PR DESCRIPTION
Fixes #978 by checking that the fragment isAdded before attempting to communicate with the childFragmentManager

To replicate the original issue using develop branch:

1. Get a new order notification
2. Click on the new order notification
3. Crash

Update release notes:

- [ ]  No release notes needed since this is a crash inside a beta release