### PR TITLE
Product Detail: Add intrumentation tests

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockedActivityBindingModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockedActivityBindingModule.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.prefs.AppSettingsModule
 import com.woocommerce.android.ui.prefs.MainSettingsModule
 import com.woocommerce.android.ui.prefs.PrivacySettingsModule
 import com.woocommerce.android.ui.products.MockedOrderProductListModule
+import com.woocommerce.android.ui.products.MockedProductDetailModule
 import com.woocommerce.android.ui.sitepicker.SitePickerActivity
 import com.woocommerce.android.ui.sitepicker.SitePickerModule
 import com.woocommerce.android.ui.stats.MockedDashboardModule
@@ -37,6 +38,7 @@ abstract class MockedActivityBindingModule {
             MockedOrderFulfillmentModule::class,
             NotifsListModule::class,
             ReviewDetailModule::class,
+            MockedProductDetailModule::class,
             MockedAddOrderShipmentTrackingModule::class,
             MockedAddOrderTrackingProviderListModule::class))
     abstract fun provideMainActivityInjector(): MainActivity

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockedActivityBindingModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockedActivityBindingModule.kt
@@ -13,11 +13,11 @@ import com.woocommerce.android.ui.orders.MockedAddOrderTrackingProviderListModul
 import com.woocommerce.android.ui.orders.MockedOrderDetailModule
 import com.woocommerce.android.ui.orders.MockedOrderFulfillmentModule
 import com.woocommerce.android.ui.orders.MockedOrderListModule
-import com.woocommerce.android.ui.orders.OrderProductListModule
 import com.woocommerce.android.ui.prefs.AppSettingsActivity
 import com.woocommerce.android.ui.prefs.AppSettingsModule
 import com.woocommerce.android.ui.prefs.MainSettingsModule
 import com.woocommerce.android.ui.prefs.PrivacySettingsModule
+import com.woocommerce.android.ui.products.MockedOrderProductListModule
 import com.woocommerce.android.ui.sitepicker.SitePickerActivity
 import com.woocommerce.android.ui.sitepicker.SitePickerModule
 import com.woocommerce.android.ui.stats.MockedDashboardModule
