### PR TITLE
Add check for selected site before accessing it

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.push.NotificationHandler.NotificationsUnseenChang
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.tools.ProductImageMap.RequestFetchProductEvent
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.tools.SelectedSite.SelectedSiteChangedEvent
 import com.woocommerce.android.util.WooLog
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -54,6 +55,7 @@ class MainPresenter @Inject constructor(
     private var mainView: MainContract.View? = null
 
     private var isHandlingMagicLink: Boolean = false
+    private var pendingUnfilledOrderCountCheck: Boolean = false
 
     override fun takeView(view: MainContract.View) {
         mainView = view
@@ -91,8 +93,13 @@ class MainPresenter @Inject constructor(
     }
 
     override fun fetchUnfilledOrderCount() {
-        val payload = FetchOrdersCountPayload(selectedSite.get(), PROCESSING.value)
-        dispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersCountAction(payload))
+        if (selectedSite.exists()) {
+            pendingUnfilledOrderCountCheck = false
+            val payload = FetchOrdersCountPayload(selectedSite.get(), PROCESSING.value)
+            dispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersCountAction(payload))
+        } else {
+            pendingUnfilledOrderCountCheck = true
+        }
     }
 
     @Suppress("unused")
@@ -218,5 +225,13 @@ class MainPresenter @Inject constructor(
     fun onEventMainThread(event: RequestFetchProductEvent) {
         val payload = WCProductStore.FetchSingleProductPayload(event.site, event.remoteProductId)
         dispatcher.dispatch(WCProductActionBuilder.newFetchSingleProductAction(payload))
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onEventMainThread(event: SelectedSiteChangedEvent) {
+        if (pendingUnfilledOrderCountCheck) {
+            fetchUnfilledOrderCount()
+        }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainPresenterTest.kt
@@ -62,6 +62,7 @@ class MainPresenterTest {
         )
         mainPresenter.takeView(mainContractView)
         doReturn(SiteModel()).whenever(selectedSite).get()
+        doReturn(true).whenever(selectedSite).exists()
         actionCaptor = argumentCaptor()
     }
 


### PR DESCRIPTION
This PR fixes #1326 which is a crash only happening in `2.4-4c-1`. I was unable to replicate the issue, but the problem was the check for unfilled orders was attempting to access `SelectedSite.get()` before selected site was set. 

To fix it, I now use `SelectedSite.exists()` before attempting to get the selected site. I also added a listener for the `SelectedSiteChangedEvent` so that if the selected site has not been set, I can set a flag to run the check for unfilled orders when the selected site is set. 

**NOTE** Only 1 developer needs to approve this PR request. Once approved, please notify Platform 9 to do a supplemental release. 

cc: @jtreanor 