### PR TITLE
Stats Improvements Step 2: add date bar to the top of the charts

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
  
 * Fixed rare crash after fulfilling an order and then minimizing the app.
 * Product names can now wrap to two lines in order detail.
+* Added a new date bar to the Stats page to better communicate the date range of the data displayed.
 
 2.4
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -77,6 +77,7 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
             // up before the chart data is added once the request completes
             if (value) {
                 clearLabelValues()
+                clearDateRangeValues()
                 chart.setNoDataText(null)
                 chart.clear()
             } else {
@@ -303,6 +304,11 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
 
         hideMarker()
         resetLastUpdated()
+
+        // update the date range view only after the Bar dataset is generated
+        // since we are using the [chartRevenueStats] variable to get the
+        // start and end date values
+        updateDateRangeView()
         isRequestingStats = false
     }
 
@@ -318,6 +324,26 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
 
     fun showVisitorStatsError() {
         fadeInLabelValue(visitors_value, "?")
+    }
+
+    /**
+     * Update the date bar range with the start and end date.
+     * If the start and end date are the same i.e. 2019 for YEARS, then only display
+     * the date and not the range
+     */
+    private fun updateDateRangeView() {
+        val startDate = getStartDateValue()
+        val endDate = getEndDateValue()
+        val dateRangeString = if (startDate == endDate) {
+            startDate
+        } else {
+            String.format("%s–%s", startDate, endDate)
+        }
+        dashboard_date_range_value.text = dateRangeString
+    }
+
+    private fun clearDateRangeValues() {
+        dashboard_date_range_value.text = ""
     }
 
     fun clearLabelValues() {
@@ -381,6 +407,27 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
         }
 
         return BarDataSet(barEntries, "")
