### PR TITLE
Remove out of date login_not_woo_store translations to fix lint

### DIFF
--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -288,7 +288,6 @@ Language: ar
     <string name="login_jetpack_view_instructions">عرض الإرشادات</string>
     <string name="login_jetpack_required_msg">لاستخدام تطبيق WooCommerce الذي تحتاج إليه لإعداد إضافة Jetpack على موقعك</string>
     <string name="login_view_connected_stores">عرض المتاجر المتصلة</string>
-    <string name="login_not_woo_store">يبدو أنَّ %1$s ليس موقع WooCommerce. يمكنك تثبيت إضافة WooCommerce على موقعك ثم تحديث هذا التطبيق للاستمرار.</string>
     <string name="login_try_another_account">تجربة حساب آخر</string>
     <string name="login_not_connected_to_account">يبدو أنَّ %1$s متصل بحساب وردبرس.كوم مختلف.</string>
     <string name="login">تسجيل الدخول</string>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -288,7 +288,6 @@ Language: de
     <string name="login_jetpack_view_instructions">Anweisungen anzeigen</string>
     <string name="login_jetpack_required_msg">Um die WooCommerce-App zu nutzen, musst du das Jetpack-Plugin auf deiner Website einrichten.</string>
     <string name="login_view_connected_stores">Verbundene Shops anzeigen</string>
-    <string name="login_not_woo_store">%1$s ist offenbar keine WooCommerce-Website. Installiere das WooCommerce-Plugin auf deiner Website und aktualisiere diese App, um fortzufahren.</string>
     <string name="login_try_another_account">Mit einem anderen Konto probieren</string>
     <string name="login_not_connected_to_account">%1$s ist offenbar mit einem anderen WordPress.com-Konto verbunden.</string>
     <string name="login">Anmelden</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -288,7 +288,6 @@ Language: es
     <string name="login_jetpack_view_instructions">Ver instrucciones</string>
     <string name="login_jetpack_required_msg">Para usar la aplicación de WooCommerce, deberás configurar el plugin de Jetpack en tu sitio</string>
     <string name="login_view_connected_stores">Ver tiendas conectadas</string>
-    <string name="login_not_woo_store">Parece que %1$s no es un sitio de WooCommerce. Instala el plugin de WooCommerce en tu sitio y, luego, actualiza esta aplicación para continuar.</string>
     <string name="login_try_another_account">Probar con otra cuenta</string>
     <string name="login_not_connected_to_account">Parece que %1$s está conectado a otra cuenta de WordPress.com.</string>
     <string name="login">Acceder</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -288,7 +288,6 @@ Language: fr
     <string name="login_jetpack_view_instructions">Voir les instructions</string>
     <string name="login_jetpack_required_msg">Pour utiliser l\'application WooCommerce, vous devrez configurer l\'extension Jetpack sur votre site</string>
     <string name="login_view_connected_stores">Voir les boutiques connectées</string>
-    <string name="login_not_woo_store">Il semblerait que %1$s ne soit pas un site WooCommerce. Installez l\'extension WooCommerce sur votre site, puis actualisez cette application pour continuer.</string>
     <string name="login_try_another_account">Essayer un autre compte</string>
     <string name="login_not_connected_to_account">Il semblerait que %1$s soit connecté à un autre compte WordPress.com.</string>
     <string name="login">Connexion</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -288,7 +288,6 @@ Language: he_IL
     <string name="login_jetpack_view_instructions">לעיון בהוראות</string>
     <string name="login_jetpack_required_msg">כדי להשתמש באפליקציה של Woocommerce עליך להגדיר את התוסף של Jetpack באתר שלך</string>
     <string name="login_view_connected_stores">להצגת החנויות המחוברות</string>
-    <string name="login_not_woo_store">נראה שהאתר %1$s אינו אתר של WooCommerce. יש להתקין את התוסף של Woocommerce באתר שלך ולאחר מכן לרענן את האפליקציה כדי להמשיך.</string>
     <string name="login_try_another_account">יש לנסות חשבון אחר</string>
     <string name="login_not_connected_to_account">נראה ששם המשתמש %1$s מחובר לחשבון אחר ב-WordPress.com.</string>
     <string name="login">התחברות</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -288,7 +288,6 @@ Language: id
     <string name="login_jetpack_view_instructions">Lihat instruksi</string>
     <string name="login_jetpack_required_msg">Untuk menggunakan aplikasi WooCommerce, Anda perlu menyiapkan plugin Jetpack di situs Anda</string>
     <string name="login_view_connected_stores">Lihat toko terhubung</string>
