### PR TITLE
Issue/1208 cleanup toplevel fragment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -1,8 +1,5 @@
 package com.woocommerce.android.ui.base
 
-import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.ViewGroup
 import com.woocommerce.android.ui.main.MainNavigationRouter
 
 /**
@@ -23,10 +20,4 @@ abstract class TopLevelFragment : BaseFragment(), TopLevelFragmentView {
                 false
             }
         }
-
-    final override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ) = onCreateFragmentView(inflater, container, savedInstanceState)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -2,12 +2,8 @@ package com.woocommerce.android.ui.base
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import android.widget.FrameLayout
-import com.woocommerce.android.R
 import com.woocommerce.android.ui.main.MainNavigationRouter
-import kotlinx.android.synthetic.main.fragment_parent.*
 
 /**
  * The main fragments hosted by the bottom bar should extend this class
@@ -32,18 +28,5 @@ abstract class TopLevelFragment : BaseFragment(), TopLevelFragmentView {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        val layout: FrameLayout = inflater.inflate(R.layout.fragment_parent,
-                container, false) as FrameLayout
-        val view: View? = onCreateFragmentView(inflater, layout, savedInstanceState)
-        view?.let {
-            layout.addView(view)
-        }
-        return layout
-    }
-
-    override fun onDestroyView() {
-        container.removeAllViews()
-        super.onDestroyView()
-    }
+    ) = onCreateFragmentView(inflater, container, savedInstanceState)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragmentView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragmentView.kt
@@ -1,10 +1,5 @@
 package com.woocommerce.android.ui.base
 
-import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
-
 /**
  * Special interface for top-level fragments hosted by the bottom bar.
  */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragmentView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragmentView.kt
@@ -12,16 +12,6 @@ interface TopLevelFragmentView : BaseFragmentView {
     var isActive: Boolean
 
     /**
-     * Inflate the fragment view and return to be added to the parent
-     * container.
-     */
-    fun onCreateFragmentView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View?
-
-    /**
      * Refresh this top-level fragment data and reset its state.
      */
     fun refreshFragmentState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -57,7 +57,7 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
         super.onAttach(context)
     }
 
-    override fun onCreateFragmentView(
+    override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
@@ -97,7 +97,7 @@ class NotifsListFragment : TopLevelFragment(),
         super.onAttach(context)
     }
 
-    override fun onCreateFragmentView(
+    override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -174,7 +174,7 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
         super.onAttach(context)
     }
 
-    override fun onCreateFragmentView(
+    override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?

--- a/WooCommerce/src/main/res/layout/activity_main.xml
+++ b/WooCommerce/src/main/res/layout/activity_main.xml
@@ -30,6 +30,7 @@
             <!-- container for top level fragments -->
             <FrameLayout
                 android:id="@+id/container"
+                android:background="@color/white"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"/>
 

--- a/WooCommerce/src/main/res/layout/fragment_parent.xml
+++ b/WooCommerce/src/main/res/layout/fragment_parent.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/container"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/white"/>


### PR DESCRIPTION
Fixes #1208 - The goal of this PR was to cleanup the `TopLevelFragment`, which contained quite a bit of code we don't need anymore. The biggest change was that fragment would inflate a separate `FrameLayout` to host each of the bottom nav fragments, which wasn't necessary since the main activity already contains a `FrameLayout` for that purpose.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
