### PR TITLE
feature/product-detail-for-all

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,9 @@ Improvements
 * Hide the external link button on shipment tracking views if no external link available
 * Redirect to username/password login when WordPress.com reports email login not allowed
  
+New Features
+* You can now tap a product to view a read-only detail view
+
 1.6
 -----
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -11,7 +11,6 @@ import android.support.v7.widget.Toolbar
 import android.view.Menu
 import android.view.MenuItem
 import com.woocommerce.android.AppPrefs
-import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
@@ -417,12 +416,8 @@ class MainActivity : AppCompatActivity(),
     }
 
     override fun showProductDetail(remoteProductId: Long) {
-        // TODO: for now product detail is only supported in debug builds, we'll roll it out to all users after design
-        // iterations are done
-        if (BuildConfig.DEBUG) {
-            showBottomNav()
-            ProductDetailActivity.show(this, remoteProductId)
-        }
+        showBottomNav()
+        ProductDetailActivity.show(this, remoteProductId)
     }
 
     override fun updateOfflineStatusBar(isConnected: Boolean) {

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = 'acd9d5d1c4bd9e0c699bf0df0627f7ce10563656'
+    fluxCVersion = '47eb9fb6d9f73b479907b3f857a45b8fd67bdafa'
     daggerVersion = '2.11'
     supportLibraryVersion = '28.0.0'
     glideVersion = '4.6.1'


### PR DESCRIPTION
This PR represents the last step of product detail: enabling it for everyone rather than just `DEBUG` users. It also updates the FluxC hash to the latest `develop` branch (which fixes that multiple `onProductChanged()` bug).

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
