### PR TITLE
Localize date formatting in shipment tracking card

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@ Improvements
 * Changed FAQ button in help section to "Help Center". The button now routes to WooCommerce mobile documentation.
 * Hide the external link button on shipment tracking views if no external link available
 * Redirect to username/password login when WordPress.com reports email login not allowed
+* Shipment Tracking date formatting is now localized
  
 1.6
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingItemView.kt
@@ -29,7 +29,7 @@ class OrderDetailShipmentTrackingItemView @JvmOverloads constructor(
         tracking_number.text = item.trackingNumber
         tracking_dateShipped.text = context.getString(
                 R.string.order_shipment_tracking_shipped_date,
-                DateUtils.getFullDateString(item.dateShipped))
+                DateUtils.getFullDateString(context, item.dateShipped))
 
         tracking_copyNumber.setOnClickListener {
             try {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingItemView.kt
@@ -29,7 +29,7 @@ class OrderDetailShipmentTrackingItemView @JvmOverloads constructor(
         tracking_number.text = item.trackingNumber
         tracking_dateShipped.text = context.getString(
                 R.string.order_shipment_tracking_shipped_date,
-                DateUtils.getFullDateString(context, item.dateShipped))
+                DateUtils.getLocalizedLongDateString(context, item.dateShipped))
 
         tracking_copyNumber.setOnClickListener {
             try {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -14,7 +14,6 @@ import java.util.Locale
 
 object DateUtils {
     val friendlyMonthDayFormat by lazy { SimpleDateFormat("MMM d", Locale.getDefault()) }
-    val friendlyFullDateFormat by lazy { SimpleDateFormat("MMMM d, YYYY", Locale.getDefault()) }
     private val weekOfYearStartingMondayFormat by lazy {
         SimpleDateFormat("yyyy-'W'ww", Locale.getDefault()).apply {
             calendar = Calendar.getInstance().apply {
@@ -103,20 +102,20 @@ object DateUtils {
     }
 
     /**
-     * Given an ISO8601 date of format YYYY-MM-DD, returns the stirng in the full format of ("MMM d, YYYY".
+     * Given a date of format YYYY-MM-DD, returns the string in the full format of ("MMM d, YYYY".
      *
      * For example, given 2018-07-03 returns "July 3, 2018".
      *
      * @throws IllegalArgumentException if the argument is not a valid iso8601 date string.
      */
     @Throws(IllegalArgumentException::class)
-    fun getFullDateString(iso8601Date: String): String {
+    fun getFullDateString(context: Context, dateString: String): String {
         return try {
-            val (year, month, day) = iso8601Date.split("-")
+            val (year, month, day) = dateString.split("-")
             val date = GregorianCalendar(year.toInt(), month.toInt() - 1, day.toInt()).time
-            friendlyFullDateFormat.format(date)
+            DateFormat.getLongDateFormat(context).format(date)
         } catch (e: Exception) {
-            throw IllegalArgumentException("Date string argument is not of format YYYY-MM-DD: $iso8601Date")
+            throw IllegalArgumentException("Date string argument is not of format YYYY-MM-DD: $dateString")
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -102,14 +102,12 @@ object DateUtils {
     }
 
     /**
-     * Given a date of format YYYY-MM-DD, returns the string in the full format of ("MMM d, YYYY".
+     * Given a date of format YYYY-MM-DD, returns the string in a localized full long date format.
      *
-     * For example, given 2018-07-03 returns "July 3, 2018".
-     *
-     * @throws IllegalArgumentException if the argument is not a valid iso8601 date string.
+     * @throws IllegalArgumentException if the argument is not a valid YYYY-MM-DD date string.
      */
     @Throws(IllegalArgumentException::class)
-    fun getFullDateString(context: Context, dateString: String): String {
+    fun getLocalizedLongDateString(context: Context, dateString: String): String {
         return try {
             val (year, month, day) = dateString.split("-")
             val date = GregorianCalendar(year.toInt(), month.toInt() - 1, day.toInt()).time


### PR DESCRIPTION
Fixes #976 

Swapped out the manual formatting in favor of `DateFormat.getLongDateFormat()` so the date string will be formatted to match the locale the device is currently in. 

Examples

**English**
![Screen Shot 2019-04-15 at 12 01 36 PM](https://user-images.githubusercontent.com/5810477/56151166-46cb0280-5f76-11e9-963f-a372f2e30b98.png)

**Espaniol**
![Screen Shot 2019-04-15 at 12 01 53 PM](https://user-images.githubusercontent.com/5810477/56151187-52b6c480-5f76-11e9-866f-bab96859f517.png)

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
