### PR TITLE
issue/1081-site-picker-out-of-bounds 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -186,6 +186,11 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
     override fun showStoreList(wcSites: List<SiteModel>) {
         progressDialog?.takeIf { it.isShowing }?.dismiss()
 
+        if (wcSites.isEmpty()) {
+            showNoStoresView()
+            return
+        }
+
         no_stores_view.visibility = View.GONE
         site_list_container.visibility = View.VISIBLE
 


### PR DESCRIPTION
Fixes #1081 - Ensure the list of stores isn't empty when showing the store list (and if it is, show the empty view).

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
