### PR TITLE
Order Fulfillment: Add intrumentation tests

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/MainActivityTestRule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/MainActivityTestRule.kt
@@ -54,13 +54,15 @@ class MainActivityTestRule : ActivityTestRule<MainActivity>(MainActivity::class.
         orderStatus: WCOrderStatusModel = WcOrderTestUtils.generateOrderStatusDetail(),
         orderNotes: List<WCOrderNoteModel> = WcOrderTestUtils.generateSampleNotes(),
         orderShipmentTrackings: List<WCOrderShipmentTrackingModel> = WcOrderTestUtils.generateOrderShipmentTrackings(),
-        isNetworkConnected: Boolean = false
+        isNetworkConnected: Boolean = false,
+        onOrderChanged: OnOrderChanged? = null
     ) {
         MockedOrderDetailModule.setOrderInfo(order)
         MockedOrderDetailModule.setOrderStatus(orderStatus)
         MockedOrderDetailModule.setOrderNotes(orderNotes)
         MockedOrderDetailModule.setOrderShipmentTrackings(orderShipmentTrackings)
         MockedOrderDetailModule.setNetworkConnected(isNetworkConnected)
+        MockedOrderDetailModule.setOnOrderChanged(onOrderChanged)
     }
 
     /**
@@ -69,12 +71,16 @@ class MainActivityTestRule : ActivityTestRule<MainActivity>(MainActivity::class.
     fun setOrderFulfillmentWithMockData(
         order: WCOrderModel,
         orderShipmentTrackings: List<WCOrderShipmentTrackingModel> = WcOrderTestUtils.generateOrderShipmentTrackings(),
-        isNetworkConnected: Boolean = false
+        isNetworkConnected: Boolean = false,
+        onOrderChanged: OnOrderChanged? = null
     ) {
-        setOrderDetailWithMockData(order, orderShipmentTrackings = orderShipmentTrackings)
+        setOrderDetailWithMockData(
+                order = order, orderShipmentTrackings = orderShipmentTrackings, onOrderChanged = onOrderChanged
+        )
         MockedOrderFulfillmentModule.setOrderInfo(order)
         MockedOrderFulfillmentModule.setOrderShipmentTrackings(orderShipmentTrackings)
         MockedOrderFulfillmentModule.setNetworkConnected(isNetworkConnected)
+        MockedOrderFulfillmentModule.setOnOrderChanged(onOrderChanged)
     }
 
     /**

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/MockedOrderDetailModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/MockedOrderDetailModule.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders
 import android.content.Context
 import com.google.gson.Gson
 import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.doAnswer
 import com.nhaarman.mockito_kotlin.doNothing
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
@@ -15,6 +16,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.android.ContributesAndroidInjector
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
@@ -26,6 +28,8 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClie
 import org.wordpress.android.fluxc.persistence.NotificationSqlUtils
 import org.wordpress.android.fluxc.store.NotificationStore
 import org.wordpress.android.fluxc.store.WCOrderStore
+import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
+import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderStatusPayload
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.tools.FormattableContentMapper
 
@@ -35,6 +39,7 @@ abstract class MockedOrderDetailModule {
     companion object {
         private var order: WCOrderModel? = null
         private var isNetworkConnected: Boolean = false
+        private var onOrderChanged: OnOrderChanged? = null
         private var orderStatus: WCOrderStatusModel? = null
         private var orderNotes: List<WCOrderNoteModel>? = null
         private var orderShipmentTrackings: List<WCOrderShipmentTrackingModel>? = null
@@ -57,6 +62,10 @@ abstract class MockedOrderDetailModule {
 
         fun setOrderShipmentTrackings(orderShipmentTrackings: List<WCOrderShipmentTrackingModel>) {
             this.orderShipmentTrackings = orderShipmentTrackings
+        }
+
+        fun setOnOrderChanged(onOrderChanged: OnOrderChanged?) {
+            this.onOrderChanged = onOrderChanged
         }
 
         @JvmStatic
@@ -90,7 +99,7 @@ abstract class MockedOrderDetailModule {
                             NotificationSqlUtils(FormattableContentMapper(Gson())), mock())
             ))
 
-            /**
+            /*
              * Mocking the below methods in [OrderDetailPresenter] class to pass mock values.
              * These are the methods that invoke [WCOrderModel], [WCOrderStatusModel] methods from FluxC.
              */
