### PR TITLE
Issue/766 top earner inflation exception take2

### DIFF
--- a/WooCommerce/src/main/res/layout/dashboard_top_earners.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_top_earners.xml
@@ -34,8 +34,7 @@
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:layout_height="wrap_content">
 
         <TextView
             android:layout_width="wrap_content"

--- a/WooCommerce/src/main/res/layout/top_earner_list_item.xml
+++ b/WooCommerce/src/main/res/layout/top_earner_list_item.xml
@@ -25,7 +25,7 @@
     </FrameLayout>
 
     <LinearLayout
-        android:id="@+id/product_contaimer"
+        android:id="@+id/product_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
@@ -65,7 +65,7 @@
         android:id="@+id/divider"
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:layout_below="@+id/product_contaimer"
+        android:layout_below="@+id/product_container"
         android:layout_marginStart="@dimen/margin_large"
         android:layout_toEndOf="@+id/frame_product"
         android:background="@color/list_divider"/>

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -65,7 +65,6 @@
     <style name="Woo.TextAppearance" parent="android:TextAppearance.DeviceDefault">
         <item name="android:textColor">@color/default_text_color</item>
         <item name="android:textSize">@dimen/text_medium</item>
-        <item name="android:fontFamily">@font/roboto</item>
     </style>
 
     <style name="Woo.TextAppearance.Bold">


### PR DESCRIPTION
Closes #766 (hopefully) - This is my second attempt at fixing this issue, which is an `InflateException` that occurs when inflating a TextView in the top earner view. The crash log shows that exception is being caused by an `ArrayOutOfBoundsException`, which [this SO post](https://stackoverflow.com/questions/20997090/textview-styles-arrayindexoutofboundsexception) suggests is due to the theme using a `fontFamily` that doesn't exist.

We _do_ specify a `fontFamily` in the theme, but it's "Roboto" which should exist on every device. But given that's the default font since ICS, it's not necessary to specify it so I removed it. I also made two other minor tweaks that are unrelated.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
