### PR TITLE
RTL support for order list/order note/product list divider

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/AlignedDividerDecoration.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/AlignedDividerDecoration.kt
@@ -5,6 +5,7 @@ import android.graphics.Canvas
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.support.constraint.ConstraintLayout
+import android.support.v4.view.ViewCompat
 import android.support.v7.widget.RecyclerView
 import android.view.View
 
@@ -94,11 +95,12 @@ class AlignedDividerDecoration @JvmOverloads constructor(
 
     private fun drawForVertical(canvas: Canvas, parent: RecyclerView) {
         val adjustedChildCount = parent.childCount - 2
+        val isRtl = ViewCompat.getLayoutDirection(parent) == ViewCompat.LAYOUT_DIRECTION_RTL
         (0..adjustedChildCount)
                 .map { parent.getChildAt(it) }
                 .forEach {
-                    val left = it.findViewById<View>(alignStartToStartOf)
-                    val right = it.findViewById<View>(alignEndToEndOf)
+                    val left = it.findViewById<View>(if (isRtl) alignEndToEndOf else alignStartToStartOf)
+                    val right = it.findViewById<View>(if (isRtl) alignStartToStartOf else alignEndToEndOf)
 
                     var dividerStart = left?.left ?: 0
                     var dividerEnd = right?.right ?: parent.width

--- a/WooCommerce/src/main/res/layout/order_detail_note_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_note_item.xml
@@ -54,6 +54,8 @@
         android:layout_marginEnd="@dimen/card_item_padding_intra_h"
         android:layout_marginStart="@dimen/card_section_padding_h"
         android:paddingBottom="@dimen/card_item_padding_intra_v"
+        android:layout_gravity="start"
+        android:textAlignment="viewStart"
         android:textAppearance="@style/Woo.OrderDetail.TextAppearance"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -280,6 +280,7 @@
         <item name="android:layout_height">@dimen/list_group_header_height</item>
         <item name="android:gravity">center_vertical</item>
         <item name="android:textAppearance">@style/Woo.TextAppearance.ListHeader</item>
+        <item name="android:textAlignment">viewStart</item>
     </style>
 
     <style name="Woo.TextAppearance.ListHeader">


### PR DESCRIPTION
Fixes #326 by adding modifications to support rtl.

Fixes include:
1. Order notes divider not rtl friendly
2. Order note item not rtl friendly
3. Order list header text not rtl friendly
4. Product list divider nor rtl friendly

### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/58777711-3ab20780-85ed-11e9-864a-6a2e69b49aa8.png">

![collage (2) (1)](https://user-images.githubusercontent.com/22608780/58777803-b449f580-85ed-11e9-997f-a814ce6da590.png)

![collage (3) (1)](https://user-images.githubusercontent.com/22608780/58777885-0c80f780-85ee-11e9-83bd-786af29b83b2.png)

