### PR TITLE
Hack Week Project: Added support for in app updates

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * The Notifications tab has been replaced by Reviews 
 * The unfulfilled order count has been removed from the dashboard and is now shown as a badge on the order list
+* Added support to update the app without even going to the play store.
  
 2.3
 -----

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -153,6 +153,7 @@ dependencies {
     kapt "com.github.bumptech.glide:compiler:$glideVersion"
     implementation "com.github.bumptech.glide:volley-integration:$glideVersion@aar"
     implementation "org.greenrobot:eventbus:$eventBusVersion"
+    implementation "com.google.android.play:core:$googlePlayCoreVersion"
 
     // Debug dependencies
     debugImplementation 'com.facebook.stetho:stetho:1.5.0'

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -43,7 +43,9 @@ object AppPrefs {
         // Play cha-ching sound on new order notifications
         NOTIFS_ORDERS_CHA_CHING_ENABLED,
         // Number of times the "mark all notifications read" icon was tapped
-        NUM_TIMES_MARK_ALL_NOTIFS_READ_SNACK_SHOWN
+        NUM_TIMES_MARK_ALL_NOTIFS_READ_SNACK_SHOWN,
+        // The app update for this version was cancelled by the user
+        CANCELLED_APP_VERSION_CODE,
     }
 
     fun init(context: Context) {
@@ -56,6 +58,14 @@ object AppPrefs {
 
     fun setLastAppVersionCode(versionCode: Int) {
         setDeletableInt(UndeletablePrefKey.LAST_APP_VERSION_CODE, versionCode)
+    }
+
+    fun getCancelledAppVersionCode(): Int {
+        return getDeletableInt(UndeletablePrefKey.CANCELLED_APP_VERSION_CODE)
+    }
+
+    fun setCancelledAppVersionCode(versionCode: Int) {
+        setDeletableInt(UndeletablePrefKey.CANCELLED_APP_VERSION_CODE, versionCode)
     }
 
     fun setSupportEmail(email: String?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
@@ -32,7 +32,7 @@ interface UIMessageResolver {
     fun getRestartSnack(
         @StringRes stringResId: Int,
         vararg stringArgs: String = arrayOf(),
-        actionListener: OnClickListener
+        actionListener: View.OnClickListener
     ): Snackbar {
         return getIndefiniteSnackbarWithAction(
                 snackbarRoot,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
@@ -34,10 +34,10 @@ interface UIMessageResolver {
         vararg stringArgs: String = arrayOf(),
         actionListener: OnClickListener
     ): Snackbar {
-        return getSnackbarWithAction(
+        return getIndefiniteSnackbarWithAction(
                 snackbarRoot,
                 snackbarRoot.context.getString(stringResId, *stringArgs),
-                snackbarRoot.context.getString(R.string.restart),
+                snackbarRoot.context.getString(R.string.install),
                 actionListener)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
@@ -23,11 +23,12 @@ interface UIMessageResolver {
     val snackbarRoot: ViewGroup
 
     /**
-     * Create and return a snackbar displaying the provided message and a RESTART button.
+     * Create and return a snackbar displaying a message to restart the app once the in app update has been
+     * successfully installed
      *
      * @param [stringResId] The string resource id of the base message
      * @param [stringArgs] Optional. One or more format argument stringArgs
-     * @param [actionListener] Listener to handle the restart button click event
+     * @param [actionListener] Listener to handle the install button click event
      */
     fun getRestartSnack(
         @StringRes stringResId: Int,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
@@ -23,6 +23,25 @@ interface UIMessageResolver {
     val snackbarRoot: ViewGroup
 
     /**
+     * Create and return a snackbar displaying the provided message and a RESTART button.
+     *
+     * @param [stringResId] The string resource id of the base message
+     * @param [stringArgs] Optional. One or more format argument stringArgs
+     * @param [actionListener] Listener to handle the restart button click event
+     */
+    fun getRestartSnack(
+        @StringRes stringResId: Int,
+        vararg stringArgs: String = arrayOf(),
+        actionListener: OnClickListener
+    ): Snackbar {
+        return getSnackbarWithAction(
+                snackbarRoot,
+                snackbarRoot.context.getString(stringResId, *stringArgs),
+                snackbarRoot.context.getString(R.string.restart),
+                actionListener)
+    }
+
+    /**
      * Create and return a snackbar displaying the provided message and a RETRY button.
      *
      * @param [stringResId] The string resource id of the base message

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/AppUpgradeActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/AppUpgradeActivity.kt
@@ -1,0 +1,185 @@
+package com.woocommerce.android.ui.main
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.play.core.appupdate.AppUpdateInfo
+import com.google.android.play.core.appupdate.AppUpdateManager
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.install.InstallState
+import com.google.android.play.core.install.InstallStateUpdatedListener
+import com.google.android.play.core.install.model.ActivityResult
+import com.google.android.play.core.install.model.AppUpdateType
+import com.google.android.play.core.install.model.InstallStatus
+import com.google.android.play.core.install.model.UpdateAvailability
+import com.woocommerce.android.BuildConfig
+import com.woocommerce.android.util.WooLog
+
+abstract class AppUpgradeActivity : AppCompatActivity(),
+        AppUpgradeActivityView,
+        InstallStateUpdatedListener {
+    companion object {
+        private const val REQUEST_CODE_IN_APP_UPDATE = 19888
+    }
+
+    private lateinit var appUpdateManager: AppUpdateManager
+
+    /**
+     * The type of in app update to display:
+     * [AppUpdateType.FLEXIBLE] OR [AppUpdateType.IMMEDIATE]
+     */
+    private val inAppUpdateType = BuildConfig.IN_APP_UPDATE_TYPE.toInt()
+
+    private var appUpdateStarted: Boolean = false
+
+    /**
+     * Listener that is passed to the calling activity, if the update has failed for some reason.
+     * If the user clicks on the Retry button, the update process will be tried again.
+     */
+    private val updateFailedActionListener: View.OnClickListener = View.OnClickListener {
+        checkForAppUpdates()
+    }
+
+    /**
+     * Listener that is passed to the calling activity, if the update has succeeded.
+     * If the user clicks on the Restart button, the install process will begin and the app
+     * will be restarted.
+     */
+    private val updateSuccessActionListener: View.OnClickListener = View.OnClickListener {
+        appUpdateManager.completeUpdate()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        // initialise appUpdateManager
+        appUpdateManager = AppUpdateManagerFactory.create(this)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        handleAppUpdateOnResumed()
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == REQUEST_CODE_IN_APP_UPDATE) {
+            when (resultCode) {
+                //  handle user's rejection
+                Activity.RESULT_CANCELED -> {
+                    appUpdateStarted = false
+                    // TODO: store the user's preference in SharedPrefs and don't show the upgrade dialog again
+                }
+                //  handle update failure
+                ActivityResult.RESULT_IN_APP_UPDATE_FAILED -> showAppUpdateFailedSnack(updateFailedActionListener)
+            }
+            return
+        }
+    }
+
+    override fun onStateUpdate(installState: InstallState) {
+        // Show module progress, log state, or install the update.
+        when (installState.installStatus()) {
+            InstallStatus.DOWNLOADED -> {
+                // After the update is downloaded, show a notification
+                // and request user confirmation to restart the app.
+                appUpdateManager.unregisterListener(this)
+                showAppUpdateSuccessSnack(updateSuccessActionListener)
+            }
+            InstallStatus.FAILED -> {
+                // App update failed for some reason. This could happen due to network
+                // issues as well. Display an error snack and ask users to try again
+                appUpdateManager.unregisterListener(this)
+                showAppUpdateFailedSnack(updateFailedActionListener)
+            }
+        }
+    }
+
+    /**
+     * Method is called from the child activity to check if there are any app updates pending.
+     * This will display either [AppUpdateType.FLEXIBLE] or [AppUpdateType.IMMEDIATE] dialog to the user,
+     * if there is a new app update.
+     */
+    internal fun checkForAppUpdates() {
+        appUpdateManager.appUpdateInfo.addOnSuccessListener { appUpdateInfo ->
+            when (appUpdateInfo.updateAvailability()) {
+                UpdateAvailability.UPDATE_AVAILABLE -> {
+                    // Checks that the platform will allow the specified type of update
+                    if (appUpdateInfo.isUpdateTypeAllowed(inAppUpdateType)) {
+                        if (isAppUpdateImmediate()) {
+                            // initiate immediate update flow
+                            requestAppUpdate(appUpdateInfo)
+                        } else if (isAppUpdateFlexible()) {
+                            // Before starting an update, register a listener for updates.
+                            // initiate flexible update flow
+                            appUpdateManager.registerListener(this)
+                            requestAppUpdate(appUpdateInfo)
+                        }
+                        // the app update process has started
+                        appUpdateStarted = true
+                    }
+                }
+                UpdateAvailability.UPDATE_NOT_AVAILABLE -> {
+                    WooLog.v(WooLog.T.UTILS, "App update not available")
+                }
+            }
+        }
+    }
+
+    /**
+     * Method is called from the [onResume] of the activity to check if the update process is
+     * started and if so, verify that the UI is updated accordingly
+     */
+    private fun handleAppUpdateOnResumed() {
+        // Check if the app update process has started.
+        // If not, there is no point in checking if app update is available, so do nothing
+        if (!appUpdateStarted) {
+            return
+        }
+        appUpdateManager.appUpdateInfo.addOnSuccessListener { appUpdateInfo ->
+            when (appUpdateInfo.updateAvailability()) {
+                UpdateAvailability.UPDATE_AVAILABLE -> {
+                    // A flexible update means that the user is able to use the app while the update is
+                    // being downloaded. if the user goes back or kills the app, or gets a call etc, and the app goes
+                    // into the background, it won’t stop the update process. But once the app comes back to the
+                    // foreground, if the update is already downloaded, we need to ask the user to manually restart the
+                    // app.
+                    if (isAppUpdateFlexible() && appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)) {
+                        if (appUpdateInfo.installStatus() == InstallStatus.DOWNLOADED) {
+                            // display a Snackbar here to ask the user to manually restart the app
+                            showAppUpdateSuccessSnack(updateSuccessActionListener)
+                        }
+                    }
+                }
+
+                // The integer UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS means that an immediate update
+                // has been started, and update is still in progress. Triggering the request flow using update info’s
+                // intent will ask Google Play to show that blocking, immediate app update screen.
+                // Post the update, Play will automatically restart the app.
+                UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS -> {
+                    // After calling appUpdateManager.startUpdateFlowForResult() for an immediate update
+                    // the play store takes control. The user will see the update progress till the time they are on the
+                    // new version. And if the user goes back or kills the app, or gets a call etc, and the app goes
+                    // into the background, it won’t stop the update process. This should be communicated to the user
+                    // the moment the app gets back to the foreground.
+                    if (isAppUpdateImmediate() && appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE)) {
+                        requestAppUpdate(appUpdateInfo)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun isAppUpdateImmediate() = AppUpdateType.IMMEDIATE == inAppUpdateType
+    private fun isAppUpdateFlexible() = AppUpdateType.FLEXIBLE == inAppUpdateType
+
+    private fun requestAppUpdate(appUpdateInfo: AppUpdateInfo?) {
+        appUpdateManager.startUpdateFlowForResult(
+                appUpdateInfo,
+                inAppUpdateType,
+                this,
+                REQUEST_CODE_IN_APP_UPDATE
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/AppUpgradeActivityView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/AppUpgradeActivityView.kt
@@ -1,0 +1,18 @@
+package com.woocommerce.android.ui.main
+
+import android.view.View
+import com.google.android.play.core.install.model.AppUpdateType
+
+interface AppUpgradeActivityView {
+    /**
+     * Method to display a snackBar once the [AppUpdateType.FLEXIBLE] upgrade
+     * is completed successfully
+     */
+    fun showAppUpdateSuccessSnack(actionListener: View.OnClickListener)
+
+    /**
+     * Method to display a snackBar once the [AppUpdateType.FLEXIBLE] upgrade
+     * results in error
+     */
+    fun showAppUpdateFailedSnack(actionListener: View.OnClickListener)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -149,7 +149,7 @@ class MainActivity : AppUpgradeActivity(),
         // show the app rating dialog if it's time
         AppRatingDialog.showIfNeeded(this)
 
-        // check for any new app updates
+        // check for any new app updates only after the user has logged into the app
         checkForAppUpdates()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -8,7 +8,6 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import androidx.annotation.DrawableRes
-import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
@@ -31,6 +30,7 @@ import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.dashboard.DashboardFragment
 import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.main.BottomNavigationPosition.DASHBOARD
@@ -62,7 +62,7 @@ import org.wordpress.android.login.LoginMode
 import org.wordpress.android.util.NetworkUtils
 import javax.inject.Inject
 
-class MainActivity : AppCompatActivity(),
+class MainActivity : AppUpgradeActivity(),
         MainContract.View,
         HasSupportFragmentInjector,
         FragmentScrollListener,
@@ -99,6 +99,7 @@ class MainActivity : AppCompatActivity(),
     @Inject lateinit var presenter: MainContract.Presenter
     @Inject lateinit var loginAnalyticsListener: LoginAnalyticsListener
     @Inject lateinit var selectedSite: SelectedSite
+    @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     private var isBottomNavShowing = true
     private var previousDestinationId: Int? = null
@@ -147,6 +148,9 @@ class MainActivity : AppCompatActivity(),
 
         // show the app rating dialog if it's time
         AppRatingDialog.showIfNeeded(this)
+
+        // check for any new app updates
+        checkForAppUpdates()
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
@@ -700,5 +704,26 @@ class MainActivity : AppCompatActivity(),
                 showSettingsScreen()
             } else -> {}
         }
+    }
+
+    /**
+     * The Flexible in app update is successful.
+     * Display a success snack bar and ask users to manually restart the app
+     */
+    override fun showAppUpdateSuccessSnack(actionListener: View.OnClickListener) {
+        uiMessageResolver.getRestartSnack(
+                stringResId = R.string.update_downloaded,
+                actionListener = actionListener)
+                .show()
+    }
+
+    /**
+     * The Flexible in app update was not successful.
+     * Display a failure snack bar and ask users to retry
+     */
+    override fun showAppUpdateFailedSnack(actionListener: View.OnClickListener) {
+        uiMessageResolver.getRetrySnack(R.string.update_failed,
+                actionListener = actionListener)
+                .show()
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -35,8 +35,8 @@
     <string name="hide_details">Hide Details</string>
     <string name="retry">Retry</string>
     <string name="undo">Undo</string>
-    <string name="restart">Restart</string>
-    <string name="update_downloaded">App update is completed. Tap to restart</string>
+    <string name="install">Install</string>
+    <string name="update_downloaded">Woo has downloaded an update</string>
     <string name="update_failed">App update failed. Tap to retry</string>
     <string name="continue_button">Continue</string>
     <string name="refresh_button">Refresh</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -37,7 +37,7 @@
     <string name="undo">Undo</string>
     <string name="install">Install</string>
     <string name="update_downloaded">Woo has downloaded an update</string>
-    <string name="update_failed">App update failed. Tap to retry</string>
+    <string name="update_failed">Woo update has failed</string>
     <string name="continue_button">Continue</string>
     <string name="refresh_button">Refresh</string>
     <string name="untitled">Untitled</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -35,6 +35,9 @@
     <string name="hide_details">Hide Details</string>
     <string name="retry">Retry</string>
     <string name="undo">Undo</string>
+    <string name="restart">Restart</string>
+    <string name="update_downloaded">App update is completed. Tap to restart</string>
+    <string name="update_failed">App update failed. Tap to retry</string>
     <string name="continue_button">Continue</string>
     <string name="refresh_button">Refresh</string>
     <string name="untitled">Untitled</string>

--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,7 @@ ext {
     multidexVersion = '1.0.3'
     libaddressinputVersion = '0.0.2'
     eventBusVersion = '3.1.1'
+    googlePlayCoreVersion = '1.6.1'
 }
 
 tasks.getByPath('WooCommerce:preBuild').dependsOn installGitHooks

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -32,3 +32,6 @@ wc.zendesk.domain = http://www.google.com/
 wc.zendesk.oauth_client_id = woocommerce
 wc.reset_db_on_downgrade = false
 wc.sentry.dsn = https://00000000000000000000000000000000@sentry.io/0000000
+
+# The type of in app update FLEXIBLE = 0; IMMEDIATE = 1
+wc.in_app_update_type = 0


### PR DESCRIPTION
Fixes #1272 by adding support for updating the app without having to go to Google Play. There are two types of in app updates: **FLEXIBLE** and **IMMEDIATE**. 

### Changes:
- Added the Google Play Core library to the app.
- Added a flag to `gradle.properties` to check if app update type is flexible or immediate.  
- Created a new activity class called `AppUpdateActivity` which handles all the app update logic. This activity is currently inherited by `MainActivity`. The logic is to check in app updates happen only **after** the user is logged in to the app. (This was mostly because I didn’t think it was good user experience to display an upgrade dialog as soon as the app is opened 🤷‍♀)
- If a user already cancels the update, it would be annoying to display the update dialog again and again. So added logic to NOT display this update dialog if the user has cancelled it for the current version. So if a new version is provided in Google Play, then the dialog will be displayed again. In the future, we could add an option somewhere in the Settings or menu to update the app (if the user wishes to do so, after cancelling the update dialog).

### Notes:
In order to support both types of updates, the following property has been added to the `gradle.properties`. This is just for testing purposes to display both types of upgrades. We would need to modify the logic in the future, to display both types of updates, in various screens, depending on the scenario involved or the app update version. 
```
# The type of in app update FLEXIBLE = 0; IMMEDIATE = 1
wc.in_app_update_type = 0
```

### Screenshots:
(LEFT: Flexible Update, RIGHT: Immediate Update)
<img width="300" src="https://user-images.githubusercontent.com/22608780/61705375-47d4b280-ad63-11e9-8424-aa0cbddf7a22.gif"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/61705407-54f1a180-ad63-11e9-81b4-330796cf819d.gif">

#### Flexible in app update dialog (with and without Wifi):
<img width="300" src="https://user-images.githubusercontent.com/22608780/61705557-997d3d00-ad63-11e9-9147-53bf9418c287.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/61705555-984c1000-ad63-11e9-90f2-2afd6037819d.png">

#### Immediate in app update dialog (with and without Wifi):
<img width="300" src="https://user-images.githubusercontent.com/22608780/61705618-bca7ec80-ad63-11e9-814a-b8d71b5df017.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/61705619-bdd91980-ad63-11e9-90e5-0e51020971f5.png">

### Testing:
While the feature itself is straightforward to implement, the testing process is quite long and irksome. I apologise in advance for the number of scenarios listed below for testing 😬 . There are two options for end to end testing: 
 - Create a release build signed with the same key used to sign the app before uploading to the Play Store. We would need to upload the app to the the internal testing track.
 - Another option is to decrease the `versionCode` and `versionName` in the `build.gradle` and create a release build. This would prompt an update in the app (since the `versionCode` is less than the `versionCode` in Google Play).

I went with Option number 2 by following the below steps to test each of the scenarios listed below:
- [x] Decrease the version code to 55 and create a release build.
- [x] Install the release build
- [x] Verify that the upgrade dialog will be displayed only after login.

#### FLEXIBLE upgrade - Cancel update scenario:
- [x] Click on `No Thanks` button.
- [x] Notice that you are able to use the app. 
- [x] Close the app and open it again. Verify that the upgrade dialog is  not displayed again.

#### FLEXIBLE upgrade - Upgrade using Wifi:
- [x] Uninstall the app and install a fresh one from the changes in this PR.
- [x] Click on `UPDATE` button.
- [x] Notice that you are able to use the app. 
- [x] Verify that once the upgrade is successful, a snackBar is displayed. (This is not dismissible and will be displayed till the Install button is clicked).
- [x] Click on Install in the SnackBar and verify that the app is installed successfully. Once install is over, verify that the Google Play app version and the app version in the device is the same.

#### FLEXIBLE upgrade - Upgrade using Mobile Network only:
- [x] Uninstall the app and install a fresh one from the changes in this PR.
- [x] Verify that only mobile network is on and Wifi is switched off. 
- [x] Click on `Now (over any network)` button (for mobile network)
- [x] Notice that you are able to use the app. 
- [x] Verify that once the upgrade is successful, a snackBar is displayed. (This is not dismissible and will be displayed till the Install button is clicked).
- [x] Click on Install in the SnackBar and verify that the app is installed successfully. Once install is over, verify that the Google Play app version and the app version in the device is the same.

##### Variant test for the above scenario:
- [x] Repeat Steps 1, 2 & 3 from above. 
- [x] **Close the app** after clicking on the Upgrade now button. 
- [x] Open the app again.
- [x]  Verify that once the upgrade is successful, a snackBar is displayed. (This is not dismissible and will be displayed till the Install button is clicked).
- [x] Click on Install in the SnackBar and verify that the app is installed successfully. Once install is over, verify that the Google Play app version and the app version in the device is the same.

#### FLEXIBLE upgrade - Upgrade only when Wifi is available:
- [x] Verify that only mobile network is on and Wifi is switched off. 
- [x] Select “When Wifi is available” radio button and click on `UPDATE` button.
- [x] Notice that you are able to use the app. 
- [x] Enable Wifi from the device notification bar. 
- [x] Verify that the upgrade is started once Wifi is connected. 
- [x] Verify that once the upgrade is successful, a snackBar is displayed. 
- [x] Click on Install in the SnackBar and verify that the app is installed successfully. Once install is over, verify that the Google Play app version and the app version in the device is the same.

##### Variant test for the above scenario:
- [x] Verify that only mobile network is on and Wifi is switched off. 
- [x] Click on “Wait for Wifi” button.
- [x] Notice that you are able to use the app. Close the app. 
- [x] Enable Wifi from the device settings. 
- [x] Open the app again and notice that you are able to use the app.
- [x] Verify that once the upgrade is successful, a snackBar is displayed.  
- [x] Click on Install in the SnackBar and verify that the app is installed successfully. Once install is over, verify that the Google Play app version and the app version in the device is the same. 

### IMMEDIATE upgrade 
- [x] Change the value of `wc.in_app_update_type` in grade.properties from 0 to 1.
- [x] Decrease the version code to 55 and create a build.
- [x] Install the build
- [x] Verify that the upgrade dialog will be displayed only after login.

#### IMMEDIATE  - Cancel update scenario:
- [x]  Click on cross icon at the top right of the page.
- [x] Notice that you are able to use the app. Close the app and open it again. Verify that the upgrade dialog is  not displayed again.

IMMEDIATE upgrade - Upgrade using Wifi OR Mobile Network:
- [x] Uninstall the app and install a fresh one from the changes in this PR.
- [x] Click on `UPDATE` button.
- [x] Notice that you are NOT able to use the app. 
- [x] Verify that once the upgrade is successful, the app is installed and restarted automatically.
- [x] Once install is over, verify that the Google Play app version and the app version in the device is the same.

##### Variant test for the above scenario:
- [x] Repeat Steps 1 & 2 from above. 
- [x] **Close the app** after clicking on the Upgrade now button. 
- [x] Open the app again.
- [x] Verify that the update progress dialog is displayed again and you are not able to use the app. 
- [x] Verify that once the upgrade is successful, the app is installed and restarted automatically. Verify that the Google Play app version and the app version in the device is the same.

#### IMMEDIATE upgrade - Upgrade using Mobile Network only:
- [x] Verify that only mobile network is on and Wifi is switched off. 
- [x] Select “When Wifi is available” radio button and click on UPDATE.
- [x] Notice that you are NOT able to use the app. 
- [x] Enable Wifi from the **device notification bar**. 
- [x] Verify that the upgrade is started and the progress dialog is displayed. 
- [x] Verify that once the upgrade is successful, the app is installed and restarted automatically.
- [x] Once install is over, verify that the Google Play app version and the app version in the device is the same.

##### Variant test for the above scenario:
- [x] Verify that only mobile network is on and Wifi is switched off. 
- [x] Click on “Wait for Wifi” button.
- [x] Notice that you are NOT able to use the app.
- [x] **Close the app** and enable Wifi from the device settings. 
- [x] Open the app again. Notice that the upgrade is started and the progress dialog is displayed. 
- [x] Verify that once the upgrade is successful, the app is installed and restarted automatically.
- [x] Once install is over, verify that the Google Play app version and the app version in the device is the same.
 
#### No Internet available when checking for app updates
 - [x] The `appUpdateInfo.isUpdateTypeAllowed` will always return `false`. So the update dialog will not be displayed.

#### Internet available when checking for app updates but not available AFTER update dialog displayed 
 - [x] If the download has started before the internet is switched off: The download is actually in a `Pending` state and it’s waiting for the Wifi to be turned back on so it can resume the download. I did some testing on whether we get a callback during this pending event and although there is an option called `InstallState.PENDING`, we don’t seem to get a callback for this particular scenario.   
     - [x] In the case of `IMMEDIATE` update: the UI displays a waiting for Wifi screen and also a notification is displayed in the notification bar stating the same.
     - [x] In the case of `FLEXIBLE` update: the user is still allowed to use the app but the notification is displayed in the notification bar to let them know that the download is still pending. It will resume automatically when the Wifi becomes available. 
 - [x] If the download has NOT started before the internet is switched off: The update is in a `FAILED` state so we display the retry snackbar here.



Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

cc @AmandaRiu and @nbradbury, could I trouble you both for a review on this please? Thank you!!! 