-    <string name="login_not_woo_store">Tampaknya %1$s bukan situs WooCommerce. Instal plugin WooCommerce di situs Anda, lalu segarkan aplikasi ini untuk melanjutkan.</string>
     <string name="login_try_another_account">Coba akun lain</string>
     <string name="login_not_connected_to_account">Sepertinya %1$s tidak terhubung ke akun WordPress.com lainnya.</string>
     <string name="login">Login</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -288,7 +288,6 @@ Language: it
     <string name="login_jetpack_view_instructions">Visualizza istruzioni</string>
     <string name="login_jetpack_required_msg">Per utilizzare l\'app WooCommerce, dovrai configurare il plugin Jetpack sul tuo sito</string>
     <string name="login_view_connected_stores">Visualizza i negozi collegati</string>
-    <string name="login_not_woo_store">%1$s non è un sito WooCommerce. Installa il plugin WooCommerce sul tuo sito, quindi aggiorna l\'app per continuare.</string>
     <string name="login_try_another_account">Prova un altro account</string>
     <string name="login_not_connected_to_account">%1$s è collegato a un altro account WordPress.com.</string>
     <string name="login">Accedi</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -288,7 +288,6 @@ Language: ja_JP
     <string name="login_jetpack_view_instructions">手順を表示</string>
     <string name="login_jetpack_required_msg">WooCommerce アプリを使用するには、サイトに Jetpack プラグインを設定する必要があります。</string>
     <string name="login_view_connected_stores">連携ストアを表示</string>
-    <string name="login_not_woo_store">%1$s は WooCommerce サイトではないようです。サイトに WooCommerce プラグインをインストールし、アプリを再読み込みして続行してください。</string>
     <string name="login_try_another_account">別のアカウントでお試しください</string>
     <string name="login_not_connected_to_account">%1$s は別の WordPress.com アカウントと関連付けられているようです。</string>
     <string name="login">ログイン</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -288,7 +288,6 @@ Language: ko_KR
     <string name="login_jetpack_view_instructions">지침 보기</string>
     <string name="login_jetpack_required_msg">WooCommerce 앱을 사용하려면 사이트에서 Jetpack 플러그인을 설정해야 합니다.</string>
     <string name="login_view_connected_stores">연결된 스토어 보기</string>
-    <string name="login_not_woo_store">%1$s은(는) WooCommerce 사이트가 아닌 것 같습니다. 계속하려면 사이트에 WooCommerce 플러그인을 설치한 다음 이 앱을 새로 고치세요.</string>
     <string name="login_try_another_account">다른 계정 사용해 보기</string>
     <string name="login_not_connected_to_account">%1$s이(가) 다른 워드프레스닷컴 계정에 연결되어 있는 것 같습니다.</string>
     <string name="login">로그인</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -288,7 +288,6 @@ Language: nl
     <string name="login_jetpack_view_instructions">Instructies bekijken</string>
     <string name="login_jetpack_required_msg">Om de WooCommerce-app te kunnen gebruiken, moet je de Jetpack-plugin op je site installeren</string>
     <string name="login_view_connected_stores">Aangesloten winkels bekijken</string>
-    <string name="login_not_woo_store">Het lijkt erop dat %1$s geen WooCommerce-site is. Installeer de WooCommerce-plugin op je site en vernieuw vervolgens deze app om door te gaan.</string>
     <string name="login_try_another_account">Een ander account proberen</string>
     <string name="login_not_connected_to_account">Het lijkt erop dat %1$s is verbonden met een ander WordPress.com-account.</string>
     <string name="login">Inloggen</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -288,7 +288,6 @@ Language: pt_BR
     <string name="login_jetpack_view_instructions">Visualizar instruções</string>
     <string name="login_jetpack_required_msg">Para usar o aplicativo WooCommerce, será preciso configurar o plugin do Jetpack no seu site</string>
     <string name="login_view_connected_stores">Visualizar lojas conectadas</string>