@@ -33,7 +33,7 @@ abstract class MockedActivityBindingModule {
             MockedDashboardModule::class,
             MockedOrderListModule::class,
             MockedOrderDetailModule::class,
-            OrderProductListModule::class,
+            MockedOrderProductListModule::class,
             MockedOrderFulfillmentModule::class,
             NotifsListModule::class,
             ReviewDetailModule::class,

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockedCurrencyModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockedCurrencyModule.kt
@@ -7,6 +7,7 @@ import com.nhaarman.mockito_kotlin.whenever
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.WcOrderTestUtils
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.utils.WCSiteUtils
 import dagger.Module
 import dagger.Provides
 import org.mockito.ArgumentMatchers.anyBoolean
@@ -43,9 +44,9 @@ object MockedCurrencyModule {
         whenever(mockCurrencyFormatter.formatCurrency(anyString(), anyString(), anyBoolean()))
                 .thenAnswer { invocation ->
             val args = invocation.arguments
-            WcOrderTestUtils.formatCurrencyForDisplay(
+            WCSiteUtils.formatCurrencyForDisplay(
                     args[0] as String,
-                    WcOrderTestUtils.generateSiteSettings(),
+                    WCSiteUtils.generateSiteSettings(),
                     args[1] as String?,
                     args[2] as Boolean
             )

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/helpers/WCMatchers.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/helpers/WCMatchers.kt
@@ -7,6 +7,7 @@ import android.widget.HorizontalScrollView
 import android.widget.ListView
 import android.widget.ScrollView
 import android.widget.TextView
+import androidx.appcompat.widget.AppCompatRatingBar
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
 import androidx.core.widget.NestedScrollView
@@ -24,6 +25,7 @@ import com.woocommerce.android.widgets.sectionedrecyclerview.SectionedRecyclerVi
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.Description
 import org.hamcrest.Matcher
+import org.hamcrest.TypeSafeMatcher
 import org.hamcrest.core.AnyOf.anyOf
 
 object WCMatchers {
@@ -230,6 +232,43 @@ object WCMatchers {
 
             override fun matchesSafely(view: TextView): Boolean {
                 return view.error == null
+            }
+        }
+    }
+
+    /**
+     * Matcher to get the particular view for a given id and get the view at a particular index provided.
+     * For instance, in Product Detail page, we have multiple dynamic views for the same view ID.
+     * Using this method, we can choose which view we want without causing an AmbiguousViewMatcherException
+     * Reference: https://stackoverflow.com/a/39756832/9862062
+     */
+    fun matchesWithIndex(matcher: Matcher<View>, index: Int): Matcher<View> {
+        return object : TypeSafeMatcher<View>() {
+            var currentIndex = 0
+
+            override fun describeTo(description: Description) {
+                description.appendText("with index: ")
+                description.appendValue(index)
+                matcher.describeTo(description)
+            }
+
+            override fun matchesSafely(view: View): Boolean {
+                return matcher.matches(view) && currentIndex++ == index
+            }
+        }
+    }
+
+    /**
+     * Matcher to check if the RatingBar have rating text that matches the incoming value
+     */
+    fun matchesRating(rating: Float): Matcher<View> {
+        return object : BoundedMatcher<View, AppCompatRatingBar>(AppCompatRatingBar::class.java) {
+            override fun describeTo(description: Description) {
+                description.appendText("RatingBar should have $rating")
+            }
+
+            override fun matchesSafely(view: AppCompatRatingBar): Boolean {
+                return view.rating == rating
             }
         }
     }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/MainActivityTestRule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/MainActivityTestRule.kt
@@ -10,12 +10,14 @@ import com.woocommerce.android.ui.orders.MockedOrderFulfillmentModule
 import com.woocommerce.android.ui.orders.MockedOrderListModule
 import com.woocommerce.android.ui.orders.WcOrderTestUtils
 import com.woocommerce.android.ui.products.MockedOrderProductListModule
+import com.woocommerce.android.ui.products.MockedProductDetailModule
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
+import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 
 class MainActivityTestRule : ActivityTestRule<MainActivity>(MainActivity::class.java, false, false) {
@@ -111,5 +113,14 @@ class MainActivityTestRule : ActivityTestRule<MainActivity>(MainActivity::class.
         order: WCOrderModel
     ) {
         MockedOrderProductListModule.setOrderInfo(order)
+    }
+
+    /**
+     * Setting mock data for order product detail screen
+     */
+    fun setOrderProductDetailWithMockData(
+        product: WCProductModel
+    ) {
+        MockedProductDetailModule.setMockProduct(product)
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/MainActivityTestRule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/MainActivityTestRule.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.orders.MockedOrderDetailModule
 import com.woocommerce.android.ui.orders.MockedOrderFulfillmentModule
 import com.woocommerce.android.ui.orders.MockedOrderListModule
 import com.woocommerce.android.ui.orders.WcOrderTestUtils
+import com.woocommerce.android.ui.products.MockedOrderProductListModule
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
@@ -101,5 +102,14 @@ class MainActivityTestRule : ActivityTestRule<MainActivity>(MainActivity::class.
         MockedAddOrderTrackingProviderListModule.setOrderInfo(order)
         MockedAddOrderTrackingProviderListModule.setStoreCountry(storeCountry)
         MockedAddOrderTrackingProviderListModule.setOrderShipmentTrackingProviders(orderProviderList)
+    }
+
+    /**
+     * Setting mock data for order product list screen
+     */
+    fun setOrderProductListWithMockData(
+        order: WCOrderModel
+    ) {
+        MockedOrderProductListModule.setOrderInfo(order)
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/WcOrderTestUtils.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/WcOrderTestUtils.kt
@@ -2,24 +2,11 @@ package com.woocommerce.android.ui.orders
 
 import com.google.gson.Gson
 import com.woocommerce.android.helpers.WCDateTimeTestUtils
-import com.woocommerce.android.ui.products.ProductType
-import com.woocommerce.android.ui.products.ProductType.SIMPLE
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
-import org.wordpress.android.fluxc.model.WCProductModel
-import org.wordpress.android.fluxc.model.WCProductSettingsModel
-import org.wordpress.android.fluxc.model.WCSettingsModel
-import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition
-import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition.LEFT
-import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition.LEFT_SPACE
-import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition.RIGHT
-import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition.RIGHT_SPACE
-import org.wordpress.android.fluxc.utils.WCCurrencyUtils
-import org.wordpress.android.util.LanguageUtils
-import kotlin.math.absoluteValue
 
 object WcOrderTestUtils {
     /**
@@ -409,124 +396,5 @@ object WcOrderTestUtils {
         result.add(pv6)
 
         return result
-    }
-
-    /**
-     * Generates a single [WCSettingsModel] object for a mock Site
-     */
-    fun generateSiteSettings(
-        localSiteId: Int = 1,
-        currencyCode: String = "USD",
-        currencyPosition: CurrencyPosition = CurrencyPosition.LEFT
-    ): WCSettingsModel {
-        return WCSettingsModel(
-                localSiteId = localSiteId,
-                currencyCode = currencyCode,
-                currencyPosition = currencyPosition,
-                currencyThousandSeparator = ",",
-                currencyDecimalSeparator = ".",
-                currencyDecimalNumber = 2)
-    }
-
-    /**
-     * Generates a single [WCProductSettingsModel] object for a mock Site
-     */
-    fun generateProductSettings(
-        localSiteId: Int = 1,
-        dimensionUnit: String = "in",
-        weightUnit: String = "oz"
-    ): WCProductSettingsModel {
-        return WCProductSettingsModel(localSiteId).apply {
-            this.dimensionUnit = dimensionUnit
-            this.weightUnit = weightUnit
-        }
-    }
-
-    /**
-     * Generates a single [WCProductModel] object for a mock Site
-     */
-    fun generateProductDetail(
-        productId: Int = 1,
-        totalSales: Int = 0,
-        productName: String = "WooTest",
-        productType: ProductType = SIMPLE
-    ): WCProductModel {
-        return WCProductModel(productId).apply {
-            this.name = productName
-            this.type = productType.name
-            this.totalSales = totalSales
-            this.permalink =
-                    "https://jamosova3.mystagingwebsite.com/product/stranger-things-t-shirt-product-add-on-text-field/"
-            this.images = Gson().toJson(listOf(
-                    mapOf("src" to "https://jamosova3.mystagingwebsite.com/wp-content/uploads/2018/11/eleven.jpg")))
-            this.downloads = Gson().toJson(listOf(
-                    mapOf("file" to "https://jamosova3.mystagingwebsite.com/wp-content/uploads/2018/11/eleven.jpg")))
-        }
-    }
-
-    /**
-     * Mock of the method in FluxC
-     * Not sure if this is the best way to mock SiteSettings in FluxC.
-     *
-     * So the issue is, formatting currency for display, depends on the store's settings.
-     * If the store settings is null, then the currency by default is displayed with only 1 decimal place,
-     * or in some cases no decimal places. But default behaviour is to display currency code to the left
-     * with 2 decimal places.
-     * In order to correctly validate the currency formatting, we need to mock the `getSiteSettings` method
-     * inside `WooCommerceStore` class. This method is called directly from FluxC when trying to format
-     * currency.
-     *
-     * The `WooCommerceStore` is final so we cannot mock/spy the class.
-     * So a simple
-     * doReturn(WcOrderTestUtils.generateSiteSettings()).whenever(mockWcStore).getSiteSettings(any())
-     * will result in cannot mock/spy the class error.
-     *
-     * This approach was to mock the CurrencyFormatter class. But the only logic in this class is to call
-     * the appropriate method in FluxC. So rather than calling this method in CurrencyFormatter class,
-     * we can mock this method to return the appropriate value. But the logic to format is still retained in
-     * fluxC so we would need to replicate this logic in this method and check if the value matches.
-     * I admit I am not sure if this is the best approach since we would only be replicating the same logic
-     * from FluxC into Woo and that too only for UI testing purposes.
-     * If in future the logic is changed in FluxC, the UI tests would fail and we would need to replicate this
-     * inside Woo UI test as well.
-     *
-     * Another approach would be to send the SiteSettingsModel to the format currency method in `WooCommerceStore`.
-     * This way we can mock the method to fetch the SiteSettings in Woo itself and then pass the value to
-     * FluxC. This would mean making modifications to FluxC and I don't see this as really useful for anything
-     * other than fixing this issue since we would be fetching the SiteSettingsModel from FluxC and then
-     * passing the same to another method in FluxC instead of keeping the entire logic inside a single method.
-     *
-     * I ran out of ideas at this point other than to just insert a mock WcSiteSettingsModel directly into the local db
-     * when UI tests first start, which seems like a bad idea!
-     */
-    fun formatCurrencyForDisplay(
-        rawValue: String,
-        siteSettings: WCSettingsModel?,
-        currencyCode: String? = null,
-        applyDecimalFormatting: Boolean
-    ): String {
-        // Resolve the currency code to a localized symbol
-        val resolvedCurrencyCode = currencyCode ?: siteSettings?.currencyCode
-        val currencySymbol = resolvedCurrencyCode?.let {
-            WCCurrencyUtils.getLocalizedCurrencySymbolForCode(it, LanguageUtils.getCurrentDeviceLanguage())
-        } ?: ""
-
-        // Format the amount for display according to the site's currency settings
-        // Use absolute values - if the value is negative, it will be handled in the next step, with the currency symbol
-        val decimalFormattedValue = siteSettings?.takeIf { applyDecimalFormatting }?.let {
-            WCCurrencyUtils.formatCurrencyForDisplay(rawValue.toDoubleOrNull()?.absoluteValue ?: 0.0, it)
-        } ?: rawValue.removePrefix("-")
-
-        // Append or prepend the currency symbol according to the site's settings
-        with(StringBuilder()) {
-            if (rawValue.startsWith("-")) { append("-") }
-            append(when (siteSettings?.currencyPosition) {
-                null, LEFT -> "$currencySymbol$decimalFormattedValue"
-                LEFT_SPACE -> "$currencySymbol $decimalFormattedValue"
-                RIGHT -> "$decimalFormattedValue$currencySymbol"
-                RIGHT_SPACE -> "$decimalFormattedValue $currencySymbol"
-            })
-            return toString()
-        }
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/WcOrderTestUtils.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/WcOrderTestUtils.kt
@@ -2,11 +2,15 @@ package com.woocommerce.android.ui.orders
 
 import com.google.gson.Gson
 import com.woocommerce.android.helpers.WCDateTimeTestUtils
+import com.woocommerce.android.ui.products.ProductType
+import com.woocommerce.android.ui.products.ProductType.SIMPLE
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
+import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.model.WCProductSettingsModel
 import org.wordpress.android.fluxc.model.WCSettingsModel
 import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition
 import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition.LEFT
@@ -422,6 +426,42 @@ object WcOrderTestUtils {
                 currencyThousandSeparator = ",",
                 currencyDecimalSeparator = ".",
                 currencyDecimalNumber = 2)
+    }
+
+    /**
+     * Generates a single [WCProductSettingsModel] object for a mock Site
+     */
+    fun generateProductSettings(
+        localSiteId: Int = 1,
+        dimensionUnit: String = "in",
+        weightUnit: String = "oz"
+    ): WCProductSettingsModel {
+        return WCProductSettingsModel(localSiteId).apply {
+            this.dimensionUnit = dimensionUnit
+            this.weightUnit = weightUnit
+        }
+    }
+
+    /**
+     * Generates a single [WCProductModel] object for a mock Site
+     */
+    fun generateProductDetail(
+        productId: Int = 1,
+        totalSales: Int = 0,
+        productName: String = "WooTest",
+        productType: ProductType = SIMPLE
+    ): WCProductModel {
+        return WCProductModel(productId).apply {
+            this.name = productName
+            this.type = productType.name
+            this.totalSales = totalSales
+            this.permalink =
+                    "https://jamosova3.mystagingwebsite.com/product/stranger-things-t-shirt-product-add-on-text-field/"
+            this.images = Gson().toJson(listOf(
+                    mapOf("src" to "https://jamosova3.mystagingwebsite.com/wp-content/uploads/2018/11/eleven.jpg")))
+            this.downloads = Gson().toJson(listOf(
+                    mapOf("file" to "https://jamosova3.mystagingwebsite.com/wp-content/uploads/2018/11/eleven.jpg")))
+        }
     }
 
     /**

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/WcOrderTestUtils.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/WcOrderTestUtils.kt
@@ -28,14 +28,21 @@ object WcOrderTestUtils {
                             "variationId" to "0",
                             "name" to "Black T-shirt",
                             "quantity" to 1,
-                            "subtotal" to 10
+                            "subtotal" to 10,
+                            "price" to 14,
+                            "total" to 15,
+                            "total_tax" to 2,
+                            "sku" to "blabla"
                     ),
                     mapOf(
                             "productId" to "291",
                             "variationId" to "2",
                             "name" to "White Pants",
                             "quantity" to 2,
-                            "subtotal" to 12
+                            "subtotal" to 12,
+                            "price" to 11,
+                            "total" to 13,
+                            "total_tax" to 3
                     )
             )
     )

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/MockedOrderProductListModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/MockedOrderProductListModule.kt
@@ -1,0 +1,59 @@
+package com.woocommerce.android.ui.products
+
+import android.content.Context
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.spy
+import com.nhaarman.mockito_kotlin.whenever
+import com.woocommerce.android.di.ActivityScope
+import com.woocommerce.android.ui.orders.OrderProductListContract
+import com.woocommerce.android.ui.orders.OrderProductListFragment
+import com.woocommerce.android.ui.orders.OrderProductListPresenter
+import dagger.Module
+import dagger.Provides
+import dagger.android.ContributesAndroidInjector
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.WCOrderModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
+import org.wordpress.android.fluxc.store.WCOrderStore
+
+@Module
+abstract class MockedOrderProductListModule {
+    @Module
+    companion object {
+        private var order: WCOrderModel? = null
+
+        fun setOrderInfo(order: WCOrderModel) {
+            this.order = order
+        }
+
+        @JvmStatic
+        @ActivityScope
+        @Provides
+        fun provideOrderProductListPresenter(): OrderProductListContract.Presenter {
+            /**
+             * Creating a spy object here since we need to mock specific methods of [OrderProductListPresenter] class
+             * instead of mocking all the methods in the class.
+             * We cannot mock final classes ([WCOrderStore]), so
+             * creating a mock instance of those classes and passing to the presenter class constructor.
+             */
+            val mockDispatcher = mock<Dispatcher>()
+            val mockContext = mock<Context>()
+
+            val mockedOrderProductListPresenter = spy(OrderProductListPresenter(
+                    WCOrderStore(mockDispatcher, OrderRestClient(mockContext, mockDispatcher, mock(), mock(), mock()))
+            ))
+
+            /**
+             * Mocking the below methods in [OrderProductListPresenter] class to pass mock values.
+             * These are the methods that invoke [WCOrderModel] methods from FluxC.
+             */
+            doReturn(order).whenever(mockedOrderProductListPresenter).getOrderDetailFromDb(any())
+            return mockedOrderProductListPresenter
+        }
+    }
+
+    @ContributesAndroidInjector
+    abstract fun orderProductListFragment(): OrderProductListFragment
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/MockedProductDetailModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/MockedProductDetailModule.kt
@@ -1,0 +1,80 @@
+package com.woocommerce.android.ui.products
+
+import android.content.Context
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.spy
+import com.nhaarman.mockito_kotlin.whenever
+import com.woocommerce.android.di.ActivityScope
+import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.WcOrderTestUtils
+import dagger.Module
+import dagger.Provides
+import dagger.android.ContributesAndroidInjector
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooCommerceRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
+import org.wordpress.android.fluxc.store.WCOrderStore
+import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WooCommerceStore
+
+@Module
+abstract class MockedProductDetailModule {
+    @Module
+    companion object {
+        private var product: WCProductModel? = null
+
+        fun setMockProduct(product: WCProductModel) {
+            this.product = product
+        }
+
+        @JvmStatic
+        @ActivityScope
+        @Provides
+        fun provideProductDetailPresenter(): ProductDetailContract.Presenter {
+            /**
+             * Creating a spy object here since we need to mock specific methods of [ProductDetailPresenter] class
+             * instead of mocking all the methods in the class.
+             * We cannot mock final classes ([WCOrderStore]), so
+             * creating a mock instance of those classes and passing to the presenter class constructor.
+             */
+            val mockDispatcher = mock<Dispatcher>()
+            val mockContext = mock<Context>()
+            val mockSelectedSite = mock<SelectedSite>()
+            val mockNetworkStatus = mock<NetworkStatus>()
+            val mockWcStore = WooCommerceStore(
+                    mockContext,
+                    mockDispatcher,
+                    WooCommerceRestClient(mockContext, mockDispatcher, mock(), mock(), mock())
+            )
+
+//            doReturn(SiteModel()).whenever(mockSelectedSite).get()
+            val mockedProductDetailPresenter = spy(ProductDetailPresenter(
+                    mockDispatcher, mockWcStore,
+                    WCProductStore(
+                            mockDispatcher,
+                            ProductRestClient(mockContext, mockDispatcher, mock(), mock(), mock())
+                    ),
+                    mockSelectedSite, mock(), mockNetworkStatus, mock()
+            ))
+
+            /**
+             * Mocking the below methods in [ProductDetailPresenter] class to pass mock values.
+             * These are the methods that invoke [WCProductModel] methods from FluxC.
+             */
+            doReturn(product).whenever(mockedProductDetailPresenter).getProduct(any())
+            doReturn(WcOrderTestUtils.generateSiteSettings()).whenever(mockedProductDetailPresenter).getSiteSettings()
+            doReturn(WcOrderTestUtils.generateProductSettings())
+                    .whenever(mockedProductDetailPresenter)
+                    .getProductSiteSettings()
+
+            return mockedProductDetailPresenter
+        }
+    }
+
+    @ContributesAndroidInjector
+    abstract fun productDetailfragment(): ProductDetailFragment
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/MockedProductDetailModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/MockedProductDetailModule.kt
@@ -9,7 +9,7 @@ import com.nhaarman.mockito_kotlin.whenever
 import com.woocommerce.android.di.ActivityScope
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.orders.WcOrderTestUtils
+import com.woocommerce.android.utils.WCSiteUtils
 import dagger.Module
 import dagger.Provides
 import dagger.android.ContributesAndroidInjector
@@ -66,8 +66,8 @@ abstract class MockedProductDetailModule {
              * These are the methods that invoke [WCProductModel] methods from FluxC.
              */
             doReturn(product).whenever(mockedProductDetailPresenter).getProduct(any())
-            doReturn(WcOrderTestUtils.generateSiteSettings()).whenever(mockedProductDetailPresenter).getSiteSettings()
-            doReturn(WcOrderTestUtils.generateProductSettings())
+            doReturn(WCSiteUtils.generateSiteSettings()).whenever(mockedProductDetailPresenter).getSiteSettings()
+            doReturn(WcProductTestUtils.generateProductSettings())
                     .whenever(mockedProductDetailPresenter)
                     .getProductSiteSettings()
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/ProductDetailNavigationTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/ProductDetailNavigationTest.kt
@@ -50,7 +50,7 @@ class ProductDetailNavigationTest : TestBase() {
     @JvmField var activityTestRule = MainActivityTestRule()
 
     private val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail(orderStatus = "Completed")
-    private val mockProductModel = WcOrderTestUtils.generateProductDetail()
+    private val mockProductModel = WcProductTestUtils.generateProductDetail()
 
     private fun chooser(matcher: Matcher<Intent>): Matcher<Intent> {
         return allOf(hasAction(Intent.ACTION_CHOOSER), hasExtra(`is`(Intent.EXTRA_INTENT), matcher))

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/ProductDetailNavigationTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/ProductDetailNavigationTest.kt
@@ -1,0 +1,705 @@
+package com.woocommerce.android.ui.products
+
+import android.app.Activity
+import android.app.Instrumentation.ActivityResult
+import android.content.Intent
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.matcher.IntentMatchers
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.Visibility.GONE
+import androidx.test.espresso.matcher.ViewMatchers.Visibility.VISIBLE
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.woocommerce.android.R
+import com.woocommerce.android.R.string
+import com.woocommerce.android.helpers.WCMatchers
+import com.woocommerce.android.helpers.WCMatchers.scrollTo
+import com.woocommerce.android.ui.TestBase
+import com.woocommerce.android.ui.main.MainActivityTestRule
+import com.woocommerce.android.ui.orders.WcOrderTestUtils
+import org.hamcrest.CoreMatchers
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.Matcher
+import org.hamcrest.Matchers.equalToIgnoringCase
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.wordpress.android.fluxc.model.SiteModel
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class ProductDetailNavigationTest : TestBase() {
+    @Rule
+    @JvmField var activityTestRule = MainActivityTestRule()
+
+    private val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail(orderStatus = "Completed")
+    private val mockProductModel = WcOrderTestUtils.generateProductDetail()
+
+    private fun chooser(matcher: Matcher<Intent>): Matcher<Intent> {
+        return allOf(hasAction(Intent.ACTION_CHOOSER), hasExtra(`is`(Intent.EXTRA_INTENT), matcher))
+    }
+
+    @Before
+    override fun setup() {
+        super.setup()
+        Intents.init()
+
+        // By default Espresso Intents does not stub any Intents. Stubbing needs to be setup before
+        // every test run. In this case all external Intents will be blocked.
+        Intents.intending(CoreMatchers.not(IntentMatchers.isInternal()))
+                .respondWith(ActivityResult(Activity.RESULT_OK, null))
+
+        // Bypass login screen and display dashboard
+        activityTestRule.launchMainActivityLoggedIn(null, SiteModel())
+
+        // Make sure the bottom navigation view is showing
+        activityTestRule.activity.showBottomNav()
+
+        // add mock data to order list screen
+        activityTestRule.setOrderListWithMockData()
+
+        // Click on Orders tab in the bottom bar
+        onView(withId(R.id.orders)).perform(click())
+
+        // inject mock data to order detail page
+        activityTestRule.setOrderDetailWithMockData(mockWCOrderModel)
+
+        // redirect to order detail page
+        onView(withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // inject mock data to order product list page
+        activityTestRule.setOrderProductListWithMockData(mockWCOrderModel)
+
+        // click on the Details button in product list card
+        onView(withId(R.id.productList_btnDetails)).perform(scrollTo(), click())
+    }
+
+    @After
+    fun tearDown() {
+        Intents.release()
+    }
+
+    @Test
+    fun verifyProductListItemClickRedirectsToProductDetail() {
+        // inject mock data to product detail
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        // verify that toolbar title is changed to the product detail name
+        onView(withId(R.id.toolbar)).check(matches(WCMatchers.withToolbarTitle(
+                equalToIgnoringCase(mockProductModel.name))))
+
+        // verify that close button is visible
+        onView(withContentDescription(string.abc_action_bar_up_description))
+                .check(matches(ViewMatchers.withEffectiveVisibility(VISIBLE)))
+
+        // verify that share button is visible
+        onView(withId(R.id.menu_share))
+                .check(matches(ViewMatchers.withEffectiveVisibility(VISIBLE)))
+
+        // Clicking the "up" button in product detail screen returns the user to the product list screen.
+        // The Toolbar title changes to "Order #1"
+        onView(withContentDescription(R.string.abc_action_bar_up_description)).perform(click())
+
+        onView(withId(R.id.toolbar)).check(matches(WCMatchers.withToolbarTitle(equalToIgnoringCase(
+                appContext.getString(R.string.orderdetail_orderstatus_ordernum, "1")
+        ))))
+    }
+
+    @Test
+    fun verifyProductDetailListItemDisplayedSuccessfully() {
+        // inject mock data to product detail
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        // since image is available, the imageView should be visible
+        onView(withId(R.id.productDetail_image)).check(matches(ViewMatchers.withEffectiveVisibility(VISIBLE)))
+
+        // verify that product title label is displayed correctly
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyName), 0))
+                .check(matches(withText(appContext.getString(R.string.product_name))))
+
+        // verify that total orders label is displayed correctly
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyName), 1))
+                .check(matches(withText(appContext.getString(R.string.product_total_orders))))
+
+        // verify that review label is displayed correctly
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyName), 2))
+                .check(matches(withText(appContext.getString(R.string.product_reviews))))
+
+        // verify that product title is displayed correctly
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 0))
+                .check(matches(withText(mockProductModel.name)))
+
+        // verify that total orders is displayed correctly
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 1))
+                .check(matches(withText(mockProductModel.totalSales.toString())))
+    }
+
+    @Test
+    fun verifyProductDetailTitleDisplayedCorrectlyForExternalProducts() {
+        // inject mock data to product detail
+        mockProductModel.type = ProductType.EXTERNAL.name
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        // verify that product title is displayed correctly
+        val productTitle = appContext.getString(R.string.product_name_external, mockProductModel.name)
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 0))
+                .check(matches(withText(productTitle)))
+
+        // verify that toolbar title is displayed correctly
+        onView(withId(R.id.toolbar)).check(matches(WCMatchers.withToolbarTitle(equalToIgnoringCase(productTitle))))
+    }
+
+    @Test
+    fun verifyProductDetailTitleDisplayedCorrectlyForGroupedProducts() {
+        // inject mock data to product detail
+        mockProductModel.type = ProductType.GROUPED.name
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        // verify that product title is displayed correctly
+        val productTitle = appContext.getString(R.string.product_name_grouped, mockProductModel.name)
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 0))
+                .check(matches(withText(productTitle)))
+
+        // verify that toolbar title is displayed correctly
+        onView(withId(R.id.toolbar)).check(matches(WCMatchers.withToolbarTitle(equalToIgnoringCase(productTitle))))
+    }
+
+    @Test
+    fun verifyProductDetailTitleDisplayedCorrectlyForVariableProducts() {
+        // inject mock data to product detail
+        mockProductModel.type = ProductType.VARIABLE.name
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        // verify that product title is displayed correctly
+        val productTitle = appContext.getString(R.string.product_name_variable, mockProductModel.name)
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 0))
+                .check(matches(withText(productTitle)))
+
+        // verify that toolbar title is displayed correctly
+        onView(withId(R.id.toolbar)).check(matches(WCMatchers.withToolbarTitle(equalToIgnoringCase(productTitle))))
+    }
+
+    @Test
+    fun verifyProductDetailTitleDisplayedCorrectlyForVirtualProducts() {
+        // inject mock data to product detail
+        mockProductModel.virtual = true
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        // verify that product title is displayed correctly
+        val productTitle = appContext.getString(R.string.product_name_virtual, mockProductModel.name)
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 0))
+                .check(matches(withText(productTitle)))
+
+        // verify that toolbar title is displayed correctly
+        onView(withId(R.id.toolbar)).check(matches(WCMatchers.withToolbarTitle(equalToIgnoringCase(productTitle))))
+    }
+
+    @Test
+    fun verifyProductDetailTotalOrderCountLessThan200FormattedCorrectly() {
+        // inject mock data to product detail
+        mockProductModel.totalSales = 200
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        // verify that total order count  = 200, is displayed correctly
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 1))
+                .check(matches(withText(mockProductModel.totalSales.toString())))
+    }
+
+    @Test
+    fun verifyProductDetailTotalOrderCountLessThan2000FormattedCorrectly() {
+        // inject mock data to product detail
+        mockProductModel.totalSales = 2000
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        // verify that total order count  = 200, is displayed correctly
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 1))
+                .check(matches(withText("2k")))
+    }
+
+    @Test
+    fun verifyProductDetailTotalOrderCountLessThan20000FormattedCorrectly() {
+        // inject mock data to product detail
+        mockProductModel.totalSales = 20000
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        // verify that total order count  = 200, is displayed correctly
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 1))
+                .check(matches(withText("20k")))
+    }
+
+    @Test
+    fun verifyProductDetailTotalOrderCountLessThan2000000FormattedCorrectly() {
+        // inject mock data to product detail
+        mockProductModel.totalSales = 2000000
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        // verify that total order count  = 200, is displayed correctly
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 1))
+                .check(matches(withText("2m")))
+    }
+
+    @Test
+    fun verifyProductDetailForVariationProductsDisplayedCorrectly() {
+        // inject mock data to product detail
+        mockProductModel.type = ProductType.VARIATION.name
+        mockProductModel.reviewsAllowed = true
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        // verify that total order view is not displayed for variation products
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 1)).check(doesNotExist())
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyName), 1)).check(doesNotExist())
+
+        // verify that reviews view is not displayed for variation products
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 2)).check(doesNotExist())
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyName), 2)).check(doesNotExist())
+    }
+
+    @Test
+    fun verifyProductDetailStoreButtonOpensWebView() {
+        // inject mock data to product detail
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        // verify that `product view on store` is displayed
+        onView(withId(R.id.textLink)).check(matches(ViewMatchers.withEffectiveVisibility(VISIBLE)))
+
+        // verify that `product view on store` text is displayed correctly
+        onView(withId(R.id.textLink)).check(matches(withText(appContext.getString(R.string.product_view_in_store))))
+
+        // click the view product in store button
+        onView(withId(R.id.textLink)).perform(WCMatchers.scrollTo(), click())
+
+        // check if webview intent is opened for the given url
+        Intents.intended(allOf(IntentMatchers.hasAction(Intent.ACTION_VIEW),
+                IntentMatchers.hasData(mockProductModel.permalink)))
+    }
+
+    @Test
+    fun verifyProductDetailReviewsDisplayedOnlyIfAllowed() {
+        // inject mock data to product detail
+        mockProductModel.reviewsAllowed = false
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        // verify that reviews view is hidden
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 2)).check(doesNotExist())
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyName), 2)).check(doesNotExist())
+    }
+
+    @Test
+    fun verifyProductDetailReviewsDisplayedCorrectlyWhenAllowed() {
+        // inject mock data to product detail
+        mockProductModel.reviewsAllowed = true
+        mockProductModel.ratingCount = 30
+        mockProductModel.averageRating = "4"
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        // verify that reviews view is displayed correctly
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyName), 2))
+                .check(matches(withText(appContext.getString(R.string.product_reviews))))
+
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 2))
+                .check(matches(withText(mockProductModel.ratingCount.toString())))
+
+        // verify the rating bar displays correct value
+        onView(WCMatchers.matchesWithIndex(withId(R.id.ratingBar), 2))
+                .check(matches(WCMatchers.matchesRating(mockProductModel.averageRating.toFloat())))
+    }
+
+    @Test
+    fun verifyProductDetailStatusBadgeDisplayedForUnpublishedProducts() {
+        // inject mock data to product detail
+        mockProductModel.status = ProductStatus.DRAFT.name
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        // verify that badge view is displayed
+        onView(withId(R.id.frameStatusBadge)).check(matches(ViewMatchers.withEffectiveVisibility(VISIBLE)))
+
+        // verify badge text is displayed correctly
+        onView(withId(R.id.textStatusBadge)).check(matches(withText(ProductStatus.DRAFT.toString(appContext))))
+    }
+
+    @Test
+    fun verifyProductDetailShareButtonOpensShareIntent() {
+        // inject mock data to product detail
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        // click the share button
+        onView(withId(R.id.menu_share)).perform(click())
+
+        // check if share intent is opened with the given product details
+        intended(chooser(allOf(
+                hasAction(Intent.ACTION_SEND),
+                hasExtra(Intent.EXTRA_TEXT, mockProductModel.permalink)
+        )))
+    }
+
+    @Test
+    fun verifyProductDetailPricingInfoDisplayedCorrectlyWhenNoPriceInfoAvailable() {
+        // inject mock data to product detail
+        mockProductModel.price = ""
+        mockProductModel.salePrice = ""
+        mockProductModel.taxClass = ""
+        mockProductModel.sku = "Blah"
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        // verify caption is displayed correctly
+        onView(WCMatchers.matchesWithIndex(withId(R.id.cardCaptionText), 1))
+                .check(matches(withText(appContext.getString(R.string.product_inventory))))
+
+        // verify that the pricing card property label = R.string.product_sku
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyName), 3))
+                .check(matches(withText(appContext.getString(R.string.product_sku))))
+
+        // verify that the pricing card sku text is displayed correctly
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 1))
+                .check(matches(withText(mockProductModel.sku)))
+    }
+
+    @Test
+    fun verifyProductDetailPricingInfoDisplayedCorrectlyWhenPriceInfoAvailable() {
+        // inject mock data to product detail
+        mockProductModel.price = "10"
+        mockProductModel.salePrice = ""
+        mockProductModel.taxClass = "2"
+        mockProductModel.sku = "Blah"
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        // verify caption is displayed correctly
+        onView(WCMatchers.matchesWithIndex(withId(R.id.cardCaptionText), 1))
+                .check(matches(withText(appContext.getString(R.string.product_pricing_and_inventory))))
+
+        // verify that the pricing card property label = R.string.product_sku
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyName), 4))
+                .check(matches(withText(appContext.getString(R.string.product_sku))))
+
+        // verify that the pricing card sku text is displayed correctly
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 2))
+                .check(matches(withText(mockProductModel.sku)))
+    }
+
+    @Test
+    fun verifyProductDetailPricingInfoDisplayedCorrectlyWhenSalePriceNotAvailable() {
+        // inject mock data to product detail
+        mockProductModel.price = "10"
+        mockProductModel.salePrice = ""
+        mockProductModel.taxClass = "2"
+        mockProductModel.sku = "Blah"
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        // verify caption is displayed correctly
+        onView(WCMatchers.matchesWithIndex(withId(R.id.cardCaptionText), 1))
+                .check(matches(withText(appContext.getString(R.string.product_pricing_and_inventory))))
+
+        // verify that the pricing card property label = R.string.product_price
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyName), 3))
+                .check(matches(withText(appContext.getString(R.string.product_price))))
+
+        // verify that the pricing card pricing text is displayed correctly
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 1))
+                .check(matches(withText(mockProductModel.price)))
+    }
+
+    @Test
+    fun verifyProductDetailPricingInfoDisplayedCorrectlyWhenSalePriceAvailable() {
+        // inject mock data to product detail
+        mockProductModel.price = "10"
+        mockProductModel.regularPrice = "10"
+        mockProductModel.salePrice = "15"
+        mockProductModel.taxClass = "2"
+        mockProductModel.sku = "Blah"
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        // verify caption is displayed correctly
+        onView(WCMatchers.matchesWithIndex(withId(R.id.cardCaptionText), 1))
+                .check(matches(withText(appContext.getString(R.string.product_pricing_and_inventory))))
+
+        // verify that the pricing card property label = R.string.product_price
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyName), 3))
+                .check(matches(withText(appContext.getString(R.string.product_price))))
+
+        // verify that the pricing card pricing text is displayed correctly
+        val regularPrice = "${appContext.getString(R.string.product_regular_price)}: ${mockProductModel.regularPrice}"
+        val salesPrice = "${appContext.getString(R.string.product_sale_price)}: ${mockProductModel.salePrice}"
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 1))
+                .check(matches(withText("$regularPrice\n$salesPrice")))
+    }
+
+    @Test
+    fun verifyProductDetailShippingInfoDisplayedCorrectlyWhenWidthHeightLengthAvailable() {
+        // inject mock data to product detail
+        mockProductModel.weight = "4"
+        mockProductModel.width = "2"
+        mockProductModel.height = "3"
+        mockProductModel.length = "1"
+        mockProductModel.shippingClass = "5"
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        // verify caption is displayed correctly
+        onView(WCMatchers.matchesWithIndex(withId(R.id.cardCaptionText), 1))
+                .check(matches(withText(appContext.getString(R.string.product_purchase_details))))
+
+        // verify that the shipping card property label = R.string.product_shipping
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyName), 3))
+                .check(matches(withText(appContext.getString(R.string.product_shipping))))
+
+        // verify that the shipping card pricing text is displayed correctly
+        val weight = "${appContext.getString(R.string.product_weight)}: ${mockProductModel.weight}oz"
+        val size = "${appContext.getString(R.string.product_size)}: " +
+                "${mockProductModel.length} x ${mockProductModel.width} x ${mockProductModel.height} in"
+        val shippingClass = "${appContext.getString(R.string.product_shipping_class)}: " +
+                mockProductModel.shippingClass
+
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 1))
+                .check(matches(withText("$weight\n$size\n$shippingClass")))
+    }
+
+    @Test
+    fun verifyProductDetailShippingInfoDisplayedCorrectlyWhenWidthHeightOnlyAvailable() {
+        // inject mock data to product detail
+        mockProductModel.weight = "4"
+        mockProductModel.width = "2"
+        mockProductModel.height = "3"
+        mockProductModel.shippingClass = "5"
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        // verify caption is displayed correctly
+        onView(WCMatchers.matchesWithIndex(withId(R.id.cardCaptionText), 1))
+                .check(matches(withText(appContext.getString(R.string.product_purchase_details))))
+
+        // verify that the shipping card property label = R.string.product_shipping
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyName), 3))
+                .check(matches(withText(appContext.getString(R.string.product_shipping))))
+
+        // verify that the shipping card pricing text is displayed correctly
+        val weight = "${appContext.getString(R.string.product_weight)}: ${mockProductModel.weight}oz"
+        val size = "${appContext.getString(R.string.product_size)}: " +
+                "${mockProductModel.width} x ${mockProductModel.height} in"
+        val shippingClass = "${appContext.getString(R.string.product_shipping_class)}: " +
+                mockProductModel.shippingClass
+
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 1))
+                .check(matches(withText("$weight\n$size\n$shippingClass")))
+    }
+
+    @Test
+    fun verifyProductDetailPurchaseInfoForDownloadableProductsDisplayedCorrectly() {
+        // inject mock data to product detail
+        mockProductModel.downloadable = true
+        mockProductModel.downloadLimit = 10
+        mockProductModel.downloadExpiry = 2
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        onView(WCMatchers.matchesWithIndex(withId(R.id.cardCaptionText), 1))
+                .check(matches(withText(appContext.getString(R.string.product_purchase_details))))
+
+        // verify that the download card property label = R.string.product_downloads
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyName), 3))
+                .check(matches(withText(appContext.getString(R.string.product_downloads))))
+
+        // verify that the shipping card pricing text is displayed correctly
+        val downloadableFiles = mockProductModel.getDownloadableFiles()
+        val count = "${appContext.getString(R.string.product_downloadable_files)}: ${downloadableFiles.size}"
+        val limit = "${appContext.getString(R.string.product_download_limit)}: ${String.format(
+                appContext.getString(R.string.product_download_limit_count),
+                mockProductModel.downloadLimit
+        )}"
+        val expiry = "${appContext.getString(R.string.product_download_expiry)}: ${String.format(
+                appContext.getString(R.string.product_download_expiry_days),
+                mockProductModel.downloadExpiry
+        )}"
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 1))
+                .check(matches(withText("$count\n$limit\n$expiry")))
+    }
+
+    @Test
+    fun verifyProductDetailPurchaseInfoForDownloadableProductsWithoutLimitAndExpiryDisplayedCorrectly() {
+        // inject mock data to product detail
+        mockProductModel.downloadable = true
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        onView(WCMatchers.matchesWithIndex(withId(R.id.cardCaptionText), 1))
+                .check(matches(withText(appContext.getString(R.string.product_purchase_details))))
+
+        // verify that the download card property label = R.string.product_downloads
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyName), 3))
+                .check(matches(withText(appContext.getString(R.string.product_downloads))))
+
+        // verify that the shipping card pricing text is displayed correctly
+        val downloadableFiles = mockProductModel.getDownloadableFiles()
+        val count = "${appContext.getString(R.string.product_downloadable_files)}: ${downloadableFiles.size}"
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 1))
+                .check(matches(withText(count)))
+    }
+
+    @Test
+    fun verifyProductDetailPurchaseNoteDisplayedCorrectlyWhenAvailable() {
+        // inject mock data to product detail
+        mockProductModel.purchaseNote = "Purchase Note"
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        onView(WCMatchers.matchesWithIndex(withId(R.id.cardCaptionText), 1))
+                .check(matches(withText(appContext.getString(R.string.product_purchase_details))))
+
+        // verify that the purchase note property label = R.string.product_purchase_note
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textCaption), 0))
+                .check(matches(withText(appContext.getString(R.string.product_purchase_note))))
+
+        // verify that the purchase note card pricing text is displayed correctly
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textContent), 0))
+                .check(matches(withText(mockProductModel.purchaseNote)))
+
+        // verify that the purchase note read more is not displayed
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textReadMore), 0))
+                .check(matches(ViewMatchers.withEffectiveVisibility(GONE)))
+    }
+
+    @Test
+    fun verifyProductDetailReallyLongPurchaseNoteDisplayedCorrectlyWhenAvailable() {
+        // inject mock data to product detail
+        mockProductModel.purchaseNote = "Lorem ipsum dolor sit amet, consectetur adipisicing elit. " +
+                "Eligendi non quis exercitationem culpa nesciunt nihil aut nostrum explicabo reprehenderit " +
+                "optio amet ab temporibus asperiores quasi cupiditate. Voluptatum ducimus voluptates voluptas?"
+        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
+
+        // click on the first item in product list page
+        onView(withId(R.id.productList_products))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
+
+        onView(WCMatchers.matchesWithIndex(withId(R.id.cardCaptionText), 1))
+                .check(matches(withText(appContext.getString(R.string.product_purchase_details))))
+
+        // verify that the purchase note property label = R.string.product_purchase_note
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textCaption), 0))
+                .check(matches(withText(appContext.getString(R.string.product_purchase_note))))
+
+        // verify that the purchase note card pricing text is displayed correctly
+        onView(WCMatchers.matchesWithIndex(withId(R.id.textContent), 0))
+                .check(matches(withText(mockProductModel.purchaseNote)))
+
+        // verify that the purchase note read more is displayed
+        onView(withId(R.id.textReadMore)).check(matches(ViewMatchers.withEffectiveVisibility(VISIBLE)))
+
+        // verify dialog is displayed when read more button is clicked
+        onView(withId(R.id.textReadMore)).perform(WCMatchers.scrollTo(), click())
+
+        onView(withText(appContext.getString(R.string.product_purchase_note)))
+                .inRoot(isDialog()).check(matches(isDisplayed()))
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/ProductListCardTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/ProductListCardTest.kt
@@ -1,0 +1,319 @@
+package com.woocommerce.android.ui.products
+
+import android.os.Build.VERSION
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.ViewMatchers.Visibility.GONE
+import androidx.test.espresso.matcher.ViewMatchers.Visibility.VISIBLE
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.woocommerce.android.R
+import com.woocommerce.android.R.string
+import com.woocommerce.android.helpers.WCMatchers
+import com.woocommerce.android.helpers.WCMatchers.scrollTo
+import com.woocommerce.android.helpers.WCMatchers.withRecyclerView
+import com.woocommerce.android.ui.TestBase
+import com.woocommerce.android.ui.main.MainActivityTestRule
+import com.woocommerce.android.ui.orders.WcOrderTestUtils
+import org.hamcrest.Matchers.equalToIgnoringCase
+import org.junit.Assert.assertSame
+import org.junit.Assume
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.wordpress.android.fluxc.model.SiteModel
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class ProductListCardTest : TestBase() {
+    @Rule
+    @JvmField var activityTestRule = MainActivityTestRule()
+
+    private val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail(orderStatus = "Completed")
+
+    @Before
+    override fun setup() {
+        super.setup()
+        // Bypass login screen and display dashboard
+        activityTestRule.launchMainActivityLoggedIn(null, SiteModel())
+
+        // Make sure the bottom navigation view is showing
+        activityTestRule.activity.showBottomNav()
+
+        // add mock data to order list screen
+        activityTestRule.setOrderListWithMockData()
+
+        // Click on Orders tab in the bottom bar
+        onView(withId(R.id.orders)).perform(click())
+
+        // inject mock data to order detail page
+        activityTestRule.setOrderDetailWithMockData(mockWCOrderModel)
+
+        // redirect to order detail page
+        onView(withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+    }
+
+    @Test
+    fun verifyProductCardListPopulatedSuccessfully() {
+        // inject mock data to order product list page
+        activityTestRule.setOrderProductListWithMockData(mockWCOrderModel)
+
+        // click on the Details button in product list card
+        onView(withId(R.id.productList_btnDetails)).perform(scrollTo(), click())
+
+        // Ensure that the toolbar title displays "Order #" + order number
+        onView(withId(R.id.toolbar)).check(matches(WCMatchers.withToolbarTitle(
+                equalToIgnoringCase(appContext.getString(string.orderdetail_orderstatus_ordernum,
+                        mockWCOrderModel.number)
+                ))))
+
+        // check if order product card label matches this title:
+        // R.string.orderdetail_product
+        onView(withId(R.id.productList_lblProduct)).check(matches(
+                withText(appContext.getString(R.string.orderdetail_product))
+        ))
+
+        // check if order product card quantity label matches this title:
+        // R.string.orderdetail_product_qty
+        onView(withId(R.id.productList_lblQty)).check(matches(
+                withText(appContext.getString(R.string.orderdetail_product_qty))
+        ))
+
+        // check if product list is 2
+        val recyclerView = activityTestRule.activity.findViewById(R.id.productList_products) as RecyclerView
+        assertSame(2, recyclerView.adapter?.itemCount)
+
+        // verify that the fulfill order and Details button are hidden
+        onView(withId(R.id.productList_btnFulfill)).check(matches(withEffectiveVisibility(GONE)))
+        onView(withId(R.id.productList_btnDetails)).check(matches(withEffectiveVisibility(GONE)))
+    }
+
+    @Test
+    fun verifyProductCardListItemPopulatedSuccessfully() {
+        // inject mock data to order product list page
+        activityTestRule.setOrderProductListWithMockData(mockWCOrderModel)
+
+        // click on the Details button in product list card
+        onView(withId(R.id.productList_btnDetails)).perform(scrollTo(), click())
+
+        // verify if the first product name matches: Black T-shirt
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_name))
+                .check(matches(withText(mockWCOrderModel.getLineItemList()[0].name)))
+
+        // verify if the second product quantity matches: 2
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_qty))
+                .check(matches(withText(mockWCOrderModel.getLineItemList()[1].quantity?.toInt().toString())))
+
+        // verify that the product total label is visible
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productTotal))
+                .check(matches(withEffectiveVisibility(VISIBLE)))
+
+        // verify that the product total tax is visible
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_totalTax))
+                .check(matches(withEffectiveVisibility(VISIBLE)))
+
+        // verify that the product total label is visible
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_lblTax))
+                .check(matches(withEffectiveVisibility(VISIBLE)))
+
+        // verify that the tax label matches : Tax:
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_lblTax))
+                .check(matches(withText(appContext.getString(R.string.orderdetail_product_lineitem_tax))))
+    }
+
+    /**
+     * Related FluxC issue in MockedStack_WCBaseStoreTest.kt#L116
+     * Some of the internals of java.util.Currency seem to be stubbed in a unit test environment,
+     * giving results inconsistent with a normal running app
+     */
+    @Test
+    fun verifyProductListItemCurrencyDisplayedCorrectlyForUSD() {
+        Assume.assumeTrue(
+                "Requires API 23 or higher due to localized currency values differing on older versions",
+                VERSION.SDK_INT >= 23
+        )
+
+        // inject mock data to order product list page
+        activityTestRule.setOrderProductListWithMockData(mockWCOrderModel)
+
+        // click on the Details button in product list card
+        onView(withId(R.id.productList_btnDetails)).perform(scrollTo(), click())
+
+        // verify that the product total is displayed correctly for multiple quantities
+        // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productTotal))
+                .check(matches(withText(appContext.getString(
+                        R.string.orderdetail_product_lineitem_total_single,
+                        "$${mockWCOrderModel.getLineItemList()[0].total}.00"
+                ))))
+
+        // for multiple quantities: $13.00 ($11.00x2)
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productTotal))
+                .check(matches(withText(appContext.getString(
+                        R.string.orderdetail_product_lineitem_total_multiple,
+                        "$${mockWCOrderModel.getLineItemList()[1].total}.00",
+                        "$${mockWCOrderModel.getLineItemList()[1].price}.00",
+                        mockWCOrderModel.getLineItemList()[1].quantity?.toInt().toString()
+                ))))
+
+        // verify that the total tax is displayed correctly
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_totalTax))
+                .check(matches(withText("$${mockWCOrderModel.getLineItemList()[0].totalTax}.00")))
+    }
+
+    /**
+     * Related FluxC issue in MockedStack_WCBaseStoreTest.kt#L116
+     * Some of the internals of java.util.Currency seem to be stubbed in a unit test environment,
+     * giving results inconsistent with a normal running app
+     */
+    @Test
+    fun verifyProductListItemCurrencyDisplayedCorrectlyForEuro() {
+        Assume.assumeTrue(
+                "Requires API 23 or higher due to localized currency values differing on older versions",
+                VERSION.SDK_INT >= 23
+        )
+
+        // inject mock data to order product list page
+        mockWCOrderModel.currency = "EUR"
+        activityTestRule.setOrderProductListWithMockData(mockWCOrderModel)
+
+        // click on the Details button in product list card
+        onView(withId(R.id.productList_btnDetails)).perform(scrollTo(), click())
+
+        // verify that the product total is displayed correctly for multiple quantities
+        // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productTotal))
+                .check(matches(withText(appContext.getString(
+                        R.string.orderdetail_product_lineitem_total_single,
+                        "€${mockWCOrderModel.getLineItemList()[0].total}.00"
+                ))))
+
+        // for multiple quantities: €13.00 (€11.00x2)
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productTotal))
+                .check(matches(withText(appContext.getString(
+                        R.string.orderdetail_product_lineitem_total_multiple,
+                        "€${mockWCOrderModel.getLineItemList()[1].total}.00",
+                        "€${mockWCOrderModel.getLineItemList()[1].price}.00",
+                        mockWCOrderModel.getLineItemList()[1].quantity?.toInt().toString()
+                ))))
+
+        // verify that the total tax is displayed correctly
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_totalTax))
+                .check(matches(withText("€${mockWCOrderModel.getLineItemList()[0].totalTax}.00")))
+    }
+
+    /**
+     * Related FluxC issue in MockedStack_WCBaseStoreTest.kt#L116
+     * Some of the internals of java.util.Currency seem to be stubbed in a unit test environment,
+     * giving results inconsistent with a normal running app
+     */
+    @Test
+    fun verifyProductListItemCurrencyDisplayedCorrectlyForInr() {
+        Assume.assumeTrue(
+                "Requires API 23 or higher due to localized currency values differing on older versions",
+                VERSION.SDK_INT >= 23
+        )
+
+        // inject mock data to order product list page
+        mockWCOrderModel.currency = "INR"
+        activityTestRule.setOrderProductListWithMockData(mockWCOrderModel)
+
+        // click on the Details button in product list card
+        onView(withId(R.id.productList_btnDetails)).perform(scrollTo(), click())
+
+        // verify that the product total is displayed correctly for multiple quantities
+        // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productTotal))
+                .check(matches(withText(appContext.getString(
+                        R.string.orderdetail_product_lineitem_total_single,
+                        "₹${mockWCOrderModel.getLineItemList()[0].total}.00"
+                ))))
+
+        // for multiple quantities: ₹13.00 (₹11.00x2)
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productTotal))
+                .check(matches(withText(appContext.getString(
+                        R.string.orderdetail_product_lineitem_total_multiple,
+                        "₹${mockWCOrderModel.getLineItemList()[1].total}.00",
+                        "₹${mockWCOrderModel.getLineItemList()[1].price}.00",
+                        mockWCOrderModel.getLineItemList()[1].quantity?.toInt().toString()
+                ))))
+
+        // verify that the total tax is displayed correctly
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_totalTax))
+                .check(matches(withText("₹${mockWCOrderModel.getLineItemList()[0].totalTax}.00")))
+    }
+
+    /**
+     * Related FluxC issue in MockedStack_WCBaseStoreTest.kt#L116
+     * Some of the internals of java.util.Currency seem to be stubbed in a unit test environment,
+     * giving results inconsistent with a normal running app
+     */
+    @Test
+    fun verifyProductListItemCurrencyDisplayedCorrectlyForAud() {
+        Assume.assumeTrue(
+                "Requires API 23 or higher due to localized currency values differing on older versions",
+                VERSION.SDK_INT >= 23
+        )
+
+        // inject mock data to order product list page
+        mockWCOrderModel.currency = "AUD"
+        activityTestRule.setOrderProductListWithMockData(mockWCOrderModel)
+
+        // click on the Details button in product list card
+        onView(withId(R.id.productList_btnDetails)).perform(scrollTo(), click())
+
+        // verify that the product total is displayed correctly for multiple quantities
+        // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productTotal))
+                .check(matches(withText(appContext.getString(
+                        R.string.orderdetail_product_lineitem_total_single,
+                        "A$${mockWCOrderModel.getLineItemList()[0].total}.00"
+                ))))
+
+        // for multiple quantities: A$13.00 (A$11.00x2)
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productTotal))
+                .check(matches(withText(appContext.getString(
+                        R.string.orderdetail_product_lineitem_total_multiple,
+                        "A\$${mockWCOrderModel.getLineItemList()[1].total}.00",
+                        "A\$${mockWCOrderModel.getLineItemList()[1].price}.00",
+                        mockWCOrderModel.getLineItemList()[1].quantity?.toInt().toString()
+                ))))
+
+        // verify that the total tax is displayed correctly
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_totalTax))
+                .check(matches(withText("A$${mockWCOrderModel.getLineItemList()[0].totalTax}.00")))
+    }
+
+    @Test
+    fun verifyProductListItemSkuIsHiddenIfNotAvailable() {
+        // inject mock data to order product list page
+        activityTestRule.setOrderProductListWithMockData(mockWCOrderModel)
+
+        // click on the Details button in product list card
+        onView(withId(R.id.productList_btnDetails)).perform(scrollTo(), click())
+
+        // sku is available for the first item. Verify it is displayed correctly
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_lblSku))
+                .check(matches(withEffectiveVisibility(VISIBLE)))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_sku))
+                .check(matches(withEffectiveVisibility(VISIBLE)))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_lblSku))
+                .check(matches(withText(appContext.getString(R.string.orderdetail_product_lineitem_sku))))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_sku))
+                .check(matches(withText(mockWCOrderModel.getLineItemList()[0].sku)))
+
+        // sku is not available for the second item. Verify it is hidden
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_lblSku))
+                .check(matches(withEffectiveVisibility(GONE)))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_sku))
+                .check(matches(withEffectiveVisibility(GONE)))
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/WcProductTestUtils.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/WcProductTestUtils.kt
@@ -1,0 +1,44 @@
+package com.woocommerce.android.ui.products
+
+import com.google.gson.Gson
+import com.woocommerce.android.ui.products.ProductType.SIMPLE
+import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.model.WCProductSettingsModel
+
+object WcProductTestUtils {
+    /**
+     * Generates a single [WCProductSettingsModel] object for a mock Site
+     */
+    fun generateProductSettings(
+        localSiteId: Int = 1,
+        dimensionUnit: String = "in",
+        weightUnit: String = "oz"
+    ): WCProductSettingsModel {
+        return WCProductSettingsModel(localSiteId).apply {
+            this.dimensionUnit = dimensionUnit
+            this.weightUnit = weightUnit
+        }
+    }
+
+    /**
+     * Generates a single [WCProductModel] object for a mock Site
+     */
+    fun generateProductDetail(
+        productId: Int = 1,
+        totalSales: Int = 0,
+        productName: String = "WooTest",
+        productType: ProductType = SIMPLE
+    ): WCProductModel {
+        return WCProductModel(productId).apply {
+            this.name = productName
+            this.type = productType.name
+            this.totalSales = totalSales
+            this.permalink =
+                    "https://jamosova3.mystagingwebsite.com/product/stranger-things-t-shirt-product-add-on-text-field/"
+            this.images = Gson().toJson(listOf(
+                    mapOf("src" to "https://jamosova3.mystagingwebsite.com/wp-content/uploads/2018/11/eleven.jpg")))
+            this.downloads = Gson().toJson(listOf(
+                    mapOf("file" to "https://jamosova3.mystagingwebsite.com/wp-content/uploads/2018/11/eleven.jpg")))
+        }
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/utils/WCSiteUtils.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/utils/WCSiteUtils.kt
@@ -1,0 +1,96 @@
+package com.woocommerce.android.utils
+
+import org.wordpress.android.fluxc.model.WCSettingsModel
+import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition
+import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition.LEFT
+import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition.LEFT_SPACE
+import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition.RIGHT
+import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition.RIGHT_SPACE
+import org.wordpress.android.fluxc.utils.WCCurrencyUtils
+import org.wordpress.android.util.LanguageUtils
+import kotlin.math.absoluteValue
+
+object WCSiteUtils {
+    /**
+     * Generates a single [WCSettingsModel] object for a mock Site
+     */
+    fun generateSiteSettings(
+        localSiteId: Int = 1,
+        currencyCode: String = "USD",
+        currencyPosition: CurrencyPosition = CurrencyPosition.LEFT
+    ): WCSettingsModel {
+        return WCSettingsModel(
+                localSiteId = localSiteId,
+                currencyCode = currencyCode,
+                currencyPosition = currencyPosition,
+                currencyThousandSeparator = ",",
+                currencyDecimalSeparator = ".",
+                currencyDecimalNumber = 2)
+    }
+
+    /**
+     * Mock of the method in FluxC
+     * Not sure if this is the best way to mock SiteSettings in FluxC.
+     *
+     * So the issue is, formatting currency for display, depends on the store's settings.
+     * If the store settings is null, then the currency by default is displayed with only 1 decimal place,
+     * or in some cases no decimal places. But default behaviour is to display currency code to the left
+     * with 2 decimal places.
+     * In order to correctly validate the currency formatting, we need to mock the `getSiteSettings` method
+     * inside `WooCommerceStore` class. This method is called directly from FluxC when trying to format
+     * currency.
+     *
+     * The `WooCommerceStore` is final so we cannot mock/spy the class.
+     * So a simple
+     * doReturn(WcOrderTestUtils.generateSiteSettings()).whenever(mockWcStore).getSiteSettings(any())
+     * will result in cannot mock/spy the class error.
+     *
+     * This approach was to mock the CurrencyFormatter class. But the only logic in this class is to call
+     * the appropriate method in FluxC. So rather than calling this method in CurrencyFormatter class,
+     * we can mock this method to return the appropriate value. But the logic to format is still retained in
+     * fluxC so we would need to replicate this logic in this method and check if the value matches.
+     * I admit I am not sure if this is the best approach since we would only be replicating the same logic
+     * from FluxC into Woo and that too only for UI testing purposes.
+     * If in future the logic is changed in FluxC, the UI tests would fail and we would need to replicate this
+     * inside Woo UI test as well.
+     *
+     * Another approach would be to send the SiteSettingsModel to the format currency method in `WooCommerceStore`.
+     * This way we can mock the method to fetch the SiteSettings in Woo itself and then pass the value to
+     * FluxC. This would mean making modifications to FluxC and I don't see this as really useful for anything
+     * other than fixing this issue since we would be fetching the SiteSettingsModel from FluxC and then
+     * passing the same to another method in FluxC instead of keeping the entire logic inside a single method.
+     *
+     * I ran out of ideas at this point other than to just insert a mock WcSiteSettingsModel directly into the local db
+     * when UI tests first start, which seems like a bad idea!
+     */
+    fun formatCurrencyForDisplay(
+        rawValue: String,
+        siteSettings: WCSettingsModel?,
+        currencyCode: String? = null,
+        applyDecimalFormatting: Boolean
+    ): String {
+        // Resolve the currency code to a localized symbol
+        val resolvedCurrencyCode = currencyCode ?: siteSettings?.currencyCode
+        val currencySymbol = resolvedCurrencyCode?.let {
+            WCCurrencyUtils.getLocalizedCurrencySymbolForCode(it, LanguageUtils.getCurrentDeviceLanguage())
+        } ?: ""
+
+        // Format the amount for display according to the site's currency settings
+        // Use absolute values - if the value is negative, it will be handled in the next step, with the currency symbol
+        val decimalFormattedValue = siteSettings?.takeIf { applyDecimalFormatting }?.let {
+            WCCurrencyUtils.formatCurrencyForDisplay(rawValue.toDoubleOrNull()?.absoluteValue ?: 0.0, it)
+        } ?: rawValue.removePrefix("-")
+
+        // Append or prepend the currency symbol according to the site's settings
+        with(StringBuilder()) {
+            if (rawValue.startsWith("-")) { append("-") }
+            append(when (siteSettings?.currencyPosition) {
+                null, LEFT -> "$currencySymbol$decimalFormattedValue"
+                LEFT_SPACE -> "$currencySymbol $decimalFormattedValue"
+                RIGHT -> "$decimalFormattedValue$currencySymbol"
+                RIGHT_SPACE -> "$decimalFormattedValue $currencySymbol"
+            })
+            return toString()
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderProductListContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderProductListContract.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.model.order.OrderIdentifier
 
 interface OrderProductListContract {
     interface Presenter : BasePresenter<View> {
+        fun getOrderDetailFromDb(orderIdentifier: OrderIdentifier): WCOrderModel?
         fun loadOrderDetail(orderIdentifier: OrderIdentifier)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderProductListPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderProductListPresenter.kt
@@ -1,9 +1,12 @@
 package com.woocommerce.android.ui.orders
 
+import com.woocommerce.android.annotations.OpenClassOnDebug
+import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.store.WCOrderStore
 import javax.inject.Inject
 
+@OpenClassOnDebug
 class OrderProductListPresenter @Inject constructor(
     private val orderStore: WCOrderStore
 ) : OrderProductListContract.Presenter {
@@ -17,10 +20,18 @@ class OrderProductListPresenter @Inject constructor(
         productView = null
     }
 
+    /**
+     * Loading order detail from local database.
+     * Segregating methods that request data from db for better ui testing
+     */
+    override fun getOrderDetailFromDb(orderIdentifier: OrderIdentifier): WCOrderModel? {
+        return orderStore.getOrderByIdentifier(orderIdentifier)
+    }
+
     override fun loadOrderDetail(orderIdentifier: OrderIdentifier) {
         if (orderIdentifier.isNotEmpty()) {
             productView?.let { view ->
-                val orderModel = orderStore.getOrderByIdentifier(orderIdentifier)
+                val orderModel = getOrderDetailFromDb(orderIdentifier)
                 orderModel?.let {
                     view.showOrderProducts(it)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailContract.kt
@@ -3,9 +3,13 @@ package com.woocommerce.android.ui.products
 import com.woocommerce.android.ui.base.BasePresenter
 import com.woocommerce.android.ui.base.BaseView
 import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.model.WCProductSettingsModel
+import org.wordpress.android.fluxc.model.WCSettingsModel
 
 interface ProductDetailContract {
     interface Presenter : BasePresenter<View> {
+        fun getSiteSettings(): WCSettingsModel?
+        fun getProductSiteSettings(): WCProductSettingsModel?
         fun getProduct(remoteProductId: Long): WCProductModel?
         fun fetchProduct(remoteProductId: Long, forced: Boolean)
         fun loadProductDetail(remoteProductId: Long)


### PR DESCRIPTION
Fixes #1043 by adding UI tests for Product list and product detail page.

The following scenarios have been added to the test cases:
### Product List - Expanded
- [x] Clicking on `Details` button in Order detail page, redirects to the expanded Product List page.
- [x] Product Item: The product name, quantity, total, tax and their labels are displayed correctly
- [x] Product Item: Currency formatting for product prices, taxes are displayed correctly for US, EUR, IND, AUD
- [x] SKU is displayed only id available and hidden, if not.

#### To Test
- [x] Run `ProductListCardTest`

### Product Detail Page
- [x] Clicking on the a product list item redirects to Product Detail page.
- [x] The toolbar title, the `X` icon and share button are displayed correctly.
- [x] Clicking on `X` icon redirects to the previous screen.
- [x] Clicking on `Share` button opens intent to share the product
- [x] Product Detail: Image is only displayed, if available
- [x] Product Detail: The product title, total orders, review labels are displayed correctly.
- [x] verify the toolbar title is displayed correctly for different product types
- [x] verify that total orders is formatted correctly for different order totals. For instance: 
  - [x] 200 -> 200
  - [x] 2000 -> 2k
  - [x] 20000 -> 20k
  - [x] 2000000 - > 2m
- [x] Check that `Product view on store button` is displayed correctly
- [x] Verify that clicking on the button opens WebView.
- [x] verify that status badge is displayed for unpublished products
- [x] verify that reviews are only displayed if allowed

#### Variation Products:
- [x] Verify that variations are not displayed for variation products
- [x] Verify that reviews are not displayed for variation products

#### Pricing and Inventory card:
- [x] Pricing card title is displayed correctly. If we have pricing info this card is "Pricing and inventory" otherwise it's just "Inventory".
- [x] When there's a sale price show price & sales price as a group, otherwise show price separately. 
- [x] show stock properties as a group if stock management is enabled, otherwise show sku separately.

#### Purchase Detail card:
- [x] Verify shipping info displayed correctly when width/height/length is not empty
- [x] Verify shipping info handled correctly when weight/height is not empty
- [x] Verify shipping title is displayed correctly
- [x] Verify weight, size, shipping class displayed correctly
- [x] Verify pricing Info is displayed correctly when sale price is available
- [x] Verify downloadable products are displayed correctly
- [x] Verify downloadable products are displayed correctly without limit or expiry
- [x] verify purchase note is displayed correctly, only if available
- [x] verify a really long purchase note opens a dialog when `Read More` button is clicked

#### To test:
- [x] Run `ProductDetailNavigationTest`