### PR TITLE
Update release-toolkit to 0.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: e00574114dddaa652ba8a720f586cb596842c0c6
-  ref: e00574114dddaa652ba8a720f586cb596842c0c6
+  revision: e4a6a7d51af7b39a9d9c12007f827223508d0ba2
+  tag: 0.4.0
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.2.2)
+    fastlane-plugin-wpmreleasetoolkit (0.4.0)
       diffy (~> 3.3)
       git (~> 1.3)
       jsonlint

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref:'e00574114dddaa652ba8a720f586cb596842c0c6' 
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag:'0.4.0'


### PR DESCRIPTION
I made a mistake and forgot to update the release-toolkit reference before merging https://github.com/woocommerce/woocommerce-android/pull/1183.

This PR only updates the reference. `release-toolkit` `0.4.0` has the same content of the previously referenced commit. 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
