### PR TITLE
Stats Improvements Step 4: Tweak x axis labels

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
@@ -15,6 +15,8 @@ fun Date.formatToMMMMdd(): String = SimpleDateFormat("MMMM dd", Locale.getDefaul
 
 fun Date.formatToDD(): String = SimpleDateFormat("d", Locale.getDefault()).format(this)
 
+fun Date.formatToMMMdd(): String = SimpleDateFormat("MMM d", Locale.getDefault()).format(this)
+
 fun Date.formatToEEEEMMMddhha(): String {
     val symbols = DateFormatSymbols(Locale.getDefault())
     symbols.amPmStrings = arrayOf("am", "pm")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
@@ -13,6 +13,8 @@ fun Date.formatToYYYYWmm(): String = SimpleDateFormat("yyyy-'W'ww", Locale.getDe
 
 fun Date.formatToMMMMdd(): String = SimpleDateFormat("MMMM dd", Locale.getDefault()).format(this)
 
+fun Date.formatToDD(): String = SimpleDateFormat("d", Locale.getDefault()).format(this)
+
 fun Date.formatToEEEEMMMddhha(): String {
     val symbols = DateFormatSymbols(Locale.getDefault())
     symbols.amPmStrings = arrayOf("am", "pm")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringDateFormatExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringDateFormatExt.kt
@@ -106,3 +106,18 @@ fun String.formatToDateOnly(): String {
         throw IllegalArgumentException("Date string argument is not of format yyyy-MM-dd: $this")
     }
 }
+
+/**
+ * Method to convert month string from yyyy-MM-dd format to MMM d
+ * i.e. 2019-08-08 is formatted to Aug 8
+ */
+@Throws(IllegalArgumentException::class)
+fun String.formatToMonthDateOnly(): String {
+    return try {
+        val (year, month, day) = this.split("-")
+        val date = GregorianCalendar(year.toInt(), month.toInt() - 1, day.toInt()).time
+        date.formatToMMMdd()
+    } catch (e: Exception) {
+        throw IllegalArgumentException("Date string argument is not of format yyyy-MM-dd: $this")
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringDateFormatExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringDateFormatExt.kt
@@ -91,3 +91,18 @@ fun String.formatDateToFriendlyLongMonthDate(): String {
         throw IllegalArgumentException("Date string argument is not of format yyyy-MM-dd: $this")
     }
 }
+
+/**
+ * Method to convert month string from yyyy-MM-dd format to dd
+ * i.e. 2019-08-08 is formatted to 8
+ */
+@Throws(IllegalArgumentException::class)
+fun String.formatToDateOnly(): String {
+    return try {
+        val (year, month, day) = this.split("-")
+        val date = GregorianCalendar(year.toInt(), month.toInt() - 1, day.toInt()).time
+        date.formatToDD()
+    } catch (e: Exception) {
+        throw IllegalArgumentException("Date string argument is not of format yyyy-MM-dd: $this")
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -169,9 +169,8 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
                 valueFormatter = StartEndDateAxisFormatter()
             }
 
-            axisLeft.isEnabled = false
-
-            with(axisRight) {
+            axisRight.isEnabled = false
+            with(axisLeft) {
                 setDrawZeroLine(false)
                 setDrawAxisLine(false)
                 setDrawGridLines(true)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.extensions.formatDateToYearMonth
 import com.woocommerce.android.extensions.formatToDateOnly
+import com.woocommerce.android.extensions.formatToMonthDateOnly
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.dashboard.DashboardStatsListener
 import com.woocommerce.android.ui.mystore.MyStoreFragment.Companion.DEFAULT_STATS_GRANULARITY
@@ -517,9 +518,24 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
         private fun getLabelValue(dateString: String): String {
             return when (activeGranularity) {
                 StatsGranularity.DAYS -> DateUtils.getShortHourString(dateString)
-                StatsGranularity.WEEKS -> dateString.formatToDateOnly()
+                StatsGranularity.WEEKS -> getWeekLabelValue(dateString)
                 StatsGranularity.MONTHS -> dateString.formatToDateOnly()
                 StatsGranularity.YEARS -> DateUtils.getShortMonthString(dateString)
+            }
+        }
+
+        /**
+         * Method returns the formatted date for the [StatsGranularity.WEEKS] tab,
+         * if the date string is the first day of the month. i.e. date is equal to 1,
+         * then the formatted date would be `MM-d` format.
+         * Otherwise the formatted date would be `d` format
+         */
+        private fun getWeekLabelValue(dateString: String): String {
+            val formattedDateString = dateString.formatToDateOnly()
+            return if (formattedDateString == "1") {
+                dateString.formatToMonthDateOnly()
+            } else {
+                dateString.formatToDateOnly()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -24,6 +24,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.extensions.formatDateToYearMonth
+import com.woocommerce.android.extensions.formatToDateOnly
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.dashboard.DashboardStatsListener
 import com.woocommerce.android.ui.mystore.MyStoreFragment.Companion.DEFAULT_STATS_GRANULARITY
@@ -38,6 +39,7 @@ import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.util.DateTimeUtils
 import java.util.ArrayList
 import java.util.Date
+import kotlin.math.round
 
 class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
     : LinearLayout(ctx, attrs), OnChartValueSelectedListener {
@@ -153,6 +155,16 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
         return context.resources.getDimensionPixelSize(resId)
     }
 
+    private fun getBarLabelCount(): Int {
+        val resId = when (activeGranularity) {
+            StatsGranularity.DAYS -> R.integer.stats_label_count_days
+            StatsGranularity.WEEKS -> R.integer.stats_label_count_weeks
+            StatsGranularity.MONTHS -> R.integer.stats_label_count_months
+            StatsGranularity.YEARS -> R.integer.stats_label_count_years
+        }
+        return context.resources.getInteger(resId)
+    }
+
     /**
      * One-time chart initialization with settings common to all granularities.
      */
@@ -163,10 +175,6 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
                 setDrawGridLines(false)
                 setDrawAxisLine(false)
                 granularity = 1f // Don't break x axis values down further than 1 unit of time
-
-                setLabelCount(2, true) // Only show first and last date
-
-                valueFormatter = StartEndDateAxisFormatter()
             }
 
             axisRight.isEnabled = false
@@ -340,6 +348,10 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
             if (wasEmpty) {
                 animateY(duration)
             }
+            with(xAxis) {
+                setLabelCount(getBarLabelCount(), true)
+                valueFormatter = StartEndDateAxisFormatter()
+            }
         }
 
         hideMarker()
@@ -487,12 +499,28 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
             return when (value) {
                 axis.mEntries.first() -> getStartValue()
                 axis.mEntries.max() -> getEndValue()
-                else -> ""
+                else -> getLabelValue(chartRevenueStats.keys.elementAt(round(value).toInt() - 1))
             }
         }
 
         fun getStartValue() = getEntryValue(chartRevenueStats.keys.first())
 
-        fun getEndValue() = getEntryValue(chartRevenueStats.keys.last())
+        fun getEndValue() = getLabelValue(chartRevenueStats.keys.last())
+
+        /**
+         * Displays the x-axis labels in the following format based on [StatsGranularity]
+         * [StatsGranularity.DAYS] would be 7am, 8am, 9am
+         * [StatsGranularity.WEEKS] would be Aug 31, Sept 1, 2, 3
+         * [StatsGranularity.MONTHS] would be Aug 1, 2, 3
+         * [StatsGranularity.YEARS] would be Jan, Feb, Mar
+         */
+        private fun getLabelValue(dateString: String): String {
+            return when (activeGranularity) {
+                StatsGranularity.DAYS -> DateUtils.getShortHourString(dateString)
+                StatsGranularity.WEEKS -> dateString.formatToDateOnly()
+                StatsGranularity.MONTHS -> dateString.formatToDateOnly()
+                StatsGranularity.YEARS -> DateUtils.getShortMonthString(dateString)
+            }
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -241,8 +241,8 @@ object DateUtils {
     @Throws(IllegalArgumentException::class)
     fun getShortHourString(iso8601Date: String): String {
         return try {
-            val originalFormat = SimpleDateFormat("yyyy-MM-dd HH", Locale.ROOT)
-            val targetFormat = SimpleDateFormat("hha", Locale.ROOT)
+            val originalFormat = SimpleDateFormat("yyyy-MM-dd HH", Locale.getDefault())
+            val targetFormat = SimpleDateFormat("hha", Locale.getDefault())
             val date = originalFormat.parse(iso8601Date)
             targetFormat.format(date).toLowerCase().trimStart('0')
         } catch (e: Exception) {

--- a/WooCommerce/src/main/res/values/integers.xml
+++ b/WooCommerce/src/main/res/values/integers.xml
@@ -2,4 +2,8 @@
 <resources>
     <integer name="anim_slide_transition">150</integer>
     <integer name="max_length_tracking_number">255</integer>
+    <integer name="stats_label_count_days">6</integer>
+    <integer name="stats_label_count_weeks">6</integer>
+    <integer name="stats_label_count_months">6</integer>
+    <integer name="stats_label_count_years">4</integer>
 </resources>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.extensions.formatDateToFriendlyLongMonthYear
 import com.woocommerce.android.extensions.formatDateToWeeksInYear
 import com.woocommerce.android.extensions.formatDateToYear
 import com.woocommerce.android.extensions.formatDateToYearMonth
+import com.woocommerce.android.extensions.formatToDateOnly
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -426,6 +427,34 @@ class DateUtilsTest {
 
         assertFailsWith(IllegalArgumentException::class) {
             "21".formatDateToFriendlyLongMonthDate()
+        }
+    }
+
+    @Test
+    fun `formatToDateOnly() returns correct values`() {
+        assertEquals("8", "2019-08-08".formatToDateOnly())
+        assertEquals("23", "2019-02-23".formatToDateOnly())
+        assertEquals("2", "2019-01-02".formatToDateOnly())
+        assertEquals("4", "2019-06-04".formatToDateOnly())
+        assertEquals("9", "2019-09-09".formatToDateOnly())
+        assertEquals("22", "2018-12-22".formatToDateOnly())
+
+        // Test for invalid value handling
+        assertFailsWith(IllegalArgumentException::class) {
+            "2019".formatToDateOnly()
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            "20-W12".formatToDateOnly()
+        }
+
+        // Test for invalid value handling
+        assertFailsWith(IllegalArgumentException::class) {
+            "".formatToDateOnly()
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            "21".formatToDateOnly()
         }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.extensions.formatDateToWeeksInYear
 import com.woocommerce.android.extensions.formatDateToYear
 import com.woocommerce.android.extensions.formatDateToYearMonth
 import com.woocommerce.android.extensions.formatToDateOnly
+import com.woocommerce.android.extensions.formatToMonthDateOnly
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -455,6 +456,34 @@ class DateUtilsTest {
 
         assertFailsWith(IllegalArgumentException::class) {
             "21".formatToDateOnly()
+        }
+    }
+
+    @Test
+    fun `formatToMonthDateOnly() returns correct values`() {
+        assertEquals("Aug 8", "2019-08-08".formatToMonthDateOnly())
+        assertEquals("Feb 23", "2019-02-23".formatToMonthDateOnly())
+        assertEquals("Jan 2", "2019-01-02".formatToMonthDateOnly())
+        assertEquals("Jun 4", "2019-06-04".formatToMonthDateOnly())
+        assertEquals("Sep 9", "2019-09-09".formatToMonthDateOnly())
+        assertEquals("Dec 22", "2018-12-22".formatToMonthDateOnly())
+
+        // Test for invalid value handling
+        assertFailsWith(IllegalArgumentException::class) {
+            "2019".formatToMonthDateOnly()
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            "20-W12".formatToMonthDateOnly()
+        }
+
+        // Test for invalid value handling
+        assertFailsWith(IllegalArgumentException::class) {
+            "".formatToMonthDateOnly()
+        }
+
+        assertFailsWith(IllegalArgumentException::class) {
+            "21".formatToMonthDateOnly()
         }
     }
 }


### PR DESCRIPTION
Fixes #1260. This PR completes the fourth step of the Stats Improvements Project as defined in the master thread [here](https://github.com/woocommerce/woocommerce-android/issues/1199).

### Changes:
- Removed the right side y-axis and added it to the left axis as defined in the designs.
- Modified label count based on the Tab selected. 
  - Today -> 6
  - This Week -> 6
  - This Month -> 6
  - This Year -> 4
- x-axis labels would be displayed in the following format for each tab:
   - Today -> 12am, 1am, 1pm, 2pm
   - This Week -> First entry would be Jun 30, subsequent entries would display only numbers unless it’s a different month, in which case, Jul 1 would be displayed.
   - This Month -> First entry would be Jun 30, subsequent entries would display only numbers
   - This Year -> Jun, Jul, Aug, Sep 
- Added unit tests in `DateUtilsTest` to test date formatting.

### Screenshots:
<img width="300" src="https://user-images.githubusercontent.com/22608780/63225520-a9ecd000-c1c8-11e9-9c6b-565dba046b95.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/63225524-ba04af80-c1c8-11e9-8cfe-5ee760e1490f.png">

<img width="300" src="https://user-images.githubusercontent.com/22608780/63225529-c5f07180-c1c8-11e9-977d-0faf4deb2471.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/63225531-c852cb80-c1c8-11e9-9cf8-19627e1e5e1d.png">
