### PR TITLE
Modify rating bar star colors to support Lollipop devices

### DIFF
--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,3 +1,4 @@
 * Tap on a product to reveal a read-only detail view.
 * Shipment Tracking date formatting is now localized.
+* Fixed a bug that displayed the rating star colors as purple on Lollipop devices.
 * In the help section, the FAQ button is now "Help Center" and routes to WooCommerce mobile documentation.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListAdapter.kt
@@ -6,6 +6,7 @@ import android.graphics.Paint
 import android.graphics.PorterDuff
 import android.graphics.Rect
 import android.graphics.drawable.LayerDrawable
+import android.os.Build
 import android.support.v4.content.ContextCompat
 import android.support.v7.widget.DividerItemDecoration
 import android.support.v7.widget.RecyclerView
@@ -40,7 +41,12 @@ import java.util.Date
 import java.util.HashSet
 import javax.inject.Inject
 
-class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
+class NotifsListAdapter @Inject constructor(context: Context) : SectionedRecyclerViewAdapter() {
+    private var starTintColor: Int = 0
+    init {
+        starTintColor = ContextCompat.getColor(context, R.color.grey_darken_30)
+    }
+
     enum class ItemType {
         HEADER,
         UNREAD_NOTIF,
@@ -69,7 +75,7 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
         listListener = listener
     }
 
-    fun setNotifications(context: Context?, notifs: List<NotificationModel>) {
+    fun setNotifications(notifs: List<NotificationModel>) {
         // make sure to exclude any notifs that we know have been removed
         val newList = notifs.filter { !removedRemoteIds.contains(it.remoteNoteId) }
 
@@ -97,23 +103,23 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
         }
 
         if (listToday.size > 0) {
-            addSection(NotifsListSection(context, TimeGroup.GROUP_TODAY.name, listToday))
+            addSection(NotifsListSection(TimeGroup.GROUP_TODAY.name, listToday))
         }
 
         if (listYesterday.size > 0) {
-            addSection(NotifsListSection(context, TimeGroup.GROUP_YESTERDAY.name, listYesterday))
+            addSection(NotifsListSection(TimeGroup.GROUP_YESTERDAY.name, listYesterday))
         }
 
         if (listTwoDays.size > 0) {
-            addSection(NotifsListSection(context, TimeGroup.GROUP_OLDER_TWO_DAYS.name, listTwoDays))
+            addSection(NotifsListSection(TimeGroup.GROUP_OLDER_TWO_DAYS.name, listTwoDays))
         }
 
         if (listWeek.size > 0) {
-            addSection(NotifsListSection(context, TimeGroup.GROUP_OLDER_WEEK.name, listWeek))
+            addSection(NotifsListSection(TimeGroup.GROUP_OLDER_WEEK.name, listWeek))
         }
 
         if (listMonth.size > 0) {
-            addSection(NotifsListSection(context, TimeGroup.GROUP_OLDER_MONTH.name, listMonth))
+            addSection(NotifsListSection(TimeGroup.GROUP_OLDER_MONTH.name, listMonth))
         }
 
         notifyDataSetChanged()
@@ -272,11 +278,11 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
      * copy of the existing list, then setting the [NotificationModel#read] property to true and
      * feeding the updated list back into the adapter.
      */
-    fun markAllNotifsAsRead(context: Context?) {
+    fun markAllNotifsAsRead() {
         val newList = mutableListOf<NotificationModel>()
                 .apply { addAll(notifsList) }.applyTransform { it.apply { read = true } }
 
-        setNotifications(context, newList)
+        setNotifications(newList)
     }
 
     fun isEmpty() = notifsList.isEmpty()
@@ -336,7 +342,6 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
     // endregion
 
     private inner class NotifsListSection(
-        val context: Context?,
         val title: String,
         val list: MutableList<NotificationModel>
     ) : StatelessSection(
@@ -363,11 +368,9 @@ class NotifsListAdapter @Inject constructor() : SectionedRecyclerViewAdapter() {
                     notif.getRating()?.let {
                         itemHolder.rating.rating = it
                         itemHolder.rating.visibility = View.VISIBLE
-                        context?.let {
+                        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
                             val stars = itemHolder.rating.progressDrawable as? LayerDrawable
-                            stars?.getDrawable(2)?.setColorFilter(
-                                    ContextCompat.getColor(it, R.color.grey_darken_30),
-                                    PorterDuff.Mode.SRC_ATOP)
+                            stars?.getDrawable(2)?.setColorFilter(starTintColor, PorterDuff.Mode.SRC_ATOP)
                         }
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
@@ -244,7 +244,7 @@ class NotifsListFragment : TopLevelFragment(),
 
     override fun showNotifications(notifsList: List<NotificationModel>, isFreshData: Boolean) {
         if (!notifsAdapter.isSameList(notifsList)) {
-            notifsAdapter.setNotifications(notifsList)
+            notifsAdapter.setNotifications(context, notifsList)
         }
         if (isFreshData) {
             isRefreshPending = false
@@ -410,7 +410,7 @@ class NotifsListFragment : TopLevelFragment(),
         // Remove all active notifications from the system bar
         context?.let { NotificationHandler.removeAllNotificationsFromSystemBar(it) }
 
-        notifsAdapter.markAllNotifsAsRead()
+        notifsAdapter.markAllNotifsAsRead(context)
     }
 
     override fun showMarkAllNotificationsReadSuccess() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
@@ -244,7 +244,7 @@ class NotifsListFragment : TopLevelFragment(),
 
     override fun showNotifications(notifsList: List<NotificationModel>, isFreshData: Boolean) {
         if (!notifsAdapter.isSameList(notifsList)) {
-            notifsAdapter.setNotifications(context, notifsList)
+            notifsAdapter.setNotifications(notifsList)
         }
         if (isFreshData) {
             isRefreshPending = false
@@ -410,7 +410,7 @@ class NotifsListFragment : TopLevelFragment(),
         // Remove all active notifications from the system bar
         context?.let { NotificationHandler.removeAllNotificationsFromSystemBar(it) }
 
-        notifsAdapter.markAllNotifsAsRead(context)
+        notifsAdapter.markAllNotifsAsRead()
     }
 
     override fun showMarkAllNotificationsReadSuccess() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/ReviewDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/ReviewDetailFragment.kt
@@ -1,8 +1,11 @@
 package com.woocommerce.android.ui.notifications
 
 import android.content.Context
+import android.graphics.PorterDuff
+import android.graphics.drawable.LayerDrawable
 import android.os.Bundle
 import android.support.v4.app.Fragment
+import android.support.v4.content.ContextCompat
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -160,6 +163,12 @@ class ReviewDetailFragment : Fragment(), ReviewDetailContract.View {
         note.getRating()?.let { rating ->
             review_rating_bar.rating = rating
             review_rating_bar.visibility = View.VISIBLE
+
+            val stars = review_rating_bar.progressDrawable as? LayerDrawable
+            stars?.getDrawable(2)?.setColorFilter(
+                    ContextCompat.getColor(requireContext(), R.color.alert_yellow),
+                    PorterDuff.Mode.SRC_ATOP
+            )
         }
 
         // Set the review text

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/ReviewDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/ReviewDetailFragment.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.notifications
 import android.content.Context
 import android.graphics.PorterDuff
 import android.graphics.drawable.LayerDrawable
+import android.os.Build
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.support.v4.content.ContextCompat
@@ -164,11 +165,13 @@ class ReviewDetailFragment : Fragment(), ReviewDetailContract.View {
             review_rating_bar.rating = rating
             review_rating_bar.visibility = View.VISIBLE
 
-            val stars = review_rating_bar.progressDrawable as? LayerDrawable
-            stars?.getDrawable(2)?.setColorFilter(
-                    ContextCompat.getColor(requireContext(), R.color.alert_yellow),
-                    PorterDuff.Mode.SRC_ATOP
-            )
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+                val stars = review_rating_bar.progressDrawable as? LayerDrawable
+                stars?.getDrawable(2)?.setColorFilter(
+                        ContextCompat.getColor(requireContext(), R.color.alert_yellow),
+                        PorterDuff.Mode.SRC_ATOP
+                )
+            }
         }
 
         // Set the review text


### PR DESCRIPTION
Fixes: #1017 
The `progressTint` feature is not supported on lollipop devices so the color of the rating bar stars were displayed as purple in notification list screen and review detail screen.

##  Before the fix:
### Notification list screen:
#### Api 21 devices:
<img src="https://user-images.githubusercontent.com/22608780/56800715-55989b80-6839-11e9-8d87-582fe7a1ef45.png" width="300"/>

#### Api 28 devices - expected:
<img src="https://user-images.githubusercontent.com/22608780/56800744-677a3e80-6839-11e9-80a4-ef9254525c77.png" width="300"/>

### Review Detail screen before the fix:
#### Api 21 devices:
<img src="https://user-images.githubusercontent.com/22608780/56800785-7bbe3b80-6839-11e9-922d-1df3a2a3feee.png" width="300"/>

#### Api 28 devices - expected:
<img src="https://user-images.githubusercontent.com/22608780/56800801-84af0d00-6839-11e9-833d-9c667c38354d.png" width="300"/>

##  After the fix:
### Notification list screen:
#### Api 21 devices:
<img src="https://user-images.githubusercontent.com/22608780/56800898-cd66c600-6839-11e9-92e9-2b9c2aae53ca.png" width="300"/>

#### Api 28 devices - expected:
<img src="https://user-images.githubusercontent.com/22608780/56800910-d5266a80-6839-11e9-95ab-c0adc558dca6.png" width="300"/>

### Review Detail screen before the fix:
#### Api 21 devices:
<img src="https://user-images.githubusercontent.com/22608780/56800931-dd7ea580-6839-11e9-983f-b5fe11e56846.png" width="300"/>

#### Api 28 devices - expected:
<img src="https://user-images.githubusercontent.com/22608780/56800939-e1aac300-6839-11e9-85c7-567cf364e05c.png" width="300"/>

### Testing
In addition to manually checking if notification list and detail screen are displayed as expected, testing includes:
* Adding a new notification for product review and checking if displayed as expected. 
* Marking the notifications as read and check if displayed as expected

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
