### PR TITLE
Updated reviews tab empty string

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
@@ -388,7 +388,7 @@ class NotifsListFragment : TopLevelFragment(),
     }
 
     override fun showEmptyView(show: Boolean) {
-        if (show) empty_view.show(R.string.notifs_empty_message) else empty_view.hide()
+        if (show) empty_view.show(R.string.reviews_empty_message) else empty_view.hide()
     }
     /**
      * Only show the "mark all read" menu item when this fragment is active and there are unread notifs

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -337,7 +337,7 @@
     <string name="waiting_for_customers_contentdesc">Waiting for customers image</string>
     <string name="orders_empty_message_with_filter">No orders</string>
     <string name="orders_empty_message_with_search">No matching orders</string>
-    <string name="notifs_empty_message">No notifications yet!</string>
+    <string name="reviews_empty_message">No reviews yet!</string>
 
     <!--
         Settings


### PR DESCRIPTION
Fixes #1269 - updates the empty state of the Reviews tab to say "No reviews yet." Previously it incorrectly said "No notifications yet."

![Screenshot_1563803901](https://user-images.githubusercontent.com/3903757/61638458-72414580-ac67-11e9-9f19-6d937c162102.png)

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
