### PR TITLE
Issue/1062 sdk v28

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -48,7 +48,7 @@ android {
         versionCode 53
 
         minSdkVersion 21
-        targetSdkVersion 27
+        targetSdkVersion 28
 
         multiDexEnabled true
         vectorDrawables.useSupportLibrary = true

--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -20,6 +20,10 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+
+        <!-- TODO: we eventually want to drop support for Apache, but for now it's used by FluxC -->
+        <uses-library android:name="org.apache.http.legacy" android:required="false"/>
+
         <activity
             android:name=".ui.main.MainActivity"
             android:windowSoftInputMode="adjustResize"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
@@ -17,6 +17,7 @@ import android.preference.PreferenceManager
 import android.support.v4.app.NotificationCompat
 import android.support.v4.app.NotificationManagerCompat
 import android.support.v4.content.ContextCompat
+import com.bumptech.glide.Glide
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -296,10 +297,16 @@ class NotificationHandler @Inject constructor(
             try {
                 val decodedIconUrl = URLDecoder.decode(iconUrl, "UTF-8")
                 val largeIconSize = context.resources.getDimensionPixelSize(
-                        android.R.dimen.notification_large_icon_height)
+                        android.R.dimen.notification_large_icon_height
+                )
                 val resizedUrl = PhotonUtils.getPhotonImageUrl(decodedIconUrl, largeIconSize, largeIconSize)
 
-                val largeIconBitmap = ImageUtils.downloadBitmap(resizedUrl)
+                val largeIconBitmap = Glide.with(context)
+                        .asBitmap()
+                        .load(resizedUrl)
+                        .submit()
+                        .get()
+
                 if (largeIconBitmap != null && shouldCircularizeIcon) {
                     return ImageUtils.getCircularBitmap(largeIconBitmap)
                 }

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -22,7 +22,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 2
         versionName "1.1"
 

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -22,7 +22,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 26
         versionCode 2
         versionName "1.1"
 


### PR DESCRIPTION
Closes #1062 by updating the `targetSdkVersion` to 28. I recommend invalidating caches and restarting before building this.

A couple notes:

* In 370a071 I changed the way we download large notification bitmaps because this relied on a WP utility method which uses Apache HTTP, and support for Apache was dropped in SDK 28.
* Despite the above, in 5feab74 I ended up using Google's workaround for enabling Apache because it turned out to be necessary for FluxC. That can be addressed when we update FluxC to SDK 28.

It would be good to test this on multiple devices & API levels. I did that myself and everything was fine, but you never know on Android!

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
