### PR TITLE
Ignore sentry.properties file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ fastlane/.env
 
 # Ruby Dependencies
 /vendor
+
+# Sentry
+sentry.properties


### PR DESCRIPTION
This PR adds the `sentry.properties` file to the `.gitignore` file so nobody accidentally checks it in. Anyone can review this PR. 

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
