### PR TITLE
Amanda/1173 signin refresh

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.2
 -----
 * Fixed a bug where the notifications list would be empty after logging out and back into app
+* Added a "refresh app" option to the sign in flow to check for updates to the selected site
 
 2.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -100,6 +100,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         SITE_PICKER_TRY_ANOTHER_ACCOUNT_BUTTON_TAPPED(siteless = true),
         SITE_PICKER_VIEW_CONNECTED_STORES_BUTTON_TAPPED(siteless = true),
         SITE_PICKER_HELP_FINDING_CONNECTED_EMAIL_LINK_TAPPED(siteless = true),
+        SITE_PICKER_NOT_WOO_STORE_REFRESH_APP_LINK_TAPPED(siteless = true),
 
         // -- Dashboard
         DASHBOARD_PULLED_TO_REFRESH,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -110,7 +110,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
                 AnalyticsTracker.track(Stat.SITE_PICKER_HELP_BUTTON_TAPPED)
             }
         } else {
-            // Called from settings to change site.
+            // Opened from settings to change active store.
             site_picker_root.setBackgroundColor(
                     ContextCompat.getColor(this, R.color.white))
 
@@ -129,12 +129,6 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
                     resources.getDimensionPixelSize(R.dimen.margin_large),
                     resources.getDimensionPixelSize(R.dimen.margin_extra_large),
                     resources.getDimensionPixelSize(R.dimen.margin_large))
-
-            // Display the primary (purple) button with the label "Continue"
-            with(button_primary) {
-                visibility = View.VISIBLE
-                text = getString(R.string.continue_button)
-            }
         }
 
         presenter.takeView(this)
