### PR TITLE
Issue/1255 runtime exception

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * The Notifications tab has been replaced by Reviews 
 * The unfulfilled order count has been removed from the dashboard and is now shown as a badge on the order list
 * Added support to update the app without even going to the play store.
+* Fixed rare crash after fulfilling an order and then minimizing the app.
  
 2.3
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,9 +1,12 @@
+2.5
+-----
+* Fixed rare crash after fulfilling an order and then minimizing the app.
+
 2.4
 -----
 * The Notifications tab has been replaced by Reviews 
 * The unfulfilled order count has been removed from the dashboard and is now shown as a badge on the order list
 * Added support to update the app without even going to the play store.
-* Fixed rare crash after fulfilling an order and then minimizing the app.
  
 2.3
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.app.ProgressDialog
 import android.content.Intent
 import android.os.Bundle
-import android.os.Handler
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
@@ -39,8 +38,8 @@ import com.woocommerce.android.ui.main.BottomNavigationPosition.ORDERS
 import com.woocommerce.android.ui.main.BottomNavigationPosition.REVIEWS
 import com.woocommerce.android.ui.notifications.NotifsListFragment
 import com.woocommerce.android.ui.notifications.ReviewDetailFragmentDirections
-import com.woocommerce.android.ui.orders.OrderDetailFragment
 import com.woocommerce.android.ui.orders.OrderDetailFragmentDirections
+import com.woocommerce.android.ui.orders.OrderDetailPresenter.MarkOrderCompleteEvent
 import com.woocommerce.android.ui.orders.OrderListFragment
 import com.woocommerce.android.ui.prefs.AppSettingsActivity
 import com.woocommerce.android.ui.products.ProductDetailFragmentDirections
@@ -57,6 +56,7 @@ import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.support.HasSupportFragmentInjector
 import kotlinx.android.synthetic.main.activity_main.*
+import org.greenrobot.eventbus.EventBus
 import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.login.LoginAnalyticsListener
@@ -664,16 +664,9 @@ class MainActivity : AppUpgradeActivity(),
             }
 
             // if we're marking the order as complete, we need to pop the backstack to the existing order
-            // detail fragment and tell it to load the updated order
+            // detail and fire an event to tell its presenter to mark it complete
             if (navController.popBackStack(R.id.orderDetailFragment, false)) {
-                // hack alert: we have to wait for the navController to execute the transaction, otherwise
-                // the active child fragment may be the order fulfillment fragment
-                Handler().postDelayed({
-                    (getActiveChildFragment() as? OrderDetailFragment)?.presenter?.loadOrderDetail(
-                            orderId,
-                            true
-                    )
-                }, 100)
+                EventBus.getDefault().postSticky(MarkOrderCompleteEvent(orderId))
             } else {
                 navController.navigate(action)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.util.WooLog.T.NOTIFICATIONS
+import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.greenrobot.eventbus.ThreadMode.MAIN
@@ -69,6 +70,8 @@ class OrderDetailPresenter @Inject constructor(
     companion object {
         private val TAG: String = OrderDetailPresenter::class.java.simpleName
     }
+
+    class MarkOrderCompleteEvent(val orderId: OrderIdentifier)
 
     override var orderModel: WCOrderModel? = null
     override var orderIdentifier: OrderIdentifier? = null
@@ -452,6 +455,14 @@ class OrderDetailPresenter @Inject constructor(
                 }
             }
         }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN, sticky = true)
+    fun onEventMainThread(event: MarkOrderCompleteEvent) {
+        // this event is posted by the main activity after the user chooses to fulfill an order
+        EventBus.getDefault().removeStickyEvent(event)
+        loadOrderDetail(event.orderId, true)
     }
 
     @SuppressWarnings("unused")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -303,7 +303,7 @@ class OrderDetailPresenter @Inject constructor(
     fun onOrderChanged(event: OnOrderChanged) {
         if (event.causeOfChange == WCOrderAction.FETCH_SINGLE_ORDER) {
             if (event.isError || (orderIdentifier.isNullOrBlank() && pendingRemoteOrderId == null)) {
-                WooLog.e(T.ORDERS, "$TAG - Error fetching order : ${event.error.message}")
+                WooLog.e(T.ORDERS, "$TAG - Error fetching order : ${event.error?.message}")
                 orderView?.showLoadOrderError()
             } else {
                 orderModel = loadOrderDetailFromDb(orderIdentifier!!)


### PR DESCRIPTION
Fixes #1255 - this crash was difficult to figure out (it took three of us to do it!) but appears to have been the result of popping the backstack to remove the existing order detail fragment and then immediately opening a new order detail fragment. This PR resolves this by _not_ removing the existing fragment and instead relying on an `EventBus` event to tell the existing fragment to mark the order complete.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
