### PR TITLE
Order Fulfill: hide shipment tracking card for virtual products

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCOrderModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCOrderModelExt.kt
@@ -1,0 +1,34 @@
+package com.woocommerce.android.extensions
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCOrderModel
+import org.wordpress.android.fluxc.model.WCOrderModel.LineItem
+import org.wordpress.android.fluxc.store.WCProductStore
+
+/**
+ * Returns true if all the products specified in the [WCOrderModel.LineItem] is a virtual product
+ * and if product exists in the local cache.
+ */
+fun isVirtualProduct(
+    site: SiteModel,
+    lineItems: List<LineItem>,
+    productStore: WCProductStore
+): Boolean {
+    if (lineItems.isNullOrEmpty()) {
+        return false
+    }
+
+    val remoteProductIds: List<Long> = lineItems.filter { it.productId != null }.map { it.productId!! }
+    if (remoteProductIds.isNullOrEmpty()) {
+        return false
+    }
+
+    // verify that the LineItem product is in the local cache and
+    // that the product count in the local cache matches the lineItem count.
+    val productModels = productStore.getProductsByRemoteIds(site, remoteProductIds)
+    if (productModels.isNullOrEmpty() || productModels.count() != remoteProductIds.count()) {
+        return false
+    }
+
+    return productModels.filter { !it.virtual }.isEmpty()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailContract.kt
@@ -33,7 +33,7 @@ interface OrderDetailContract {
         fun getOrderStatusOptions(): Map<String, WCOrderStatusModel>
         fun refreshOrderStatusOptions()
         fun deleteOrderShipmentTracking(wcOrderShipmentTrackingModel: WCOrderShipmentTrackingModel)
-        fun isVirtualProduct(lineItems: List<WCOrderModel.LineItem>): Boolean
+        fun isVirtualProduct(order: WCOrderModel): Boolean
     }
 
     interface View : BaseView<Presenter>, OrderActionListener, OrderProductActionListener,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -220,7 +220,7 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
             orderDetail_customerInfo.initView(
                     order = order,
                     shippingOnly = false,
-                    billingOnly = presenter.isVirtualProduct(order.getLineItemList()))
+                    billingOnly = presenter.isVirtualProduct(order))
 
             // Populate the Payment Information Card
             orderDetail_paymentInfo.initView(order, currencyFormatter.buildFormatter(order.currency))
@@ -241,7 +241,7 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
 
     override fun refreshCustomerInfoCard(order: WCOrderModel) {
         // hide the shipping details if products in an order is virtual
-        val hideShipping = presenter.isVirtualProduct(order.getLineItemList())
+        val hideShipping = presenter.isVirtualProduct(order)
         orderDetail_customerInfo.initShippingSection(order, hideShipping)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentContract.kt
@@ -19,7 +19,7 @@ interface OrderFulfillmentContract {
         fun getShipmentTrackingsFromDb(order: WCOrderModel): List<WCOrderShipmentTrackingModel>
         fun markOrderComplete()
         fun deleteOrderShipmentTracking(wcOrderShipmentTrackingModel: WCOrderShipmentTrackingModel)
-        fun isVirtualProduct(lineItems: List<WCOrderModel.LineItem>): Boolean
+        fun isVirtualProduct(order: WCOrderModel): Boolean
     }
 
     interface View : BaseView<Presenter>, OrderProductActionListener, OrderShipmentTrackingActionListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragment.kt
@@ -118,7 +118,7 @@ class OrderFulfillmentFragment : BaseFragment(), OrderFulfillmentContract.View, 
         }
 
         // check if product is a virtual product
-        val isVirtualProduct = presenter.isVirtualProduct(order.getLineItemList())
+        val isVirtualProduct = presenter.isVirtualProduct(order)
 
         // Populate the Customer Information Card
         // hide shipping card if product is virtual or if no shipping address is available

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragment.kt
@@ -117,16 +117,23 @@ class OrderFulfillmentFragment : BaseFragment(), OrderFulfillmentContract.View, 
             orderFulfill_customerNote.initView(order)
         }
 
