### PR TITLE
Issue/1327 empty shipment provider list

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderTrackingProviderListPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderTrackingProviderListPresenter.kt
@@ -105,9 +105,14 @@ class AddOrderTrackingProviderListPresenter @Inject constructor(
     fun onOrderShipmentProviderChanged(event: OnOrderShipmentProvidersChanged) {
         providerListView?.showSkeleton(false)
         if (event.isError) {
-            WooLog.e(T.ORDERS, "$TAG - Error fetching order notes : ${event.error.message}")
+            WooLog.e(T.ORDERS, "$TAG - Error fetching shipment providers : ${event.error.message}")
             providerListView?.showProviderListErrorSnack(
                     R.string.order_shipment_tracking_provider_list_error_fetch_generic
+            )
+        } else if (event.rowsAffected == 0) {
+            WooLog.e(T.ORDERS, "$TAG - Error fetching shipment providers : empty list")
+            providerListView?.showProviderListErrorSnack(
+                    R.string.order_shipment_tracking_provider_list_error_empty_list
             )
         } else {
             AnalyticsTracker.track(Stat.ORDER_TRACKING_PROVIDERS_LOADED)

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -271,6 +271,7 @@
     <string name="order_shipment_tracking_provider_toolbar_title">Shipping Providers</string>
     <string name="order_shipment_tracking_provider_list_item">Selected Shipment Provider</string>
     <string name="order_shipment_tracking_provider_list_error_fetch_generic">Error fetching providers</string>
+    <string name="order_shipment_tracking_provider_list_error_empty_list">No providers found</string>
     <string name="order_shipment_tracking_added">Shipment tracking added</string>
     <string name="order_shipment_tracking_error">Unable to add tracking</string>
     <string name="order_shipment_tracking_confirm_discard">Are you sure you want to discard this tracking?</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/AddOrderTrackingProviderListPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/AddOrderTrackingProviderListPresenterTest.kt
@@ -149,6 +149,7 @@ class AddOrderTrackingProviderListPresenterTest {
 
     @Test
     fun `Display error snackbar when provider list is empty`() {
+        presenter.takeView(view)
         val event = OnOrderShipmentProvidersChanged(0)
         presenter.onOrderShipmentProviderChanged(event)
         verify(view, times(1)).showProviderListErrorSnack(any())

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/AddOrderTrackingProviderListPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/AddOrderTrackingProviderListPresenterTest.kt
@@ -139,12 +139,18 @@ class AddOrderTrackingProviderListPresenterTest {
     fun `Do not refresh shipment providers on network connected event if cached data already refreshed`() {
         presenter.takeView(view)
         doReturn(order).whenever(presenter).orderModel
-        doReturn(false).whenever(networkStatus).isConnected()
         doReturn(wcOrderShipmentProviderModels).whenever(orderStore).getShipmentProvidersForSite(any())
 
         presenter.loadShipmentTrackingProviders(order.getIdentifier())
 
         presenter.onEventMainThread(ConnectionChangeEvent(true))
         verify(presenter, times(0)).fetchShipmentTrackingProvidersFromApi(any())
+    }
+
+    @Test
+    fun `Display error snackbar when provider list is empty`() {
+        val event = OnOrderShipmentProvidersChanged(0)
+        presenter.onOrderShipmentProviderChanged(event)
+        verify(view, times(1)).showProviderListErrorSnack(any())
     }
 }


### PR DESCRIPTION
Fixes #1327 - shows an error snackbar when the fetched shipment provider list is empty.

I've marked this as a draft PR because the test I added fails with the message below. I'm not sure why it's failing so perhaps the reviewer can lend a hand :)

```
Wanted but not invoked:
view.showProviderListErrorSnack(
    <any java.lang.Integer>
);
-> at com.woocommerce.android.ui.orders.AddOrderTrackingProviderListPresenterTest.Display error snackbar when provider list is empty(AddOrderTrackingProviderListPresenterTest.kt:154)
Actually, there were zero interactions with this mock.
```

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
