### PR TITLE
issue/1306-order-detail-product-names

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.5
 -----
 * Fixed rare crash after fulfilling an order and then minimizing the app.
+* Product names can now wrap to two lines in order detail.
 
 2.4
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
@@ -38,7 +38,9 @@ class OrderDetailProductItemView @JvmOverloads constructor(
         productInfo_productTotal.visibility = viewMode
         productInfo_totalTax.visibility = viewMode
         productInfo_lblTax.visibility = viewMode
-        productInfo_name.setSingleLine(!expanded)
+
+        val maxLinesInName = if (expanded) Int.MAX_VALUE else 2
+        productInfo_name.maxLines = maxLinesInName
 
         if (item.sku.isNullOrEmpty() || !expanded) {
             productInfo_lblSku.visibility = View.GONE

--- a/WooCommerce/src/main/res/layout/order_detail_product_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_product_item.xml
@@ -35,7 +35,6 @@
         android:ellipsize="end"
         android:paddingEnd="8dp"
         android:paddingStart="0dp"
-        android:singleLine="true"
         android:textAppearance="@style/Woo.OrderDetail.TextAppearance.Heading"
         app:layout_constrainedWidth="true"
         app:layout_constraintBaseline_toBaselineOf="@+id/productInfo_qty"


### PR DESCRIPTION
Fixes #1306 - Allows the product name to wrap to two lines in unexpanded order detail. As before, when expanded there is no limit.

![Screenshot_1564601904](https://user-images.githubusercontent.com/3903757/62242674-ac1df480-b3a9-11e9-9a52-418511276602.png)


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
