### PR TITLE
Add missing translations from GlotPress

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 2.0
 ----
+* Translations have been added for the "Orders to Fulfill" card in My Store.
 
 1.9
 -----

--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2019-05-01 10:54:08+0000
+Translation-Revision-Date: 2019-05-27 13:45:21+0000
 Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;
 Generator: GlotPress/2.4.0-alpha
 Language: ar
@@ -327,6 +327,7 @@ Language: ar
     <string name="orderdetail_product_image_contentdesc">صورة المنتج</string>
     <string name="orderdetail_product_lineitem_sku">وحدة SKU:</string>
     <string name="orderdetail_product_lineitem_tax">الضريبة:</string>
+    <string name="orderdetail_product_lineitem_total_multiple">%1$s (%2$s x %3$s)</string>
     <string name="orderdetail_email_contentdesc">إرسال بريد إلكتروني إلى العميل</string>
     <string name="orderdetail_billing_details">تفاصيل الفوترة</string>
     <string name="orderdetail_shipping_details">تفاصيل الشحن</string>
@@ -341,6 +342,8 @@ Language: ar
     <string name="orderlist_item_order_name">%1$s %2$s</string>
     <string name="orderlist_item_order_num">#%s</string>
     <string name="orderlist_no_orders">لا توجد طلبات</string>
+    <string name="dashboard_fulfill_order_title_multiple">لديك %1$d من الطلبات لإتمامها</string>
+    <string name="dashboard_fulfill_order_title_single">لديك طلب واحد لإتمامه</string>
     <string name="dashboard_action_view_orders">عرض الطلبات</string>
     <string name="dashboard_action_view_order">عرض الطلب</string>
     <string name="dashboard_top_earners_empty">لا يوجد أي نشاط في هذه الفترة</string>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2019-05-02 10:54:03+0000
+Translation-Revision-Date: 2019-05-27 13:41:16+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/2.4.0-alpha
 Language: de
@@ -130,6 +130,7 @@ Language: de
     <string name="notification_channel_order_title">Benachrichtigungen bei neuer Bestellung</string>
     <string name="orderdetail_note_system">Systemstatus</string>
     <string name="orderdetail_note_public">Hinweis an Kunden</string>
+    <string name="login_verifying_site">Website wird verifiziert …</string>
     <string name="button_update_instructions">Aktualisierungsanweisungen</string>
     <string name="search">Suche</string>
     <string name="refresh_button">Neu laden</string>
@@ -327,6 +328,7 @@ Language: de
     <string name="orderdetail_product_image_contentdesc">Produktabbildung</string>
     <string name="orderdetail_product_lineitem_sku">SKU:</string>
     <string name="orderdetail_product_lineitem_tax">Steuern:</string>
+    <string name="orderdetail_product_lineitem_total_multiple">%1$s (%2$s x %3$s)</string>
     <string name="orderdetail_email_contentdesc">E-Mail an Kunden senden</string>
     <string name="orderdetail_billing_details">Abrechnungsdetails</string>
     <string name="orderdetail_shipping_details">Versanddetails</string>
@@ -341,6 +343,8 @@ Language: de
     <string name="orderlist_item_order_name">%1$s %2$s</string>
     <string name="orderlist_item_order_num">#%s</string>
     <string name="orderlist_no_orders">Keine Bestellungen</string>
+    <string name="dashboard_fulfill_order_title_multiple">Du musst %1$d Bestellungen abschließen</string>
+    <string name="dashboard_fulfill_order_title_single">Du musst 1 Bestellung abschließen</string>
     <string name="dashboard_action_view_orders">Bestellungen anzeigen</string>
     <string name="dashboard_action_view_order">Bestellung anzeigen</string>
     <string name="dashboard_top_earners_empty">Keine Aktivitäten in diesem Zeitraum</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2019-04-30 11:54:03+0000
+Translation-Revision-Date: 2019-05-27 13:43:56+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/2.4.0-alpha
 Language: es
@@ -327,6 +327,7 @@ Language: es
     <string name="orderdetail_product_image_contentdesc">Imagen del producto</string>
     <string name="orderdetail_product_lineitem_sku">SKU:</string>
     <string name="orderdetail_product_lineitem_tax">Impuesto:</string>
+    <string name="orderdetail_product_lineitem_total_multiple">%1$s (%2$sx%3$s)</string>
     <string name="orderdetail_email_contentdesc">enviar correo electrónico al cliente</string>
     <string name="orderdetail_billing_details">Detalles de la facturación</string>
     <string name="orderdetail_shipping_details">Detalles del envío</string>
