### PR TITLE
Product Detail: Fix CallbackException

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -531,14 +531,18 @@ class ProductDetailFragment : BaseFragment(), ProductDetailContract.View, Reques
         isFirstResource: Boolean
     ): Boolean {
         productImageUrl?.let { imageUrl ->
-            productDetail_image.setOnClickListener {
-                AnalyticsTracker.track(PRODUCT_DETAIL_IMAGE_TAPPED)
-                ImageViewerActivity.show(
-                        activity!!,
-                        imageUrl,
-                        title = productTitle,
-                        sharedElement = productDetail_image
-                )
+            // this is added to avoid nullPointerException when user clicks the back button exactly when this method
+            // is called. In that case, the productDetail_image will be null.
+            productDetail_image?.let { imageView ->
+                imageView.setOnClickListener {
+                    AnalyticsTracker.track(PRODUCT_DETAIL_IMAGE_TAPPED)
+                    ImageViewerActivity.show(
+                            activity!!,
+                            imageUrl,
+                            title = productTitle,
+                            sharedElement = imageView
+                    )
+                }
             }
         }
         return false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -77,6 +77,8 @@ class ProductDetailFragment : BaseFragment(), ProductDetailContract.View, Reques
     }
 
     override fun onDestroyView() {
+        // hide the skeleton view if fragment is destroyed
+        skeletonView.hide()
         presenter.dropView()
         super.onDestroyView()
     }


### PR DESCRIPTION
Fixes #1234. The app is crashing when the user clicks the back button in Product detail page, right when the product detail image is trying to load into the `ImageView`.

### Changes:
* Adds a null check to the product detail `ImageView` when `onResourceReady` method is called once the image is loaded. 
* The `SkeletonView` is displayed even when the `ProductDetailFragment` is destroyed. So added logic to hide the `SkeletonView` when the fragment is destroyed.

#### Crash issue:
<img src="https://user-images.githubusercontent.com/22608780/61107500-ad8c8900-a49d-11e9-9f3c-0dfd2c2fd818.gif">

#### Behaviour before the `SkeletionView` fix:
<img width="300" src="https://user-images.githubusercontent.com/22608780/61107836-736fb700-a49e-11e9-8199-283122037041.gif">

#### Behaviour after the `SkeletionView` fix:
<img width="300" src="https://user-images.githubusercontent.com/22608780/61107684-24298680-a49e-11e9-910f-2bc4eedc02cc.gif">