-    <string name="login_not_woo_store">Parece que %1$s não é um site do WooCommerce. Instale o plugin do WooCommerce no seu site e atualize o aplicativo para continuar.</string>
     <string name="login_try_another_account">Tente outra conta</string>
     <string name="login_not_connected_to_account">Parece que %1$s está conectado(a) a uma conta diferente do WordPress.com.</string>
     <string name="login">Fazer login</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -288,7 +288,6 @@ Language: ru
     <string name="login_jetpack_view_instructions">Открыть инструкции</string>
     <string name="login_jetpack_required_msg">Чтобы использовать приложение WooCommerce необходимо настроить плагин Jetpack на своем сайте.</string>
     <string name="login_view_connected_stores">Открыть список подключенных магазинов</string>
-    <string name="login_not_woo_store">Похоже, %1$s не является сайтом WooCommerce. Установите плагин WooCommerce на свой сайт и обновите страницу в приложении, чтобы продолжить.</string>
     <string name="login_try_another_account">Используйте другую учётную запись</string>
     <string name="login_not_connected_to_account">Похоже, что %1$s подключен к другой учетной записи WordPress.com.</string>
     <string name="login">Войти</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -288,7 +288,6 @@ Language: sv_SE
     <string name="login_jetpack_view_instructions">Visa anvisningar</string>
     <string name="login_jetpack_required_msg">För att använda appen WooCommerce måste du ställa in tillägget Jetpack på dni webbplats</string>
     <string name="login_view_connected_stores">Visa anslutna butiker</string>
-    <string name="login_not_woo_store">Det ser ut som att %1$s inte är en WooCommerce-webbplats. Installera tillägget WooCommerce på din webbplats och starta om appen för att fortsätta.</string>
     <string name="login_try_another_account">Prova med ett annat konto</string>
     <string name="login_not_connected_to_account">Det ser ut som att %1$s är ansluten till ett annat WordPress.com-konto.</string>
     <string name="login">Logga in</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -288,7 +288,6 @@ Language: tr
     <string name="login_jetpack_view_instructions">Talimatları görüntüle</string>
     <string name="login_jetpack_required_msg">WooCommerce uygulamasını kullanmak için sitenize Jetpack eklentisini kurmanız gerekir</string>
     <string name="login_view_connected_stores">Bağlanılan mağazaları görüntüle</string>
-    <string name="login_not_woo_store">Görünüşe göre %1$s bir WooCommerce sitesi değil. Sitenize WooCommerce eklentisini yükleyin ve devam etmek için bu uygulamayı yenileyin.</string>
     <string name="login_try_another_account">Farklı bir hesap deneyin</string>
     <string name="login_not_connected_to_account">Görünüşe göre %1$s başka bir WordPress.com hesabına bağlı.</string>
     <string name="login">Oturum aç</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -288,7 +288,6 @@ Language: zh_CN
     <string name="login_jetpack_view_instructions">查看说明</string>
     <string name="login_jetpack_required_msg">要使用 WooCommerce 应用程序，您需要在您的站点上设置 Jetpack 插件</string>
     <string name="login_view_connected_stores">查看连接的商店</string>
-    <string name="login_not_woo_store">%1$s 似乎不是 WooCommerce 站点。在您的站点上安装 WooCommerce 插件，然后刷新此应用程序以继续。</string>
     <string name="login_try_another_account">试试其他帐户</string>
     <string name="login_not_connected_to_account">%1$s 似乎连接了其他 WordPress.com 帐户。</string>
     <string name="login">登录</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -288,7 +288,6 @@ Language: zh_TW
     <string name="login_jetpack_view_instructions">查看說明</string>
     <string name="login_jetpack_required_msg">若要使用 WooCommerce 應用程式，你需要在你的網站上設定 Jetpack 外掛程式</string>
     <string name="login_view_connected_stores">檢視連結的商店</string>
-    <string name="login_not_woo_store">%1$s 似乎不是 WooCommerce 網站。在你的網站上安裝 WooCommerce 外掛程式，然後重新整理此應用程式以繼續。</string>
     <string name="login_try_another_account">嘗試其他帳號</string>
     <string name="login_not_connected_to_account">%1$s 似乎已經連結至不同的 WordPress.com 帳號。</string>
     <string name="login">登入</string>


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce-android/pull/1174 added a new format string to `login_not_woo_store` but since the translations don't have that, has been causing lint errors. This removes the now out of date translations.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
