### PR TITLE
issue/979-npe-clear-bar-data-1.6

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -330,7 +330,7 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
     }
 
     fun clearChartData() {
-        chart.data.clearValues()
+        chart.data?.clearValues()
     }
 
     private fun fadeInLabelValue(view: TextView, value: String) {


### PR DESCRIPTION
Fixes #979 by accounting for null chart data before accessing it