### PR TITLE
Anitaa/navigation tests order detail info card

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -168,6 +168,7 @@ dependencies {
     androidTestImplementation "com.android.support.test:runner:$testRunnerVersion"
     androidTestImplementation "com.android.support.test:rules:$testRunnerVersion"
     androidTestImplementation "com.android.support.test.espresso:espresso-core:$espressoVersion"
+    androidTestImplementation "com.android.support.test.espresso:espresso-contrib:$espressoVersion"
     androidTestImplementation "com.nhaarman:mockito-kotlin-kt1.1:$mockitoKotlinVersion"
     androidTestImplementation "org.mockito:mockito-android:$mockitoVersion"
     kaptAndroidTest "com.google.dagger:dagger-compiler:$daggerVersion"

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -169,6 +169,7 @@ dependencies {
     androidTestImplementation "com.android.support.test:rules:$testRunnerVersion"
     androidTestImplementation "com.android.support.test.espresso:espresso-core:$espressoVersion"
     androidTestImplementation "com.android.support.test.espresso:espresso-contrib:$espressoVersion"
+    androidTestImplementation "com.android.support.test.espresso:espresso-intents:$espressoVersion"
     androidTestImplementation "com.nhaarman:mockito-kotlin-kt1.1:$mockitoKotlinVersion"
     androidTestImplementation "org.mockito:mockito-android:$mockitoVersion"
     kaptAndroidTest "com.google.dagger:dagger-compiler:$daggerVersion"

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockedActivityBindingModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockedActivityBindingModule.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.di
 
-import com.woocommerce.android.ui.dashboard.DashboardModule
 import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.MagicLinkInterceptActivity
 import com.woocommerce.android.ui.main.MainActivity
@@ -13,6 +12,7 @@ import com.woocommerce.android.ui.orders.OrderFulfillmentModule
 import com.woocommerce.android.ui.orders.OrderProductListModule
 import com.woocommerce.android.ui.sitepicker.SitePickerActivity
 import com.woocommerce.android.ui.sitepicker.SitePickerModule
+import com.woocommerce.android.ui.stats.MockedDashboardModule
 import dagger.Module
 import dagger.android.ContributesAndroidInjector
 import org.wordpress.android.login.di.LoginFragmentModule
@@ -22,7 +22,7 @@ abstract class MockedActivityBindingModule {
     @ActivityScope
     @ContributesAndroidInjector(modules = arrayOf(
             MockedMainModule::class,
-            DashboardModule::class,
+            MockedDashboardModule::class,
             MockedOrderListModule::class,
             MockedOrderDetailModule::class,
             OrderProductListModule::class,

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockedActivityBindingModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockedActivityBindingModule.kt
@@ -7,9 +7,9 @@ import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MockedMainModule
 import com.woocommerce.android.ui.notifications.NotifsListModule
 import com.woocommerce.android.ui.notifications.ReviewDetailModule
-import com.woocommerce.android.ui.orders.OrderDetailModule
+import com.woocommerce.android.ui.orders.MockedOrderDetailModule
+import com.woocommerce.android.ui.orders.MockedOrderListModule
 import com.woocommerce.android.ui.orders.OrderFulfillmentModule
-import com.woocommerce.android.ui.orders.OrderListModule
 import com.woocommerce.android.ui.orders.OrderProductListModule
 import com.woocommerce.android.ui.sitepicker.SitePickerActivity
 import com.woocommerce.android.ui.sitepicker.SitePickerModule
@@ -23,8 +23,8 @@ abstract class MockedActivityBindingModule {
     @ContributesAndroidInjector(modules = arrayOf(
             MockedMainModule::class,
             DashboardModule::class,
-            OrderListModule::class,
-            OrderDetailModule::class,
+            MockedOrderListModule::class,
+            MockedOrderDetailModule::class,
             OrderProductListModule::class,
             OrderFulfillmentModule::class,
             NotifsListModule::class,

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/helpers/WCMatchers.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/helpers/WCMatchers.kt
@@ -10,6 +10,19 @@ import android.widget.TextView
 import com.woocommerce.android.widgets.FlowLayout
 import org.hamcrest.Description
 import org.hamcrest.Matcher
+import android.support.test.espresso.action.ScrollToAction
+import android.support.test.espresso.UiController
+import android.support.v4.widget.NestedScrollView
+import android.widget.HorizontalScrollView
+import android.widget.ScrollView
+import android.support.test.espresso.matcher.ViewMatchers.isDescendantOfA
+import android.support.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import android.support.test.espresso.ViewAction
+import android.support.test.espresso.matcher.ViewMatchers
+import android.support.test.espresso.matcher.ViewMatchers.isAssignableFrom
+import android.widget.ListView
+import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.core.AnyOf.anyOf
 
 object WCMatchers {
     /**
@@ -70,6 +83,42 @@ object WCMatchers {
 
             override fun describeTo(description: Description) {
                 description.appendText("with child text: ")
+            }
+        }
+    }
+
+    fun scrollTo(): ViewAction {
+        return object : ViewAction {
+            override fun getConstraints(): Matcher<View> {
+                return allOf(
+                        withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE), isDescendantOfA(
+                        anyOf(
+                                isAssignableFrom(ScrollView::class.java),
+                                isAssignableFrom(HorizontalScrollView::class.java),
+                                isAssignableFrom(NestedScrollView::class.java)
+                        )
+                ))
+            }
+
+            override fun getDescription(): String? {
+                return null
+            }
+
+            override fun perform(uiController: UiController, view: View) {
+                ScrollToAction().perform(uiController, view)
+            }
+        }
+    }
+
+    fun correctNumberOfItems(itemsCount: Int): Matcher<View> {
+        return object : BoundedMatcher<View, ListView>(ListView::class.java) {
+            override fun describeTo(description: Description) {
+                description.appendText("with number of items: $itemsCount")
+            }
+
+            override fun matchesSafely(listView: ListView): Boolean {
+                val adapter = listView.getAdapter()
+                return adapter.count == itemsCount
             }
         }
     }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/helpers/WCMatchers.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/helpers/WCMatchers.kt
@@ -2,26 +2,26 @@ package com.woocommerce.android.helpers
 
 import android.content.Context
 import android.graphics.drawable.GradientDrawable
-import android.support.test.espresso.matcher.BoundedMatcher
-import android.support.v4.content.ContextCompat
-import android.support.v7.widget.Toolbar
-import android.view.View
-import android.widget.TextView
-import com.woocommerce.android.widgets.FlowLayout
-import org.hamcrest.Description
-import org.hamcrest.Matcher
-import android.support.test.espresso.action.ScrollToAction
 import android.support.test.espresso.UiController
-import android.support.v4.widget.NestedScrollView
-import android.widget.HorizontalScrollView
-import android.widget.ScrollView
-import android.support.test.espresso.matcher.ViewMatchers.isDescendantOfA
-import android.support.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import android.support.test.espresso.ViewAction
+import android.support.test.espresso.action.ScrollToAction
+import android.support.test.espresso.matcher.BoundedMatcher
 import android.support.test.espresso.matcher.ViewMatchers
 import android.support.test.espresso.matcher.ViewMatchers.isAssignableFrom
+import android.support.test.espresso.matcher.ViewMatchers.isDescendantOfA
+import android.support.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import android.support.v4.content.ContextCompat
+import android.support.v4.widget.NestedScrollView
+import android.support.v7.widget.Toolbar
+import android.view.View
+import android.widget.HorizontalScrollView
 import android.widget.ListView
+import android.widget.ScrollView
+import android.widget.TextView
+import com.woocommerce.android.widgets.FlowLayout
 import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.Description
+import org.hamcrest.Matcher
 import org.hamcrest.core.AnyOf.anyOf
 
 object WCMatchers {

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/helpers/WCMatchers.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/helpers/WCMatchers.kt
@@ -1,8 +1,13 @@
 package com.woocommerce.android.helpers
 
+import android.content.Context
+import android.graphics.drawable.GradientDrawable
 import android.support.test.espresso.matcher.BoundedMatcher
+import android.support.v4.content.ContextCompat
 import android.support.v7.widget.Toolbar
 import android.view.View
+import android.widget.TextView
+import com.woocommerce.android.widgets.FlowLayout
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 
@@ -20,6 +25,51 @@ object WCMatchers {
             override fun describeTo(description: Description) {
                 description.appendText("with toolbar title: ")
                 textMatcher.describeTo(description)
+            }
+        }
+    }
+
+    fun withTagTextColor(context: Context, color: Int): Matcher<View> {
+        return object : BoundedMatcher<View, FlowLayout>(FlowLayout::class.java) {
+            public override fun matchesSafely(view: FlowLayout): Boolean {
+                val child = view.getChildAt(0)
+                return if (child != null && child is TextView) {
+                    ContextCompat.getColor(context, color) == child.textColors.defaultColor
+                } else false
+            }
+
+            override fun describeTo(description: Description) {
+                description.appendText("with text color: ")
+            }
+        }
+    }
+
+    fun withTagBackgroundColor(context: Context, color: Int): Matcher<View> {
+        return object : BoundedMatcher<View, FlowLayout>(FlowLayout::class.java) {
+            public override fun matchesSafely(view: FlowLayout): Boolean {
+                val child = view.getChildAt(0)
+                return if (child != null && child is TextView) {
+                    ContextCompat.getColor(context, color) == (child.background as GradientDrawable).color.defaultColor
+                } else false
+            }
+
+            override fun describeTo(description: Description) {
+                description.appendText("with text color: ")
+            }
+        }
+    }
+
+    fun withTagText(string: String): Matcher<View> {
+        return object : BoundedMatcher<View, FlowLayout>(FlowLayout::class.java) {
+            public override fun matchesSafely(view: FlowLayout): Boolean {
+                val child = view.getChildAt(0)
+                return if (child != null && child is TextView) {
+                    child.text.toString() == string
+                } else false
+            }
+
+            override fun describeTo(description: Description) {
+                description.appendText("with child text: ")
             }
         }
     }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/MainActivityTestRule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/MainActivityTestRule.kt
@@ -3,7 +3,11 @@ package com.woocommerce.android.ui.main
 import android.content.Intent
 import android.support.test.rule.ActivityTestRule
 import com.woocommerce.android.di.MockedSelectedSiteModule
+import com.woocommerce.android.ui.orders.MockedOrderDetailModule
+import com.woocommerce.android.ui.orders.WcOrderTestUtils
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCOrderModel
+import org.wordpress.android.fluxc.model.WCOrderStatusModel
 
 class MainActivityTestRule : ActivityTestRule<MainActivity>(MainActivity::class.java, false, false) {
     /**
@@ -21,5 +25,16 @@ class MainActivityTestRule : ActivityTestRule<MainActivity>(MainActivity::class.
         // The reason for doing this here is the same as for the MockedMainModule
         MockedSelectedSiteModule.setSiteModel(siteModel)
         return super.launchActivity(startIntent)
+    }
+
+    /**
+     * Setting mock data for order detail screen
+     */
+    fun setOrderDetailWithMockData(
+        order: WCOrderModel,
+        orderStatus: WCOrderStatusModel = WcOrderTestUtils.generateOrderStatusDetail()
+    ) {
+        MockedOrderDetailModule.setOrderInfo(order)
+        MockedOrderDetailModule.setOrderStatus(orderStatus)
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/MockedOrderDetailModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/MockedOrderDetailModule.kt
@@ -1,0 +1,87 @@
+package com.woocommerce.android.ui.orders
+
+import android.content.Context
+import com.google.gson.Gson
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.spy
+import com.nhaarman.mockito_kotlin.whenever
+import com.woocommerce.android.di.ActivityScope
+import com.woocommerce.android.di.FragmentScope
+import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.tools.SelectedSite
+import dagger.Module
+import dagger.Provides
+import dagger.android.ContributesAndroidInjector
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.WCOrderModel
+import org.wordpress.android.fluxc.model.WCOrderStatusModel
+import org.wordpress.android.fluxc.network.rest.wpcom.notifications.NotificationRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
+import org.wordpress.android.fluxc.persistence.NotificationSqlUtils
+import org.wordpress.android.fluxc.store.NotificationStore
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.WCOrderStore
+import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.tools.FormattableContentMapper
+
+@Module
+abstract class MockedOrderDetailModule {
+    @Module
+    companion object {
+        private var order: WCOrderModel? = null
+        private var orderStatus: WCOrderStatusModel? = null
+
+        fun setOrderInfo(order: WCOrderModel) {
+            this.order = order
+        }
+
+        fun setOrderStatus(orderStatus: WCOrderStatusModel) {
+            this.orderStatus = orderStatus
+        }
+
+        @JvmStatic
+        @ActivityScope
+        @Provides
+        fun provideOrderDetailPresenter(): OrderDetailContract.Presenter {
+            /**
+             * Creating a spy object here since we need to mock specific methods of [OrderDetailPresenter] class
+             * instead of mocking all the methods in the class.
+             * We cannot mock final classes ([WCOrderStore], [WCProductStore], [SelectedSite] and [NetworkStatus]), so
+             * creating a mock instance of those classes and passing to the presenter class constructor.
+             */
+            val mockDispatcher = mock<Dispatcher>()
+            val mockContext = mock<Context>()
+            val mockSiteStore = mock<SiteStore>()
+
+            val mockedOrderDetailPresenter = spy(OrderDetailPresenter(
+                    mockDispatcher,
+                    WCOrderStore(mockDispatcher, OrderRestClient(mockContext, mockDispatcher, mock(), mock(), mock())),
+                    WCProductStore(
+                            mockDispatcher,
+                            ProductRestClient(mockContext, mockDispatcher, mock(), mock(), mock())),
+                    SelectedSite(mockContext, mockSiteStore),
+                    mock(),
+                    NetworkStatus(mockContext),
+                    NotificationStore(
+                            mock(), mockContext,
+                            NotificationRestClient(mockContext, mockDispatcher, mock(), mock(), mock()),
+                            NotificationSqlUtils(FormattableContentMapper(Gson())), mockSiteStore)
+            ))
+
+            /**
+             * Mocking the below methods in [OrderDetailPresenter] class to pass mock values.
+             * These are the methods that invoke [WCOrderModel], [WCOrderStatusModel] methods from FluxC.
+             */
+            doReturn(order).whenever(mockedOrderDetailPresenter).loadOrderDetailFromDb(any())
+            doReturn(orderStatus).whenever(mockedOrderDetailPresenter).getOrderStatusForStatusKey(any())
+            return mockedOrderDetailPresenter
+        }
+    }
+
+    @FragmentScope
+    @ContributesAndroidInjector
+    abstract fun orderDetailfragment(): OrderDetailFragment
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/MockedOrderListModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/MockedOrderListModule.kt
@@ -1,0 +1,59 @@
+package com.woocommerce.android.ui.orders
+
+import android.content.Context
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.spy
+import com.nhaarman.mockito_kotlin.whenever
+import com.woocommerce.android.di.ActivityScope
+import com.woocommerce.android.di.FragmentScope
+import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.tools.SelectedSite
+import dagger.Module
+import dagger.Provides
+import dagger.android.ContributesAndroidInjector
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.WCOrderModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
+import org.wordpress.android.fluxc.store.WCOrderStore
+
+@Module
+abstract class MockedOrderListModule {
+    @Module
+    companion object {
+        private val orders: List<WCOrderModel> = WcOrderTestUtils.generateOrders()
+
+        @JvmStatic
+        @ActivityScope
+        @Provides
+        fun provideOrderListPresenter(): OrderListContract.Presenter {
+            /**
+             * Creating a spy object here since we need to mock specific methods of [OrderListPresenter] class
+             * instead of mocking all the methods in the class.
+             * We cannot mock final classes ([WCOrderStore], [SelectedSite] and [NetworkStatus]), so
+             * creating a mock instance of those classes and passing to the presenter class constructor.
+             */
+            val mockDispatcher = mock<Dispatcher>()
+            val mockContext = mock<Context>()
+            val mockedOrderListPresenter = spy(OrderListPresenter(
+                    mockDispatcher,
+                    WCOrderStore(mockDispatcher, OrderRestClient(mockContext, mockDispatcher, mock(), mock(), mock())),
+                    SelectedSite(mockContext, mock()),
+                    NetworkStatus(mockContext)
+            ))
+
+            /**
+             * Mocking the below methods in [OrderListPresenter] class to pass mock values.
+             * These are the methods that invoke [WCOrderStore] methods from FluxC
+             */
+            doReturn(true).whenever(mockedOrderListPresenter).isOrderStatusOptionsRefreshing()
+            doReturn(emptyMap<String, WCOrderModel>()).whenever(mockedOrderListPresenter).getOrderStatusOptions()
+            doReturn(orders).whenever(mockedOrderListPresenter).fetchOrdersFromDb(null, false)
+            return mockedOrderListPresenter
+        }
+    }
+
+    @FragmentScope
+    @ContributesAndroidInjector
+    abstract fun orderListFragment(): OrderListFragment
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderDetailCustomerInfoCardTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderDetailCustomerInfoCardTest.kt
@@ -1,0 +1,396 @@
+package com.woocommerce.android.ui.orders
+
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Intent
+import android.net.Uri
+import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.action.ViewActions.click
+import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.contrib.RecyclerViewActions
+import android.support.test.espresso.intent.Intents
+import android.support.test.espresso.intent.Intents.intended
+import android.support.test.espresso.intent.Intents.intending
+import android.support.test.espresso.intent.matcher.IntentMatchers.hasAction
+import android.support.test.espresso.intent.matcher.IntentMatchers.hasData
+import android.support.test.espresso.intent.matcher.IntentMatchers.isInternal
+import android.support.test.espresso.matcher.RootMatchers.isPlatformPopup
+import android.support.test.espresso.matcher.ViewMatchers
+import android.support.test.espresso.matcher.ViewMatchers.Visibility.GONE
+import android.support.test.espresso.matcher.ViewMatchers.Visibility.VISIBLE
+import android.support.test.espresso.matcher.ViewMatchers.isAssignableFrom
+import android.support.test.espresso.matcher.ViewMatchers.isChecked
+import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
+import android.support.test.espresso.matcher.ViewMatchers.isNotChecked
+import android.support.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import android.support.test.espresso.matcher.ViewMatchers.withId
+import android.support.test.espresso.matcher.ViewMatchers.withText
+import android.support.test.filters.LargeTest
+import android.support.test.runner.AndroidJUnit4
+import android.support.v7.widget.RecyclerView
+import android.widget.ListView
+import com.woocommerce.android.R
+import com.woocommerce.android.helpers.WCMatchers
+import com.woocommerce.android.ui.TestBase
+import com.woocommerce.android.ui.main.MainActivityTestRule
+import com.woocommerce.android.util.AddressUtils
+import com.woocommerce.android.util.PhoneUtils
+import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.CoreMatchers.not
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.wordpress.android.fluxc.model.SiteModel
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class OrderDetailCustomerInfoCardTest : TestBase() {
+    @Rule
+    @JvmField var activityTestRule = MainActivityTestRule()
+
+    @Before
+    override fun setup() {
+        super.setup()
+        Intents.init()
+
+        // Bypass login screen and display dashboard
+        activityTestRule.launchMainActivityLoggedIn(null, SiteModel())
+
+        // Make sure the bottom navigation view is showing
+        activityTestRule.activity.showBottomNav()
+
+        // Click on Orders tab in the bottom bar
+        onView(withId(R.id.orders)).perform(click())
+    }
+
+    @After
+    fun tearDown() {
+        Intents.release()
+    }
+
+    @Test
+    fun verifyOrderDetailCardViewPopulatedSuccessfully() {
+        // add mock data to order detail screen
+        val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail(
+                billingAddress1 = "Ramada Plaza, 450 Capitol Ave SE Atlanta",
+                billingCountry = "USA"
+        )
+        activityTestRule.setOrderDetailWithMockData(mockWCOrderModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // check if order customer info card label matches this title:
+        // R.string.customer_information
+        onView(withId(R.id.customerInfo_label)).check(matches(
+                withText(appContext.getString(R.string.customer_information))
+        ))
+
+        // check if order customer info card shipping label matches this title:
+        // R.string.customer_information
+        onView(withId(R.id.customerInfo_shippingLabel)).check(matches(
+                withText(appContext.getString(R.string.orderdetail_shipping_details))
+        ))
+
+        // check if order customer info card shipping label matches this title:
+        // R.string.customer_information
+        onView(withId(R.id.customerInfo_billingLabel)).check(matches(
+                withText(appContext.getString(R.string.orderdetail_billing_details))
+        ))
+
+        // verify that the customer shipping details is displayed
+        onView(withId(R.id.customerInfo_shippingAddr)).check(matches(isDisplayed()))
+
+        // verify that the billing view is condensed and load more button is visible
+        onView(withId(R.id.customerInfo_morePanel)).check(matches(ViewMatchers.withEffectiveVisibility(GONE)))
+        onView(withId(R.id.customerInfo_viewMore)).check(matches(isNotChecked()))
+        onView(withId(R.id.customerInfo_viewMore)).check(matches(
+                withText(appContext.getString(R.string.orderdetail_show_billing))
+        ))
+    }
+
+    @Test
+    fun verifyOrderDetailCardViewShowBillingViewPopulatedSuccessfully() {
+        // add mock data to order detail screen
+        val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail(
+                billingAddress1 = "Ramada Plaza, 450 Capitol",
+                billingCountry = "USA"
+        )
+        activityTestRule.setOrderDetailWithMockData(mockWCOrderModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // click on Show Billing button
+        onView(withId(R.id.customerInfo_viewMore)).perform(click())
+
+        // verify that the billing view is expanded and load more button is visible
+        onView(withId(R.id.customerInfo_morePanel)).check(matches(withEffectiveVisibility(VISIBLE)))
+        onView(withId(R.id.customerInfo_viewMore)).check(matches(isChecked()))
+        onView(withId(R.id.customerInfo_viewMore)).check(matches(
+                withText(appContext.getString(R.string.orderdetail_hide_billing))
+        ))
+
+        // verify that billing details is displayed
+        onView(withId(R.id.customerInfo_billingAddr)).check(matches(isDisplayed()))
+
+        // verify that the customer email is displayed
+        onView(withId(R.id.customerInfo_emailAddr)).check(matches(isDisplayed()))
+        onView(withId(R.id.customerInfo_emailBtn)).check(matches(isDisplayed()))
+
+        // since the customer info phone is empty, the view should not be displayed
+        onView(withId(R.id.customerInfo_phone)).check(matches(withEffectiveVisibility(GONE)))
+        onView(withId(R.id.customerInfo_callOrMessageBtn)).check(matches(withEffectiveVisibility(GONE)))
+
+        // click on Hide Billing button
+        onView(withId(R.id.customerInfo_viewMore)).perform(WCMatchers.scrollTo(), click())
+
+        // verify that the billing view is condensed and load more button is visible
+        onView(withId(R.id.customerInfo_morePanel)).check(matches(withEffectiveVisibility(GONE)))
+        onView(withId(R.id.customerInfo_viewMore)).check(matches(isNotChecked()))
+        onView(withId(R.id.customerInfo_viewMore)).check(matches(
+                withText(appContext.getString(R.string.orderdetail_show_billing))
+        ))
+    }
+
+    @Test
+    fun verifyOrderDetailCardViewBillingMatchesShippingPopulatedSuccessfully() {
+        // add mock data to order detail screen
+        val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail(
+                billingAddress1 = "Ramada Plaza, 450 Capitol Ave SE Atlanta",
+                billingCountry = "USA"
+        )
+        activityTestRule.setOrderDetailWithMockData(mockWCOrderModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // check if order customer info card shipping details matches this format:
+        // Anitaa Murthy
+        // 60, Fast lane, Chicago,
+        // USA
+        val billingName = appContext.getString(
+                R.string.customer_full_name,
+                mockWCOrderModel.billingFirstName, mockWCOrderModel.billingLastName
+        )
+        val billingAddr = AddressUtils.getEnvelopeAddress(mockWCOrderModel.getBillingAddress())
+        val billingCountry = AddressUtils.getCountryLabelByCountryCode(mockWCOrderModel.billingCountry)
+
+        // Assumes that the name, address and country info is available
+        val billingAddrFull = "$billingName\n$billingAddr\n$billingCountry"
+        onView(withId(R.id.customerInfo_shippingAddr)).check(matches(withText(billingAddrFull)))
+
+        // Note: the shipping address should match the billing address
+        onView(withId(R.id.customerInfo_billingAddr)).check(matches(withText(billingAddrFull)))
+    }
+
+    @Test
+    fun verifyOrderDetailCardViewWithSeparateBillingPopulatedSuccessfully() {
+        // add mock data to order detail screen
+        val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail(
+                billingAddress1 = "Ramada Plaza, 450 Capitol Ave SE Atlanta",
+                billingCountry = "USA",
+                shippingFirstName = "Anitaa",
+                shippingLastName = "Murthy",
+                shippingAddress1 = "1234, Abs avenue",
+                shippingCountry = "USA"
+        )
+        activityTestRule.setOrderDetailWithMockData(mockWCOrderModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // check if order customer info card shipping details matches this format:
+        // Anitaa Murthy
+        // 60, Fast lane, Chicago,
+        // USA
+        val shippingName = appContext.getString(
+                R.string.customer_full_name,
+                mockWCOrderModel.shippingFirstName, mockWCOrderModel.shippingLastName
+        )
+        val shippingAddr = AddressUtils.getEnvelopeAddress(mockWCOrderModel.getShippingAddress())
+        val shippingCountry = AddressUtils.getCountryLabelByCountryCode(mockWCOrderModel.shippingCountry)
+
+        // Assumes that the shipping name, address and country info is available
+        // & is different from the billing address
+        val shippingAddrFull = "$shippingName\n$shippingAddr\n$shippingCountry"
+        onView(withId(R.id.customerInfo_shippingAddr)).check(matches(withText(shippingAddrFull)))
+
+        // Assumes that the billing name, address and country info is available
+        // & is different from the shipping address
+        val billingName = appContext.getString(
+                R.string.customer_full_name,
+                mockWCOrderModel.billingFirstName, mockWCOrderModel.billingLastName
+        )
+        val billingAddr = AddressUtils.getEnvelopeAddress(mockWCOrderModel.getBillingAddress())
+        val billingCountry = AddressUtils.getCountryLabelByCountryCode(mockWCOrderModel.billingCountry)
+        val billingAddrFull = "$billingName\n$billingAddr\n$billingCountry"
+        onView(withId(R.id.customerInfo_billingAddr)).check(matches(withText(billingAddrFull)))
+    }
+
+    @Test
+    fun verifyOrderDetailCardViewWithShippingForDifferentLocalePopulatedSuccessfully() {
+        // add mock data to order detail screen
+        val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail(
+                billingAddress1 = "29, Kuppam Beach Road",
+                billingCountry = "India",
+                billingPostalCode = "600041"
+        )
+        activityTestRule.setOrderDetailWithMockData(mockWCOrderModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // check if order customer info card shipping details matches this format:
+        // Anitaa Murthy
+        // 29, Kuppam Beach Road,
+        // India, 600041
+        val billingName = appContext.getString(
+                R.string.customer_full_name,
+                mockWCOrderModel.billingFirstName, mockWCOrderModel.billingLastName
+        )
+        val billingAddr = AddressUtils.getEnvelopeAddress(mockWCOrderModel.getBillingAddress())
+        val billingCountry = AddressUtils.getCountryLabelByCountryCode(mockWCOrderModel.billingCountry)
+
+        // Assumes that the name, address and country info is available
+        val billingAddrFull = "$billingName\n$billingAddr\n$billingCountry"
+        onView(withId(R.id.customerInfo_shippingAddr)).check(matches(withText(billingAddrFull)))
+    }
+
+    @Test
+    fun verifyOrderDetailCardViewWithBillingPhonePopulatedSuccessfully() {
+        // add mock data to order detail screen
+        val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail(
+                billingPhone = "9962789522"
+        )
+        activityTestRule.setOrderDetailWithMockData(mockWCOrderModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // click on Show Billing button
+        onView(withId(R.id.customerInfo_viewMore)).perform(click())
+
+        // since the customer info phone is NOT empty, the view should be displayed
+        onView(withId(R.id.customerInfo_phone)).check(matches(withEffectiveVisibility(VISIBLE)))
+        onView(withId(R.id.customerInfo_callOrMessageBtn)).check(matches(withEffectiveVisibility(VISIBLE)))
+        onView(withId(R.id.customerInfo_phone)).check(matches(
+                withText(PhoneUtils.formatPhone(mockWCOrderModel.billingPhone))
+        ))
+    }
+
+    @Test
+    fun verifyOrderDetailCardViewWithBillingPhoneForDifferentLocalePopulatedSuccessfully() {
+        // add mock data to order detail screen
+        val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail(
+                billingPhone = "07911123456"
+        )
+        activityTestRule.setOrderDetailWithMockData(mockWCOrderModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // click on Show Billing button
+        onView(withId(R.id.customerInfo_viewMore)).perform(click())
+
+        // since the customer info phone is NOT empty, the view should be displayed
+        onView(withId(R.id.customerInfo_phone)).check(matches(withEffectiveVisibility(VISIBLE)))
+        onView(withId(R.id.customerInfo_callOrMessageBtn)).check(matches(withEffectiveVisibility(VISIBLE)))
+        onView(withId(R.id.customerInfo_phone)).check(matches(
+                withText(PhoneUtils.formatPhone(mockWCOrderModel.billingPhone))
+        ))
+    }
+
+    @Test
+    fun testDisplayPopupForCorrectPhoneNumber() {
+        // add mock data to order detail screen
+        val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail(
+                billingPhone = "9962789422"
+        )
+        activityTestRule.setOrderDetailWithMockData(mockWCOrderModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // click on Show Billing button
+        onView(withId(R.id.customerInfo_viewMore)).perform(click())
+
+        // since the customer info phone is NOT empty, the view should be displayed & clickable
+        onView(withId(R.id.customerInfo_callOrMessageBtn)).perform(WCMatchers.scrollTo(), click())
+
+        // The Android System Popups and Alerts are displayed in a different window.
+        // So, you have to try to find the view in that particular window rather than the main activity window
+        // by checking if the menu text with "Call" menu item is displayed
+        onView(withText(appContext.getString(R.string.orderdetail_call_customer)))
+                .inRoot(isPlatformPopup()).check(matches(isDisplayed()))
+
+        // by checking if the menu text with "Message" menu item is displayed
+        onView(withText(appContext.getString(R.string.orderdetail_message_customer)))
+                .inRoot(isPlatformPopup()).check(matches(isDisplayed()))
+
+        onView(isAssignableFrom(ListView::class.java))
+                .check(matches(WCMatchers.correctNumberOfItems(2)))
+    }
+
+    @Test
+    fun testDisplayPopupAndCallForCorrectPhoneNumber() {
+        // add mock data to order detail screen
+        val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail(
+                billingPhone = "9962789422"
+        )
+        activityTestRule.setOrderDetailWithMockData(mockWCOrderModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // click on Show Billing button
+        onView(withId(R.id.customerInfo_viewMore)).perform(click())
+
+        // since the customer info phone is NOT empty, the view should be displayed & clickable
+//        onView(withId(R.id.customerInfo_callOrMessageBtn)).perform(WCMatchers.scrollTo(), click())
+        onView(withId(R.id.customerInfo_callOrMessageBtn)).perform(click())
+
+        onView(withText(appContext.getString(R.string.orderdetail_call_customer)))
+                .inRoot(isPlatformPopup()).perform(click())
+
+        // check if phone intent is opened for the given phone number
+        intended(allOf(hasAction(Intent.ACTION_DIAL), hasData(
+                Uri.parse("tel:${mockWCOrderModel.billingPhone}")
+        )))
+    }
+
+    @Test
+    fun testEmailCustomerWithCorrectEmail() {
+        // add mock data to order detail screen
+        val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail()
+        activityTestRule.setOrderDetailWithMockData(mockWCOrderModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // click on Show Billing button
+        onView(withId(R.id.customerInfo_viewMore)).perform(click())
+
+        intending(not(isInternal())).respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, null))
+
+        // since the customer info phone is NOT empty, the view should be displayed
+        onView(withId(R.id.customerInfo_emailBtn)).perform(click())
+
+        // check if email intent is opened for the given email address
+        intended(allOf(hasAction(Intent.ACTION_SENDTO), hasData(
+                Uri.parse("mailto:${mockWCOrderModel.billingEmail}")
+        )))
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderDetailNavigationTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderDetailNavigationTest.kt
@@ -1,0 +1,378 @@
+package com.woocommerce.android.ui.orders
+
+import android.support.test.espresso.Espresso
+import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.action.ViewActions
+import android.support.test.espresso.action.ViewActions.click
+import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.contrib.RecyclerViewActions
+import android.support.test.espresso.matcher.ViewMatchers
+import android.support.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import android.support.test.espresso.matcher.ViewMatchers.withId
+import android.support.test.espresso.matcher.ViewMatchers.withText
+import android.support.test.filters.LargeTest
+import android.support.test.runner.AndroidJUnit4
+import android.support.v7.widget.RecyclerView
+import com.woocommerce.android.R
+import com.woocommerce.android.helpers.WCMatchers
+import com.woocommerce.android.ui.TestBase
+import com.woocommerce.android.ui.main.MainActivityTestRule
+import com.woocommerce.android.util.DateUtils
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.wordpress.android.fluxc.model.SiteModel
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class OrderDetailNavigationTest : TestBase() {
+    @Rule
+    @JvmField var activityTestRule = MainActivityTestRule()
+
+    val dateFormat by lazy { DateTimeFormatter.ofPattern("YYYY-mm-dd'T'hh:mm:ss", Locale.getDefault()) }
+
+    @Before
+    override fun setup() {
+        super.setup()
+        // Bypass login screen and display dashboard
+        activityTestRule.launchMainActivityLoggedIn(null, SiteModel())
+
+        // Make sure the bottom navigation view is showing
+        activityTestRule.activity.showBottomNav()
+
+        // Click on Orders tab in the bottom bar
+        Espresso.onView(ViewMatchers.withId(R.id.orders)).perform(ViewActions.click())
+    }
+
+    @Test
+    fun verifyOrderDetailCardViewPopulatedSuccessfully() {
+        // add mock data to order detail screen
+        val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail()
+        activityTestRule.setOrderDetailWithMockData(mockWCOrderModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        Espresso.onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // check if order card heading matches this format:
+        // #1 Jane Masterson
+        onView(withId(R.id.orderStatus_orderNum)).check(matches(
+                withText(appContext.getString(
+                R.string.orderdetail_orderstatus_heading,
+                mockWCOrderModel.number, mockWCOrderModel.billingFirstName, mockWCOrderModel.billingLastName)))
+        )
+
+        // check if order card date created matches this format:
+        // Created 8/12/2017 at 4:11 PM:
+        val todayDateString = DateUtils.getFriendlyShortDateAtTimeString(
+                appContext,
+                mockWCOrderModel.dateCreated
+        )
+        onView(withId(R.id.orderStatus_created)).check(
+                matches(withText(appContext.getString(R.string.orderdetail_orderstatus_created, todayDateString))))
+    }
+
+    @Test
+    fun verifyOrderDetailCardDateCreatedTodayView() {
+        // add mock data to order detail screen
+        val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail(
+                LocalDateTime.now().format(dateFormat)
+        )
+        activityTestRule.setOrderDetailWithMockData(mockWCOrderModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        Espresso.onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // check if order card created date is displayed in this format:
+        // Created <friendly date category> at <time> message, for Today:
+        val todayDateString = DateUtils.getFriendlyShortDateAtTimeString(
+                appContext,
+                mockWCOrderModel.dateCreated
+        )
+        onView(withId(R.id.orderStatus_created)).check(
+                matches(withText(appContext.getString(R.string.orderdetail_orderstatus_created, todayDateString))))
+    }
+
+    @Test
+    fun verifyOrderDetailCardDateCreatedYesterdayView() {
+        // add mock data to order detail screen
+        val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail(
+                LocalDateTime.now().minusDays(1).format(dateFormat)
+        )
+        activityTestRule.setOrderDetailWithMockData(mockWCOrderModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        Espresso.onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // check if order card created date is displayed in this format:
+        // Created <friendly date category> at <time> message, for Yesterday:
+        val yDayDateString = DateUtils.getFriendlyShortDateAtTimeString(
+                appContext,
+                mockWCOrderModel.dateCreated
+        )
+        onView(withId(R.id.orderStatus_created)).check(
+                matches(withText(appContext.getString(R.string.orderdetail_orderstatus_created, yDayDateString))))
+    }
+
+    @Test
+    fun verifyOrderDetailCardDateCreatedTwoDaysView() {
+        // add mock data to order detail screen
+        val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail(
+                LocalDateTime.now().minusDays(3).format(dateFormat)
+        )
+        activityTestRule.setOrderDetailWithMockData(mockWCOrderModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        Espresso.onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // check if order card created date is displayed in this format:
+        // Created <friendly date category> at <time> message, for Older than 2 days:
+        val yDayDateString = DateUtils.getFriendlyShortDateAtTimeString(
+                appContext,
+                mockWCOrderModel.dateCreated
+        )
+        onView(withId(R.id.orderStatus_created)).check(
+                matches(withText(appContext.getString(R.string.orderdetail_orderstatus_created, yDayDateString))))
+    }
+
+    @Test
+    fun verifyOrderDetailCardDateCreatedOlderThanAWeekView() {
+        // add mock data to order detail screen
+        val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail(
+                LocalDateTime.now().minusWeeks(2).format(dateFormat)
+        )
+        activityTestRule.setOrderDetailWithMockData(mockWCOrderModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        Espresso.onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // check if order card created date is displayed in this format:
+        // Created <friendly date category> at <time> message, for Older than a week:
+        val yDayDateString = DateUtils.getFriendlyShortDateAtTimeString(
+                appContext,
+                mockWCOrderModel.dateCreated
+        )
+        onView(withId(R.id.orderStatus_created)).check(
+                matches(withText(appContext.getString(R.string.orderdetail_orderstatus_created, yDayDateString))))
+    }
+
+    @Test
+    fun verifyOrderDetailCardDateCreatedOlderThanAMonthView() {
+        // add mock data to order detail screen
+        val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail(
+                LocalDateTime.now().minusMonths(2).format(dateFormat)
+        )
+        activityTestRule.setOrderDetailWithMockData(mockWCOrderModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        Espresso.onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // check if order card created date is displayed in this format:
+        // Created <friendly date category> at <time> message, for Older than a month:
+        val yDayDateString = DateUtils.getFriendlyShortDateAtTimeString(
+                appContext,
+                mockWCOrderModel.dateCreated
+        )
+        onView(withId(R.id.orderStatus_created)).check(
+                matches(withText(appContext.getString(R.string.orderdetail_orderstatus_created, yDayDateString))))
+    }
+
+    @Test
+    fun verifyOrderDetailCardPendingStatusLabelView() {
+        // add mock data to order detail screen
+        activityTestRule.setOrderDetailWithMockData(WcOrderTestUtils.generateOrderDetail())
+
+        // click on the first order in the list and check if redirected to order detail
+        Espresso.onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // check if order status label is displayed correctly
+        // Check if order status label name, label text color, label background color is displayed correctly
+        onView(withId(R.id.orderStatus_orderTags)).check(
+                matches(WCMatchers.withTagText("Pending"))
+        )
+        onView(withId(R.id.orderStatus_orderTags)).check(
+                matches(WCMatchers.withTagTextColor(appContext, R.color.orderStatus_pending_text))
+        )
+        onView(withId(R.id.orderStatus_orderTags)).check(
+                matches(WCMatchers.withTagBackgroundColor(appContext, R.color.orderStatus_pending_bg))
+        )
+    }
+
+    @Test
+    fun verifyOrderDetailCardProcessingStatusLabelView() {
+        // add mock data to order detail screen
+        val wcOrderStatusModel = WcOrderTestUtils.generateOrderStatusDetail("Processing")
+        activityTestRule.setOrderDetailWithMockData(WcOrderTestUtils.generateOrderDetail(), wcOrderStatusModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        Espresso.onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // check if order status label is displayed correctly
+        // Check if order status label name, label text color, label background color is displayed correctly
+        onView(withId(R.id.orderStatus_orderTags)).check(
+                matches(WCMatchers.withTagText(wcOrderStatusModel.label))
+        )
+        onView(withId(R.id.orderStatus_orderTags)).check(
+                matches(WCMatchers.withTagTextColor(appContext, R.color.orderStatus_processing_text))
+        )
+        onView(withId(R.id.orderStatus_orderTags)).check(
+                matches(WCMatchers.withTagBackgroundColor(appContext, R.color.orderStatus_processing_bg))
+        )
+    }
+
+    @Test
+    fun verifyOrderDetailCardOnHoldStatusLabelView() {
+        // add mock data to order detail screen
+        val wcOrderStatusModel = WcOrderTestUtils.generateOrderStatusDetail("On Hold")
+        activityTestRule.setOrderDetailWithMockData(WcOrderTestUtils.generateOrderDetail(), wcOrderStatusModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        Espresso.onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // check if order status label is displayed correctly
+        // Check if order status label name, label text color, label background color is displayed correctly
+        onView(withId(R.id.orderStatus_orderTags)).check(
+                matches(WCMatchers.withTagText(wcOrderStatusModel.label))
+        )
+        onView(withId(R.id.orderStatus_orderTags)).check(
+                matches(WCMatchers.withTagTextColor(appContext, R.color.orderStatus_hold_text))
+        )
+        onView(withId(R.id.orderStatus_orderTags)).check(
+                matches(WCMatchers.withTagBackgroundColor(appContext, R.color.orderStatus_hold_bg))
+        )
+    }
+
+    @Test
+    fun verifyOrderDetailCardCompletedStatusLabelView() {
+        // add mock data to order detail screen
+        val wcOrderStatusModel = WcOrderTestUtils.generateOrderStatusDetail("Completed")
+        activityTestRule.setOrderDetailWithMockData(WcOrderTestUtils.generateOrderDetail(), wcOrderStatusModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        Espresso.onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // check if order status label is displayed correctly
+        // Check if order status label name, label text color, label background color is displayed correctly
+        onView(withId(R.id.orderStatus_orderTags)).check(
+                matches(WCMatchers.withTagText(wcOrderStatusModel.label))
+        )
+        onView(withId(R.id.orderStatus_orderTags)).check(
+                matches(WCMatchers.withTagTextColor(appContext, R.color.orderStatus_completed_text))
+        )
+        onView(withId(R.id.orderStatus_orderTags)).check(
+                matches(WCMatchers.withTagBackgroundColor(appContext, R.color.orderStatus_completed_bg))
+        )
+    }
+
+    @Test
+    fun verifyOrderDetailCardCancelledStatusLabelView() {
+        // add mock data to order detail screen
+        val wcOrderStatusModel = WcOrderTestUtils.generateOrderStatusDetail("Cancelled")
+        activityTestRule.setOrderDetailWithMockData(WcOrderTestUtils.generateOrderDetail(), wcOrderStatusModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        Espresso.onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // check if order status label is displayed correctly
+        // Check if order status label name, label text color, label background color is displayed correctly
+        onView(withId(R.id.orderStatus_orderTags)).check(
+                matches(WCMatchers.withTagText(wcOrderStatusModel.label))
+        )
+        onView(withId(R.id.orderStatus_orderTags)).check(
+                matches(WCMatchers.withTagTextColor(appContext, R.color.orderStatus_cancelled_text))
+        )
+        onView(withId(R.id.orderStatus_orderTags)).check(
+                matches(WCMatchers.withTagBackgroundColor(appContext, R.color.orderStatus_cancelled_bg))
+        )
+    }
+
+    @Test
+    fun verifyOrderDetailCardRefundedStatusLabelView() {
+        // add mock data to order detail screen
+        val wcOrderStatusModel = WcOrderTestUtils.generateOrderStatusDetail("Refunded")
+        activityTestRule.setOrderDetailWithMockData(WcOrderTestUtils.generateOrderDetail(), wcOrderStatusModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        Espresso.onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // check if order status label is displayed correctly
+        // Check if order status label name, label text color, label background color is displayed correctly
+        onView(withId(R.id.orderStatus_orderTags)).check(
+                matches(WCMatchers.withTagText(wcOrderStatusModel.label))
+        )
+        onView(withId(R.id.orderStatus_orderTags)).check(
+                matches(WCMatchers.withTagTextColor(appContext, R.color.orderStatus_refunded_text))
+        )
+        onView(withId(R.id.orderStatus_orderTags)).check(
+                matches(WCMatchers.withTagBackgroundColor(appContext, R.color.orderStatus_refunded_bg))
+        )
+    }
+
+    @Test
+    fun verifyOrderDetailCardFailedStatusLabelView() {
+        // add mock data to order detail screen
+        val wcOrderStatusModel = WcOrderTestUtils.generateOrderStatusDetail("Failed")
+        activityTestRule.setOrderDetailWithMockData(WcOrderTestUtils.generateOrderDetail(), wcOrderStatusModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        Espresso.onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // check if order status label is displayed correctly
+        // Check if order status label name, label text color, label background color is displayed correctly
+        onView(withId(R.id.orderStatus_orderTags)).check(
+                matches(WCMatchers.withTagText(wcOrderStatusModel.label))
+        )
+        onView(withId(R.id.orderStatus_orderTags)).check(
+                matches(WCMatchers.withTagTextColor(appContext, R.color.orderStatus_failed_text))
+        )
+        onView(withId(R.id.orderStatus_orderTags)).check(
+                matches(WCMatchers.withTagBackgroundColor(appContext, R.color.orderStatus_failed_bg))
+        )
+    }
+
+    @Test
+    fun verifyOrderDetailNotesCardEmptyView() {
+        // add mock data to order detail screen
+        val wcOrderStatusModel = WcOrderTestUtils.generateOrderDetail()
+        activityTestRule.setOrderDetailWithMockData(wcOrderStatusModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        Espresso.onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // customerNote is empty so Hide Customer Note card
+        onView(withId(R.id.orderDetail_customerNote)).check(
+                matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)))
+    }
+
+    @Test
+    fun verifyOrderDetailNotesCardViewIsDisplayed() {
+        // add mock data to order detail screen
+        val wcOrderStatusModel = WcOrderTestUtils.generateOrderDetail(note = "This is a test note")
+        activityTestRule.setOrderDetailWithMockData(wcOrderStatusModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        Espresso.onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // customerNote is empty so Hide Customer Note card
+        onView(withId(R.id.orderDetail_customerNote)).check(matches(
+                withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderListNavigationTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderListNavigationTest.kt
@@ -1,0 +1,117 @@
+package com.woocommerce.android.ui.orders
+
+import android.support.test.InstrumentationRegistry.getInstrumentation
+import android.support.test.espresso.Espresso
+import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.action.ViewActions
+import android.support.test.espresso.action.ViewActions.click
+import android.support.test.espresso.assertion.ViewAssertions.doesNotExist
+import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.contrib.RecyclerViewActions
+import android.support.test.espresso.matcher.ViewMatchers
+import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
+import android.support.test.espresso.matcher.ViewMatchers.withContentDescription
+import android.support.test.espresso.matcher.ViewMatchers.withId
+import android.support.test.filters.LargeTest
+import android.support.test.runner.AndroidJUnit4
+import android.support.v7.widget.RecyclerView
+import com.woocommerce.android.R
+import com.woocommerce.android.helpers.WCMatchers
+import com.woocommerce.android.ui.TestBase
+import com.woocommerce.android.ui.main.MainActivityTestRule
+import junit.framework.Assert.assertNotSame
+import org.hamcrest.Matchers.equalToIgnoringCase
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.wordpress.android.fluxc.model.SiteModel
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class OrderListNavigationTest : TestBase() {
+    @Rule
+    @JvmField var activityTestRule = MainActivityTestRule()
+
+    @Before
+    override fun setup() {
+        super.setup()
+        // Bypass login screen and display dashboard
+        activityTestRule.launchMainActivityLoggedIn(null, SiteModel())
+
+        // Make sure the bottom navigation view is showing
+        activityTestRule.activity.showBottomNav()
+
+        // Click on Orders tab in the bottom bar
+        Espresso.onView(ViewMatchers.withId(R.id.orders)).perform(ViewActions.click())
+    }
+
+    @Test
+    fun switchToOrderDetailViewFromOrderListView() {
+        // ensure that the recyclerView order list count > 0
+        val recyclerView = activityTestRule.activity.findViewById(R.id.ordersList) as RecyclerView
+        assertNotSame(0, recyclerView.adapter?.itemCount)
+
+        // add mock data to order detail screen
+        activityTestRule.setOrderDetailWithMockData(WcOrderTestUtils.generateOrderDetail())
+
+        // click on the first order in the list and check if redirected to order detail
+        Espresso.onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // Ensure that the toolbar title displays "Order #" + order number
+        onView(withId(R.id.toolbar)).check(matches(WCMatchers.withToolbarTitle(
+                equalToIgnoringCase(appContext.getString(R.string.orderdetail_orderstatus_ordernum, "1")))
+        ))
+
+        // Check that the "UP" navigation button is displayed in the toolbar
+        onView(withContentDescription(R.string.abc_action_bar_up_description)).check(matches(isDisplayed()))
+
+        // Clicking the "up" button in order detail screen returns the user to the orders list screen.
+        // The Toolbar title changes to "Orders"
+        // The "UP" button is no longer shown
+        onView(withContentDescription(R.string.abc_action_bar_up_description)).perform(click())
+        onView(withId(R.id.toolbar)).check(matches(
+                WCMatchers.withToolbarTitle(equalToIgnoringCase(appContext.getString(R.string.orders)))))
+        onView(withContentDescription(getString(R.string.abc_action_bar_up_description))).check(doesNotExist())
+    }
+
+    @Test
+    fun switchBackToDashboardViewFromOrderDetailView() {
+        // ensure that the recyclerView order list count > 0
+        val recyclerView = activityTestRule.activity.findViewById(R.id.ordersList) as RecyclerView
+        assertNotSame(0, recyclerView.adapter?.itemCount)
+
+        // click on the first order in the list and check if redirected to order detail
+        Espresso.onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, ViewActions.click()))
+
+        // Clicking the "Dashboard" bottom bar option loads the DashboardFragment,
+        // then clicking the "Orders" bottom bar option loads the OrderListFragment (so the detail view should no longer be visible)
+        onView(withId(R.id.dashboard)).perform(click())
+        onView(withId(R.id.orders)).perform(click())
+        onView(withId(R.id.toolbar)).check(matches(
+                WCMatchers.withToolbarTitle(equalToIgnoringCase(appContext.getString(R.string.orders)))))
+    }
+
+    @Test
+    fun switchBackToOrderListViewFromOrderDetailView() {
+        // ensure that the recyclerView order list count > 0
+        val recyclerView = activityTestRule.activity.findViewById(R.id.ordersList) as RecyclerView
+        assertNotSame(0, recyclerView.adapter?.itemCount)
+
+        // click on the first order in the list and check if redirected to order detail
+        Espresso.onView(ViewMatchers.withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, ViewActions.click()))
+
+        // Clicking the "Orders" bottom bar option loads the OrderListFragment and
+        // Changes the Toolbar title to "Orders"
+        onView(withId(R.id.orders)).perform(click())
+        onView(withId(R.id.toolbar)).check(matches(
+                WCMatchers.withToolbarTitle(equalToIgnoringCase(appContext.getString(R.string.orders)))))
+    }
+
+    private fun getString(resId: Int): String {
+        return getInstrumentation().targetContext.getString(resId)
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/WcOrderTestUtils.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/WcOrderTestUtils.kt
@@ -88,13 +88,33 @@ object WcOrderTestUtils {
     /**
      * Generates a single [WCOrderModel] object for Order detail screen.
      */
-    fun generateOrderDetail(dateCreatedString: String = "", note: String = ""): WCOrderModel {
+    fun generateOrderDetail(
+        dateCreatedString: String = "",
+        note: String = "",
+        billingAddress1: String = "",
+        billingCountry: String = "",
+        billingPostalCode: String = "",
+        shippingFirstName: String = "",
+        shippingLastName: String = "",
+        shippingAddress1: String = "",
+        shippingCountry: String = "",
+        billingPhone: String = ""
+    ): WCOrderModel {
         return WCOrderModel(2).apply {
             billingFirstName = "Jane"
             billingLastName = "Masterson"
+            this.billingAddress1 = billingAddress1
+            this.billingCountry = billingCountry
             currency = "USD"
             dateCreated = dateCreatedString
             localSiteId = 1
+            this.shippingFirstName = shippingFirstName
+            this.shippingLastName = shippingLastName
+            this.shippingAddress1 = shippingAddress1
+            this.shippingCountry = shippingCountry
+            this.billingPostcode = billingPostalCode
+            billingEmail = "test@testing.com"
+            this.billingPhone = billingPhone
             number = "1"
             status = "pending"
             total = "106.00"

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/WcOrderTestUtils.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/WcOrderTestUtils.kt
@@ -1,0 +1,114 @@
+package com.woocommerce.android.ui.orders
+
+import org.wordpress.android.fluxc.model.WCOrderModel
+import org.wordpress.android.fluxc.model.WCOrderStatusModel
+
+object WcOrderTestUtils {
+    /**
+     * Generates an array containing multiple [WCOrderModel] objects.
+     */
+    fun generateOrders(): List<WCOrderModel> {
+        val result = ArrayList<WCOrderModel>()
+        val om1 = WCOrderModel(1).apply {
+            billingFirstName = "John"
+            billingLastName = "Peters"
+            currency = "USD"
+            dateCreated = "2018-01-05T05:14:30Z"
+            localSiteId = 1
+            number = "1"
+            status = "processing"
+            total = "14.53"
+        }
+
+        val om2 = WCOrderModel(2).apply {
+            billingFirstName = "Jane"
+            billingLastName = "Masterson"
+            currency = "CAD"
+            dateCreated = "2017-12-08T16:11:13Z"
+            localSiteId = 1
+            number = "63"
+            status = "pending"
+            total = "106.00"
+        }
+
+        val om3 = WCOrderModel(2).apply {
+            billingFirstName = "Mandy"
+            billingLastName = "Sykes"
+            currency = "USD"
+            dateCreated = "2018-02-05T16:11:13Z"
+            localSiteId = 1
+            number = "14"
+            status = "processing"
+            total = "25.73"
+        }
+
+        val om4 = WCOrderModel(2).apply {
+            billingFirstName = "Jennifer"
+            billingLastName = "Johnson"
+            currency = "CAD"
+            dateCreated = "2018-02-06T09:11:13Z"
+            localSiteId = 1
+            number = "15"
+            status = "pending, on-hold, complete"
+            total = "106.00"
+        }
+
+        val om5 = WCOrderModel(2).apply {
+            billingFirstName = "Christopher"
+            billingLastName = "Jones"
+            currency = "USD"
+            dateCreated = "2018-02-05T16:11:13Z"
+            localSiteId = 1
+            number = "3"
+            status = "pending"
+            total = "106.00"
+        }
+
+        val om6 = WCOrderModel(2).apply {
+            billingFirstName = "Carissa"
+            billingLastName = "King"
+            currency = "USD"
+            dateCreated = "2018-02-02T16:11:13Z"
+            localSiteId = 1
+            number = "55"
+            status = "pending, Custom 1,Custom 2,Custom 3"
+            total = "106.00"
+        }
+
+        result.add(om1)
+        result.add(om2)
+        result.add(om3)
+        result.add(om4)
+        result.add(om5)
+        result.add(om6)
+
+        return result
+    }
+
+    /**
+     * Generates a single [WCOrderModel] object for Order detail screen.
+     */
+    fun generateOrderDetail(dateCreatedString: String = "", note: String = ""): WCOrderModel {
+        return WCOrderModel(2).apply {
+            billingFirstName = "Jane"
+            billingLastName = "Masterson"
+            currency = "USD"
+            dateCreated = dateCreatedString
+            localSiteId = 1
+            number = "1"
+            status = "pending"
+            total = "106.00"
+            customerNote = note
+        }
+    }
+
+    /**
+     * Generates a single [WCOrderModel] object for Order detail screen.
+     */
+    fun generateOrderStatusDetail(status: String = "Pending"): WCOrderStatusModel {
+        return WCOrderStatusModel(1).apply {
+            label = status
+            statusKey = status
+        }
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/stats/MockedDashboardModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/stats/MockedDashboardModule.kt
@@ -1,0 +1,72 @@
+package com.woocommerce.android.ui.stats
+
+import android.content.Context
+import com.nhaarman.mockito_kotlin.doNothing
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.spy
+import com.nhaarman.mockito_kotlin.whenever
+import com.woocommerce.android.di.ActivityScope
+import com.woocommerce.android.di.FragmentScope
+import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.dashboard.DashboardContract
+import com.woocommerce.android.ui.dashboard.DashboardFragment
+import com.woocommerce.android.ui.dashboard.DashboardPresenter
+import dagger.Module
+import dagger.Provides
+import dagger.android.ContributesAndroidInjector
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooCommerceRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient
+import org.wordpress.android.fluxc.store.WCOrderStore
+import org.wordpress.android.fluxc.store.WCStatsStore
+import org.wordpress.android.fluxc.store.WooCommerceStore
+
+@Module
+abstract class MockedDashboardModule {
+    @Module
+    companion object {
+        @JvmStatic
+        @ActivityScope
+        @Provides
+        fun provideDashboardPresenter(): DashboardContract.Presenter {
+            /**
+             * Creating a spy object here since we need to mock specific methods of [DashboardPresenter] class
+             * instead of mocking all the methods in the class.
+             * We cannot mock final classes ([WCStatsStore], [WCOrderStore], [SelectedSite] and [NetworkStatus]), so
+             * creating a mock instance of those classes and passing to the presenter class constructor.
+             */
+            val mockDispatcher = mock<Dispatcher>()
+            val mockContext = mock<Context>()
+            val mockedDashboardPresenter = spy(DashboardPresenter(
+                    mockDispatcher,
+                    WooCommerceStore(
+                            mockContext,
+                            mockDispatcher,
+                            WooCommerceRestClient(mockContext, mockDispatcher, mock(), mock(), mock())
+                    ),
+                    WCStatsStore(
+                            mockDispatcher,
+                            OrderStatsRestClient(mockContext, mockDispatcher, mock(), mock(), mock())
+                    ),
+                    WCOrderStore(mockDispatcher, OrderRestClient(mockContext, mockDispatcher, mock(), mock(), mock())),
+                    SelectedSite(mockContext, mock()),
+                    NetworkStatus(mockContext)
+            ))
+
+            /**
+             * Mocking the below methods in [DashboardPresenter] class to pass mock values.
+             * These are the methods that invoke [WCStatsStore] methods from FluxC
+             */
+            doNothing().whenever(mockedDashboardPresenter).fetchHasOrders()
+//            doReturn(any()).whenever(mockedDashboardPresenter).getStatsCurrency()
+//            doReturn(orders).whenever(mockedDashboardPresenter).loadStats(DAYS, false)
+            return mockedDashboardPresenter
+        }
+    }
+
+    @FragmentScope
+    @ContributesAndroidInjector
+    abstract fun dashboardFragment(): DashboardFragment
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardPresenter.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.dashboard
 
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.network.ConnectionChangeReceiver
 import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
 import com.woocommerce.android.tools.NetworkStatus
@@ -33,6 +34,7 @@ import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
+@OpenClassOnDebug
 class DashboardPresenter @Inject constructor(
     private val dispatcher: Dispatcher,
     private val wooCommerceStore: WooCommerceStore, // Required to ensure the WooCommerceStore is initialized!

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailContract.kt
@@ -16,6 +16,7 @@ interface OrderDetailContract {
         var isUsingCachedNotes: Boolean
         var isUsingCachedShipmentTrackings: Boolean
         fun fetchOrder(remoteOrderId: Long)
+        fun loadOrderDetailFromDb(orderIdentifier: OrderIdentifier): WCOrderModel?
         fun loadOrderDetail(orderIdentifier: OrderIdentifier, markComplete: Boolean)
         fun loadOrderNotes()
         fun loadOrderShipmentTrackings()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_NOTE_ADD
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_NOTE_ADD_FAILED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_NOTE_ADD_SUCCESS
+import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.network.ConnectionChangeReceiver
 import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
 import com.woocommerce.android.push.NotificationHandler
@@ -47,6 +48,7 @@ import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
 import javax.inject.Inject
 
+@OpenClassOnDebug
 class OrderDetailPresenter @Inject constructor(
     private val dispatcher: Dispatcher,
     private val orderStore: WCOrderStore,
@@ -84,10 +86,20 @@ class OrderDetailPresenter @Inject constructor(
         ConnectionChangeReceiver.getEventBus().unregister(this)
     }
 
+    /**
+     * Loading order detail from local database
+     */
+    override fun loadOrderDetailFromDb(orderIdentifier: OrderIdentifier): WCOrderModel? {
+        return orderStore.getOrderByIdentifier(orderIdentifier)
+    }
+
+    /**
+     * displaying the loaded order detail data in UI
+     */
     override fun loadOrderDetail(orderIdentifier: OrderIdentifier, markComplete: Boolean) {
         this.orderIdentifier = orderIdentifier
         if (orderIdentifier.isNotEmpty()) {
-            orderModel = orderStore.getOrderByIdentifier(orderIdentifier)
+            orderModel = loadOrderDetailFromDb(orderIdentifier)
             orderModel?.let { order ->
                 orderView?.showOrderDetail(order)
                 if (markComplete) orderView?.showChangeOrderStatusSnackbar(CoreOrderStatus.COMPLETED.value)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListContract.kt
@@ -11,7 +11,9 @@ interface OrderListContract {
         fun loadMoreOrders(orderStatusFilter: String? = null)
         fun canLoadMoreOrders(): Boolean
         fun isLoadingOrders(): Boolean
+        fun isOrderStatusOptionsRefreshing(): Boolean
         fun openOrderDetail(order: WCOrderModel)
+        fun fetchOrdersFromDb(orderStatusFilter: String? = null, isForceRefresh: Boolean): List<WCOrderModel>
         fun fetchAndLoadOrdersFromDb(orderStatusFilter: String? = null, isForceRefresh: Boolean)
         fun searchOrders(searchQuery: String)
         fun searchMoreOrders(searchQuery: String)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListPresenter.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders
 
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.network.ConnectionChangeReceiver
 import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
 import com.woocommerce.android.tools.NetworkStatus
@@ -27,6 +28,7 @@ import org.wordpress.android.util.DateTimeUtils
 import java.util.Date
 import javax.inject.Inject
 
+@OpenClassOnDebug
 class OrderListPresenter @Inject constructor(
     private val dispatcher: Dispatcher,
     private val orderStore: WCOrderStore,
@@ -115,6 +117,10 @@ class OrderListPresenter @Inject constructor(
         return orderListState != OrderListState.IDLE
     }
 
+    override fun isOrderStatusOptionsRefreshing(): Boolean {
+        return isRefreshingOrderStatusOptions
+    }
+
     override fun canLoadMoreOrders(): Boolean {
         orderView?.let {
             if (it.isSearching) return canSearchMore
@@ -134,7 +140,7 @@ class OrderListPresenter @Inject constructor(
 
     override fun refreshOrderStatusOptions() {
         // Refresh the order status options from the API
-        if (!isRefreshingOrderStatusOptions) {
+        if (!isOrderStatusOptionsRefreshing()) {
             isRefreshingOrderStatusOptions = true
             dispatcher.dispatch(
                     WCOrderActionBuilder
@@ -236,10 +242,20 @@ class OrderListPresenter @Inject constructor(
      * @param orderStatusFilter If not null, only pull orders whose status matches this filter. Default null.
      * @param isForceRefresh True if orders were refreshed from the API, else false.
      */
-    override fun fetchAndLoadOrdersFromDb(orderStatusFilter: String?, isForceRefresh: Boolean) {
-        val orders = orderStatusFilter?.let {
+    override fun fetchOrdersFromDb(orderStatusFilter: String?, isForceRefresh: Boolean): List<WCOrderModel> {
+        return orderStatusFilter?.let {
             orderStore.getOrdersForSite(selectedSite.get(), it)
         } ?: orderStore.getOrdersForSite(selectedSite.get())
+    }
+
+    /**
+     * Load orders from the local database and display it in UI.
+     *
+     * @param orderStatusFilter If not null, only pull orders whose status matches this filter. Default null.
+     * @param isForceRefresh True if orders were refreshed from the API, else false.
+     */
+    override fun fetchAndLoadOrdersFromDb(orderStatusFilter: String?, isForceRefresh: Boolean) {
+        val orders = fetchOrdersFromDb(orderStatusFilter, isForceRefresh)
         orderView?.let { view ->
             val currentOrders = removeFutureOrders(orders)
             if (currentOrders.count() > 0) {


### PR DESCRIPTION
Fixes #179. This is PR number 3 for UI test and focuses on:

### Populating the Form
- [x] verify that customer info card labels are displayed correctly
- [x] Populating customer name, shipping address, shipping country
- [x] if `hasSeparateShippingDetails()` then billing address should be different from shipping address
- [x] Address formatting for different locales
- [x] Verify that billing email address is displayed correctly
- [x] Verify that billing phone is displayed correctly, if available. 
- [x] Handle empty billing phone number
- [x] Billing phone formatting for different locales

### Expand/Minimize View
- [x] `onLoad` - view is condensed and VIEW MORE button is visible
- [x] When VIEW MORE is clicked: expand to full view and label change to VIEW LESS
- [x] When VIEW LESS is clicked: condense view and label changes to VIEW MORE

### Action Buttons
- [x] email customer when intent is present
- [x] email customer when no activity is available to handle intent
- [x] Verify that popup is displayed with Call/Message items displayed
- [x] Verify that when `Call` item is clicked in popup menu, an intent to dial the number is called.
- [x] Verify that when `Message` item is clicked in popup menu, an intent to sms is called.

### To Test:
- [x] Run `OrderDetailCustomerInfoCardTest`