### PR TITLE
Issue/999 product detail fixed badge

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,9 @@ Improvements
 * Hide the external link button on shipment tracking views if no external link available
 * Redirect to username/password login when WordPress.com reports email login not allowed
  
+New Features
+* You can now tap a product to view a read-only detail view
+
 1.6
 -----
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -11,7 +11,6 @@ import android.support.v7.widget.Toolbar
 import android.view.Menu
 import android.view.MenuItem
 import com.woocommerce.android.AppPrefs
-import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
@@ -417,12 +416,8 @@ class MainActivity : AppCompatActivity(),
     }
 
     override fun showProductDetail(remoteProductId: Long) {
-        // TODO: for now product detail is only supported in debug builds, we'll roll it out to all users after design
-        // iterations are done
-        if (BuildConfig.DEBUG) {
-            showBottomNav()
-            ProductDetailActivity.show(this, remoteProductId)
-        }
+        showBottomNav()
+        ProductDetailActivity.show(this, remoteProductId)
     }
 
     override fun updateOfflineStatusBar(isConnected: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -118,8 +118,6 @@ class MainActivity : AppCompatActivity(),
 
         // show the app rating dialog if it's time
         AppRatingDialog.showIfNeeded(this)
-
-        showProductDetail(152) // TODO remove
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -118,6 +118,8 @@ class MainActivity : AppCompatActivity(),
 
         // show the app rating dialog if it's time
         AppRatingDialog.showIfNeeded(this)
+
+        showProductDetail(152) // TODO remove
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailActivity.kt
@@ -13,6 +13,7 @@ import android.support.v7.widget.Toolbar
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.LinearLayout
@@ -217,8 +218,8 @@ class ProductDetailActivity : AppCompatActivity(), ProductDetailContract.View, R
             }
         }
 
-        // if there's no product image we should disable the collapsible toolbar and adjust the status badge's parent
-        // frame to differentiate it from the toolbar
+        // if there's no product image we should disable the collapsible toolbar and move the badge's parent frame
+        // to the scrolling container
         if (imageUrl == null && collapsingToolbarEnabled) {
             collapsingToolbarEnabled = false
             val params = collapsing_toolbar.getLayoutParams() as AppBarLayout.LayoutParams
@@ -227,6 +228,8 @@ class ProductDetailActivity : AppCompatActivity(), ProductDetailContract.View, R
             collapsing_toolbar.isTitleEnabled = false
             toolbar.title = productTitle
             frameStatusBadge.background = ColorDrawable(ContextCompat.getColor(this, R.color.wc_grey_light))
+            (frameStatusBadge.parent as ViewGroup).removeView(frameStatusBadge)
+            productDetail_container.addView(frameStatusBadge)
         }
 
         addPrimaryCard(product)

--- a/WooCommerce/src/main/res/layout/activity_product_detail.xml
+++ b/WooCommerce/src/main/res/layout/activity_product_detail.xml
@@ -56,7 +56,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_gravity="start|bottom"
-                    android:layout_marginTop="76dp"
                     android:padding="@dimen/margin_large"
                     android:visibility="gone"
                     tools:visibility="visible">

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = 'acd9d5d1c4bd9e0c699bf0df0627f7ce10563656'
+    fluxCVersion = '47eb9fb6d9f73b479907b3f857a45b8fd67bdafa'
     daggerVersion = '2.11'
     supportLibraryVersion = '28.0.0'
     glideVersion = '4.6.1'


### PR DESCRIPTION
Fixes #999 - this PR updates the product detail's status badge to scroll with the content when there's no product image. Prior to this, the badge would be fixed.

To test, view the product detail for a private product that has no image.

![ezgif-3-cba15153cc80](https://user-images.githubusercontent.com/3903757/56242844-29299600-6067-11e9-919f-08b829fe1432.gif)
