### PR TITLE
issue/1393-v4-stats-timezone-fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreDateRangeView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreDateRangeView.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.extensions.formatDateToFriendlyDayHour
 import com.woocommerce.android.extensions.formatDateToFriendlyLongMonthDate
 import com.woocommerce.android.extensions.formatDateToFriendlyLongMonthYear
+import com.woocommerce.android.extensions.formatToMonthDateOnly
 import com.woocommerce.android.util.DateUtils
 import kotlinx.android.synthetic.main.my_store_date_bar.view.*
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
@@ -66,7 +67,7 @@ class MyStoreDateRangeView @JvmOverloads constructor(ctx: Context, attrs: Attrib
     fun updateDateViewOnScrubbing(dateString: String, activeGranularity: StatsGranularity) {
         dashboard_date_range_value.text = when (activeGranularity) {
             StatsGranularity.DAYS -> dateString.formatDateToFriendlyDayHour()
-            StatsGranularity.WEEKS -> DateUtils.getShortMonthDayString(dateString)
+            StatsGranularity.WEEKS -> dateString.formatToMonthDateOnly()
             StatsGranularity.MONTHS -> dateString.formatDateToFriendlyLongMonthDate()
             StatsGranularity.YEARS -> dateString.formatDateToFriendlyLongMonthYear()
         }
@@ -86,7 +87,7 @@ class MyStoreDateRangeView @JvmOverloads constructor(ctx: Context, attrs: Attrib
     ): String {
         return when (activeGranularity) {
             StatsGranularity.DAYS -> DateUtils.getDayMonthDateString(dateString)
-            StatsGranularity.WEEKS -> DateUtils.getShortMonthDayString(dateString)
+            StatsGranularity.WEEKS -> dateString.formatToMonthDateOnly()
             StatsGranularity.MONTHS -> DateUtils.getMonthString(dateString)
             StatsGranularity.YEARS -> DateUtils.getYearString(dateString)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -468,8 +468,8 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
     private fun getEntryValue(dateString: String): String {
         return when (activeGranularity) {
             StatsGranularity.DAYS -> DateUtils.getShortHourString(dateString)
-            StatsGranularity.WEEKS -> DateUtils.getShortMonthDayString(dateString)
-            StatsGranularity.MONTHS -> DateUtils.getShortMonthDayString(dateString)
+            StatsGranularity.WEEKS -> dateString.formatToMonthDateOnly()
+            StatsGranularity.MONTHS -> dateString.formatToMonthDateOnly()
             StatsGranularity.YEARS -> DateUtils.getShortMonthString(dateString)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -166,7 +166,11 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
             StatsGranularity.MONTHS -> R.integer.stats_label_count_months
             StatsGranularity.YEARS -> R.integer.stats_label_count_years
         }
-        return context.resources.getInteger(resId)
+        val chartRevenueStatsSize = chartRevenueStats.keys.size
+        val barLabelCount = context.resources.getInteger(resId)
+        return if (chartRevenueStatsSize < barLabelCount) {
+            chartRevenueStatsSize
+        } else barLabelCount
     }
 
     /**

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '0926d4b97bfdb40c1f699fdbe70f805c7833c313'
+    fluxCVersion = 'cdb64c29e1c38dd339051e25e99ccd364895a4f7'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '329e1e36a56bf3ac75e516585d8f1bc8b382047f'
+    fluxCVersion = '0926d4b97bfdb40c1f699fdbe70f805c7833c313'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
This PR Fixes #1393. The fix is purely a FluxC side fix and this PR just updates the FluxC hash to the app.

~~This PR is in draft till this [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1375) is merged.~~ More details on the issue can be found [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1375).

### Testing
It would be good to test with multiple timezones to verify if the dates passed to the API request is correct. I changed the timezone of my testing device to GMT+14 and verify that the date bar displays the correct start date for the current day, this week, this month and this year.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
