### PR TITLE
Shipment Tracking: Support Rtl changes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderShipmentTrackingActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderShipmentTrackingActivity.kt
@@ -181,6 +181,7 @@ class AddOrderShipmentTrackingActivity : AppCompatActivity(), AddOrderShipmentTr
                 if (addTracking_number.text.isNullOrEmpty()) {
                     addTracking_editCarrier.error = null
                     addTracking_custom_provider_name.error = null
+                    addTracking_number.requestFocus()
                     addTracking_number.error = getString(R.string.order_shipment_tracking_empty_tracking_num)
                     return true
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderTrackingProviderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderTrackingProviderListFragment.kt
@@ -93,7 +93,7 @@ class AddOrderTrackingProviderListFragment : DialogFragment(), AddOrderTrackingP
 
         val toolbar = toolbar as Toolbar
         toolbar.title = getString(R.string.order_shipment_tracking_provider_toolbar_title)
-        toolbar.navigationIcon = ContextCompat.getDrawable(requireContext(), R.drawable.zui_ic_back)
+        toolbar.navigationIcon = ContextCompat.getDrawable(requireContext(), R.drawable.ic_back_white_24dp)
         toolbar.setNavigationOnClickListener { dismiss() }
         toolbar.inflateMenu(R.menu.menu_search)
         val searchMenuItem = toolbar.menu?.findItem(R.id.menu_search)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingListView.kt
@@ -78,7 +78,7 @@ class OrderDetailShipmentTrackingListView @JvmOverloads constructor(
      */
     fun addTransientTrackingProvider(wcOrderShipmentTrackingModel: WCOrderShipmentTrackingModel) {
         wcOrderShipmentTrackingModel.id = nextTransientTrackingId
-        (shipmentTrack_items.adapter as ShipmentTrackingListAdapter).addTracking(wcOrderShipmentTrackingModel)
+        (shipmentTrack_items.adapter as? ShipmentTrackingListAdapter)?.addTracking(wcOrderShipmentTrackingModel)
         nextTransientTrackingId--
         shipmentTrack_items.scrollToPosition(0)
         showOrHideDivider()

--- a/WooCommerce/src/main/res/drawable/ic_back_white_24dp.xml
+++ b/WooCommerce/src/main/res/drawable/ic_back_white_24dp.xml
@@ -2,7 +2,8 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    android:autoMirrored="true">
   <path
       android:fillColor="#FFFFFFFF"
       android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>

--- a/WooCommerce/src/main/res/drawable/ic_done_purple_24dp.xml
+++ b/WooCommerce/src/main/res/drawable/ic_done_purple_24dp.xml
@@ -1,4 +1,4 @@
-<vector android:autoMirrored="true" android:height="24dp"
+<vector android:height="24dp"
     android:tint="#96588A" android:viewportHeight="24.0"
     android:viewportWidth="24.0" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="#FF000000" android:pathData="M9,16.2L4.8,12l-1.4,1.4L9,19 21,7l-1.4,-1.4L9,16.2z"/>

--- a/WooCommerce/src/main/res/layout/activity_add_shipment_tracking.xml
+++ b/WooCommerce/src/main/res/layout/activity_add_shipment_tracking.xml
@@ -29,7 +29,7 @@
         <!-- Select provider view -->
         <TextView
             android:id="@+id/addTracking_carrier_label"
-            style="@style/Woo.TextAppearance"
+            style="@style/Woo.Add.Tracking.TextAppearance"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/order_shipment_tracking_carrier_label"/>
@@ -69,7 +69,7 @@
 
             <TextView
                 android:id="@+id/addTracking_custom_provider_name_label"
-                style="@style/Woo.TextAppearance"
+                style="@style/Woo.Add.Tracking.TextAppearance"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_medium"
@@ -99,7 +99,7 @@
         <!-- Add tracking number view -->
         <TextView
             android:id="@+id/addTracking_number_label"
-            style="@style/Woo.TextAppearance"
+            style="@style/Woo.Add.Tracking.TextAppearance"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_medium"
@@ -127,7 +127,7 @@
 
             <TextView
                 android:id="@+id/addTracking_custom_provider_url_label"
-                style="@style/Woo.TextAppearance"
+                style="@style/Woo.Add.Tracking.TextAppearance"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_medium"
@@ -156,7 +156,7 @@
         <!-- Select date shipped view -->
         <TextView
             android:id="@+id/addTracking_date_label"
-            style="@style/Woo.TextAppearance"
+            style="@style/Woo.Add.Tracking.TextAppearance"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_medium"

--- a/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_item.xml
@@ -23,7 +23,7 @@
 
         <TextView
             android:id="@+id/tracking_type"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:paddingTop="@dimen/card_item_padding_intra_v"
             android:textAppearance="@style/Woo.TextAppearance.Medium"
@@ -31,7 +31,7 @@
 
         <TextView
             android:id="@+id/tracking_number"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:paddingBottom="@dimen/card_item_padding_intra_v"
             android:paddingTop="@dimen/card_item_padding_intra_v"
@@ -40,7 +40,7 @@
 
         <TextView
             android:id="@+id/tracking_dateShipped"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:paddingBottom="@dimen/card_item_padding_intra_v"
             android:textAppearance="@style/Woo.OrderDetail.TextAppearance.Content"

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -88,6 +88,7 @@
     <style name="Woo.TextAppearance.Title.Large">
         <item name="android:textColor">@color/default_text_title</item>
         <item name="android:textSize">@dimen/text_extra_large</item>
+        <item name="android:textAlignment">viewStart</item>
     </style>
 
     <style name="Woo.TextAppearance.Title.Large.Bold">
@@ -518,6 +519,7 @@
         <item name="android:textStyle">bold</item>
         <item name="android:textColor">@color/wc_purple</item>
         <item name="android:textSize">@dimen/list_item_text_size</item>
+        <item name="android:textAlignment">viewStart</item>
     </style>
 
     <!--

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -492,6 +492,13 @@
         <item name="colorControlNormal">@color/list_divider</item>
         <item name="colorControlActivated">@color/list_divider</item>
         <item name="colorControlHighlight">@color/list_divider</item>
+        <item name="android:textAlignment">viewStart</item>
+        <item name="android:gravity">start</item>
+    </style>
+
+    <style name="Woo.Add.Tracking.TextAppearance" parent="@style/Woo.TextAppearance">
+        <item name="android:textAlignment">viewStart</item>
+        <item name="android:gravity">start</item>
     </style>
 
     <style name="Woo.Dialog.Promo">


### PR DESCRIPTION
Fixes #1106 . Shipment Tracking views now obey RTL changes.

#### Shipment Tracking List View - Order Detail
<img src="https://user-images.githubusercontent.com/22608780/58689867-d8b39100-83a5-11e9-9c0e-de4cda4c889b.png"/>

#### Shipment Tracking List View - Order Fulfill
<img src="https://user-images.githubusercontent.com/22608780/58689876-dbae8180-83a5-11e9-954a-76534dc7acb9.png"/>

#### Add Shipment Tracking View
<img src="https://user-images.githubusercontent.com/22608780/58689880-dea97200-83a5-11e9-8f17-a24450ffdca0.png"/>

This PR also fixes a bug:
When add button is clicked in Add shipment tracking without adding a tracking number, error should was not displayed in the tracking number field.

<img src="https://user-images.githubusercontent.com/22608780/58690046-42cc3600-83a6-11e9-9be5-50e63000eb01.png" width="300"/>