### PR TITLE
Issue/1196 notification nav crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -23,6 +23,7 @@ import com.woocommerce.android.extensions.FragmentScrollListener
 import com.woocommerce.android.extensions.WooNotificationType.NEW_ORDER
 import com.woocommerce.android.extensions.WooNotificationType.PRODUCT_REVIEW
 import com.woocommerce.android.extensions.active
+import com.woocommerce.android.extensions.getCommentId
 import com.woocommerce.android.extensions.getRemoteOrderId
 import com.woocommerce.android.extensions.getWooType
 import com.woocommerce.android.push.NotificationHandler
@@ -36,6 +37,7 @@ import com.woocommerce.android.ui.main.BottomNavigationPosition.DASHBOARD
 import com.woocommerce.android.ui.main.BottomNavigationPosition.NOTIFICATIONS
 import com.woocommerce.android.ui.main.BottomNavigationPosition.ORDERS
 import com.woocommerce.android.ui.notifications.NotifsListFragment
+import com.woocommerce.android.ui.notifications.ReviewDetailFragmentDirections
 import com.woocommerce.android.ui.orders.OrderDetailFragmentDirections
 import com.woocommerce.android.ui.orders.OrderListFragment
 import com.woocommerce.android.ui.prefs.AppSettingsActivity
@@ -53,6 +55,7 @@ import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.support.HasSupportFragmentInjector
 import kotlinx.android.synthetic.main.activity_main.*
+import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.login.LoginAnalyticsListener
 import org.wordpress.android.login.LoginMode
@@ -541,7 +544,6 @@ class MainActivity : AppCompatActivity(),
         showBottomNav()
         bottomNavView.currentPosition = NOTIFICATIONS
 
-        val fragment = bottomNavView.getFragment(NOTIFICATIONS)
         val navPos = BottomNavigationPosition.NOTIFICATIONS.position
         bottom_nav.active(navPos)
 
@@ -554,7 +556,7 @@ class MainActivity : AppCompatActivity(),
                         }
                     }
                 }
-                PRODUCT_REVIEW -> (fragment as? NotifsListFragment)?.openReviewDetail(note)
+                PRODUCT_REVIEW -> showReviewDetail(note)
                 else -> { /* do nothing */ }
             }
         }