@@ -341,6 +342,8 @@ Language: es
     <string name="orderlist_item_order_name">%1$s %2$s</string>
     <string name="orderlist_item_order_num">Núm. %s</string>
     <string name="orderlist_no_orders">No hay pedidos</string>
+    <string name="dashboard_fulfill_order_title_multiple">Tienes %1$d pedidos por realizar</string>
+    <string name="dashboard_fulfill_order_title_single">Tienes 1 pedido por realizar</string>
     <string name="dashboard_action_view_orders">Ver pedidos</string>
     <string name="dashboard_action_view_order">Ver pedido</string>
     <string name="dashboard_top_earners_empty">Sin actividad durante este periodo</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2019-05-02 14:54:03+0000
+Translation-Revision-Date: 2019-05-27 13:45:36+0000
 Plural-Forms: nplurals=2; plural=n > 1;
 Generator: GlotPress/2.4.0-alpha
 Language: fr
@@ -326,6 +326,7 @@ Language: fr
     <string name="orderdetail_product_image_contentdesc">Image produit</string>
     <string name="orderdetail_product_lineitem_sku">UGS :</string>
     <string name="orderdetail_product_lineitem_tax">TVA :</string>
+    <string name="orderdetail_product_lineitem_total_multiple">%1$s (%2$s x %3$s)</string>
     <string name="orderdetail_email_contentdesc">envoyer un e-mail au client</string>
     <string name="orderdetail_billing_details">Détails de facturation</string>
     <string name="orderdetail_shipping_details">Détails de livraison</string>
@@ -340,6 +341,8 @@ Language: fr
     <string name="orderlist_item_order_name">%2$s %1$s</string>
     <string name="orderlist_item_order_num">N° %s</string>
     <string name="orderlist_no_orders">Aucune commande</string>
+    <string name="dashboard_fulfill_order_title_multiple">Vous avez %1$d commandes à exécuter</string>
+    <string name="dashboard_fulfill_order_title_single">Vous avez 1 commande à exécuter</string>
     <string name="dashboard_action_view_orders">Voir les commandes</string>
     <string name="dashboard_action_view_order">Voir la commande</string>
     <string name="dashboard_top_earners_empty">Aucune activité sur cette période</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2019-05-01 08:54:02+0000
+Translation-Revision-Date: 2019-05-27 13:41:43+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/2.4.0-alpha
 Language: he_IL
@@ -327,6 +327,7 @@ Language: he_IL
     <string name="orderdetail_product_image_contentdesc">תמונת מוצר</string>
     <string name="orderdetail_product_lineitem_sku">מק\"ט:</string>
     <string name="orderdetail_product_lineitem_tax">מס:</string>
+    <string name="orderdetail_product_lineitem_total_multiple">%1$s (%2$s x %3$s)</string>
     <string name="orderdetail_email_contentdesc">שליחת הודעת אימייל ללקוח</string>
     <string name="orderdetail_billing_details">פרטי חיוב</string>
     <string name="orderdetail_shipping_details">פרטי משלוח</string>
@@ -341,6 +342,8 @@ Language: he_IL
     <string name="orderlist_item_order_name">%1$s %2$s</string>
     <string name="orderlist_item_order_num">#%s</string>
     <string name="orderlist_no_orders">אין הזמנות</string>
+    <string name="dashboard_fulfill_order_title_multiple">יש לך %1$d הזמנות להשלמה</string>
+    <string name="dashboard_fulfill_order_title_single">יש לך הזמנה אחת להשלמה</string>
     <string name="dashboard_action_view_orders">הצגת הזמנות</string>
     <string name="dashboard_action_view_order">הצגת הזמנה</string>
     <string name="dashboard_top_earners_empty">אין פעילות בפרק זמן זה</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2019-04-30 09:54:31+0000
+Translation-Revision-Date: 2019-05-27 13:42:04+0000
 Plural-Forms: nplurals=2; plural=n > 1;
 Generator: GlotPress/2.4.0-alpha
 Language: id
@@ -327,6 +327,7 @@ Language: id
     <string name="orderdetail_product_image_contentdesc">Gambar Produk</string>
     <string name="orderdetail_product_lineitem_sku">SKU:</string>
     <string name="orderdetail_product_lineitem_tax">Pajak:</string>
+    <string name="orderdetail_product_lineitem_total_multiple">%1$s (%2$s x %3$s)</string>
     <string name="orderdetail_email_contentdesc">kirim email ke pelanggan</string>
     <string name="orderdetail_billing_details">Detail Tagihan</string>
     <string name="orderdetail_shipping_details">Detail Pengiriman</string>
