### PR TITLE
issue/1209-dont-reanimate-orders-to-fulfill

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.3
 -----
 * Added option to request for new features right from the app in the Settings page
+* The unfilled order count doesn't re-animate in every time the dashboard is restored or refreshed
 
 2.2
 -----


### PR DESCRIPTION
Fixes #1209. To test:

1. Enable "Don't keep activities"
2. Run the `develop` branch and wait for the unfilled orders card to appear in the dashboard
3. Minimize the app
4. Open it again and notice the unfilled orders card is missing, but will animate in again within a few seconds.

Then repeat the above steps running this branch and notice the card appears immediately after the dashboard is restored.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
