### PR TITLE
Fix stats getting refreshed twice when app opened the second time

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -47,6 +47,10 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
     override var isRefreshPending: Boolean = false // If true, the fragment will refresh its data when it's visible
     private var errorSnackbar: Snackbar? = null
 
+    // If false, the fragment will refresh its data when it's visible on onHiddenChanged
+    // this is to prevent the stats getting refreshed twice when the fragment is loaded when app is closed and opened
+    private var isStatsRefreshed: Boolean = false
+
     override fun onAttach(context: Context?) {
         AndroidSupportInjection.inject(this)
         super.onAttach(context)
@@ -120,6 +124,7 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
         }
 
         if (isActive && !deferInit) {
+            isStatsRefreshed = true
             refreshDashboard(forced = this.isRefreshPending)
         }
     }
@@ -133,8 +138,10 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
         super.onHiddenChanged(hidden)
 
         // silently refresh if this fragment is no longer hidden
-        if (!isHidden) {
+        if (!isHidden && !isStatsRefreshed) {
             refreshDashboard(forced = false)
+        } else {
+            isStatsRefreshed = false
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardPresenter.kt
@@ -12,7 +12,6 @@ import com.woocommerce.android.util.WooLog.T
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.WCOrderAction
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_HAS_ORDERS
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS_COUNT
 import org.wordpress.android.fluxc.action.WCStatsAction.FETCH_ORDER_STATS
@@ -223,11 +222,6 @@ class DashboardPresenter @Inject constructor(
                     dashboardView?.showUnfilledOrdersCard(count)
                 } ?: dashboardView?.hideUnfilledOrdersCard()
             }
-            else -> {
-                if (!event.isError && !isIgnoredOrderEvent(event.causeOfChange)) {
-                    dashboardView?.refreshDashboard(forced = false)
-                }
-            }
         }
     }
 
@@ -242,14 +236,5 @@ class DashboardPresenter @Inject constructor(
                 }
             }
         }
-    }
-
-    /**
-     * Use this function to add [OnOrderChanged] events that should be ignored.
-     */
-    private fun isIgnoredOrderEvent(actionType: WCOrderAction?): Boolean {
-        return actionType == null ||
-                actionType == WCOrderAction.FETCH_ORDER_NOTES ||
-                actionType == WCOrderAction.POST_ORDER_NOTE
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardPresenterTest.kt
@@ -173,7 +173,7 @@ class DashboardPresenterTest {
         presenter.onOrderChanged(OnOrderChanged(0).apply { causeOfChange = FETCH_ORDERS })
         verify(dashboardView, times(0)).showUnfilledOrdersCard(any())
         verify(dashboardView, times(0)).hideUnfilledOrdersCard()
-        verify(dashboardView, times(1)).refreshDashboard(forced = any())
+        verify(dashboardView, times(0)).refreshDashboard(forced = any())
     }
 
     @Test
@@ -184,7 +184,7 @@ class DashboardPresenterTest {
         presenter.onOrderChanged(OnOrderChanged(0).apply { causeOfChange = UPDATE_ORDER_STATUS })
         verify(dashboardView, times(0)).showUnfilledOrdersCard(any())
         verify(dashboardView, times(0)).hideUnfilledOrdersCard()
-        verify(dashboardView, times(1)).refreshDashboard(forced = any())
+        verify(dashboardView, times(0)).refreshDashboard(forced = any())
     }
 
     @Test


### PR DESCRIPTION
Fixes #1178 . The `My Store` tab was getting refreshed twice when the app is closed and open again. This was because when the app is opened again, the fragment was getting re-created and at the same time, the `OnHiddenChanged` method was getting called right away. Since the fragment was not hidden, the stats was getting refreshed again.

### The tracking events:
`dashboard_main_stats_loaded`
`dashboard_top_performers_loaded`
`dashboard_unfulfilled_orders_loaded`

### Changes:
- Added a new variable called `isStatsRefreshed` which is checked in `OnHiddenChanged` method. Only if the value is set to `false`, the request to refresh the stats will be initiated.

### Testing:
- Click on the `Orders` and `Notifications` tab. Click on the `My Store` tab and verify that fragment is refreshed. i.e. the dashboard tracking events are called once.
- Click on the `Orders` tab and click on any order. Click on the `My Store` tab and verify that fragment is refreshed. i.e. the dashboard tracking events are called once.
- Click on the `Orders` tab and click on any order. Click on `Fulfill` button or `Details` button. Click on the `My Store` tab and verify that fragment is refreshed. i.e. the dashboard tracking events are called once.
- Open the app. Click on the back button. Now open the app again and verify that the dashboard tracking events are called only once.

### Behaviour before the fix:
![ezgif com-crop (1)](https://user-images.githubusercontent.com/22608780/60081119-d3e8bf80-974e-11e9-924e-5d7579c9378a.gif)

### Behaviour after the fix:
![ezgif com-crop](https://user-images.githubusercontent.com/22608780/60160184-6f8f3400-9812-11e9-8a5b-2f2fba125887.gif)

