### PR TITLE
Order Detail: provide option to add shipment tracking

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -39,5 +39,5 @@ Improvements
 
 New Features
 * New support for the Shipment Tracking plugin. Read-only Shipment tracking information will now be displayed on a completed order and packages may be tracked directly from the order detail screen.
-* Added support for adding a new shipment tracking information on an order before it is fulfilled.
+* Added support for adding a new shipment tracking information on an order.
 * Added support for deleting shipment tracking information on an order.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -124,6 +124,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         ORDER_DETAIL_TRACK_PACKAGE_BUTTON_TAPPED,
         ORDER_TRACKING_LOADED,
         ORDER_DETAIL_TRACKING_DELETE_BUTTON_TAPPED,
+        ORDER_DETAIL_TRACKING_ADD_TRACKING_BUTTON_TAPPED,
 
         // -- Order Notes
         ADD_ORDER_NOTE_ADD_BUTTON_TAPPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailContract.kt
@@ -31,7 +31,7 @@ interface OrderDetailContract {
         fun getOrderStatusOptions(): Map<String, WCOrderStatusModel>
         fun refreshOrderStatusOptions()
         fun deleteOrderShipmentTracking(wcOrderShipmentTrackingModel: WCOrderShipmentTrackingModel)
-        fun pushShipmentTrackingProvider(
+        fun pushShipmentTrackingRecord(
             wcOrderShipmentTrackingModel: WCOrderShipmentTrackingModel,
             isCustomProvider: Boolean
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailContract.kt
@@ -31,6 +31,10 @@ interface OrderDetailContract {
         fun getOrderStatusOptions(): Map<String, WCOrderStatusModel>
         fun refreshOrderStatusOptions()
         fun deleteOrderShipmentTracking(wcOrderShipmentTrackingModel: WCOrderShipmentTrackingModel)
+        fun pushShipmentTrackingProvider(
+            wcOrderShipmentTrackingModel: WCOrderShipmentTrackingModel,
+            isCustomProvider: Boolean
+        )
     }
 
     interface View : BaseView<Presenter>, OrderActionListener, OrderProductActionListener,
@@ -56,5 +60,7 @@ interface OrderDetailContract {
         fun undoDeletedTrackingOnError(wcOrderShipmentTrackingModel: WCOrderShipmentTrackingModel?)
         fun markTrackingDeletedOnSuccess()
         fun showDeleteTrackingErrorSnack()
+        fun showAddShipmentTrackingSnack()
+        fun showAddAddShipmentTrackingErrorSnack()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -179,7 +179,7 @@ class OrderDetailFragment : Fragment(), OrderDetailContract.View, OrderDetailNot
                     }
 
                     orderDetail_shipmentList.addTransientTrackingProvider(orderShipmentTrackingModel)
-                    presenter.pushShipmentTrackingProvider(orderShipmentTrackingModel, isCustomProvider)
+                    presenter.pushShipmentTrackingRecord(orderShipmentTrackingModel, isCustomProvider)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -267,7 +267,7 @@ class OrderDetailPresenter @Inject constructor(
         }
     }
 
-    override fun pushShipmentTrackingProvider(
+    override fun pushShipmentTrackingRecord(
         wcOrderShipmentTrackingModel: WCOrderShipmentTrackingModel,
         isCustomProvider: Boolean
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingItemView.kt
@@ -54,7 +54,7 @@ class OrderDetailShipmentTrackingItemView @JvmOverloads constructor(
             }
         }
 
-        if (!isOrderDetail) {
+        if (isOrderDetail) {
             tracking_btnTrack.visibility = View.VISIBLE
             tracking_btnTrack.setOnClickListener {
                 showTrackingOrDeleteOptionPopup(item)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingItemView.kt
@@ -31,7 +31,7 @@ class OrderDetailShipmentTrackingItemView @JvmOverloads constructor(
     fun initView(
         item: WCOrderShipmentTrackingModel,
         uiMessageResolver: UIMessageResolver,
-        allowAddTrackingOption: Boolean,
+        isOrderDetail: Boolean,
         shipmentTrackingActionListener: OrderShipmentTrackingActionListener?
     ) {
         this.listener = shipmentTrackingActionListener
@@ -54,7 +54,7 @@ class OrderDetailShipmentTrackingItemView @JvmOverloads constructor(
             }
         }
 
-        if (!allowAddTrackingOption) {
+        if (!isOrderDetail) {
             tracking_btnTrack.visibility = View.VISIBLE
             tracking_btnTrack.setOnClickListener {
                 showTrackingOrDeleteOptionPopup(item)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingListView.kt
@@ -10,8 +10,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.woocommerce.android.R
-import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_FULFILLMENT_TRACKING_ADD_TRACKING_BUTTON_TAPPED
 import com.woocommerce.android.ui.base.UIMessageResolver
 import kotlinx.android.synthetic.main.order_detail_shipment_tracking_list.view.*
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
@@ -27,17 +25,22 @@ class OrderDetailShipmentTrackingListView @JvmOverloads constructor(
     // negative IDs denote transient tracking providers
     private var nextTransientTrackingId = -1
 
+    /**
+     * @param [isOrderDetail] = true, then
+     * 1. the delete icon would not be displayed. The hanburger menu should be displayed instead
+     * 2. The title should be "Tracking" instead of "Optional shipment tracking"
+     */
     fun initView(
         trackings: List<WCOrderShipmentTrackingModel>,
         uiMessageResolver: UIMessageResolver,
-        allowAddTrackingOption: Boolean = false,
+        isOrderDetail: Boolean,
         shipmentTrackingActionListener: OrderShipmentTrackingActionListener? = null
     ) {
         val viewManager = LinearLayoutManager(context)
         val viewAdapter = ShipmentTrackingListAdapter(
                 trackings.toMutableList(),
                 uiMessageResolver,
-                allowAddTrackingOption,
+                isOrderDetail,
                 shipmentTrackingActionListener
         )
 
@@ -48,14 +51,14 @@ class OrderDetailShipmentTrackingListView @JvmOverloads constructor(
             adapter = viewAdapter
         }
 
-        if (allowAddTrackingOption) {
-            showOrHideDivider()
+        showOrHideDivider()
+        shipmentTrack_btnAddTracking.visibility = View.VISIBLE
+        shipmentTrack_btnAddTracking.setOnClickListener {
+            shipmentTrackingActionListener?.openAddOrderShipmentTrackingScreen()
+        }
+
+        if (!isOrderDetail) {
             shipmentTrack_label.text = context.getString(R.string.order_shipment_tracking_add_label)
-            shipmentTrack_btnAddTracking.visibility = View.VISIBLE
-            shipmentTrack_btnAddTracking.setOnClickListener {
-                AnalyticsTracker.track(ORDER_FULFILLMENT_TRACKING_ADD_TRACKING_BUTTON_TAPPED)
-                shipmentTrackingActionListener?.openAddOrderShipmentTrackingScreen()
-            }
         }
     }
 
@@ -101,7 +104,7 @@ class OrderDetailShipmentTrackingListView @JvmOverloads constructor(
     class ShipmentTrackingListAdapter(
         private val trackings: MutableList<WCOrderShipmentTrackingModel>,
         private val uiMessageResolver: UIMessageResolver,
-        private val allowAddTrackingOption: Boolean,
+        private val isOrderDetail: Boolean,
         private val shipmentTrackingActionListener: OrderShipmentTrackingActionListener?
     ) : RecyclerView.Adapter<ShipmentTrackingListAdapter.ViewHolder>() {
         private var deletedTrackingModelIndex = -1
@@ -119,7 +122,7 @@ class OrderDetailShipmentTrackingListView @JvmOverloads constructor(
             holder.view.initView(
                     item = trackings[position],
                     uiMessageResolver = uiMessageResolver,
-                    allowAddTrackingOption = allowAddTrackingOption,
+                    isOrderDetail = isOrderDetail,
                     shipmentTrackingActionListener = shipmentTrackingActionListener
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentContract.kt
@@ -13,7 +13,7 @@ interface OrderFulfillmentContract {
         var deletedOrderShipmentTrackingModel: WCOrderShipmentTrackingModel?
         fun loadOrderDetail(orderIdentifier: OrderIdentifier, isShipmentTrackingsFetched: Boolean = false)
         fun loadOrderShipmentTrackings()
-        fun pushShipmentTrackingProvider(
+        fun pushShipmentTrackingRecord(
             wcOrderShipmentTrackingModel: WCOrderShipmentTrackingModel,
             isCustomProvider: Boolean
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragment.kt
@@ -147,7 +147,7 @@ class OrderFulfillmentFragment : Fragment(), OrderFulfillmentContract.View, View
                     }
 
                     orderFulfill_addShipmentTracking.addTransientTrackingProvider(orderShipmentTrackingModel)
-                    presenter.pushShipmentTrackingProvider(orderShipmentTrackingModel, isCustomProvider)
+                    presenter.pushShipmentTrackingRecord(orderShipmentTrackingModel, isCustomProvider)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragment.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.R.layout
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_FULFILLMENT_MARK_ORDER_COMPLETE_BUTTON_TAPPED
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_FULFILLMENT_TRACKING_ADD_TRACKING_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_FULFILLMENT_TRACKING_DELETE_BUTTON_TAPPED
 import com.woocommerce.android.extensions.onScrollDown
 import com.woocommerce.android.extensions.onScrollUp
@@ -186,7 +187,7 @@ class OrderFulfillmentFragment : Fragment(), OrderFulfillmentContract.View, View
             orderFulfill_addShipmentTracking.initView(
                     trackings = trackings,
                     uiMessageResolver = uiMessageResolver,
-                    allowAddTrackingOption = true,
+                    isOrderDetail = false,
                     shipmentTrackingActionListener = this
             )
             if (orderFulfill_addShipmentTracking.visibility != View.VISIBLE) {
@@ -256,6 +257,7 @@ class OrderFulfillmentFragment : Fragment(), OrderFulfillmentContract.View, View
     }
 
     override fun openAddOrderShipmentTrackingScreen() {
+        AnalyticsTracker.track(ORDER_FULFILLMENT_TRACKING_ADD_TRACKING_BUTTON_TAPPED)
         presenter.orderModel?.let {
             val intent = Intent(activity, AddOrderShipmentTrackingActivity::class.java)
             intent.putExtra(AddOrderShipmentTrackingActivity.FIELD_ORDER_IDENTIFIER, it.getIdentifier())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentPresenter.kt
@@ -105,7 +105,7 @@ class OrderFulfillmentPresenter @Inject constructor(
         }
     }
 
-    override fun pushShipmentTrackingProvider(
+    override fun pushShipmentTrackingRecord(
         wcOrderShipmentTrackingModel: WCOrderShipmentTrackingModel,
         isCustomProvider: Boolean
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderShipmentTrackingActionListener.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderShipmentTrackingActionListener.kt
@@ -3,11 +3,6 @@ package com.woocommerce.android.ui.orders
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 
 interface OrderShipmentTrackingActionListener {
-    /**
-     * This method is needed only in [OrderFulfillmentFragment] and not in [OrderDetailFragment]
-     * so adding a default implementation here to mark the method as optional so that
-     * implementing classes do not have to implement this method if not needed
-     */
-    fun openAddOrderShipmentTrackingScreen() { }
+    fun openAddOrderShipmentTrackingScreen()
     fun deleteOrderShipmentTracking(item: WCOrderShipmentTrackingModel)
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenterTest.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import org.junit.Before
 import org.junit.Test
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.WCOrderAction.ADD_ORDER_SHIPMENT_TRACKING
 import org.wordpress.android.fluxc.action.WCOrderAction.DELETE_ORDER_SHIPMENT_TRACKING
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDER_NOTES
 import org.wordpress.android.fluxc.action.WCOrderAction.POST_ORDER_NOTE
@@ -24,6 +25,7 @@ import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.NotificationStore
 import org.wordpress.android.fluxc.store.WCOrderStore
+import org.wordpress.android.fluxc.store.WCOrderStore.AddOrderShipmentTrackingPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.DeleteOrderShipmentTrackingPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
@@ -368,7 +370,7 @@ class OrderDetailPresenterTest {
     }
 
     @Test
-    fun `Add order shipment tracking request correctly`() {
+    fun `Add order shipment tracking when network is available - success`() {
         presenter.takeView(orderDetailView)
         doReturn(order).whenever(presenter).orderModel
 
@@ -378,34 +380,51 @@ class OrderDetailPresenterTest {
             dateShipped = "2019-05-13T16:11:13Z"
         }
         presenter.pushShipmentTrackingRecord(defaultShipmentTrackingModel, false)
+
+        // ensure that dispatcher is invoked
+        verify(dispatcher, times(1)).dispatch(any<Action<AddOrderShipmentTrackingPayload>>())
+
+        // verify that add shipment tracking snackbar is displayed
         verify(orderDetailView).showAddShipmentTrackingSnack()
+
+        // mock success response
+        presenter.onOrderChanged(OnOrderChanged(1).apply {
+            causeOfChange = ADD_ORDER_SHIPMENT_TRACKING
+        })
+
+        // verify shipment trackings is loaded from db
+        verify(presenter, times(1)).loadShipmentTrackingsFromDb()
     }
 
     @Test
-    fun `Add order shipment tracking with custom provider name request correctly`() {
-        presenter.takeView(orderDetailView)
+    fun `Add order shipment tracking when network is available - error`() {
         doReturn(order).whenever(presenter).orderModel
+        presenter.takeView(orderDetailView)
 
-        val customShipmentTrackingModel = WCOrderShipmentTrackingModel(id = 1).apply {
-            trackingProvider = "Anitaa Inc"
+        val defaultShipmentTrackingModel = WCOrderShipmentTrackingModel(id = 1).apply {
+            trackingProvider = "Anitaa Test"
+            trackingLink = "123456"
             dateShipped = "2019-05-13T16:11:13Z"
         }
-        presenter.pushShipmentTrackingRecord(customShipmentTrackingModel, true)
-        verify(orderDetailView).showAddShipmentTrackingSnack()
-    }
+        presenter.pushShipmentTrackingRecord(defaultShipmentTrackingModel, false)
 
-    @Test
-    fun `Add order shipment tracking with custom provider tracking link request correctly`() {
-        presenter.takeView(orderDetailView)
-        doReturn(order).whenever(presenter).orderModel
+        // ensure that dispatcher is invoked
+        verify(dispatcher, times(1)).dispatch(any<Action<AddOrderShipmentTrackingPayload>>())
 
-        val customShipmentTrackingModel = WCOrderShipmentTrackingModel(id = 1).apply {
-            trackingProvider = "Anitaa Inc"
-            dateShipped = "2019-05-13T16:11:13Z"
-            trackingLink = "sample.com"
-        }
-        presenter.pushShipmentTrackingRecord(customShipmentTrackingModel, true)
+        // verify that add shipment tracking snackbar is displayed
         verify(orderDetailView).showAddShipmentTrackingSnack()
+
+        // mock error response
+        presenter.onOrderChanged(OnOrderChanged(1).apply {
+            causeOfChange = ADD_ORDER_SHIPMENT_TRACKING
+            error = OrderError()
+        })
+
+        // ensure that error snack message is displayed
+        verify(orderDetailView, times(1)).showAddAddShipmentTrackingErrorSnack()
+
+        // verify shipment trackings is loaded from db
+        verify(presenter, times(1)).loadShipmentTrackingsFromDb()
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenterTest.kt
@@ -366,4 +366,62 @@ class OrderDetailPresenterTest {
         // ensure that success snack message is displayed
         verify(orderDetailView, times(1)).markTrackingDeletedOnSuccess()
     }
+
+    @Test
+    fun `Add order shipment tracking request correctly`() {
+        presenter.takeView(orderDetailView)
+        doReturn(order).whenever(presenter).orderModel
+
+        val defaultShipmentTrackingModel = WCOrderShipmentTrackingModel(id = 1).apply {
+            trackingProvider = "Anitaa Test"
+            trackingLink = "123456"
+            dateShipped = "2019-05-13T16:11:13Z"
+        }
+        presenter.pushShipmentTrackingProvider(defaultShipmentTrackingModel, false)
+        verify(orderDetailView).showAddShipmentTrackingSnack()
+    }
+
+    @Test
+    fun `Add order shipment tracking with custom provider name request correctly`() {
+        presenter.takeView(orderDetailView)
+        doReturn(order).whenever(presenter).orderModel
+
+        val customShipmentTrackingModel = WCOrderShipmentTrackingModel(id = 1).apply {
+            trackingProvider = "Anitaa Inc"
+            dateShipped = "2019-05-13T16:11:13Z"
+        }
+        presenter.pushShipmentTrackingProvider(customShipmentTrackingModel, true)
+        verify(orderDetailView).showAddShipmentTrackingSnack()
+    }
+
+    @Test
+    fun `Add order shipment tracking with custom provider tracking link request correctly`() {
+        presenter.takeView(orderDetailView)
+        doReturn(order).whenever(presenter).orderModel
+
+        val customShipmentTrackingModel = WCOrderShipmentTrackingModel(id = 1).apply {
+            trackingProvider = "Anitaa Inc"
+            dateShipped = "2019-05-13T16:11:13Z"
+            trackingLink = "sample.com"
+        }
+        presenter.pushShipmentTrackingProvider(customShipmentTrackingModel, true)
+        verify(orderDetailView).showAddShipmentTrackingSnack()
+    }
+
+    @Test
+    fun `Show offline message on request to add order shipment tracking if not connected`() {
+        presenter.takeView(orderDetailView)
+        doReturn(order).whenever(presenter).orderModel
+        doReturn(false).whenever(networkStatus).isConnected()
+
+        val defaultShipmentTrackingModel = WCOrderShipmentTrackingModel(id = 1).apply {
+            trackingProvider = "Anitaa Test"
+            trackingLink = "123456"
+            dateShipped = "2019-05-13T16:11:13Z"
+        }
+        presenter.pushShipmentTrackingProvider(defaultShipmentTrackingModel, false)
+
+        verify(orderDetailView, times(0)).showAddShipmentTrackingSnack()
+        verify(uiMessageResolver, times(1)).showOfflineSnack()
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenterTest.kt
@@ -377,7 +377,7 @@ class OrderDetailPresenterTest {
             trackingLink = "123456"
             dateShipped = "2019-05-13T16:11:13Z"
         }
-        presenter.pushShipmentTrackingProvider(defaultShipmentTrackingModel, false)
+        presenter.pushShipmentTrackingRecord(defaultShipmentTrackingModel, false)
         verify(orderDetailView).showAddShipmentTrackingSnack()
     }
 
@@ -390,7 +390,7 @@ class OrderDetailPresenterTest {
             trackingProvider = "Anitaa Inc"
             dateShipped = "2019-05-13T16:11:13Z"
         }
-        presenter.pushShipmentTrackingProvider(customShipmentTrackingModel, true)
+        presenter.pushShipmentTrackingRecord(customShipmentTrackingModel, true)
         verify(orderDetailView).showAddShipmentTrackingSnack()
     }
 
@@ -404,7 +404,7 @@ class OrderDetailPresenterTest {
             dateShipped = "2019-05-13T16:11:13Z"
             trackingLink = "sample.com"
         }
-        presenter.pushShipmentTrackingProvider(customShipmentTrackingModel, true)
+        presenter.pushShipmentTrackingRecord(customShipmentTrackingModel, true)
         verify(orderDetailView).showAddShipmentTrackingSnack()
     }
 
@@ -419,7 +419,7 @@ class OrderDetailPresenterTest {
             trackingLink = "123456"
             dateShipped = "2019-05-13T16:11:13Z"
         }
-        presenter.pushShipmentTrackingProvider(defaultShipmentTrackingModel, false)
+        presenter.pushShipmentTrackingRecord(defaultShipmentTrackingModel, false)
 
         verify(orderDetailView, times(0)).showAddShipmentTrackingSnack()
         verify(uiMessageResolver, times(1)).showOfflineSnack()


### PR DESCRIPTION
Originally intended as a 4 PR feature, adding this as PR no 5 to be merged after this [PR](https://github.com/woocommerce/woocommerce-android/pull/1078) is merged.

This PR fixes #1099 by adding logic to add a new shipment tracking in the Order Detail page. 

### Changes
- [x] Adds a new `Add Tracking` button to Order Detail page
- [x] Clicking on the Add Tracking button should redirect to Add Shipment activity
- [x] Clicking ADD should add the tracking record to the Optional Tracking card
- [x] Unit tests for Presenter class
- [x] Add relevant events to the shipment tracking feature

### Notes
I am adding the label `Not Ready for review` since this [PR](https://github.com/woocommerce/woocommerce-android/pull/1078) needs to be merged before this PR can be reviewed.

### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/58555007-109bc680-8236-11e9-8a91-6bfac32f38f2.gif" width="300"/>

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
