### PR TITLE
Fix padding on Customer Info Card

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -28,6 +28,7 @@ Bugfixes
 * Fixed rare crash in order detail while loading product images
 * Fixed rare crash when showing order note
 * Fixed a very rare crash when showing the filter menu options button
+* Minor style fixes
 
 Improvements
 * Dashboard no longer reloads every time you return to it

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -42,6 +42,7 @@
             android:layout_height="wrap_content"
             android:textAppearance="@style/Woo.OrderDetail.TextAppearance"
             android:textIsSelectable="true"
+            android:layout_marginBottom="@dimen/card_item_padding_intra_h"
             tools:text="John Vilanzo\n123 Sesame Pl\nWarner, FL\nUnited States"/>
 
 
@@ -50,7 +51,6 @@
             android:id="@+id/customerInfo_morePanel"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingTop="@dimen/card_item_padding_intra_h"
             android:visibility="gone"
             tools:visibility="visible">
 


### PR DESCRIPTION
Fixes #689 by moving the padding in the view so it is still visible even if the billing section of the card is not visible.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
