### PR TITLE
Fix order list fragment is blank after closing and opening the app

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
@@ -129,14 +129,14 @@ class MainNavigationView @JvmOverloads constructor(
         val fragmentTransaction = fragmentManager.beginTransaction()
         previousNavPos?.let { fragmentTransaction.hide(navAdapter.getFragment(it)) }
 
-        // add the fragment if it hasn't been added yet, otherwise show the new fragment
+        // add the fragment if it hasn't been added yet
         val tag = navPos.getTag()
         if (fragmentManager.findFragmentByTag(tag) == null) {
             fragmentTransaction.add(R.id.container, fragment, tag)
-        } else {
-            fragmentTransaction.show(fragment)
         }
 
+        // show the new fragment
+        fragmentTransaction.show(fragment)
         fragmentTransaction.commitAllowingStateLoss()
 
         previousNavPos = navPos


### PR DESCRIPTION
Fixes #1038 . This issue was introduced when fixing #1030: This [PR](https://github.com/woocommerce/woocommerce-android/pull/1031) added logic to hide a previously added fragment, before adding a new fragment. When app is closed and opened again, the previously added fragment i.e. (`OrdersFragment`) was hidden and when the `Orders` tab is selected again, it was still hidden so the page was blank. 

This PR adds logic to show the newly added fragment. 

### Behaviour after the fix:
<img src="https://user-images.githubusercontent.com/22608780/57009803-7e90a600-6c16-11e9-9b4f-408c125ab6a1.gif" width="350"/>

### Testing
I was able to spot this issue by running all the tests from this [PR](https://github.com/woocommerce/woocommerce-android/pull/1007). 
Aside from this, manual testing included trying to [reproduce the issue](https://github.com/woocommerce/woocommerce-android/issues/1038) when:
* Clicking on app notification when app is in background.
* Enable/Disable `Do not keep activities` and testing the same