### PR TITLE
Display cached orders in the order list if available on first run

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.1
 -----
 * The sign in flow has been completely revamped with new help screens and documentation to help users successfully login to the app.
+* The orders list will now populate with cached data while it attempts to fetch fresh orders from the API.
 
 2.0
 ----

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -162,6 +162,7 @@ dependencies {
     testImplementation "junit:junit:4.12"
     testImplementation "com.nhaarman:mockito-kotlin-kt1.1:$mockitoKotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
+    testImplementation "org.mockito:mockito-android:$mockitoVersion"
 
     // Dependencies for Espresso UI tests
     androidTestImplementation "androidx.test.ext:junit:1.1.1"

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -162,7 +162,6 @@ dependencies {
     testImplementation "junit:junit:4.12"
     testImplementation "com.nhaarman:mockito-kotlin-kt1.1:$mockitoKotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
-    testImplementation "org.mockito:mockito-android:$mockitoVersion"
 
     // Dependencies for Espresso UI tests
     androidTestImplementation "androidx.test.ext:junit:1.1.1"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListContract.kt
@@ -8,14 +8,18 @@ import org.wordpress.android.fluxc.model.WCOrderStatusModel
 interface OrderListContract {
     interface Presenter : BasePresenter<View> {
         var isShipmentTrackingProviderFetched: Boolean
-        fun loadOrders(filterByStatus: String? = null, forceRefresh: Boolean)
+        fun loadOrders(filterByStatus: String? = null, forceRefresh: Boolean, isFirstRun: Boolean = false)
         fun loadMoreOrders(orderStatusFilter: String? = null)
         fun canLoadMoreOrders(): Boolean
         fun isLoadingOrders(): Boolean
         fun isOrderStatusOptionsRefreshing(): Boolean
         fun openOrderDetail(order: WCOrderModel)
         fun fetchOrdersFromDb(orderStatusFilter: String? = null, isForceRefresh: Boolean): List<WCOrderModel>
-        fun fetchAndLoadOrdersFromDb(orderStatusFilter: String? = null, isForceRefresh: Boolean)
+        fun fetchAndLoadOrdersFromDb(
+            orderStatusFilter: String? = null,
+            isForceRefresh: Boolean,
+            isFirstRun: Boolean = false
+        )
         fun searchOrders(searchQuery: String)
         fun searchMoreOrders(searchQuery: String)
         fun getOrderStatusOptions(): Map<String, WCOrderStatusModel>
@@ -41,7 +45,9 @@ interface OrderListContract {
         fun addSearchResults(query: String, orders: List<WCOrderModel>)
         fun clearSearchResults()
 
+        fun showLoading(show: Boolean)
         fun showSkeleton(show: Boolean)
+        fun showRefreshingIndicator(show: Boolean)
 
         fun setOrderStatusOptions(orderStatusOptions: Map<String, WCOrderStatusModel>)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -251,7 +251,7 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
         empty_view.setSiteToShare(selectedSite.get(), Stat.ORDERS_LIST_SHARE_YOUR_STORE_BUTTON_TAPPED)
 
         if (isActive && !deferInit) {
-            presenter.loadOrders(orderStatusFilter, forceRefresh = this.isRefreshPending)
+            presenter.loadOrders(orderStatusFilter, forceRefresh = this.isRefreshPending, isFirstRun = true)
         }
 
         listState?.let {
@@ -324,6 +324,18 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
             skeletonView.show(ordersView, R.layout.skeleton_order_list, delayed = true)
         } else {
             skeletonView.hide()
+        }
+    }
+
+    override fun showRefreshingIndicator(show: Boolean) {
+        orderRefreshLayout?.isRefreshing = show
+    }
+
+    override fun showLoading(show: Boolean) {
+        if (ordersAdapter.itemCount > 0) {
+            showRefreshingIndicator(show)
+        } else {
+            showSkeleton(show)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -356,7 +356,7 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
         }
 
         // Update the toolbar title
-        if (!isHidden) {
+        if (isActive) {
             activity?.title = getFragmentTitle()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListPresenter.kt
@@ -73,15 +73,17 @@ class OrderListPresenter @Inject constructor(
         ConnectionChangeReceiver.getEventBus().unregister(this)
     }
 
-    override fun loadOrders(filterByStatus: String?, forceRefresh: Boolean) {
+    override fun loadOrders(filterByStatus: String?, forceRefresh: Boolean, isFirstRun: Boolean) {
+        // Seed orders list with whatever we have in the db
+        fetchAndLoadOrdersFromDb(filterByStatus, isForceRefresh = false, isFirstRun = isFirstRun)
+
         if (networkStatus.isConnected() && forceRefresh) {
+            // Refresh the orders from the API
             orderListState = OrderListState.LOADING
             orderView?.showEmptyView(false)
-            orderView?.showSkeleton(true)
+            orderView?.showLoading(true)
             val payload = FetchOrdersPayload(selectedSite.get(), filterByStatus)
             dispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(payload))
-        } else {
-            fetchAndLoadOrdersFromDb(filterByStatus, isForceRefresh = false)
         }
     }
 
@@ -157,7 +159,7 @@ class OrderListPresenter @Inject constructor(
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onOrderChanged(event: OnOrderChanged) {
-        orderView?.showSkeleton(false)
+        orderView?.showLoading(false)
         when (event.causeOfChange) {
             FETCH_ORDERS -> {
                 if (event.isError) {
@@ -215,7 +217,7 @@ class OrderListPresenter @Inject constructor(
         orderListState = OrderListState.IDLE
     }
 
-    @Suppress
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onOrderStatusOptionsChanged(event: OnOrderStatusOptionsChanged) {
         isRefreshingOrderStatusOptions = false
@@ -259,7 +261,7 @@ class OrderListPresenter @Inject constructor(
      * @param orderStatusFilter If not null, only pull orders whose status matches this filter. Default null.
      * @param isForceRefresh True if orders were refreshed from the API, else false.
      */
-    override fun fetchAndLoadOrdersFromDb(orderStatusFilter: String?, isForceRefresh: Boolean) {
+    override fun fetchAndLoadOrdersFromDb(orderStatusFilter: String?, isForceRefresh: Boolean, isFirstRun: Boolean) {
         val orders = fetchOrdersFromDb(orderStatusFilter, isForceRefresh)
         orderView?.let { view ->
             val currentOrders = removeFutureOrders(orders)
@@ -272,10 +274,10 @@ class OrderListPresenter @Inject constructor(
                 // so passing the first order in the order list
                 loadShipmentTrackingProviders(currentOrders[0])
             } else {
-                if (!networkStatus.isConnected()) {
-                    // if the device is offline with no cached orders to display, show the loading
-                    // indicator until a successful online refresh.
-                    view.showSkeleton(true)
+                if (!networkStatus.isConnected() || isFirstRun) {
+                    // if the device is offline or has not yet been initialized and has no cached orders to display,
+                    // show the loading indicator until a successful online refresh.
+                    view.showLoading(true)
                 } else {
                     view.showEmptyView(true)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListPresenter.kt
@@ -236,11 +236,8 @@ class OrderListPresenter @Inject constructor(
         AnalyticsTracker.track(Stat.ORDER_OPEN, mapOf(
                 AnalyticsTracker.KEY_ID to order.remoteOrderId,
                 AnalyticsTracker.KEY_STATUS to order.status))
-        orderView?.let {
-            if (!it.isRefreshing) {
-                it.openOrderDetail(order)
-            }
-        }
+
+        orderView?.openOrderDetail(order)
     }
 
     /**

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListPresenterTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders
 
 import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.atLeastOnce
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.never
@@ -73,15 +74,34 @@ class OrderListPresenterTest {
     }
 
     @Test
-    fun `Displays the no orders list view correctly`() {
+    fun `Displays loading skeleton then no orders list view correctly on first run`() {
         presenter.takeView(orderListView)
-        presenter.loadOrders(forceRefresh = true)
+        presenter.loadOrders(forceRefresh = true, isFirstRun = true)
         verify(dispatcher, times(1)).dispatch(any<Action<FetchOrdersPayload>>())
 
         // OnOrderChanged callback from FluxC should trigger the appropriate UI update
         doReturn(noOrders).whenever(orderStore).getOrdersForSite(any())
         presenter.onOrderChanged(OnOrderChanged(0).apply { causeOfChange = FETCH_ORDERS })
-        verify(orderListView).showEmptyView(true)
+        verify(orderListView, times(1)).showEmptyView(true)
+        verify(orderListView, times(2)).showLoading(true)
+    }
+
+    @Test
+    fun `Displays loading indicator then orders when cached orders present`() {
+        presenter.takeView(orderListView)
+        doReturn(orders).whenever(orderStore).getOrdersForSite(any())
+        presenter.loadOrders(forceRefresh = true, isFirstRun = false)
+
+        // This is called twice, once for fetching orders, then again for shipment tracking
+        // the payload type in `any<Action<FetchOrdersPayload>>` does not actually get evaluated.
+        // The only thing this confirms is the type of `Action`
+        verify(dispatcher, times(2)).dispatch(any<Action<FetchOrdersPayload>>())
+
+        // OnOrderChanged callback from FluxC should trigger the appropriate UI update
+        presenter.onOrderChanged(OnOrderChanged(0).apply { causeOfChange = FETCH_ORDERS })
+        verify(orderListView, atLeastOnce()).showEmptyView(false)
+        verify(orderListView, never()).showEmptyView(true)
+        verify(orderListView, times(1)).showLoading(true)
     }
 
     @Test
@@ -178,17 +198,17 @@ class OrderListPresenterTest {
 
         // mock a network status change
         presenter.loadMoreOrders(null)
-        verify(presenter, times(0)).fetchAndLoadOrdersFromDb(any(), any())
+        verify(presenter, never()).fetchAndLoadOrdersFromDb(null, false)
     }
 
     @Test
     fun `Show and hide order list skeleton correctly`() {
         presenter.takeView(orderListView)
         presenter.loadOrders("processing", forceRefresh = true)
-        verify(orderListView, times(1)).showSkeleton(true)
+        verify(orderListView, times(1)).showLoading(true)
 
         presenter.onOrderChanged(OnOrderChanged(orders.size).apply { causeOfChange = FETCH_ORDERS })
-        verify(orderListView, times(1)).showSkeleton(false)
+        verify(orderListView, times(1)).showLoading(false)
     }
 
     @Test


### PR DESCRIPTION
Fixes #1154 by adding the logic needed to display cached orders in the orders list while we fetch a fresh copy when the list is first loaded. 

This required some tweaks to clean up the UI:
- Prevent showing the "No orders" view while we're in the process of fetching orders for the first time since the app started. The "no orders" view should only be displayed if we've already attempted to fetch orders and the user has none.
- Which loading indicator to show? If the orders adapter has no orders to display, show loading skeleton. If there are orders to display, display the refresh indicator.
- The user can now click to open an order from the order list even while the page is refreshing. Added new logic to make sure the page title doesn't get updated if the orders list is not visible.

Here are some gif's displaying an initial load of the app, then killing the app and opening it back up.

### Before
<img src="https://user-images.githubusercontent.com/5810477/59545045-16e89e80-8ed6-11e9-9cd7-12ed260760a6.gif" width="300"/>


### After
<img src="https://user-images.githubusercontent.com/5810477/59545048-1a7c2580-8ed6-11e9-9b6b-cff4dab3f74a.gif" width="300"/>


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

## See it in action
1. Completely sign out of the app
2. Log into the app and click the "orders" tab. The loading skeleton should be visible since no cached data is available.
3. Once orders are loaded, close the app entirely.
4. Open the app again, click on the orders tab. Orders should load cached data immediately while it fetches fresh data from the api (the refresh indicator will be visible).
5. Click on an order while the refresh indicator is still visible - order detail should open. 

## Recommended test scenarios
- Verify the steps above complete as expected
- Verify "no stores" view is still working properly if there are no orders.
- Verify doing a pull to refresh does not show the skeleton view unless there are no orders visible (should always be the refresh indicator once we have data).
- Verify opening an order while loading orders doesn't cause any issues