@@ -341,6 +342,8 @@ Language: id
     <string name="orderlist_item_order_name">%1$s %2$s</string>
     <string name="orderlist_item_order_num">#%s</string>
     <string name="orderlist_no_orders">Tidak Ada Pesanan</string>
+    <string name="dashboard_fulfill_order_title_multiple">Anda memiliki %1$d pesanan untuk dipenuhi</string>
+    <string name="dashboard_fulfill_order_title_single">Anda memiliki 1 pesanan untuk dipenuhi</string>
     <string name="dashboard_action_view_orders">Lihat Pesanan</string>
     <string name="dashboard_action_view_order">Lihat Pesanan</string>
     <string name="dashboard_top_earners_empty">Tidak ada aktivitas dalam periode ini</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2019-05-02 12:54:03+0000
+Translation-Revision-Date: 2019-05-27 13:30:29+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/2.4.0-alpha
 Language: it
@@ -327,6 +327,7 @@ Language: it
     <string name="orderdetail_product_image_contentdesc">Immagine prodotto</string>
     <string name="orderdetail_product_lineitem_sku">SKU:</string>
     <string name="orderdetail_product_lineitem_tax">Tasse:</string>
+    <string name="orderdetail_product_lineitem_total_multiple">%1$s (%2$s x %3$s)</string>
     <string name="orderdetail_email_contentdesc">invia e-mail al cliente</string>
     <string name="orderdetail_billing_details">Dati di fatturazione</string>
     <string name="orderdetail_shipping_details">Dati di spedizione</string>
@@ -341,6 +342,8 @@ Language: it
     <string name="orderlist_item_order_name">%1$s %2$s</string>
     <string name="orderlist_item_order_num">N. %s</string>
     <string name="orderlist_no_orders">Nessun ordine</string>
+    <string name="dashboard_fulfill_order_title_multiple">Hai %1$d ordini da evadere</string>
+    <string name="dashboard_fulfill_order_title_single">Hai un ordine da evadere</string>
     <string name="dashboard_action_view_orders">Visualizza ordini</string>
     <string name="dashboard_action_view_order">Visualizza ordine</string>
     <string name="dashboard_top_earners_empty">Nessuna attività per questo periodo</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2019-05-03 03:54:03+0000
+Translation-Revision-Date: 2019-05-27 13:42:33+0000
 Plural-Forms: nplurals=1; plural=0;
 Generator: GlotPress/2.4.0-alpha
 Language: ja_JP
@@ -327,6 +327,7 @@ Language: ja_JP
     <string name="orderdetail_product_image_contentdesc">商品画像</string>
     <string name="orderdetail_product_lineitem_sku">商品コード:</string>
     <string name="orderdetail_product_lineitem_tax">税:</string>
+    <string name="orderdetail_product_lineitem_total_multiple">%1$s (%2$s x %3$s)</string>
     <string name="orderdetail_email_contentdesc">顧客にメールを送信</string>
     <string name="orderdetail_billing_details">請求詳細</string>
     <string name="orderdetail_shipping_details">配送詳細</string>
@@ -341,6 +342,8 @@ Language: ja_JP
     <string name="orderlist_item_order_name">%1$s %2$s</string>
     <string name="orderlist_item_order_num">番号%s</string>
     <string name="orderlist_no_orders">注文はありません</string>
+    <string name="dashboard_fulfill_order_title_multiple">履行する注文が%1$d件あります</string>
+    <string name="dashboard_fulfill_order_title_single">履行する注文が1件あります</string>
     <string name="dashboard_action_view_orders">注文を表示</string>
     <string name="dashboard_action_view_order">注文を表示</string>
     <string name="dashboard_top_earners_empty">この期間のアクティビティはありません</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2019-05-02 06:54:03+0000
+Translation-Revision-Date: 2019-05-27 13:43:11+0000
 Plural-Forms: nplurals=1; plural=0;
 Generator: GlotPress/2.4.0-alpha
 Language: ko_KR
@@ -327,6 +327,7 @@ Language: ko_KR
     <string name="orderdetail_product_image_contentdesc">상품 이미지</string>
     <string name="orderdetail_product_lineitem_sku">SKU:</string>
     <string name="orderdetail_product_lineitem_tax">세금:</string>
+    <string name="orderdetail_product_lineitem_total_multiple">%1$s(%2$s x %3$s)</string>
     <string name="orderdetail_email_contentdesc">고객에게 이메일 보내기</string>
     <string name="orderdetail_billing_details">청구 상세 내역</string>
     <string name="orderdetail_shipping_details">배송 상세 내역</string>
