### PR TITLE
issue/1001-wcandroid-manage-stock 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = '47eb9fb6d9f73b479907b3f857a45b8fd67bdafa'
+    fluxCVersion = '4da633e58fece0423750ffe4c3c7800deb23ead3'
     daggerVersion = '2.11'
     supportLibraryVersion = '28.0.0'
     glideVersion = '4.6.1'


### PR DESCRIPTION
Closes #1001 by updating the FluxC hash to the latest `develop`, which includes [this fix](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1224) for a product's `manage_stock` field.