+        // check if product is a virtual product
+        val isVirtualProduct = presenter.isVirtualProduct(order.getLineItemList())
+
         // Populate the Customer Information Card
-        // check if product is a virtual product. If it is, hide the shipping details card
-        val hideShipping = presenter.isVirtualProduct(order.getLineItemList()) ||
-                !orderFulfill_customerInfo.isShippingAvailable(order)
+        // hide shipping card if product is virtual or if no shipping address is available
+        val hideShipping = isVirtualProduct || !orderFulfill_customerInfo.isShippingAvailable(order)
         if (hideShipping) {
             orderFulfill_customerInfo.visibility = View.GONE
         } else {
             // Populate the Customer Information Card
             orderFulfill_customerInfo.visibility = View.VISIBLE
             orderFulfill_customerInfo.initView(order, true)
+        }
+
+        // load shipment tracking card only if product is NOT virtual
+        if (!isVirtualProduct) {
+            presenter.loadOrderShipmentTrackings()
         }
 
         orderFulfill_btnComplete.setOnClickListener(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentPresenter.kt
@@ -70,7 +70,6 @@ class OrderFulfillmentPresenter @Inject constructor(
             orderModel = getOrderDetailFromDb(orderIdentifier)
             orderModel?.let { order ->
                 view.showOrderDetail(order)
-                loadOrderShipmentTrackings()
             }
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenterTest.kt
@@ -380,7 +380,7 @@ class OrderDetailPresenterTest {
         presenter.loadOrderDetail(orderIdentifier, false)
         verify(orderDetailView).showOrderDetail(any(), any())
 
-        assertTrue(presenter.isVirtualProduct(order.getLineItemList()))
+        assertTrue(presenter.isVirtualProduct(order))
     }
 
     @Test
@@ -394,7 +394,7 @@ class OrderDetailPresenterTest {
         presenter.loadOrderDetail(orderIdentifier, false)
         verify(orderDetailView).showOrderDetail(any(), any())
 
-        assertFalse(presenter.isVirtualProduct(order.getLineItemList()))
+        assertFalse(presenter.isVirtualProduct(order))
     }
 
     @Test
@@ -413,7 +413,7 @@ class OrderDetailPresenterTest {
         presenter.loadOrderDetail(orderIdentifier, false)
         verify(orderDetailView).showOrderDetail(any(), any())
 
-        assertFalse(presenter.isVirtualProduct(order.getLineItemList()))
+        assertFalse(presenter.isVirtualProduct(order))
     }
 
     @Test
@@ -426,7 +426,7 @@ class OrderDetailPresenterTest {
         verify(orderDetailView).showOrderDetail(any(), any())
 
         verify(productStore, times(0)).getProductsByRemoteIds(any(), any())
-        assertFalse(presenter.isVirtualProduct(order.getLineItemList()))
+        assertFalse(presenter.isVirtualProduct(order))
     }
 
     @Test
@@ -439,7 +439,7 @@ class OrderDetailPresenterTest {
         presenter.loadOrderDetail(orderIdentifier, false)
         verify(orderDetailView).showOrderDetail(any(), any())
 
-        assertFalse(presenter.isVirtualProduct(order.getLineItemList()))
+        assertFalse(presenter.isVirtualProduct(order))
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentPresenterTest.kt
@@ -302,7 +302,7 @@ class OrderFulfillmentPresenterTest {
         presenter.loadOrderDetail(order.getIdentifier())
         verify(view).showOrderDetail(any())
 
-        assertTrue(presenter.isVirtualProduct(order.getLineItemList()))
+        assertTrue(presenter.isVirtualProduct(order))
     }
 
     @Test
@@ -316,7 +316,7 @@ class OrderFulfillmentPresenterTest {
         presenter.loadOrderDetail(order.getIdentifier())
         verify(view).showOrderDetail(any())
 
-        assertFalse(presenter.isVirtualProduct(order.getLineItemList()))
+        assertFalse(presenter.isVirtualProduct(order))
     }
 
     @Test
@@ -335,7 +335,7 @@ class OrderFulfillmentPresenterTest {
         presenter.loadOrderDetail(order.getIdentifier())
         verify(view).showOrderDetail(any())
 
-        assertFalse(presenter.isVirtualProduct(order.getLineItemList()))
+        assertFalse(presenter.isVirtualProduct(order))
     }
 
     @Test
@@ -348,7 +348,7 @@ class OrderFulfillmentPresenterTest {
         verify(view).showOrderDetail(any())
 
         verify(productStore, times(0)).getProductsByRemoteIds(any(), any())
-        assertFalse(presenter.isVirtualProduct(order.getLineItemList()))
+        assertFalse(presenter.isVirtualProduct(order))
     }
 
     @Test
@@ -361,6 +361,6 @@ class OrderFulfillmentPresenterTest {
         presenter.loadOrderDetail(order.getIdentifier())
         verify(view).showOrderDetail(any())
 
-        assertFalse(presenter.isVirtualProduct(order.getLineItemList()))
+        assertFalse(presenter.isVirtualProduct(order))
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentPresenterTest.kt
@@ -91,6 +91,7 @@ class OrderFulfillmentPresenterTest {
 
         // order shipment tracking is already fetched from api
         presenter.loadOrderDetail(order.getIdentifier(), true)
+        presenter.loadOrderShipmentTrackings()
 
         // fetch order shipment trackings
         verify(presenter, times(1)).loadShipmentTrackingsFromDb()
@@ -111,6 +112,7 @@ class OrderFulfillmentPresenterTest {
 
         // order shipment tracking is not fetched from api
         presenter.loadOrderDetail(order.getIdentifier(), false)
+        presenter.loadOrderShipmentTrackings()
 
         // fetch order shipment trackings
         assertFalse(presenter.isShipmentTrackingsFetched)
@@ -138,6 +140,7 @@ class OrderFulfillmentPresenterTest {
 
         // order shipment tracking is not fetched from api
         presenter.loadOrderDetail(order.getIdentifier(), false)
+        presenter.loadOrderShipmentTrackings()
 
         // fetch order shipment trackings
         assertFalse(presenter.isShipmentTrackingsFetched)
@@ -163,6 +166,7 @@ class OrderFulfillmentPresenterTest {
         presenter.takeView(view)
 
         presenter.loadOrderDetail(order.getIdentifier(), true)
+        presenter.loadOrderShipmentTrackings()
         verify(presenter, times(1)).loadShipmentTrackingsFromDb()
         verify(presenter, times(0)).fetchShipmentTrackingsFromApi(any())
     }


### PR DESCRIPTION
Fixes #1233 by adding logic to hide the shipment tracking card for virtual products. This logic is added only to the `Order Fulfill` screen as we hide the shipment tracking card in `Order Detail` screen unless the user has added a tracking card for an unfulfilled order in `Order Fulfill` screen. 

### Notes:
~~- This [PR](https://github.com/woocommerce/woocommerce-android/pull/1171) must be merged before this PR can be reviewed. So marking the PR as `Not Ready for Review` for now.~~

### Screenshots
#### Virtual Products (Before and After):
<img width="300" src="https://user-images.githubusercontent.com/22608780/61110638-538fc180-a4a5-11e9-8c00-5ef145394cd5.png"> .  <img width="300" src="https://user-images.githubusercontent.com/22608780/61110342-b6cd2400-a4a4-11e9-9dc0-329cf0b4f21a.png">

#### Virtual + Physical Products (Before and After):
<img width="300" src="https://user-images.githubusercontent.com/22608780/61110721-88037d80-a4a5-11e9-8f60-9ef7a5d683eb.png"> .  <img width="300" src="https://user-images.githubusercontent.com/22608780/61110832-d57fea80-a4a5-11e9-8310-8f5257fbc113.png">

### Tests
- Run `OrderFulfillmentPresenterTest`