### PR TITLE
Use only the isJetpackConnected property for jetpack validation

### DIFF
--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -412,13 +412,24 @@ public class LoginSiteAddressFragment extends LoginBaseFormFragment<LoginListene
             // TODO: If we plan to keep this logic we should convert these labels to constants
             HashMap<String, String> properties = new HashMap<>();
             properties.put("url", event.info.url);
-            properties.put("urlAfterRedirects", event.info.urlAfterRedirects);
+            properties.put("url_after_redirects", event.info.urlAfterRedirects);
             properties.put("exists", Boolean.toString(event.info.exists));
-            properties.put("hasJetpack", Boolean.toString(event.info.hasJetpack));
-            properties.put("isJetpackActive", Boolean.toString(event.info.isJetpackActive));
-            properties.put("isJetpackConnected", Boolean.toString(event.info.isJetpackConnected));
-            properties.put("isWordPress", Boolean.toString(event.info.isWordPress));
-            properties.put("isWPCom", Boolean.toString(event.info.isWPCom));
+            properties.put("has_jetpack", Boolean.toString(event.info.hasJetpack));
+            properties.put("is_jetpack_active", Boolean.toString(event.info.isJetpackActive));
+            properties.put("is_jetpack_connected", Boolean.toString(event.info.isJetpackConnected));
+            properties.put("is_wordpress", Boolean.toString(event.info.isWordPress));
+            properties.put("is_wp_com", Boolean.toString(event.info.isWPCom));
+
+            // Determining if jetpack is actually installed takes additional logic. This final
+            // calculated event property will make querying this event more straight-forward:
+            boolean hasJetpack = false;
+            if (event.info.isWPCom && event.info.hasJetpack) {
+                // This is likely an atomic site.
+                hasJetpack = true;
+            } else if (event.info.hasJetpack && event.info.isJetpackActive && event.info.isJetpackConnected) {
+                hasJetpack = true;
+            }
+            properties.put("login_calculated_has_jetpack", Boolean.toString(hasJetpack));
             mAnalyticsListener.trackConnectedSiteInfoSucceeded(properties);
 
             if (!event.info.exists) {
@@ -428,13 +439,6 @@ public class LoginSiteAddressFragment extends LoginBaseFormFragment<LoginListene
                 // Not a WordPress site
                 showError(R.string.enter_wordpress_site);
             } else {
-                boolean hasJetpack = false;
-                if (event.info.isWPCom && event.info.hasJetpack) {
-                    // This is likely an atomic site.
-                    hasJetpack = true;
-                } else if (event.info.hasJetpack && event.info.isJetpackActive && event.info.isJetpackConnected) {
-                    hasJetpack = true;
-                }
                 mLoginListener.gotConnectedSiteInfo(
                         event.info.url,
                         event.info.urlAfterRedirects,

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -426,7 +426,7 @@ public class LoginSiteAddressFragment extends LoginBaseFormFragment<LoginListene
             if (event.info.isWPCom && event.info.hasJetpack) {
                 // This is likely an atomic site.
                 hasJetpack = true;
-            } else if (event.info.hasJetpack && event.info.isJetpackActive && event.info.isJetpackConnected) {
+            } else if (event.info.isJetpackConnected) {
                 hasJetpack = true;
             }
             properties.put("login_calculated_has_jetpack", Boolean.toString(hasJetpack));


### PR DESCRIPTION
Fixes #954 This applies only to non-atomic stores. Due to some bugs in the connected site info endpoint the other properties are not currently reporting properly and this is causing the check for jetpack to fail during the login process. All we need to know is if jetpack is connected so I've verified this field will work for our uses.

Ref: 135308856-p2 for add'l details

**Only 1 developer required to approve and merge this PR**

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

Todo:
- [ ] Once this has been approved and merged new PRs will need to be created to merge to the WPLoginFlow and WPAndroid repos. (me)