### PR TITLE
issue/1255-runtime-exception-take2

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+2.5
+-----
+* Fixed rare crash after fulfilling an order and then minimizing the app.
+
 2.4
 -----
 * The Notifications tab has been replaced by Reviews 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -100,7 +100,11 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
         val didMarkComplete = arguments?.getBoolean(ARG_DID_MARK_COMPLETE) ?: false
         val markComplete = navArgs.markComplete && !didMarkComplete
         if (markComplete) {
-            arguments = Bundle().also { it.putBoolean(ARG_DID_MARK_COMPLETE, true) }
+            arguments?.putBoolean(ARG_DID_MARK_COMPLETE, true) ?: run {
+                arguments = Bundle().also {
+                    it.putBoolean(ARG_DID_MARK_COMPLETE, true)
+                }
+            }
         }
 
         val orderIdentifier = navArgs.orderId


### PR DESCRIPTION
Fixes #1255 (take two) - as mentioned by @AmandaRiu [here](https://github.com/woocommerce/woocommerce-android/pull/1297#issuecomment-516560889) the cause of this crash turned out to be simple -  so simple it took three of us hours to figure it out :)

The PR implements the fix. To test:

* Have "Don't keep activities" enabled
* Fulfill an order
* Minimize the app
* Restore the app

Prior to this PR, following those steps would result in a crash.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
