### PR TITLE
Subclass BarChart class to handle nullPointerException in MpAndroidChart

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsBarChart.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsBarChart.kt
@@ -1,0 +1,49 @@
+package com.woocommerce.android.ui.dashboard
+
+import android.content.Context
+import android.graphics.Canvas
+import android.util.AttributeSet
+import com.github.mikephil.charting.charts.BarChart
+import com.github.mikephil.charting.data.BarEntry
+
+/**
+ * Creating a custom BarChart to fix this issue:
+ * https://github.com/woocommerce/woocommerce-android/issues/1048
+ */
+class DashboardStatsBarChart(context: Context?, attrs: AttributeSet?) : BarChart(
+        context,
+        attrs
+) {
+    // Overriding this method from the Chart.java: line 719
+    override fun drawMarkers(canvas: Canvas?) {
+        // if there is no marker view or drawing marker is disabled
+        if (mMarker == null || !isDrawMarkersEnabled || !valuesToHighlight())
+            return
+
+        for (i in mIndicesToHighlight.indices) {
+            val highlight = mIndicesToHighlight[i]
+
+            // This is the line that causes the crash
+            val set = mData.getDataSetByIndex(highlight.dataSetIndex) ?: continue
+
+            val e = mData.getEntryForHighlight(mIndicesToHighlight[i]) as? BarEntry ?: continue
+            val entryIndex = set.getEntryIndex(e)
+
+            // make sure entry not null
+            if (entryIndex > set.entryCount * mAnimator.phaseX) {
+                continue
+            }
+
+            val pos = getMarkerPosition(highlight)
+            // check bounds
+            if (!mViewPortHandler.isInBounds(pos[0], pos[1]))
+                continue
+
+            // callbacks to update the content
+            mMarker.refreshContent(e, highlight)
+
+            // draw the marker
+            mMarker.draw(canvas, pos[0], pos[1])
+        }
+    }
+}

--- a/WooCommerce/src/main/res/layout/dashboard_stats.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_stats.xml
@@ -115,7 +115,7 @@
         android:layout_width="match_parent"
         android:layout_height="@dimen/chart_height">
 
-        <com.github.mikephil.charting.charts.BarChart
+        <com.woocommerce.android.ui.dashboard.DashboardStatsBarChart
             android:id="@+id/chart"
             android:layout_width="match_parent"
             android:layout_height="match_parent"/>


### PR DESCRIPTION
Fixes #1048 . This crash is a known issue with MPAndroidChart and is already tracked [here](https://github.com/PhilJay/MPAndroidChart/issues/2917).

I haven't been able to reproduce this issue but based on the discussion [here](https://github.com/woocommerce/woocommerce-android/pull/1049#discussion_r286633747) this PR adds a sub class to the `BarChart` and overrides the `drawMarkers` method to check if the data set is `null` before drawing the markers. 