@@ -341,6 +342,8 @@ Language: ko_KR
     <string name="orderlist_item_order_name">%1$s %2$s</string>
     <string name="orderlist_item_order_num">#%s</string>
     <string name="orderlist_no_orders">주문 없음</string>
+    <string name="dashboard_fulfill_order_title_multiple">%1$d건의 처리할 주문이 있음</string>
+    <string name="dashboard_fulfill_order_title_single">1건의 처리할 주문이 있음</string>
     <string name="dashboard_action_view_orders">주문 보기</string>
     <string name="dashboard_action_view_order">주문 보기</string>
     <string name="dashboard_top_earners_empty">이 기간에 활동이 없음</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2019-05-07 07:54:03+0000
+Translation-Revision-Date: 2019-05-27 13:40:38+0000
 Plural-Forms: nplurals=2; plural=n != 1;
 Generator: GlotPress/2.4.0-alpha
 Language: nl
@@ -327,6 +327,7 @@ Language: nl
     <string name="orderdetail_product_image_contentdesc">Productafbeelding</string>
     <string name="orderdetail_product_lineitem_sku">SKU:</string>
     <string name="orderdetail_product_lineitem_tax">Belasting:</string>
+    <string name="orderdetail_product_lineitem_total_multiple">%1$s (%2$s x %3$s)</string>
     <string name="orderdetail_email_contentdesc">e-mail verzenden naar klant</string>
     <string name="orderdetail_billing_details">Factuurgegevens</string>
     <string name="orderdetail_shipping_details">Verzendgegevens</string>
@@ -341,6 +342,8 @@ Language: nl
     <string name="orderlist_item_order_name">%1$s %2$s</string>
     <string name="orderlist_item_order_num">Nr. %s</string>
     <string name="orderlist_no_orders">Geen bestellingen</string>
+    <string name="dashboard_fulfill_order_title_multiple">Je moet nog %1$d bestellingen voltooien</string>
+    <string name="dashboard_fulfill_order_title_single">Je moet nog 1 bestelling voltooien</string>
     <string name="dashboard_action_view_orders">Bestellingen weergeven</string>
     <string name="dashboard_action_view_order">Bestelling weergeven</string>
     <string name="dashboard_top_earners_empty">Geen activiteiten deze periode</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2019-04-29 19:54:36+0000
+Translation-Revision-Date: 2019-05-27 13:43:34+0000
 Plural-Forms: nplurals=2; plural=(n > 1);
 Generator: GlotPress/2.4.0-alpha
 Language: pt_BR
@@ -327,6 +327,7 @@ Language: pt_BR
     <string name="orderdetail_product_image_contentdesc">Imagem do produto</string>
     <string name="orderdetail_product_lineitem_sku">SKU:</string>
     <string name="orderdetail_product_lineitem_tax">Imposto:</string>
+    <string name="orderdetail_product_lineitem_total_multiple">%1$s (%2$s x %3$s)</string>
     <string name="orderdetail_email_contentdesc">enviar e-mail para o cliente</string>
     <string name="orderdetail_billing_details">Detalhes de cobrança</string>
     <string name="orderdetail_shipping_details">Detalhes de envio</string>
@@ -341,6 +342,8 @@ Language: pt_BR
     <string name="orderlist_item_order_name">%1$s %2$s</string>
     <string name="orderlist_item_order_num">Nº %s</string>
     <string name="orderlist_no_orders">Não há pedidos</string>
+    <string name="dashboard_fulfill_order_title_multiple">Você tem %1$d pedidos para concluir</string>
+    <string name="dashboard_fulfill_order_title_single">Você tem um pedido para concluir</string>
     <string name="dashboard_action_view_orders">Visualizar pedidos</string>
     <string name="dashboard_action_view_order">Ver pedido</string>
     <string name="dashboard_top_earners_empty">Nenhuma atividade no período</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2019-05-02 15:54:03+0000
+Translation-Revision-Date: 2019-05-27 13:30:00+0000
 Plural-Forms: nplurals=2; plural=(n > 1);
 Generator: GlotPress/2.4.0-alpha
 Language: tr
@@ -42,6 +42,7 @@ Language: tr
     <string name="product_backorders">Geri dönen siparişler</string>
     <string name="product_stock_quantity">Stok miktarı</string>
     <string name="product_stock_status">Stok durumu</string>
+    <string name="product_sku">Stok kodu (SKU)</string>
     <string name="product_sale_price">İndirimli satış fiyatı</string>
     <string name="product_regular_price">Normal fiyat</string>
     <string name="product_price">Fiyat</string>
@@ -322,6 +323,7 @@ Language: tr
     <string name="orderdetail_product_image_contentdesc">Ürün Görseli</string>
     <string name="orderdetail_product_lineitem_sku">SKU:</string>
     <string name="orderdetail_product_lineitem_tax">Vergi:</string>