@@ -463,7 +457,6 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         }
 
         with(button_primary) {
-            visibility = View.VISIBLE
             setOnClickListener {
                 AnalyticsTracker.track(Stat.SITE_PICKER_TRY_ANOTHER_ACCOUNT_BUTTON_TAPPED)
 
@@ -527,7 +520,6 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         }
 
         with(button_primary) {
-            visibility = View.VISIBLE
             setOnClickListener {
                 AnalyticsTracker.track(Stat.SITE_PICKER_TRY_ANOTHER_ACCOUNT_BUTTON_TAPPED)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -249,6 +249,9 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             loginSiteUrl?.let { processLoginSite(it) }
             return
         }
+        // Hide "show connected stores" button now that we're displaying
+        // the store list.
+        button_secondary.visibility = View.GONE
 
         AnalyticsTracker.track(
                 Stat.SITE_PICKER_STORES_SHOWN,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -502,6 +502,8 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             val spannable = SpannableString(notWooMessage)
             spannable.setSpan(
                     WooClickableSpan {
+                        AnalyticsTracker.track(Stat.SITE_PICKER_NOT_WOO_STORE_REFRESH_APP_LINK_TAPPED)
+
                         // TODO AMANDA: Fetch fresh site info from API
                         Toast.makeText(this@SitePickerActivity, "Amanda Test", Toast.LENGTH_LONG).show()
                     },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -8,7 +8,7 @@ import android.os.Bundle
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.TextUtils
-import android.text.style.ForegroundColorSpan
+import android.text.method.LinkMovementMethod
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
@@ -37,6 +37,7 @@ import com.woocommerce.android.ui.sitepicker.SitePickerAdapter.OnSiteClickListen
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.util.CrashUtils
+import com.woocommerce.android.widgets.WooClickableSpan
 import dagger.android.AndroidInjection
 import kotlinx.android.synthetic.main.activity_site_picker.*
 import kotlinx.android.synthetic.main.view_login_epilogue_button_bar.*
@@ -491,23 +492,25 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         site_picker_root.visibility = View.VISIBLE
         no_stores_view.visibility = View.VISIBLE
 
-        // Build and configure the error message and make the text view clickable
-        // to refresh the app.
-        val siteName = name.takeIf { !it.isNullOrEmpty() } ?: url
-        val refreshAppText = getString(R.string.login_refresh_app)
-        val notWooMessage = getString(R.string.login_not_woo_store, siteName, refreshAppText)
-
-        val spannable = SpannableString(notWooMessage)
-        spannable.setSpan(
-                ForegroundColorSpan(resources.getColor(R.color.wc_purple)),
-                (notWooMessage.length - refreshAppText.length),
-                notWooMessage.length,
-                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
-
         with(no_stores_view) {
-            setText(spannable, TextView.BufferType.SPANNABLE)
+            // Build and configure the error message and make part of the message
+            // clickable. When clicked, we'll fetch a fresh copy of the active site from the API.
+            val siteName = name.takeIf { !it.isNullOrEmpty() } ?: url
+            val refreshAppText = getString(R.string.login_refresh_app)
+            val notWooMessage = getString(R.string.login_not_woo_store, siteName, refreshAppText)
 
-            // TODO AMANDA: make clickable
+            val spannable = SpannableString(notWooMessage)
+            spannable.setSpan(
+                    WooClickableSpan {
+                        // TODO AMANDA: Fetch fresh site info from API
+                        Toast.makeText(this@SitePickerActivity, "Amanda Test", Toast.LENGTH_LONG).show()
+                    },
+                    (notWooMessage.length - refreshAppText.length),
+                    notWooMessage.length,
+                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+
+            setText(spannable, TextView.BufferType.SPANNABLE)
+            movementMethod = LinkMovementMethod.getInstance()
         }
 
         with(button_try_another) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -279,9 +279,9 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         siteAdapter.siteList = wcSites
         siteAdapter.selectedSiteId = selectedSite.getIfExists()?.siteId ?: wcSites[0].siteId
 
-        button_secondary.text = getString(R.string.continue_button)
-        button_secondary.isEnabled = true
-        button_secondary.setOnClickListener {
+        button_primary.text = getString(R.string.continue_button)
+        button_primary.isEnabled = true
+        button_primary.setOnClickListener {
             presenter.getSiteBySiteId(siteAdapter.selectedSiteId)?.let { site -> siteSelected(site) }
         }
     }
@@ -345,7 +345,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
 
         // re-select the previous site, if there was one
         siteAdapter.selectedSiteId = currentSite?.siteId ?: 0L
-        button_secondary.isEnabled = siteAdapter.selectedSiteId != 0L
+        button_primary.isEnabled = siteAdapter.selectedSiteId != 0L
 
         WooUpgradeRequiredDialog().show(supportFragmentManager)
     }
@@ -375,9 +375,9 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
                 else AppCompatResources.getDrawable(this, R.drawable.ic_woo_no_store)
         no_stores_view.setCompoundDrawablesWithIntrinsicBounds(null, noStoresImage, null, null)
 
-        button_secondary.text = getString(R.string.login_with_a_different_account)
-        button_secondary.isEnabled = true
-        button_secondary.setOnClickListener {
+        button_primary.text = getString(R.string.login_try_another_account)
+        button_primary.isEnabled = true
+        button_primary.setOnClickListener {
             presenter.logout()
         }
     }
@@ -468,13 +468,14 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         }
 
         with(button_secondary) {
-            text = getString(R.string.login_view_connected_stores)
-            setOnClickListener {
-                AnalyticsTracker.track(Stat.SITE_PICKER_VIEW_CONNECTED_STORES_BUTTON_TAPPED)
-
-                showConnectedSites()
-            }
             visibility = if (hasConnectedStores) {
+                text = getString(R.string.login_view_connected_stores)
+
+                setOnClickListener {
+                    AnalyticsTracker.track(Stat.SITE_PICKER_VIEW_CONNECTED_STORES_BUTTON_TAPPED)
+                    showConnectedSites()
+                }
+
                 View.VISIBLE
             } else {
                 View.GONE
@@ -531,13 +532,14 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         }
 
         with(button_secondary) {
-            text = getString(R.string.login_view_connected_stores)
-            setOnClickListener {
-                AnalyticsTracker.track(Stat.SITE_PICKER_VIEW_CONNECTED_STORES_BUTTON_TAPPED)
-
-                showConnectedSites()
-            }
             visibility = if (hasConnectedStores) {
+                text = getString(R.string.login_view_connected_stores)
+
+                setOnClickListener {
+                    AnalyticsTracker.track(Stat.SITE_PICKER_VIEW_CONNECTED_STORES_BUTTON_TAPPED)
+                    showConnectedSites()
+                }
+
                 View.VISIBLE
             } else {
                 View.GONE

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -110,6 +110,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
                 AnalyticsTracker.track(Stat.SITE_PICKER_HELP_BUTTON_TAPPED)
             }
         } else {
+            // Called from settings to change site.
             site_picker_root.setBackgroundColor(
                     ContextCompat.getColor(this, R.color.white))
 
@@ -128,6 +129,12 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
                     resources.getDimensionPixelSize(R.dimen.margin_large),
                     resources.getDimensionPixelSize(R.dimen.margin_extra_large),
                     resources.getDimensionPixelSize(R.dimen.margin_large))
+
+            // Display the primary (purple) button with the label "Continue"
+            with(button_primary) {
+                visibility = View.VISIBLE
+                text = getString(R.string.continue_button)
+            }
         }
 
         presenter.takeView(this)
@@ -237,12 +244,12 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
                 hasConnectedStores = true
 
                 // Make "show connected stores" visible to the user
-                button_continue.visibility = View.VISIBLE
+                button_secondary.visibility = View.VISIBLE
             } else {
                 hasConnectedStores = false
 
                 // Hide "show connected stores"
-                button_continue.visibility = View.GONE
+                button_secondary.visibility = View.GONE
             }
 
             loginSiteUrl?.let { processLoginSite(it) }
@@ -275,15 +282,15 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         siteAdapter.siteList = wcSites
         siteAdapter.selectedSiteId = selectedSite.getIfExists()?.siteId ?: wcSites[0].siteId
 
-        button_continue.text = getString(R.string.continue_button)
-        button_continue.isEnabled = true
-        button_continue.setOnClickListener {
+        button_secondary.text = getString(R.string.continue_button)
+        button_secondary.isEnabled = true
+        button_secondary.setOnClickListener {
             presenter.getSiteBySiteId(siteAdapter.selectedSiteId)?.let { site -> siteSelected(site) }
         }
     }
 
     override fun onSiteClick(siteId: Long) {
-        button_continue.isEnabled = true
+        button_primary.isEnabled = true
     }
 
     override fun siteSelected(site: SiteModel, isAutoLogin: Boolean) {
@@ -341,7 +348,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
 
         // re-select the previous site, if there was one
         siteAdapter.selectedSiteId = currentSite?.siteId ?: 0L
-        button_continue.isEnabled = siteAdapter.selectedSiteId != 0L
+        button_secondary.isEnabled = siteAdapter.selectedSiteId != 0L
 
         WooUpgradeRequiredDialog().show(supportFragmentManager)
     }
@@ -371,9 +378,9 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
                 else AppCompatResources.getDrawable(this, R.drawable.ic_woo_no_store)
         no_stores_view.setCompoundDrawablesWithIntrinsicBounds(null, noStoresImage, null, null)
 
-        button_continue.text = getString(R.string.login_with_a_different_account)
-        button_continue.isEnabled = true
-        button_continue.setOnClickListener {
+        button_secondary.text = getString(R.string.login_with_a_different_account)
+        button_secondary.isEnabled = true
+        button_secondary.setOnClickListener {
             presenter.logout()
         }
     }
@@ -455,7 +462,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             LoginEmailHelpDialogFragment().show(supportFragmentManager, LoginEmailHelpDialogFragment.TAG)
         }
 
-        with(button_try_another) {
+        with(button_primary) {
             visibility = View.VISIBLE
             setOnClickListener {
                 AnalyticsTracker.track(Stat.SITE_PICKER_TRY_ANOTHER_ACCOUNT_BUTTON_TAPPED)
@@ -464,7 +471,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             }
         }
 
-        with(button_continue) {
+        with(button_secondary) {
             text = getString(R.string.login_view_connected_stores)
             setOnClickListener {
                 AnalyticsTracker.track(Stat.SITE_PICKER_VIEW_CONNECTED_STORES_BUTTON_TAPPED)
@@ -519,7 +526,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             movementMethod = LinkMovementMethod.getInstance()
         }
 
-        with(button_try_another) {
+        with(button_primary) {
             visibility = View.VISIBLE
             setOnClickListener {
                 AnalyticsTracker.track(Stat.SITE_PICKER_TRY_ANOTHER_ACCOUNT_BUTTON_TAPPED)
@@ -528,7 +535,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             }
         }
 
-        with(button_continue) {
+        with(button_secondary) {
             text = getString(R.string.login_view_connected_stores)
             setOnClickListener {
                 AnalyticsTracker.track(Stat.SITE_PICKER_VIEW_CONNECTED_STORES_BUTTON_TAPPED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -5,11 +5,16 @@ import android.app.ProgressDialog
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.text.Spannable
+import android.text.SpannableString
 import android.text.TextUtils
+import android.text.style.ForegroundColorSpan
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.MarginLayoutParams
+import android.widget.TextView
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.Toolbar
@@ -486,8 +491,24 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         site_picker_root.visibility = View.VISIBLE
         no_stores_view.visibility = View.VISIBLE
 
+        // Build and configure the error message and make the text view clickable
+        // to refresh the app.
         val siteName = name.takeIf { !it.isNullOrEmpty() } ?: url
-        no_stores_view.text = getString(R.string.login_not_woo_store, siteName)
+        val refreshAppText = getString(R.string.login_refresh_app)
+        val notWooMessage = getString(R.string.login_not_woo_store, siteName, refreshAppText)
+
+        val spannable = SpannableString(notWooMessage)
+        spannable.setSpan(
+                ForegroundColorSpan(resources.getColor(R.color.wc_purple)),
+                (notWooMessage.length - refreshAppText.length),
+                notWooMessage.length,
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+
+        with(no_stores_view) {
+            setText(spannable, TextView.BufferType.SPANNABLE)
+
+            // TODO AMANDA: make clickable
+        }
 
         with(button_try_another) {
             visibility = View.VISIBLE

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerContract.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 interface SitePickerContract {
     interface Presenter : BasePresenter<View> {
         fun loadAndFetchSites()
+        fun fetchUpdatedSiteFromAPI(site: SiteModel)
         fun loadSites()
         fun getWooCommerceSites(): List<SiteModel>
         fun getSiteBySiteId(siteId: Long): SiteModel?
@@ -26,7 +27,7 @@ interface SitePickerContract {
         fun showStoreList(wcSites: List<SiteModel>)
         fun showNoStoresView()
         fun showSiteNotConnectedView(url: String)
-        fun showSiteNotWooStore(url: String, name: String?)
+        fun showSiteNotWooStore(site: SiteModel)
         fun didLogout()
         fun siteSelected(site: SiteModel, isAutoLogin: Boolean = false)
         fun siteVerificationPassed(site: SiteModel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
@@ -64,6 +64,11 @@ class SitePickerPresenter @Inject constructor(
         dispatcher.dispatch(SiteActionBuilder.newFetchSitesAction())
     }
 
+    override fun fetchUpdatedSiteFromAPI(site: SiteModel) {
+        view?.showSkeleton(true)
+        dispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(site))
+    }
+
     override fun loadSites() {
         val wcSites = wooCommerceStore.getWooCommerceSites()
         view?.showStoreList(wcSites)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WooClickableSpan.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WooClickableSpan.kt
@@ -1,0 +1,20 @@
+package com.woocommerce.android.widgets
+
+import android.text.TextPaint
+import android.text.style.ClickableSpan
+import android.view.View
+
+/**
+ * Custom [ClickableSpan] that removes the default text underline, as well as sets the color
+ * of the text to the link color.
+ */
+class WooClickableSpan(val onClickListener: (view: View) -> Unit) : ClickableSpan() {
+    override fun onClick(widget: View) {
+        onClickListener(widget)
+    }
+
+    override fun updateDrawState(ds: TextPaint) {
+        ds.isUnderlineText = false
+        ds.color = ds.linkColor
+    }
+}

--- a/WooCommerce/src/main/res/layout-land/view_login_epilogue_button_bar.xml
+++ b/WooCommerce/src/main/res/layout-land/view_login_epilogue_button_bar.xml
@@ -11,7 +11,7 @@
     android:orientation="horizontal">
 
     <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/button_continue"
+        android:id="@+id/button_secondary"
         android:theme="@style/Woo.Button.White"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -21,7 +21,7 @@
         tools:visibility="visible"/>
 
     <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/button_try_another"
+        android:id="@+id/button_primary"
         style="@style/Woo.Button.Purple"
         android:layout_width="0sp"
         android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/layout-land/view_login_epilogue_button_bar.xml
+++ b/WooCommerce/src/main/res/layout-land/view_login_epilogue_button_bar.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/frame_bottom"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -10,19 +11,20 @@
     android:orientation="horizontal">
 
     <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/button_try_another"
+        android:id="@+id/button_continue"
         android:theme="@style/Woo.Button.White"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:visibility="gone"
-        android:text="@string/login_try_another_account"/>
+        android:text="@string/continue_button"
+        tools:visibility="visible"/>
 
     <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/button_continue"
+        android:id="@+id/button_try_another"
         style="@style/Woo.Button.Purple"
         android:layout_width="0sp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:text="@string/continue_button"/>
+        android:text="@string/login_try_another_account"/>
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout-land/view_login_epilogue_button_bar.xml
+++ b/WooCommerce/src/main/res/layout-land/view_login_epilogue_button_bar.xml
@@ -17,7 +17,7 @@
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:visibility="gone"
-        android:text="@string/continue_button"
+        android:text="@string/login_view_connected_stores"
         tools:visibility="visible"/>
 
     <androidx.appcompat.widget.AppCompatButton

--- a/WooCommerce/src/main/res/layout/view_login_epilogue_button_bar.xml
+++ b/WooCommerce/src/main/res/layout/view_login_epilogue_button_bar.xml
@@ -16,7 +16,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:visibility="gone"
-        android:text="@string/continue_button"
+        android:text="@string/login_view_connected_stores"
         tools:visibility="visible"/>
 
     <androidx.appcompat.widget.AppCompatButton

--- a/WooCommerce/src/main/res/layout/view_login_epilogue_button_bar.xml
+++ b/WooCommerce/src/main/res/layout/view_login_epilogue_button_bar.xml
@@ -11,7 +11,7 @@
     android:orientation="vertical">
 
     <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/button_continue"
+        android:id="@+id/button_secondary"
         android:theme="@style/Woo.Button.White"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -20,7 +20,7 @@
         tools:visibility="visible"/>
 
     <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/button_try_another"
+        android:id="@+id/button_primary"
         style="@style/Woo.Button.Purple"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/layout/view_login_epilogue_button_bar.xml
+++ b/WooCommerce/src/main/res/layout/view_login_epilogue_button_bar.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/frame_bottom"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -10,17 +11,18 @@
     android:orientation="vertical">
 
     <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/button_try_another"
+        android:id="@+id/button_continue"
         android:theme="@style/Woo.Button.White"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:visibility="gone"
-        android:text="@string/login_try_another_account"/>
+        android:text="@string/continue_button"
+        tools:visibility="visible"/>
 
     <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/button_continue"
+        android:id="@+id/button_try_another"
         style="@style/Woo.Button.Purple"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/continue_button"/>
+        android:text="@string/login_try_another_account"/>
 </LinearLayout>

--- a/WooCommerce/src/main/res/values/colors.xml
+++ b/WooCommerce/src/main/res/values/colors.xml
@@ -81,6 +81,9 @@
     <color name="edit_text_text_color_highlight">@color/wc_purple_highlight</color>
     <color name="edit_text_text_hint_color">@color/wc_grey_dark</color>
 
+    <!-- Default Link Color -->
+    <color name="link_text_color">@color/wc_purple</color>
+
     <!--
         Bottom Navigation Bar
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -110,6 +110,7 @@
     <string name="login_try_another_account">Try another account</string>
     <string name="login_not_woo_store">It looks like %1$s is not a WooCommerce site. Install the WooCommerce plugin on your site and then %2$s</string>
     <string name="login_refresh_app">refresh the app</string>
+    <string name="login_refresh_app_progress">Checking for WooCommerce...</string>
     <string name="login_view_connected_stores">View connected stores</string>
     <string name="login_jetpack_required_msg">To use the WooCommerce app you’ll need to set up the Jetpack plugin on your site</string>
     <string name="login_jetpack_view_instructions">View instructions</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -108,7 +108,8 @@
     <string name="login_no_stores">Unable to find WooCommerce stores\nconnected to this account</string>
     <string name="login_not_connected_to_account">It looks like %1$s is connected to a different WordPress.com account.</string>
     <string name="login_try_another_account">Try another account</string>
-    <string name="login_not_woo_store">It looks like %1$s is not a WooCommerce site. Install the WooCommerce plugin on your site and then refresh this app to continue.</string>
+    <string name="login_not_woo_store">It looks like %1$s is not a WooCommerce site. Install the WooCommerce plugin on your site and then %2$s</string>
+    <string name="login_refresh_app">refresh the app</string>
     <string name="login_view_connected_stores">View connected stores</string>
     <string name="login_jetpack_required_msg">To use the WooCommerce app you’ll need to set up the Jetpack plugin on your site</string>
     <string name="login_jetpack_view_instructions">View instructions</string>


### PR DESCRIPTION
This PR fixes #1173 by completing the following:
- Adding a "refresh app" link to the error message the users sees when presented with the "not a woo store" error.
- Reordered the primary and secondary buttons to match the design specs

<img src="https://user-images.githubusercontent.com/5810477/59865603-aa8ef480-9346-11e9-8a9a-45119c6708b2.gif" width="300"/>

## To Test
1. Log in with a site that has Jetpack installed, but not woo
2. Get to the "not a woo store" error screen
3. Install and activate the Woo plugin on the site
4. Click "refresh app" in the error message
5. Confirm the app refreshes and logs the user in successfully

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
