### PR TITLE
issue/1385-stats-v4-ui-crash-fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -514,7 +514,12 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
             return when (value) {
                 axis.mEntries.first() -> getStartValue()
                 axis.mEntries.max() -> getEndValue()
-                else -> getLabelValue(chartRevenueStats.keys.elementAt(round(value).toInt() - 1))
+                else -> {
+                    val index = round(value).toInt() - 1
+                    return if (index > 0 && index < chartRevenueStats.keys.size - 1) {
+                        getLabelValue(chartRevenueStats.keys.elementAt(index))
+                    } else ""
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #1385 by adding a check when trying to get the x-axis label for a single bar.

### Testing:
I have been able to reproduce this randomly by using this test site `testwooshop.mystagingwebsite.com` and clicking on the `This Week` tab. 
- Click on the `This Year` tab.
- Click on the `This Month` tab and before it is fully loaded click on the `This week` tab.
- Notice the crash
- Pull changes from this PR and verify that the app no longer crashes.

#### Behaviour before the fix:
<img width="300" src="https://user-images.githubusercontent.com/22608780/63829474-482a2400-c987-11e9-88bc-7c8609ba21ae.gif">



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
