### PR TITLE
Merge Release/2.4 into develop

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -43,8 +43,8 @@ android {
 
     defaultConfig {
         applicationId "com.woocommerce.android"
-        versionName "2.4-rc-1"
-        versionCode 68
+        versionName "2.4-rc-2"
+        versionCode 69
 
         minSdkVersion 21
         targetSdkVersion 28

--- a/WooCommerce/metadata/PlayStoreStrings.pot
+++ b/WooCommerce/metadata/PlayStoreStrings.pot
@@ -11,19 +11,22 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_024"
+msgid ""
+"2.4:\n"
+"The tab formerly known as Notifications is now Reviews. As notifications are now shown under Orders, the Notifications tab was in need of a new identity. We have cunningly renamed it ‘Reviews,’ as it now just shows reviews.\n"
+"\n"
+"The number of unfulfilled orders is gone from the dashboard and is now shown as a badge on the order list.\n"
+"\n"
+"You will be prompted to perform updates within the app, so the hassle of having to open the Play store to do so is no more.\n"
+msgstr ""
+
 msgctxt "release_note_023"
 msgid ""
 "2.3:\n"
 "* Have an idea for a new feature? Request it right from your Settings page.\n"
 "* There’s a “Copy tracking number” link in the tracking popup menu in the order details, so sharing tracking info is easier.\n"
 "* Bug squashing: We fixed a problem that caused virtual orders to display shipping details, and sites with redirects can now log in without issue.\n"
-msgstr ""
-
-msgctxt "release_note_022"
-msgid ""
-"2.2:\n"
-"* Fixed a bug where the notifications list didn’t display anything after you logged out and back into the app.\n"
-"* Improved how the order detail screen displays when there’s no shipping or billing info.\n"
 msgstr ""
 
 #. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,3 +1,5 @@
-* The Notifications tab has been replaced by a new tab for Reviews.
-* The unfulfilled order count has been removed from the dashboard and is now shown as a badge on the order list.
-* Added support to update the app without opening the Play Store.
+The tab formerly known as Notifications is now Reviews. As notifications are now shown under Orders, the Notifications tab was in need of a new identity. We have cunningly renamed it ‘Reviews,’ as it now just shows reviews.
+
+The number of unfulfilled orders is gone from the dashboard and is now shown as a badge on the order list.
+
+You will be prompted to perform updates within the app, so the hassle of having to open the Play store to do so is no more.


### PR DESCRIPTION
Includes the changes from https://github.com/woocommerce/woocommerce-android/pull/1329.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
