### PR TITLE
Feature/wc db downgrade

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -44,7 +44,6 @@ import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.generated.WCCoreActionBuilder
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.OnJetpackTimeoutError
-import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.SiteStore
@@ -107,7 +106,7 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
             VolleyLog.DEBUG = false
         }
 
-        val wellSqlConfig = WellSqlConfig(applicationContext, WellSqlConfig.ADDON_WOOCOMMERCE)
+        val wellSqlConfig = WooWellSqlConfig(applicationContext)
         WellSql.init(wellSqlConfig)
 
         component.inject(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
@@ -32,7 +32,7 @@ class WooWellSqlConfig(context: Context?) : WellSqlConfig(context, WellSqlConfig
 
     // TODO: remove this
     override fun getDbVersion(): Int {
-        return 989
+        return 983
     }
 
     private fun recreateTables(helper: WellTableManager?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
@@ -26,7 +26,7 @@ class WooWellSqlConfig(context: Context?) : WellSqlConfig(context, WellSqlConfig
 
     // TODO: remove this
     override fun getDbVersion(): Int {
-        return 997
+        return 996
     }
 
     private fun recreateTables(helper: WellTableManager?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
@@ -29,9 +29,4 @@ class WooWellSqlConfig(context: Context?) : WellSqlConfig(context, WellSqlConfig
             super.onDowngrade(db, helper, oldVersion, newVersion)
         }
     }
-
-    // TODO: remove this
-    override fun getDbVersion(): Int {
-        return 998
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
@@ -14,12 +14,12 @@ import org.wordpress.android.util.AppLog.T
 
 class WooWellSqlConfig(context: Context?) : WellSqlConfig(context, WellSqlConfig.ADDON_WOOCOMMERCE) {
     /**
-     * Detect when the database is downgraded, and if this is a debug user recreate all the tables and show
-     * a toast alerting to the downgrade. The sole purpose of this is to avoid the hassle of devs switching
+     * Detect when the database is downgraded in debug builds, and if the flag is set recreate all the tables and
+     * show a toast alerting to the downgrade. The sole purpose of this is to avoid the hassle of devs switching
      * branches and having to clear storage and login again due to a version downgrade.
      */
     override fun onDowngrade(db: SQLiteDatabase?, helper: WellTableManager?, oldVersion: Int, newVersion: Int) {
-        if (BuildConfig.DEBUG && helper != null) {
+        if (BuildConfig.DEBUG && BuildConfig.RESET_DB_ON_DOWNGRADE.toBoolean()) {
             // note: don't call super() here because it throws an exception
             AppLog.w(T.DB, "Resetting database due to downgrade from version $oldVersion to $newVersion")
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
@@ -6,11 +6,18 @@ import com.yarolegovich.wellsql.WellTableManager
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.ToastUtils
+import org.wordpress.android.util.ToastUtils.Duration
 
 class WooWellSqlConfig(context: Context?) : WellSqlConfig(context, WellSqlConfig.ADDON_WOOCOMMERCE) {
     override fun onDowngrade(db: SQLiteDatabase?, helper: WellTableManager?, oldVersion: Int, newVersion: Int) {
         if (BuildConfig.DEBUG) {
             AppLog.w(T.DB, "Resetting database due to downgrade from version $oldVersion to $newVersion")
+            ToastUtils.showToast(
+                    context,
+                    "Database downgraded, recreating tables and fetching stores",
+                    Duration.LONG
+            )
             recreateTables(helper)
         } else {
             super.onDowngrade(db, helper, oldVersion, newVersion)
@@ -19,7 +26,7 @@ class WooWellSqlConfig(context: Context?) : WellSqlConfig(context, WellSqlConfig
 
     // TODO: remove this
     override fun getDbVersion(): Int {
-        return 999
+        return 997
     }
 
     private fun recreateTables(helper: WellTableManager?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
@@ -2,12 +2,15 @@ package com.woocommerce.android
 
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase
+import android.graphics.Color
+import android.graphics.PorterDuff
+import android.view.Gravity
+import android.widget.TextView
+import android.widget.Toast
 import com.yarolegovich.wellsql.WellTableManager
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
-import org.wordpress.android.util.ToastUtils
-import org.wordpress.android.util.ToastUtils.Duration
 
 class WooWellSqlConfig(context: Context?) : WellSqlConfig(context, WellSqlConfig.ADDON_WOOCOMMERCE) {
     /**
@@ -19,11 +22,19 @@ class WooWellSqlConfig(context: Context?) : WellSqlConfig(context, WellSqlConfig
         if (BuildConfig.DEBUG && helper != null) {
             // note: don't call super() here because it throws an exception
             AppLog.w(T.DB, "Resetting database due to downgrade from version $oldVersion to $newVersion")
-            ToastUtils.showToast(
+
+            val toast = Toast.makeText(
                     context,
                     "Database downgraded, recreating tables and loading stores",
-                    Duration.LONG
+                    Toast.LENGTH_LONG
             )
+            toast.view?.let { view ->
+                view.background.setColorFilter(Color.RED, PorterDuff.Mode.SRC_IN)
+                view.findViewById<TextView>(android.R.id.message)?.setTextColor(Color.WHITE)
+            }
+            toast.setGravity(Gravity.CENTER, 0, 0)
+            toast.show()
+
             reset(helper)
         } else {
             super.onDowngrade(db, helper, oldVersion, newVersion)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
@@ -1,0 +1,21 @@
+package com.woocommerce.android
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import com.yarolegovich.wellsql.WellTableManager
+import org.wordpress.android.fluxc.persistence.WellSqlConfig
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
+
+class WooWellSqlConfig(context: Context?) : WellSqlConfig(context, WellSqlConfig.ADDON_WOOCOMMERCE) {
+    override fun onDowngrade(db: SQLiteDatabase?, helper: WellTableManager?, oldVersion: Int, newVersion: Int) {
+        // note: don't call super since it throws an exception
+        AppLog.w(T.DB, "Resetting database due to downgrade from version $oldVersion to $newVersion")
+        recreateDatabase(helper)
+    }
+
+    // TODO: remove this
+    override fun getDbVersion(): Int {
+        return super.getDbVersion() - 1
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
@@ -16,7 +16,7 @@ class WooWellSqlConfig(context: Context?) : WellSqlConfig(context, WellSqlConfig
      * branches and having to clear storage and login again due to a version downgrade.
      */
     override fun onDowngrade(db: SQLiteDatabase?, helper: WellTableManager?, oldVersion: Int, newVersion: Int) {
-        if (BuildConfig.DEBUG) {
+        if (BuildConfig.DEBUG && helper != null) {
             // note: don't call super() here because it throws an exception
             AppLog.w(T.DB, "Resetting database due to downgrade from version $oldVersion to $newVersion")
             ToastUtils.showToast(
@@ -24,7 +24,7 @@ class WooWellSqlConfig(context: Context?) : WellSqlConfig(context, WellSqlConfig
                     "Database downgraded, recreating tables and loading stores",
                     Duration.LONG
             )
-            recreateTables(helper)
+            reset(helper)
         } else {
             super.onDowngrade(db, helper, oldVersion, newVersion)
         }
@@ -32,14 +32,6 @@ class WooWellSqlConfig(context: Context?) : WellSqlConfig(context, WellSqlConfig
 
     // TODO: remove this
     override fun getDbVersion(): Int {
-        return 983
-    }
-
-    private fun recreateTables(helper: WellTableManager?) {
-        for (table in mTables) {
-            AppLog.w(T.DB, "recreating table ${table.simpleName}")
-            helper?.dropTable(table)
-            helper?.createTable(table)
-        }
+        return 998
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
@@ -32,7 +32,7 @@ class WooWellSqlConfig(context: Context?) : WellSqlConfig(context, WellSqlConfig
 
     // TODO: remove this
     override fun getDbVersion(): Int {
-        return 993
+        return 989
     }
 
     private fun recreateTables(helper: WellTableManager?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
@@ -10,12 +10,18 @@ import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration
 
 class WooWellSqlConfig(context: Context?) : WellSqlConfig(context, WellSqlConfig.ADDON_WOOCOMMERCE) {
+    /**
+     * Detect when the database is downgraded, and if this is a debug user recreate all the tables and show
+     * a toast alerting to the downgrade. The sole purpose of this is to avoid the hassle of devs switching
+     * branches and having to clear storage and login again due to a version downgrade.
+     */
     override fun onDowngrade(db: SQLiteDatabase?, helper: WellTableManager?, oldVersion: Int, newVersion: Int) {
         if (BuildConfig.DEBUG) {
+            // note: don't call super() here because it throws an exception
             AppLog.w(T.DB, "Resetting database due to downgrade from version $oldVersion to $newVersion")
             ToastUtils.showToast(
                     context,
-                    "Database downgraded, recreating tables and fetching stores",
+                    "Database downgraded, recreating tables and loading stores",
                     Duration.LONG
             )
             recreateTables(helper)
@@ -26,7 +32,7 @@ class WooWellSqlConfig(context: Context?) : WellSqlConfig(context, WellSqlConfig
 
     // TODO: remove this
     override fun getDbVersion(): Int {
-        return 996
+        return 993
     }
 
     private fun recreateTables(helper: WellTableManager?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
@@ -9,13 +9,24 @@ import org.wordpress.android.util.AppLog.T
 
 class WooWellSqlConfig(context: Context?) : WellSqlConfig(context, WellSqlConfig.ADDON_WOOCOMMERCE) {
     override fun onDowngrade(db: SQLiteDatabase?, helper: WellTableManager?, oldVersion: Int, newVersion: Int) {
-        // note: don't call super since it throws an exception
-        AppLog.w(T.DB, "Resetting database due to downgrade from version $oldVersion to $newVersion")
-        recreateDatabase(helper)
+        if (BuildConfig.DEBUG) {
+            AppLog.w(T.DB, "Resetting database due to downgrade from version $oldVersion to $newVersion")
+            recreateTables(helper)
+        } else {
+            super.onDowngrade(db, helper, oldVersion, newVersion)
+        }
     }
 
     // TODO: remove this
     override fun getDbVersion(): Int {
-        return super.getDbVersion() - 1
+        return 999
+    }
+
+    private fun recreateTables(helper: WellTableManager?) {
+        for (table in mTables) {
+            AppLog.w(T.DB, "recreating table ${table.simpleName}")
+            helper?.dropTable(table)
+            helper?.createTable(table)
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -115,7 +115,11 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         } ?: run {
             site_list_container.visibility = View.GONE
 
-            presenter.loadSites()
+            if (presenter.hasSites()) {
+                presenter.loadSites()
+            } else {
+                progress.visibility = View.VISIBLE
+            }
             presenter.fetchSites()
 
             AnalyticsTracker.track(
@@ -181,6 +185,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
 
     override fun showStoreList(wcSites: List<SiteModel>) {
         progressDialog?.takeIf { it.isShowing }?.dismiss()
+        progress.visibility = View.GONE
 
         if (wcSites.isEmpty()) {
             showNoStoresView()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -186,11 +186,6 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
     override fun showStoreList(wcSites: List<SiteModel>) {
         progressDialog?.takeIf { it.isShowing }?.dismiss()
 
-        if (wcSites.isEmpty()) {
-            showNoStoresView()
-            return
-        }
-
         no_stores_view.visibility = View.GONE
         site_list_container.visibility = View.VISIBLE
 
@@ -279,7 +274,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         ).show()
     }
 
-    private fun showNoStoresView() {
+    override fun showNoStoresView() {
         site_list_container.visibility = View.GONE
         no_stores_view.visibility = View.VISIBLE
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -115,6 +115,9 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         } ?: run {
             site_list_container.visibility = View.GONE
 
+            // if we have cached sites load them then fetch them silently, otherwise show a progress bar to
+            // signify that we're fetching sites (this should rarely be necessary because unless the database
+            // has been reset, sites will already have been fetched before we get to this screen)
             if (presenter.hasSites()) {
                 presenter.loadSites()
             } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -165,7 +165,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         if (calledFromLogin) {
             text_displayname.text = presenter.getUserDisplayName()
 
-            presenter.getUserName()?.let {userName ->
+            presenter.getUserName()?.let { userName ->
                 if (userName.isNotEmpty()) {
                     text_username.text = String.format(getString(R.string.at_username), userName)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -187,6 +187,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             return
         }
 
+        no_stores_view.visibility = View.GONE
         site_list_container.visibility = View.VISIBLE
         site_list_label.text = if (wcSites.size == 1) {
             getString(R.string.login_connected_store)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -189,6 +189,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
 
         no_stores_view.visibility = View.GONE
         site_list_container.visibility = View.VISIBLE
+
         site_list_label.text = if (wcSites.size == 1) {
             getString(R.string.login_connected_store)
         } else if (calledFromLogin) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerContract.kt
@@ -23,6 +23,7 @@ interface SitePickerContract {
     interface View : BaseView<Presenter> {
         fun showUserInfo()
         fun showStoreList(wcSites: List<SiteModel>)
+        fun showNoStoresView()
         fun didLogout()
         fun siteSelected(site: SiteModel)
         fun siteVerificationPassed(site: SiteModel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerContract.kt
@@ -15,6 +15,7 @@ interface SitePickerContract {
         fun logout()
         fun userIsLoggedIn(): Boolean
         fun loadSites()
+        fun hasSites(): Boolean
         fun getSitesForLocalIds(siteIdList: IntArray): List<SiteModel>
         fun verifySiteApiVersion(site: SiteModel)
         fun updateWooSiteSettings(site: SiteModel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerContract.kt
@@ -6,7 +6,8 @@ import org.wordpress.android.fluxc.model.SiteModel
 
 interface SitePickerContract {
     interface Presenter : BasePresenter<View> {
-        fun fetchSites()
+        fun loadAndFetchSites()
+        fun loadSites()
         fun getWooCommerceSites(): List<SiteModel>
         fun getSiteBySiteId(siteId: Long): SiteModel?
         fun getUserAvatarUrl(): String?
@@ -14,8 +15,6 @@ interface SitePickerContract {
         fun getUserDisplayName(): String?
         fun logout()
         fun userIsLoggedIn(): Boolean
-        fun loadSites()
-        fun hasSites(): Boolean
         fun getSitesForLocalIds(siteIdList: IntArray): List<SiteModel>
         fun verifySiteApiVersion(site: SiteModel)
         fun updateWooSiteSettings(site: SiteModel)
@@ -29,5 +28,6 @@ interface SitePickerContract {
         fun siteVerificationPassed(site: SiteModel)
         fun siteVerificationFailed(site: SiteModel)
         fun siteVerificationError(site: SiteModel)
+        fun showSkeleton(show: Boolean)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
@@ -58,6 +58,8 @@ class SitePickerPresenter @Inject constructor(
         return accountStore.hasAccessToken()
     }
 
+    override fun hasSites(): Boolean = wooCommerceStore.getWooCommerceSites().size > 0
+
     override fun loadSites() {
         val wcSites = wooCommerceStore.getWooCommerceSites()
         view?.showStoreList(wcSites)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
@@ -35,10 +35,6 @@ class SitePickerPresenter @Inject constructor(
         view = null
     }
 
-    override fun fetchSites() {
-        dispatcher.dispatch(SiteActionBuilder.newFetchSitesAction())
-    }
-
     override fun getWooCommerceSites() = wooCommerceStore.getWooCommerceSites()
 
     override fun getSiteBySiteId(siteId: Long): SiteModel? = siteStore.getSiteBySiteId(siteId)
@@ -58,7 +54,15 @@ class SitePickerPresenter @Inject constructor(
         return accountStore.hasAccessToken()
     }
 
-    override fun hasSites(): Boolean = wooCommerceStore.getWooCommerceSites().size > 0
+    override fun loadAndFetchSites() {
+        val wcSites = wooCommerceStore.getWooCommerceSites()
+        if (wcSites.size > 0) {
+            view?.showStoreList(wcSites)
+        } else {
+            view?.showSkeleton(true)
+        }
+        dispatcher.dispatch(SiteActionBuilder.newFetchSitesAction())
+    }
 
     override fun loadSites() {
         val wcSites = wooCommerceStore.getWooCommerceSites()
@@ -88,6 +92,7 @@ class SitePickerPresenter @Inject constructor(
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onSiteChanged(event: OnSiteChanged) {
+        view?.showSkeleton(false)
         if (!event.isError) {
             loadSites()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
@@ -66,7 +66,11 @@ class SitePickerPresenter @Inject constructor(
 
     override fun loadSites() {
         val wcSites = wooCommerceStore.getWooCommerceSites()
-        view?.showStoreList(wcSites)
+        if (wcSites.size > 0) {
+            view?.showStoreList(wcSites)
+        } else {
+            view?.showNoStoresView()
+        }
     }
 
     override fun verifySiteApiVersion(site: SiteModel) {

--- a/WooCommerce/src/main/res/layout/activity_site_picker.xml
+++ b/WooCommerce/src/main/res/layout/activity_site_picker.xml
@@ -55,6 +55,19 @@
         app:layout_constraintTop_toBottomOf="@+id/text_displayname"
         tools:text="\@droidtester2018"/>
 
+    <ProgressBar
+        android:id="@+id/progress"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:elevation="2dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible"/>
+
     <android.support.v7.widget.CardView
         android:id="@+id/site_list_container"
         android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/layout/activity_site_picker.xml
+++ b/WooCommerce/src/main/res/layout/activity_site_picker.xml
@@ -55,19 +55,6 @@
         app:layout_constraintTop_toBottomOf="@+id/text_displayname"
         tools:text="\@droidtester2018"/>
 
-    <ProgressBar
-        android:id="@+id/progress"
-        style="?android:attr/progressBarStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:elevation="2dp"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:visibility="visible"/>
-
     <android.support.v7.widget.CardView
         android:id="@+id/site_list_container"
         android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/layout/skeleton_site_picker.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_site_picker.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/Woo.OrderList.Item"
+    android:orientation="vertical">
+
+    <include layout="@layout/skeleton_site_picker_item"/>
+
+    <include layout="@layout/skeleton_site_picker_item"/>
+
+    <include layout="@layout/skeleton_site_picker_item"/>
+
+    <include layout="@layout/skeleton_site_picker_item"/>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/skeleton_site_picker_item.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_site_picker_item.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<View
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/Woo.OrderList.Item"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/skeleton_default_text_height_two_lines"
+    android:layout_marginBottom="@dimen/margin_medium"
+    android:layout_marginTop="8dp"
+    android:background="@drawable/skeleton_background"/>

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = '4da633e58fece0423750ffe4c3c7800deb23ead3'
+    fluxCVersion = 'fa8ef8b4fb08ce7ee7fc1d95bc5d9b44f1e63083'
     daggerVersion = '2.11'
     supportLibraryVersion = '28.0.0'
     glideVersion = '4.6.1'

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    fluxCVersion = 'fa8ef8b4fb08ce7ee7fc1d95bc5d9b44f1e63083'
+    fluxCVersion = '052ba9fb67eaa6f5b53233e8c9d8db6a26d36205'
     daggerVersion = '2.11'
     supportLibraryVersion = '28.0.0'
     glideVersion = '4.6.1'

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -26,3 +26,4 @@ wc.oauth.app_secret = woocommerce
 wc.zendesk_app_id = woocommerce
 wc.zendesk.domain = http://www.google.com/
 wc.zendesk.oauth_client_id = woocommerce
+wc.reset_db_on_downgrade = false


### PR DESCRIPTION
In the past, the app would crash after we switched to a branch that used a previous db version. Getting around that required clearing storage or uninstalling, and then logging into the app again. I found myself doing that multiple times almost every day, so I made fixing that my hack week project.

The solution required creating a `WellSqlConfig` descendant which overrides `onDowngrade()`, and uses that to drop & recreate all the tables. This is only enabled for debug builds when the following has been added to `gradle.properties`:

```
wc.reset_db_on_downgrade = true
```

So now when a downgrade is detected, you'll see a red toast alerting that the db has been reset, and you'll be sent to the site picker. This required changing a few minor things in the site picker to provide a better experience. I won't claim it's a _great_ experience, but since it's just for us I figured it was okay :)

To test, I recommend adding this to `WooWellSqlConfig`:
```
override fun getDbVersion(): Int {
    return 999
}
```
Run that once, then each time afterwards reduce the version by one. That will trigger the downgrade.

![Screenshot_1556113705](https://user-images.githubusercontent.com/3903757/56664657-7a90e100-6676-11e9-90ab-9c3e75f9173b.png)
