### PR TITLE
Issue/1333 hide visitor stats if stats module is disabled

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
  * Added brand new stats page for user with the WooCommerce Admin plugin and provided an option for users to opt in or out directly from the Settings page.
 * Added an option to bypass the Jetpack required screen during the login process and attempt to log into the site anyway.
 * Fixed a bug in the Jetpack connection check during login where a small percentage of sites with Jetpack properly connected were coming back as not connected and preventing users from logging in successfully.
+* The visitor stats is hidden from the stats page if the stats module is disabled for a site.
 
 2.5
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -296,11 +296,14 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
 
     fun showVisitorStats(visitorStats: Map<String, Int>) {
         chartVisitorStats = getFormattedVisitorStats(visitorStats)
+        if (visitors_layout.visibility == View.GONE) {
+            WooAnimUtils.fadeIn(visitors_layout)
+        }
         fadeInLabelValue(visitors_value, visitorStats.values.sum().toString())
     }
 
     fun showVisitorStatsError() {
-        fadeInLabelValue(visitors_value, "?")
+        WooAnimUtils.fadeOut(visitors_layout)
     }
 
     private fun updateChartView() {
@@ -440,7 +443,7 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
 
     private fun fadeInLabelValue(view: TextView, value: String) {
         // do nothing if value hasn't changed
-        if (view.text.toString().equals(value)) {
+        if (view.text.toString() == value) {
             return
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -303,7 +303,9 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
     }
 
     fun showVisitorStatsError() {
-        WooAnimUtils.fadeOut(visitors_layout)
+        if (visitors_layout.visibility == View.VISIBLE) {
+            WooAnimUtils.fadeOut(visitors_layout)
+        }
     }
 
     private fun updateChartView() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -294,12 +294,14 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
 
     fun showVisitorStats(visitorStats: Map<String, Int>) {
         chartVisitorStats = getFormattedVisitorStats(visitorStats)
-        visitors_layout.visibility = View.VISIBLE
+        if (visitors_layout.visibility == View.GONE) {
+            WooAnimUtils.fadeIn(visitors_layout)
+        }
         fadeInLabelValue(visitors_value, visitorStats.values.sum().toString())
     }
 
     fun showVisitorStatsError() {
-        fadeInLabelValue(visitors_value, "?")
+        WooAnimUtils.fadeOut(visitors_layout)
     }
 
     fun clearLabelValues() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -301,7 +301,9 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
     }
 
     fun showVisitorStatsError() {
-        WooAnimUtils.fadeOut(visitors_layout)
+        if (visitors_layout.visibility == View.VISIBLE) {
+            WooAnimUtils.fadeOut(visitors_layout)
+        }
     }
 
     fun clearLabelValues() {


### PR DESCRIPTION
Fixes #1333 by hiding the visitor stats view in both the old and the new stats UI, if the stats module is disabled for a site.

### Notes:
~~This PR is in draft till the [stats UI master PR](https://github.com/woocommerce/woocommerce-android/pull/1372) is merged to `develop`.~~

### Testing:
- Go to `{{your_site_url}}/wp-admin/admin.php?page=jetpack_modules` and deactivate the site stats for a test site.
- Open/refresh the app and verify that the visitor stats view is hidden.
- Go to `{{your_site_url}}/wp-admin/admin.php?page=jetpack_modules` and **activate** the site stats again.
- Open/refresh the app and verify that the visitor stats view is displayed.
- Go to the same test site and disable/enable `wc-admin` and follow the above steps again to verify that the visitor stats is hidden/displayed in both the old stats and new stats UI. 

### Screenshots:
(LEFT: old stats UI .  RIGHT: new stats UI)
<img width="300" src="https://user-images.githubusercontent.com/22608780/63747175-1f8d2600-c8c4-11e9-9fc1-a3d87a4f60c3.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/63747124-fec4d080-c8c3-11e9-890a-fc29ab23e0bf.png">


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
