### PR TITLE
Fix app title persistence issues

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.1
 -----
 * The sign in flow has been completely revamped with new help screens and documentation to help users successfully login to the app.
+* Fixed a bug where the title of the current view may not update appropriately when navigating the app.
 
 2.0
 ----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -152,10 +152,13 @@ abstract class TopLevelFragment : androidx.fragment.app.Fragment(), TopLevelFrag
             container?.getChildAt(0)?.visibility = View.VISIBLE
             mainActivity?.supportActionBar?.setDisplayHomeAsUpEnabled(false)
             mainActivity?.supportActionBar?.setDisplayShowHomeEnabled(false)
+            updateActivityTitle()
         }
     }
 
     fun updateActivityTitle() {
-        activity?.title = getFragmentTitle()
+        if (isActive) {
+            activity?.title = getFragmentTitle()
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/ReviewDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/ReviewDetailFragment.kt
@@ -91,6 +91,13 @@ class ReviewDetailFragment : androidx.fragment.app.Fragment(), ReviewDetailContr
         return inflater.inflate(R.layout.fragment_review_detail, container, false)
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // Set the page title
+        activity?.title = getString(R.string.wc_review_title)
+    }
+
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         val dimen = activity!!.resources.getDimensionPixelSize(R.dimen.product_icon_sz)

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -415,6 +415,7 @@
     <string name="wc_trash">Trash</string>
     <string name="wc_load_review_error">Error loading product review detail</string>
     <string name="wc_moderate_review_error">Error updating product review status</string>
+    <string name="wc_review_title">Review</string>
     <!--
         Notifications List
     -->


### PR DESCRIPTION
This PR fixes #1155 (and #1040) by adding the appropriate logic to update the app title when navigating throughout the app, as well as when the activity is recreated. The best way to test this is to toggle on **Don't keep activities** in the device **Developer Options**

**Note:** While I was in there I also updated the title of the `ReviewDetailFragment` to be "Review" like the designs specify in i7.

## BEFORE & AFTER
Open **My Store**, then minimize the app and bring it back to the foreground. App title is now "WooCommerce" (left). Fixed version on the right.

<img src="https://user-images.githubusercontent.com/5810477/59546326-7cde2180-8ee8-11e9-8622-dcad93822616.gif" width="300"/> <img src="https://user-images.githubusercontent.com/5810477/59546345-a434ee80-8ee8-11e9-9505-f904cd5ae998.gif" width="300"/>

Open **Notifications**, then minimize the app and bring it back to the foreground. App title is now "WooCommerce" (left). Fixed version on the right.

<img src="https://user-images.githubusercontent.com/5810477/59546327-7f407b80-8ee8-11e9-82d2-bb0538212e59.gif" width="300"/> <img src="https://user-images.githubusercontent.com/5810477/59546360-26bdae00-8ee9-11e9-9ece-161e5ea0b802.gif" width="300"/>

Open a **Product Review Notification**, then minimize the app and bring it back to the foreground. App title is now "WooCommerce" (left). Fixed version on the right.

<img src="https://user-images.githubusercontent.com/5810477/59546329-810a3f00-8ee8-11e9-905a-d068178c9d84.gif" width="300"/> <img src="https://user-images.githubusercontent.com/5810477/59546362-29b89e80-8ee9-11e9-9d31-5b96f84fa966.gif" width="300"/>

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
