### PR TITLE
Issue/1282 fix failing ui tests

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/MainActivityTestRuleExt.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/main/MainActivityTestRuleExt.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.ui.main
+
+import com.woocommerce.android.ui.orders.OrderDetailFragment
+
+/**
+ * Helper method to update the network status for the current fragment to test
+ * offline scenarios
+ */
+fun MainActivityTestRule.getOrderDetailFragment(): OrderDetailFragment? {
+    return activity.supportFragmentManager.primaryNavigationFragment?.let { navFragment ->
+        navFragment.childFragmentManager.fragments[0] as? OrderDetailFragment
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingCardTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingCardTest.kt
@@ -35,6 +35,7 @@ import com.woocommerce.android.helpers.WCMatchers
 import com.woocommerce.android.helpers.WCMatchers.withRecyclerView
 import com.woocommerce.android.ui.TestBase
 import com.woocommerce.android.ui.main.MainActivityTestRule
+import com.woocommerce.android.ui.main.getOrderDetailFragment
 import com.woocommerce.android.util.DateUtils
 import org.hamcrest.CoreMatchers
 import org.hamcrest.Matchers
@@ -59,16 +60,6 @@ class OrderDetailShipmentTrackingCardTest : TestBase() {
 
     private val mockWCOrderModel = WcOrderTestUtils.generateOrderDetail()
     private val mockShipmentTrackingList = WcOrderTestUtils.generateOrderShipmentTrackings()
-
-    /**
-     * Helper method to update the network status for the current fragment to test
-     * offline scenarios
-     */
-    private fun getOrderDetailFragment(): OrderDetailFragment? {
-        return activityTestRule.activity.supportFragmentManager.primaryNavigationFragment?.let { navFragment ->
-            navFragment.childFragmentManager.fragments[0] as? OrderDetailFragment
-        }
-    }
 
     @Before
     override fun setup() {
@@ -322,7 +313,7 @@ class OrderDetailShipmentTrackingCardTest : TestBase() {
                 .perform(WCMatchers.scrollTo(), click())
 
         // mock network not available
-        val orderDetailFragment = getOrderDetailFragment()
+        val orderDetailFragment = activityTestRule.getOrderDetailFragment()
         doReturn(false).whenever(orderDetailFragment?.networkStatus)?.isConnected()
 
         // click on the popup menu item "Delete shipment"
@@ -401,7 +392,7 @@ class OrderDetailShipmentTrackingCardTest : TestBase() {
         Assert.assertSame(mockShipmentTrackingList.size - 1, recyclerView.adapter?.itemCount)
 
         // mock api success response
-        val orderDetailFragment = getOrderDetailFragment()
+        val orderDetailFragment = activityTestRule.getOrderDetailFragment()
         val onOrderChangedSuccessResponse = OnOrderChanged(1).apply {
             causeOfChange = DELETE_ORDER_SHIPMENT_TRACKING
         }
@@ -446,7 +437,7 @@ class OrderDetailShipmentTrackingCardTest : TestBase() {
         Assert.assertSame(mockShipmentTrackingList.size - 1, recyclerView.adapter?.itemCount)
 
         // mock api success response
-        val orderDetailFragment = getOrderDetailFragment()
+        val orderDetailFragment = activityTestRule.getOrderDetailFragment()
         val onOrderChangedErrorResponse = OnOrderChanged(1).apply {
             causeOfChange = DELETE_ORDER_SHIPMENT_TRACKING
             error = OrderError()

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingCardTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingCardTest.kt
@@ -187,15 +187,19 @@ class OrderDetailShipmentTrackingCardTest : TestBase() {
         onView(withRecyclerView(R.id.shipmentTrack_items).atPositionOnView(0, R.id.tracking_btnTrack))
                 .perform(WCMatchers.scrollTo(), click())
 
-        // verify that since the first item in the shipment tracking list has a tracking link, the popup item count = 2
+        // verify that since the first item in the shipment tracking list has a tracking link, the popup item count = 3
         onView(ViewMatchers.isAssignableFrom(ListView::class.java))
-                .check(matches(WCMatchers.withItemCount(2)))
+                .check(matches(WCMatchers.withItemCount(3)))
 
-        // verify that the popup menu is displayed & the first item in the list is Track shipment
+        // verify that the popup menu is displayed & the first item in the list is Copy shipment
+        onView(withText(appContext.getString(R.string.orderdetail_copy_tracking_number)))
+                .inRoot(RootMatchers.isPlatformPopup()).check(matches(ViewMatchers.isDisplayed()))
+
+        // verify that the popup menu is displayed & the second item in the list is Track shipment
         onView(withText(appContext.getString(R.string.orderdetail_track_shipment)))
                 .inRoot(RootMatchers.isPlatformPopup()).check(matches(ViewMatchers.isDisplayed()))
 
-        // verify that the popup menu is displayed & the second item in the list is Delete shipment
+        // verify that the popup menu is displayed & the third item in the list is Delete shipment
         onView(withText(appContext.getString(R.string.orderdetail_delete_tracking)))
                 .inRoot(RootMatchers.isPlatformPopup()).check(matches(ViewMatchers.isDisplayed()))
     }
@@ -217,9 +221,13 @@ class OrderDetailShipmentTrackingCardTest : TestBase() {
 
         // verify that since the first item in the shipment tracking list has a tracking link, the popup item count = 2
         onView(ViewMatchers.isAssignableFrom(ListView::class.java))
-                .check(matches(WCMatchers.withItemCount(1)))
+                .check(matches(WCMatchers.withItemCount(2)))
 
-        // verify that the popup menu is displayed & the first item in the list is Delete shipment
+        // verify that the popup menu is displayed & the first item in the list is Copy tracking number
+        onView(withText(appContext.getString(R.string.orderdetail_copy_tracking_number)))
+                .inRoot(RootMatchers.isPlatformPopup()).check(matches(ViewMatchers.isDisplayed()))
+
+        // verify that the popup menu is displayed & the second item in the list is Delete shipment
         onView(withText(appContext.getString(R.string.orderdetail_delete_tracking)))
                 .inRoot(RootMatchers.isPlatformPopup()).check(matches(ViewMatchers.isDisplayed()))
     }
@@ -235,7 +243,7 @@ class OrderDetailShipmentTrackingCardTest : TestBase() {
         onView(withId(R.id.ordersList))
                 .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
 
-        // verify that the Hamburger icon button for first item is clicked and popup is opened
+        // verify that the Hamburger icon button for second item is clicked and popup is opened
         onView(withRecyclerView(R.id.shipmentTrack_items).atPositionOnView(0, R.id.tracking_btnTrack))
                 .perform(WCMatchers.scrollTo(), click())
 
@@ -244,13 +252,10 @@ class OrderDetailShipmentTrackingCardTest : TestBase() {
                 .inRoot(RootMatchers.isPlatformPopup()).perform(click())
 
         // check if webview intent is opened for the given url
-        Intents.intended(
-                CoreMatchers.allOf(
+        Intents.intended(CoreMatchers.allOf(
                         IntentMatchers.hasAction(Intent.ACTION_VIEW), IntentMatchers.hasData(
-                        mockShipmentTrackingList[0].trackingLink
-                )
-                )
-        )
+                        mockShipmentTrackingList[0].trackingLink)
+                ))
     }
 
     @Test
@@ -267,6 +272,32 @@ class OrderDetailShipmentTrackingCardTest : TestBase() {
         // click on the shipment tracking item - this should copy the text to clipboard
         onView(withRecyclerView(R.id.shipmentTrack_items).atPositionOnView(0, R.id.tracking_copyNumber))
                 .perform(WCMatchers.scrollTo(), click())
+
+        // tests are failing in devices below api 27 when getting clipboard text without handler
+        Handler(Looper.getMainLooper()).post {
+            val clipboardText = WCHelperUtils.getClipboardText(appContext)
+            Assert.assertEquals(mockShipmentTrackingList[0].trackingNumber, clipboardText)
+        }
+    }
+
+    @Test
+    fun verifyShipmentTrackingItemPopupItemClickCopiesToClipboard() {
+        activityTestRule.setOrderDetailWithMockData(
+                order = mockWCOrderModel,
+                orderShipmentTrackings = mockShipmentTrackingList
+        )
+
+        // click on the first order in the list and check if redirected to order detail
+        onView(withId(R.id.ordersList))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(1, click()))
+
+        // verify that the Hamburger icon button for first item is clicked and popup is opened
+        onView(withRecyclerView(R.id.shipmentTrack_items).atPositionOnView(0, R.id.tracking_btnTrack))
+                .perform(WCMatchers.scrollTo(), click())
+
+        // click on the popup menu item "Track shipment"
+        onView(withText(appContext.getString(R.string.orderdetail_copy_tracking_number)))
+                .inRoot(RootMatchers.isPlatformPopup()).perform(click())
 
         // tests are failing in devices below api 27 when getting clipboard text without handler
         Handler(Looper.getMainLooper()).post {

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragmentTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragmentTest.kt
@@ -17,10 +17,13 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.whenever
 import com.woocommerce.android.R
 import com.woocommerce.android.helpers.WCMatchers
 import com.woocommerce.android.ui.TestBase
 import com.woocommerce.android.ui.main.MainActivityTestRule
+import com.woocommerce.android.ui.main.getOrderDetailFragment
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.equalToIgnoringCase
 import org.junit.Before
@@ -133,6 +136,10 @@ class OrderFulfillmentFragmentTest : TestBase() {
 
         // verify that fulfill button is hidden
         onView(withId(R.id.productList_btnFulfill)).check(matches(withEffectiveVisibility(GONE)))
+
+        // mock network available
+        val orderDetailFragment = activityTestRule.getOrderDetailFragment()
+        doReturn(true).whenever(orderDetailFragment?.networkStatus)?.isConnected()
 
         // verify undo snackbar is displayed and swipe to dismiss it
         onView(withId(com.google.android.material.R.id.snackbar_text))


### PR DESCRIPTION
Fixes #1282 . This tiny PR fixes the following UI tests:
- `OrderDetailShipmentTrackingCardTest.verifyShipmentTrackingItemPopupDisplayedSuccessfully`
-`OrderDetailShipmentTrackingCardTest.verifyShipmentTrackingItemPopupItemDisplayedSuccessfullyIfTrackingLinkNotAvailable()`
- `OrderFulfillmentFragmentTest.markOrderCompleteWhenNetworkAvailableResponseError()`

### Changes:
- The hamburger menu in shipment tracking card has 3 list items and not 2, since we included logic to copy tracking number as part of the menu item. The UI tests are fixed to handle this change. Also added a new UI test to test that the tracking number is copied when the `Copy Tracking number` list item is selected.
- Fixed the `markOrderCompleteWhenNetworkAvailableResponseError()` test case failing by adding logic to mock `networkStatus` of `OrderDetailFragment` when running the test. 

### Testing:
- Run all the UI tests in `com.woocommerce.android.ui.orders` package.
