### PR TITLE
Issue/1299 bottom nav background

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -7,6 +7,7 @@ import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentManager
 import com.google.android.material.bottomnavigation.BottomNavigationItemView
 import com.google.android.material.bottomnavigation.BottomNavigationMenuView
@@ -17,8 +18,8 @@ import com.woocommerce.android.R
 import com.woocommerce.android.extensions.active
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.main.BottomNavigationPosition.DASHBOARD
-import com.woocommerce.android.ui.main.BottomNavigationPosition.REVIEWS
 import com.woocommerce.android.ui.main.BottomNavigationPosition.ORDERS
+import com.woocommerce.android.ui.main.BottomNavigationPosition.REVIEWS
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
 
@@ -55,6 +56,7 @@ class MainBottomNavigationView @JvmOverloads constructor(
         this.listener = listener
 
         navAdapter = NavAdapter()
+        addTopDivider()
 
         // set up the bottom bar and add the badge views
         val menuView = getChildAt(0) as BottomNavigationMenuView
@@ -62,7 +64,7 @@ class MainBottomNavigationView @JvmOverloads constructor(
 
         val ordersItemView = menuView.getChildAt(ORDERS.position) as BottomNavigationItemView
         ordersBadgeView = inflater.inflate(R.layout.order_badge_view, menuView, false)
-        ordersBadgeTextView = ordersBadgeView.findViewById<TextView>(R.id.textOrderCount)
+        ordersBadgeTextView = ordersBadgeView.findViewById(R.id.textOrderCount)
         ordersItemView.addView(ordersBadgeView)
 
         val notifsItemView = menuView.getChildAt(REVIEWS.position) as BottomNavigationItemView
@@ -73,6 +75,23 @@ class MainBottomNavigationView @JvmOverloads constructor(
 
         // Default to the dashboard position
         active(DASHBOARD.position)
+    }
+
+    /**
+     * When we changed the background to white, the top shadow provided by BottomNavigationView wasn't
+     * dark enough to provide enough separation between the bar and the content above it. For this
+     * reason we add a darker top divider here.
+     */
+    private fun addTopDivider() {
+        val divider = View(context)
+        val dividerColor = ContextCompat.getColor(context, R.color.list_divider)
+        divider.setBackgroundColor(dividerColor)
+
+        val dividerHeight = resources.getDimensionPixelSize(R.dimen.bottomm_nav_top_border)
+        val dividerParams = LayoutParams(LayoutParams.MATCH_PARENT, dividerHeight)
+        divider.layoutParams = dividerParams
+
+        addView(divider)
     }
 
     fun getFragment(navPos: BottomNavigationPosition): TopLevelFragment = navAdapter.getFragment(navPos)

--- a/WooCommerce/src/main/res/drawable/badge_notifs.xml
+++ b/WooCommerce/src/main/res/drawable/badge_notifs.xml
@@ -4,5 +4,5 @@
     <solid android:color="@color/wc_purple"/>
     <stroke
         android:width="1dp"
-        android:color="@color/white"/>
+        android:color="@color/bottomBar_bg"/>
 </shape>

--- a/WooCommerce/src/main/res/drawable/badge_orders.xml
+++ b/WooCommerce/src/main/res/drawable/badge_orders.xml
@@ -18,6 +18,6 @@
 
     <stroke
         android:width="1dp"
-        android:color="@color/white" />
+        android:color="@color/bottomBar_bg" />
 
 </shape>

--- a/WooCommerce/src/main/res/layout/activity_main.xml
+++ b/WooCommerce/src/main/res/layout/activity_main.xml
@@ -59,7 +59,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:background="@color/bottomBar_bg"
-        app:elevation="4dp"
+        app:elevation="8dp"
         app:itemIconTint="@drawable/selector_bottom_navbar"
         app:itemTextColor="@drawable/selector_bottom_navbar"
         app:menu="@menu/menu_bottom_bar"

--- a/WooCommerce/src/main/res/values/colors.xml
+++ b/WooCommerce/src/main/res/values/colors.xml
@@ -88,7 +88,7 @@
         Bottom Navigation Bar
     -->
     <!-- Bar Background color -->
-    <color name="bottomBar_bg">@color/wc_grey_lightest</color>
+    <color name="bottomBar_bg">@color/white</color>
     <!-- Option icon/text color when NOT selected -->
     <color name="bottomBar_fg_normal">@color/wc_grey_darker</color>
     <!-- Option icon/text color when selected -->

--- a/WooCommerce/src/main/res/values/dimens.xml
+++ b/WooCommerce/src/main/res/values/dimens.xml
@@ -22,9 +22,10 @@
     <dimen name="default_padding_tablet">16dp</dimen>
 
     <!--
-        Appbar
+        Appbar and bottom navigation
     -->
     <dimen name="appbar_elevation">4dp</dimen>
+    <dimen name="bottomm_nav_top_border">1dp</dimen>
 
     <!--
         Default Card


### PR DESCRIPTION
Closes #1299 - As per design, the bottom navigation is changed to solid white. Note that this seemingly simple task had me on a wild goose chase because after changing the color, the top border on the bottom nav was so light it provided very little separation between it and the content above it.

In the end I gave up trying to figure out why this was happening and simply added my own top broder.

![Screenshot_1564600849](https://user-images.githubusercontent.com/3903757/62241548-5c3e2e00-b3a7-11e9-8585-1ba57257938f.png)


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
