### PR TITLE
Issue/1051-illegal-state-crash-fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
@@ -159,7 +159,7 @@ class MainNavigationView @JvmOverloads constructor(
             with(it.childFragmentManager) {
                 if (backStackEntryCount > 0) {
                     val firstEntry = getBackStackEntryAt(0)
-                    popBackStackImmediate(firstEntry.id, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+                    popBackStack(firstEntry.id, FragmentManager.POP_BACK_STACK_INCLUSIVE)
                     return true
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
@@ -153,7 +153,10 @@ class MainNavigationView @JvmOverloads constructor(
      */
     private fun clearFragmentBackStack(fragment: Fragment?): Boolean {
         fragment?.let {
-            if (!it.isAdded) {
+            /**
+             * if isStateSaved  = true then the fragment is added and its state has already been saved by its host.
+             */
+            if (!it.isAdded || it.isStateSaved) {
                 return false
             }
             with(it.childFragmentManager) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
@@ -159,7 +159,7 @@ class MainNavigationView @JvmOverloads constructor(
             with(it.childFragmentManager) {
                 if (backStackEntryCount > 0) {
                     val firstEntry = getBackStackEntryAt(0)
-                    popBackStack(firstEntry.id, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+                    popBackStackImmediate(firstEntry.id, FragmentManager.POP_BACK_STACK_INCLUSIVE)
                     return true
                 }
             }


### PR DESCRIPTION
Fixes #1051 . 

The previous fix of using `popBackStack()` rather than `popBackStackImmediate` method has already been tried in this [commit](https://github.com/woocommerce/woocommerce-android/commit/cd0df172afcb81ca5e0c9eacad729868f67da7ff). This had no effect in fixing the crash. So modified the PR to check if the fragment state is already saved by calling `isStateSaved` before processing the request. 