+    <string name="orderdetail_product_lineitem_total_multiple">%1$s (%2$s x %3$s)</string>
     <string name="orderdetail_email_contentdesc">müşteriye e-posta gönderin</string>
     <string name="orderdetail_billing_details">Fatura Ayrıntıları</string>
     <string name="orderdetail_shipping_details">Gönderim Ayrıntıları</string>
@@ -336,6 +338,8 @@ Language: tr
     <string name="orderlist_item_order_name">%1$s %2$s</string>
     <string name="orderlist_item_order_num">#%s</string>
     <string name="orderlist_no_orders">Sipariş Yok</string>
+    <string name="dashboard_fulfill_order_title_multiple">%1$d sipariş yerine getirilmeyi bekliyor</string>
+    <string name="dashboard_fulfill_order_title_single">1 sipariş yerine getirilmeyi bekliyor</string>
     <string name="dashboard_action_view_orders">Siparişleri Görüntüle</string>
     <string name="dashboard_action_view_order">Siparişi Görüntüle</string>
     <string name="dashboard_top_earners_empty">Bu dönemde hiç etkinlik yok</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2019-05-07 07:54:03+0000
+Translation-Revision-Date: 2019-05-27 13:44:16+0000
 Plural-Forms: nplurals=1; plural=0;
 Generator: GlotPress/2.4.0-alpha
 Language: zh_CN
@@ -324,6 +324,7 @@ Language: zh_CN
     <string name="orderdetail_product_image_contentdesc">产品图片</string>
     <string name="orderdetail_product_lineitem_sku">SKU：</string>
     <string name="orderdetail_product_lineitem_tax">税费：</string>
+    <string name="orderdetail_product_lineitem_total_multiple">%1$s (%2$s x %3$s)</string>
     <string name="orderdetail_email_contentdesc">向客户发送电子邮件</string>
     <string name="orderdetail_billing_details">账单详情</string>
     <string name="orderdetail_shipping_details">配送详情</string>
@@ -338,6 +339,8 @@ Language: zh_CN
     <string name="orderlist_item_order_name">%1$s %2$s</string>
     <string name="orderlist_item_order_num">订单号 %s</string>
     <string name="orderlist_no_orders">无订单</string>
+    <string name="dashboard_fulfill_order_title_multiple">您有 %1$d 个订单待处理</string>
+    <string name="dashboard_fulfill_order_title_single">您有 1 个订单待处理</string>
     <string name="dashboard_action_view_orders">查看订单</string>
     <string name="dashboard_action_view_order">查看订单</string>
     <string name="dashboard_top_earners_empty">这段时间内没有任何活动</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Translation-Revision-Date: 2019-05-07 14:54:04+0000
+Translation-Revision-Date: 2019-05-27 13:44:34+0000
 Plural-Forms: nplurals=1; plural=0;
 Generator: GlotPress/2.4.0-alpha
 Language: zh_TW
@@ -324,6 +324,7 @@ Language: zh_TW
     <string name="orderdetail_product_image_contentdesc">商品圖片</string>
     <string name="orderdetail_product_lineitem_sku">貨號：</string>
     <string name="orderdetail_product_lineitem_tax">稅金：</string>
+    <string name="orderdetail_product_lineitem_total_multiple">%1$s (%2$s x %3$s)</string>
     <string name="orderdetail_email_contentdesc">傳送電子郵件給客戶</string>
     <string name="orderdetail_billing_details">帳單詳細資料</string>
     <string name="orderdetail_shipping_details">運送詳細資料</string>
@@ -338,6 +339,8 @@ Language: zh_TW
     <string name="orderlist_item_order_name">%1$s %2$s</string>
     <string name="orderlist_item_order_num">編號%s</string>
     <string name="orderlist_no_orders">無訂單</string>
+    <string name="dashboard_fulfill_order_title_multiple">你有 %1$d 筆訂單尚未履行</string>
+    <string name="dashboard_fulfill_order_title_single">你有 1 筆訂單尚未履行</string>
     <string name="dashboard_action_view_orders">查看訂單</string>
     <string name="dashboard_action_view_order">查看訂單</string>
     <string name="dashboard_top_earners_empty">此期間沒有任何活動</string>


### PR DESCRIPTION
Fixes #1090 by adding some missing translations from GlotPress. This was done by running the script in `./tools/update-translations.sh`

### To Test
1. Change the device language to Spanish
2. Verify the "Orders to Fulfill" title in the My Store dashboard updates appropriately.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
