### PR TITLE
Issue/1319 order notif removed review tab

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,8 @@
  
 * Fixed rare crash after fulfilling an order and then minimizing the app.
 * Product names can now wrap to two lines in order detail.
-* Bug fix: Reviews tab incorrectly shows a badge when an order notification is received.
+* Bug fix: reviews tab incorrectly shows a badge when an order notification is received.
+* Bug fix: switching to the reviews tab removes order notifications.
 
 2.4
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
@@ -116,13 +116,13 @@ class NotificationHandler @Inject constructor(
         }
 
         /**
-         * Removes only review notifications from the system bar
+         * Removes only a specific type of notification from the system bar
          */
-        @Synchronized fun removeAllReviewNotifsFromSystemBar(context: Context) {
+        @Synchronized private fun removeAllNotifsOfTypeFromSystemBar(context: Context, type: String) {
             val notificationManager = NotificationManagerCompat.from(context)
 
             ACTIVE_NOTIFICATIONS_MAP.asSequence().forEach { entry ->
-                if (entry.value.getString(PUSH_ARG_TYPE) == PUSH_TYPE_COMMENT) {
+                if (entry.value.getString(PUSH_ARG_TYPE) == type) {
                     notificationManager.cancel(entry.key)
                     ACTIVE_NOTIFICATIONS_MAP.remove(entry.key)
                 }
@@ -132,7 +132,17 @@ class NotificationHandler @Inject constructor(
                 notificationManager.cancel(GROUP_NOTIFICATION_ID)
             }
 
-            setHasUnseenReviewNotifs(false)
+            if (type == PUSH_TYPE_COMMENT) {
+                setHasUnseenReviewNotifs(false)
+            }
+        }
+
+        fun removeAllReviewNotifsFromSystemBar(context: Context) {
+            removeAllNotifsOfTypeFromSystemBar(context, PUSH_TYPE_COMMENT)
+        }
+
+        fun removeAllOrderNotifsFromSystemBar(context: Context) {
+            removeAllNotifsOfTypeFromSystemBar(context, PUSH_TYPE_NEW_ORDER)
         }
 
         /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
@@ -119,21 +119,15 @@ class NotificationHandler @Inject constructor(
          * Removes only review notifications from the system bar
          */
         @Synchronized fun removeAllReviewNotificationsFromSystemBar(context: Context) {
-            val nonReviewNotifs = HashMap<Int, Bundle>()
-            ACTIVE_NOTIFICATIONS_MAP.forEach {
-                // if this is a review we remove it otherwise add it to the list of non-review notifs
-                val type = it.value.getString(PUSH_ARG_TYPE) ?: ""
-                if (type == PUSH_TYPE_COMMENT) {
-                    val wpComNoteId = it.value.getString(PUSH_ARG_NOTE_ID) ?: ""
-                    removeNotificationWithNoteIdFromSystemBar(context, wpComNoteId)
-                } else {
-                    nonReviewNotifs.put(it.key, it.value)
+            val notificationManager = NotificationManagerCompat.from(context)
+
+            ACTIVE_NOTIFICATIONS_MAP.asSequence().forEach { entry ->
+                if (entry.value.getString(PUSH_ARG_TYPE) == PUSH_TYPE_COMMENT) {
+                    val wpComNoteId = entry.value.getString(PUSH_ARG_NOTE_ID) ?: ""
+                    notificationManager.cancel(entry.key)
+                    ACTIVE_NOTIFICATIONS_MAP.remove(entry.key)
                 }
             }
-
-            // clear the active list then add back non-review notifs
-            ACTIVE_NOTIFICATIONS_MAP.clear()
-            ACTIVE_NOTIFICATIONS_MAP.putAll(nonReviewNotifs)
 
             setHasUnseenReviewNotifss(false)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
@@ -112,24 +112,27 @@ class NotificationHandler @Inject constructor(
             val notificationManager = NotificationManagerCompat.from(context)
             notificationManager.cancelAll()
 
-            setHasUnseenReviewNotifss(false)
+            setHasUnseenReviewNotifs(false)
         }
 
         /**
          * Removes only review notifications from the system bar
          */
-        @Synchronized fun removeAllReviewNotificationsFromSystemBar(context: Context) {
+        @Synchronized fun removeAllReviewNotifsFromSystemBar(context: Context) {
             val notificationManager = NotificationManagerCompat.from(context)
 
             ACTIVE_NOTIFICATIONS_MAP.asSequence().forEach { entry ->
                 if (entry.value.getString(PUSH_ARG_TYPE) == PUSH_TYPE_COMMENT) {
-                    val wpComNoteId = entry.value.getString(PUSH_ARG_NOTE_ID) ?: ""
                     notificationManager.cancel(entry.key)
                     ACTIVE_NOTIFICATIONS_MAP.remove(entry.key)
                 }
             }
 
-            setHasUnseenReviewNotifss(false)
+            if (!hasNotifications()) {
+                notificationManager.cancel(GROUP_NOTIFICATION_ID)
+            }
+
+            setHasUnseenReviewNotifs(false)
         }
 
         /**
@@ -152,7 +155,7 @@ class NotificationHandler @Inject constructor(
             // If there are no notifications left, cancel the group as well and clear the unseen state
             if (!hasNotifications()) {
                 notificationManager.cancel(GROUP_NOTIFICATION_ID)
-                setHasUnseenReviewNotifss(false)
+                setHasUnseenReviewNotifs(false)
             }
         }
 
@@ -185,7 +188,7 @@ class NotificationHandler @Inject constructor(
          * Called when we want to update the unseen state of review notifs - changes the related
          * shared preference and posts an EventBus event so main activity can update the badge
          */
-        private fun setHasUnseenReviewNotifss(hasUnseen: Boolean) {
+        private fun setHasUnseenReviewNotifs(hasUnseen: Boolean) {
             if (hasUnseen != AppPrefs.getHasUnseenReviews()) {
                 AppPrefs.setHasUnseenReviews(hasUnseen)
                 EventBus.getDefault().post(NotificationsUnseenReviewsEvent(hasUnseen))
@@ -295,7 +298,7 @@ class NotificationHandler @Inject constructor(
         showGroupNotificationForBuilder(context, builder, noteType, wpComNoteId, message)
 
         if (noteType == REVIEW) {
-            setHasUnseenReviewNotifss(true)
+            setHasUnseenReviewNotifs(true)
         }
 
         EventBus.getDefault().post(NotificationReceivedEvent(noteType))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
@@ -116,6 +116,29 @@ class NotificationHandler @Inject constructor(
         }
 
         /**
+         * Removes only review notifications from the system bar
+         */
+        @Synchronized fun removeAllReviewNotificationsFromSystemBar(context: Context) {
+            val nonReviewNotifs = HashMap<Int, Bundle>()
+            ACTIVE_NOTIFICATIONS_MAP.forEach {
+                // if this is a review we remove it otherwise add it to the list of non-review notifs
+                val type = it.value.getString(PUSH_ARG_TYPE) ?: ""
+                if (type == PUSH_TYPE_COMMENT) {
+                    val wpComNoteId = it.value.getString(PUSH_ARG_NOTE_ID) ?: ""
+                    removeNotificationWithNoteIdFromSystemBar(context, wpComNoteId)
+                } else {
+                    nonReviewNotifs.put(it.key, it.value)
+                }
+            }
+
+            // clear the active list then add back non-review notifs
+            ACTIVE_NOTIFICATIONS_MAP.clear()
+            ACTIVE_NOTIFICATIONS_MAP.putAll(nonReviewNotifs)
+
+            setHasUnseenReviewNotifss(false)
+        }
+
+        /**
          * Removes a specific notification from the system bar.
          */
         @Synchronized fun removeNotificationWithNoteIdFromSystemBar(context: Context, wpComNoteId: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.push
 
+import android.annotation.SuppressLint
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.NotificationManager.IMPORTANCE_DEFAULT
@@ -118,15 +119,20 @@ class NotificationHandler @Inject constructor(
         /**
          * Removes only a specific type of notification from the system bar
          */
+        @SuppressLint("UseSparseArrays")
         @Synchronized private fun removeAllNotifsOfTypeFromSystemBar(context: Context, type: String) {
             val notificationManager = NotificationManagerCompat.from(context)
 
+            val keptNotifs = HashMap<Int, Bundle>()
             ACTIVE_NOTIFICATIONS_MAP.asSequence().forEach { entry ->
                 if (entry.value.getString(PUSH_ARG_TYPE) == type) {
                     notificationManager.cancel(entry.key)
-                    ACTIVE_NOTIFICATIONS_MAP.remove(entry.key)
+                } else {
+                    keptNotifs[entry.key] = entry.value
                 }
             }
+            ACTIVE_NOTIFICATIONS_MAP.clear()
+            ACTIVE_NOTIFICATIONS_MAP.putAll(keptNotifs)
 
             if (!hasNotifications()) {
                 notificationManager.cancel(GROUP_NOTIFICATION_ID)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -469,7 +469,7 @@ class MainActivity : AppUpgradeActivity(),
 
     override fun hideReviewsBadge() {
         bottomNavView.showReviewsBadge(false)
-        NotificationHandler.removeAllNotificationsFromSystemBar(this)
+        NotificationHandler.removeAllReviewNotifsFromSystemBar(this)
     }
 
     override fun showReviewsBadge() {
@@ -508,7 +508,7 @@ class MainActivity : AppUpgradeActivity(),
 
         // Update the unseen notifications badge visibility
         if (navPos == REVIEWS) {
-            NotificationHandler.removeAllNotificationsFromSystemBar(this)
+            NotificationHandler.removeAllReviewNotifsFromSystemBar(this)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -506,9 +506,10 @@ class MainActivity : AppUpgradeActivity(),
             navigateToRoot()
         }
 
-        // Update the unseen notifications badge visibility
         if (navPos == REVIEWS) {
             NotificationHandler.removeAllReviewNotifsFromSystemBar(this)
+        } else if (navPos == ORDERS) {
+            NotificationHandler.removeAllOrderNotifsFromSystemBar(this)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/notifications/NotifsListFragment.kt
@@ -374,7 +374,7 @@ class NotifsListFragment : TopLevelFragment(),
      */
     override fun visuallyMarkNotificationsAsRead() {
         // Remove all active notifications from the system bar
-        context?.let { NotificationHandler.removeAllNotificationsFromSystemBar(it) }
+        context?.let { NotificationHandler.removeAllReviewNotifsFromSystemBar(it) }
 
         notifsAdapter.markAllNotifsAsRead()
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -429,8 +429,8 @@
         Notifications List
     -->
     <string name="wc_mark_all_read">Mark all as read</string>
-    <string name="wc_mark_all_read_success">All notifications marked as read</string>
-    <string name="wc_mark_all_read_error">Error marking all notifications as read</string>
+    <string name="wc_mark_all_read_success">All reviews marked as read</string>
+    <string name="wc_mark_all_read_error">Error marking all reviews as read</string>
     <!--
         Login Library Imported Strings
     -->


### PR DESCRIPTION
Fixes #1319 - previously switching to the Reviews tab would remove all notifications from the system bar, which made sense when it was the Notifications tab. This PR addresses this by only removing review notifications when the Reviews tab is tapped. Likewise, order notifications are removed when the Orders tab is tapped.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
