### PR TITLE
Fix localization crash on date shipped button in Add Order Tracking view

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderShipmentTrackingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderShipmentTrackingFragment.kt
@@ -301,7 +301,6 @@ class AddOrderShipmentTrackingFragment : androidx.fragment.app.Fragment(), AddOr
      * example: May 9, 2019 -> 2019-05-09
      */
     override fun getDateShippedText(): String {
-        // TODO AMANDA - requireActivity() throws and IllegalStateException
         val dateSelected = DateUtils.getDateFromLocalizedLongDateString(
                 requireActivity(),
                 addTracking_date.text.toString())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderShipmentTrackingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderShipmentTrackingFragment.kt
@@ -18,12 +18,13 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_SHIPMENT_TR
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
+import com.woocommerce.android.util.DateUtils
+import org.wordpress.android.fluxc.utils.DateUtils as FluxCDateUtils
 import com.woocommerce.android.widgets.AppRatingDialog
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_add_shipment_tracking.*
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
-import org.wordpress.android.fluxc.utils.DateUtils
 import java.util.Calendar
 import javax.inject.Inject
 
@@ -109,7 +110,7 @@ class AddOrderShipmentTrackingFragment : androidx.fragment.app.Fragment(), AddOr
             orderId = arguments?.getString(FIELD_ORDER_IDENTIFIER) ?: ""
             isSelectedProviderCustom = arguments?.getBoolean(FIELD_IS_CUSTOM_PROVIDER, false) ?: false
             val dateShipped = arguments?.getString(FIELD_ORDER_TRACKING_DATE_SHIPPED)?.let { it }
-                    ?: DateUtils.getCurrentDateString()
+                    ?: FluxCDateUtils.getCurrentDateString()
             displayFormatDateShippedText(dateShipped)
         }
 
@@ -130,7 +131,7 @@ class AddOrderShipmentTrackingFragment : androidx.fragment.app.Fragment(), AddOr
         // When date field is clicked, open calendar dialog with default date set to
         // current date if no date was previously selected
         addTracking_date.setOnClickListener {
-            val calendar = DateUtils.getCalendarInstance(getDateShippedText())
+            val calendar = FluxCDateUtils.getCalendarInstance(getDateShippedText())
             dateShippedPickerDialog = DatePickerDialog(requireActivity(),
                     DatePickerDialog.OnDateSetListener { _, year, month, dayOfMonth ->
                         val actualMonth = month + 1
@@ -293,9 +294,18 @@ class AddOrderShipmentTrackingFragment : androidx.fragment.app.Fragment(), AddOr
         }
     }
 
+    /**
+     * Formats the localized date string and returns it in the format of yyyy-MM-dd
+     * for use with the API.
+     *
+     * example: May 9, 2019 -> 2019-05-09
+     */
     override fun getDateShippedText(): String {
-        // format displayed date to YYY-MM-dd i.e. from May 9, 2019 -> 2019-05-09
-        return com.woocommerce.android.util.DateUtils.getDateString(addTracking_date.text.toString())
+        // TODO AMANDA - requireActivity() throws and IllegalStateException
+        val dateSelected = DateUtils.getDateFromLocalizedLongDateString(
+                requireActivity(),
+                addTracking_date.text.toString())
+        return DateUtils.getYearMonthDayStringFromDate(dateSelected)
     }
 
     override fun onTrackingProviderSelected(selectedCarrierName: String) {
@@ -329,7 +339,7 @@ class AddOrderShipmentTrackingFragment : androidx.fragment.app.Fragment(), AddOr
 
     private fun displayFormatDateShippedText(dateString: String) {
         context?.let {
-            addTracking_date.text = com.woocommerce.android.util.DateUtils.getLocalizedLongDateString(
+            addTracking_date.text = DateUtils.getLocalizedLongDateString(
                     it,
                     dateString
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -27,6 +27,10 @@ object DateUtils {
     }
     private val shortMonths by lazy { DateFormatSymbols().shortMonths }
 
+    private val yyyyMMddFormat by lazy {
+        SimpleDateFormat("yyyy-MM-dd", Locale.US)
+    }
+
     /**
      * Returns a string in the format of {date} at {time}.
      */
@@ -118,6 +122,18 @@ object DateUtils {
     }
 
     /**
+     * Given a date string in localized format, returns a date object.
+     *
+     * @throws IllegalArgumentException is thronw by the [DateFormat] class if [dateString] cannot be
+     * properly parsed
+     */
+    @Throws(IllegalArgumentException::class)
+    fun getDateFromLocalizedLongDateString(context: Context, dateString: String): Date {
+        val df = DateFormat.getLongDateFormat(context)
+        return df.parse(dateString)
+    }
+
+    /**
      * Given a date of format YYYY-'W'WW, returns the String in short month ("MMM d") format,
      * with the day being the first day of that week (a Monday, by ISO8601 convention).
      *
@@ -185,4 +201,9 @@ object DateUtils {
             throw IllegalArgumentException("Date string argument is not of format MMMM dd, yyyy: $dateString")
         }
     }
+
+    /**
+     * Formats a date object and returns it in the format of yyyy-MM-dd
+     */
+    fun getYearMonthDayStringFromDate(date: Date): String = yyyyMMddFormat.format(date)
 }

--- a/WooCommerce/src/main/res/layout/fragment_add_shipment_tracking.xml
+++ b/WooCommerce/src/main/res/layout/fragment_add_shipment_tracking.xml
@@ -51,8 +51,7 @@
                 android:paddingLeft="0dp"
                 android:paddingRight="0dp"
                 android:paddingStart="0dp"
-                android:paddingTop="@dimen/default_padding"
-                />
+                android:paddingTop="@dimen/default_padding"/>
 
             <View
                 android:id="@+id/addTracking_editCarrierDivider"
@@ -167,6 +166,8 @@
             <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/addTracking_date"
                 style="@style/Woo.OrderTracking.Add.EditText"
+                android:background="?android:attr/selectableItemBackground"
+                android:backgroundTint="@color/list_divider"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:gravity="top"
@@ -177,7 +178,9 @@
                 android:paddingRight="0dp"
                 android:paddingStart="0dp"
                 android:textColor="@color/edit_text_text_color"
-                tools:text="May 8, 2019"/>
+                tools:text="May 8, 2019"
+                android:paddingTop="@dimen/default_padding"
+                android:paddingBottom="@dimen/default_padding"/>
         </LinearLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Fixes #1164 localization crashes by adding some logic to properly parse localized date strings. Also fixed the style of this button that had lost it's style since the default transparent button style was removed from the app theme due to conflicts in this same release. 

## To Test
Follow the same instructions listed in the original ticket #1164 

## Style fixes
Before and after shots:

<img src="https://user-images.githubusercontent.com/5810477/59628236-61982f80-90fd-11e9-9953-c6db343c9888.png" width="300"/> <img src="https://user-images.githubusercontent.com/5810477/59628249-65c44d00-90fd-11e9-93f4-d888d854fc4b.png" width="300"/>

## Note
This PR targets the `release/2.1` branch since this is a fix for the active beta cycle. These changes will also need to be merged into `develop`. cc: @jtreanor 