### PR TITLE
Added logic to enable drawing markers only when value is selected

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -19,6 +19,8 @@ import com.github.mikephil.charting.data.BarDataSet
 import com.github.mikephil.charting.data.BarEntry
 import com.github.mikephil.charting.data.Entry
 import com.github.mikephil.charting.formatter.IAxisValueFormatter
+import com.github.mikephil.charting.highlight.Highlight
+import com.github.mikephil.charting.listener.OnChartValueSelectedListener
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
@@ -40,7 +42,7 @@ import java.util.ArrayList
 import java.util.Date
 
 class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
-    : LinearLayout(ctx, attrs), RequestMarkerCaptionListener {
+    : LinearLayout(ctx, attrs), RequestMarkerCaptionListener, OnChartValueSelectedListener {
     init {
         View.inflate(context, R.layout.dashboard_stats, this)
     }
@@ -214,7 +216,7 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
             isScaleXEnabled = false
             isScaleYEnabled = false
             isDragEnabled = false
-
+            setOnChartValueSelectedListener(this@DashboardStatsView)
             setNoDataTextColor(ContextCompat.getColor(context, R.color.graph_no_data_text_color))
         }
 
@@ -223,6 +225,19 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
         markerView.captionListener = this
         chart.marker = markerView
     }
+
+    /**
+     * Called when a value has been selected inside the chart.
+     *
+     * @param e The selected Entry
+     * @param h The corresponding highlight object that contains information
+     *          about the highlighted position such as dataSetIndex
+     */
+    override fun onValueSelected(e: Entry?, h: Highlight?) {
+        chart.setDrawMarkers(true)
+    }
+
+    override fun onNothingSelected() {}
 
     /**
      * the chart MarkerView relies on this to know what to display when the user taps a chart bar


### PR DESCRIPTION
Fixes #1048 . This crash is a known issue with MPAndroidChart and is already tracked [here](https://github.com/PhilJay/MPAndroidChart/issues/2917).

I haven't been able to reproduce this issue but this draft PR adds logic a possible fix by adding `.setDrawMarkers(true);` inside `onValueSelected()` rather than on chart creation.

@nbradbury @AmandaRiu, since this issue happened for one user and I haven't been able to reproduce it, not sure if we can go ahead with the fix or wait for more data to reproduce this. Could I trouble you to review this and let me know your thoughts? 