### PR TITLE
Customer information section redesign

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailCustomerInfoView.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
@@ -24,6 +25,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(ctx: Context, attrs:
         View.inflate(context, R.layout.order_detail_customer_info, this)
     }
 
+    @SuppressLint("SetTextI18n")
     fun initView(
         order: WCOrderModel,
         shippingOnly: Boolean,
@@ -46,7 +48,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(ctx: Context, attrs:
             customerInfo_customerNoteSection.hide()
         } else {
             customerInfo_customerNoteSection.show()
-            customerInfo_customerNote.text = order.customerNote
+            customerInfo_customerNote.text = "\"${order.customerNote}\""
         }
 
         // show shipping section only for non virtual products or if shipping info available

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -230,14 +230,6 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
             // Populate the Payment Information Card
             orderDetail_paymentInfo.initView(order, currencyFormatter.buildFormatter(order.currency))
 
-            // Check for customer note, show if available
-            if (order.customerNote.isEmpty()) {
-                orderDetail_customerNote.visibility = View.GONE
-            } else {
-                orderDetail_customerNote.visibility = View.VISIBLE
-                orderDetail_customerNote.initView(order)
-            }
-
             if (isFreshData) {
                 isRefreshPending = false
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ViewExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ViewExt.kt
@@ -1,5 +1,0 @@
-package com.woocommerce.android.util
-
-import android.view.View
-
-fun Boolean.toVisibility(): Int = if (this) View.VISIBLE else View.GONE

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ViewExtensions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ViewExtensions.kt
@@ -1,6 +1,10 @@
 package com.woocommerce.android.util
 
 import android.view.View
+import android.view.animation.Animation
+import android.view.animation.Transformation
+import android.widget.LinearLayout.LayoutParams
+import android.view.View.MeasureSpec
 
 fun View.show() {
     this.visibility = View.VISIBLE
@@ -8,4 +12,53 @@ fun View.show() {
 
 fun View.hide() {
     this.visibility = View.GONE
+}
+
+fun View.expand() {
+    this.visibility = View.VISIBLE
+    this.measure(MeasureSpec.makeMeasureSpec(width, MeasureSpec.AT_MOST),
+            MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED))
+    val targetHeight = this.measuredHeight
+    val view = this
+
+    this.layoutParams.height = 0
+    val a = object : Animation() {
+        override fun applyTransformation(interpolatedTime: Float, t: Transformation) {
+            view.layoutParams.height = if (interpolatedTime == 1f)
+                LayoutParams.WRAP_CONTENT
+            else
+                (targetHeight * interpolatedTime).toInt()
+            view.requestLayout()
+        }
+
+        override fun willChangeBounds(): Boolean {
+            return true
+        }
+    }
+
+    a.duration = 300
+    this.startAnimation(a)
+}
+
+fun View.collapse() {
+    val initialHeight = this.measuredHeight
+    val view = this
+
+    val a = object : Animation() {
+        override fun applyTransformation(interpolatedTime: Float, t: Transformation) {
+            if (interpolatedTime == 1f) {
+                view.visibility = View.GONE
+            } else {
+                view.layoutParams.height = initialHeight - (initialHeight * interpolatedTime).toInt()
+                view.requestLayout()
+            }
+        }
+
+        override fun willChangeBounds(): Boolean {
+            return true
+        }
+    }
+
+    a.duration = 300
+    this.startAnimation(a)
 }

--- a/WooCommerce/src/main/res/drawable/card_expander_bg.xml
+++ b/WooCommerce/src/main/res/drawable/card_expander_bg.xml
@@ -6,7 +6,7 @@
             <stroke android:width="1dp" android:color="@color/list_divider" />
         </shape>
     </item>
-    <item android:top="1dp" android:bottom="1dp">
+    <item android:top="1dp">
         <shape
             android:shape="rectangle">
             <solid android:color="@color/white" />

--- a/WooCommerce/src/main/res/layout/fragment_order_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_detail.xml
@@ -41,20 +41,6 @@
                     android:clipToPadding="false"
                     android:contentDescription="@string/products"/>
 
-                <!-- Customer Note -->
-                <com.woocommerce.android.ui.orders.OrderDetailCustomerNoteView
-                    android:id="@+id/orderDetail_customerNote"
-                    style="@style/Woo.Card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"/>
-
-                <!-- Customer Info -->
-                <com.woocommerce.android.ui.orders.OrderDetailCustomerInfoView
-                    android:id="@+id/orderDetail_customerInfo"
-                    style="@style/Woo.Card.Expandable"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"/>
-
                 <!-- Payments -->
                 <com.woocommerce.android.ui.orders.OrderDetailPaymentView
                     android:id="@+id/orderDetail_paymentInfo"
@@ -63,6 +49,13 @@
                     android:layout_height="wrap_content"
                     android:animateLayoutChanges="true"
                     android:focusable="true"/>
+
+                <!-- Customer Info -->
+                <com.woocommerce.android.ui.orders.OrderDetailCustomerInfoView
+                    android:id="@+id/orderDetail_customerInfo"
+                    style="@style/Woo.Card.Expandable"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"/>
 
                 <!-- Shipment Tracking -->
                 <com.woocommerce.android.ui.orders.OrderDetailShipmentTrackingListView

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -25,27 +25,69 @@
             android:text="@string/customer_information"
             android:textAppearance="@style/Woo.TextAppearance.Medium.Purple"/>
 
+        <!-- Label: Customer note -->
+        <LinearLayout
+            android:id="@+id/customerInfo_customerNoteSection"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:focusable="true"
+            android:layout_marginTop="@dimen/card_item_padding_intra_double"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/customerInfo_customerNoteTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/orderdetail_customer_provided_note"
+                android:textAppearance="@style/Woo.OrderDetail.TextAppearance.SectionTitle"/>
+
+            <TextView
+                android:id="@+id/customerInfo_customerNote"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/card_item_padding_intra_h"
+                android:textAppearance="@style/Woo.OrderDetail.TextAppearance"
+                android:textAlignment="viewStart"
+                android:textIsSelectable="true"
+                tools:text="This is a nice note from the customer"/>
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginTop="@dimen/card_item_padding_intra_double"
+                android:background="@color/list_divider"
+                app:srcCompat="@drawable/list_divider"/>
+
+        </LinearLayout>
+
         <!-- Label: Shipping -->
-        <TextView
-            android:id="@+id/customerInfo_shippingLabel"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:id="@+id/customerInfo_shippingSection"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingBottom="@dimen/card_section_padding_h"
-            android:paddingTop="@dimen/card_section_padding_h"
-            android:text="@string/orderdetail_shipping_details"
-            android:textAppearance="@style/Woo.OrderDetail.TextAppearance.SectionTitle"/>
+            android:focusable="true"
+            android:layout_marginTop="@dimen/card_item_padding_intra_double"
+            android:layout_marginBottom="@dimen/card_item_padding_intra_double"
+            android:orientation="vertical">
 
-        <!-- Shipping Address -->
-        <TextView
-            android:id="@+id/customerInfo_shippingAddr"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAppearance="@style/Woo.OrderDetail.TextAppearance"
-            android:textAlignment="viewStart"
-            android:textIsSelectable="true"
-            android:layout_marginBottom="@dimen/card_padding_bottom"
-            tools:text="John Vilanzo\n123 Sesame Pl\nWarner, FL\nUnited States"/>
+            <TextView
+                android:id="@+id/customerInfo_shippingLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/orderdetail_shipping_details"
+                android:textAppearance="@style/Woo.OrderDetail.TextAppearance.SectionTitle"/>
 
+            <TextView
+                android:id="@+id/customerInfo_shippingAddr"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/card_item_padding_intra_h"
+                android:textAppearance="@style/Woo.OrderDetail.TextAppearance"
+                android:textAlignment="viewStart"
+                android:textIsSelectable="true"
+                tools:text="John Vilanzo\n123 Sesame Pl\nWarner, FL\nUnited States"/>
+
+        </LinearLayout>
 
         <!-- Billing Section -->
         <androidx.constraintlayout.widget.ConstraintLayout
@@ -182,14 +224,41 @@
     </LinearLayout>
 
     <!-- VIEW MORE Button -->
-    <ToggleButton
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/customerInfo_viewMore"
-        style="@style/Woo.CardExtenderButton"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textOff="@string/orderdetail_show_billing"
-        android:textOn="@string/orderdetail_hide_billing"
+        android:orientation="horizontal"
+        android:clickable="true"
+        android:focusable="true"
+        style="@style/Woo.CardExtenderButton"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/customerInfo_card"/>
+        app:layout_constraintTop_toBottomOf="@+id/customerInfo_card">
+
+        <TextView
+            android:id="@+id/customerInfo_viewMoreButtonTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/orderdetail_show_billing"
+            android:textAllCaps="true"
+            android:textColor="@color/colorPrimary"
+            android:textSize="@dimen/text_large"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageView
+            android:id="@+id/customerInfo_viewMoreButtonImage"
+            style="@android:style/Widget.ActionButton"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:background="@null"
+            android:contentDescription="@string/orderdetail_show_billing"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            android:src="@drawable/ic_arrow_down" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </merge>

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -235,11 +235,9 @@
     </style>
     <style name="Woo.CardExtenderButton">
         <item name="android:background">@drawable/card_expander_bg</item>
-        <item name="android:textColor">@color/colorPrimary</item>
-        <item name="android:textSize">@dimen/text_large</item>
         <item name="android:textAlignment">viewStart</item>
-        <item name="android:drawableEnd">@drawable/card_expander_selector</item>
         <item name="android:paddingEnd">@dimen/card_padding_end</item>
+        <item name="android:paddingStart">@dimen/card_padding_end</item>
     </style>
 
     <!--


### PR DESCRIPTION
Fixes #1238.

This PR updates the Customer information card based on the design updates in preparation for refunds (step 1). 

The expanding Billing address section is now animated:
![customer_info](https://user-images.githubusercontent.com/1522856/63597540-f9af0b00-c5bd-11e9-975c-e51b8b5870a0.gif)
