### PR TITLE
Updated to Glide 4.9.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ ext {
     fluxCVersion = '052ba9fb67eaa6f5b53233e8c9d8db6a26d36205'
     daggerVersion = '2.11'
     supportLibraryVersion = '28.0.0'
-    glideVersion = '4.6.1'
+    glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.0.1'
     mockitoKotlinVersion = '1.5.0'

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -57,8 +57,8 @@ dependencies {
         }
     }
 
-    implementation 'com.github.bumptech.glide:glide:4.6.1'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.6.1'
+    implementation 'com.github.bumptech.glide:glide:4.9.0'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.9.0'
 
     // Dagger
     implementation 'com.google.dagger:dagger:2.11'


### PR DESCRIPTION
Closes #1065 by updating Glide to v4.9.0. This was necessary because the version we were using was incompatible with AndroidX.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
