### PR TITLE
Only update the title of the fragment if the order list is visible

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -344,7 +344,9 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
         }
 
         // Update the toolbar title
-        activity?.title = getFragmentTitle()
+        if (!isHidden) {
+            activity?.title = getFragmentTitle()
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #1083 by only updating the title of the activity to Orders if the orders list is not hidden. This prevents the change in title after changing tabs while the order list is loading.

## To Test
1. Pull to refresh the order list, then quickly change to a different tab while the list is refreshing.
2. Verify the title of the active fragment does not change to "Orders" once the refresh completes.
