### PR TITLE
Update FluxC build hash to import notification table fix

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 2.2
 -----
+* Fixed a bug where the notifications list would be empty after logging out and back into app
 
 2.1
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '40587199907d6af9198b85dc38c7e05a93d6b690'
+    fluxCVersion = 'be0866a122475538df22e76ee1c27ce631e8477e'
     daggerVersion = '2.22.1'
     supportLibraryVersion = '28.0.0'
     glideVersion = '4.9.0'

--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '3a44520084671ff0018086933626075b5e323d98'
+    fluxCVersion = '40587199907d6af9198b85dc38c7e05a93d6b690'
     daggerVersion = '2.22.1'
     supportLibraryVersion = '28.0.0'
     glideVersion = '4.9.0'


### PR DESCRIPTION
Fixes #1158 by adding a foreign key constraint to the Notification table on `local_site_id`. This is 100% a FluxC fix. More details about this fix can be found in the FluxC PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1285 

Note: this PR must be approved and merged before this one can be approved, that's why it's in draft

<img src="https://user-images.githubusercontent.com/5810477/59652021-4fdc7980-9149-11e9-8135-9574039bfa43.gif" width="300"/>


### To Test
1. Log into the app and load the notifications tab
2. Logout of the app
3. Log back into the app
4. Click on the notifications tab - the list should populate as expected. 

Update release notes:
- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
