### PR TITLE
Send redirectUrl to listener and strip protocol before saving

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
  
 * Added option to request for new features right from the app in the Settings page
 * The unfilled order count doesn't re-animate in every time the dashboard is restored or refreshed
+* Login now works properly for sites with redirects
 
 2.2
 -----

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -48,7 +48,7 @@ public interface LoginListener {
     // Login Site Address input callbacks
     void alreadyLoggedInWpcom(ArrayList<Integer> oldSitesIds);
     void gotWpcomSiteInfo(String siteAddress, String siteName, String siteIconUrl);
-    void gotConnectedSiteInfo(String siteAddress, boolean hasJetpack);
+    void gotConnectedSiteInfo(@NonNull String siteAddress, @Nullable String redirectUrl, boolean hasJetpack);
     void gotXmlRpcEndpoint(String inputSiteAddress, String endpointAddress);
     void handleSslCertificateError(MemorizingTrustManager memorizingTrustManager, SelfSignedSSLCallback callback);
     void helpSiteAddress(String url);

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -425,7 +425,10 @@ public class LoginSiteAddressFragment extends LoginBaseFormFragment<LoginListene
                 } else if (event.info.hasJetpack && event.info.isJetpackActive && event.info.isJetpackConnected) {
                     hasJetpack = true;
                 }
-                mLoginListener.gotConnectedSiteInfo(event.info.url, hasJetpack);
+                mLoginListener.gotConnectedSiteInfo(
+                        event.info.url,
+                        event.info.urlAfterRedirects,
+                        hasJetpack);
             }
         }
     }


### PR DESCRIPTION
Fixes #1218 by using the redirect url when available instead of the entered url for matching the site to the authenticated user. 

If the url the user logs in with is redirected, we want to know the redirect url and use that for the rest of the login process. We save this redirect url (or the original url) to `AppPrefs` with the protocol stripped since it's not needed for the rest of the login process and can cause issues when looking up the site by the url to find a match for the authenticated user.

Some special things to note:
The login process does not care which protocol the user enters (or if any at all). So entering `www.droidtester2018.com`, `droidtester2018.com`, `http://www.droidtester2018.com` or `https://droidtester2018.com` will all be handled identically. Here are examples:

### Examples

prepending with `www`:

<img src="https://user-images.githubusercontent.com/5810477/60852519-3e6d1700-a1b5-11e9-86dd-d534fb2141a8.gif" width="350"/>

prepending with `http://www`:

<img src="https://user-images.githubusercontent.com/5810477/60853055-bb998b80-a1b7-11e9-9f88-9557e406b091.gif" width="350"/>

prepending with `https://`

<img src="https://user-images.githubusercontent.com/5810477/60853063-bfc5a900-a1b7-11e9-8bac-5e0ca2092278.gif" width="350"/>

### Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
