### PR TITLE
issue/933-crash-fix-for-no-activity-found-exception

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.login;
 
 import android.app.PendingIntent;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
@@ -437,6 +438,8 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
             startIntentSenderForResult(intent.getIntentSender(), EMAIL_CREDENTIALS_REQUEST_CODE, null, 0, 0, 0, null);
         } catch (IntentSender.SendIntentException exception) {
             AppLog.d(T.NUX, LOG_TAG + "Could not start email hint picker" + exception);
+        } catch (ActivityNotFoundException exception) {
+            AppLog.d(T.NUX, LOG_TAG + "Could not find any activity to handle email hint picker" + exception);
         }
     }
 


### PR DESCRIPTION
Fixes #933  by adding an exception block to handle `NoActivityFoundException`

This crash happens only in rooted devices where there is no Google Play Services available. 

To reproduce the bug, install app on a rooted device and click on `Login with Jetpack` and click on the email address field. The app will crash. Then pull changes from this branch and follow the same steps. The app should no longer crash.

P.S. I tested on a rooted emulator from [Genymotion](https://www.genymotion.com/download/)