@@ -108,6 +117,11 @@ abstract class MockedOrderDetailModule {
                     doReturn(it[0]).whenever(mockedOrderDetailPresenter).deletedOrderShipmentTrackingModel
                 }
             }
+
+            // adding mock response when order status is marked as complete
+            doAnswer {
+                onOrderChanged?.let { mockedOrderDetailPresenter.onOrderChanged(it) }
+            }.whenever(mockDispatcher).dispatch(any<Action<UpdateOrderStatusPayload>>())
 
             return mockedOrderDetailPresenter
         }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentCustomerInfoCardTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentCustomerInfoCardTest.kt
@@ -1,0 +1,182 @@
+package com.woocommerce.android.ui.orders
+
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.ViewMatchers.Visibility.GONE
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.TestBase
+import com.woocommerce.android.ui.main.MainActivityTestRule
+import com.woocommerce.android.util.AddressUtils
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.wordpress.android.fluxc.model.SiteModel
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class OrderFulfillmentCustomerInfoCardTest : TestBase() {
+    @Rule
+    @JvmField var activityTestRule = MainActivityTestRule()
+
+    private val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail(orderStatus = "processing")
+
+    @Before
+    override fun setup() {
+        super.setup()
+        // Bypass login screen and display dashboard
+        activityTestRule.launchMainActivityLoggedIn(null, SiteModel())
+
+        // Make sure the bottom navigation view is showing
+        activityTestRule.activity.showBottomNav()
+
+        // add mock data to order list screen
+        activityTestRule.setOrderListWithMockData()
+
+        // Click on Orders tab in the bottom bar
+        onView(withId(R.id.orders)).perform(click())
+    }
+
+    @Test
+    fun verifyCustomerInfoCardPopulatedSuccessfully() {
+        // Set Order fulfillment with mock data
+        mockWCOrderModel.billingFirstName = "Anitaa"
+        mockWCOrderModel.billingLastName = "Murthy"
+        mockWCOrderModel.billingAddress1 = "Ramada Plaza, 450 Capitol Ave SE Atlanta"
+        mockWCOrderModel.billingCountry = "USA"
+        activityTestRule.setOrderFulfillmentWithMockData(mockWCOrderModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        onView(withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // click on Order Fulfill button to redirect to Order Fulfillment
+        onView(withId(R.id.productList_btnFulfill)).perform(click())
+
+        // check if order customer info card label matches this title:
+        // R.string.customer_information
+        onView(withId(R.id.customerInfo_label)).check(matches(
+                withText(appContext.getString(R.string.customer_information))
+        ))
+
+        // check if order customer info card shipping label matches this title:
+        // R.string.customer_information
+        onView(withId(R.id.customerInfo_shippingLabel)).check(matches(
+                withText(appContext.getString(R.string.orderdetail_shipping_details))
+        ))
+
+        // verify that the customer shipping details is displayed
+        onView(withId(R.id.customerInfo_shippingAddr)).check(matches(isDisplayed()))
+
+        // check that the billing info is hidden
+        onView(withId(R.id.customerInfo_billingLabel)).check(matches(withEffectiveVisibility(GONE)))
+
+        // check if customer info card shipping details matches this format:
+        val billingName = appContext.getString(
+                R.string.customer_full_name,
+                mockWCOrderModel.billingFirstName, mockWCOrderModel.billingLastName
+        )
+        val billingAddr = AddressUtils.getEnvelopeAddress(mockWCOrderModel.getBillingAddress())
+        val billingCountry = AddressUtils.getCountryLabelByCountryCode(mockWCOrderModel.billingCountry)
+
+        // Assumes that the shipping name, address and country info is available
+        val shippingAddrFull = "$billingName\n$billingAddr\n$billingCountry"
+        onView(withId(R.id.customerInfo_shippingAddr)).check(matches(withText(shippingAddrFull)))
+    }
+
+    @Test
+    fun verifyCustomerInfoCardViewWithLongNamePopulatedSuccessfully() {
+        // Set Order fulfillment with mock data
+        mockWCOrderModel.billingFirstName = "Itsareallylongfirstname"
+        mockWCOrderModel.billingLastName = "Itsareallylonglastname"
+        mockWCOrderModel.billingAddress1 = "Its a really long address to see how it is handled in UI. More to comehere"
+        mockWCOrderModel.billingCountry = "India"
+        activityTestRule.setOrderFulfillmentWithMockData(mockWCOrderModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        onView(withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // click on Order Fulfill button to redirect to Order Fulfillment
+        onView(withId(R.id.productList_btnFulfill)).perform(click())
+
+        // check if customer info card shipping details matches this format:
+        val billingName = appContext.getString(
+                R.string.customer_full_name,
+                mockWCOrderModel.billingFirstName, mockWCOrderModel.billingLastName
+        )
+        val billingAddr = AddressUtils.getEnvelopeAddress(mockWCOrderModel.getBillingAddress())
+        val billingCountry = AddressUtils.getCountryLabelByCountryCode(mockWCOrderModel.billingCountry)
+
+        // Assumes that the shipping name, address and country info is available
+        val shippingAddrFull = "$billingName\n$billingAddr\n$billingCountry"
+        onView(withId(R.id.customerInfo_shippingAddr)).check(matches(withText(shippingAddrFull)))
+    }
+
+    @Test
+    fun verifyCustomerInfoCardWithNoBillingAddressPopulatedSuccessfully() {
+        // Set Order fulfillment with mock data
+        activityTestRule.setOrderFulfillmentWithMockData(mockWCOrderModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        onView(withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // click on Order Fulfill button to redirect to Order Fulfillment
+        onView(withId(R.id.productList_btnFulfill)).perform(click())
+
+        // check if customer info card shipping details matches this format:
+        val shippingName = appContext.getString(
+                R.string.customer_full_name,
+                mockWCOrderModel.billingFirstName, mockWCOrderModel.billingLastName
+        )
+        val shippingAddr = AddressUtils.getEnvelopeAddress(mockWCOrderModel.getBillingAddress())
+        val shippingCountry = AddressUtils.getCountryLabelByCountryCode(mockWCOrderModel.billingCountry)
+
+        // Assumes that the shipping name, address and country info is available
+        var shippingAddrFull = if (!shippingName.trim().isBlank()) "$shippingName\n" else ""
+        if (!shippingAddr.isBlank()) shippingAddrFull += "$shippingAddr\n"
+        if (!shippingCountry.isBlank()) shippingAddrFull += shippingCountry
+        onView(withId(R.id.customerInfo_shippingAddr)).check(matches(withText(shippingAddrFull)))
+    }
+
+    @Test
+    fun verifyCustomerInfoCardWithSeparateShippingAddressPopulatedSuccessfully() {
+        // Set Order fulfillment with mock data
+        mockWCOrderModel.shippingFirstName = "Anitaa"
+        mockWCOrderModel.shippingLastName = "Murthy"
+        mockWCOrderModel.shippingAddress1 = "Ramada Plaza, 450 Capitol Ave SE Atlanta"
+        mockWCOrderModel.shippingCountry = "USA"
+        activityTestRule.setOrderFulfillmentWithMockData(mockWCOrderModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        onView(withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // click on Order Fulfill button to redirect to Order Fulfillment
+        onView(withId(R.id.productList_btnFulfill)).perform(click())
+
+        // check if customer info card shipping details matches this format:
+        val shippingName = appContext.getString(
+                R.string.customer_full_name,
+                mockWCOrderModel.shippingFirstName, mockWCOrderModel.shippingLastName
+        )
+        val shippingAddr = AddressUtils.getEnvelopeAddress(mockWCOrderModel.getShippingAddress())
+        val shippingCountry = AddressUtils.getCountryLabelByCountryCode(mockWCOrderModel.shippingCountry)
+
+        // Assumes that the shipping name, address and country info is available
+        var shippingAddrFull = if (!shippingName.trim().isBlank()) "$shippingName\n" else ""
+        if (!shippingAddr.isBlank()) shippingAddrFull += "$shippingAddr\n"
+        if (!shippingCountry.isBlank()) shippingAddrFull += shippingCountry
+        onView(withId(R.id.customerInfo_shippingAddr)).check(matches(withText(shippingAddrFull)))
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragmentTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragmentTest.kt
@@ -5,6 +5,7 @@ import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.swipeRight
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers
@@ -133,14 +134,11 @@ class OrderFulfillmentFragmentTest : TestBase() {
         // verify that fulfill button is hidden
         onView(withId(R.id.productList_btnFulfill)).check(matches(withEffectiveVisibility(GONE)))
 
-        // verify undo snackbar is displayed
-        onView(allOf(
-                withId(com.google.android.material.R.id.snackbar_text),
-                withText(R.string.order_fulfill_marked_complete))
-        ).check(matches(isDisplayed()))
+        // verify undo snackbar is displayed and swipe to dismiss it
+        onView(withId(com.google.android.material.R.id.snackbar_text))
+                .check(matches(withText(R.string.order_fulfill_marked_complete))).perform(swipeRight())
 
-        // wait till the snackbar is dismissed
-        Thread.sleep(5000)
+        Thread.sleep(1000) // Added to make it more reliable
 
         // check if the error snack is displayed
         onView(allOf(

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragmentTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragmentTest.kt
@@ -1,0 +1,151 @@
+package com.woocommerce.android.ui.orders
+
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.Visibility.GONE
+import androidx.test.espresso.matcher.ViewMatchers.Visibility.VISIBLE
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.woocommerce.android.R
+import com.woocommerce.android.helpers.WCMatchers
+import com.woocommerce.android.ui.TestBase
+import com.woocommerce.android.ui.main.MainActivityTestRule
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.equalToIgnoringCase
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.wordpress.android.fluxc.action.WCOrderAction.UPDATE_ORDER_STATUS
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
+import org.wordpress.android.fluxc.store.WCOrderStore.OrderError
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class OrderFulfillmentFragmentTest : TestBase() {
+    @Rule
+    @JvmField var activityTestRule = MainActivityTestRule()
+
+    private val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail(orderStatus = "processing")
+
+    private fun redirectToOrderFulfillmentAndMarkOrderAsComplete(
+        isNetworkConnected: Boolean = false,
+        onOrderChanged: OnOrderChanged? = null
+    ) {
+        // Set Order Detail with mock data
+        activityTestRule.setOrderDetailWithMockData(order = mockWCOrderModel, isNetworkConnected = isNetworkConnected)
+
+        // Click on Orders tab in the bottom bar
+        Espresso.onView(ViewMatchers.withId(R.id.orders)).perform(ViewActions.click())
+
+        // click on the first order in the list and check if redirected to order detail
+        onView(withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // Set Order fulfillment with mock data
+        activityTestRule.setOrderFulfillmentWithMockData(
+                order = mockWCOrderModel,
+                isNetworkConnected = isNetworkConnected,
+                onOrderChanged = onOrderChanged
+        )
+
+        // click on Order Fulfill button to redirect to Order Fulfillment
+        onView(withId(R.id.productList_btnFulfill)).perform(click())
+
+        // click on `Mark Order Complete` button
+        onView(withId(R.id.orderFulfill_btnComplete)).perform(WCMatchers.scrollTo(), click())
+    }
+
+    @Before
+    override fun setup() {
+        super.setup()
+        // Bypass login screen and display dashboard
+        activityTestRule.launchMainActivityLoggedIn(null, SiteModel())
+
+        // Make sure the bottom navigation view is showing
+        activityTestRule.activity.showBottomNav()
+
+        // add mock data to order list screen
+        activityTestRule.setOrderListWithMockData()
+    }
+
+    @Test
+    fun markOrderCompleteWhenNoNetworkAvailable() {
+        redirectToOrderFulfillmentAndMarkOrderAsComplete()
+
+        // verify that screen is not redirected to Order detail
+        onView(withId(R.id.toolbar)).check(matches(WCMatchers.withToolbarTitle(equalToIgnoringCase(
+                appContext.getString(R.string.orderdetail_order_fulfillment, "1")
+        ))))
+    }
+
+    @Test
+    fun markOrderCompleteWhenNetworkAvailableAndUndoClicked() {
+        redirectToOrderFulfillmentAndMarkOrderAsComplete(true)
+
+        // verify redirection to Order Detail page with order marked as complete
+        onView(withId(R.id.toolbar)).check(matches(WCMatchers.withToolbarTitle(
+                equalToIgnoringCase(appContext.getString(R.string.orderdetail_orderstatus_ordernum, "1")))
+        ))
+
+        // verify that fulfill button is hidden
+        onView(withId(R.id.productList_btnFulfill)).check(matches(withEffectiveVisibility(GONE)))
+
+        // verify undo snackbar is displayed
+        onView(allOf(
+                withId(com.google.android.material.R.id.snackbar_text),
+                withText(R.string.order_fulfill_marked_complete))
+        ).check(matches(isDisplayed()))
+
+        // click on undo snackbar
+        onView(withText(appContext.getString(R.string.undo))).perform(click())
+
+        // verify that fulfill button is displayed
+        onView(withId(R.id.productList_btnFulfill)).check(matches(withEffectiveVisibility(VISIBLE)))
+    }
+
+    @Test
+    fun markOrderCompleteWhenNetworkAvailableResponseError() {
+        // set mock error response when updating order status to complete
+        val onOrderChangedErrorResponse = OnOrderChanged(1).apply {
+            causeOfChange = UPDATE_ORDER_STATUS
+            error = OrderError()
+        }
+
+        redirectToOrderFulfillmentAndMarkOrderAsComplete(true, onOrderChangedErrorResponse)
+
+        // verify redirection to Order Detail page with order marked as complete
+        onView(withId(R.id.toolbar)).check(matches(WCMatchers.withToolbarTitle(
+                equalToIgnoringCase(appContext.getString(R.string.orderdetail_orderstatus_ordernum, "1")))
+        ))
+
+        // verify that fulfill button is hidden
+        onView(withId(R.id.productList_btnFulfill)).check(matches(withEffectiveVisibility(GONE)))
+
+        // verify undo snackbar is displayed
+        onView(allOf(
+                withId(com.google.android.material.R.id.snackbar_text),
+                withText(R.string.order_fulfill_marked_complete))
+        ).check(matches(isDisplayed()))
+
+        // wait till the snackbar is dismissed
+        Thread.sleep(5000)
+
+        // check if the error snack is displayed
+        onView(allOf(
+                withId(com.google.android.material.R.id.snackbar_text),
+                withText(R.string.order_error_update_general))
+        ).check(matches(withEffectiveVisibility(VISIBLE)))
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentNavigationTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentNavigationTest.kt
@@ -1,0 +1,81 @@
+package com.woocommerce.android.ui.orders
+
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.woocommerce.android.R
+import com.woocommerce.android.helpers.WCMatchers
+import com.woocommerce.android.ui.TestBase
+import com.woocommerce.android.ui.main.MainActivityTestRule
+import org.hamcrest.Matchers.equalToIgnoringCase
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.wordpress.android.fluxc.model.SiteModel
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class OrderFulfillmentNavigationTest : TestBase() {
+    @Rule
+    @JvmField var activityTestRule = MainActivityTestRule()
+
+    private val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail(orderStatus = "processing")
+
+    @Before
+    override fun setup() {
+        super.setup()
+        // Bypass login screen and display dashboard
+        activityTestRule.launchMainActivityLoggedIn(null, SiteModel())
+
+        // Make sure the bottom navigation view is showing
+        activityTestRule.activity.showBottomNav()
+
+        // add mock data to order list screen
+        activityTestRule.setOrderListWithMockData()
+
+        // Set Order fulfillment with mock data
+        activityTestRule.setOrderFulfillmentWithMockData(mockWCOrderModel)
+
+        // Click on Orders tab in the bottom bar
+        Espresso.onView(ViewMatchers.withId(R.id.orders)).perform(ViewActions.click())
+
+        // click on the first order in the list and check if redirected to order detail
+        onView(withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // click on Order Fulfill button to redirect to Order Fulfillment
+        onView(withId(R.id.productList_btnFulfill)).perform(click())
+    }
+
+    @Test
+    fun verifyToolbarItemsDisplayedCorrectly() {
+        // verify toolbar title is displayed correctly
+        onView(withId(R.id.toolbar)).check(matches(WCMatchers.withToolbarTitle(equalToIgnoringCase(
+                appContext.getString(R.string.orderdetail_order_fulfillment, "1")
+        ))))
+
+        // Check that the "UP" navigation button is displayed in the toolbar
+        onView(withContentDescription(R.string.abc_action_bar_up_description)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun verifyClickingBackRedirectsToOrderDetailCorrectly() {
+        // Clicking the "up" button in order fulfillment screen returns the user to the orders detail screen.
+        // The Toolbar title changes to "Order #1"
+        onView(withContentDescription(R.string.abc_action_bar_up_description)).perform(click())
+        onView(withId(R.id.toolbar)).check(matches(WCMatchers.withToolbarTitle(
+                equalToIgnoringCase(appContext.getString(R.string.orderdetail_orderstatus_ordernum, "1")))
+        ))
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentProductListCardTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentProductListCardTest.kt
@@ -1,0 +1,309 @@
+package com.woocommerce.android.ui.orders
+
+import android.os.Build.VERSION
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.ViewMatchers.Visibility.GONE
+import androidx.test.espresso.matcher.ViewMatchers.Visibility.VISIBLE
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.google.gson.Gson
+import com.woocommerce.android.R
+import com.woocommerce.android.helpers.WCMatchers.withRecyclerView
+import com.woocommerce.android.ui.TestBase
+import com.woocommerce.android.ui.main.MainActivityTestRule
+import org.junit.Assert.assertSame
+import org.junit.Assume
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.wordpress.android.fluxc.model.SiteModel
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class OrderFulfillmentProductListCardTest : TestBase() {
+    @Rule
+    @JvmField var activityTestRule = MainActivityTestRule()
+
+    private val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail(orderStatus = "processing")
+
+    private fun redirectToOrderFulfillment() {
+        // Set Order fulfillment with mock data
+        activityTestRule.setOrderFulfillmentWithMockData(mockWCOrderModel)
+
+        // click on the first order in the list and check if redirected to order detail
+        onView(withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // click on Order Fulfill button to redirect to Order Fulfillment
+        onView(withId(R.id.productList_btnFulfill)).perform(click())
+    }
+
+    @Before
+    override fun setup() {
+        super.setup()
+        // Bypass login screen and display dashboard
+        activityTestRule.launchMainActivityLoggedIn(null, SiteModel())
+
+        // Make sure the bottom navigation view is showing
+        activityTestRule.activity.showBottomNav()
+
+        // add mock data to order list screen
+        activityTestRule.setOrderListWithMockData()
+
+        // Click on Orders tab in the bottom bar
+        onView(withId(R.id.orders)).perform(click())
+    }
+
+    @Test
+    fun verifyProductCardListPopulatedSuccessfullyForSingleProduct() {
+        // Set Order fulfillment with mock data
+        val lineItems = Gson().toJson(
+                listOf(mapOf(
+                                "productId" to "290",
+                                "variationId" to "0",
+                                "name" to "Black T-shirt",
+                                "quantity" to 1,
+                                "subtotal" to 10
+                        )))
+        mockWCOrderModel.lineItems = lineItems
+        redirectToOrderFulfillment()
+
+        // check if product list is 1
+        val recyclerView = activityTestRule.activity.findViewById(R.id.productList_products) as RecyclerView
+        assertSame(1, recyclerView.adapter?.itemCount)
+    }
+
+    @Test
+    fun verifyProductCardListPopulatedSuccessfullyForMultipleProducts() {
+        redirectToOrderFulfillment()
+
+        // check if product list is 2
+        val recyclerView = activityTestRule.activity.findViewById(R.id.productList_products) as RecyclerView
+        assertSame(2, recyclerView.adapter?.itemCount)
+    }
+
+    @Test
+    fun verifyProductCardListItemsPopulatedSuccessfully() {
+        redirectToOrderFulfillment()
+
+        // verify that the fulfill order and Details button are hidden
+        onView(withId(R.id.productList_btnFulfill)).check(matches(withEffectiveVisibility(GONE)))
+        onView(withId(R.id.productList_btnDetails)).check(matches(withEffectiveVisibility(GONE)))
+
+        // check if order product card label matches this title:
+        // R.string.orderdetail_product
+        onView(withId(R.id.productList_lblProduct)).check(matches(
+                withText(appContext.getString(R.string.orderdetail_product))
+        ))
+
+        // check if order product card quantity label matches this title:
+        // R.string.orderdetail_product_qty
+        onView(withId(R.id.productList_lblQty)).check(matches(
+                withText(appContext.getString(R.string.orderdetail_product_qty))
+        ))
+
+        // verify that the product total label is visible
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productTotal))
+                .check(matches(withEffectiveVisibility(VISIBLE)))
+
+        // verify that the product total tax label is visible
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_lblTax))
+                .check(matches(withEffectiveVisibility(VISIBLE)))
+
+        // verify that the tax label matches : Tax:
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_lblTax))
+                .check(matches(withText(appContext.getString(R.string.orderdetail_product_lineitem_tax))))
+
+        // verify if the first product name matches: Black T-shirt
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_name))
+                .check(matches(withText(mockWCOrderModel.getLineItemList()[0].name)))
+
+        // verify if the second product quantity matches: 2
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_qty))
+                .check(matches(withText(mockWCOrderModel.getLineItemList()[1].quantity?.toInt().toString())))
+
+        // verify that the product total tax is visible
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_totalTax))
+                .check(matches(withEffectiveVisibility(VISIBLE)))
+    }
+
+    /**
+     * Related FluxC issue in MockedStack_WCBaseStoreTest.kt#L116
+     * Some of the internals of java.util.Currency seem to be stubbed in a unit test environment,
+     * giving results inconsistent with a normal running app
+     */
+    @Test
+    fun verifyProductListItemCurrencyDisplayedCorrectlyForUSD() {
+        Assume.assumeTrue(
+                "Requires API 23 or higher due to localized currency values differing on older versions",
+                VERSION.SDK_INT >= 23
+        )
+
+        redirectToOrderFulfillment()
+
+        // verify that the product total is displayed correctly for multiple quantities
+        // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productTotal))
+                .check(matches(withText(appContext.getString(
+                        R.string.orderdetail_product_lineitem_total_single,
+                        "$${mockWCOrderModel.getLineItemList()[0].total}.00"
+                ))))
+
+        // for multiple quantities: $13.00 ($11.00x2)
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productTotal))
+                .check(matches(withText(appContext.getString(
+                        R.string.orderdetail_product_lineitem_total_multiple,
+                        "$${mockWCOrderModel.getLineItemList()[1].total}.00",
+                        "$${mockWCOrderModel.getLineItemList()[1].price}.00",
+                        mockWCOrderModel.getLineItemList()[1].quantity?.toInt().toString()
+                ))))
+
+        // verify that the total tax is displayed correctly
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_totalTax))
+                .check(matches(withText("$${mockWCOrderModel.getLineItemList()[0].totalTax}.00")))
+    }
+
+    /**
+     * Related FluxC issue in MockedStack_WCBaseStoreTest.kt#L116
+     * Some of the internals of java.util.Currency seem to be stubbed in a unit test environment,
+     * giving results inconsistent with a normal running app
+     */
+    @Test
+    fun verifyProductListItemCurrencyDisplayedCorrectlyForEuro() {
+        Assume.assumeTrue(
+                "Requires API 23 or higher due to localized currency values differing on older versions",
+                VERSION.SDK_INT >= 23
+        )
+
+        // inject mock data to order product list page
+        mockWCOrderModel.currency = "EUR"
+        redirectToOrderFulfillment()
+
+        // verify that the product total is displayed correctly for multiple quantities
+        // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productTotal))
+                .check(matches(withText(appContext.getString(
+                        R.string.orderdetail_product_lineitem_total_single,
+                        "€${mockWCOrderModel.getLineItemList()[0].total}.00"
+                ))))
+
+        // for multiple quantities: €13.00 (€11.00x2)
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productTotal))
+                .check(matches(withText(appContext.getString(
+                        R.string.orderdetail_product_lineitem_total_multiple,
+                        "€${mockWCOrderModel.getLineItemList()[1].total}.00",
+                        "€${mockWCOrderModel.getLineItemList()[1].price}.00",
+                        mockWCOrderModel.getLineItemList()[1].quantity?.toInt().toString()
+                ))))
+
+        // verify that the total tax is displayed correctly
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_totalTax))
+                .check(matches(withText("€${mockWCOrderModel.getLineItemList()[0].totalTax}.00")))
+    }
+
+    /**
+     * Related FluxC issue in MockedStack_WCBaseStoreTest.kt#L116
+     * Some of the internals of java.util.Currency seem to be stubbed in a unit test environment,
+     * giving results inconsistent with a normal running app
+     */
+    @Test
+    fun verifyProductListItemCurrencyDisplayedCorrectlyForInr() {
+        Assume.assumeTrue(
+                "Requires API 23 or higher due to localized currency values differing on older versions",
+                VERSION.SDK_INT >= 23
+        )
+
+        // inject mock data to order product list page
+        mockWCOrderModel.currency = "INR"
+        redirectToOrderFulfillment()
+
+        // verify that the product total is displayed correctly for multiple quantities
+        // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productTotal))
+                .check(matches(withText(appContext.getString(
+                        R.string.orderdetail_product_lineitem_total_single,
+                        "₹${mockWCOrderModel.getLineItemList()[0].total}.00"
+                ))))
+
+        // for multiple quantities: ₹13.00 (₹11.00x2)
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productTotal))
+                .check(matches(withText(appContext.getString(
+                        R.string.orderdetail_product_lineitem_total_multiple,
+                        "₹${mockWCOrderModel.getLineItemList()[1].total}.00",
+                        "₹${mockWCOrderModel.getLineItemList()[1].price}.00",
+                        mockWCOrderModel.getLineItemList()[1].quantity?.toInt().toString()
+                ))))
+
+        // verify that the total tax is displayed correctly
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_totalTax))
+                .check(matches(withText("₹${mockWCOrderModel.getLineItemList()[0].totalTax}.00")))
+    }
+
+    /**
+     * Related FluxC issue in MockedStack_WCBaseStoreTest.kt#L116
+     * Some of the internals of java.util.Currency seem to be stubbed in a unit test environment,
+     * giving results inconsistent with a normal running app
+     */
+    @Test
+    fun verifyProductListItemCurrencyDisplayedCorrectlyForAud() {
+        Assume.assumeTrue(
+                "Requires API 23 or higher due to localized currency values differing on older versions",
+                VERSION.SDK_INT >= 23
+        )
+
+        // inject mock data to order product list page
+        mockWCOrderModel.currency = "AUD"
+        redirectToOrderFulfillment()
+
+        // verify that the product total is displayed correctly for multiple quantities
+        // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productTotal))
+                .check(matches(withText(appContext.getString(
+                        R.string.orderdetail_product_lineitem_total_single,
+                        "A$${mockWCOrderModel.getLineItemList()[0].total}.00"
+                ))))
+
+        // for multiple quantities: A$13.00 (A$11.00x2)
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productTotal))
+                .check(matches(withText(appContext.getString(
+                        R.string.orderdetail_product_lineitem_total_multiple,
+                        "A\$${mockWCOrderModel.getLineItemList()[1].total}.00",
+                        "A\$${mockWCOrderModel.getLineItemList()[1].price}.00",
+                        mockWCOrderModel.getLineItemList()[1].quantity?.toInt().toString()
+                ))))
+
+        // verify that the total tax is displayed correctly
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_totalTax))
+                .check(matches(withText("A$${mockWCOrderModel.getLineItemList()[0].totalTax}.00")))
+    }
+
+    @Test
+    fun verifyProductListItemSkuIsHiddenIfNotAvailable() {
+        // inject mock data to order product list page
+        redirectToOrderFulfillment()
+
+        // sku is available for the first item. Verify it is displayed correctly
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_lblSku))
+                .check(matches(withEffectiveVisibility(VISIBLE)))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_sku))
+                .check(matches(withEffectiveVisibility(VISIBLE)))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_lblSku))
+                .check(matches(withText(appContext.getString(R.string.orderdetail_product_lineitem_sku))))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_sku))
+                .check(matches(withText(mockWCOrderModel.getLineItemList()[0].sku)))
+
+        // sku is not available for the second item. Verify it is hidden
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_lblSku))
+                .check(matches(withEffectiveVisibility(GONE)))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_sku))
+                .check(matches(withEffectiveVisibility(GONE)))
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/WcOrderTestUtils.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/WcOrderTestUtils.kt
@@ -28,14 +28,21 @@ object WcOrderTestUtils {
                             "variationId" to "0",
                             "name" to "Black T-shirt",
                             "quantity" to 1,
-                            "subtotal" to 10
+                            "subtotal" to 10,
+                            "price" to 14,
+                            "total" to 15,
+                            "total_tax" to 2,
+                            "sku" to "blabla"
                     ),
                     mapOf(
                             "productId" to "291",
                             "variationId" to "2",
                             "name" to "White Pants",
                             "quantity" to 2,
-                            "subtotal" to 12
+                            "subtotal" to 12,
+                            "price" to 11,
+                            "total" to 13,
+                            "total_tax" to 3
                     )
             )
     )


### PR DESCRIPTION
Fixes #1144 by adding UI tests for Order Fulfillment page.

The following scenarios have been added to the test cases:

### Navigation Tests:
- [x] Toolbar title in Order Fulfilment is displayed correctly
- [x] UP navigation icon is displayed correctly. Clicking on the UP icon redirects to Order Detail

### Customer Info Card
- [x] Verify shipping label, shipping address is displayed correctly and billing address is hidden
- [x] Verify billing address is wrapped correctly for really long address
- [x] Verify billing address is empty when no address is available
- [x] Verify shipping address displayed correctly when both shipping and billing address is separate

### Product List Card:
- [x] populate with one product
- [x] populate with at least multiple products
- [x] verify that product labels are displayed correctly
- [x] Product Item: The product name, quantity, total, tax and their labels are displayed correctly
- [x] Product Item: Currency formatting for product prices, taxes are displayed correctly for US, EUR, IND, AUD
- [x] SKU is displayed only id available and hidden, if not.

### Mark Order complete:
- [x] Mark order complete when no network available
- [x] Mark order complete when network available but undo is clicked
- [x] Mark order complete when network available - failure
