### PR TITLE
Destroy child fragments of previously active fragment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationView.kt
@@ -121,12 +121,17 @@ class MainNavigationView @JvmOverloads constructor(
         val fragment = navAdapter.getFragment(navPos)
         fragment.deferInit = deferInit
 
-        // Close any child fragments if open
+        // Close any child fragments of active fragments, if open
         clearFragmentBackStack(fragment)
 
         // hide previous fragment if it exists
+        // close any child fragments of previous fragments, if open before hiding
         val fragmentTransaction = fragmentManager.beginTransaction()
-        previousNavPos?.let { fragmentTransaction.hide(navAdapter.getFragment(it)) }
+        previousNavPos?.let {
+            val previousFragment = navAdapter.getFragment(it)
+            clearFragmentBackStack(previousFragment)
+            fragmentTransaction.hide(previousFragment)
+        }
 
         // add the fragment if it hasn't been added yet
         val tag = navPos.getTag()


### PR DESCRIPTION
Fixes #1120  by adding logic to destroy child fragments, if available, before adding a new fragment.

When a tab is selected from the `BottomNavigationView`, we hide the previous fragment, if it exists, before adding the new fragment. This PR adds logic to destroy any child fragments of the previously active fragment, before hiding it. This ensures that `onDestroyView()` of child fragments are called.

### Steps to reproduce the bug:
* Open the app and click on `Orders` tab. 
* Select any order and click on `Add A Note` button at the bottom of the screen.
* Notice that the soft keypad is opened. 
* Click on `My Store` tab. Notice that the soft keypad is not closed.

This is because the `onDestroyView()` method of `AddOrderNoteFragment` is not called. Pull the changes from this PR and test again. The soft keypad should be closed now.

### Behaviour before the fix:
<img width="300" src="https://user-images.githubusercontent.com/22608780/59326930-b4d93f00-8d05-11e9-8673-da4afbd76aa2.gif">

### Behaviour after the fix:
<img width="300" src="https://user-images.githubusercontent.com/22608780/59326866-822f4680-8d05-11e9-92aa-349b3b99b0c7.gif">
