### PR TITLE
Added the proper style tag to style the review buttons per designs

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_review_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_review_detail.xml
@@ -156,7 +156,7 @@
 
             <Button
                 android:id="@+id/review_spam"
-                style="@style/Woo.Button.White"
+                style="@style/Woo.Button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="@dimen/margin_extra_large"
@@ -167,7 +167,7 @@
 
             <Button
                 android:id="@+id/review_trash"
-                style="@style/Woo.Button.White"
+                style="@style/Woo.Button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="@dimen/margin_extra_large"

--- a/WooCommerce/src/main/res/layout/fragment_review_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_review_detail.xml
@@ -156,6 +156,7 @@
 
             <Button
                 android:id="@+id/review_spam"
+                style="@style/Woo.Button.White"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="@dimen/margin_extra_large"
@@ -166,6 +167,7 @@
 
             <Button
                 android:id="@+id/review_trash"
+                style="@style/Woo.Button.White"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="@dimen/margin_extra_large"


### PR DESCRIPTION
Fixes #1152  

**Background: ** Before the new sign-in m1 project, we had a theme-level button style set to `Woo.Button`. This button style is a transparent, borderless button with purple text. When the sign-in project started, I had a need for a button with a white background, border/shadow, and purple text, but for some reason this style was conflicting with the theme level style so the style I needed just wouldn't apply properly in the app. The fix was to remove the theme-level default button style. The side effect was these two buttons in the `ProductReviewFragment` didn't have a style applied originally so now they were styled all wrong. I've now added the appropriate style to the buttons. 

![2019-06-14_15-46-37](https://user-images.githubusercontent.com/5810477/59541559-214b6e00-8ebf-11e9-9b21-4f130cd2ff7c.png)


