### PR TITLE
issue/1310-order-detail-npe

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -303,7 +303,8 @@ class OrderDetailPresenter @Inject constructor(
     fun onOrderChanged(event: OnOrderChanged) {
         if (event.causeOfChange == WCOrderAction.FETCH_SINGLE_ORDER) {
             if (event.isError || (orderIdentifier.isNullOrBlank() && pendingRemoteOrderId == null)) {
-                WooLog.e(T.ORDERS, "$TAG - Error fetching order : ${event.error.message}")
+                val message = event.error?.message ?: "empty orderIdentifier"
+                WooLog.e(T.ORDERS, "$TAG - Error fetching order : $message")
                 orderView?.showLoadOrderError()
             } else {
                 orderModel = loadOrderDetailFromDb(orderIdentifier!!)


### PR DESCRIPTION
Fixes #1310 - the code [here](https://github.com/woocommerce/woocommerce-android/blob/901614da0311091b398409bd0ac6a7fe48d79362/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt#L306) could cause a crash because we access `error.message` when `error` has the potential to be null. This PR resolves it.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
