### PR TITLE
Fix tracks connected info property naming

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -402,13 +402,24 @@ public class LoginSiteAddressFragment extends LoginBaseFormFragment<LoginListene
             // TODO: If we plan to keep this logic we should convert these labels to constants
             HashMap<String, String> properties = new HashMap<>();
             properties.put("url", event.info.url);
-            properties.put("urlAfterRedirects", event.info.urlAfterRedirects);
+            properties.put("url_after_redirects", event.info.urlAfterRedirects);
             properties.put("exists", Boolean.toString(event.info.exists));
-            properties.put("hasJetpack", Boolean.toString(event.info.hasJetpack));
-            properties.put("isJetpackActive", Boolean.toString(event.info.isJetpackActive));
-            properties.put("isJetpackConnected", Boolean.toString(event.info.isJetpackConnected));
-            properties.put("isWordPress", Boolean.toString(event.info.isWordPress));
-            properties.put("isWPCom", Boolean.toString(event.info.isWPCom));
+            properties.put("has_jetpack", Boolean.toString(event.info.hasJetpack));
+            properties.put("is_jetpack_active", Boolean.toString(event.info.isJetpackActive));
+            properties.put("is_jetpack_connected", Boolean.toString(event.info.isJetpackConnected));
+            properties.put("is_wordpress", Boolean.toString(event.info.isWordPress));
+            properties.put("is_wp_com", Boolean.toString(event.info.isWPCom));
+
+            // Determining if jetpack is actually installed takes additional logic. This final
+            // calculated event property will make querying this event more straight-forward:
+            boolean hasJetpack = false;
+            if (event.info.isWPCom && event.info.hasJetpack) {
+                // This is likely an atomic site.
+                hasJetpack = true;
+            } else if (event.info.hasJetpack && event.info.isJetpackActive && event.info.isJetpackConnected) {
+                hasJetpack = true;
+            }
+            properties.put("login_calculated_has_jetpack", Boolean.toString(hasJetpack));
             mAnalyticsListener.trackConnectedSiteInfoSucceeded(properties);
 
             if (!event.info.exists) {
@@ -418,13 +429,6 @@ public class LoginSiteAddressFragment extends LoginBaseFormFragment<LoginListene
                 // Not a WordPress site
                 showError(R.string.enter_wordpress_site);
             } else {
-                boolean hasJetpack = false;
-                if (event.info.isWPCom && event.info.hasJetpack) {
-                    // This is likely an atomic site.
-                    hasJetpack = true;
-                } else if (event.info.hasJetpack && event.info.isJetpackActive && event.info.isJetpackConnected) {
-                    hasJetpack = true;
-                }
                 mLoginListener.gotConnectedSiteInfo(event.info.url, hasJetpack);
             }
         }


### PR DESCRIPTION
Fixes #1284 by renaming the event properties for  `LOGIN_CONNECTED_SITE_INFO_SUCCEEDED` to conform to the tracks property naming convention. Also added a new property called `login_calculated_has_jetpack` to make it easier to report on whether or not jetpack is active and connected since determining that requires looking at several properties.

Logcat event:
```
Tracked: login_connected_site_info_succeeded, Properties: {"is_wp_com":"false","has_jetpack":"true","is_wordpress":"true","login_calculated_has_jetpack":"true","is_jetpack_active":"true","url_after_redirects":"http:\/\/testwooshop.mystagingwebsite.com","exists":"true","is_jetpack_connected":"true","url":"testwooshop.mystagingwebsite.com"}
```

I already verified in Tracks the new events are properly being saved, so the reviewer need only approve and merge :)

![Screen Shot 2019-07-26 at 11 08 27 AM](https://user-images.githubusercontent.com/5810477/61968662-d16bc680-af95-11e9-916a-6b3f6cdb11e7.png)


This fix has been built off of the `2.2` release tag in the hopes that we can get it released as a hotfix.

cc: @jkmassel  @loremattei 