### PR TITLE
Issue/993 move up fabric initialization

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -106,9 +106,10 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
             VolleyLog.DEBUG = false
         }
 
-        // we init Crashlytics further down using the selected site and account, but we also want to init it here
+        // We init Crashlytics further down using the selected site and account, but we also want to init it here
         // to catch crashes that may occur before we can access the site and account (most notably crashes with
-        // initializing WellSql)
+        // initializing WellSql). In order to do this, we must first init AppPrefs since Crashlytics uses it.
+        AppPrefs.init(this)
         CrashlyticsUtils.initCrashlytics(this, null, null)
 
         val wellSqlConfig = WooWellSqlConfig(applicationContext)
@@ -117,7 +118,6 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
         component.inject(this)
         dispatcher.register(this)
 
-        AppPrefs.init(this)
         AppRatingDialog.init(this)
 
         initAnalytics()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -106,6 +106,11 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
             VolleyLog.DEBUG = false
         }
 
+        // we init Crashlytics further down using the selected site and account, but we also want to init it here
+        // to catch crashes that may occur before we can access the site and account (most notably crashes with
+        // initializing WellSql)
+        CrashlyticsUtils.initCrashlytics(this, null, null)
+
         val wellSqlConfig = WooWellSqlConfig(applicationContext)
         WellSql.init(wellSqlConfig)
 


### PR DESCRIPTION
Resolves #993 by initializing Fabric prior to initializing WellSql. This is done so we can capture WellSql crashes at startup, before we're able to access the account and selected site.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