+    }
+
+    private fun getStartDateValue(): String {
+        val dateString = chartRevenueStats.keys.first()
+        return when (activeGranularity) {
+            StatsGranularity.DAYS -> DateUtils.getShortMonthDayString(dateString)
+            StatsGranularity.WEEKS -> DateUtils.getShortMonthDayStringForWeek(dateString)
+            StatsGranularity.MONTHS -> DateUtils.getShortMonthYearString(dateString)
+            StatsGranularity.YEARS -> dateString
+        }
+    }
+
+    private fun getEndDateValue(): String {
+        val dateString = chartRevenueStats.keys.last()
+        return when (activeGranularity) {
+            StatsGranularity.DAYS -> DateUtils.getShortMonthDayString(dateString)
+            StatsGranularity.WEEKS ->
+                SiteUtils.getCurrentDateTimeForSite(selectedSite.get(), DateUtils.friendlyMonthDayFormat)
+            StatsGranularity.MONTHS -> DateUtils.getShortMonthYearString(dateString)
+            StatsGranularity.YEARS -> dateString
+        }
     }
 
     @StringRes

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -337,7 +337,7 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
         val dateRangeString = if (startDate == endDate) {
             startDate
         } else {
-            String.format("%s–%s", startDate, endDate)
+            String.format("%s – %s", startDate, endDate)
         }
         dashboard_date_range_value.text = dateRangeString
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreDateRangeView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreDateRangeView.kt
@@ -1,0 +1,57 @@
+package com.woocommerce.android.ui.mystore
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.widget.LinearLayout
+import com.woocommerce.android.R
+import com.woocommerce.android.util.DateUtils
+import kotlinx.android.synthetic.main.my_store_date_bar.view.*
+import org.wordpress.android.fluxc.model.WCRevenueStatsModel
+import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
+
+class MyStoreDateRangeView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
+    : LinearLayout(ctx, attrs) {
+    init {
+        View.inflate(context, R.layout.my_store_date_bar, this)
+    }
+
+    fun initView() {
+        clearDateRangeValues()
+    }
+
+    fun updateDateRangeView(
+        revenueStatsModel: WCRevenueStatsModel?,
+        granularity: StatsGranularity) {
+        val startInterval = revenueStatsModel?.getIntervalList()?.first()?.interval
+        val startDate = startInterval?.let { getDateValue(it, granularity) }
+
+        val dateRangeString = when (granularity) {
+            StatsGranularity.WEEKS -> {
+                val endInterval = revenueStatsModel?.getIntervalList()?.last()?.interval
+                val endDate = endInterval?.let { getDateValue(it, granularity) }
+                String.format("%s–%s", startDate, endDate)
+            }
+            else -> {
+                startDate
+            }
+        }
+        dashboard_date_range_value.text = dateRangeString
+    }
+
+    fun clearDateRangeValues() {
+        dashboard_date_range_value.text = ""
+    }
+
+    private fun getDateValue(
+        dateString: String,
+        activeGranularity: StatsGranularity
+    ): String {
+        return when (activeGranularity) {
+            StatsGranularity.DAYS -> DateUtils.getDayMonthDateString(dateString)
+            StatsGranularity.WEEKS -> DateUtils.getShortMonthDayString(dateString)
+            StatsGranularity.MONTHS -> DateUtils.getMonthString(dateString)
+            StatsGranularity.YEARS -> DateUtils.getYearString(dateString)
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreDateRangeView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreDateRangeView.kt
@@ -31,7 +31,7 @@ class MyStoreDateRangeView @JvmOverloads constructor(ctx: Context, attrs: Attrib
             StatsGranularity.WEEKS -> {
                 val endInterval = revenueStatsModel?.getIntervalList()?.last()?.interval
                 val endDate = endInterval?.let { getDateValue(it, granularity) }
-                String.format("%s–%s", startDate, endDate)
+                String.format("%s – %s", startDate, endDate)
             }
             else -> {
                 startDate

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreDateRangeView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreDateRangeView.kt
@@ -22,7 +22,8 @@ class MyStoreDateRangeView @JvmOverloads constructor(ctx: Context, attrs: Attrib
 
     fun updateDateRangeView(
         revenueStatsModel: WCRevenueStatsModel?,
-        granularity: StatsGranularity) {
+        granularity: StatsGranularity
+    ) {
         val startInterval = revenueStatsModel?.getIntervalList()?.first()?.interval
         val startDate = startInterval?.let { getDateValue(it, granularity) }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -119,6 +119,7 @@ class MyStoreFragment : TopLevelFragment(),
             }
         }
 
+        my_store_date_bar.initView()
         my_store_stats.initView(
                 activeGranularity,
                 listener = this,
@@ -141,6 +142,7 @@ class MyStoreFragment : TopLevelFragment(),
         tab_layout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
             override fun onTabSelected(tab: TabLayout.Tab) {
                 tabStatsPosition = tab.position
+                my_store_date_bar.clearDateRangeValues()
                 my_store_stats.loadDashboardStats(activeGranularity)
                 my_store_top_earners.loadTopEarnerStats(activeGranularity)
             }
@@ -204,6 +206,7 @@ class MyStoreFragment : TopLevelFragment(),
         if (activeGranularity == granularity) {
             my_store_stats.showErrorView(false)
             my_store_stats.updateView(revenueStatsModel, presenter.getStatsCurrency())
+            my_store_date_bar.updateDateRangeView(revenueStatsModel, granularity)
         }
     }
 
@@ -283,6 +286,7 @@ class MyStoreFragment : TopLevelFragment(),
                 if (forced) {
                     my_store_stats.clearLabelValues()
                     my_store_stats.clearChartData()
+                    my_store_date_bar.clearDateRangeValues()
                 }
                 presenter.loadStats(activeGranularity, forced)
                 presenter.loadTopEarnerStats(activeGranularity, forced)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -229,4 +229,21 @@ object DateUtils {
             throw IllegalArgumentException("Date string argument is not of format yyyy-MM-dd H: $iso8601Date")
         }
     }
+
+    /**
+     * Given a date of format YYYY-MM, returns the corresponding short month format.
+     *
+     * For example, given 2018-07, returns "Jul 2018".
+     *
+     * @throws IllegalArgumentException if the argument is not a valid iso8601 date string.
+     */
+    @Throws(IllegalArgumentException::class)
+    fun getShortMonthYearString(iso8601Month: String): String {
+        return try {
+            val (year, month) = iso8601Month.split("-")
+            "${shortMonths[month.toInt() - 1]} $year"
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Date string argument is not of format yyyy-MM: $iso8601Month")
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -14,7 +14,6 @@ import java.util.Locale
 
 object DateUtils {
     val friendlyMonthDayFormat by lazy { SimpleDateFormat("MMM d", Locale.getDefault()) }
-    val friendlyDayMonthDateFormat by lazy { SimpleDateFormat("EEEE, MMM d", Locale.ROOT) }
     private val weekOfYearStartingMondayFormat by lazy {
         SimpleDateFormat("yyyy-'W'ww", Locale.getDefault()).apply {
             calendar = Calendar.getInstance().apply {
@@ -102,10 +101,11 @@ object DateUtils {
     @Throws(IllegalArgumentException::class)
     fun getDayMonthDateString(iso8601Date: String): String {
         return try {
+            val targetFormat = SimpleDateFormat("EEEE, MMM d", Locale.getDefault())
             val (dateString, _) = iso8601Date.split(" ")
             val (year, month, day) = dateString.split("-")
             val date = GregorianCalendar(year.toInt(), month.toInt() - 1, day.toInt()).time
-            friendlyDayMonthDateFormat.format(date)
+            targetFormat.format(date)
         } catch (e: Exception) {
             throw IllegalArgumentException("Date string argument is not of format YYYY-MM-DD hh: $iso8601Date")
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -14,6 +14,7 @@ import java.util.Locale
 
 object DateUtils {
     val friendlyMonthDayFormat by lazy { SimpleDateFormat("MMM d", Locale.getDefault()) }
+    val friendlyDayMonthDateFormat by lazy { SimpleDateFormat("EEEE, MMM d", Locale.ROOT) }
     private val weekOfYearStartingMondayFormat by lazy {
         SimpleDateFormat("yyyy-'W'ww", Locale.getDefault()).apply {
             calendar = Calendar.getInstance().apply {
@@ -88,6 +89,25 @@ object DateUtils {
             return calendar.getActualMaximum(Calendar.DAY_OF_MONTH)
         } catch (e: IndexOutOfBoundsException) {
             throw IllegalArgumentException("Date string argument is not of format YYYY-MM-DD: $iso8601Date")
+        }
+    }
+
+    /**
+     * Given an ISO8601 date of format YYYY-MM-DD hh, returns the String in short month ("EEEE, MMM d") format.
+     *
+     * For example, given 2019-08-05 11 returns "Monday, Aug 5"
+     *
+     * @throws IllegalArgumentException if the argument is not a valid iso8601 date string.
+     */
+    @Throws(IllegalArgumentException::class)
+    fun getDayMonthDateString(iso8601Date: String): String {
+        return try {
+            val (dateString, _) = iso8601Date.split(" ")
+            val (year, month, day) = dateString.split("-")
+            val date = GregorianCalendar(year.toInt(), month.toInt() - 1, day.toInt()).time
+            friendlyDayMonthDateFormat.format(date)
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Date string argument is not of format YYYY-MM-DD hh: $iso8601Date")
         }
     }
 
@@ -242,6 +262,40 @@ object DateUtils {
         return try {
             val (year, month) = iso8601Month.split("-")
             "${shortMonths[month.toInt() - 1]} $year"
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Date string argument is not of format yyyy-MM: $iso8601Month")
+        }
+    }
+
+    /**
+     * Given a date of format YYYY-MM-dd, returns the corresponding full month format.
+     *
+     * For example, given 2018-07-02, returns "July".
+     *
+     * @throws IllegalArgumentException if the argument is not a valid iso8601 date string.
+     */
+    @Throws(IllegalArgumentException::class)
+    fun getMonthString(iso8601Date: String): String {
+        return try {
+            val (_, month, _) = iso8601Date.split("-")
+            DateFormatSymbols().months[month.toInt() - 1]
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Date string argument is not of format yyyy-MM-dd: $iso8601Date")
+        }
+    }
+
+    /**
+     * Given a date of format YYYY-MM, returns the corresponding year format.
+     *
+     * For example, given 2018-07, returns "2018".
+     *
+     * @throws IllegalArgumentException if the argument is not a valid iso8601 date string.
+     */
+    @Throws(IllegalArgumentException::class)
+    fun getYearString(iso8601Month: String): String {
+        return try {
+            val (year, month) = iso8601Month.split("-")
+            year
         } catch (e: Exception) {
             throw IllegalArgumentException("Date string argument is not of format yyyy-MM: $iso8601Month")
         }

--- a/WooCommerce/src/main/res/layout/dashboard_stats.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_stats.xml
@@ -23,6 +23,8 @@
     <TextView
         android:id="@+id/dashboard_date_range_value"
         style="@style/Woo.Stats.DateBar"
+        android:paddingStart="0dp"
+        android:paddingEnd="0dp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="center_horizontal"

--- a/WooCommerce/src/main/res/layout/dashboard_stats.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_stats.xml
@@ -19,6 +19,22 @@
         android:background="@color/list_divider"
         app:srcCompat="@drawable/list_divider"/>
 
+    <!-- Date bar -->
+    <TextView
+        android:id="@+id/dashboard_date_range_value"
+        style="@style/Woo.Stats.DateBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        tools:text="June 30-Jul 06"/>
+
+    <FrameLayout
+        android:id="@+id/tab_layout_divider_bottom"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/list_divider"
+        app:srcCompat="@drawable/list_divider"/>
+
     <LinearLayout
         android:id="@+id/label_layout"
         android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/layout/fragment_my_store.xml
+++ b/WooCommerce/src/main/res/layout/fragment_my_store.xml
@@ -46,6 +46,14 @@
                     android:descendantFocusability="blocksDescendants"
                     android:orientation="vertical">
 
+                    <!-- Date bar -->
+                    <com.woocommerce.android.ui.mystore.MyStoreDateRangeView
+                        android:id="@+id/my_store_date_bar"
+                        android:background="@color/card_bgColor"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"/>
+
                     <!-- Order stats -->
                     <com.woocommerce.android.ui.mystore.MyStoreStatsView
                         android:id="@+id/my_store_stats"

--- a/WooCommerce/src/main/res/layout/my_store_date_bar.xml
+++ b/WooCommerce/src/main/res/layout/my_store_date_bar.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <!-- Date bar -->
+    <TextView
+        android:id="@+id/dashboard_date_range_value"
+        style="@style/Woo.Stats.DateBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin_large"
+        android:gravity="start"
+        tools:text="June 30-Jul 06"/>
+
+    <FrameLayout
+        android:id="@+id/tab_layout_divider_bottom"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/list_divider"
+        app:srcCompat="@drawable/list_divider"/>
+
+</merge>

--- a/WooCommerce/src/main/res/layout/my_store_date_bar.xml
+++ b/WooCommerce/src/main/res/layout/my_store_date_bar.xml
@@ -11,8 +11,9 @@
         android:id="@+id/dashboard_date_range_value"
         style="@style/Woo.Stats.DateBar"
         android:layout_width="wrap_content"
+        android:paddingStart="@dimen/card_padding_start"
+        android:paddingEnd="@dimen/card_padding_end"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/margin_large"
         android:gravity="start"
         tools:text="June 30-Jul 06"/>
 

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -572,11 +572,8 @@
     </style>
 
     <style name="Woo.Stats.DateBar" parent="Woo.TextView">
-        <item name="android:textStyle">bold</item>
         <item name="android:textColor">@color/wc_grey_darker</item>
         <item name="android:textSize">@dimen/text_large</item>
-        <item name="android:paddingStart">@dimen/default_padding</item>
-        <item name="android:paddingEnd">@dimen/default_padding</item>
         <item name="android:paddingTop">@dimen/margin_large</item>
         <item name="android:paddingBottom">@dimen/margin_large</item>
     </style>

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -571,4 +571,14 @@
         <item name="android:layout_marginBottom">@dimen/card_item_padding_intra_h</item>
     </style>
 
+    <style name="Woo.Stats.DateBar" parent="Woo.TextView">
+        <item name="android:textStyle">bold</item>
+        <item name="android:textColor">@color/wc_grey_darker</item>
+        <item name="android:textSize">@dimen/text_large</item>
+        <item name="android:paddingStart">@dimen/default_padding</item>
+        <item name="android:paddingEnd">@dimen/default_padding</item>
+        <item name="android:paddingTop">@dimen/margin_large</item>
+        <item name="android:paddingBottom">@dimen/margin_large</item>
+    </style>
+
 </resources>

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -572,6 +572,7 @@
     </style>
 
     <style name="Woo.Stats.DateBar" parent="Woo.TextView">
+        <item name="android:fontFamily">@font/roboto_medium</item>
         <item name="android:textColor">@color/wc_grey_darker</item>
         <item name="android:textSize">@dimen/text_large</item>
         <item name="android:paddingTop">@dimen/margin_large</item>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenterTest.kt
@@ -1,16 +1,16 @@
 package com.woocommerce.android.ui.mystore
 
-import com.nhaarman.mockito_kotlin.KArgumentCaptor
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.anyOrNull
-import com.nhaarman.mockito_kotlin.argumentCaptor
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.eq
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.spy
-import com.nhaarman.mockito_kotlin.times
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.whenever
+import com.nhaarman.mockitokotlin2.KArgumentCaptor
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.spy
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
@@ -231,7 +231,6 @@ class DateUtilsTest {
         assertEquals("2019", DateUtils.getYearString("2019-02-23"))
         assertEquals("2017", DateUtils.getYearString("2017-10"))
 
-
         // Test for invalid value handling
         assertFailsWith(IllegalArgumentException::class) {
             DateUtils.getYearString("Dec 30 2018")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
@@ -156,4 +156,26 @@ class DateUtilsTest {
             DateUtils.getShortHourString("5am")
         }
     }
+
+    @Test
+    fun `getShortMonthYearString() returns correct values`() {
+        assertEquals("May 2019", DateUtils.getShortMonthYearString("2019-05"))
+        assertEquals("Dec 2018", DateUtils.getShortMonthYearString("2018-12"))
+        assertEquals("Jan 2019", DateUtils.getShortMonthYearString("2019-01"))
+        assertEquals("Feb 2019", DateUtils.getShortMonthYearString("2019-02"))
+
+        // Test for invalid value handling
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortMonthYearString("Dec 30 2018")
+        }
+
+        // Test for invalid value handling
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortMonthYearString("")
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortMonthYearString("22")
+        }
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
@@ -178,4 +178,76 @@ class DateUtilsTest {
             DateUtils.getShortMonthYearString("22")
         }
     }
+
+    @Test
+    fun `getDayMonthDateString() returns correct values`() {
+        assertEquals("Wednesday, May 1", DateUtils.getDayMonthDateString("2019-05-01 12"))
+        assertEquals("Tuesday, Dec 4", DateUtils.getDayMonthDateString("2018-12-04 14"))
+        assertEquals("Tuesday, Jan 22", DateUtils.getDayMonthDateString("2019-01-22 00"))
+        assertEquals("Saturday, Feb 23", DateUtils.getDayMonthDateString("2019-02-23 23"))
+
+        // Test for invalid value handling
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortMonthYearString("Dec 30 2018")
+        }
+
+        // Test for invalid value handling
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortMonthYearString("")
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getShortMonthYearString("22")
+        }
+    }
+
+    @Test
+    fun `getMonthString() returns correct values`() {
+        assertEquals("May", DateUtils.getMonthString("2019-05-01"))
+        assertEquals("December", DateUtils.getMonthString("2018-12-04"))
+        assertEquals("January", DateUtils.getMonthString("2019-01-22"))
+        assertEquals("February", DateUtils.getMonthString("2019-02-23"))
+
+        // Test for invalid value handling
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getMonthString("Dec 30 2018")
+        }
+
+        // Test for invalid value handling
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getMonthString("")
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getMonthString("22")
+        }
+    }
+
+    @Test
+    fun `getYearString() returns correct values`() {
+        assertEquals("2019", DateUtils.getYearString("2019-05-01"))
+        assertEquals("2018", DateUtils.getYearString("2018-12-04"))
+        assertEquals("2019", DateUtils.getYearString("2019-01-22"))
+        assertEquals("2019", DateUtils.getYearString("2019-02-23"))
+        assertEquals("2017", DateUtils.getYearString("2017-10"))
+
+
+        // Test for invalid value handling
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getYearString("Dec 30 2018")
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getYearString("2019")
+        }
+
+        // Test for invalid value handling
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getYearString("")
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            DateUtils.getYearString("22")
+        }
+    }
 }


### PR DESCRIPTION
Fixes #1253 . This PR completes the second step of the Stats Improvements Project as defined in the master thread [here](https://github.com/woocommerce/woocommerce-android/issues/1199).

### Changes
This PR adds the date bar to both the old and the new stats UI.

### Behaviour
(LEFT: old stats .  RIGHT: v4 stats)
<img width="300" src="https://user-images.githubusercontent.com/22608780/62442378-5bc1e080-b775-11e9-9f2b-915529dba198.gif"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/62442429-8875f800-b775-11e9-9120-08d07fa41428.gif">

### Screenshots 
(LEFT: old stats .  RIGHT: v4 stats)
<img width="300" src="https://user-images.githubusercontent.com/22608780/62442456-9af03180-b775-11e9-8e8f-9caa27af494f.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/62442466-9fb4e580-b775-11e9-9719-a10700ee3d49.png">

<img width="300" src="https://user-images.githubusercontent.com/22608780/62442479-af342e80-b775-11e9-9d1b-9dfd121102c5.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/62442488-b2c7b580-b775-11e9-8f18-4cff2589e03a.png">

<img width="300" src="https://user-images.githubusercontent.com/22608780/62442502-bfe4a480-b775-11e9-93a7-6023447fe17f.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/62442507-c246fe80-b775-11e9-9fa1-947bafccea09.png">

<img width="300" src="https://user-images.githubusercontent.com/22608780/62442523-cffc8400-b775-11e9-9135-82f6efcb882e.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/62442533-d1c64780-b775-11e9-9a24-f273ef4dd798.png">

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
