### PR TITLE
Page title doesn't update after switching device language

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -21,7 +21,6 @@ abstract class TopLevelFragment : Fragment(), TopLevelFragmentView {
         // If the value associated with this label is true, then this
         // fragment is currently hosting a child fragment (drilled in).
         const val CHILD_FRAGMENT_ACTIVE = "child-fragment-active"
-        const val FRAGMENT_TITLE = "fragment-title"
     }
 
     /**
@@ -117,9 +116,6 @@ abstract class TopLevelFragment : Fragment(), TopLevelFragmentView {
         super.onSaveInstanceState(outState)
         // Save the current view state of this top-level fragment.
         outState.putBoolean(CHILD_FRAGMENT_ACTIVE, childFragmentManager.backStackEntryCount > 0)
-
-        // Save the current fragment title
-        outState.putString(FRAGMENT_TITLE, activity?.title.toString())
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
@@ -127,11 +123,6 @@ abstract class TopLevelFragment : Fragment(), TopLevelFragmentView {
         savedInstanceState?.let { bundle ->
             val childViewActive = bundle.getBoolean(CHILD_FRAGMENT_ACTIVE, false)
             updateParentViewState(childViewActive)
-
-            val title = bundle.getString(FRAGMENT_TITLE)
-            title?.let {
-                activity?.title = it
-            }
         } ?: updateActivityTitle()
     }
 


### PR DESCRIPTION
Fixes #1082 . In order to fix issue #1040 - I had added logic to store the current toolbar title to `savedInstanceState` and retrieve it when activity is created again. This meant the toolbar title was not translated to the correct language after a language switch.

This PR reverts the logic to store the toolbar title in `onSaveInstanceState`. Instead, adds logic to update the toolbar title only if the activity is first created and the `savedInstanceState` is `null`. 

This fixes both #1082 and #1040 without having to save the toolbar title.

### Behaviour before the fix:
<img src="https://user-images.githubusercontent.com/22608780/58235049-a4b0ee00-7d5d-11e9-8eef-6f48bfdd880c.gif" width="300"/>

### Behaviour after the fix: 
<img src="https://user-images.githubusercontent.com/22608780/58235049-a4b0ee00-7d5d-11e9-8eef-6f48bfdd880c.gif" width="300"/>

