### PR TITLE
Fix dashboard title not changing when stats tab is reselected the first time

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
@@ -125,33 +125,19 @@ class MainNavigationView @JvmOverloads constructor(
         // Close any child fragments if open
         clearFragmentBackStack(fragment)
 
-        // add the fragment if it hasn't been added yet, otherwise hide the previously active
-        // fragment and show the incoming one
+        // hide previous fragment if it exists
+        val fragmentTransaction = fragmentManager.beginTransaction()
+        previousNavPos?.let { fragmentTransaction.hide(navAdapter.getFragment(it)) }
+
+        // add the fragment if it hasn't been added yet, otherwise show the new fragment
         val tag = navPos.getTag()
         if (fragmentManager.findFragmentByTag(tag) == null) {
-            val fragmentTransaction = fragmentManager.beginTransaction()
-            previousNavPos?.let { fragmentTransaction.hide(navAdapter.getFragment(it)) }
-            fragmentTransaction
-                    .add(R.id.container, fragment, tag)
-                    .commitAllowingStateLoss()
+            fragmentTransaction.add(R.id.container, fragment, tag)
         } else {
-            val shouldHidePrev = previousNavPos?.let {
-                it.position != navPos.position
-            } ?: false
-            if (shouldHidePrev) {
-                val prevFragment = navAdapter.getFragment(previousNavPos!!)
-                fragmentManager
-                        .beginTransaction()
-                        .hide(prevFragment)
-                        .show(fragment)
-                        .commitAllowingStateLoss()
-            } else {
-                fragmentManager
-                        .beginTransaction()
-                        .show(fragment)
-                        .commitAllowingStateLoss()
-            }
+            fragmentTransaction.show(fragment)
         }
+
+        fragmentTransaction.commitAllowingStateLoss()
 
         previousNavPos = navPos
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
@@ -129,8 +129,9 @@ class MainNavigationView @JvmOverloads constructor(
         // fragment and show the incoming one
         val tag = navPos.getTag()
         if (fragmentManager.findFragmentByTag(tag) == null) {
-            fragmentManager
-                    .beginTransaction()
+            val fragmentTransaction = fragmentManager.beginTransaction()
+            previousNavPos?.let { fragmentTransaction.hide(navAdapter.getFragment(it)) }
+            fragmentTransaction
                     .add(R.id.container, fragment, tag)
                     .commitAllowingStateLoss()
         } else {


### PR DESCRIPTION
Fixes #1030. The dashboard stats tab when re-selected for the first time (i.e. select another tab and then click on `My Store` tab again), the toolbar title does not change. 

This PR adds logic to hide a previously added fragment, if available, before adding a new fragment. This ensures that the fragment's `onHiddenChanged(hidden: Boolean)` method will be correctly called.

### Behaviour before the fix:
<img src="https://user-images.githubusercontent.com/22608780/56941909-2e8de280-6b35-11e9-82f9-dad736d04773.gif" width="350"/>

### Behaviour after the fix:
<img src="https://user-images.githubusercontent.com/22608780/56942240-2afb5b00-6b37-11e9-8f9d-57339f4b7584.gif" width="350"/>