### PR TITLE
issue/948-gms-crash-fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -293,10 +293,10 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
         mDefaultExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
         mUIThreadId = Thread.currentThread().id
         Thread.setDefaultUncaughtExceptionHandler(Thread.UncaughtExceptionHandler { t, e ->
-            if (e != null && t.id != mUIThreadId && e.stackTrace != null && e.stackTrace.size > 0
-                    && e.stackTrace[0].toString().contains("com.google.android.gms")
-                    && e.message != null && e.message!!.contains("Results have already been set")) {
-                return@UncaughtExceptionHandler  // non-UI thread
+            if (e != null && t.id != mUIThreadId && e.stackTrace != null && e.stackTrace.size > 0 &&
+                    e.stackTrace[0].toString().contains("com.google.android.gms") &&
+                    e.message != null && e.message!!.contains("Results have already been set")) {
+                return@UncaughtExceptionHandler // non-UI thread
             }
             if (mDefaultExceptionHandler != null)
                 mDefaultExceptionHandler!!.uncaughtException(t, e)


### PR DESCRIPTION
Fixes #948 

This crash is caused by gms and there is an issue tracker already started [here](https://issuetracker.google.com/issues/70416429). There hasn't been any update from Google's end on this. 

This PR provides a hack to catch this particular exception when initialising the app, and handling it based on this [SO answer](https://stackoverflow.com/a/49165418/9862062).

This, by no means, is a fix and it is a dirty hack to just catch the exception and do nothing. 