### PR TITLE
Stats Improvements Part I: Add changes to fetch stats data from the v4 API

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContract.kt
@@ -12,13 +12,18 @@ interface DashboardContract {
         fun getStatsCurrency(): String?
         fun fetchUnfilledOrderCount(forced: Boolean = false)
         fun fetchHasOrders()
+        fun fetchOrderStats(granularity: StatsGranularity, forced: Boolean)
+        fun fetchVisitorStats(granularity: StatsGranularity, forced: Boolean)
+        fun fetchTopEarnerStats(granularity: StatsGranularity, forced: Boolean)
+        fun getRevenueStats(granularity: StatsGranularity, startDate: String, endDate: String): Map<String, Double>
+        fun getOrderStats(granularity: StatsGranularity, startDate: String, endDate: String): Map<String, Long>
     }
 
     interface View : BaseView<Presenter> {
         var isRefreshPending: Boolean
 
         fun refreshDashboard(forced: Boolean = false)
-        fun showStats(revenueStats: Map<String, Double>, salesStats: Map<String, Int>, granularity: StatsGranularity)
+        fun showStats(revenueStats: Map<String, Double>, salesStats: Map<String, Long>, granularity: StatsGranularity)
         fun showStatsError(granularity: StatsGranularity)
         fun showTopEarners(topEarnerList: List<WCTopEarnerModel>, granularity: StatsGranularity)
         fun showTopEarnersError(granularity: StatsGranularity)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -184,7 +184,7 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
 
     override fun showStats(
         revenueStats: Map<String, Double>,
-        salesStats: Map<String, Int>,
+        salesStats: Map<String, Long>,
         granularity: StatsGranularity
     ) {
         // Only update the order stats view if the new stats match the currently selected timeframe

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -114,7 +114,6 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
                 selectedSite = selectedSite,
                 formatCurrencyForDisplay = currencyFormatter::formatCurrencyRounded)
         dashboard_top_earners.initView(
-                dashboard_top_earners.activeGranularity,
                 listener = this,
                 selectedSite = selectedSite,
                 formatCurrencyForDisplay = currencyFormatter::formatCurrencyRounded)
@@ -179,7 +178,7 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
         outState.putBoolean(STATE_KEY_REFRESH_PENDING, isRefreshPending)
         outState.putInt(STATE_KEY_UNFILLED_ORDER_COUNT, unfilledOrderCount)
         outState.putSerializable(STATE_KEY_TAB_STATS, dashboard_stats.activeGranularity)
-        outState.putSerializable(STATE_KEY_TAB_EARNERS, dashboard_top_earners.activeGranularity)
+        outState.putSerializable(STATE_KEY_TAB_EARNERS, dashboard_stats.activeGranularity)
     }
 
     override fun showStats(
@@ -203,14 +202,14 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
     }
 
     override fun showTopEarners(topEarnerList: List<WCTopEarnerModel>, granularity: StatsGranularity) {
-        if (dashboard_top_earners.activeGranularity == granularity) {
+        if (dashboard_stats.activeGranularity == granularity) {
             dashboard_top_earners.showErrorView(false)
             dashboard_top_earners.updateView(topEarnerList)
         }
     }
 
     override fun showTopEarnersError(granularity: StatsGranularity) {
-        if (dashboard_top_earners.activeGranularity == granularity) {
+        if (dashboard_stats.activeGranularity == granularity) {
             dashboard_top_earners.updateView(emptyList())
             dashboard_top_earners.showErrorView(true)
             showErrorSnack()
@@ -268,7 +267,7 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
                     dashboard_stats.clearChartData()
                 }
                 presenter.loadStats(dashboard_stats.activeGranularity, forced)
-                presenter.loadTopEarnerStats(dashboard_top_earners.activeGranularity, forced)
+                presenter.loadTopEarnerStats(dashboard_stats.activeGranularity, forced)
                 presenter.fetchUnfilledOrderCount(forced)
                 presenter.fetchHasOrders()
             }
@@ -291,6 +290,7 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
     override fun onRequestLoadStats(period: StatsGranularity) {
         dashboard_stats.showErrorView(false)
         presenter.loadStats(period)
+        dashboard_top_earners.loadTopEarnerStats(period)
     }
 
     override fun onRequestLoadTopEarnerStats(period: StatsGranularity) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -33,7 +33,6 @@ import com.woocommerce.android.widgets.SkeletonView
 import kotlinx.android.synthetic.main.dashboard_stats.view.*
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.YEARS
-import org.wordpress.android.fluxc.utils.SiteUtils
 import org.wordpress.android.util.DateTimeUtils
 import java.io.Serializable
 import java.util.ArrayList
@@ -256,7 +255,7 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
         chart.highlightValue(null)
     }
 
-    fun updateView(revenueStats: Map<String, Double>, orderStats: Map<String, Int>, currencyCode: String?) {
+    fun updateView(revenueStats: Map<String, Double>, orderStats: Map<String, Long>, currencyCode: String?) {
         chartCurrencyCode = currencyCode
 
         val wasEmpty = chart.barData?.let { it.dataSetCount == 0 } ?: true
@@ -357,30 +356,10 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
     }
 
     private fun generateBarDataSet(revenueStats: Map<String, Double>): BarDataSet {
-        val barEntries = when (activeGranularity) {
-            StatsGranularity.DAYS,
-            StatsGranularity.WEEKS,
-            StatsGranularity.MONTHS -> {
-                chartRevenueStats = revenueStats
-                chartRevenueStats.values.mapIndexed { index, value ->
-                    BarEntry((index + 1).toFloat(), value.toFloat())
-                }
-            }
-            StatsGranularity.YEARS -> {
-                // Clean up leading empty years and start from first year with non-zero sales
-                // (but always include current year)
-                val modifiedRevenueStats = revenueStats.toMutableMap()
-                for (entry in revenueStats) {
-                    if (entry.value != 0.0 || entry.key == revenueStats.keys.last()) {
-                        break
-                    }
-                    modifiedRevenueStats.remove(entry.key)
-                }
-                chartRevenueStats = modifiedRevenueStats
-                chartRevenueStats.map { BarEntry(it.key.toFloat(), it.value.toFloat()) }
-            }
+        chartRevenueStats = revenueStats
+        val barEntries = chartRevenueStats.values.mapIndexed { index, value ->
+            BarEntry((index + 1).toFloat(), value.toFloat())
         }
-
         return BarDataSet(barEntries, "")
     }
 
@@ -468,21 +447,20 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
         fun getStartValue(): String {
             val dateString = chartRevenueStats.keys.first()
             return when (activeGranularity) {
-                StatsGranularity.DAYS -> DateUtils.getShortMonthDayString(dateString)
-                StatsGranularity.WEEKS -> DateUtils.getShortMonthDayStringForWeek(dateString)
-                StatsGranularity.MONTHS -> DateUtils.getShortMonthString(dateString)
-                StatsGranularity.YEARS -> dateString
+                StatsGranularity.DAYS -> DateUtils.getShortHourString(dateString)
+                StatsGranularity.WEEKS -> DateUtils.getShortMonthDayString(dateString)
+                StatsGranularity.MONTHS -> DateUtils.getShortMonthDayString(dateString)
+                StatsGranularity.YEARS -> DateUtils.getShortMonthString(dateString)
             }
         }
 
         fun getEndValue(): String {
             val dateString = chartRevenueStats.keys.last()
             return when (activeGranularity) {
-                StatsGranularity.DAYS -> DateUtils.getShortMonthDayString(dateString)
-                StatsGranularity.WEEKS ->
-                    SiteUtils.getCurrentDateTimeForSite(selectedSite.get(), DateUtils.friendlyMonthDayFormat)
-                StatsGranularity.MONTHS -> DateUtils.getShortMonthString(dateString)
-                StatsGranularity.YEARS -> dateString
+                StatsGranularity.DAYS -> DateUtils.getShortHourString(dateString)
+                StatsGranularity.WEEKS -> DateUtils.getShortMonthDayString(dateString)
+                StatsGranularity.MONTHS -> DateUtils.getShortMonthDayString(dateString)
+                StatsGranularity.YEARS -> DateUtils.getShortMonthString(dateString)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -366,10 +366,10 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
     @StringRes
     fun getStringForGranularity(timeframe: StatsGranularity): Int {
         return when (timeframe) {
-            StatsGranularity.DAYS -> R.string.dashboard_stats_granularity_days
-            StatsGranularity.WEEKS -> R.string.dashboard_stats_granularity_weeks
-            StatsGranularity.MONTHS -> R.string.dashboard_stats_granularity_months
-            StatsGranularity.YEARS -> R.string.dashboard_stats_granularity_years
+            StatsGranularity.DAYS -> R.string.today
+            StatsGranularity.WEEKS -> R.string.this_week
+            StatsGranularity.MONTHS -> R.string.this_month
+            StatsGranularity.YEARS -> R.string.this_year
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardTopEarnersView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardTopEarnersView.kt
@@ -24,14 +24,12 @@ import org.wordpress.android.fluxc.model.WCTopEarnerModel
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.util.FormatUtils
 import org.wordpress.android.util.PhotonUtils
-import java.io.Serializable
 
 class DashboardTopEarnersView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
     : LinearLayout(ctx, attrs) {
     init {
         View.inflate(context, R.layout.dashboard_top_earners, this)
     }
-    var tabStateStats: Serializable? = null // Save the current position of top earners tab view
 
     private lateinit var selectedSite: SelectedSite
     private lateinit var listener: DashboardStatsListener

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -206,4 +206,23 @@ object DateUtils {
      * Formats a date object and returns it in the format of yyyy-MM-dd
      */
     fun getYearMonthDayStringFromDate(date: Date): String = yyyyMMddFormat.format(date)
+
+    /**
+     * Given an ISO8601 date of format YYYY-MM-DD hh, returns the hour String in ("hh") format.
+     *
+     * For example, given 2019-07-15 13 returns "1pm", and given 2019-07-28 01 returns "1am".
+     *
+     * @throws IllegalArgumentException if the argument is not a valid iso8601 date string.
+     */
+    @Throws(IllegalArgumentException::class)
+    fun getShortHourString(iso8601Date: String): String {
+        return try {
+            val originalFormat = SimpleDateFormat("yyyy-MM-dd HH", Locale.ROOT)
+            val targetFormat = SimpleDateFormat("hha", Locale.ROOT)
+            val date = originalFormat.parse(iso8601Date)
+            targetFormat.format(date).toLowerCase().trimStart('0')
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Date string argument is not of format yyyy-MM-dd H: $iso8601Date")
+        }
+    }
 }

--- a/WooCommerce/src/main/res/layout/dashboard_stats.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_stats.xml
@@ -6,24 +6,10 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.google.android.material.tabs.TabLayout
-        android:id="@+id/tab_layout"
-        style="@style/Woo.TabLayout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
-
-    <FrameLayout
-        android:id="@+id/tab_layout_divider"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/list_divider"
-        app:srcCompat="@drawable/list_divider"/>
-
     <LinearLayout
         android:id="@+id/label_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
         android:baselineAligned="false"
         android:gravity="center_horizontal"
         android:orientation="horizontal">

--- a/WooCommerce/src/main/res/layout/dashboard_top_earners.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_top_earners.xml
@@ -6,17 +6,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <com.google.android.material.tabs.TabLayout
-        android:id="@+id/topEarners_tab_layout"
-        style="@style/Woo.TabLayout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
-
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/list_divider"/>
-
     <TextView
         android:id="@+id/topEarners_title"
         style="@style/Woo.TextAppearance.Title.Bold"

--- a/WooCommerce/src/main/res/layout/fragment_dashboard.xml
+++ b/WooCommerce/src/main/res/layout/fragment_dashboard.xml
@@ -1,62 +1,87 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/dashboardStats_root"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    tools:context="com.woocommerce.android.ui.dashboard.DashboardFragment">
 
-    <com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout
-        android:id="@+id/dashboard_refresh_layout"
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="false">
+
+        <!-- Single tab for all stats -->
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tab_layout"
+            style="@style/Woo.TabLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/default_window_background">
+        android:background="@color/default_window_background"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        <androidx.core.widget.NestedScrollView
-            android:id="@+id/scroll_view"
+        <com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout
+            android:id="@+id/dashboard_refresh_layout"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-            <LinearLayout
+            <androidx.core.widget.NestedScrollView
+                android:id="@+id/scroll_view"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:animateLayoutChanges="true"
-                android:descendantFocusability="blocksDescendants"
-                android:orientation="vertical">
+                android:layout_height="match_parent">
 
-                <!-- Order stats -->
-                <com.woocommerce.android.ui.dashboard.DashboardStatsView
-                    android:id="@+id/dashboard_stats"
-                    style="@style/Woo.Card"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"/>
+                    android:animateLayoutChanges="true"
+                    android:descendantFocusability="blocksDescendants"
+                    android:layout_marginTop="@dimen/margin_large"
+                    android:orientation="vertical">
 
-                <!-- Orders waiting fulfillment -->
-                <com.woocommerce.android.ui.dashboard.DashboardUnfilledOrdersCard
-                    android:id="@+id/dashboard_unfilled_orders"
-                    style="@style/Woo.Card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:visibility="gone"
-                    tools:visibility="visible"/>
+                    <!-- Order stats -->
+                    <com.woocommerce.android.ui.dashboard.DashboardStatsView
+                        android:id="@+id/dashboard_stats"
+                        style="@style/Woo.Stats.Card"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"/>
 
-                <!-- Top earner stats -->
-                <com.woocommerce.android.ui.dashboard.DashboardTopEarnersView
-                    android:id="@+id/dashboard_top_earners"
-                    style="@style/Woo.Card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_small"
-                    android:orientation="vertical"/>
+                    <!-- Orders waiting fulfillment -->
+                    <com.woocommerce.android.ui.dashboard.DashboardUnfilledOrdersCard
+                        android:id="@+id/dashboard_unfilled_orders"
+                        style="@style/Woo.Stats.Card"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:visibility="gone"
+                        tools:visibility="visible"/>
 
-            </LinearLayout>
-        </androidx.core.widget.NestedScrollView>
-    </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
+                    <!-- Top earner stats -->
+                    <com.woocommerce.android.ui.dashboard.DashboardTopEarnersView
+                        android:id="@+id/dashboard_top_earners"
+                        style="@style/Woo.Stats.Card"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"/>
 
-    <com.woocommerce.android.widgets.WCEmptyView
-        android:id="@+id/empty_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone"/>
+                </LinearLayout>
+            </androidx.core.widget.NestedScrollView>
+        </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
 
-</FrameLayout>
+        <com.woocommerce.android.widgets.WCEmptyView
+            android:id="@+id/empty_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone"/>
+
+    </FrameLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -309,9 +309,12 @@
         <item name="tabMode">scrollable</item>
         <item name="tabTextAppearance">@style/Woo.TabLayout.Text</item>
         <item name="tabTextColor">@color/wc_grey_mid</item>
-        <item name="tabContentStart">48dp</item>
-        <item name="tabPaddingStart">40dp</item>
-        <item name="tabPaddingEnd">40dp</item>
+        <item name="tabSelectedTextColor">@color/black</item>
+        <item name="android:background">@color/card_bgColor</item>
+        <item name="android:elevation">10dp</item>
+        <item name="tabPaddingStart">25dp</item>
+        <item name="tabPaddingEnd">25dp</item>
+        <item name="tabIndicatorHeight">2.5dp</item>
     </style>
 
     <style name="Woo.TabLayout.Text" parent="TextAppearance.Design.Tab">
@@ -550,6 +553,15 @@
         <item name="android:textColor">@color/default_text_color</item>
         <item name="android:textAlignment">viewStart</item>
         <item name="android:textSize">@dimen/text_large</item>
+    </style>
+
+    <!--
+        Stats
+    -->
+    <style name="Woo.Stats.Card" parent="Woo.Card">
+        <item name="android:elevation">2dp</item>
+        <item name="android:layout_marginStart">@dimen/margin_medium</item>
+        <item name="android:layout_marginEnd">@dimen/margin_medium</item>
     </style>
 
 </resources>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardPresenterTest.kt
@@ -22,7 +22,7 @@ import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS_COUNT
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDER_NOTES
 import org.wordpress.android.fluxc.action.WCOrderAction.UPDATE_ORDER_STATUS
-import org.wordpress.android.fluxc.action.WCStatsAction.FETCH_ORDER_STATS
+import org.wordpress.android.fluxc.action.WCStatsAction.FETCH_ORDER_STATS_V4
 import org.wordpress.android.fluxc.action.WCStatsAction.FETCH_TOP_EARNERS_STATS
 import org.wordpress.android.fluxc.action.WCStatsAction.FETCH_VISITOR_STATS
 import org.wordpress.android.fluxc.annotations.action.Action
@@ -34,13 +34,15 @@ import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderError
 import org.wordpress.android.fluxc.store.WCStatsStore
-import org.wordpress.android.fluxc.store.WCStatsStore.FetchOrderStatsPayload
+import org.wordpress.android.fluxc.store.WCStatsStore.FetchOrderStatsV4Payload
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchTopEarnersStatsPayload
 import org.wordpress.android.fluxc.store.WCStatsStore.OnWCStatsChanged
+import org.wordpress.android.fluxc.store.WCStatsStore.OnWCStatsV4Changed
 import org.wordpress.android.fluxc.store.WCStatsStore.OnWCTopEarnersChanged
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsError
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
+import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -75,9 +77,9 @@ class DashboardPresenterTest {
 
         // note that we expect two dispatches because there's one to get stats and another to get visitors
         verify(dispatcher, times(2)).dispatch(actionCaptor.capture())
-        assertEquals(FETCH_ORDER_STATS, actionCaptor.firstValue.type)
+        assertEquals(FETCH_ORDER_STATS_V4, actionCaptor.firstValue.type)
 
-        val payload = actionCaptor.firstValue.payload as FetchOrderStatsPayload
+        val payload = actionCaptor.firstValue.payload as FetchOrderStatsV4Payload
         assertEquals(StatsGranularity.DAYS, payload.granularity)
     }
 
@@ -86,9 +88,11 @@ class DashboardPresenterTest {
         presenter.takeView(dashboardView)
 
         // Simulate OnChanged event from FluxC
-        val onChanged = OnWCStatsChanged(1, granularity = StatsGranularity.DAYS)
-        onChanged.causeOfChange = FETCH_ORDER_STATS
-        presenter.onWCStatsChanged(onChanged)
+        val onChanged = OnWCStatsV4Changed(
+                1, granularity = DAYS, startDate = "2019-07-15", endDate = "2019-07-15"
+        )
+        onChanged.causeOfChange = FETCH_ORDER_STATS_V4
+        presenter.onWCStatsV4Changed(onChanged)
 
         verify(dashboardView).showStats(any(), any(), eq(StatsGranularity.DAYS))
     }
@@ -98,11 +102,11 @@ class DashboardPresenterTest {
         presenter.takeView(dashboardView)
 
         // Simulate OnChanged event from FluxC
-        val onChanged = OnWCStatsChanged(1, granularity = StatsGranularity.DAYS).apply {
-            causeOfChange = FETCH_ORDER_STATS
+        val onChanged = OnWCStatsV4Changed(1, granularity = StatsGranularity.DAYS).apply {
+            causeOfChange = FETCH_ORDER_STATS_V4
             error = OrderStatsError(OrderStatsErrorType.INVALID_PARAM)
         }
-        presenter.onWCStatsChanged(onChanged)
+        presenter.onWCStatsV4Changed(onChanged)
         verify(dashboardView, times(1)).showStatsError(StatsGranularity.DAYS)
     }
 
@@ -318,7 +322,7 @@ class DashboardPresenterTest {
     fun `Handles FETCH_VISITOR_STATS error event correctly`() {
         presenter.takeView(dashboardView)
 
-        val onChanged = OnWCStatsChanged(1, granularity = StatsGranularity.DAYS)
+        val onChanged = OnWCStatsChanged(1, granularity = DAYS)
         onChanged.causeOfChange = FETCH_VISITOR_STATS
         onChanged.error = OrderStatsError(OrderStatsErrorType.INVALID_PARAM)
 
@@ -332,9 +336,11 @@ class DashboardPresenterTest {
         presenter.loadStats(StatsGranularity.DAYS, forced = true)
         verify(dashboardView, times(1)).showChartSkeleton(true)
 
-        val onChanged = OnWCStatsChanged(1, granularity = StatsGranularity.DAYS)
-        onChanged.causeOfChange = FETCH_ORDER_STATS
-        presenter.onWCStatsChanged(onChanged)
+        val onChanged = OnWCStatsV4Changed(
+                1, granularity = DAYS, startDate = "2019-07-15", endDate = "2019-07-15"
+        )
+        onChanged.causeOfChange = FETCH_ORDER_STATS_V4
+        presenter.onWCStatsV4Changed(onChanged)
         verify(dashboardView, times(1)).showChartSkeleton(false)
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
@@ -122,4 +122,38 @@ class DateUtilsTest {
             DateUtils.getDateString("")
         }
     }
+
+    @Test
+    fun `getShortHourString() returns correct values`() {
+        assertEquals("12am", DateUtils.getShortHourString("2019-05-09 00"))
+        assertEquals("12pm", DateUtils.getShortHourString("2019-05-09 12"))
+        assertEquals("1am", DateUtils.getShortHourString("2018-12-31 01"))
+        assertEquals("5am", DateUtils.getShortHourString("2019-07-15 05"))
+        assertEquals("2pm", DateUtils.getShortHourString("2019-01-01 14"))
+        assertEquals("11pm", DateUtils.getShortHourString("2019-02-28 23"))
+        assertEquals("4pm", DateUtils.getShortHourString("2019-02-28 16"))
+        assertEquals("9am", DateUtils.getShortHourString("2019-02-28 09"))
+
+        // Test for invalid value handling
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortHourString("Dec 30 2018")
+        }
+
+        // Test for invalid value handling
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortHourString("2019-12-31")
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortHourString("-07-41")
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortHourString("")
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortHourString("5am")
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'e85ccc029dbb3de3f7113822cc7c14dcdb17ba8a'
+    fluxCVersion = '95a4c5b6833aa412f7547fbc936d474c630e05c5'
     daggerVersion = '2.22.1'
     supportLibraryVersion = '28.0.0'
     glideVersion = '4.9.0'


### PR DESCRIPTION
Fixes the first step of #1199. To keep the PRs smaller, I'm breaking them down for review to be merged into a feature branch. This PR covers the following changes:

- [x] Use the new stats v4 endpoints to fetch data.
- [x] Display the new stats for Today, This Week, This Month, and This Year.
- [x] Consolidate the chart and top selling products to display and update under the same date range.
- [x] Anchor the tabLayout when the view is scrolled

### Notes:
- This [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1302) needs to be merged before this PR can be merged.
- The Unfulfilled Order card is removed in another [PR](https://github.com/woocommerce/woocommerce-android/pull/1245) which is in review.

### Behaviour:
<img width="300" src="https://user-images.githubusercontent.com/22608780/61204692-8a671100-a70b-11e9-96cb-f7b1bd6aee2a.gif">

#### Screenshots:
<img width="300" src="https://user-images.githubusercontent.com/22608780/61204743-b2ef0b00-a70b-11e9-910d-0ee359e8b20a.png"> .  <img width="300" src="https://user-images.githubusercontent.com/22608780/61204760-bc787300-a70b-11e9-8025-eef708490fcf.png"> .  <img width="300" src="https://user-images.githubusercontent.com/22608780/61204781-c8fccb80-a70b-11e9-93ba-dc9211401201.png"> .  <img width="300" src="https://user-images.githubusercontent.com/22608780/61204800-d44ff700-a70b-11e9-9cce-52e6a441115c.png">

#### When no stats data:
<img width="300" src="https://user-images.githubusercontent.com/22608780/61214760-65cc6280-a726-11e9-98b0-6e52b2d55b17.png">

### Testing:
- Run `DashboardPresenterTest`.
- Run `DateUtilsTest`
- Test a new order completion and verify that the Stats is updated for the current day.