### PR TITLE
Stats Improvements Step 1: Added UI to support the new stats v4 api

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -20,7 +20,7 @@ object AppPrefs {
     private enum class DeletablePrefKey : PrefKey {
         SUPPORT_EMAIL,
         SUPPORT_NAME,
-        IS_USING_V3_API,
+        IS_USING_V4_API,
         HAS_UNSEEN_NOTIFS,
         SELECTED_SHIPMENT_TRACKING_PROVIDER_NAME,
         SELECTED_SHIPMENT_TRACKING_PROVIDER_IS_CUSTOM,
@@ -94,9 +94,9 @@ object AppPrefs {
         remove(DeletablePrefKey.SUPPORT_NAME)
     }
 
-    fun isUsingV3Api() = getBoolean(DeletablePrefKey.IS_USING_V3_API, false)
+    fun isUsingV4Api() = getBoolean(DeletablePrefKey.IS_USING_V4_API, false)
 
-    fun setIsUsingV3Api() = setBoolean(DeletablePrefKey.IS_USING_V3_API, true)
+    fun setIsUsingV4Api(isUsingV4Api: Boolean) = setBoolean(DeletablePrefKey.IS_USING_V4_API, isUsingV4Api)
 
     fun isCrashReportingEnabled(): Boolean {
         // default to False for debug builds

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ActivityBindingModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ActivityBindingModule.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.MagicLinkInterceptActivity
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainModule
+import com.woocommerce.android.ui.mystore.MyStoreModule
 import com.woocommerce.android.ui.notifications.NotifsListModule
 import com.woocommerce.android.ui.notifications.ReviewDetailModule
 import com.woocommerce.android.ui.orders.AddOrderNoteModule
@@ -33,6 +34,7 @@ abstract class ActivityBindingModule {
     @ContributesAndroidInjector(modules = arrayOf(
             MainModule::class,
             DashboardModule::class,
+            MyStoreModule::class,
             OrderListModule::class,
             OrderDetailModule::class,
             OrderProductListModule::class,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StatsGranularityExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StatsGranularityExt.kt
@@ -1,0 +1,18 @@
+package com.woocommerce.android.extensions
+
+import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
+import org.wordpress.android.fluxc.utils.DateUtils
+
+/**
+ * TEMP CODE: Method returns the start date for visitor stats based on the [StatsGranularity]
+ * This is just a temp method till we remove support for the old version.
+ * Then the date ranges for visitor stats can be modified in FluxC and this method can be removed
+ */
+fun StatsGranularity.getVisitorStatsStartDate(): String {
+    return when (this) {
+        StatsGranularity.DAYS -> DateUtils.getStartOfCurrentDay()
+        StatsGranularity.WEEKS -> DateUtils.getFirstDayOfCurrentWeek()
+        StatsGranularity.MONTHS -> DateUtils.getFirstDayOfCurrentMonth()
+        StatsGranularity.YEARS -> DateUtils.getFirstDayOfCurrentYear()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.extensions.onScrollUp
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.util.CurrencyFormatter
 import dagger.android.support.AndroidSupportInjection
@@ -71,6 +72,9 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
                 setOnRefreshListener {
                     // Track the user gesture
                     AnalyticsTracker.track(Stat.DASHBOARD_PULLED_TO_REFRESH)
+
+                    // check for new revenue stats availability
+                    (activity as? MainActivity)?.fetchRevenueStatsAvailability(selectedSite.get())
 
                     DashboardPresenter.resetForceRefresh()
                     dashboard_refresh_layout.isRefreshing = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/BottomNavigationPosition.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/BottomNavigationPosition.kt
@@ -1,8 +1,10 @@
 package com.woocommerce.android.ui.main
 
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.dashboard.DashboardFragment
+import com.woocommerce.android.ui.mystore.MyStoreFragment
 import com.woocommerce.android.ui.notifications.NotifsListFragment
 import com.woocommerce.android.ui.orders.OrderListFragment
 
@@ -20,13 +22,39 @@ fun findNavigationPositionById(id: Int): BottomNavigationPosition = when (id) {
 }
 
 fun BottomNavigationPosition.getTag(): String = when (this) {
-    BottomNavigationPosition.DASHBOARD -> DashboardFragment.TAG
+    BottomNavigationPosition.DASHBOARD -> getMyStoreTag()
     BottomNavigationPosition.ORDERS -> OrderListFragment.TAG
     BottomNavigationPosition.REVIEWS -> NotifsListFragment.TAG
 }
 
 fun BottomNavigationPosition.createFragment(): TopLevelFragment = when (this) {
-    BottomNavigationPosition.DASHBOARD -> DashboardFragment.newInstance()
+    BottomNavigationPosition.DASHBOARD -> createMyStoreFragment()
     BottomNavigationPosition.ORDERS -> OrderListFragment.newInstance()
     BottomNavigationPosition.REVIEWS -> NotifsListFragment.newInstance()
+}
+
+/**
+ * Temp method that returns
+ * [DashboardFragment] if v4 stats api is not supported for the site
+ * [MyStoreFragment] if v4 stats api is supported for the site
+ */
+private fun createMyStoreFragment(): TopLevelFragment {
+    return if (AppPrefs.isUsingV4Api()) {
+        MyStoreFragment.newInstance()
+    } else {
+        DashboardFragment.newInstance()
+    }
+}
+
+/**
+ * Temp method that returns
+ * [DashboardFragment.TAG] if v4 stats api is not supported for the site
+ * [MyStoreFragment.TAG] if v4 stats api is supported for the site
+ */
+private fun getMyStoreTag(): String {
+    return if (AppPrefs.isUsingV4Api()) {
+        MyStoreFragment.TAG
+    } else {
+        DashboardFragment.TAG
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -38,7 +38,6 @@ import com.woocommerce.android.ui.main.BottomNavigationPosition.ORDERS
 import com.woocommerce.android.ui.main.BottomNavigationPosition.REVIEWS
 import com.woocommerce.android.ui.mystore.MyStoreFragment
 import com.woocommerce.android.ui.mystore.RevenueStatsAvailabilityFetcher
-import com.woocommerce.android.ui.notifications.NotifsListFragment
 import com.woocommerce.android.ui.notifications.ReviewDetailFragmentDirections
 import com.woocommerce.android.ui.orders.OrderDetailFragmentDirections
 import com.woocommerce.android.ui.orders.OrderListFragment

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -255,11 +255,7 @@ class MainActivity : AppUpgradeActivity(),
      * Returns the current top level fragment (ie: the one showing in the bottom nav)
      */
     private fun getActiveTopLevelFragment(): TopLevelFragment? {
-        val tag = when (bottomNavView.currentPosition) {
-            DASHBOARD -> DashboardFragment.TAG
-            ORDERS -> OrderListFragment.TAG
-            REVIEWS -> NotifsListFragment.TAG
-        }
+        val tag = bottomNavView.currentPosition.getTag()
         return supportFragmentManager.findFragmentByTag(tag) as? TopLevelFragment
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -512,6 +512,9 @@ class MainActivity : AppUpgradeActivity(),
      *
      * if revenue stats v4 support is NOT available but we are currently displaying the v4 stats UI,
      * display an error snackbar to the user with the option to unload the v4 and display the old stats UI
+     *
+     * This implementation is on hold till we can finalise on the design interaction.
+     *
      */
     override fun updateStatsView(isAvailable: Boolean) {
         val fragment = bottomNavView.getFragment(DASHBOARD)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -142,6 +142,25 @@ class MainBottomNavigationView @JvmOverloads constructor(
         listener.onNavItemReselected(navPos)
     }
 
+    /**
+     * Replaces the fragment in [DASHBOARD] based on whether the revenue stats is available.
+     * This method is not used so far and is added to support future implementations when we would need to
+     * add support for switching between the two new versions of stats
+     */
+    fun replaceMyStoreFragment() {
+        val fragment = fragmentManager.findFragment(currentPosition)
+        val tag = currentPosition.getTag()
+
+        // replace the fragment
+        fragmentManager.beginTransaction()
+                .replace(R.id.container, fragment, tag)
+                .show(fragment)
+                .commitAllowingStateLoss()
+
+        // update the correct fragment in the navigation adapter
+        navAdapter.replaceFragment(currentPosition, fragment)
+    }
+
     private fun updateCurrentPosition(navPos: BottomNavigationPosition, deferInit: Boolean = false) {
         assignNavigationListeners(false)
         try {
@@ -199,6 +218,9 @@ class MainBottomNavigationView @JvmOverloads constructor(
             fragments.put(navPos.position, fragment)
             return fragment
         }
+
+        internal fun replaceFragment(navPos: BottomNavigationPosition, fragment: TopLevelFragment) =
+                fragments.put(navPos.position, fragment)
     }
     // endregion
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainContract.kt
@@ -32,5 +32,7 @@ interface MainContract {
         fun hideOrderBadge()
         fun showOrderBadge(count: Int)
         fun updateOrderBadge(hideCountUntilComplete: Boolean)
+        fun fetchRevenueStatsAvailability(site: SiteModel)
+        fun updateStatsView(isAvailable: Boolean)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.push.NotificationHandler.NotificationsUnseenChang
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.tools.ProductImageMap.RequestFetchProductEvent
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.mystore.RevenueStatsAvailabilityFetcher.RevenueStatsAvailabilityChangeEvent
 import com.woocommerce.android.util.WooLog
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -218,5 +219,11 @@ class MainPresenter @Inject constructor(
     fun onEventMainThread(event: RequestFetchProductEvent) {
         val payload = WCProductStore.FetchSingleProductPayload(event.site, event.remoteProductId)
         dispatcher.dispatch(WCProductActionBuilder.newFetchSingleProductAction(payload))
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onEventMainThread(event: RevenueStatsAvailabilityChangeEvent) {
+        mainView?.updateStatsView(event.available)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreContract.kt
@@ -1,0 +1,36 @@
+package com.woocommerce.android.ui.mystore
+
+import com.woocommerce.android.ui.base.BasePresenter
+import com.woocommerce.android.ui.base.BaseView
+import org.wordpress.android.fluxc.model.WCRevenueStatsModel
+import org.wordpress.android.fluxc.model.WCTopEarnerModel
+import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
+
+interface MyStoreContract {
+    interface Presenter : BasePresenter<View> {
+        fun loadStats(granularity: StatsGranularity, forced: Boolean = false)
+        fun loadTopEarnerStats(granularity: StatsGranularity, forced: Boolean = false)
+        fun getStatsCurrency(): String?
+        fun fetchHasOrders()
+        fun fetchRevenueStats(granularity: StatsGranularity, forced: Boolean)
+        fun fetchVisitorStats(granularity: StatsGranularity, forced: Boolean)
+        fun fetchTopEarnerStats(granularity: StatsGranularity, forced: Boolean)
+    }
+
+    interface View : BaseView<Presenter> {
+        var isRefreshPending: Boolean
+
+        fun refreshMyStoreStats(forced: Boolean = false)
+        fun showStats(revenueStatsModel: WCRevenueStatsModel?, granularity: StatsGranularity)
+        fun showStatsError(granularity: StatsGranularity)
+        fun showTopEarners(topEarnerList: List<WCTopEarnerModel>, granularity: StatsGranularity)
+        fun showTopEarnersError(granularity: StatsGranularity)
+        fun showVisitorStats(visits: Int, granularity: StatsGranularity)
+        fun showVisitorStatsError(granularity: StatsGranularity)
+        fun showErrorSnack()
+        fun showEmptyView(show: Boolean)
+
+        fun showChartSkeleton(show: Boolean)
+        fun showTopEarnersSkeleton(show: Boolean)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreContract.kt
@@ -23,6 +23,7 @@ interface MyStoreContract {
         fun refreshMyStoreStats(forced: Boolean = false)
         fun showStats(revenueStatsModel: WCRevenueStatsModel?, granularity: StatsGranularity)
         fun showStatsError(granularity: StatsGranularity)
+        fun updateStatsAvailabilityError()
         fun showTopEarners(topEarnerList: List<WCTopEarnerModel>, granularity: StatsGranularity)
         fun showTopEarnersError(granularity: StatsGranularity)
         fun showVisitorStats(visits: Int, granularity: StatsGranularity)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -16,7 +16,6 @@ import com.woocommerce.android.extensions.onScrollUp
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.mystore.MyStoreContract.Presenter
 import com.woocommerce.android.ui.dashboard.DashboardStatsListener
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainNavigationRouter
@@ -42,7 +41,7 @@ class MyStoreFragment : TopLevelFragment(),
         val DEFAULT_STATS_GRANULARITY = StatsGranularity.DAYS
     }
 
-    @Inject lateinit var presenter: Presenter
+    @Inject lateinit var presenter: MyStoreContract.Presenter
     @Inject lateinit var selectedSite: SelectedSite
     @Inject lateinit var currencyFormatter: CurrencyFormatter
     @Inject lateinit var uiMessageResolver: UIMessageResolver
@@ -92,21 +91,20 @@ class MyStoreFragment : TopLevelFragment(),
 
         savedInstanceState?.let { bundle ->
             isRefreshPending = bundle.getBoolean(STATE_KEY_REFRESH_PENDING, false)
-            dashboard_stats.tabStateStats = bundle.getSerializable(STATE_KEY_TAB_STATS)
-            dashboard_top_earners.tabStateStats = bundle.getSerializable(STATE_KEY_TAB_EARNERS)
+            my_store_stats.tabStateStats = bundle.getSerializable(STATE_KEY_TAB_STATS)
+            my_store_top_earners.tabStateStats = bundle.getSerializable(STATE_KEY_TAB_EARNERS)
         }
 
         presenter.takeView(this)
 
         empty_view.setSiteToShare(selectedSite.get(), Stat.DASHBOARD_SHARE_YOUR_STORE_BUTTON_TAPPED)
 
-        dashboard_stats.initView(
-                dashboard_stats.activeGranularity,
+        my_store_stats.initView(
+                my_store_stats.activeGranularity,
                 listener = this,
                 selectedSite = selectedSite,
                 formatCurrencyForDisplay = currencyFormatter::formatCurrencyRounded)
-        dashboard_top_earners.initView(
-                dashboard_top_earners.activeGranularity,
+        my_store_top_earners.initView(
                 listener = this,
                 selectedSite = selectedSite,
                 formatCurrencyForDisplay = currencyFormatter::formatCurrencyRounded)
@@ -163,8 +161,8 @@ class MyStoreFragment : TopLevelFragment(),
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         outState.putBoolean(STATE_KEY_REFRESH_PENDING, isRefreshPending)
-        outState.putSerializable(STATE_KEY_TAB_STATS, dashboard_stats.activeGranularity)
-        outState.putSerializable(STATE_KEY_TAB_EARNERS, dashboard_top_earners.activeGranularity)
+        outState.putSerializable(STATE_KEY_TAB_STATS, my_store_stats.activeGranularity)
+        outState.putSerializable(STATE_KEY_TAB_EARNERS, my_store_stats.activeGranularity)
     }
 
     override fun showStats(
@@ -172,49 +170,49 @@ class MyStoreFragment : TopLevelFragment(),
         granularity: StatsGranularity
     ) {
         // Only update the order stats view if the new stats match the currently selected timeframe
-        if (dashboard_stats.activeGranularity == granularity) {
-            dashboard_stats.showErrorView(false)
-            dashboard_stats.updateView(revenueStatsModel, presenter.getStatsCurrency())
+        if (my_store_stats.activeGranularity == granularity) {
+            my_store_stats.showErrorView(false)
+            my_store_stats.updateView(revenueStatsModel, presenter.getStatsCurrency())
         }
     }
 
     override fun showStatsError(granularity: StatsGranularity) {
-        if (dashboard_stats.activeGranularity == granularity) {
+        if (my_store_stats.activeGranularity == granularity) {
             showStats(null, granularity)
-            dashboard_stats.showErrorView(true)
+            my_store_stats.showErrorView(true)
             showErrorSnack()
         }
     }
 
     override fun showTopEarners(topEarnerList: List<WCTopEarnerModel>, granularity: StatsGranularity) {
-        if (dashboard_top_earners.activeGranularity == granularity) {
-            dashboard_top_earners.showErrorView(false)
-            dashboard_top_earners.updateView(topEarnerList)
+        if (my_store_stats.activeGranularity == granularity) {
+            my_store_top_earners.showErrorView(false)
+            my_store_top_earners.updateView(topEarnerList)
         }
     }
 
     override fun showTopEarnersError(granularity: StatsGranularity) {
-        if (dashboard_top_earners.activeGranularity == granularity) {
-            dashboard_top_earners.updateView(emptyList())
-            dashboard_top_earners.showErrorView(true)
+        if (my_store_stats.activeGranularity == granularity) {
+            my_store_top_earners.updateView(emptyList())
+            my_store_top_earners.showErrorView(true)
             showErrorSnack()
         }
     }
 
     override fun showVisitorStats(visits: Int, granularity: StatsGranularity) {
-        if (dashboard_stats.activeGranularity == granularity) {
-            dashboard_stats.showVisitorStats(visits)
+        if (my_store_stats.activeGranularity == granularity) {
+            my_store_stats.showVisitorStats(visits)
         }
     }
 
     override fun showVisitorStatsError(granularity: StatsGranularity) {
-        if (dashboard_stats.activeGranularity == granularity) {
-            dashboard_stats.showVisitorStatsError()
+        if (my_store_stats.activeGranularity == granularity) {
+            my_store_stats.showVisitorStatsError()
         }
     }
 
     override fun showErrorSnack() {
-        if (errorSnackbar?.isShownOrQueued() == true) {
+        if (errorSnackbar?.isShownOrQueued == true) {
             return
         }
         errorSnackbar = uiMessageResolver.getSnack(R.string.dashboard_stats_error)
@@ -252,11 +250,11 @@ class MyStoreFragment : TopLevelFragment(),
             isActive -> {
                 isRefreshPending = false
                 if (forced) {
-                    dashboard_stats.clearLabelValues()
-                    dashboard_stats.clearChartData()
+                    my_store_stats.clearLabelValues()
+                    my_store_stats.clearChartData()
                 }
-                presenter.loadStats(dashboard_stats.activeGranularity, forced)
-                presenter.loadTopEarnerStats(dashboard_top_earners.activeGranularity, forced)
+                presenter.loadStats(my_store_stats.activeGranularity, forced)
+                presenter.loadTopEarnerStats(my_store_stats.activeGranularity, forced)
                 presenter.fetchHasOrders()
             }
             else -> isRefreshPending = true
@@ -264,20 +262,21 @@ class MyStoreFragment : TopLevelFragment(),
     }
 
     override fun showChartSkeleton(show: Boolean) {
-        dashboard_stats.showSkeleton(show)
+        my_store_stats.showSkeleton(show)
     }
 
     override fun showTopEarnersSkeleton(show: Boolean) {
-        dashboard_top_earners.showSkeleton(show)
+        my_store_top_earners.showSkeleton(show)
     }
 
     override fun onRequestLoadStats(period: StatsGranularity) {
-        dashboard_stats.showErrorView(false)
+        my_store_stats.showErrorView(false)
         presenter.loadStats(period)
+        my_store_top_earners.loadTopEarnerStats(period)
     }
 
     override fun onRequestLoadTopEarnerStats(period: StatsGranularity) {
-        dashboard_top_earners.showErrorView(false)
+        my_store_top_earners.showErrorView(false)
         presenter.loadTopEarnerStats(period)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.mystore.MyStoreContract.Presenter
 import com.woocommerce.android.ui.dashboard.DashboardStatsListener
+import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.util.CurrencyFormatter
 import dagger.android.support.AndroidSupportInjection
@@ -76,6 +77,9 @@ class MyStoreFragment : TopLevelFragment(),
                 setOnRefreshListener {
                     // Track the user gesture
                     AnalyticsTracker.track(Stat.DASHBOARD_PULLED_TO_REFRESH)
+
+                    // check for new revenue stats availability
+                    (activity as? MainActivity)?.fetchRevenueStatsAvailability(selectedSite.get())
 
                     MyStorePresenter.resetForceRefresh()
                     dashboard_refresh_layout.isRefreshing = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -78,9 +78,6 @@ class MyStoreFragment : TopLevelFragment(),
                     // Track the user gesture
                     AnalyticsTracker.track(Stat.DASHBOARD_PULLED_TO_REFRESH)
 
-                    // check for new revenue stats availability
-                    (activity as? MainActivity)?.fetchRevenueStatsAvailability(selectedSite.get())
-
                     MyStorePresenter.resetForceRefresh()
                     dashboard_refresh_layout.isRefreshing = false
                     refreshMyStoreStats(forced = true)
@@ -222,6 +219,10 @@ class MyStoreFragment : TopLevelFragment(),
         }
         errorSnackbar = uiMessageResolver.getSnack(R.string.dashboard_stats_error)
         errorSnackbar?.show()
+    }
+
+    override fun updateStatsAvailabilityError() {
+        (activity as? MainActivity)?.updateStatsView(false)
     }
 
     override fun getFragmentTitle(): String {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -1,0 +1,286 @@
+package com.woocommerce.android.ui.mystore
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.core.widget.NestedScrollView
+import com.google.android.material.snackbar.Snackbar
+import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.extensions.onScrollDown
+import com.woocommerce.android.extensions.onScrollUp
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.base.TopLevelFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.mystore.MyStoreContract.Presenter
+import com.woocommerce.android.ui.dashboard.DashboardStatsListener
+import com.woocommerce.android.ui.main.MainNavigationRouter
+import com.woocommerce.android.util.CurrencyFormatter
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.fragment_my_store.*
+import kotlinx.android.synthetic.main.fragment_my_store.view.*
+import org.wordpress.android.fluxc.model.WCRevenueStatsModel
+import org.wordpress.android.fluxc.model.WCTopEarnerModel
+import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
+import javax.inject.Inject
+
+class MyStoreFragment : TopLevelFragment(),
+        MyStoreContract.View,
+        DashboardStatsListener {
+    companion object {
+        val TAG: String = MyStoreFragment::class.java.simpleName
+        const val STATE_KEY_TAB_STATS = "tab-stats-state"
+        const val STATE_KEY_TAB_EARNERS = "tab-earners-state"
+        const val STATE_KEY_REFRESH_PENDING = "is-refresh-pending"
+        fun newInstance() = MyStoreFragment()
+
+        val DEFAULT_STATS_GRANULARITY = StatsGranularity.DAYS
+    }
+
+    @Inject lateinit var presenter: Presenter
+    @Inject lateinit var selectedSite: SelectedSite
+    @Inject lateinit var currencyFormatter: CurrencyFormatter
+    @Inject lateinit var uiMessageResolver: UIMessageResolver
+
+    override var isRefreshPending: Boolean = false // If true, the fragment will refresh its data when it's visible
+    private var errorSnackbar: Snackbar? = null
+
+    // If false, the fragment will refresh its data when it's visible on onHiddenChanged
+    // this is to prevent the stats getting refreshed twice when the fragment is loaded when app is closed and opened
+    private var isStatsRefreshed: Boolean = false
+
+    override fun onAttach(context: Context?) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val view = inflater.inflate(R.layout.fragment_my_store, container, false)
+        with(view) {
+            dashboard_refresh_layout.apply {
+                activity?.let { activity ->
+                    setColorSchemeColors(
+                            ContextCompat.getColor(activity, R.color.colorPrimary),
+                            ContextCompat.getColor(activity, R.color.colorAccent),
+                            ContextCompat.getColor(activity, R.color.colorPrimaryDark)
+                    )
+                }
+                setOnRefreshListener {
+                    // Track the user gesture
+                    AnalyticsTracker.track(Stat.DASHBOARD_PULLED_TO_REFRESH)
+
+                    MyStorePresenter.resetForceRefresh()
+                    dashboard_refresh_layout.isRefreshing = false
+                    refreshMyStoreStats(forced = true)
+                }
+            }
+        }
+        return view
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+
+        savedInstanceState?.let { bundle ->
+            isRefreshPending = bundle.getBoolean(STATE_KEY_REFRESH_PENDING, false)
+            dashboard_stats.tabStateStats = bundle.getSerializable(STATE_KEY_TAB_STATS)
+            dashboard_top_earners.tabStateStats = bundle.getSerializable(STATE_KEY_TAB_EARNERS)
+        }
+
+        presenter.takeView(this)
+
+        empty_view.setSiteToShare(selectedSite.get(), Stat.DASHBOARD_SHARE_YOUR_STORE_BUTTON_TAPPED)
+
+        dashboard_stats.initView(
+                dashboard_stats.activeGranularity,
+                listener = this,
+                selectedSite = selectedSite,
+                formatCurrencyForDisplay = currencyFormatter::formatCurrencyRounded)
+        dashboard_top_earners.initView(
+                dashboard_top_earners.activeGranularity,
+                listener = this,
+                selectedSite = selectedSite,
+                formatCurrencyForDisplay = currencyFormatter::formatCurrencyRounded)
+
+        scroll_view.setOnScrollChangeListener {
+            v: NestedScrollView?, scrollX: Int, scrollY: Int, oldScrollX: Int, oldScrollY: Int ->
+            if (scrollY > oldScrollY) {
+                onScrollDown()
+            } else if (scrollY < oldScrollY) {
+                onScrollUp()
+            }
+        }
+
+        if (isActive && !deferInit) {
+            isStatsRefreshed = true
+            refreshMyStoreStats(forced = this.isRefreshPending)
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        AnalyticsTracker.trackViewShown(this)
+    }
+
+    override fun onHiddenChanged(hidden: Boolean) {
+        super.onHiddenChanged(hidden)
+
+        // silently refresh if this fragment is no longer hidden
+        if (!isHidden && !isStatsRefreshed) {
+            refreshMyStoreStats(forced = false)
+        } else {
+            isStatsRefreshed = false
+        }
+    }
+
+    override fun onReturnedFromChildFragment() {
+        // If this fragment is now visible and we've deferred loading stats due to it not
+        // being visible - go ahead and load the stats.
+        if (!deferInit) {
+            refreshMyStoreStats(forced = this.isRefreshPending)
+        }
+    }
+
+    override fun onStop() {
+        errorSnackbar?.dismiss()
+        super.onStop()
+    }
+
+    override fun onDestroyView() {
+        presenter.dropView()
+        super.onDestroyView()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putBoolean(STATE_KEY_REFRESH_PENDING, isRefreshPending)
+        outState.putSerializable(STATE_KEY_TAB_STATS, dashboard_stats.activeGranularity)
+        outState.putSerializable(STATE_KEY_TAB_EARNERS, dashboard_top_earners.activeGranularity)
+    }
+
+    override fun showStats(
+        revenueStatsModel: WCRevenueStatsModel?,
+        granularity: StatsGranularity
+    ) {
+        // Only update the order stats view if the new stats match the currently selected timeframe
+        if (dashboard_stats.activeGranularity == granularity) {
+            dashboard_stats.showErrorView(false)
+            dashboard_stats.updateView(revenueStatsModel, presenter.getStatsCurrency())
+        }
+    }
+
+    override fun showStatsError(granularity: StatsGranularity) {
+        if (dashboard_stats.activeGranularity == granularity) {
+            showStats(null, granularity)
+            dashboard_stats.showErrorView(true)
+            showErrorSnack()
+        }
+    }
+
+    override fun showTopEarners(topEarnerList: List<WCTopEarnerModel>, granularity: StatsGranularity) {
+        if (dashboard_top_earners.activeGranularity == granularity) {
+            dashboard_top_earners.showErrorView(false)
+            dashboard_top_earners.updateView(topEarnerList)
+        }
+    }
+
+    override fun showTopEarnersError(granularity: StatsGranularity) {
+        if (dashboard_top_earners.activeGranularity == granularity) {
+            dashboard_top_earners.updateView(emptyList())
+            dashboard_top_earners.showErrorView(true)
+            showErrorSnack()
+        }
+    }
+
+    override fun showVisitorStats(visits: Int, granularity: StatsGranularity) {
+        if (dashboard_stats.activeGranularity == granularity) {
+            dashboard_stats.showVisitorStats(visits)
+        }
+    }
+
+    override fun showVisitorStatsError(granularity: StatsGranularity) {
+        if (dashboard_stats.activeGranularity == granularity) {
+            dashboard_stats.showVisitorStatsError()
+        }
+    }
+
+    override fun showErrorSnack() {
+        if (errorSnackbar?.isShownOrQueued() == true) {
+            return
+        }
+        errorSnackbar = uiMessageResolver.getSnack(R.string.dashboard_stats_error)
+        errorSnackbar?.show()
+    }
+
+    override fun getFragmentTitle(): String {
+        selectedSite.getIfExists()?.let { site ->
+            if (!site.displayName.isNullOrBlank()) {
+                return site.displayName
+            } else if (!site.name.isNullOrBlank()) {
+                return site.name
+            }
+        }
+        return getString(R.string.my_store)
+    }
+
+    override fun scrollToTop() {
+        scroll_view.smoothScrollTo(0, 0)
+    }
+
+    override fun refreshFragmentState() {
+        MyStorePresenter.resetForceRefresh()
+        refreshMyStoreStats(forced = false)
+    }
+
+    override fun refreshMyStoreStats(forced: Boolean) {
+        // If this fragment is currently active, force a refresh of data. If not, set
+        // a flag to force a refresh when it becomes active
+        when {
+            isActive -> {
+                isRefreshPending = false
+                if (forced) {
+                    dashboard_stats.clearLabelValues()
+                    dashboard_stats.clearChartData()
+                }
+                presenter.loadStats(dashboard_stats.activeGranularity, forced)
+                presenter.loadTopEarnerStats(dashboard_top_earners.activeGranularity, forced)
+                presenter.fetchHasOrders()
+            }
+            else -> isRefreshPending = true
+        }
+    }
+
+    override fun showChartSkeleton(show: Boolean) {
+        dashboard_stats.showSkeleton(show)
+    }
+
+    override fun showTopEarnersSkeleton(show: Boolean) {
+        dashboard_top_earners.showSkeleton(show)
+    }
+
+    override fun onRequestLoadStats(period: StatsGranularity) {
+        dashboard_stats.showErrorView(false)
+        presenter.loadStats(period)
+    }
+
+    override fun onRequestLoadTopEarnerStats(period: StatsGranularity) {
+        dashboard_top_earners.showErrorView(false)
+        presenter.loadTopEarnerStats(period)
+    }
+
+    override fun onTopEarnerClicked(topEarner: WCTopEarnerModel) {
+        (activity as? MainNavigationRouter)?.showProductDetail(topEarner.id)
+    }
+
+    override fun showEmptyView(show: Boolean) {
+        if (show) empty_view.show(R.string.waiting_for_customers) else empty_view.hide()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreModule.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.ui.mystore
+
+import com.woocommerce.android.ui.mystore.MyStoreContract.Presenter
+import dagger.Binds
+import dagger.Module
+import dagger.android.ContributesAndroidInjector
+
+@Module
+internal abstract class MyStoreModule {
+    @Binds
+    abstract fun provideMyStorePresenter(dashboardPresenter: MyStorePresenter): Presenter
+
+    @ContributesAndroidInjector
+    abstract fun myStoreFragment(): MyStoreFragment
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenter.kt
@@ -30,6 +30,7 @@ import org.wordpress.android.fluxc.store.WCStatsStore.FetchVisitorStatsPayload
 import org.wordpress.android.fluxc.store.WCStatsStore.OnWCRevenueStatsChanged
 import org.wordpress.android.fluxc.store.WCStatsStore.OnWCStatsChanged
 import org.wordpress.android.fluxc.store.WCStatsStore.OnWCTopEarnersChanged
+import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType.PLUGIN_NOT_ACTIVE
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
@@ -151,7 +152,13 @@ class MyStorePresenter @Inject constructor(
                 dashboardView?.showChartSkeleton(false)
                 if (event.isError) {
                     WooLog.e(T.DASHBOARD, "$TAG - Error fetching stats: ${event.error.message}")
-                    dashboardView?.showStatsError(event.granularity)
+                    // display a different error snackbar if the error type is not "plugin not active", since
+                    // this error is already being handled by the activity class
+                    if (event.error.type == PLUGIN_NOT_ACTIVE) {
+                        dashboardView?.updateStatsAvailabilityError()
+                    } else {
+                        dashboardView?.showStatsError(event.granularity)
+                    }
                     return
                 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenter.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.mystore
 
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.annotations.OpenClassOnDebug
@@ -159,10 +160,12 @@ class MyStorePresenter @Inject constructor(
                     // display a different error snackbar if the error type is not "plugin not active", since
                     // this error is already being handled by the activity class
                     if (event.error.type == PLUGIN_NOT_ACTIVE) {
-                        dashboardView?.updateStatsAvailabilityError()
-                    } else {
-                        dashboardView?.showStatsError(event.granularity)
+                        // TODO: handle the scenario where the plugin is deactivated but V4 UI is still displayed
+                        // Currently only updating the local cache as false
+                        AppPrefs.setIsUsingV4Api(false)
+//                        dashboardView?.updateStatsAvailabilityError()
                     }
+                    dashboardView?.showStatsError(event.granularity)
                     return
                 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenter.kt
@@ -1,0 +1,231 @@
+package com.woocommerce.android.ui.mystore
+
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.annotations.OpenClassOnDebug
+import com.woocommerce.android.di.ActivityScope
+import com.woocommerce.android.network.ConnectionChangeReceiver
+import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
+import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.mystore.MyStoreContract.Presenter
+import com.woocommerce.android.ui.mystore.MyStoreContract.View
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_HAS_ORDERS
+import org.wordpress.android.fluxc.action.WCStatsAction.FETCH_REVENUE_STATS
+import org.wordpress.android.fluxc.action.WCStatsAction.FETCH_VISITOR_STATS
+import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
+import org.wordpress.android.fluxc.generated.WCStatsActionBuilder
+import org.wordpress.android.fluxc.store.WCOrderStore
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersPayload
+import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
+import org.wordpress.android.fluxc.store.WCStatsStore
+import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsPayload
+import org.wordpress.android.fluxc.store.WCStatsStore.FetchTopEarnersStatsPayload
+import org.wordpress.android.fluxc.store.WCStatsStore.FetchVisitorStatsPayload
+import org.wordpress.android.fluxc.store.WCStatsStore.OnWCRevenueStatsChanged
+import org.wordpress.android.fluxc.store.WCStatsStore.OnWCStatsChanged
+import org.wordpress.android.fluxc.store.WCStatsStore.OnWCTopEarnersChanged
+import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import javax.inject.Inject
+
+@OpenClassOnDebug
+@ActivityScope
+class MyStorePresenter @Inject constructor(
+    private val dispatcher: Dispatcher,
+    private val wooCommerceStore: WooCommerceStore, // Required to ensure the WooCommerceStore is initialized!
+    private val wcStatsStore: WCStatsStore,
+    private val wcOrderStore: WCOrderStore, // Required to ensure the WCOrderStore is initialized!
+    private val selectedSite: SelectedSite,
+    private val networkStatus: NetworkStatus
+) : Presenter {
+    companion object {
+        private val TAG = MyStorePresenter::class.java
+        private const val NUM_TOP_EARNERS = 3
+        private val statsForceRefresh = BooleanArray(StatsGranularity.values().size)
+        private val topEarnersForceRefresh = BooleanArray(StatsGranularity.values().size)
+
+        init {
+            resetForceRefresh()
+        }
+
+        /**
+         * this tells the presenter to force a refresh for all granularities on the next request - this is
+         * used after a swipe-to-refresh on the dashboard to ensure we don't get cached data
+         */
+        fun resetForceRefresh() {
+            for (i in 0 until statsForceRefresh.size) {
+                statsForceRefresh[i] = true
+            }
+            for (i in 0 until topEarnersForceRefresh.size) {
+                topEarnersForceRefresh[i] = true
+            }
+        }
+    }
+
+    private var dashboardView: View? = null
+
+    override fun takeView(view: View) {
+        dashboardView = view
+        dispatcher.register(this)
+        ConnectionChangeReceiver.getEventBus().register(this)
+    }
+
+    override fun dropView() {
+        dashboardView = null
+        dispatcher.unregister(this)
+        ConnectionChangeReceiver.getEventBus().unregister(this)
+    }
+
+    override fun loadStats(granularity: StatsGranularity, forced: Boolean) {
+        if (!networkStatus.isConnected()) {
+            dashboardView?.isRefreshPending = true
+            return
+        }
+
+        val forceRefresh = forced || statsForceRefresh[granularity.ordinal]
+        if (forceRefresh) {
+            statsForceRefresh[granularity.ordinal] = false
+            dashboardView?.showChartSkeleton(true)
+        }
+
+        // fetch revenue stats
+        fetchRevenueStats(granularity, forceRefresh)
+
+        // fetch visitor stats
+        fetchVisitorStats(granularity, forceRefresh)
+    }
+
+    override fun loadTopEarnerStats(granularity: StatsGranularity, forced: Boolean) {
+        if (!networkStatus.isConnected()) {
+            dashboardView?.isRefreshPending = true
+            return
+        }
+
+        val forceRefresh = forced || topEarnersForceRefresh[granularity.ordinal]
+        if (forceRefresh) {
+            topEarnersForceRefresh[granularity.ordinal] = false
+            dashboardView?.showTopEarnersSkeleton(true)
+        }
+
+        fetchTopEarnerStats(granularity, forceRefresh)
+    }
+
+    override fun fetchRevenueStats(granularity: StatsGranularity, forced: Boolean) {
+        val statsPayload = FetchRevenueStatsPayload(selectedSite.get(), granularity, forced = forced)
+        dispatcher.dispatch(WCStatsActionBuilder.newFetchRevenueStatsAction(statsPayload))
+    }
+
+    override fun fetchVisitorStats(granularity: StatsGranularity, forced: Boolean) {
+        val visitsPayload = FetchVisitorStatsPayload(selectedSite.get(), granularity, forced = forced)
+        dispatcher.dispatch(WCStatsActionBuilder.newFetchVisitorStatsAction(visitsPayload))
+    }
+
+    override fun fetchTopEarnerStats(granularity: StatsGranularity, forced: Boolean) {
+        val payload = FetchTopEarnersStatsPayload(
+                selectedSite.get(), granularity, NUM_TOP_EARNERS, forced = forced
+        )
+        dispatcher.dispatch(WCStatsActionBuilder.newFetchTopEarnersStatsAction(payload))
+    }
+
+    override fun getStatsCurrency() = wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyCode
+
+    /**
+     * dispatches a FETCH_HAS_ORDERS action which tells us whether this store has *ever* had any orders
+     */
+    override fun fetchHasOrders() {
+        val payload = FetchHasOrdersPayload(selectedSite.get())
+        dispatcher.dispatch(WCOrderActionBuilder.newFetchHasOrdersAction(payload))
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onWCRevenueStatsChanged(event: OnWCRevenueStatsChanged) {
+        when (event.causeOfChange) {
+            FETCH_REVENUE_STATS -> {
+                dashboardView?.showChartSkeleton(false)
+                if (event.isError) {
+                    WooLog.e(T.DASHBOARD, "$TAG - Error fetching stats: ${event.error.message}")
+                    dashboardView?.showStatsError(event.granularity)
+                    return
+                }
+
+                // Track fresh data load
+                AnalyticsTracker.track(Stat.DASHBOARD_MAIN_STATS_LOADED,
+                        mapOf(AnalyticsTracker.KEY_RANGE to event.granularity.name.toLowerCase()))
+
+                val revenueStatsModel = wcStatsStore.getRawRevenueStats(
+                        selectedSite.get(), event.granularity, event.startDate!!, event.endDate!!
+                )
+                dashboardView?.showStats(revenueStatsModel, event.granularity)
+            }
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onWCStatsChanged(event: OnWCStatsChanged) {
+        when (event.causeOfChange) {
+            FETCH_VISITOR_STATS -> {
+                if (event.isError) {
+                    WooLog.e(T.DASHBOARD, "$TAG - Error fetching visitor stats: ${event.error.message}")
+                    dashboardView?.showVisitorStatsError(event.granularity)
+                    return
+                }
+
+                val visits = event.rowsAffected
+                dashboardView?.showVisitorStats(visits, event.granularity)
+            }
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onWCTopEarnersChanged(event: OnWCTopEarnersChanged) {
+        dashboardView?.showTopEarnersSkeleton(false)
+        if (event.isError) {
+            dashboardView?.showTopEarnersError(event.granularity)
+        } else {
+            // Track fresh data loaded
+            AnalyticsTracker.track(
+                    Stat.DASHBOARD_TOP_PERFORMERS_LOADED,
+                    mapOf(AnalyticsTracker.KEY_RANGE to event.granularity.name.toLowerCase()))
+
+            dashboardView?.showTopEarners(event.topEarners, event.granularity)
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onOrderChanged(event: OnOrderChanged) {
+        when (event.causeOfChange) {
+            FETCH_HAS_ORDERS -> {
+                if (event.isError) {
+                    WooLog.e(T.DASHBOARD,
+                            "$TAG - Error fetching whether orders exist: ${event.error.message}")
+                } else {
+                    val hasNoOrders = event.rowsAffected == 0
+                    dashboardView?.showEmptyView(hasNoOrders)
+                }
+            }
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onEventMainThread(event: ConnectionChangeEvent) {
+        if (event.isConnected) {
+            // Refresh data if needed now that a connection is active
+            dashboardView?.let { view ->
+                if (view.isRefreshPending) {
+                    view.refreshMyStoreStats(forced = false)
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenter.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.di.ActivityScope
+import com.woocommerce.android.extensions.getVisitorStatsStartDate
 import com.woocommerce.android.network.ConnectionChangeReceiver
 import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
 import com.woocommerce.android.tools.NetworkStatus
@@ -33,6 +34,7 @@ import org.wordpress.android.fluxc.store.WCStatsStore.OnWCTopEarnersChanged
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType.PLUGIN_NOT_ACTIVE
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.fluxc.store.WooCommerceStore
+import org.wordpress.android.fluxc.utils.DateUtils
 import javax.inject.Inject
 
 @OpenClassOnDebug
@@ -123,7 +125,9 @@ class MyStorePresenter @Inject constructor(
     }
 
     override fun fetchVisitorStats(granularity: StatsGranularity, forced: Boolean) {
-        val visitsPayload = FetchVisitorStatsPayload(selectedSite.get(), granularity, forced = forced)
+        val startDate = granularity.getVisitorStatsStartDate()
+        val endDate = DateUtils.getStartOfCurrentDay()
+        val visitsPayload = FetchVisitorStatsPayload(selectedSite.get(), granularity, forced, startDate, endDate)
         dispatcher.dispatch(WCStatsActionBuilder.newFetchVisitorStatsAction(visitsPayload))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -1,0 +1,476 @@
+package com.woocommerce.android.ui.mystore
+
+import android.content.Context
+import android.os.Handler
+import android.text.format.DateFormat
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.annotation.StringRes
+import androidx.core.content.ContextCompat
+import com.github.mikephil.charting.components.AxisBase
+import com.github.mikephil.charting.components.XAxis.XAxisPosition
+import com.github.mikephil.charting.data.BarData
+import com.github.mikephil.charting.data.BarDataSet
+import com.github.mikephil.charting.data.BarEntry
+import com.github.mikephil.charting.data.Entry
+import com.github.mikephil.charting.formatter.IAxisValueFormatter
+import com.google.android.material.tabs.TabLayout
+import com.woocommerce.android.R
+import com.woocommerce.android.R.layout
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.dashboard.DashboardStatsListener
+import com.woocommerce.android.ui.dashboard.DashboardStatsMarkerView
+import com.woocommerce.android.ui.dashboard.DashboardStatsMarkerView.RequestMarkerCaptionListener
+import com.woocommerce.android.ui.mystore.MyStoreFragment.Companion.DEFAULT_STATS_GRANULARITY
+import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.util.FormatCurrencyRounded
+import com.woocommerce.android.util.WooAnimUtils
+import com.woocommerce.android.util.WooAnimUtils.Duration
+import com.woocommerce.android.widgets.SkeletonView
+import kotlinx.android.synthetic.main.dashboard_stats.view.*
+import org.wordpress.android.fluxc.model.WCRevenueStatsModel
+import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
+import org.wordpress.android.util.DateTimeUtils
+import java.io.Serializable
+import java.util.ArrayList
+import java.util.Date
+
+class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
+    : LinearLayout(ctx, attrs), RequestMarkerCaptionListener {
+    init {
+        View.inflate(context, R.layout.my_store_stats, this)
+    }
+
+    companion object {
+        private const val UPDATE_DELAY_TIME_MS = 60 * 1000L
+    }
+
+    var tabStateStats: Serializable? = null // Save the current position of stats tab view
+
+    val activeGranularity: StatsGranularity
+        get() {
+            return tab_layout.getTabAt(tab_layout.selectedTabPosition)?.let {
+                it.tag as StatsGranularity
+            } ?: tabStateStats?.let { it as StatsGranularity } ?: DEFAULT_STATS_GRANULARITY
+        }
+
+    private lateinit var selectedSite: SelectedSite
+
+    private lateinit var formatCurrencyForDisplay: FormatCurrencyRounded
+
+    private var chartRevenueStats = mapOf<String, Double>()
+    private var chartCurrencyCode: String? = null
+
+    private var skeletonView = SkeletonView()
+
+    private lateinit var lastUpdatedRunnable: Runnable
+    private var lastUpdatedHandler: Handler? = null
+    private var lastUpdated: Date? = null
+
+    private var isRequestingStats = false
+        set(value) {
+            // if we're requesting chart data we clear the existing data so it doesn't continue
+            // to appear, and we remove the chart's empty string so it doesn't briefly show
+            // up before the chart data is added once the request completes
+            if (value) {
+                clearLabelValues()
+                chart.setNoDataText(null)
+                chart.clear()
+            } else {
+                // TODO: add a custom empty view
+                chart.setNoDataText(context.getString(R.string.dashboard_state_no_data))
+            }
+        }
+
+    private val fadeHandler = Handler()
+
+    fun initView(
+        period: StatsGranularity = DEFAULT_STATS_GRANULARITY,
+        listener: DashboardStatsListener,
+        selectedSite: SelectedSite,
+        formatCurrencyForDisplay: FormatCurrencyRounded
+    ) {
+        this.selectedSite = selectedSite
+        this.formatCurrencyForDisplay = formatCurrencyForDisplay
+
+        StatsGranularity.values().forEach { granularity ->
+            val tab = tab_layout.newTab().apply {
+                setText(getStringForGranularity(granularity))
+                tag = granularity
+            }
+            tab_layout.addTab(tab)
+
+            // Start with the given time period selected
+            if (granularity == period) {
+                tab.select()
+            }
+        }
+
+        tab_layout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
+            override fun onTabSelected(tab: TabLayout.Tab) {
+                // Track range change
+                AnalyticsTracker.track(
+                        Stat.DASHBOARD_MAIN_STATS_DATE,
+                        mapOf(AnalyticsTracker.KEY_RANGE to tab.tag.toString().toLowerCase()))
+
+                isRequestingStats = true
+                listener.onRequestLoadStats(tab.tag as StatsGranularity)
+            }
+
+            override fun onTabUnselected(tab: TabLayout.Tab) {}
+
+            override fun onTabReselected(tab: TabLayout.Tab) {}
+        })
+
+        initChart()
+
+        lastUpdatedHandler = Handler()
+        lastUpdatedRunnable = Runnable {
+            updateRecencyMessage()
+            lastUpdatedHandler?.postDelayed(lastUpdatedRunnable,
+                    UPDATE_DELAY_TIME_MS
+            )
+        }
+    }
+
+    override fun onVisibilityChanged(changedView: View, visibility: Int) {
+        super.onVisibilityChanged(changedView, visibility)
+        if (visibility == View.VISIBLE) {
+            updateRecencyMessage()
+        } else {
+            lastUpdatedHandler?.removeCallbacks(lastUpdatedRunnable)
+        }
+    }
+
+    fun showSkeleton(show: Boolean) {
+        if (show) {
+            // inflate the skeleton view and adjust the bar widths based on the granularity
+            val inflater = LayoutInflater.from(context)
+            val skeleton = inflater.inflate(R.layout.skeleton_dashboard_stats, chart_container, false) as ViewGroup
+            val barWidth = getSkeletonBarWidth()
+            for (i in 0 until skeleton.childCount) {
+                skeleton.getChildAt(i).layoutParams.width = barWidth
+            }
+
+            skeletonView.show(chart_container, skeleton, delayed = true)
+            dashboard_recency_text.text = null
+        } else {
+            skeletonView.hide()
+        }
+    }
+
+    private fun getSkeletonBarWidth(): Int {
+        val resId = when (activeGranularity) {
+            StatsGranularity.DAYS -> R.dimen.skeleton_bar_chart_bar_width_days
+            StatsGranularity.WEEKS -> R.dimen.skeleton_bar_chart_bar_width_weeks
+            StatsGranularity.MONTHS -> R.dimen.skeleton_bar_chart_bar_width_months
+            StatsGranularity.YEARS -> R.dimen.skeleton_bar_chart_bar_width_years
+        }
+        return context.resources.getDimensionPixelSize(resId)
+    }
+
+    /**
+     * One-time chart initialization with settings common to all granularities.
+     */
+    private fun initChart() {
+        with(chart) {
+            with(xAxis) {
+                position = XAxisPosition.BOTTOM
+                setDrawGridLines(false)
+                setDrawAxisLine(false)
+                granularity = 1f // Don't break x axis values down further than 1 unit of time
+
+                setLabelCount(2, true) // Only show first and last date
+
+                valueFormatter = StartEndDateAxisFormatter()
+            }
+
+            axisLeft.isEnabled = false
+
+            with(axisRight) {
+                setDrawZeroLine(false)
+                setDrawAxisLine(false)
+                setDrawGridLines(true)
+                gridColor = ContextCompat.getColor(context, R.color.wc_border_color)
+                setLabelCount(3, true)
+
+                valueFormatter = IAxisValueFormatter { value, _ ->
+                    // Only use non-zero values for the axis
+                    value.toDouble().takeIf { it > 0 }?.let {
+                        formatCurrencyForDisplay(it, chartCurrencyCode.orEmpty())
+                    }.orEmpty()
+                }
+            }
+
+            description.isEnabled = false
+            legend.isEnabled = false
+
+            // touch has to be enabled in order to show a marker when a bar is tapped, but we don't want
+            // pinch/zoom, drag, or scaling to be enabled
+            setTouchEnabled(true)
+            setPinchZoom(false)
+            isScaleXEnabled = false
+            isScaleYEnabled = false
+            isDragEnabled = false
+
+            setNoDataTextColor(ContextCompat.getColor(context, R.color.graph_no_data_text_color))
+        }
+
+        val markerView = DashboardStatsMarkerView(
+                context,
+                layout.dashboard_stats_marker_view
+        )
+        markerView.chartView = chart
+        markerView.captionListener = this
+        chart.marker = markerView
+    }
+
+    /**
+     * the chart MarkerView relies on this to know what to display when the user taps a chart bar
+     */
+    override fun onRequestMarkerCaption(entry: Entry): String? {
+        val barEntry = entry as BarEntry
+
+        // get the date for this entry
+        val dateindex = barEntry.x.toInt()
+        val date = if (activeGranularity == StatsGranularity.YEARS) dateindex.toString() else
+            chartRevenueStats.keys.elementAt(dateindex - 1)
+        val formattedDate = when (activeGranularity) {
+            StatsGranularity.DAYS -> DateUtils.getShortMonthDayString(date)
+            StatsGranularity.WEEKS -> DateUtils.getShortMonthDayStringForWeek(date)
+            StatsGranularity.MONTHS -> DateUtils.getShortMonthString(date)
+            StatsGranularity.YEARS -> date
+        }
+
+        // get the revenue for this entry
+        val revenue = barEntry.y.toDouble()
+        val formattedRevenue = formatCurrencyForDisplay(revenue, chartCurrencyCode.orEmpty())
+
+        // show the date and revenue on separate lines
+        return formattedDate + "\n" + formattedRevenue
+    }
+
+    /**
+     * removes the highlighted value, which in turn removes the marker view
+     */
+    private fun hideMarker() {
+        chart.highlightValue(null)
+    }
+
+    fun updateView(revenueStatsModel: WCRevenueStatsModel?, currencyCode: String?) {
+        chartCurrencyCode = currencyCode
+
+        val wasEmpty = chart.barData?.let { it.dataSetCount == 0 } ?: true
+
+        val grossRevenue = revenueStatsModel?.getTotal()?.grossRevenue ?: 0.0
+        val revenue = formatCurrencyForDisplay(grossRevenue, currencyCode.orEmpty())
+
+        val orderCount = revenueStatsModel?.getTotal()?.ordersCount ?: 0
+        val orders = orderCount.toString()
+        fadeInLabelValue(revenue_value, revenue)
+        fadeInLabelValue(orders_value, orders)
+
+        val revenueStats = revenueStatsModel?.getIntervalList()?.map {
+            it.interval!! to it.subtotals?.grossRevenue!!
+        }?.toMap() ?: mapOf()
+        if (revenueStats.isEmpty()) {
+            clearLastUpdated()
+            isRequestingStats = false
+            return
+        }
+
+        val barColors = ArrayList<Int>()
+        val normalColor = ContextCompat.getColor(context, R.color.graph_data_color)
+        for (entry in revenueStats) {
+            barColors.add(normalColor)
+        }
+
+        val dataSet = generateBarDataSet(revenueStats).apply {
+            colors = barColors
+            setDrawValues(false)
+            isHighlightEnabled = true
+            highLightColor = ContextCompat.getColor(context, R.color.graph_highlight_color)
+        }
+
+        // determine the min revenue so we can set the min value for the left axis, which should be zero unless
+        // the stats contain any negative revenue
+        var minRevenue = 0f
+        for (value in dataSet.values) {
+            if (value.y < minRevenue) minRevenue = value.y
+        }
+
+        val duration = context.resources.getInteger(android.R.integer.config_shortAnimTime)
+        with(chart) {
+            axisLeft.axisMinimum = minRevenue
+            axisRight.axisMinimum = 0f
+            data = BarData(dataSet)
+            if (wasEmpty) {
+                animateY(duration)
+            }
+        }
+
+        hideMarker()
+        resetLastUpdated()
+        isRequestingStats = false
+    }
+
+    fun showErrorView(show: Boolean) {
+        isRequestingStats = false
+        dashboard_stats_error.visibility = if (show) View.VISIBLE else View.GONE
+        chart.visibility = if (show) View.GONE else View.VISIBLE
+    }
+
+    fun showVisitorStats(visits: Int) {
+        fadeInLabelValue(visitors_value, visits.toString())
+    }
+
+    fun showVisitorStatsError() {
+        fadeInLabelValue(visitors_value, "?")
+    }
+
+    fun clearLabelValues() {
+        val color = ContextCompat.getColor(context, R.color.skeleton_color)
+        visitors_value.setTextColor(color)
+        revenue_value.setTextColor(color)
+        orders_value.setTextColor(color)
+
+        visitors_value.setText(R.string.emdash)
+        revenue_value.setText(R.string.emdash)
+        orders_value.setText(R.string.emdash)
+    }
+
+    fun clearChartData() {
+        chart.data?.clearValues()
+    }
+
+    private fun fadeInLabelValue(view: TextView, value: String) {
+        // do nothing if value hasn't changed
+        if (view.text.toString().equals(value)) {
+            return
+        }
+
+        // fade out the current value
+        val duration = Duration.SHORT
+        WooAnimUtils.fadeOut(view, duration, View.INVISIBLE)
+
+        // fade in the new value after fade out finishes
+        val delay = duration.toMillis(context) + 100
+        fadeHandler.postDelayed({
+            val color = ContextCompat.getColor(context, R.color.default_text_title)
+            view.setTextColor(color)
+            view.text = value
+            WooAnimUtils.fadeIn(view, duration)
+        }, delay)
+    }
+
+    private fun generateBarDataSet(revenueStats: Map<String, Double>): BarDataSet {
+        chartRevenueStats = revenueStats
+        val barEntries = chartRevenueStats.values.mapIndexed { index, value ->
+            BarEntry((index + 1).toFloat(), value.toFloat())
+        }
+        return BarDataSet(barEntries, "")
+    }
+
+    @StringRes
+    fun getStringForGranularity(timeframe: StatsGranularity): Int {
+        return when (timeframe) {
+            StatsGranularity.DAYS -> R.string.today
+            StatsGranularity.WEEKS -> R.string.this_week
+            StatsGranularity.MONTHS -> R.string.this_month
+            StatsGranularity.YEARS -> R.string.this_year
+        }
+    }
+
+    private fun clearLastUpdated() {
+        lastUpdated = null
+        updateRecencyMessage()
+    }
+
+    private fun resetLastUpdated() {
+        lastUpdated = Date()
+        updateRecencyMessage()
+    }
+
+    private fun updateRecencyMessage() {
+        dashboard_recency_text.text = getRecencyMessage()
+        lastUpdatedHandler?.removeCallbacks(lastUpdatedRunnable)
+
+        if (lastUpdated != null) {
+            lastUpdatedHandler?.postDelayed(lastUpdatedRunnable,
+                    UPDATE_DELAY_TIME_MS
+            )
+        }
+    }
+
+    /**
+     * Returns the text to use for the "recency message" which tells the user when stats were last updated
+     */
+    private fun getRecencyMessage(): String? {
+        if (lastUpdated == null) {
+            return null
+        }
+
+        val now = Date()
+
+        // up to 2 minutes -> "Updated moments ago"
+        val minutes = DateTimeUtils.minutesBetween(now, lastUpdated)
+        if (minutes <= 2) {
+            return context.getString(R.string.dashboard_stats_updated_now)
+        }
+
+        // up to 59 minutes -> "Updated 5 minutes ago"
+        if (minutes <= 59) {
+            return String.format(context.getString(R.string.dashboard_stats_updated_minutes), minutes)
+        }
+
+        // 1 hour -> "Updated 1 hour ago"
+        val hours = DateTimeUtils.hoursBetween(now, lastUpdated)
+        if (hours == 1) {
+            return context.getString(R.string.dashboard_stats_updated_one_hour)
+        }
+
+        // up to 23 hours -> "Updated 5 hours ago"
+        if (hours <= 23) {
+            return String.format(context.getString(R.string.dashboard_stats_updated_hours), hours)
+        }
+
+        // up to 47 hours -> "Updated 1 day ago"
+        if (hours <= 47) {
+            return context.getString(R.string.dashboard_stats_updated_one_day)
+        }
+
+        // otherwise date & time
+        val dateStr = DateFormat.getDateFormat(context).format(lastUpdated)
+        val timeStr = DateFormat.getTimeFormat(context).format(lastUpdated)
+        return String.format(context.getString(R.string.dashboard_stats_updated_date_time), "$dateStr $timeStr")
+    }
+
+    private inner class StartEndDateAxisFormatter : IAxisValueFormatter {
+        override fun getFormattedValue(value: Float, axis: AxisBase): String {
+            return when (value) {
+                axis.mEntries.first() -> getStartValue()
+                axis.mEntries.max() -> getEndValue()
+                else -> ""
+            }
+        }
+
+        fun getStartValue() = getEntryValue(chartRevenueStats.keys.first())
+
+        fun getEndValue() = getEntryValue(chartRevenueStats.keys.last())
+
+        fun getEntryValue(dateString: String): String {
+            return when (activeGranularity) {
+                StatsGranularity.DAYS -> DateUtils.getShortHourString(dateString)
+                StatsGranularity.WEEKS -> DateUtils.getShortMonthDayString(dateString)
+                StatsGranularity.MONTHS -> DateUtils.getShortMonthDayString(dateString)
+                StatsGranularity.YEARS -> DateUtils.getShortMonthString(dateString)
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -18,7 +18,6 @@ import com.github.mikephil.charting.data.BarDataSet
 import com.github.mikephil.charting.data.BarEntry
 import com.github.mikephil.charting.data.Entry
 import com.github.mikephil.charting.formatter.IAxisValueFormatter
-import com.google.android.material.tabs.TabLayout
 import com.woocommerce.android.R
 import com.woocommerce.android.R.layout
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -37,7 +36,6 @@ import kotlinx.android.synthetic.main.dashboard_stats.view.*
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.util.DateTimeUtils
-import java.io.Serializable
 import java.util.ArrayList
 import java.util.Date
 
@@ -51,17 +49,10 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
         private const val UPDATE_DELAY_TIME_MS = 60 * 1000L
     }
 
-    var tabStateStats: Serializable? = null // Save the current position of stats tab view
-
-    val activeGranularity: StatsGranularity
-        get() {
-            return tab_layout.getTabAt(tab_layout.selectedTabPosition)?.let {
-                it.tag as StatsGranularity
-            } ?: tabStateStats?.let { it as StatsGranularity } ?: DEFAULT_STATS_GRANULARITY
-        }
+    private lateinit var activeGranularity: StatsGranularity
+    private lateinit var listener: DashboardStatsListener
 
     private lateinit var selectedSite: SelectedSite
-
     private lateinit var formatCurrencyForDisplay: FormatCurrencyRounded
 
     private var chartRevenueStats = mapOf<String, Double>()
@@ -96,37 +87,10 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
         selectedSite: SelectedSite,
         formatCurrencyForDisplay: FormatCurrencyRounded
     ) {
+        this.listener = listener
         this.selectedSite = selectedSite
+        this.activeGranularity = period
         this.formatCurrencyForDisplay = formatCurrencyForDisplay
-
-        StatsGranularity.values().forEach { granularity ->
-            val tab = tab_layout.newTab().apply {
-                setText(getStringForGranularity(granularity))
-                tag = granularity
-            }
-            tab_layout.addTab(tab)
-
-            // Start with the given time period selected
-            if (granularity == period) {
-                tab.select()
-            }
-        }
-
-        tab_layout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
-            override fun onTabSelected(tab: TabLayout.Tab) {
-                // Track range change
-                AnalyticsTracker.track(
-                        Stat.DASHBOARD_MAIN_STATS_DATE,
-                        mapOf(AnalyticsTracker.KEY_RANGE to tab.tag.toString().toLowerCase()))
-
-                isRequestingStats = true
-                listener.onRequestLoadStats(tab.tag as StatsGranularity)
-            }
-
-            override fun onTabUnselected(tab: TabLayout.Tab) {}
-
-            override fun onTabReselected(tab: TabLayout.Tab) {}
-        })
 
         initChart()
 
@@ -137,6 +101,17 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
                     UPDATE_DELAY_TIME_MS
             )
         }
+    }
+
+    fun loadDashboardStats(granularity: StatsGranularity) {
+        this.activeGranularity = granularity
+        // Track range change
+        AnalyticsTracker.track(
+                Stat.DASHBOARD_MAIN_STATS_DATE,
+                mapOf(AnalyticsTracker.KEY_RANGE to granularity.toString().toLowerCase()))
+
+        isRequestingStats = true
+        listener.onRequestLoadStats(granularity)
     }
 
     override fun onVisibilityChanged(changedView: View, visibility: Int) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -254,7 +254,7 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
         val revenueStats = revenueStatsModel?.getIntervalList()?.map {
             it.interval!! to it.subtotals?.grossRevenue!!
         }?.toMap() ?: mapOf()
-        if (revenueStats.isEmpty()) {
+        if (revenueStats.isEmpty() || revenueStatsModel?.getTotal()?.grossRevenue?.toInt() == 0) {
             clearLastUpdated()
             isRequestingStats = false
             return

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreTopEarnersView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreTopEarnersView.kt
@@ -25,14 +25,12 @@ import org.wordpress.android.fluxc.model.WCTopEarnerModel
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.util.FormatUtils
 import org.wordpress.android.util.PhotonUtils
-import java.io.Serializable
 
 class MyStoreTopEarnersView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
     : LinearLayout(ctx, attrs) {
     init {
         View.inflate(context, R.layout.my_store_top_earners, this)
     }
-    var tabStateStats: Serializable? = null // Save the current position of top earners tab view
 
     private lateinit var selectedSite: SelectedSite
     private lateinit var listener: DashboardStatsListener
@@ -55,7 +53,7 @@ class MyStoreTopEarnersView @JvmOverloads constructor(ctx: Context, attrs: Attri
     }
 
     /**
-     * Load top earners stats when tab is selected in [DashboardStatsView]
+     * Load top earners stats when tab is selected in [MyStoreStatsView]
      */
     fun loadTopEarnerStats(granularity: StatsGranularity) {
         // Track range change

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreTopEarnersView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreTopEarnersView.kt
@@ -1,0 +1,158 @@
+package com.woocommerce.android.ui.mystore
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.TOP_EARNER_PRODUCT_TAPPED
+import com.woocommerce.android.di.GlideApp
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.dashboard.DashboardStatsListener
+import com.woocommerce.android.util.FormatCurrencyRounded
+import com.woocommerce.android.widgets.SkeletonView
+import kotlinx.android.synthetic.main.my_store_top_earners.view.*
+import kotlinx.android.synthetic.main.top_earner_list_item.view.*
+import org.apache.commons.text.StringEscapeUtils
+import org.wordpress.android.fluxc.model.WCTopEarnerModel
+import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
+import org.wordpress.android.util.FormatUtils
+import org.wordpress.android.util.PhotonUtils
+import java.io.Serializable
+
+class MyStoreTopEarnersView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
+    : LinearLayout(ctx, attrs) {
+    init {
+        View.inflate(context, R.layout.my_store_top_earners, this)
+    }
+    var tabStateStats: Serializable? = null // Save the current position of top earners tab view
+
+    private lateinit var selectedSite: SelectedSite
+    private lateinit var listener: DashboardStatsListener
+    private lateinit var formatCurrencyForDisplay: FormatCurrencyRounded
+
+    private var skeletonView = SkeletonView()
+
+    fun initView(
+        listener: DashboardStatsListener,
+        selectedSite: SelectedSite,
+        formatCurrencyForDisplay: FormatCurrencyRounded
+    ) {
+        this.listener = listener
+        this.selectedSite = selectedSite
+        this.formatCurrencyForDisplay = formatCurrencyForDisplay
+
+        topEarners_recycler.layoutManager = androidx.recyclerview.widget.LinearLayoutManager(context)
+        topEarners_recycler.adapter = TopEarnersAdapter(context, formatCurrencyForDisplay, listener)
+        topEarners_recycler.itemAnimator = androidx.recyclerview.widget.DefaultItemAnimator()
+    }
+
+    /**
+     * Load top earners stats when tab is selected in [DashboardStatsView]
+     */
+    fun loadTopEarnerStats(granularity: StatsGranularity) {
+        // Track range change
+        AnalyticsTracker.track(
+                Stat.DASHBOARD_TOP_PERFORMERS_DATE,
+                mapOf(AnalyticsTracker.KEY_RANGE to granularity.toString().toLowerCase()))
+
+        topEarners_recycler.adapter = TopEarnersAdapter(context, formatCurrencyForDisplay, listener)
+        showEmptyView(false)
+        showErrorView(false)
+        listener.onRequestLoadTopEarnerStats(granularity)
+    }
+
+    fun showSkeleton(show: Boolean) {
+        if (show) {
+            skeletonView.show(dashboard_top_earners_container, R.layout.skeleton_dashboard_top_earners, delayed = true)
+        } else {
+            skeletonView.hide()
+        }
+    }
+
+    private fun showEmptyView(show: Boolean) {
+        topEarners_emptyView.visibility = if (show) View.VISIBLE else View.GONE
+    }
+
+    fun updateView(topEarnerList: List<WCTopEarnerModel>) {
+        (topEarners_recycler.adapter as TopEarnersAdapter).setTopEarnersList(topEarnerList)
+        showEmptyView(topEarnerList.isEmpty())
+    }
+
+    fun showErrorView(show: Boolean) {
+        showEmptyView(false)
+        topEarners_error.visibility = if (show) View.VISIBLE else View.GONE
+        topEarners_recycler.visibility = if (show) View.GONE else View.VISIBLE
+    }
+
+    class TopEarnersViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        var productNameText: TextView = view.text_ProductName
+        var productOrdersText: TextView = view.text_ProductOrders
+        var totalSpendText: TextView = view.text_TotalSpend
+        var productImage: ImageView = view.image_product
+        var divider: View = view.divider
+    }
+
+    class TopEarnersAdapter(
+        context: Context,
+        val formatCurrencyForDisplay: FormatCurrencyRounded,
+        val listener: DashboardStatsListener
+    ) : RecyclerView.Adapter<TopEarnersViewHolder>() {
+        private val orderString: String
+        private val imageSize: Int
+        private val topEarnerList: ArrayList<WCTopEarnerModel> = ArrayList()
+
+        init {
+            setHasStableIds(true)
+            orderString = context.getString(R.string.dashboard_top_earners_total_orders)
+            imageSize = context.resources.getDimensionPixelSize(R.dimen.product_icon_sz)
+        }
+
+        fun setTopEarnersList(newList: List<WCTopEarnerModel>) {
+            topEarnerList.clear()
+            topEarnerList.addAll(newList)
+            notifyDataSetChanged()
+        }
+
+        override fun getItemCount() = topEarnerList.size
+
+        override fun getItemId(position: Int): Long {
+            return topEarnerList[position].id
+        }
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TopEarnersViewHolder {
+            val view = LayoutInflater.from(parent.context)
+                    .inflate(R.layout.top_earner_list_item, parent, false)
+            return TopEarnersViewHolder(view)
+        }
+
+        override fun onBindViewHolder(holder: TopEarnersViewHolder, position: Int) {
+            val topEarner = topEarnerList[position]
+            val numOrders = String.format(orderString, FormatUtils.formatDecimal(topEarner.quantity))
+            val total = formatCurrencyForDisplay(topEarner.total, topEarner.currency)
+
+            holder.productNameText.text = StringEscapeUtils.unescapeHtml4(topEarner.name)
+            holder.productOrdersText.text = numOrders
+            holder.totalSpendText.text = total
+            holder.divider.visibility = if (position < itemCount - 1) View.VISIBLE else View.GONE
+
+            val imageUrl = PhotonUtils.getPhotonImageUrl(topEarner.image, imageSize, 0)
+            GlideApp.with(holder.itemView.context)
+                    .load(imageUrl)
+                    .placeholder(R.drawable.ic_product)
+                    .into(holder.productImage)
+
+            holder.itemView.setOnClickListener {
+                AnalyticsTracker.track(TOP_EARNER_PRODUCT_TAPPED)
+                listener.onTopEarnerClicked(topEarner)
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/RevenueStatsAvailabilityFetcher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/RevenueStatsAvailabilityFetcher.kt
@@ -1,0 +1,42 @@
+package com.woocommerce.android.ui.mystore
+
+import com.woocommerce.android.AppPrefs
+import org.greenrobot.eventbus.EventBus
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.WCStatsAction.FETCH_REVENUE_STATS_AVAILABILITY
+import org.wordpress.android.fluxc.generated.WCStatsActionBuilder
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.WCStatsStore
+import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsAvailabilityPayload
+import org.wordpress.android.fluxc.store.WCStatsStore.OnWCRevenueStatsChanged
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class RevenueStatsAvailabilityFetcher @Inject constructor(
+    private val wcStatsStore: WCStatsStore, // Required to ensure instantiated
+    private val dispatcher: Dispatcher
+) {
+    init {
+        dispatcher.register(this)
+    }
+
+    fun fetchRevenueStatsAvailability(siteModel: SiteModel) {
+        val payload = FetchRevenueStatsAvailabilityPayload(siteModel)
+        dispatcher.dispatch(WCStatsActionBuilder.newFetchRevenueStatsAvailabilityAction(payload))
+    }
+
+    class RevenueStatsAvailabilityChangeEvent(var available: Boolean)
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onWCRevenueStatsChanged(event: OnWCRevenueStatsChanged) {
+        if (event.causeOfChange == FETCH_REVENUE_STATS_AVAILABILITY) {
+            // update the v4 stats availability to SharedPreferences
+            AppPrefs.setIsUsingV4Api(event.availability)
+            EventBus.getDefault().post(RevenueStatsAvailabilityChangeEvent(event.availability))
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -32,10 +32,11 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.LoginEmailHelpDialogFragment
 import com.woocommerce.android.ui.main.MainActivity
+import com.woocommerce.android.ui.mystore.RevenueStatsAvailabilityFetcher
 import com.woocommerce.android.ui.sitepicker.SitePickerAdapter.OnSiteClickListener
 import com.woocommerce.android.util.ActivityUtils
-import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.util.CrashUtils
+import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WooClickableSpan
 import dagger.android.AndroidInjection
 import kotlinx.android.synthetic.main.activity_site_picker.*
@@ -68,6 +69,8 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
 
     @Inject lateinit var presenter: SitePickerContract.Presenter
     @Inject lateinit var selectedSite: SelectedSite
+
+    @Inject lateinit var revenueStatsAvailabilityFetcher: RevenueStatsAvailabilityFetcher
 
     private lateinit var siteAdapter: SitePickerAdapter
 
@@ -318,7 +321,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         presenter.updateWooSiteSettings(site)
 
         // also check if the site supports the new v4 revenue stats api changes
-        presenter.fetchRevenueStatsAvailability(site)
+        revenueStatsAvailabilityFetcher.fetchRevenueStatsAvailability(site)
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -316,6 +316,9 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
 
         // Preemptively also update the site settings so we have them available sooner
         presenter.updateWooSiteSettings(site)
+
+        // also check if the site supports the new v4 revenue stats api changes
+        presenter.fetchRevenueStatsAvailability(site)
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerContract.kt
@@ -19,6 +19,7 @@ interface SitePickerContract {
         fun getSitesForLocalIds(siteIdList: IntArray): List<SiteModel>
         fun verifySiteApiVersion(site: SiteModel)
         fun updateWooSiteSettings(site: SiteModel)
+        fun fetchRevenueStatsAvailability(site: SiteModel)
         fun getSiteModelByUrl(url: String): SiteModel?
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerContract.kt
@@ -19,7 +19,6 @@ interface SitePickerContract {
         fun getSitesForLocalIds(siteIdList: IntArray): List<SiteModel>
         fun verifySiteApiVersion(site: SiteModel)
         fun updateWooSiteSettings(site: SiteModel)
-        fun fetchRevenueStatsAvailability(site: SiteModel)
         fun getSiteModelByUrl(url: String): SiteModel?
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
@@ -1,18 +1,23 @@
 package com.woocommerce.android.ui.sitepicker
 
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.WCStatsAction.FETCH_REVENUE_STATS_AVAILABILITY
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.generated.WCCoreActionBuilder
+import org.wordpress.android.fluxc.generated.WCStatsActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
+import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsAvailabilityPayload
+import org.wordpress.android.fluxc.store.WCStatsStore.OnWCRevenueStatsChanged
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.store.WooCommerceStore.OnApiVersionFetched
 import javax.inject.Inject
@@ -82,6 +87,11 @@ class SitePickerPresenter @Inject constructor(
         dispatcher.dispatch(WCCoreActionBuilder.newFetchSiteSettingsAction(site))
     }
 
+    override fun fetchRevenueStatsAvailability(site: SiteModel) {
+        val payload = FetchRevenueStatsAvailabilityPayload(site)
+        dispatcher.dispatch(WCStatsActionBuilder.newFetchRevenueStatsAvailabilityAction(payload))
+    }
+
     override fun getSitesForLocalIds(siteIdList: IntArray): List<SiteModel> {
         return siteIdList.map { siteStore.getSiteByLocalId(it) }
     }
@@ -127,6 +137,15 @@ class SitePickerPresenter @Inject constructor(
             view?.siteVerificationPassed(event.site)
         } else {
             view?.siteVerificationFailed(event.site)
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onWCRevenueStatsChanged(event: OnWCRevenueStatsChanged) {
+        if (event.causeOfChange == FETCH_REVENUE_STATS_AVAILABILITY) {
+            // update the v4 stats availability to SharedPreferences
+            AppPrefs.setIsUsingV4Api(event.availability)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
@@ -1,23 +1,18 @@
 package com.woocommerce.android.ui.sitepicker
 
-import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.WCStatsAction.FETCH_REVENUE_STATS_AVAILABILITY
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.generated.WCCoreActionBuilder
-import org.wordpress.android.fluxc.generated.WCStatsActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
-import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsAvailabilityPayload
-import org.wordpress.android.fluxc.store.WCStatsStore.OnWCRevenueStatsChanged
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.store.WooCommerceStore.OnApiVersionFetched
 import javax.inject.Inject
@@ -87,11 +82,6 @@ class SitePickerPresenter @Inject constructor(
         dispatcher.dispatch(WCCoreActionBuilder.newFetchSiteSettingsAction(site))
     }
 
-    override fun fetchRevenueStatsAvailability(site: SiteModel) {
-        val payload = FetchRevenueStatsAvailabilityPayload(site)
-        dispatcher.dispatch(WCStatsActionBuilder.newFetchRevenueStatsAvailabilityAction(payload))
-    }
-
     override fun getSitesForLocalIds(siteIdList: IntArray): List<SiteModel> {
         return siteIdList.map { siteStore.getSiteByLocalId(it) }
     }
@@ -137,15 +127,6 @@ class SitePickerPresenter @Inject constructor(
             view?.siteVerificationPassed(event.site)
         } else {
             view?.siteVerificationFailed(event.site)
-        }
-    }
-
-    @Suppress("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onWCRevenueStatsChanged(event: OnWCRevenueStatsChanged) {
-        if (event.causeOfChange == FETCH_REVENUE_STATS_AVAILABILITY) {
-            // update the v4 stats availability to SharedPreferences
-            AppPrefs.setIsUsingV4Api(event.availability)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -207,7 +207,6 @@ object DateUtils {
      */
     fun getYearMonthDayStringFromDate(date: Date): String = yyyyMMddFormat.format(date)
 
-
     /**
      * Given an ISO8601 date of format YYYY-MM-DD hh, returns the hour String in ("hh") format.
      *

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -206,4 +206,24 @@ object DateUtils {
      * Formats a date object and returns it in the format of yyyy-MM-dd
      */
     fun getYearMonthDayStringFromDate(date: Date): String = yyyyMMddFormat.format(date)
+
+
+    /**
+     * Given an ISO8601 date of format YYYY-MM-DD hh, returns the hour String in ("hh") format.
+     *
+     * For example, given 2019-07-15 13 returns "1pm", and given 2019-07-28 01 returns "1am".
+     *
+     * @throws IllegalArgumentException if the argument is not a valid iso8601 date string.
+     */
+    @Throws(IllegalArgumentException::class)
+    fun getShortHourString(iso8601Date: String): String {
+        return try {
+            val originalFormat = SimpleDateFormat("yyyy-MM-dd HH", Locale.ROOT)
+            val targetFormat = SimpleDateFormat("hha", Locale.ROOT)
+            val date = originalFormat.parse(iso8601Date)
+            targetFormat.format(date).toLowerCase().trimStart('0')
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Date string argument is not of format yyyy-MM-dd H: $iso8601Date")
+        }
+    }
 }

--- a/WooCommerce/src/main/res/layout/fragment_my_store.xml
+++ b/WooCommerce/src/main/res/layout/fragment_my_store.xml
@@ -24,15 +24,15 @@
 
                 <!-- Order stats -->
                 <com.woocommerce.android.ui.mystore.MyStoreStatsView
-                    android:id="@+id/dashboard_stats"
+                    android:id="@+id/my_store_stats"
                     style="@style/Woo.Card"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"/>
 
                 <!-- Top earner stats -->
-                <com.woocommerce.android.ui.dashboard.DashboardTopEarnersView
-                    android:id="@+id/dashboard_top_earners"
+                <com.woocommerce.android.ui.mystore.MyStoreTopEarnersView
+                    android:id="@+id/my_store_top_earners"
                     style="@style/Woo.Card"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/layout/fragment_my_store.xml
+++ b/WooCommerce/src/main/res/layout/fragment_my_store.xml
@@ -17,7 +17,7 @@
         <!-- Single tab for all stats -->
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tab_layout"
-            style="@style/Woo.TabLayout"
+            style="@style/Woo.TabLayout.MyStore"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"/>
 
@@ -42,7 +42,6 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_large"
                     android:animateLayoutChanges="true"
                     android:descendantFocusability="blocksDescendants"
                     android:orientation="vertical">

--- a/WooCommerce/src/main/res/layout/fragment_my_store.xml
+++ b/WooCommerce/src/main/res/layout/fragment_my_store.xml
@@ -1,52 +1,78 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/dashboardStats_root"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    tools:context="com.woocommerce.android.ui.mystore.MyStoreFragment">
 
-    <com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout
-        android:id="@+id/dashboard_refresh_layout"
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="false">
+
+        <!-- Single tab for all stats -->
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tab_layout"
+            style="@style/Woo.TabLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/default_window_background">
+        android:background="@color/default_window_background"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        <androidx.core.widget.NestedScrollView
-            android:id="@+id/scroll_view"
+        <com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout
+            android:id="@+id/dashboard_refresh_layout"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-            <LinearLayout
+            <androidx.core.widget.NestedScrollView
+                android:id="@+id/scroll_view"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:animateLayoutChanges="true"
-                android:descendantFocusability="blocksDescendants"
-                android:orientation="vertical">
+                android:layout_height="match_parent">
 
-                <!-- Order stats -->
-                <com.woocommerce.android.ui.mystore.MyStoreStatsView
-                    android:id="@+id/my_store_stats"
-                    style="@style/Woo.Card"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"/>
+                    android:layout_marginTop="@dimen/margin_large"
+                    android:animateLayoutChanges="true"
+                    android:descendantFocusability="blocksDescendants"
+                    android:orientation="vertical">
 
-                <!-- Top earner stats -->
-                <com.woocommerce.android.ui.mystore.MyStoreTopEarnersView
-                    android:id="@+id/my_store_top_earners"
-                    style="@style/Woo.Card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_small"
-                    android:orientation="vertical"/>
+                    <!-- Order stats -->
+                    <com.woocommerce.android.ui.mystore.MyStoreStatsView
+                        android:id="@+id/my_store_stats"
+                        style="@style/Woo.Stats.Card"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"/>
 
-            </LinearLayout>
-        </androidx.core.widget.NestedScrollView>
-    </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
+                    <!-- Top earner stats -->
+                    <com.woocommerce.android.ui.mystore.MyStoreTopEarnersView
+                        android:id="@+id/my_store_top_earners"
+                        style="@style/Woo.Stats.Card"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"/>
 
-    <com.woocommerce.android.widgets.WCEmptyView
-        android:id="@+id/empty_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone"/>
+                </LinearLayout>
+            </androidx.core.widget.NestedScrollView>
+        </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
 
-</FrameLayout>
+        <com.woocommerce.android.widgets.WCEmptyView
+            android:id="@+id/empty_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone"/>
+
+    </FrameLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WooCommerce/src/main/res/layout/fragment_my_store.xml
+++ b/WooCommerce/src/main/res/layout/fragment_my_store.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout
+        android:id="@+id/dashboard_refresh_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/default_window_background">
+
+        <androidx.core.widget.NestedScrollView
+            android:id="@+id/scroll_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:animateLayoutChanges="true"
+                android:descendantFocusability="blocksDescendants"
+                android:orientation="vertical">
+
+                <!-- Order stats -->
+                <com.woocommerce.android.ui.mystore.MyStoreStatsView
+                    android:id="@+id/dashboard_stats"
+                    style="@style/Woo.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"/>
+
+                <!-- Top earner stats -->
+                <com.woocommerce.android.ui.dashboard.DashboardTopEarnersView
+                    android:id="@+id/dashboard_top_earners"
+                    style="@style/Woo.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_small"
+                    android:orientation="vertical"/>
+
+            </LinearLayout>
+        </androidx.core.widget.NestedScrollView>
+    </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
+
+    <com.woocommerce.android.widgets.WCEmptyView
+        android:id="@+id/empty_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"/>
+
+</FrameLayout>

--- a/WooCommerce/src/main/res/layout/my_store_stats.xml
+++ b/WooCommerce/src/main/res/layout/my_store_stats.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.tabs.TabLayout
+        android:id="@+id/tab_layout"
+        style="@style/Woo.TabLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+
+    <FrameLayout
+        android:id="@+id/tab_layout_divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/list_divider"
+        app:srcCompat="@drawable/list_divider"/>
+
+    <LinearLayout
+        android:id="@+id/label_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:baselineAligned="false"
+        android:gravity="center_horizontal"
+        android:orientation="horizontal">
+
+        <LinearLayout
+            android:id="@+id/visitors_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center_horizontal"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/visitors_label"
+                style="@style/Woo.TextAppearance.Title.Small"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:text="@string/dashboard_stats_visitors"
+                tools:text="Visitors"/>
+
+            <TextView
+                android:id="@+id/visitors_value"
+                style="@style/Woo.TextAppearance.Label.XL"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                tools:text="400"/>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/orders_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center_horizontal"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/orders_label"
+                style="@style/Woo.TextAppearance.Title.Small"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:text="@string/dashboard_stats_orders"
+                tools:text="Orders"/>
+
+            <TextView
+                android:id="@+id/orders_value"
+                style="@style/Woo.TextAppearance.Label.XL"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                tools:text="10"/>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/revenue_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center_horizontal"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/revenue_label"
+                style="@style/Woo.TextAppearance.Title.Small"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:text="@string/dashboard_stats_revenue"/>
+
+            <TextView
+                android:id="@+id/revenue_value"
+                style="@style/Woo.TextAppearance.Label.XL"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                tools:text="$1.6k"/>
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+    <FrameLayout
+        android:id="@+id/chart_container"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/chart_height">
+
+        <com.woocommerce.android.ui.dashboard.DashboardStatsBarChart
+            android:id="@+id/chart"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
+
+        <ImageView
+            android:id="@+id/dashboard_stats_error"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:contentDescription="@string/dashboard_stats_error_content_description"
+            android:visibility="gone"
+            app:srcCompat="@drawable/ic_woo_error_state"
+            tools:visibility="visible"/>
+    </FrameLayout>
+
+    <TextView
+        android:id="@+id/dashboard_recency_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        tools:text="dashboard_recency_text"/>
+
+</merge>

--- a/WooCommerce/src/main/res/layout/my_store_stats.xml
+++ b/WooCommerce/src/main/res/layout/my_store_stats.xml
@@ -6,24 +6,10 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.google.android.material.tabs.TabLayout
-        android:id="@+id/tab_layout"
-        style="@style/Woo.TabLayout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
-
-    <FrameLayout
-        android:id="@+id/tab_layout_divider"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/list_divider"
-        app:srcCompat="@drawable/list_divider"/>
-
     <LinearLayout
         android:id="@+id/label_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
         android:baselineAligned="false"
         android:gravity="center_horizontal"
         android:orientation="horizontal">

--- a/WooCommerce/src/main/res/layout/my_store_top_earners.xml
+++ b/WooCommerce/src/main/res/layout/my_store_top_earners.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/topEarners_title"
+        style="@style/Woo.TextAppearance.Title.Bold"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/dashboard_top_earners_title"/>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/margin_large"
+        android:layout_marginTop="@dimen/margin_small"
+        android:text="@string/dashboard_top_earners_description"/>
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="start"
+            android:layout_marginBottom="@dimen/margin_large"
+            android:layout_marginTop="@dimen/margin_small"
+            android:text="@string/product"
+            android:textStyle="bold"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:layout_marginBottom="@dimen/margin_large"
+            android:layout_marginTop="@dimen/margin_small"
+            android:text="@string/dashboard_top_earners_total_spend"
+            android:textStyle="bold"/>
+    </FrameLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/list_divider"/>
+
+    <RelativeLayout
+        android:id="@+id/dashboard_top_earners_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/topEarners_recycler"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:minHeight="@dimen/top_earner_min_height"
+            tools:listitem="@layout/top_earner_list_item"/>
+
+        <ImageView
+            android:id="@+id/topEarners_error"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:contentDescription="@string/dashboard_stats_error_content_description"
+            android:visibility="gone"
+            app:srcCompat="@drawable/ic_woo_error_state"
+            tools:visibility="visible"/>
+
+        <TextView
+            android:id="@+id/topEarners_emptyView"
+            style="@style/Woo.Settings.Label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:text="@string/dashboard_top_earners_empty"
+            android:visibility="gone"
+            tools:visibility="visible"/>
+    </RelativeLayout>
+
+</merge>

--- a/WooCommerce/src/main/res/values/dimens.xml
+++ b/WooCommerce/src/main/res/values/dimens.xml
@@ -27,6 +27,11 @@
     <dimen name="appbar_elevation">4dp</dimen>
 
     <!--
+        TabLayout
+    -->
+    <dimen name="tablayout_elevation">4dp</dimen>
+
+    <!--
         Default Card
     -->
     <dimen name="card_padding_start">16dp</dimen>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -134,7 +134,7 @@
     <string name="dashboard_stats_visitors">Visitors</string>
     <string name="dashboard_stats_orders">Orders</string>
     <string name="dashboard_stats_revenue">Revenue</string>
-    <string name="dashboard_state_no_data">No data available</string>
+    <string name="dashboard_state_no_data">No revenue this period</string>
     <string name="dashboard_stats_error">Error fetching data</string>
     <string name="dashboard_stats_error_content_description">Error image</string>
 

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -309,9 +309,12 @@
         <item name="tabMode">scrollable</item>
         <item name="tabTextAppearance">@style/Woo.TabLayout.Text</item>
         <item name="tabTextColor">@color/wc_grey_mid</item>
-        <item name="tabContentStart">48dp</item>
-        <item name="tabPaddingStart">40dp</item>
-        <item name="tabPaddingEnd">40dp</item>
+        <item name="tabSelectedTextColor">@color/black</item>
+        <item name="android:background">@color/card_bgColor</item>
+        <item name="android:elevation">10dp</item>
+        <item name="tabPaddingStart">25dp</item>
+        <item name="tabPaddingEnd">25dp</item>
+        <item name="tabIndicatorHeight">2.5dp</item>
     </style>
 
     <style name="Woo.TabLayout.Text" parent="TextAppearance.Design.Tab">
@@ -550,6 +553,15 @@
         <item name="android:textColor">@color/default_text_color</item>
         <item name="android:textAlignment">viewStart</item>
         <item name="android:textSize">@dimen/text_large</item>
+    </style>
+
+    <!--
+         Stats
+        -->
+    <style name="Woo.Stats.Card" parent="Woo.Card">
+        <item name="android:elevation">2dp</item>
+        <item name="android:layout_marginStart">@dimen/margin_medium</item>
+        <item name="android:layout_marginEnd">@dimen/margin_medium</item>
     </style>
 
 </resources>

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -310,8 +310,17 @@
         <item name="tabTextAppearance">@style/Woo.TabLayout.Text</item>
         <item name="tabTextColor">@color/wc_grey_mid</item>
         <item name="tabSelectedTextColor">@color/black</item>
+        <item name="tabContentStart">48dp</item>
+        <item name="tabPaddingStart">40dp</item>
+        <item name="tabPaddingEnd">40dp</item>
+    </style>
+
+    <!--
+        TabLayout Style
+    -->
+    <style name="Woo.TabLayout.MyStore" parent="Woo.TabLayout">
         <item name="android:background">@color/card_bgColor</item>
-        <item name="android:elevation">10dp</item>
+        <item name="android:elevation">@dimen/tablayout_elevation</item>
         <item name="tabPaddingStart">25dp</item>
         <item name="tabPaddingEnd">25dp</item>
         <item name="tabIndicatorHeight">2.5dp</item>
@@ -559,9 +568,7 @@
          Stats
         -->
     <style name="Woo.Stats.Card" parent="Woo.Card">
-        <item name="android:elevation">2dp</item>
-        <item name="android:layout_marginStart">@dimen/margin_medium</item>
-        <item name="android:layout_marginEnd">@dimen/margin_medium</item>
+        <item name="android:layout_marginBottom">@dimen/card_item_padding_intra_h</item>
     </style>
 
 </resources>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenterTest.kt
@@ -1,0 +1,288 @@
+package com.woocommerce.android.ui.mystore
+
+import com.nhaarman.mockito_kotlin.KArgumentCaptor
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.anyOrNull
+import com.nhaarman.mockito_kotlin.argumentCaptor
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.spy
+import com.nhaarman.mockito_kotlin.times
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
+import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.tools.SelectedSite
+import org.junit.Before
+import org.junit.Test
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_HAS_ORDERS
+import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS
+import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDER_NOTES
+import org.wordpress.android.fluxc.action.WCOrderAction.UPDATE_ORDER_STATUS
+import org.wordpress.android.fluxc.action.WCStatsAction.FETCH_REVENUE_STATS
+import org.wordpress.android.fluxc.action.WCStatsAction.FETCH_TOP_EARNERS_STATS
+import org.wordpress.android.fluxc.action.WCStatsAction.FETCH_VISITOR_STATS
+import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCTopEarnerModel
+import org.wordpress.android.fluxc.store.WCOrderStore
+import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
+import org.wordpress.android.fluxc.store.WCOrderStore.OrderError
+import org.wordpress.android.fluxc.store.WCStatsStore
+import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsPayload
+import org.wordpress.android.fluxc.store.WCStatsStore.FetchTopEarnersStatsPayload
+import org.wordpress.android.fluxc.store.WCStatsStore.OnWCRevenueStatsChanged
+import org.wordpress.android.fluxc.store.WCStatsStore.OnWCStatsChanged
+import org.wordpress.android.fluxc.store.WCStatsStore.OnWCTopEarnersChanged
+import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsError
+import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType
+import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
+import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.DAYS
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MyStorePresenterTest {
+    private val myStoreView: MyStoreContract.View = mock()
+    private val dispatcher: Dispatcher = mock()
+    private val wooCommerceStore: WooCommerceStore = mock()
+    private val wcStatsStore: WCStatsStore = mock()
+    private val wcOrderStore: WCOrderStore = mock()
+    private val selectedSite: SelectedSite = mock()
+    private val networkStatus: NetworkStatus = mock()
+
+    private lateinit var presenter: MyStorePresenter
+
+    private lateinit var actionCaptor: KArgumentCaptor<Action<*>>
+
+    @Before
+    fun setup() {
+        presenter = spy(MyStorePresenter(
+                dispatcher, wooCommerceStore, wcStatsStore, wcOrderStore, selectedSite, networkStatus))
+        // Use a dummy selected site
+        doReturn(SiteModel()).whenever(selectedSite).get()
+        doReturn(true).whenever(networkStatus).isConnected()
+        actionCaptor = argumentCaptor()
+    }
+
+    @Test
+    fun `Requests revenue stats data correctly`() {
+        presenter.takeView(myStoreView)
+        presenter.loadStats(StatsGranularity.DAYS)
+
+        // note that we expect two dispatches because there's one to get stats and another to get visitors
+        verify(dispatcher, times(2)).dispatch(actionCaptor.capture())
+        assertEquals(FETCH_REVENUE_STATS, actionCaptor.firstValue.type)
+
+        val payload = actionCaptor.firstValue.payload as FetchRevenueStatsPayload
+        assertEquals(StatsGranularity.DAYS, payload.granularity)
+    }
+
+    @Test
+    fun `Handles stats OnChanged result correctly`() {
+        presenter.takeView(myStoreView)
+
+        // Simulate OnChanged event from FluxC
+        val onChanged = OnWCRevenueStatsChanged(
+                1, StatsGranularity.DAYS, "2019-07-30", "2019-07-30"
+        )
+        onChanged.causeOfChange = FETCH_REVENUE_STATS
+        presenter.onWCRevenueStatsChanged(onChanged)
+
+        verify(myStoreView).showStats(anyOrNull(), eq(StatsGranularity.DAYS))
+    }
+
+    @Test
+    fun `Handles stats OnChanged error result correctly`() {
+        presenter.takeView(myStoreView)
+
+        // Simulate OnChanged event from FluxC
+        val onChanged = OnWCRevenueStatsChanged(1, granularity = DAYS).apply {
+            causeOfChange = FETCH_REVENUE_STATS
+            error = OrderStatsError(OrderStatsErrorType.INVALID_PARAM)
+        }
+        presenter.onWCRevenueStatsChanged(onChanged)
+        verify(myStoreView, times(1)).showStatsError(StatsGranularity.DAYS)
+    }
+
+    @Test
+    fun `Handles FETCH-ORDERS order event correctly`() {
+        presenter.takeView(myStoreView)
+
+        // Simulate onOrderChanged event: FETCH-ORDERS - My Store TAB should refresh
+        presenter.onOrderChanged(OnOrderChanged(0).apply { causeOfChange = FETCH_ORDERS })
+        verify(myStoreView, times(0)).refreshMyStoreStats(forced = any())
+    }
+
+    @Test
+    fun `Handles UPDATE-ORDER-STATUS order event correctly`() {
+        presenter.takeView(myStoreView)
+
+        // Simulate onOrderChanged event: UPDATE-ORDER-STATUS - My Store TAB should refresh
+        presenter.onOrderChanged(OnOrderChanged(0).apply { causeOfChange = UPDATE_ORDER_STATUS })
+        verify(myStoreView, times(0)).refreshMyStoreStats(forced = any())
+    }
+
+    @Test
+    fun `Handles FETCH-ORDER-NOTES order event correctly`() {
+        presenter.takeView(myStoreView)
+
+        // Simulate onOrderChanged event: FETCH-ORDER-NOTES - My Store TAB should ignore
+        presenter.onOrderChanged(OnOrderChanged(0).apply { causeOfChange = FETCH_ORDER_NOTES })
+        verify(myStoreView, times(0)).refreshMyStoreStats(forced = true)
+    }
+
+    @Test
+    fun `Handles FETCH-ORDERS order event with error correctly`() {
+        presenter.takeView(myStoreView)
+
+        // Simulate onOrderChanged event: FETCH-ORDERS w/error - My Store TAB should ignore
+        presenter.onOrderChanged(OnOrderChanged(0).apply {
+            causeOfChange = FETCH_ORDERS
+            error = OrderError()
+        })
+        verify(myStoreView, times(0)).refreshMyStoreStats(forced = any())
+    }
+
+    @Test
+    fun `Refreshes my store on network connected event if needed`() {
+        presenter.takeView(myStoreView)
+        doReturn(true).whenever(myStoreView).isRefreshPending
+
+        // Simulate the network connected event
+        presenter.onEventMainThread(ConnectionChangeEvent(true))
+        verify(myStoreView, times(1)).refreshMyStoreStats(forced = any())
+    }
+
+    @Test
+    fun `Does not refresh my store on network connected event if not needed`() {
+        presenter.takeView(myStoreView)
+        doReturn(false).whenever(myStoreView).isRefreshPending
+
+        // Simulate the network connected event
+        presenter.onEventMainThread(ConnectionChangeEvent(true))
+        verify(myStoreView, times(0)).refreshMyStoreStats(forced = any())
+    }
+
+    @Test
+    fun `Ignores network disconnected event correctly`() {
+        presenter.takeView(myStoreView)
+
+        // Simulate the network disconnected event
+        presenter.onEventMainThread(ConnectionChangeEvent(false))
+        verify(myStoreView, times(0)).refreshMyStoreStats(forced = any())
+    }
+
+    @Test
+    fun `Requests top earners stats data correctly - forced`() {
+        presenter.takeView(myStoreView)
+
+        presenter.loadTopEarnerStats(StatsGranularity.DAYS, forced = true)
+        verify(dispatcher, times(1)).dispatch(actionCaptor.capture())
+        assertEquals(FETCH_TOP_EARNERS_STATS, actionCaptor.firstValue.type)
+
+        val payload = actionCaptor.firstValue.payload as FetchTopEarnersStatsPayload
+        assertEquals(StatsGranularity.DAYS, payload.granularity)
+        assertTrue(payload.forced)
+    }
+
+    @Test
+    fun `Requests top earners stats data correctly - not forced`() {
+        presenter.takeView(myStoreView)
+
+        presenter.loadTopEarnerStats(StatsGranularity.DAYS, forced = false)
+        verify(dispatcher, times(1)).dispatch(actionCaptor.capture())
+        assertEquals(FETCH_TOP_EARNERS_STATS, actionCaptor.firstValue.type)
+
+        val payload = actionCaptor.firstValue.payload as FetchTopEarnersStatsPayload
+        assertEquals(StatsGranularity.DAYS, payload.granularity)
+    }
+
+    @Test
+    fun `Handles FETCH_TOP_EARNERS_STATS event correctly`() {
+        presenter.takeView(myStoreView)
+
+        val topEarners = ArrayList<WCTopEarnerModel>()
+        topEarners.add(WCTopEarnerModel())
+        presenter.onWCTopEarnersChanged(OnWCTopEarnersChanged(topEarners, StatsGranularity.DAYS).apply {
+            causeOfChange = FETCH_TOP_EARNERS_STATS
+        })
+        verify(myStoreView, times(1)).showTopEarners(topEarners, StatsGranularity.DAYS)
+    }
+
+    @Test
+    fun `Handles FETCH_TOP_EARNERS_STATS error event correctly`() {
+        presenter.takeView(myStoreView)
+
+        presenter.onWCTopEarnersChanged(OnWCTopEarnersChanged(emptyList(), StatsGranularity.DAYS).apply {
+            causeOfChange = FETCH_TOP_EARNERS_STATS
+            error = OrderStatsError(OrderStatsErrorType.INVALID_PARAM)
+        })
+        verify(myStoreView, times(1)).showTopEarnersError(StatsGranularity.DAYS)
+    }
+
+    @Test
+    fun `Handles FETCH_HAS_ORDERS when there aren't any orders`() {
+        presenter.takeView(myStoreView)
+        presenter.onOrderChanged(OnOrderChanged(0).apply { causeOfChange = FETCH_HAS_ORDERS })
+        verify(myStoreView, times(1)).showEmptyView(true)
+    }
+
+    @Test
+    fun `Handles FETCH_HAS_ORDERS when there are orders`() {
+        presenter.takeView(myStoreView)
+        presenter.onOrderChanged(OnOrderChanged(1).apply { causeOfChange = FETCH_HAS_ORDERS })
+        verify(myStoreView, times(1)).showEmptyView(false)
+    }
+
+    @Test
+    fun `Handles FETCH_VISITOR_STATS event correctly`() {
+        presenter.takeView(myStoreView)
+
+        val onChanged = OnWCStatsChanged(1, granularity = StatsGranularity.DAYS)
+        onChanged.causeOfChange = FETCH_VISITOR_STATS
+
+        presenter.onWCStatsChanged(onChanged)
+        verify(myStoreView, times(1)).showVisitorStats(1, StatsGranularity.DAYS)
+    }
+
+    @Test
+    fun `Handles FETCH_VISITOR_STATS error event correctly`() {
+        presenter.takeView(myStoreView)
+
+        val onChanged = OnWCStatsChanged(1, granularity = StatsGranularity.DAYS)
+        onChanged.causeOfChange = FETCH_VISITOR_STATS
+        onChanged.error = OrderStatsError(OrderStatsErrorType.INVALID_PARAM)
+
+        presenter.onWCStatsChanged(onChanged)
+        verify(myStoreView, times(1)).showVisitorStatsError(StatsGranularity.DAYS)
+    }
+
+    @Test
+    fun `Show and hide stats skeleton correctly`() {
+        presenter.takeView(myStoreView)
+        presenter.loadStats(StatsGranularity.DAYS, forced = true)
+        verify(myStoreView, times(1)).showChartSkeleton(true)
+
+        val onChanged = OnWCRevenueStatsChanged(
+                1, granularity = StatsGranularity.DAYS, startDate = "2019-07-30", endDate = "2019-07-30"
+        )
+        onChanged.causeOfChange = FETCH_REVENUE_STATS
+        presenter.onWCRevenueStatsChanged(onChanged)
+        verify(myStoreView, times(1)).showChartSkeleton(false)
+    }
+
+    @Test
+    fun `Show and hide top earners skeleton correctly`() {
+        presenter.takeView(myStoreView)
+        presenter.loadTopEarnerStats(StatsGranularity.DAYS, forced = true)
+        verify(myStoreView, times(1)).showTopEarnersSkeleton(true)
+
+        presenter.onWCTopEarnersChanged(OnWCTopEarnersChanged(emptyList(), StatsGranularity.DAYS).apply {
+            causeOfChange = FETCH_TOP_EARNERS_STATS
+        })
+        verify(myStoreView, times(1)).showTopEarnersSkeleton(false)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
@@ -122,4 +122,38 @@ class DateUtilsTest {
             DateUtils.getDateString("")
         }
     }
+
+    @Test
+    fun `getShortHourString() returns correct values`() {
+        assertEquals("12am", DateUtils.getShortHourString("2019-05-09 00"))
+        assertEquals("12pm", DateUtils.getShortHourString("2019-05-09 12"))
+        assertEquals("1am", DateUtils.getShortHourString("2018-12-31 01"))
+        assertEquals("5am", DateUtils.getShortHourString("2019-07-15 05"))
+        assertEquals("2pm", DateUtils.getShortHourString("2019-01-01 14"))
+        assertEquals("11pm", DateUtils.getShortHourString("2019-02-28 23"))
+        assertEquals("4pm", DateUtils.getShortHourString("2019-02-28 16"))
+        assertEquals("9am", DateUtils.getShortHourString("2019-02-28 09"))
+
+        // Test for invalid value handling
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortHourString("Dec 30 2018")
+        }
+
+        // Test for invalid value handling
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortHourString("2019-12-31")
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortHourString("-07-41")
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortHourString("")
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortHourString("5am")
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'e85ccc029dbb3de3f7113822cc7c14dcdb17ba8a'
+    fluxCVersion = '491f3b985a0d0c83d5c8082687c399f26826a63a'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Fixes #1259. This PR completes the first step of the Stats Improvements Project as defined in the master thread [here](https://github.com/woocommerce/woocommerce-android/issues/1199). 

### Changes:
- [x] Adds a new FluxC hash that includes the latest v4 api changes.
- [x] Checks if v4 stats api is supported:
  - [x] Adds a new `RevenueStatsAvailabilityFetcher` class that handles the logic to fetch the stats v4 api availability for a site and stores the availability flag in `SharedPreferences`.
  - [x] The availability check is added to the `MainActivity` class and is called every time the app is opened.
  - [x] The availability check is added to the `SitePickerActivity` class and is called every time the user switches a store or picks a store after logging to the app.
  - [x] The availability check is added to the pull to refresh gesture in the old and the new stats. 
- [x] Duplicates the current Dashboard architecture for displaying the new Stats data - This include s duplicating the existing implementation of `DashboardFragment`, `DashboardPresenter`, `DashboardContract`, `DashboardStatsView`, `DashboardModule`. The new classes are added to a separate package called `mystore`.
- [x] The TAB bar title for the v4 stats UI has been changed to `Today`, `This Week`, `This Month`, and `This Year`.
- [x] Since the date ranges have been modified, the date range is passed to FluxC when querying for the visitor stats in v4 UI. 
- [x] Remove the top selling products tab layout.
- [x] Anchor the tabLayout when the view is scrolled.

 ### Notes:
- There is no logic in place, at the moment, to change the UI, if it is already visible to the user. This will be handled in a separate PR. For instance:
  - If the api response returned is successful but the user has already seen the v3 stats screen.
  - If the api response returned is error but the user has already seen the v4 stats screen (happens when the user has disabled this plugin). 
- The v4 stats api does not provide the currency for the data in the api response. So, the logic is modified to fetch the currency from the `Site Settings`.

### Behaviour:
<img width="300" src="https://user-images.githubusercontent.com/22608780/62352407-b2d17680-b525-11e9-8f70-ff0a3295d2b4.gif">

### Screenshots:
#### No Data UI
(LEFT: old stats data . RIGHT: v4 stats data):
<img width="300" src="https://user-images.githubusercontent.com/22608780/62279898-96233900-b468-11e9-8bfa-abfe3e7ec86e.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/62352454-d4caf900-b525-11e9-85a3-ffbf90a2ca38.png"> 

#### V4 Stats UI
<img width="300" src="https://user-images.githubusercontent.com/22608780/62352527-fc21c600-b525-11e9-8b6b-aaa053682be6.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/62352531-ff1cb680-b525-11e9-8716-a920aa9aa04b.png"> 
<img width="300" src="https://user-images.githubusercontent.com/22608780/62352574-1a87c180-b526-11e9-8525-a94452aa1c3c.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/62352578-1cea1b80-b526-11e9-8cab-7a5353b79614.png"> 

### Testing
- Run `MyStorePresenterTest`.
- Run `DateUtilsTest`
- Test a new order completion and verify that the Stats is updated for the current day.
- Test on site without `wc-admin` installed/activated.
- Test on site with `wc-admin` installed.
- Test on site without `wc-admin`, then install `wc-admin` and try again for the same site. The app will not refresh automatically. We would need to close the app and open again to verify the changes.

### Questions:
~~I accidentally changed the style of `TabLayout` so now there is an elevation added to the old stats UI as well. I thought it looked good so I left it that way 😊. We could certainly remove it without much hassle. But WDYT?~~ Removing the elevation for the old stats since there are two tabs and it looks confusing.
~~I noticed while testing that since today is the first of August and there are no orders for my test site today, that:~~
  - ~~Today TAB: has 0 stats.~~
  - ~~This week TAB: has some data (since the stats data is from the start of this week i.e. 29 July).~~
  - ~~This Month TAB: has no data (since the stats data is from the start of the current month i.e. today).~~
  - ~~This Year TAB: has data (since the stats data is from the start of this year)~~

~~I'm not sure if the difference between the data in WEEK and MONTH tab, would be confusing to the user. 😕~~ As @nbradbury mentioned [here](https://github.com/woocommerce/woocommerce-android/pull/1314#issuecomment-517279821), this might not be a problem since we would be adding the date bar to the tabs in another PR.