### PR TITLE
If offline show error snack and exit order status change process

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -400,7 +400,6 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_REVIEW = "review"
         const val VALUE_ORDER_DETAIL = "order_detail"
         const val VALUE_ORDER_FULFILL = "order_fulfill"
-        const val VALUE_NETWORK_ERROR = "Device Offline"
 
         private const val PREFKEY_SEND_USAGE_STATS = "wc_pref_send_usage_stats"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -400,6 +400,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_REVIEW = "review"
         const val VALUE_ORDER_DETAIL = "order_detail"
         const val VALUE_ORDER_FULFILL = "order_fulfill"
+        const val VALUE_NETWORK_ERROR = "Device Offline"
 
         private const val PREFKEY_SEND_USAGE_STATS = "wc_pref_send_usage_stats"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -510,6 +510,12 @@ class OrderDetailFragment : androidx.fragment.app.Fragment(), OrderDetailContrac
     }
 
     private fun showOrderStatusSelector() {
+        // If the device is offline, alert the user with a snack and exit (do not show order status selector).
+        if (!networkStatus.isConnected()) {
+            uiMessageResolver.showOfflineSnack()
+            return
+        }
+
         presenter.orderModel?.let { order ->
             val orderStatusOptions = presenter.getOrderStatusOptions()
             val orderStatus = order.status

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -256,19 +256,6 @@ class OrderDetailFragment : androidx.fragment.app.Fragment(), OrderDetailContrac
                     AnalyticsTracker.KEY_FROM to order.status,
                     AnalyticsTracker.KEY_TO to newStatus))
 
-            // If not connected, exit the process immediately and alert
-            // the user. Track as a failure so tracks data makes sense.
-            if (!networkStatus.isConnected()) {
-                AnalyticsTracker.track(
-                        Stat.ORDER_STATUS_CHANGE_FAILED, mapOf(
-                        AnalyticsTracker.KEY_ERROR_CONTEXT to this::class.java.simpleName,
-                        AnalyticsTracker.KEY_ERROR_TYPE to AnalyticsTracker.VALUE_NETWORK_ERROR,
-                        AnalyticsTracker.KEY_ERROR_DESC to ""))
-
-                uiMessageResolver.showOfflineSnack()
-                return
-            }
-
             previousOrderStatus = order.status
             order.status = newStatus
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -256,6 +256,19 @@ class OrderDetailFragment : androidx.fragment.app.Fragment(), OrderDetailContrac
                     AnalyticsTracker.KEY_FROM to order.status,
                     AnalyticsTracker.KEY_TO to newStatus))
 
+            // If not connected, exit the process immediately and alert
+            // the user. Track as a failure so tracks data makes sense.
+            if (!networkStatus.isConnected()) {
+                AnalyticsTracker.track(
+                        Stat.ORDER_STATUS_CHANGE_FAILED, mapOf(
+                        AnalyticsTracker.KEY_ERROR_CONTEXT to this::class.java.simpleName,
+                        AnalyticsTracker.KEY_ERROR_TYPE to AnalyticsTracker.VALUE_NETWORK_ERROR,
+                        AnalyticsTracker.KEY_ERROR_DESC to ""))
+
+                uiMessageResolver.showOfflineSnack()
+                return
+            }
+
             previousOrderStatus = order.status
             order.status = newStatus
 


### PR DESCRIPTION
Fixes #1194 by checking for network connectivity before showing the snack message alerting the user that the order status has been changed. 

<img src="https://user-images.githubusercontent.com/5810477/60554285-2d736000-9cf4-11e9-85d0-eecce7030455.gif" width="350"/>


### To Test
1. Open an order
2. Put the device in Airplane mode
3. Click the order status bar to open the order status change dialog
4. Select a different order status and click "apply". The request should not complete and the standard offline message should be displayed to the user.
5. Verify the order status does not get changed visually.