### PR TITLE
Add scripts to use Android App Bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 bin/
 gen/
 out/
+artifacts/
 
 # Gradle files
 .gradle/

--- a/tools/build-app-bundle.sh
+++ b/tools/build-app-bundle.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+# Check for bundletool
+command -v bundletool > /dev/null || { echo "bundletool is required to build the APKs. Install it with 'brew install bundletool'" >&2; exit 1; }
+
+# Exit if any command fails
+set -eu
+
+# Load the Gradle helper functions
+source "./tools/gradle-functions.sh"
+
+function extract_universal_apk {
+  app_bundle="$1"
+  apk_output="$2"
+  tmp_dir=$(mktemp -d)
+
+  echo "Extracting universal APK..." | tee -a $LOGFILE
+  bundletool build-apks --bundle="$app_bundle" \
+                        --output="$tmp_dir/universal.apks" \
+                        --mode=universal \
+                        --ks="$(get_gradle_property gradle.properties storeFile)" \
+                        --ks-pass="pass:$(get_gradle_property gradle.properties storePassword)" \
+                        --ks-key-alias="$(get_gradle_property gradle.properties keyAlias)" \
+                        --key-pass="pass:$(get_gradle_property gradle.properties keyPassword)" >> $LOGFILE 2>&1
+  
+  unzip "$tmp_dir/universal.apks" -d "$tmp_dir"  >> $LOGFILE 2>&1
+  cp "$tmp_dir/universal.apk" "$apk_output" | tee -a $LOGFILE
+}
+
+OUTPUT_DIR="artifacts"
+LOGFILE="$OUTPUT_DIR/build.log"
+
+mkdir -p "$OUTPUT_DIR" && > "$LOGFILE"
+
+# Print the logs on failure
+function cleanup {
+  cat "$LOGFILE"
+}
+trap cleanup ERR
+
+FLAVOR="Vanilla"
+AAB_PATH="WooCommerce/build/outputs/bundle/"$FLAVOR"Release/WooCommerce.aab"
+
+VERSION_NAME=$(gradle_version_name "WooCommerce/build.gradle")
+VERSION_CODE=$(gradle_version_code "WooCommerce/build.gradle")
+AAB_NAME="wcandroid-$VERSION_NAME.aab"
+APK_NAME="wcandroid-$VERSION_NAME-universal.apk"
+
+echo "Cleaning $VERSION_NAME / $VERSION_CODE ..." | tee -a $LOGFILE
+./gradlew clean >> $LOGFILE 2>&1
+echo "Linting $VERSION_NAME / $VERSION_CODE ..." | tee -a $LOGFILE
+./gradlew lint"$FLAVOR"Release >> $LOGFILE 2>&1
+echo "Building $VERSION_NAME / $VERSION_CODE ..." | tee -a $LOGFILE
+./gradlew bundle"$FLAVOR"Release >> $LOGFILE 2>&1
+cp -v "$AAB_PATH" "$OUTPUT_DIR/$AAB_NAME" | tee -a $LOGFILE
+echo "Bundle ready: $AAB_NAME" | tee -a $LOGFILE
+extract_universal_apk "$OUTPUT_DIR/$AAB_NAME" "$OUTPUT_DIR/$APK_NAME"

--- a/tools/gradle-functions.sh
+++ b/tools/gradle-functions.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# This script defines some shared functions that are used by the app bundles scipts.
+
+function get_gradle_property {
+  GRADLE_PROPERTIES=$1
+  PROP_KEY=$2
+  PROP_VALUE=`cat "$GRADLE_PROPERTIES" | grep "$PROP_KEY" | cut -d'=' -f2`
+  echo $PROP_VALUE
+}
+
+function gradle_version_name {
+  BUILDFILE=$1
+  grep -E 'versionName' $BUILDFILE | sed s/versionName// | grep -Eo "[a-zA-Z0-9.-]+"
+}
+
+function gradle_version_code {
+  BUILDFILE=$1
+  grep -E 'versionCode' $BUILDFILE | sed s/versionCode// | grep -Eo "[a-zA-Z0-9.-]+"
+}

--- a/tools/install-app-bundle.sh
+++ b/tools/install-app-bundle.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# This script installs an Android App Bundle (.aab) file on a device or emulator, using the code signing from gradle.properties
+
+# Check for bundletool
+command -v bundletool > /dev/null || { echo "bundletool is required to build the APKs. Install it with 'brew install bundletool'" >&2; exit 1; }
+
+# Exit if any command fails
+set -eu
+
+# Load the Gradle helper functions
+source "./tools/gradle-functions.sh"
+
+APP_BUNDLE="$1"
+TMP_DIR=$(mktemp -d)
+
+echo "Generating APKs..."
+bundletool build-apks --bundle="$APP_BUNDLE" \
+                      --output="$TMP_DIR/output.apks" \
+                      --ks="$(get_gradle_property gradle.properties storeFile)" \
+                      --ks-pass="pass:$(get_gradle_property gradle.properties storePassword)" \
+                      --ks-key-alias="$(get_gradle_property gradle.properties keyAlias)" \
+                      --key-pass="pass:$(get_gradle_property gradle.properties keyPassword)"
+echo "Installing..."
+bundletool install-apks --apks="$TMP_DIR/output.apks"


### PR DESCRIPTION
This adds two scripts script, `tools/build-app-bundle.sh` and `tools/install-app-bundle.sh` which makes it easier to build and test Android App Bundle (.aab) files.

The scripts are simplified versions of the ones in WPAndroid. We should think about sharing these at some point.

Related to https://github.com/wordpress-mobile/WordPress-Android/pull/9734.

To test:

- Build an Android App Bundle: `./tools/build-app-bundle.sh`. This will prompt you to install `bundletool` if you don't have it installed.
- Install it in a device or emulator: `./tools/install-app-bundle.sh artifacts/wcandroid-1.8-rc-1.aab`. 
- Check that it works correctly (particularly Google login).
- Install the APK: `adb install artifacts/wcandroid-1.8-rc-1-universal.apk`.
- Check that it works correctly (particularly Google login).

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
