### PR TITLE
issue/1353-unable-to-bind-login-service

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <!-- Normal permissions, access automatically granted to app -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <!-- Dangerous permissions, access must be requested at runtime -->
 


### PR DESCRIPTION
Fixes #1353 by adding the `FOREGROUND_SERVICE` permission to the manifest to fix a potential security exception when attempting to bind the login service. From the API 28 [migration notes](https://developer.android.com/about/versions/pie/android-9.0-migration#tya):

> Apps wanting to use foreground services must now request the FOREGROUND_SERVICE permission first. This is a normal permission, so the system automatically grants it to the requesting app. Starting a foreground service without the permission throws a SecurityException.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
