### PR TITLE
issue/1344-order-refresh-layout-null 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -319,14 +319,16 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
     }
 
     override fun refreshOrderDetail(displaySkeleton: Boolean) {
-        orderRefreshLayout.isRefreshing = false
-        if (!isRefreshPending) {
-            if (!networkStatus.isConnected()) {
-                uiMessageResolver.showOfflineSnack()
-                return
+        if (isAdded) {
+            orderRefreshLayout.isRefreshing = false
+            if (!isRefreshPending) {
+                if (!networkStatus.isConnected()) {
+                    uiMessageResolver.showOfflineSnack()
+                    return
+                }
+                isRefreshPending = true
+                presenter.refreshOrderDetail(displaySkeleton)
             }
-            isRefreshPending = true
-            presenter.refreshOrderDetail(displaySkeleton)
         }
     }
 


### PR DESCRIPTION
Fixes #1344 - we had several "orderRefreshLayout must not be null" crash reports in order detail. I wasn't able to reproduce the crash, but I'm pretty sure it could only happen if the fragment wasn't added yet. This PR simply adds an `isAdded` check before accessing the `orderRefreshLayout` view.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
