### PR TITLE
issue/develop-fluxc-hash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = '193bde6161d4bdf907f91cabc6de3e3cdbf3c468'
+    fluxCVersion = 'acd9d5d1c4bd9e0c699bf0df0627f7ce10563656'
     daggerVersion = '2.11'
     supportLibraryVersion = '28.0.0'
     glideVersion = '4.6.1'


### PR DESCRIPTION
This PR updates to the latest FluxC hash. The one currently used by `develop` causes the build to fail.