### PR TITLE
feature/simple-product-variations 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductListView.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.tools.ProductImageMap
+import com.woocommerce.android.ui.products.ProductHelper
 import com.woocommerce.android.widgets.AlignedDividerDecoration
 import kotlinx.android.synthetic.main.order_detail_product_list.view.*
 import org.wordpress.android.fluxc.model.WCOrderModel
@@ -151,14 +152,12 @@ class OrderDetailProductListView @JvmOverloads constructor(ctx: Context, attrs: 
         }
 
         override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-            val productImage = orderItems[position].productId?.let {
-                productImageMap.get(it)
-            }
+            val item = orderItems[position]
+            val productId = ProductHelper.productOrVariationId(item.productId, item.variationId)
+            val productImage = productImageMap.get(productId)
             holder.view.initView(orderItems[position], productImage, isExpanded, formatCurrencyForDisplay)
             holder.view.setOnClickListener {
-                orderItems[position].productId?.let {
-                    productListener?.openOrderProductDetail(it)
-                }
+                productListener?.openOrderProductDetail(productId)
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductHelper.kt
@@ -2,10 +2,10 @@ package com.woocommerce.android.ui.products
 
 object ProductHelper {
     /**
-     * Simple helper which returns the variation ID if it's not null an non-zero, otherwise returns the product ID
+     * Simple helper which returns the variation ID if it's not null and non-zero, otherwise returns the product ID
      * if it's not null (and if it is, returns 0). This is useful when deciding whether to use a product ID or a
      * variation ID when looking up a product - we want to favor the variation ID when available because that will
-     * get us the actual variation
+     * get us the actual variation (the productId in this situation will be the ID of the parent product)
      */
     fun productOrVariationId(productId: Long?, variationId: Long?): Long {
         variationId?.let {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductHelper.kt
@@ -1,0 +1,21 @@
+package com.woocommerce.android.ui.products
+
+object ProductHelper {
+    /**
+     * Simple helper which returns the variation ID if it's not null an non-zero, otherwise returns the product ID
+     * if it's not null (and if it is, returns 0). This is useful when deciding whether to use a product ID or a
+     * variation ID when looking up a product - we want to favor the variation ID when available because that will
+     * get us the actual variation
+     */
+    fun productOrVariationId(productId: Long?, variationId: Long?): Long {
+        variationId?.let {
+            if (it != 0L) {
+                return it
+            }
+         }
+        productId?.let {
+            return it
+        }
+        return 0L
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductHelper.kt
@@ -12,7 +12,7 @@ object ProductHelper {
             if (it != 0L) {
                 return it
             }
-         }
+        }
         productId?.let {
             return it
         }

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = '2526f3919165a82be86ba66854b4dfae984c4e7e'
+    fluxCVersion = 'ee52bf1e9174ce11a8556c5c33bbdabbe87f3071'
     daggerVersion = '2.11'
     supportLibraryVersion = '28.0.0'
     glideVersion = '4.6.1'


### PR DESCRIPTION
Adds support for product variations by favoring the variation ID when accessing a product. To test:

* Create an order for a product variation
* View the order in the app
* Verify that the variation shows in the order
* Tap to view product detail
* Verify that the variation shows in the product detail