### PR TITLE
Switch order of custom provider and store country sections in list of tracking providers

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderTrackingProviderListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderTrackingProviderListAdapter.kt
@@ -57,12 +57,11 @@ class AddOrderTrackingProviderListAdapter(
         removeAllSections()
 
         /**
-         * Add a new section at the top of the list to display custom provider
-         */
-        getCustomProviderSection()?.let { addSection(it) }
-
-        /**
-         * Build a list of [WCOrderShipmentProviderModel] for each country section
+         * Build a list of [WCOrderShipmentProviderModel] for each country section.
+         * Order of provider list should be:
+         * 1. Store country
+         * 2. Custom
+         * 3. Other countries
          * if the country that the store is associated with matches a country on the providers list
          * then that country section should be displayed first
          * */
@@ -74,6 +73,11 @@ class AddOrderTrackingProviderListAdapter(
         countryProvidersMap[storeCountry]?.let { wcOrderShipmentProviderModels ->
             storeCountry?.let { finalMap.put(it, wcOrderShipmentProviderModels) }
         }
+
+        /*
+         * Add a new section below the store country provider list section to display custom provider
+         */
+        getCustomProviderSection()?.let { finalMap.put(it.country, it.list) }
         finalMap.putAll(countryProvidersMap)
 
         finalMap.forEach {


### PR DESCRIPTION
Fixes #1097 

The provider list should be sorted in the following manner:
* If the store country is present, then the list of providers for the particular country should be displayed first.
* The "Custom" section should be second in the list, after the "store country" section.
* Then the other list of providers should be displayed

### Behaviour before the change:
<img src="https://user-images.githubusercontent.com/22608780/58448082-55cfd380-8124-11e9-8b5e-9c065d092f27.png" width="350"/>

### Behaviour after the change:
<img src="https://user-images.githubusercontent.com/22608780/58448977-4bfb9f80-8127-11e9-8df5-7d48b261172a.png" width="350"/>


