### PR TITLE
Added ui tests for navigating to settings & help page

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockedActivityBindingModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockedActivityBindingModule.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.di
 
+import com.woocommerce.android.support.HelpActivity
+import com.woocommerce.android.support.HelpModule
 import com.woocommerce.android.ui.dashboard.DashboardModule
 import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.MagicLinkInterceptActivity
@@ -11,6 +13,10 @@ import com.woocommerce.android.ui.orders.OrderDetailModule
 import com.woocommerce.android.ui.orders.OrderFulfillmentModule
 import com.woocommerce.android.ui.orders.OrderListModule
 import com.woocommerce.android.ui.orders.OrderProductListModule
+import com.woocommerce.android.ui.prefs.AppSettingsActivity
+import com.woocommerce.android.ui.prefs.AppSettingsModule
+import com.woocommerce.android.ui.prefs.MainSettingsModule
+import com.woocommerce.android.ui.prefs.PrivacySettingsModule
 import com.woocommerce.android.ui.sitepicker.SitePickerActivity
 import com.woocommerce.android.ui.sitepicker.SitePickerModule
 import dagger.Module
@@ -20,26 +26,39 @@ import org.wordpress.android.login.di.LoginFragmentModule
 @Module
 abstract class MockedActivityBindingModule {
     @ActivityScope
-    @ContributesAndroidInjector(modules = arrayOf(
-            MockedMainModule::class,
-            DashboardModule::class,
-            OrderListModule::class,
-            OrderDetailModule::class,
-            OrderProductListModule::class,
-            OrderFulfillmentModule::class,
-            NotifsListModule::class,
-            ReviewDetailModule::class))
+    @ContributesAndroidInjector(modules = [
+        MockedMainModule::class,
+        DashboardModule::class,
+        OrderListModule::class,
+        OrderDetailModule::class,
+        OrderProductListModule::class,
+        OrderFulfillmentModule::class,
+        NotifsListModule::class,
+        ReviewDetailModule::class
+    ])
     abstract fun provideMainActivityInjector(): MainActivity
 
     @ActivityScope
-    @ContributesAndroidInjector(modules = arrayOf(LoginFragmentModule::class))
+    @ContributesAndroidInjector(modules = [LoginFragmentModule::class])
     abstract fun provideLoginActivityInjector(): LoginActivity
 
     @ActivityScope
-    @ContributesAndroidInjector(modules = arrayOf(SitePickerModule::class))
+    @ContributesAndroidInjector(modules = [SitePickerModule::class])
     abstract fun provideSitePickerActivityInjector(): SitePickerActivity
 
     @ActivityScope
     @ContributesAndroidInjector
     abstract fun provideMagicLinkInterceptActivityInjector(): MagicLinkInterceptActivity
+
+    @ActivityScope
+    @ContributesAndroidInjector(modules = [
+        AppSettingsModule::class,
+        MainSettingsModule::class,
+        PrivacySettingsModule::class
+    ])
+    abstract fun provideAppSettingsActivityInjector(): AppSettingsActivity
+
+    @ActivityScope
+    @ContributesAndroidInjector(modules = [HelpModule::class])
+    abstract fun provideHelpActivity(): HelpActivity
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/helpers/WCMatchers.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/helpers/WCMatchers.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.helpers
 import android.support.test.espresso.matcher.BoundedMatcher
 import android.support.v7.widget.Toolbar
 import android.view.View
+import android.widget.ListView
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 
@@ -20,6 +21,19 @@ object WCMatchers {
             override fun describeTo(description: Description) {
                 description.appendText("with toolbar title: ")
                 textMatcher.describeTo(description)
+            }
+        }
+    }
+
+    fun correctNumberOfItems(itemsCount: Int): Matcher<View> {
+        return object : BoundedMatcher<View, ListView>(ListView::class.java) {
+            override fun describeTo(description: Description) {
+                description.appendText("with number of items: $itemsCount")
+            }
+
+            override fun matchesSafely(listView: ListView): Boolean {
+                val adapter = listView.adapter
+                return adapter.count == itemsCount
             }
         }
     }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/helpers/WCMatchers.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/helpers/WCMatchers.kt
