### PR TITLE
Added logic to retain the state of the "My Store" tab when the activity is destroyed

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -35,6 +35,7 @@ import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.YEARS
 import org.wordpress.android.fluxc.utils.SiteUtils
 import org.wordpress.android.util.DateTimeUtils
+import java.io.Serializable
 import java.util.ArrayList
 import java.util.Date
 
@@ -48,11 +49,13 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
         private const val UPDATE_DELAY_TIME_MS = 60 * 1000L
     }
 
+    var tabStateStats: Serializable? = null // Save the current position of stats tab view
+
     var activeGranularity: StatsGranularity = DEFAULT_STATS_GRANULARITY
         get() {
             return tab_layout.getTabAt(tab_layout.selectedTabPosition)?.let {
                 it.tag as StatsGranularity
-            } ?: DEFAULT_STATS_GRANULARITY
+            } ?: tabStateStats?.let { it as StatsGranularity } ?: DEFAULT_STATS_GRANULARITY
         }
 
     private lateinit var selectedSite: SelectedSite

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -51,7 +51,7 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
 
     var tabStateStats: Serializable? = null // Save the current position of stats tab view
 
-    var activeGranularity: StatsGranularity = DEFAULT_STATS_GRANULARITY
+    val activeGranularity: StatsGranularity
         get() {
             return tab_layout.getTabAt(tab_layout.selectedTabPosition)?.let {
                 it.tag as StatsGranularity

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardTopEarnersView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardTopEarnersView.kt
@@ -29,18 +29,20 @@ import org.wordpress.android.fluxc.model.WCTopEarnerModel
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.util.FormatUtils
 import org.wordpress.android.util.PhotonUtils
+import java.io.Serializable
 
 class DashboardTopEarnersView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
     : LinearLayout(ctx, attrs) {
     init {
         View.inflate(context, R.layout.dashboard_top_earners, this)
     }
+    var tabStateStats: Serializable? = null // Save the current position of top earners tab view
 
     var activeGranularity: StatsGranularity = DEFAULT_STATS_GRANULARITY
         get() {
             return topEarners_tab_layout.getTabAt(topEarners_tab_layout.selectedTabPosition)?.let {
                 it.tag as StatsGranularity
-            } ?: DEFAULT_STATS_GRANULARITY
+            } ?: tabStateStats?.let { it as StatsGranularity } ?: DEFAULT_STATS_GRANULARITY
         }
 
     private lateinit var selectedSite: SelectedSite


### PR DESCRIPTION
Fixes #812

This PR adds logic to retain the state of stats screen app is resumed from the background. The solution was to save the currently selected tab for stats and top earners and retrieve it when activity is resumed.

### Testing Steps
1. Enable "don't keep activities" in developer options
2. Using the current `develop`, install and open the app.
3. Click on any tab other than DAYS tab
4. Click Home button
5. Open WooCommerce app again
6. Notice that the current tab is 'DAYS'

Now checkout `issue/812-retain-stats-fragment-state-fix` and follow the above steps again. 

### Screenshots
**BEFORE**
<img src="https://user-images.githubusercontent.com/22608780/52998296-f5f0cf00-3448-11e9-9984-7ce419bff4bd.gif" width="300"/>

**AFTER**
<img src="https://user-images.githubusercontent.com/22608780/56794694-4bbc6b80-682c-11e9-9e2a-9ff6333dbf6a.gif" width="300"/>

