### PR TITLE
Add translated open source licenses html files

### DIFF
--- a/WooCommerce/src/main/res/raw-ar/licenses.html
+++ b/WooCommerce/src/main/res/raw-ar/licenses.html
@@ -1,0 +1,43 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <style>
+      body {
+        margin: 28px;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>WooCommerce لنظام التشغيل Android</h2>
+
+    <p>كود المصدر المتاح من
+    <a href="https://github.com/woocommerce/">github.com/woocommerce</a>.</p>
+
+    <p>تم إصدار WooCommerce لنظام التشغيل Android بموجب شروط <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html">GNU GPL v2</a>.</p>
+
+    <h3>المكتبات الإضافية</h3>
+
+    <p>أصبح WooCommerce لنظام التشغيل Android ممكنًا بمساعدة العديد من المكتبات الرائعة مفتوحة المصدر!</p>
+
+    <p>تم ترخيص المكتبات التالية بموجب <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache v2</a>:</p>
+
+    <ul>
+      <li><a href="https://github.com/greenrobot/EventBus">EventBus</a>: Copyright 2012-2016 Markus Junginger, greenrobot</li>
+      <li><a href="https://github.com/google/dagger">Dagger</a>: Copyright 2012 The Dagger Authors</li>
+      <li><a href="https://github.com/PhilJay/MPAndroidChart">MPAndroidChart</a>: Copyright 2018 Philipp Jahoda</li>
+      <li><a href="https://github.com/bumptech/glide">Glide</a>: Copyright 2014 Google, Inc.</li>
+      <li><a href="https://github.com/googlei18n/libaddressinput">libaddressinput</a>: Copyright 2014 Google, Inc.</li>
+    </ul>
+
+    <p>وفيما يلي التبعية الوحيدة المرخصة لدينا لنظام التشغيل BSD:</p>
+    <ul>
+        <li><a href="https://github.com/facebook/shimmer-android">Shimmer</a>: Copyright 2015, Facebook, Inc.</li>
+    </ul>
+
+    <p>الأرصدة الإضافية:</p>
+    <ul>
+      <li><a href="https://freesound.org/people/Zott820/sounds/209578/">Cash register sound‏</a> ("cha-ching") بواسطة CapsLok المُعاد خلطه للحصول على عمق إضافي بواسطة Zott820</li>
+    </ul>
+
+  </body>
+</html>

--- a/WooCommerce/src/main/res/raw-de/licenses.html
+++ b/WooCommerce/src/main/res/raw-de/licenses.html
@@ -1,0 +1,43 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <style>
+      body {
+        margin: 28px;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>WooCommerce für Android</h2>
+
+    <p>Quellcode verfügbar von
+    <a href="https://github.com/woocommerce/">github.com/woocommerce</a>.</p>
+
+    <p>WooCommerce für Android wird unter der GNU <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html">General Public License (GPL) Version 2</a> herausgegeben.</p>
+
+    <h3>Weitere Bibliotheken</h3>
+
+    <p>WooCommerce für Android wird ermöglicht durch eine Reihe wunderbarer Open-Source-Bibliotheken!</p>
+
+    <p>Die folgenden Bibliotheken sind unter <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache Version 2.0</a> lizenziert:</p>
+
+    <ul>
+      <li><a href="https://github.com/greenrobot/EventBus">EventBus</a>: Copyright 2012–2016 Markus Junginger, greenrobot</li>
+      <li><a href="https://github.com/google/dagger">Dagger</a>: Copyright 2012 The Dagger Authors</li>
+      <li><a href="https://github.com/PhilJay/MPAndroidChart">MPAndroidChart</a>: Copyright 2018 Philipp Jahoda</li>
+      <li><a href="https://github.com/bumptech/glide">Glide</a>: Copyright 2014 Google, Inc.</li>
+      <li><a href="https://github.com/googlei18n/libaddressinput">libaddressinput</a>: Copyright 2014 Google, Inc.</li>
+    </ul>
+
+    <p>Unsere einzige Abhängigkeit unter BSD-Lizenz:</p>
+    <ul>
+        <li><a href="https://github.com/facebook/shimmer-android">Shimmer</a>: Copyright 2015, Facebook, Inc.</li>
+    </ul>
+
+    <p>Weitere Verdienste:</p>
+    <ul>
+      <li><a href="https://freesound.org/people/Zott820/sounds/209578/">Kassengeräusch</a> („Ka-Ching“) von CapsLok, für eine besondere Klangtiefe neu gemischt von Zott820</li>
+    </ul>
+
+  </body>
+</html>

--- a/WooCommerce/src/main/res/raw-es/licenses.html
+++ b/WooCommerce/src/main/res/raw-es/licenses.html
@@ -1,0 +1,43 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <style>
+      body {
+        margin: 28px;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>WooCommerce para Android</h2>
+
+    <p>Código fuente disponible en
+    <a href="https://github.com/woocommerce/">github.com/woocommerce</a>.</p>
+
+    <p>WooCommerce para Android se publica según las condiciones de la licencia <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html">GPL v2</a> de GNU.</p>
+
+    <h3>Bibliotecas adicionales</h3>
+
+    <p>WooCommerce para Android es posible gracias a la ayuda de muchas bibliotecas de código abierto fantásticas.</p>
+
+    <p>Las siguientes bibliotecas están bajo licencia de <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache v2</a>:</p>
+
+    <ul>
+      <li><a href="https://github.com/greenrobot/EventBus">EventBus</a>: Derechos de autor 2012-2016 de Markus Junginger, greenrobot</li>
+      <li><a href="https://github.com/google/dagger">Dagger</a>: Derechos de autor 2012 The Dagger Authors</li>
+      <li><a href="https://github.com/PhilJay/MPAndroidChart">MPAndroidChart</a>: Derechos de autor 2018 Philipp Jahoda</li>
+      <li><a href="https://github.com/bumptech/glide">Glide</a>: Derechos de autor 2014 Google, Inc.</li>
+      <li><a href="https://github.com/googlei18n/libaddressinput">libaddressinput</a>: Derechos de autor 2014 Google, Inc.</li>
+    </ul>
+
+    <p>Y esta es nuestra única dependencia con licencia BSD:</p>
+    <ul>
+        <li><a href="https://github.com/facebook/shimmer-android">Shimmer</a>: Derechos de autor 2015, Facebook, Inc.</li>
+    </ul>
+
+    <p>Créditos adicionales:</p>
+    <ul>
+      <li><a href="https://freesound.org/people/Zott820/sounds/209578/">Sonido de caja registradora</a> ("Clinc, caja") de CapsLok remezclado para una mayor profundidad por Zott820</li>
+    </ul>
+
+  </body>
+</html>

--- a/WooCommerce/src/main/res/raw-fr/licenses.html
+++ b/WooCommerce/src/main/res/raw-fr/licenses.html
@@ -1,0 +1,43 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <style>
+      body {
+        margin: 28px;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>WooCommerce pour Android</h2>
+
+    <p>Code source disponible sur
+    <a href="https://github.com/woocommerce/">github.com/woocommerce</a>.</p>
+
+    <p>WooCommerce pour Android est soumis aux conditions d’utilisation de GNU <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html">GPL v2</a>.</p>
+
+    <h3>Bibliothèques supplémentaires</h3>
+
+    <p>WooCommerce pour Android existe grâce à de nombreuses et fantastiques bibliothèques Open Source !</p>
+
+    <p>Les bibliothèques suivantes sont soumises à la licence <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache v2</a>:</p>
+
+    <ul>
+      <li><a href="https://github.com/greenrobot/EventBus">EventBus</a>: Copyright 2012-2016 Markus Junginger, greenrobot</li>
+      <li><a href="https://github.com/google/dagger">Dagger</a>: Copyright 2012 The Dagger Authors</li>
+      <li><a href="https://github.com/PhilJay/MPAndroidChart">MPAndroidChart</a>: Copyright 2018 Philipp Jahoda</li>
+      <li><a href="https://github.com/bumptech/glide">Glide</a>: Copyright 2014 Google, Inc.</li>
+      <li><a href="https://github.com/googlei18n/libaddressinput">libaddressinput</a>: Copyright 2014 Google, Inc.</li>
+    </ul>
+
+    <p>And here's our lone BSD licensed dependency:</p>
+    <ul>
+        <li><a href="https://github.com/facebook/shimmer-android">Shimmer</a>: Copyright 2015, Facebook, Inc.</li>
+    </ul>
+
+    <p>Additional credits:</p>
+    <ul>
+      <li><a href="https://freesound.org/people/Zott820/sounds/209578/">Son de caisse enregistreuse</a> (« cha-ching ») par CapsLok remixé par Zott820</li>
+    </ul>
+
+  </body>
+</html>

--- a/WooCommerce/src/main/res/raw-he/licenses.html
+++ b/WooCommerce/src/main/res/raw-he/licenses.html
@@ -1,0 +1,43 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <style>
+      body {
+        margin: 28px;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>WooCommerce ל-Android</h2>
+
+    <p>קוד המקור זמין מאתר
+    <a href="https://github.com/woocommerce/">github.com/woocommerce</a>.</p>
+
+    <p>WooCommerce ל-Android מפורסם בהתאם לתנאים של GNU <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html">GPL v2</a>‎.</p>
+
+    <h3>ספריות נוספות</h3>
+
+    <p>הפעילות של WooCommerce ל-Android מתאפשרת בעזרת ספריות רבות ומצוינות שעובדות עם קוד פתוח!</p>
+
+    <p>לספריות הבאות יש רישיון מאת <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache v2</a>:</p>
+
+    <ul>
+      <li><a href="https://github.com/greenrobot/EventBus">EventBus</a>: זכויות יוצרים 2012-2016‏ Markus Junginger, greenrobot</li>
+      <li><a href="https://github.com/google/dagger">Dagger</a>: זכויות יוצרים 2012 The Dagger Authors</li>
+      <li><a href="https://github.com/PhilJay/MPAndroidChart">MPAndroidChart</a>: זכויות יוצרים 2018 Philipp Jahoda</li>
+      <li><a href="https://github.com/bumptech/glide">Glide</a>: זכויות יוצרים 2014 Google, Inc.</li>
+      <li><a href="https://github.com/googlei18n/libaddressinput">libaddressinput</a>: זכויות יוצרים 2014 Google, Inc.</li>
+    </ul>
+
+    <p>ולהלן התלות עם רישיון BSD בודד שבה אנחנו משתמשים:</p>
+    <ul>
+        <li><a href="https://github.com/facebook/shimmer-android">Shimmer</a>: זכויות יוצרים 2015, Facebook, Inc.</li>
+    </ul>
+
+    <p>משתתפים נוספים:</p>
+    <ul>
+      <li><a href="https://freesound.org/people/Zott820/sounds/209578/">אפקט הסאונד של הקופה</a> ("צ'ה-צ'ינג") מאתCapsLok עם רמיקס לעומק נוסף מאת Zott820</li>
+    </ul>
+
+  </body>
+</html>

--- a/WooCommerce/src/main/res/raw-id/licenses.html
+++ b/WooCommerce/src/main/res/raw-id/licenses.html
@@ -1,0 +1,43 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <style>
+      body {
+        margin: 28px;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>WooCommerce untuk Android</h2>
+
+    <p>Kode sumber tersedia di
+    <a href="https://github.com/woocommerce/">github.com/woocommerce</a>.</p>
+
+    <p>WooCommerce untuk Android dirilis dengan ketentuan dari GNU <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html">GPL v2</a>.</p>
+
+    <h3>Pustaka Tambahan</h3>
+
+    <p>WooCommerce untuk Android hadir berkat bantuan dari sejumlah pustaka sumber terbuka yang luar biasa!</p>
+
+    <p>Pustaka berikut memiliki lisensi dari <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache v2</a>:</p>
+
+    <ul>
+      <li><a href="https://github.com/greenrobot/EventBus">EventBus</a>: Hak Cipta 2012-2016 Markus Junginger, greenrobot</li>
+      <li><a href="https://github.com/google/dagger">Dagger</a>: Hak Cipta 2012 The Dagger Authors</li>
+      <li><a href="https://github.com/PhilJay/MPAndroidChart">MPAndroidChart</a>: Hak Cipta 2018 Philipp Jahoda</li>
+      <li><a href="https://github.com/bumptech/glide">Glide</a>: Hak Cipta 2014 Google, Inc.</li>
+      <li><a href="https://github.com/googlei18n/libaddressinput">libaddressinput</a>: Hak Cipta 2014 Google, Inc.</li>
+    </ul>
+
+    <p>Dan berikut ini adalah dependensi kami dengan lisensi BSD tersendiri:</p>
+    <ul>
+        <li><a href="https://github.com/facebook/shimmer-android">Shimmer</a>: Hak Cipta 2015, Facebook, Inc.</li>
+    </ul>
+
+    <p>Kredit tambahan:</p>
+    <ul>
+      <li><a href="https://freesound.org/people/Zott820/sounds/209578/">Suara mesin kasir</a> ("cha-ching") oleh CapsLok, di-remix untuk kedalaman tambahan oleh Zott820</li>
+    </ul>
+
+  </body>
+</html>

--- a/WooCommerce/src/main/res/raw-it/licenses.html
+++ b/WooCommerce/src/main/res/raw-it/licenses.html
@@ -1,0 +1,43 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <style>
+      body {
+        margin: 28px;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>WooCommerce per Android</h2>
+
+    <p>Codice sorgente disponibile su
+    <a href="https://github.com/woocommerce/">github.com/woocommerce</a>.</p>
+
+    <p>WooCommerce per Android viene rilasciato conformemente ai termini di GNU <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html">GPL v2</a>.</p>
+
+    <h3>Librerie aggiuntive</h3>
+
+    <p>WooCommerce per Android è reso possibile dal contributo di numerose fantastiche librerie open source.</p>
+
+    <p>Le seguenti librerie sono dotate della licenza <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache v2</a>:</p>
+
+    <ul>
+      <li><a href="https://github.com/greenrobot/EventBus">EventBus</a>: copyright 2012-2016 Markus Junginger, greenrobot</li>
+      <li><a href="https://github.com/google/dagger">Dagger</a>: copyright 2012 The Dagger Authors</li>
+      <li><a href="https://github.com/PhilJay/MPAndroidChart">MPAndroidChart</a>: copyright 2018 Philipp Jahoda</li>
+      <li><a href="https://github.com/bumptech/glide">Glide</a>: copyright 2014 Google, Inc.</li>
+      <li><a href="https://github.com/googlei18n/libaddressinput">libaddressinput</a>: copyright 2014 Google, Inc.</li>
+    </ul>
+
+    <p>Inoltre, ecco la nostra sola dipendenza con licenza BSD:</p>
+    <ul>
+        <li><a href="https://github.com/facebook/shimmer-android">Shimmer</a>: copyright 2015, Facebook, Inc.</li>
+    </ul>
+
+    <p>Ulteriori meriti:</p>
+    <ul>
+      <li><a href="https://freesound.org/people/Zott820/sounds/209578/">Suono di registratore di cassa</a> ("cha-ching") di CapsLok remixato per maggiore profondità da Zott820</li>
+    </ul>
+
+  </body>
+</html>

--- a/WooCommerce/src/main/res/raw-ja/licenses.html
+++ b/WooCommerce/src/main/res/raw-ja/licenses.html
@@ -1,0 +1,43 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <style>
+      body {
+        margin: 28px;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>WooCommerce for Android</h2>
+
+    <p>ソースコードは、
+<a href="https://github.com/woocommerce/">github.com/woocommerce</a> から取得できます。</p>
+
+    <p>WooCommerce for Android は GNU <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html">GPL v2</a>の規約に準拠してリリースされています。</p>
+
+    <h3>追加ライブラリ</h3>
+
+    <p>WooCommerce for Android の実現には、多数のすばらしいソースライブラリの貢献がありました。</p>
+
+    <p>次のライブラリは、<a href="http://www.apache.org/licenses/LICENSE-2.0">Apache v2</a>に準拠してライセンスが提供されています。</p>
+
+    <ul>
+      <li><a href="https://github.com/greenrobot/EventBus">EventBus</a>:Copyright 2012-2016 Markus Junginger, greenrobot</li>
+      <li><a href="https://github.com/google/dagger">Dagger</a>:Copyright 2012 The Dagger Authors</li>
+      <li><a href="https://github.com/PhilJay/MPAndroidChart">MPAndroidChart</a>:Copyright 2018 Philipp Jahoda</li>
+      <li><a href="https://github.com/bumptech/glide">Glide</a>:Copyright 2014 Google, Inc.</li>
+      <li><a href="https://github.com/googlei18n/libaddressinput">libaddressinput</a>:Copyright 2014 Google, Inc.</li>
+    </ul>
+
+    <p>また、唯一 BSD ライセンスで依存しているソフトウェアは、次のとおりです。</p>
+    <ul>
+        <li><a href="https://github.com/facebook/shimmer-android">Shimmer</a>:Copyright 2015, Facebook, Inc.</li>
+    </ul>
+
+    <p>追加クレジット:</p>
+    <ul>
+      <li>CapsLok による<a href="https://freesound.org/people/Zott820/sounds/209578/">キャッシュレジスターの効果音</a> ("cha-ching") には、Zott820によるリミックスで奥行きが加えられています。</li>
+    </ul>
+
+  </body>
+</html>

--- a/WooCommerce/src/main/res/raw-ko/licenses.html
+++ b/WooCommerce/src/main/res/raw-ko/licenses.html
@@ -1,0 +1,43 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <style>
+      body {
+        margin: 28px;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>Android용 WooCommerce</h2>
+
+    <p>소스 코드 출처는
+    <a href="https://github.com/woocommerce/">github.com/woocommerce</a>입니다.</p>
+
+    <p>Android용 WooCommerce 출시는 GNU <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html">GPL v2</a> 약관을 따릅니다.</p>
+
+    <h3>추가 라이브러리</h3>
+
+    <p>Android용 WooCommerce가 있으면 다양하고 멋진 오픈 소스 라이브러리를 활용할 수 있습니다!</p>
+
+    <p>다음 라이브러리는 <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache v2</a> 라이선스를 받았습니다.</p>
+
+    <ul>
+      <li><a href="https://github.com/greenrobot/EventBus">EventBus</a>: Copyright 2012-2016 Markus Junginger, greenrobot</li>
+      <li><a href="https://github.com/google/dagger">Dagger</a>: Copyright 2012 The Dagger Authors</li>
+      <li><a href="https://github.com/PhilJay/MPAndroidChart">MPAndroidChart</a>: Copyright 2018 Philipp Jahoda</li>
+      <li><a href="https://github.com/bumptech/glide">Glide</a>: Copyright 2014 Google, Inc.</li>
+      <li><a href="https://github.com/googlei18n/libaddressinput">libaddressinput</a>: Copyright 2014 Google, Inc.</li>
+    </ul>
+
+    <p>다음은 워드프레스 단독 BSD 라이선스된 종속성입니다.</p>
+    <ul>
+        <li><a href="https://github.com/facebook/shimmer-android">Shimmer</a>: Copyright 2015, Facebook, Inc.</li>
+    </ul>
+
+    <p>추가 크레딧:</p>
+    <ul>
+      <li>Zott820가 더욱 깊이 있게 리믹스한 CapsLok의 <a href="https://freesound.org/people/Zott820/sounds/209578/">Cash 등록 사운드</a>("cha-ching")</li>
+    </ul>
+
+  </body>
+</html>

--- a/WooCommerce/src/main/res/raw-nl/licenses.html
+++ b/WooCommerce/src/main/res/raw-nl/licenses.html
@@ -1,0 +1,43 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <style>
+      body {
+        margin: 28px;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>WooCommerce voor Android</h2>
+
+    <p>Sourcecode beschikbaar via
+    <a href="https://github.com/woocommerce/">github.com/woocommerce</a>.</p>
+
+    <p>WooCommerce voor Android is uitgebracht onder de voorwaarden van de GNU <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html">GPL v2</a>.</p>
+
+    <h3>Aanvullende bibliotheken</h3>
+
+    <p>WooCommerce voor Android is mogelijk gemaakt dankzij veel fantastische opensource bibliotheken!</p>
+
+    <p>De volgende bibliotheken zijn gelicentieerd onder <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache v2</a>:</p>
+
+    <ul>
+      <li><a href="https://github.com/greenrobot/EventBus">EventBus</a>: Copyright 2012-2016 Markus Junginger, greenrobot</li>
+      <li><a href="https://github.com/google/dagger">Dagger</a>: Copyright 2012 The Dagger Authors</li>
+      <li><a href="https://github.com/PhilJay/MPAndroidChart">MPAndroidChart</a>: Copyright 2018 Philipp Jahoda</li>
+      <li><a href="https://github.com/bumptech/glide">Glide</a>: Copyright 2014 Google, Inc.</li>
+      <li><a href="https://github.com/googlei18n/libaddressinput">libaddressinput</a>: Copyright 2014 Google, Inc.</li>
+    </ul>
+
+    <p>En dit is onze enige BSD-gelicentieerde afhankelijkheid:</p>
+    <ul>
+        <li><a href="https://github.com/facebook/shimmer-android">Shimmer</a>: Copyright 2015, Facebook, Inc.</li>
+    </ul>
+
+    <p>Aanvullende vermeldingen:</p>
+    <ul>
+      <li><a href="https://freesound.org/people/Zott820/sounds/209578/">Geluid kassa</a> ('cha-ching') van CapsLok, geremixt voor een diepere klank door Zott820</li>
+    </ul>
+
+  </body>
+</html>

--- a/WooCommerce/src/main/res/raw-pt-rBR/licenses.html
+++ b/WooCommerce/src/main/res/raw-pt-rBR/licenses.html
@@ -1,0 +1,43 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <style>
+      body {
+        margin: 28px;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>WooCommerce para Android</h2>
+
+    <p>Código-fonte disponível em
+    <a href="https://github.com/woocommerce/">github.com/woocommerce</a>.</p>
+
+    <p>O WooCommerce para Android foi lançado de acordo com os termos do GNU <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html">GPL v2</a>.</p>
+
+    <h3>Bibliotecas adicionais</h3>
+
+    <p>O WooCommerce para Android só foi possível graças a ajuda de muitas bibliotecas fantásticas de código aberto!</p>
+
+    <p>As seguintes bibliotecas estão licenciadas de acordo com o <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache v2</a>:</p>
+
+    <ul>
+      <li><a href="https://github.com/greenrobot/EventBus">EventBus</a>: Copyright 2012-2016 Markus Junginger, greenrobot</li>
+      <li><a href="https://github.com/google/dagger">Dagger</a>: Copyright 2012 The Dagger Authors</li>
+      <li><a href="https://github.com/PhilJay/MPAndroidChart">MPAndroidChart</a>: Copyright 2018 Philipp Jahoda</li>
+      <li><a href="https://github.com/bumptech/glide">Glide</a>: Copyright 2014 Google, Inc.</li>
+      <li><a href="https://github.com/googlei18n/libaddressinput">libaddressinput</a>: Copyright 2014 Google, Inc.</li>
+    </ul>
+
+    <p>E aqui está nossa única dependência licenciada pela BSD:</p>
+    <ul>
+        <li><a href="https://github.com/facebook/shimmer-android">Shimmer</a>: Copyright 2015, Facebook, Inc.</li>
+    </ul>
+
+    <p>Créditos adicionais:</p>
+    <ul>
+      <li><a href="https://freesound.org/people/Zott820/sounds/209578/">Som de caixa registradora</a> ("cha-ching") de CapsLok remixada para maior densidade por Zott820</li>
+    </ul>
+
+  </body>
+</html>

--- a/WooCommerce/src/main/res/raw-ru/licenses.html
+++ b/WooCommerce/src/main/res/raw-ru/licenses.html
@@ -1,0 +1,43 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <style>
+      body {
+        margin: 28px;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>WooCommerce для Android</h2>
+
+    <p>Исходный код доступен на странице
+    <a href="https://github.com/woocommerce/">github.com/woocommerce</a>.</p>
+
+    <p>WooCommerce для Android выпускается в соответствии с условиями GNU <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html">GPL v2</a>.</p>
+
+    <h3>Дополнительные библиотеки</h3>
+
+    <p>Приложение WooCommerce для Android создано на базе множества невероятных библиотек с открытым исходным кодом.</p>
+
+    <p>Следующие библиотеки лицензируются в соответствии с <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache v2</a>:</p>
+
+    <ul>
+      <li><a href="https://github.com/greenrobot/EventBus">EventBus</a>: © 2012–2016 Markus Junginger, greenrobot</li>
+      <li><a href="https://github.com/google/dagger">Dagger</a>: © 2012 The Dagger Authors</li>
+      <li><a href="https://github.com/PhilJay/MPAndroidChart">MPAndroidChart</a>: © 2018 Philipp Jahoda</li>
+      <li><a href="https://github.com/bumptech/glide">Glide</a>: © 2014 Google, Inc.</li>
+      <li><a href="https://github.com/googlei18n/libaddressinput">libaddressinput</a>: © 2014 Google, Inc.</li>
+    </ul>
+
+    <p>Наша единственная библиотека на базе лицензии BSD:</p>
+    <ul>
+        <li><a href="https://github.com/facebook/shimmer-android">Shimmer</a>: © 2015, Facebook, Inc.</li>
+    </ul>
+
+    <p>Дополнительные авторы:</p>
+    <ul>
+      <li><a href="https://freesound.org/people/Zott820/sounds/209578/">Звук кассового аппарата</a> (сыплющиеся монеты) от CapsLok в аранжировке Zott820 для добавления глубины звука</li>
+    </ul>
+
+  </body>
+</html>

--- a/WooCommerce/src/main/res/raw-sv/licenses.html
+++ b/WooCommerce/src/main/res/raw-sv/licenses.html
@@ -1,0 +1,43 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <style>
+      body {
+        margin: 28px;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>WooCommerce för Android</h2>
+
+    <p>Källkoden är tillgänglig från
+    <a href="https://github.com/woocommerce/">github.com/woocommerce</a>.</p>
+
+    <p>WooCommerce för Android släpps under villkoren i GNU <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html">GPL v2</a>.</p>
+
+    <h3>Ytterligare bibliotek</h3>
+
+    <p>WooCommerce för Android görs möjlig med hjälp av många fantastiska bibliotek med öppen källkod!</p>
+
+    <p>Följande bibliotek licensieras under <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache v2</a>:</p>
+
+    <ul>
+      <li><a href="https://github.com/greenrobot/EventBus">EventBus</a>: Copyright 2012-2016 Markus Junginger, greenrobot</li>
+      <li><a href="https://github.com/google/dagger">Dagger</a>: Copyright 2012 The Dagger Authors</li>
+      <li><a href="https://github.com/PhilJay/MPAndroidChart">MPAndroidChart</a>: Copyright 2018 Philipp Jahoda</li>
+      <li><a href="https://github.com/bumptech/glide">Glide</a>: Copyright 2014 Google, Inc.</li>
+      <li><a href="https://github.com/googlei18n/libaddressinput">libaddressinput</a>: Copyright 2014 Google, Inc.</li>
+    </ul>
+
+    <p>Och här är vårt enda BSD-licensierade beroende:</p>
+    <ul>
+        <li><a href="https://github.com/facebook/shimmer-android">Shimmer</a>: Copyright 2015, Facebook, Inc.</li>
+    </ul>
+
+    <p>Ytterligare medverkande:</p>
+    <ul>
+      <li><a href="https://freesound.org/people/Zott820/sounds/209578/">Kassaljudet</a> ("cha-ching") av CapsLok remixat för mer djup av Zott820</li>
+    </ul>
+
+  </body>
+</html>

--- a/WooCommerce/src/main/res/raw-tr/licenses.html
+++ b/WooCommerce/src/main/res/raw-tr/licenses.html
@@ -1,0 +1,43 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <style>
+      body {
+        margin: 28px;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>Android için WooCommerce</h2>
+
+    <p>Kaynak kod için:
+    <a href="https://github.com/woocommerce/">github.com/woocommerce</a>.</p>
+
+    <p>Android için WooCommerce GNU <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html">GPL v2</a> koşulları altında yayımlanır.</p>
+
+    <h3>Ek Kitaplıklar</h3>
+
+    <p>Android için WooCommerce olağanüstü özelliklere sahip birçok açık kaynak kitaplığının yardımıyla oluşturulmuştur!</p>
+
+    <p>Aşağıdaki kitaplıklar <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache v2</a> altında lisanslanır:</p>
+
+    <ul>
+      <li><a href="https://github.com/greenrobot/EventBus">EventBus</a>: Telif Hakkı 2012-2016 Markus Junginger, greenrobot</li>
+      <li><a href="https://github.com/google/dagger">Dagger</a>: Telif Hakkı 2012 The Dagger Authors</li>
+      <li><a href="https://github.com/PhilJay/MPAndroidChart">MPAndroidChart</a>: Telif Hakkı 2018 Philipp Jahoda</li>
+      <li><a href="https://github.com/bumptech/glide">Glide</a>: Telif Hakkı 2014 Google, Inc.</li>
+      <li><a href="https://github.com/googlei18n/libaddressinput">libaddressinput</a>: Telif Hakkı 2014 Google, Inc.</li>
+    </ul>
+
+    <p>Tek BSD lisanslı bağımlı öğemiz:</p>
+    <ul>
+        <li><a href="https://github.com/facebook/shimmer-android">Shimmer</a>: Telif Hakkı 2015, Facebook, Inc.</li>
+    </ul>
+
+    <p>Ek bilgiler:</p>
+    <ul>
+      <li>CapsLok’un hazırladığı <a href="https://freesound.org/people/Zott820/sounds/209578/">yazar kasa sesi</a> ("ça-çing") ekstra derinlik için Zott820 tarafından remikslenmiştir</li>
+    </ul>
+
+  </body>
+</html>

--- a/WooCommerce/src/main/res/raw-zh-rCN/licenses.html
+++ b/WooCommerce/src/main/res/raw-zh-rCN/licenses.html
@@ -1,0 +1,43 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <style>
+      body {
+        margin: 28px;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>Android 版 WooCommerce</h2>
+
+    <p>可从
+<a href="https://github.com/woocommerce/">github.com/woocommerce</a> 获取源代码。</p>
+
+    <p>Android 版 WooCommerce 是根据 GNU <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html">GPL v2</a> 条款发布的。</p>
+
+    <h3>更多库</h3>
+
+    <p>Android 版 WooCommerce 是借重许多出色的开源库打造而成的！</p>
+
+    <p>以下库拥有 <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache v2</a> 许可：</p>
+
+    <ul>
+      <li><a href="https://github.com/greenrobot/EventBus">EventBus</a>：版权所有 2012-2016 Markus Junginger, greenrobot</li>
+      <li><a href="https://github.com/google/dagger">Dagger</a>：版权所有 2012 The Dagger Authors</li>
+      <li><a href="https://github.com/PhilJay/MPAndroidChart">MPAndroidChart</a>：版权所有 2018 Philipp Jahoda</li>
+      <li><a href="https://github.com/bumptech/glide">Glide</a>：版权所有 2014 Google, Inc.</li>
+      <li><a href="https://github.com/googlei18n/libaddressinput">libaddressinput</a>：版权所有 2014 Google, Inc.</li>
+    </ul>
+
+    <p>以下是我们依赖的唯一 BSD 许可：</p>
+    <ul>
+        <li><a href="https://github.com/facebook/shimmer-android">Shimmer</a>：版权所有 2015, Facebook, Inc.</li>
+    </ul>
+
+    <p>其他鸣谢：</p>
+    <ul>
+      <li>由 Zott820 提供的经 CapsLok 混音实现的深度增加的<a href="https://freesound.org/people/Zott820/sounds/209578/">收银机音效</a>（“cha-ching”）</li>
+    </ul>
+
+  </body>
+</html>

--- a/WooCommerce/src/main/res/raw-zh-rTW/licenses.html
+++ b/WooCommerce/src/main/res/raw-zh-rTW/licenses.html
@@ -1,0 +1,43 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <style>
+      body {
+        margin: 28px;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>Android 版 WooCommerce</h2>
+
+    <p>原始程式碼可從以下網站取得：
+<a href="https://github.com/woocommerce/">github.com/woocommerce</a>.</p>
+
+    <p>Android 版 WooCommerce 係依據 GNU <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html">GPL v2</a>　條款而發行。</p>
+
+    <h3>其他媒體櫃</h3>
+
+    <p>Android 版 WooCommerce 能夠發行，完全得益於以下出色的開放原始碼媒體庫！</p>
+
+    <p>以下媒體庫已獲 <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache v2</a> 授權：</p>
+
+    <ul>
+      <li><a href="https://github.com/greenrobot/EventBus">EventBus</a>：版權所有 2012-2016 Markus Junginger, greenrobot</li>
+      <li><a href="https://github.com/google/dagger">Dagger</a>：版權所有 2012 The Dagger Authors</li>
+      <li><a href="https://github.com/PhilJay/MPAndroidChart">MPAndroidChart</a>：版權所有 2018 Philipp Jahoda</li>
+      <li><a href="https://github.com/bumptech/glide">Glide</a>：版權所有 2014 Google, Inc.</li>
+      <li><a href="https://github.com/googlei18n/libaddressinput">libaddressinput</a>：版權所有 2014 Google, Inc.</li>
+    </ul>
+
+    <p>以下是我們唯一的BSD 授權相依性：</p>
+    <ul>
+        <li><a href="https://github.com/facebook/shimmer-android">Shimmer</a>：版權所有 2015, Facebook, Inc.</li>
+    </ul>
+
+    <p>其他點數：</p>
+    <ul>
+      <li>CapsLok 的<a href="https://freesound.org/people/Zott820/sounds/209578/">收銀機音效</a> (「cha-ching」)，由 Zott820 重新混音，讓音效更有深度</li>
+    </ul>
+
+  </body>
+</html>


### PR DESCRIPTION
As part of fixing #909, this PR adds translated HTML files for the open source licences page. 