@@ -25,7 +25,11 @@ object WCMatchers {
         }
     }
 
-    fun correctNumberOfItems(itemsCount: Int): Matcher<View> {
+    /**
+     * Matcher to check if the listView count matches
+     * the incoming count value
+     */
+    fun withItemCount(itemsCount: Int): Matcher<View> {
         return object : BoundedMatcher<View, ListView>(ListView::class.java) {
             override fun describeTo(description: Description) {
                 description.appendText("with number of items: $itemsCount")

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/MainNavigationTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/MainNavigationTest.kt
@@ -1,14 +1,22 @@
 package com.woocommerce.android.ui.main
 
 import android.support.design.widget.BottomNavigationView
+import android.support.test.InstrumentationRegistry
 import android.support.test.espresso.Espresso
 import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu
 import android.support.test.espresso.NoActivityResumedException
 import android.support.test.espresso.action.ViewActions.click
+import android.support.test.espresso.assertion.ViewAssertions.doesNotExist
 import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.matcher.ViewMatchers.isAssignableFrom
+import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
+import android.support.test.espresso.matcher.ViewMatchers.withContentDescription
 import android.support.test.espresso.matcher.ViewMatchers.withId
+import android.support.test.espresso.matcher.ViewMatchers.withText
 import android.support.test.filters.LargeTest
 import android.support.test.runner.AndroidJUnit4
+import android.widget.ListView
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.TestBase
 import org.junit.Assert.fail
@@ -106,6 +114,66 @@ class MainNavigationTest : TestBase() {
         // Verify the toolbar title has changed to 'My Store'
         onView(withId(R.id.toolbar)).check(matches(
                 WCMatchers.withToolbarTitle(equalToIgnoringCase(appContext.getString(R.string.my_store)))))
+    }
+
+    @Test
+    fun verifyOverFlowMenuAndSettingsIsDisplayed() {
+        // Open the overflow menu OR open the options menu,
+        // depending on if the device has a hardware or software overflow menu button.
+        openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext())
+
+        // verify that there are 2 items in the menu list
+        onView(isAssignableFrom(ListView::class.java))
+                .check(matches(WCMatchers.correctNumberOfItems(2)))
+
+        // verify that the menu is displayed & the first item in the list is Settings
+        onView(withText(appContext.getString(R.string.settings))).check(matches(isDisplayed()))
+
+        // verify that when first item is clicked, it opens settings
+        // by checking if the toolbar title is changed to Settings
+        // by checking if the UP indicator is visible
+        onView(withText(appContext.getString(R.string.settings))).perform(click())
+        onView(withId(R.id.toolbar)).check(matches(
+                WCMatchers.withToolbarTitle(equalToIgnoringCase(appContext.getString(R.string.settings)))))
+        onView(withContentDescription(R.string.abc_action_bar_up_description)).check(matches(isDisplayed()))
+
+
+        // click back button and verify that the toolbar title is changed
+        // up button is no longer visible
+        onView(withContentDescription(R.string.abc_action_bar_up_description)).perform(click())
+        onView(withId(R.id.toolbar)).check(matches(
+                WCMatchers.withToolbarTitle(equalToIgnoringCase(appContext.getString(R.string.my_store)))))
+        onView(withContentDescription(appContext.getString(R.string.abc_action_bar_up_description))).check(doesNotExist())
+    }
+
+    @Test
+    fun verifyOverFlowMenuAndHelpIsDisplayed() {
+        // Open the overflow menu OR open the options menu,
+        // depending on if the device has a hardware or software overflow menu button.
+        openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext())
+
+        // verify that there are 2 items in the menu list
+        onView(isAssignableFrom(ListView::class.java))
+                .check(matches(WCMatchers.correctNumberOfItems(2)))
+
+        // verify that the menu is displayed & the second item in the list is Help
+        onView(withText(appContext.getString(R.string.support_help))).check(matches(isDisplayed()))
+
+        // verify that when first item is clicked, it opens Help & Support
+        // by checking if the toolbar title is changed to Help & Support
+        // by checking if the UP indicator is visible
+        onView(withText(appContext.getString(R.string.support_help))).perform(click())
+        onView(withId(R.id.toolbar)).check(matches(
+                WCMatchers.withToolbarTitle(equalToIgnoringCase(appContext.getString(R.string.support_help)))))
+        onView(withContentDescription(R.string.abc_action_bar_up_description)).check(matches(isDisplayed()))
+
+
+        // click back button and verify that the toolbar title is changed
+        // up button is no longer visible
+        onView(withContentDescription(R.string.abc_action_bar_up_description)).perform(click())
+        onView(withId(R.id.toolbar)).check(matches(
+                WCMatchers.withToolbarTitle(equalToIgnoringCase(appContext.getString(R.string.my_store)))))
+        onView(withContentDescription(appContext.getString(R.string.abc_action_bar_up_description))).check(doesNotExist())
     }
 
     private fun assertPressingBackExitsApp() {

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/MainNavigationTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/MainNavigationTest.kt
@@ -124,7 +124,7 @@ class MainNavigationTest : TestBase() {
 
         // verify that there are 2 items in the menu list
         onView(isAssignableFrom(ListView::class.java))
-                .check(matches(WCMatchers.correctNumberOfItems(2)))
+                .check(matches(WCMatchers.withItemCount(2)))
 
         // verify that the menu is displayed & the first item in the list is Settings
         onView(withText(appContext.getString(R.string.settings))).check(matches(isDisplayed()))
@@ -155,7 +155,7 @@ class MainNavigationTest : TestBase() {
 
         // verify that there are 2 items in the menu list
         onView(isAssignableFrom(ListView::class.java))
-                .check(matches(WCMatchers.correctNumberOfItems(2)))
+                .check(matches(WCMatchers.withItemCount(2)))
 
         // verify that the menu is displayed & the second item in the list is Help
         onView(withText(appContext.getString(R.string.support_help))).check(matches(isDisplayed()))

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/MainNavigationTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/MainNavigationTest.kt
@@ -137,13 +137,14 @@ class MainNavigationTest : TestBase() {
                 WCMatchers.withToolbarTitle(equalToIgnoringCase(appContext.getString(R.string.settings)))))
         onView(withContentDescription(R.string.abc_action_bar_up_description)).check(matches(isDisplayed()))
 
-
         // click back button and verify that the toolbar title is changed
         // up button is no longer visible
         onView(withContentDescription(R.string.abc_action_bar_up_description)).perform(click())
         onView(withId(R.id.toolbar)).check(matches(
                 WCMatchers.withToolbarTitle(equalToIgnoringCase(appContext.getString(R.string.my_store)))))
-        onView(withContentDescription(appContext.getString(R.string.abc_action_bar_up_description))).check(doesNotExist())
+        onView(withContentDescription(
+                appContext.getString(R.string.abc_action_bar_up_description))
+        ).check(doesNotExist())
     }
 
     @Test
@@ -167,13 +168,14 @@ class MainNavigationTest : TestBase() {
                 WCMatchers.withToolbarTitle(equalToIgnoringCase(appContext.getString(R.string.support_help)))))
         onView(withContentDescription(R.string.abc_action_bar_up_description)).check(matches(isDisplayed()))
 
-
         // click back button and verify that the toolbar title is changed
         // up button is no longer visible
         onView(withContentDescription(R.string.abc_action_bar_up_description)).perform(click())
         onView(withId(R.id.toolbar)).check(matches(
                 WCMatchers.withToolbarTitle(equalToIgnoringCase(appContext.getString(R.string.my_store)))))
-        onView(withContentDescription(appContext.getString(R.string.abc_action_bar_up_description))).check(doesNotExist())
+        onView(withContentDescription(
+                appContext.getString(R.string.abc_action_bar_up_description))
+        ).check(doesNotExist())
     }
 
     private fun assertPressingBackExitsApp() {


### PR DESCRIPTION
Fixes #1032 

Adds the following UI navigation tests for MainActivity:
- [x] verify that when settings clicked, menu is displayed
- [x] verify there are only 2 items in menu
- [x] verify that when first item is clicked, it opens settings
- [x] verify that when 2nd item is clicked, it opens help screen

### To Test:
- [x] Run MainNavigationTest