### PR TITLE
issue/1349-npe-get-note-text

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderNoteFragment.kt
@@ -149,7 +149,9 @@ class AddOrderNoteFragment : BaseFragment(), AddOrderNoteContract.View, BackPres
         super.onSaveInstanceState(outState)
     }
 
-    override fun getNoteText() = addNote_editor.text.toString().trim()
+    override fun getNoteText(): String {
+        return addNote_editor?.text?.toString()?.trim() ?: ""
+    }
 
     /**
      * Prevent back press in the main activity if the user entered a note so we can confirm the discard

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderNoteFragment.kt
@@ -149,9 +149,7 @@ class AddOrderNoteFragment : BaseFragment(), AddOrderNoteContract.View, BackPres
         super.onSaveInstanceState(outState)
     }
 
-    override fun getNoteText(): String {
-        return addNote_editor?.text?.toString()?.trim() ?: ""
-    }
+    override fun getNoteText() = addNote_editor?.text?.toString()?.trim() ?: ""
 
     /**
      * Prevent back press in the main activity if the user entered a note so we can confirm the discard


### PR DESCRIPTION
Fixes #1349 - handles the (rare) case that we attempt to access the note text when the view isn't available (due to the fragment not being added yet).

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