@@ -563,6 +565,16 @@ class MainActivity : AppCompatActivity(),
     override fun showProductDetail(remoteProductId: Long) {
         showBottomNav()
         val action = ProductDetailFragmentDirections.actionGlobalProductDetailFragment(remoteProductId)
+        navController.navigate(action)
+    }
+
+    override fun showReviewDetail(notification: NotificationModel, tempStatus: String?) {
+        showBottomNav()
+        val action = ReviewDetailFragmentDirections.actionGlobalReviewDetailFragment(
+                notification.remoteNoteId,
+                notification.getCommentId(),
+                tempStatus
+        )
         navController.navigate(action)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
@@ -1,9 +1,12 @@
 package com.woocommerce.android.ui.main
 
+import org.wordpress.android.fluxc.model.notification.NotificationModel
+
 interface MainNavigationRouter {
     fun isAtNavigationRoot(): Boolean
     fun isChildFragmentShowing(): Boolean
 
     fun showOrderDetail(localSiteId: Int, remoteOrderId: Long, remoteNoteId: Long = 0, markComplete: Boolean = false)
     fun showProductDetail(remoteProductId: Long)
+    fun showReviewDetail(notification: NotificationModel, tempStatus: String? = null)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListContract.kt
@@ -27,6 +27,7 @@ interface NotifsListContract {
         fun refreshFragmentState()
         fun showSkeleton(show: Boolean)
         fun showEmptyView(show: Boolean)
+        fun openOrderDetail(notification: NotificationModel)
         fun openReviewDetail(notification: NotificationModel)
         fun visuallyMarkNotificationsAsRead()
         fun showMarkAllNotificationsReadError()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
@@ -277,18 +277,8 @@ class NotifsListFragment : TopLevelFragment(),
                 }
             }
             NEW_ORDER -> {
-                notification.getRemoteOrderId()?.let {
-                    AnalyticsTracker.track(Stat.NOTIFICATION_OPEN, mapOf(
-                            AnalyticsTracker.KEY_TYPE to AnalyticsTracker.VALUE_ORDER,
-                            AnalyticsTracker.KEY_ALREADY_READ to notification.read))
-                    showOptionsMenu(false)
-                    (activity as? MainNavigationRouter)?.showOrderDetail(
-                            selectedSite.get().id,
-                            it,
-                            notification.remoteNoteId
-                    )
-                } ?: WooLog.e(NOTIFICATIONS, "New order notification is missing the order id!").also {
-                    showLoadNotificationDetailError()
+                if (!notifsRefreshLayout.isRefreshing) {
+                    openOrderDetail(notification)
                 }
             }
             UNKNOWN -> {
@@ -300,6 +290,22 @@ class NotifsListFragment : TopLevelFragment(),
         AppRatingDialog.incrementInteractions()
     }
 
+    override fun openOrderDetail(notification: NotificationModel) {
+        notification.getRemoteOrderId()?.let {
+            AnalyticsTracker.track(Stat.NOTIFICATION_OPEN, mapOf(
+                    AnalyticsTracker.KEY_TYPE to AnalyticsTracker.VALUE_ORDER,
+                    AnalyticsTracker.KEY_ALREADY_READ to notification.read))
+            showOptionsMenu(false)
+            (activity as? MainNavigationRouter)?.showOrderDetail(
+                    selectedSite.get().id,
+                    it,
+                    notification.remoteNoteId
+            )
+        } ?: WooLog.e(NOTIFICATIONS, "New order notification is missing the order id!").also {
+            showLoadNotificationDetailError()
+        }
+    }
+
     override fun openReviewDetail(notification: NotificationModel) {
         AnalyticsTracker.track(Stat.NOTIFICATION_OPEN, mapOf(
                 AnalyticsTracker.KEY_TYPE to AnalyticsTracker.VALUE_REVIEW,
@@ -308,8 +314,8 @@ class NotifsListFragment : TopLevelFragment(),
         // If the notification is pending moderation, override the status to display in the detail view.
         val isPendingModeration = pendingModerationRemoteNoteId?.let { it == notification.remoteNoteId } ?: false
         val tempStatus = if (isPendingModeration) pendingModerationNewStatus else null
-        (activity as? MainNavigationRouter)?.showReviewDetail(notification, tempStatus)
         showOptionsMenu(false)
+        (activity as? MainNavigationRouter)?.showReviewDetail(notification, tempStatus)
     }
 
     override fun scrollToTop() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
@@ -10,7 +10,6 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
-import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.R
@@ -19,7 +18,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.extensions.WooNotificationType.NEW_ORDER
 import com.woocommerce.android.extensions.WooNotificationType.PRODUCT_REVIEW
 import com.woocommerce.android.extensions.WooNotificationType.UNKNOWN
-import com.woocommerce.android.extensions.getCommentId
 import com.woocommerce.android.extensions.getRemoteOrderId
 import com.woocommerce.android.extensions.getWooType
 import com.woocommerce.android.extensions.onScrollDown
@@ -310,13 +308,8 @@ class NotifsListFragment : TopLevelFragment(),
         // If the notification is pending moderation, override the status to display in the detail view.
         val isPendingModeration = pendingModerationRemoteNoteId?.let { it == notification.remoteNoteId } ?: false
         val tempStatus = if (isPendingModeration) pendingModerationNewStatus else null
-        val action = ReviewDetailFragmentDirections.actionGlobalReviewDetailFragment(
-                notification.remoteNoteId,
-                notification.getCommentId(),
-                tempStatus
-        )
+        (activity as? MainNavigationRouter)?.showReviewDetail(notification, tempStatus)
         showOptionsMenu(false)
-        findNavController().navigate(action)
     }
 
     override fun scrollToTop() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
@@ -291,14 +291,14 @@ class NotifsListFragment : TopLevelFragment(),
     }
 
     override fun openOrderDetail(notification: NotificationModel) {
-        notification.getRemoteOrderId()?.let {
+        notification.getRemoteOrderId()?.let { remoteOrderId ->
             AnalyticsTracker.track(Stat.NOTIFICATION_OPEN, mapOf(
                     AnalyticsTracker.KEY_TYPE to AnalyticsTracker.VALUE_ORDER,
                     AnalyticsTracker.KEY_ALREADY_READ to notification.read))
             showOptionsMenu(false)
             (activity as? MainNavigationRouter)?.showOrderDetail(
                     selectedSite.get().id,
-                    it,
+                    remoteOrderId,
                     notification.remoteNoteId
             )
         } ?: WooLog.e(NOTIFICATIONS, "New order notification is missing the order id!").also {


### PR DESCRIPTION
Fixes #1196 - I'm pretty sure the crash was caused by attempting to access the nav component from a fragment that hasn't been attached yet. Moving the navigation to the main activity resolves the crash.

To test:

* Force close the app
* Generate a review notification
* Tap the notification

In `develop` right now this causes a crash, but the crash doesn't happen with this PR.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
