### PR TITLE
issue/1159-notification-glide-exception-fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
@@ -42,6 +42,7 @@ import org.wordpress.android.util.PhotonUtils
 import org.wordpress.android.util.StringUtils
 import java.io.UnsupportedEncodingException
 import java.net.URLDecoder
+import java.util.concurrent.ExecutionException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -314,6 +315,11 @@ class NotificationHandler @Inject constructor(
                 return largeIconBitmap
             } catch (e: UnsupportedEncodingException) {
                 WooLog.e(T.NOTIFS, e)
+            } catch (e: ExecutionException) {
+                // ExecutionException happens when the image fails to load.
+                // handling the exception here to gracefully display notification, without icon
+                // instead of crashing the app
+                WooLog.e(T.NOTIFS, "Failed to load image with url $iconUrl")
             }
         }
         return null


### PR DESCRIPTION
Based on the crash logs [here](https://github.com/woocommerce/woocommerce-android/issues/1159), the exception happens when the image url fails to load due to a connectivity issue or if the request is blocked, for some reason. Some of the exceptions from the logs include:

- `com.android.volley.TimeoutError(null)`
- `com.android.volley.ClientError(null)`
- `com.android.volley.NoConnectionError(java.net.ConnectException: Failed to connect to i0.wp.com/192.0.77.2:443)`

This PR fixes #1159  by catching the exception when we attempt to load an image url synchronously when a new notification is received. 
