### PR TITLE
Added failure event when unable to read current app version code

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -229,6 +229,13 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
             // store the latest version code to SharedPrefs, only if the value
             // is greater than the stored version code
             AppPrefs.setLastAppVersionCode(versionCode)
+        } else if (versionCode == PACKAGE_VERSION_CODE_DEFAULT) {
+            // we are not able to read the current app version code
+            // track this event along with the last stored version code
+            AnalyticsTracker.track(
+                    Stat.APPLICATION_VERSION_CHECK_FAILED,
+                    mapOf(AnalyticsTracker.KEY_LAST_KNOWN_VERSION_CODE to oldVersionCode)
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -21,6 +21,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         APPLICATION_CLOSED(siteless = true),
         APPLICATION_INSTALLED(siteless = true),
         APPLICATION_UPGRADED(siteless = true),
+        APPLICATION_VERSION_CHECK_FAILED(siteless = true),
         BACK_PRESSED(siteless = true),
         VIEW_SHOWN(siteless = true),
 
@@ -395,6 +396,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_SOURCE = "source"
         const val KEY_URL = "url"
         const val KEY_HAS_CONNECTED_STORES = "has_connected_stores"
+        const val KEY_LAST_KNOWN_VERSION_CODE = "last_known_version_code"
 
         const val VALUE_ORDER = "order"
         const val VALUE_REVIEW = "review"


### PR DESCRIPTION
Fixes #1204. If for some reason we are unable to fetch the app version code from `PackageManager`, the current app version code will return -1. This PR adds a new Track events called `APPLICATION_VERSION_CHECK_FAILED`. This event will be tracked every time the current app version code returns -1. 