### PR TITLE
Fix license page not loading in release build

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/LicensesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/LicensesFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.util.StringUtils
 import kotlinx.android.synthetic.main.fragment_licenses.*
 
 class LicensesFragment : androidx.fragment.app.Fragment() {
@@ -20,7 +21,10 @@ class LicensesFragment : androidx.fragment.app.Fragment() {
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        webView.loadUrl("file:///android_res/raw/licenses.html")
+        context?.let {
+            val prompt = StringUtils.getRawFileUrl(it, R.raw.licenses)
+            webView.loadData(prompt, "text/html", "utf-8")
+        }
     }
 
     override fun onResume() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import android.util.Patterns
 import androidx.annotation.StringRes
 import org.wordpress.android.fluxc.model.SiteModel
+import java.io.IOException
 
 object StringUtils {
     private const val ONE_MILLION = 1000000
@@ -109,5 +110,20 @@ object StringUtils {
             WooLog.d(WooLog.T.UTILS, "Unable to find a valid country name for country code: $storeCountry")
         }
         return null
+    }
+
+    /**
+     * Given a raw HTML file, returns the url for the file
+     */
+    fun getRawFileUrl(context: Context, rawId: Int): String {
+        return try {
+            val inputStream = context.resources.openRawResource(rawId)
+            val buffer = ByteArray(inputStream.available())
+            inputStream.read(buffer)
+            inputStream.close()
+            String(buffer)
+        } catch (e: IOException) {
+            ""
+        }
     }
 }


### PR DESCRIPTION
Fixes #1278 . This PR modifies the logic to read the local Licenses HTML page from the raw folder to fix the issue of the page not loading in a release build.

### Testing
* Verify that the licenses page is displayed correctly in the **debug** build and the **release** build.
* Change the device language to something else and verify that the English version of the page is still displayed. This is to verify that the license page is loaded even without the translation.
* The file needs to be translated to verify that localisation works. But I was able to manually add a translated HTML file for French and verify that it is working correctly.

### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/22608780/61805096-cb210180-ae52-11e9-8e5c-e36db73a97f6.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/61805049-b5abd780-ae52-11e9-875c-23cff0a01ea9.png">

cc @loremattei and @jtreanor 