### PR TITLE
Add SQLScout plugin support

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -40,6 +40,9 @@
       <option name="CONTINUATION_INDENT_IN_PARAMETER_LISTS" value="false" />
       <option name="WRAP_EXPRESSION_BODY_FUNCTIONS" value="1" />
     </JetCodeStyleSettings>
+    <MarkdownNavigatorCodeStyleSettings>
+      <option name="RIGHT_MARGIN" value="72" />
+    </MarkdownNavigatorCodeStyleSettings>
     <XML>
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -156,6 +156,11 @@ dependencies {
     implementation "org.greenrobot:eventbus:$eventBusVersion"
     implementation "com.google.android.play:core:$googlePlayCoreVersion"
 
+    // For use with SqlScout, a Sqlite plugin for Android Studio
+    // https://plugins.jetbrains.com/plugin/8322-sqlscout-sqlite-support-
+    debugImplementation 'com.idescout.sql:sqlscout-server:4.1'
+    releaseImplementation 'com.idescout.sql:sqlscout-server-noop:4.1'
+
     // Debug dependencies
     debugImplementation 'com.facebook.stetho:stetho:1.5.0'
     debugImplementation 'com.facebook.stetho:stetho-okhttp3:1.5.0'

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -14,6 +14,7 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.findNavController
+import com.idescout.sql.SqlScoutServer
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.R
@@ -106,6 +107,8 @@ class MainActivity : AppUpgradeActivity(),
     private var previousDestinationId: Int? = null
     private var unfilledOrderCount: Int = 0
 
+    private lateinit var sqlScoutServer: SqlScoutServer
+
     private lateinit var bottomNavView: MainBottomNavigationView
     private lateinit var navController: NavController
 
@@ -116,6 +119,8 @@ class MainActivity : AppUpgradeActivity(),
         AndroidInjection.inject(this)
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        sqlScoutServer = SqlScoutServer.create(this, getPackageName())
 
         // Set the toolbar
         setSupportActionBar(toolbar as Toolbar)
@@ -163,12 +168,18 @@ class MainActivity : AppUpgradeActivity(),
 
     override fun onResume() {
         super.onResume()
+        sqlScoutServer.resume()
         AnalyticsTracker.trackViewShown(this)
 
         updateReviewsBadge()
         updateOrderBadge(false)
 
         checkConnection()
+    }
+
+    override fun onPause() {
+        sqlScoutServer.pause()
+        super.onPause()
     }
 
     override fun onNewIntent(intent: Intent?) {
@@ -179,6 +190,7 @@ class MainActivity : AppUpgradeActivity(),
     }
 
     public override fun onDestroy() {
+        sqlScoutServer.destroy()
         presenter.dropView()
         super.onDestroy()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven {
+            url 'http://www.idescout.com/maven/repo/'
+        }
     }
 
     task checkstyle(type: Checkstyle) {


### PR DESCRIPTION
Adds optional support for the [SQLScout Android studio plugin](https://plugins.jetbrains.com/plugin/8322-sqlscout-sqlite-support-), and implements the necessary logic to allow for live DB connections on debug builds. Having the plugin installed is not a requirement, this logic exists just to have it supported if the developer wants to install it. 

SQLScout includes a database explorer (the left panel in the screenshot below), db console, and table viewer (bottom panel in the screenshot below).

![Screen Shot 2019-08-06 at 5 24 54 PM](https://user-images.githubusercontent.com/5810477/62583844-2ef1f400-b86f-11e9-96c2-19c6d23e5088.png)

Only requires 1 developer review and approve for merge.
