### PR TITLE
Issue/1340 scrubbing changes take 2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
@@ -11,10 +11,12 @@ fun Date.formatToYYYY(): String = SimpleDateFormat("yyyy", Locale.getDefault()).
 
 fun Date.formatToYYYYWmm(): String = SimpleDateFormat("yyyy-'W'ww", Locale.getDefault()).format(this)
 
+fun Date.formatToMMMMdd(): String = SimpleDateFormat("MMMM dd", Locale.getDefault()).format(this)
+
 fun Date.formatToEEEEMMMddhha(): String {
     val symbols = DateFormatSymbols(Locale.getDefault())
     symbols.amPmStrings = arrayOf("am", "pm")
-    val dateFormat = SimpleDateFormat("EEEE, MMM d › ha", Locale.getDefault())
+    val dateFormat = SimpleDateFormat("EEEE, MMM dd › ha", Locale.getDefault())
     dateFormat.dateFormatSymbols = symbols
     return dateFormat.format(this)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringDateFormatExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringDateFormatExt.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.extensions
 
+import java.text.DateFormatSymbols
 import java.text.SimpleDateFormat
 import java.util.GregorianCalendar
 import java.util.Locale
@@ -54,10 +55,39 @@ fun String.formatDateToWeeksInYear(): String {
 @Throws(IllegalArgumentException::class)
 fun String.formatDateToFriendlyDayHour(): String {
     return try {
-        val originalFormat = SimpleDateFormat("yyyy-MM-d HH", Locale.getDefault())
+        val originalFormat = SimpleDateFormat("yyyy-MM-dd HH", Locale.getDefault())
         val date = originalFormat.parse(this)
         date.formatToEEEEMMMddhha()
     } catch (e: Exception) {
         throw IllegalArgumentException("Date string argument is not of format yyyy-MM-dd HH: $this")
+    }
+}
+
+/**
+ * Method to convert month string from yyyy-MM-dd format to MMMM
+ * i.e. 2019-08-08 is formatted to 2019›August
+ */
+@Throws(IllegalArgumentException::class)
+fun String.formatDateToFriendlyLongMonthYear(): String {
+    return try {
+        val (year, month, _) = this.split("-")
+        "$year › ${DateFormatSymbols().months[month.toInt() - 1]}"
+    } catch (e: Exception) {
+        throw IllegalArgumentException("Date string argument is not of format yyyy-MM-dd: $this")
+    }
+}
+
+/**
+ * Method to convert month string from yyyy-MM-dd format to MMMM dd
+ * i.e. 2019-08-08 is formatted to August 08
+ */
+@Throws(IllegalArgumentException::class)
+fun String.formatDateToFriendlyLongMonthDate(): String {
+    return try {
+        val (year, month, day) = this.split("-")
+        val date = GregorianCalendar(year.toInt(), month.toInt() - 1, day.toInt()).time
+        date.formatToMMMMdd()
+    } catch (e: Exception) {
+        throw IllegalArgumentException("Date string argument is not of format yyyy-MM-dd: $this")
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -5,6 +5,7 @@ import android.os.Handler
 import android.text.format.DateFormat
 import android.util.AttributeSet
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
@@ -19,6 +20,7 @@ import com.github.mikephil.charting.data.BarEntry
 import com.github.mikephil.charting.data.Entry
 import com.github.mikephil.charting.formatter.IAxisValueFormatter
 import com.github.mikephil.charting.highlight.Highlight
+import com.github.mikephil.charting.listener.ChartTouchListener.ChartGesture
 import com.github.mikephil.charting.listener.OnChartValueSelectedListener
 import com.google.android.material.tabs.TabLayout
 import com.woocommerce.android.R
@@ -29,6 +31,7 @@ import com.woocommerce.android.extensions.formatDateToYear
 import com.woocommerce.android.extensions.formatDateToYearMonth
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.dashboard.DashboardFragment.Companion.DEFAULT_STATS_GRANULARITY
+import com.woocommerce.android.ui.mystore.BarChartGestureListener
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.FormatCurrencyRounded
 import com.woocommerce.android.util.WooAnimUtils
@@ -43,7 +46,7 @@ import java.util.ArrayList
 import java.util.Date
 
 class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
-    : LinearLayout(ctx, attrs), OnChartValueSelectedListener {
+    : LinearLayout(ctx, attrs), OnChartValueSelectedListener, BarChartGestureListener {
     init {
         View.inflate(context, R.layout.dashboard_stats, this)
     }
@@ -214,7 +217,7 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
             legend.isEnabled = false
 
             // touch has to be enabled in order to show a marker when a bar is tapped, but we don't want
-            // pinch/zoom, drag, or scaling to be enabled
+            // pinch/zoom, or scaling to be enabled
             setTouchEnabled(true)
             setPinchZoom(false)
             isScaleXEnabled = false
@@ -225,6 +228,7 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
         }
 
         chart.setOnChartValueSelectedListener(this)
+        chart.onChartGestureListener = this
     }
 
     /**
@@ -256,6 +260,16 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
 
         // update date bar
         dashboard_date_range_value.text = getFormattedDateValue(date)
+    }
+
+    /**
+     * Method called when a touch-gesture has ended on the chart (ACTION_UP, ACTION_CANCEL)
+     * If the touch gesture has ended, then display the entire chart data again
+     */
+    override fun onChartGestureEnd(me: MotionEvent?, lastPerformedGesture: ChartGesture?) {
+        if (lastPerformedGesture == ChartGesture.DRAG || lastPerformedGesture == ChartGesture.FLING) {
+            onNothingSelected()
+        }
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -24,12 +24,11 @@ import com.google.android.material.tabs.TabLayout
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
-import com.woocommerce.android.extensions.formatDateToYearMonth
-import com.woocommerce.android.extensions.formatDateToYear
 import com.woocommerce.android.extensions.formatDateToWeeksInYear
+import com.woocommerce.android.extensions.formatDateToYear
+import com.woocommerce.android.extensions.formatDateToYearMonth
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.dashboard.DashboardFragment.Companion.DEFAULT_STATS_GRANULARITY
-import com.woocommerce.android.ui.dashboard.DashboardStatsMarkerView.RequestMarkerCaptionListener
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.FormatCurrencyRounded
 import com.woocommerce.android.util.WooAnimUtils
@@ -44,7 +43,7 @@ import java.util.ArrayList
 import java.util.Date
 
 class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
-    : LinearLayout(ctx, attrs), RequestMarkerCaptionListener, OnChartValueSelectedListener {
+    : LinearLayout(ctx, attrs), OnChartValueSelectedListener {
     init {
         View.inflate(context, R.layout.dashboard_stats, this)
     }
@@ -225,28 +224,7 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
             setNoDataTextColor(ContextCompat.getColor(context, R.color.graph_no_data_text_color))
         }
 
-        val markerView = DashboardStatsMarkerView(context, R.layout.dashboard_stats_marker_view)
-        markerView.chartView = chart
-        markerView.captionListener = this
-        chart.marker = markerView
         chart.setOnChartValueSelectedListener(this)
-    }
-
-    /**
-     * the chart MarkerView relies on this to know what to display when the user taps a chart bar
-     */
-    override fun onRequestMarkerCaption(entry: Entry): String? {
-        val barEntry = entry as BarEntry
-
-        // get the date for this entry
-        val date = getDateFromIndex(barEntry.x.toInt())
-        val formattedDate = getFormattedDateValue(date)
-
-        // get the revenue for this entry
-        val formattedRevenue = getFormattedRevenueValue(barEntry.y.toDouble())
-
-        // show the date and revenue on separate lines
-        return formattedDate + "\n" + formattedRevenue
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/BarChartGestureListener.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/BarChartGestureListener.kt
@@ -1,0 +1,19 @@
+package com.woocommerce.android.ui.mystore
+
+import android.view.MotionEvent
+import com.github.mikephil.charting.listener.ChartTouchListener.ChartGesture
+import com.github.mikephil.charting.listener.OnChartGestureListener
+
+/**
+ * Interface that overrides the [OnChartGestureListener] class so as to NOT
+ * implement unused methods to the implementing class
+ */
+interface BarChartGestureListener : OnChartGestureListener {
+    override fun onChartLongPressed(me: MotionEvent?) {}
+    override fun onChartSingleTapped(me: MotionEvent?) {}
+    override fun onChartDoubleTapped(me: MotionEvent?) {}
+    override fun onChartTranslate(me: MotionEvent?, dX: Float, dY: Float) {}
+    override fun onChartScale(me: MotionEvent?, scaleX: Float, scaleY: Float) {}
+    override fun onChartGestureStart(me: MotionEvent?, lastPerformedGesture: ChartGesture?) {}
+    override fun onChartFling(me1: MotionEvent?, me2: MotionEvent?, velocityX: Float, velocityY: Float) {}
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreDateRangeView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreDateRangeView.kt
@@ -6,6 +6,8 @@ import android.view.View
 import android.widget.LinearLayout
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.formatDateToFriendlyDayHour
+import com.woocommerce.android.extensions.formatDateToFriendlyLongMonthDate
+import com.woocommerce.android.extensions.formatDateToFriendlyLongMonthYear
 import com.woocommerce.android.util.DateUtils
 import kotlinx.android.synthetic.main.my_store_date_bar.view.*
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
@@ -57,7 +59,7 @@ class MyStoreDateRangeView @JvmOverloads constructor(ctx: Context, attrs: Attrib
      * Method to update the date value for a given [dateString] based on the [activeGranularity]
      * This is used to display the date bar when the **scrubbing interaction is taking place**
      * [StatsGranularity.DAYS] would be Tuesday, Aug 08›7am
-     * [StatsGranularity.WEEKS] would be August 08
+     * [StatsGranularity.WEEKS] would be Aug 08
      * [StatsGranularity.MONTHS] would be August›08
      * [StatsGranularity.YEARS] would be 2019›August
      */
@@ -65,8 +67,8 @@ class MyStoreDateRangeView @JvmOverloads constructor(ctx: Context, attrs: Attrib
         dashboard_date_range_value.text = when (activeGranularity) {
             StatsGranularity.DAYS -> dateString.formatDateToFriendlyDayHour()
             StatsGranularity.WEEKS -> DateUtils.getShortMonthDayString(dateString)
-            StatsGranularity.MONTHS -> DateUtils.getShortMonthDayString(dateString)
-            StatsGranularity.YEARS -> DateUtils.getShortMonthString(dateString)
+            StatsGranularity.MONTHS -> dateString.formatDateToFriendlyLongMonthDate()
+            StatsGranularity.YEARS -> dateString.formatDateToFriendlyLongMonthYear()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -5,6 +5,7 @@ import android.os.Handler
 import android.text.format.DateFormat
 import android.util.AttributeSet
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
@@ -19,6 +20,7 @@ import com.github.mikephil.charting.data.BarEntry
 import com.github.mikephil.charting.data.Entry
 import com.github.mikephil.charting.formatter.IAxisValueFormatter
 import com.github.mikephil.charting.highlight.Highlight
+import com.github.mikephil.charting.listener.ChartTouchListener.ChartGesture
 import com.github.mikephil.charting.listener.OnChartValueSelectedListener
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -40,7 +42,7 @@ import java.util.ArrayList
 import java.util.Date
 
 class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
-    : LinearLayout(ctx, attrs), OnChartValueSelectedListener {
+    : LinearLayout(ctx, attrs), OnChartValueSelectedListener, BarChartGestureListener {
     init {
         View.inflate(context, R.layout.my_store_stats, this)
     }
@@ -200,6 +202,7 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
             setNoDataTextColor(ContextCompat.getColor(context, R.color.graph_no_data_text_color))
         }
         chart.setOnChartValueSelectedListener(this)
+        chart.onChartGestureListener = this
     }
 
     /**
@@ -240,6 +243,16 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
 
         // update the date bar
         listener.onChartValueSelected(date, activeGranularity)
+    }
+
+    /**
+     * Method called when a touch-gesture has ended on the chart (ACTION_UP, ACTION_CANCEL)
+     * If the touch gesture has ended, then display the entire chart data again
+     */
+    override fun onChartGestureEnd(me: MotionEvent?, lastPerformedGesture: ChartGesture?) {
+        if (lastPerformedGesture == ChartGesture.DRAG || lastPerformedGesture == ChartGesture.FLING) {
+            onNothingSelected()
+        }
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -21,14 +21,11 @@ import com.github.mikephil.charting.formatter.IAxisValueFormatter
 import com.github.mikephil.charting.highlight.Highlight
 import com.github.mikephil.charting.listener.OnChartValueSelectedListener
 import com.woocommerce.android.R
-import com.woocommerce.android.R.layout
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.extensions.formatDateToYearMonth
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.dashboard.DashboardStatsListener
-import com.woocommerce.android.ui.dashboard.DashboardStatsMarkerView
-import com.woocommerce.android.ui.dashboard.DashboardStatsMarkerView.RequestMarkerCaptionListener
 import com.woocommerce.android.ui.mystore.MyStoreFragment.Companion.DEFAULT_STATS_GRANULARITY
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.FormatCurrencyRounded
@@ -43,7 +40,7 @@ import java.util.ArrayList
 import java.util.Date
 
 class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
-    : LinearLayout(ctx, attrs), RequestMarkerCaptionListener, OnChartValueSelectedListener {
+    : LinearLayout(ctx, attrs), OnChartValueSelectedListener {
     init {
         View.inflate(context, R.layout.my_store_stats, this)
     }
@@ -202,32 +199,7 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
 
             setNoDataTextColor(ContextCompat.getColor(context, R.color.graph_no_data_text_color))
         }
-
-        val markerView = DashboardStatsMarkerView(
-                context,
-                layout.dashboard_stats_marker_view
-        )
-        markerView.chartView = chart
-        markerView.captionListener = this
-        chart.marker = markerView
         chart.setOnChartValueSelectedListener(this)
-    }
-
-    /**
-     * the chart MarkerView relies on this to know what to display when the user taps a chart bar
-     */
-    override fun onRequestMarkerCaption(entry: Entry): String? {
-        val barEntry = entry as BarEntry
-
-        // get the date for this entry
-        val date = getDateFromIndex(barEntry.x.toInt())
-        val formattedDate = getEntryValue(date)
-
-        // get the revenue for this entry
-        val formattedRevenue = getFormattedRevenueValue(barEntry.y.toDouble())
-
-        // show the date and revenue on separate lines
-        return formattedDate + "\n" + formattedRevenue
     }
 
     /**

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.util
 
 import com.woocommerce.android.extensions.formatDateToFriendlyDayHour
+import com.woocommerce.android.extensions.formatDateToFriendlyLongMonthDate
+import com.woocommerce.android.extensions.formatDateToFriendlyLongMonthYear
 import com.woocommerce.android.extensions.formatDateToWeeksInYear
 import com.woocommerce.android.extensions.formatDateToYear
 import com.woocommerce.android.extensions.formatDateToYearMonth
@@ -344,11 +346,11 @@ class DateUtilsTest {
 
     @Test
     fun `formatDateToDayHour() returns correct values`() {
-        assertEquals("Thursday, Aug 8 › 7am", "2019-08-08 07".formatDateToFriendlyDayHour())
-        assertEquals("Thursday, Aug 8 › 11pm", "2019-08-08 23".formatDateToFriendlyDayHour())
-        assertEquals("Wednesday, Jan 2 › 12am", "2019-01-02 00".formatDateToFriendlyDayHour())
-        assertEquals("Tuesday, Jun 4 › 1am", "2019-06-04 01".formatDateToFriendlyDayHour())
-        assertEquals("Monday, Sep 9 › 1pm", "2019-09-09 13".formatDateToFriendlyDayHour())
+        assertEquals("Thursday, Aug 08 › 7am", "2019-08-08 07".formatDateToFriendlyDayHour())
+        assertEquals("Thursday, Aug 08 › 11pm", "2019-08-08 23".formatDateToFriendlyDayHour())
+        assertEquals("Wednesday, Jan 02 › 12am", "2019-01-02 00".formatDateToFriendlyDayHour())
+        assertEquals("Tuesday, Jun 04 › 1am", "2019-06-04 01".formatDateToFriendlyDayHour())
+        assertEquals("Monday, Sep 09 › 1pm", "2019-09-09 13".formatDateToFriendlyDayHour())
         assertEquals("Saturday, Dec 22 › 5pm", "2018-12-22 17".formatDateToFriendlyDayHour())
 
         // Test for invalid value handling
@@ -367,6 +369,63 @@ class DateUtilsTest {
 
         assertFailsWith(IllegalArgumentException::class) {
             "21".formatDateToFriendlyDayHour()
+        }
+    }
+
+    @Test
+    fun `formatDateToFriendlyLongMonth() returns correct values`() {
+        assertEquals("2019 › August", "2019-08-02".formatDateToFriendlyLongMonthYear())
+        assertEquals("2019 › January", "2019-01-02".formatDateToFriendlyLongMonthYear())
+        assertEquals("2019 › June", "2019-06-04".formatDateToFriendlyLongMonthYear())
+        assertEquals("2019 › September", "2019-09-11".formatDateToFriendlyLongMonthYear())
+        assertEquals("2018 › December", "2018-12-22".formatDateToFriendlyLongMonthYear())
+        assertEquals("2018 › November", "2018-11-12".formatDateToFriendlyLongMonthYear())
+        assertEquals("2018 › August", "2018-08".formatDateToFriendlyLongMonthYear())
+
+        // Test for invalid value handling
+        assertFailsWith(IllegalArgumentException::class) {
+            "2019".formatDateToFriendlyLongMonthYear()
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            "20-W12".formatDateToFriendlyLongMonthYear()
+        }
+
+        // Test for invalid value handling
+        assertFailsWith(IllegalArgumentException::class) {
+            "".formatDateToFriendlyLongMonthYear()
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            "21".formatDateToFriendlyLongMonthYear()
+        }
+    }
+
+    @Test
+    fun `formatDateToFriendlyLongMonthDate() returns correct values`() {
+        assertEquals("August 08", "2019-08-08".formatDateToFriendlyLongMonthDate())
+        assertEquals("February 23", "2019-02-23".formatDateToFriendlyLongMonthDate())
+        assertEquals("January 02", "2019-01-02".formatDateToFriendlyLongMonthDate())
+        assertEquals("June 04", "2019-06-04".formatDateToFriendlyLongMonthDate())
+        assertEquals("September 09", "2019-09-09".formatDateToFriendlyLongMonthDate())
+        assertEquals("December 22", "2018-12-22".formatDateToFriendlyLongMonthDate())
+
+        // Test for invalid value handling
+        assertFailsWith(IllegalArgumentException::class) {
+            "2019".formatDateToFriendlyLongMonthDate()
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            "20-W12".formatDateToFriendlyLongMonthDate()
+        }
+
+        // Test for invalid value handling
+        assertFailsWith(IllegalArgumentException::class) {
+            "".formatDateToFriendlyLongMonthDate()
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            "21".formatDateToFriendlyLongMonthDate()
         }
     }
 }


### PR DESCRIPTION
Fixes #1340. This PR adds some modifications to the stats UI during scrubbing interaction. 

### Changes:
- [x] Uses the short version of the month on the `Today` and `This week` TAB.
- [x] Includes the 0 before single digit dates.
- [x] Removes marker view from UI since scrubbing is enabled and this is no longer necessary.

### Screenshots:
(LEFT: Old Stats UI . RIGHT: V4 Stats UI)

<img width="300" src="https://user-images.githubusercontent.com/22608780/62917479-0f505380-bdba-11e9-9593-e6c5c29a7611.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/62917485-12e3da80-bdba-11e9-8a52-88d1e03cde46.png">

<img width="300" src="https://user-images.githubusercontent.com/22608780/62917524-3870e400-bdba-11e9-9caa-88efc1cf06bc.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/62917519-34dd5d00-bdba-11e9-991c-7ae90c24153d.png"> 

<img width="300" src="https://user-images.githubusercontent.com/22608780/62917548-4aeb1d80-bdba-11e9-9e43-876b0516ca1f.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/62917550-4de60e00-bdba-11e9-83b4-7828158bce05.png">

<img width="300" src="https://user-images.githubusercontent.com/22608780/62917559-5dfded80-bdba-11e9-8592-cbbcc801e3e9.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/62917567-60604780-bdba-11e9-825b-3238dc138ecc.png">

