### PR TITLE
Allow null value for intent param in notification service

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationsProcessingService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationsProcessingService.kt
@@ -41,7 +41,7 @@ class NotificationsProcessingService : Service() {
         super.onDestroy()
     }
 
-    override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         // Offload to a separate thread.
         actionProcessor = ActionProcessor(this, intent, startId)
         Thread(Runnable { actionProcessor.process() }).start()
@@ -51,11 +51,11 @@ class NotificationsProcessingService : Service() {
 
     private inner class ActionProcessor internal constructor(
         private val context: Context,
-        private val intent: Intent,
+        private val intent: Intent?,
         private val taskId: Int
     ) {
         fun process() {
-            intent.getStringExtra(ARG_ACTION_TYPE)?.let { actionType ->
+            intent?.getStringExtra(ARG_ACTION_TYPE)?.let { actionType ->
                 // Check notification dismissed pending intent
                 if (actionType == ARG_ACTION_NOTIFICATION_DISMISS) {
                     val notificationId = intent.getIntExtra(ARG_PUSH_ID, 0)


### PR DESCRIPTION
Fixes #981

According to [this](https://developer.android.com/reference/android/app/Service.html#onStartCommand) documentation `null` intent is a valid input to `onStartCommand`. So modified the method to allow nullable `Intent` parameter.