### PR TITLE
Stats improvements - Step 5: Handle corner cases design review

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCToggleSingleOptionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCToggleSingleOptionView.kt
@@ -53,6 +53,10 @@ class WCToggleSingleOptionView @JvmOverloads constructor(ctx: Context, attrs: At
                 switchSetting_switch.textOn = resources.getString(R.string.toggle_option_checked)
                 switchSetting_switch.textOff = resources.getString(R.string.toggle_option_not_checked)
 
+                // add top padding between the switch title and subtitle
+                val topPadding = a.getDimensionPixelSize(R.styleable.WCToggleSingleOptionView_switchTopPadding, 0)
+                switchSetting_switch.setPadding(0, topPadding, 0, 0)
+
                 setOnClickListener { toggle() }
             } finally {
                 a.recycle()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCToggleSingleOptionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCToggleSingleOptionView.kt
@@ -9,6 +9,7 @@ import android.widget.Checkable
 import android.widget.CompoundButton
 import android.widget.CompoundButton.OnCheckedChangeListener
 import android.widget.LinearLayout
+import androidx.core.content.ContextCompat
 import com.woocommerce.android.R
 import kotlinx.android.synthetic.main.view_toggle_single_option.view.*
 
@@ -30,6 +31,16 @@ class WCToggleSingleOptionView @JvmOverloads constructor(ctx: Context, attrs: At
             try {
                 // Set the view title
                 switchSetting_title.text = a.getString(R.styleable.WCToggleSingleOptionView_switchTitle).orEmpty()
+
+                // set the summary text color
+                var textColor = a.getColor(R.styleable.WCToggleSingleOptionView_switchSummaryTextColor, 0)
+                if (textColor == 0) {
+                    val textColorResId = a.getResourceId(
+                            R.styleable.WCToggleSingleOptionView_switchSummaryTextColor, R.color.wc_grey_medium
+                    )
+                    textColor = ContextCompat.getColor(context, textColorResId)
+                }
+                switchSetting_switch.setTextColor(textColor)
 
                 // Set the summary and switch state
                 switchSetting_switch.isChecked =

--- a/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
@@ -11,6 +11,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:switchSummary="@string/settings_enable_v4_stats_message"
+        app:switchSummaryTextColor="@color/wc_grey_medium"
         app:switchTitle="@string/settings_enable_v4_stats_title"
         android:background="@color/white"
         app:layout_constraintStart_toStartOf="parent"

--- a/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
@@ -12,6 +12,7 @@
         android:layout_height="wrap_content"
         app:switchSummary="@string/settings_enable_v4_stats_message"
         app:switchSummaryTextColor="@color/wc_grey_medium"
+        app:switchTopPadding="@dimen/default_padding"
         app:switchTitle="@string/settings_enable_v4_stats_title"
         android:background="@color/white"
         app:layout_constraintStart_toStartOf="parent"

--- a/WooCommerce/src/main/res/layout/my_store_stats_availability_notice.xml
+++ b/WooCommerce/src/main/res/layout/my_store_stats_availability_notice.xml
@@ -27,7 +27,8 @@
             android:layout_height="wrap_content"
             android:paddingBottom="@dimen/default_padding"
             android:paddingTop="@dimen/default_padding"
-            android:paddingStart="@dimen/margin_extra_extra_medium_large"
+            android:paddingStart="@dimen/card_padding_start"
+            android:layout_marginStart="9dp"
             android:paddingEnd="0dp"
             android:visibility="gone"
             tools:visibility="visible">
@@ -35,9 +36,9 @@
             <!-- Message -->
             <TextView
                 android:id="@+id/my_store_availability_message"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/margin_large"
+                android:layout_marginStart="@dimen/margin_extra_large"
                 android:gravity="start"
                 android:lineSpacingExtra="4sp"
                 android:paddingBottom="@dimen/default_padding"

--- a/WooCommerce/src/main/res/layout/my_store_stats_availability_notice.xml
+++ b/WooCommerce/src/main/res/layout/my_store_stats_availability_notice.xml
@@ -19,10 +19,7 @@
             android:layout_height="wrap_content"
             android:background="@null"
             android:textOff="@string/my_store_stats_availability_title"
-            android:textOn="@string/my_store_stats_availability_title"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"/>
+            android:textOn="@string/my_store_stats_availability_title"/>
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/my_store_availability_morePanel"
@@ -30,6 +27,8 @@
             android:layout_height="wrap_content"
             android:paddingBottom="@dimen/default_padding"
             android:paddingTop="@dimen/default_padding"
+            android:paddingStart="@dimen/margin_extra_extra_medium_large"
+            android:paddingEnd="0dp"
             android:visibility="gone"
             tools:visibility="visible">
 

--- a/WooCommerce/src/main/res/layout/my_store_stats_availability_notice.xml
+++ b/WooCommerce/src/main/res/layout/my_store_stats_availability_notice.xml
@@ -45,7 +45,7 @@
                 android:paddingEnd="@dimen/card_padding_end"
                 android:paddingStart="@dimen/card_padding_start"
                 android:text="@string/my_store_stats_availability_message"
-                android:textAppearance="@style/Woo.TextAppearance.Medium"
+                android:textAppearance="@style/Woo.TextAppearance.Medium.Gray"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"/>

--- a/WooCommerce/src/main/res/layout/my_store_stats_reverted_notice.xml
+++ b/WooCommerce/src/main/res/layout/my_store_stats_reverted_notice.xml
@@ -22,13 +22,15 @@
         <!-- Message -->
         <TextView
             android:id="@+id/my_store_reverted_title"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/default_padding"
+            android:paddingBottom="@dimen/default_padding"
             android:gravity="start"
             android:lineSpacingExtra="4sp"
             android:text="@string/my_store_stats_reverted_message"
             android:textAppearance="@style/Woo.TextAppearance.Medium.Gray"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@+id/my_store_info_icon"
             app:layout_constraintTop_toTopOf="parent"/>
 

--- a/WooCommerce/src/main/res/layout/my_store_stats_reverted_notice.xml
+++ b/WooCommerce/src/main/res/layout/my_store_stats_reverted_notice.xml
@@ -28,7 +28,7 @@
             android:gravity="start"
             android:lineSpacingExtra="4sp"
             android:text="@string/my_store_stats_reverted_message"
-            android:textAppearance="@style/Woo.TextAppearance"
+            android:textAppearance="@style/Woo.TextAppearance.Medium.Gray"
             app:layout_constraintStart_toEndOf="@+id/my_store_info_icon"
             app:layout_constraintTop_toTopOf="parent"/>
 

--- a/WooCommerce/src/main/res/layout/view_toggle_single_option.xml
+++ b/WooCommerce/src/main/res/layout/view_toggle_single_option.xml
@@ -22,5 +22,6 @@
         android:textAlignment="viewStart"
         android:importantForAccessibility="no"
         android:clickable="false"
+        android:lineSpacingExtra="4sp"
         tools:text="If disabled will add the note as private"/>
 </merge>

--- a/WooCommerce/src/main/res/values/attrs.xml
+++ b/WooCommerce/src/main/res/values/attrs.xml
@@ -34,5 +34,6 @@
         <attr name="switchSummary" format="reference|string"/>
         <attr name="switchChecked" format="boolean"/>
         <attr name="switchSummaryTextColor" format="reference|color"/>
+        <attr name="switchTopPadding" format="dimension" />
     </declare-styleable>
 </resources>

--- a/WooCommerce/src/main/res/values/attrs.xml
+++ b/WooCommerce/src/main/res/values/attrs.xml
@@ -33,5 +33,6 @@
         <attr name="switchTitle" format="reference|string"/>
         <attr name="switchSummary" format="reference|string"/>
         <attr name="switchChecked" format="boolean"/>
+        <attr name="switchSummaryTextColor" format="reference|color"/>
     </declare-styleable>
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -370,7 +370,7 @@
     <string name="settings_confirm_logout">Are you sure you want to logout from the account %s?</string>
     <string name="settings_send_stats">Collect information</string>
     <string name="settings_enable_v4_stats_title">Improved stats</string>
-    <string name="settings_enable_v4_stats_message">Try the new stats available with the WooCommerce admin plugin</string>
+    <string name="settings_enable_v4_stats_message">Try the new stats available with the\nWooCommerce admin plugin</string>
     <string name="settings_send_stats_detail">Share information with our analytics tool about your use of services while logged in to your WordPress account</string>
     <string name="settings_privacy_detail">This information helps us improve our products, make marketing to you more relevant, personalize your WooCommerce experience, and more as detailed in our privacy policy</string>
     <string name="settings_privacy_policy">Read privacy policy</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -370,7 +370,7 @@
     <string name="settings_confirm_logout">Are you sure you want to logout from the account %s?</string>
     <string name="settings_send_stats">Collect information</string>
     <string name="settings_enable_v4_stats_title">Improved stats</string>
-    <string name="settings_enable_v4_stats_message">Try the new stats available with the\nWooCommerce admin plugin</string>
+    <string name="settings_enable_v4_stats_message">Try the new stats available with the WooCommerce admin plugin</string>
     <string name="settings_send_stats_detail">Share information with our analytics tool about your use of services while logged in to your WordPress account</string>
     <string name="settings_privacy_detail">This information helps us improve our products, make marketing to you more relevant, personalize your WooCommerce experience, and more as detailed in our privacy policy</string>
     <string name="settings_privacy_policy">Read privacy policy</string>

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -100,6 +100,11 @@
         <item name="android:textSize">@dimen/text_medium</item>
     </style>
 
+    <style name="Woo.TextAppearance.Medium.Gray">
+        <item name="android:textColor">@color/wc_grey_medium</item>
+        <item name="android:textSize">@dimen/text_medium</item>
+    </style>
+
     <style name="Woo.TextAppearance.Medium.Purple">
         <item name="android:textColor">@color/colorPrimary</item>
         <item name="android:fontFamily">@font/roboto_medium</item>
@@ -587,7 +592,7 @@
 
     <style name="Woo.Stats.Availability.CardExtenderButton" parent="Woo.CardExtenderButton">
         <item name="android:background">@drawable/button_white_bg</item>
-        <item name="android:textColor">@color/wc_grey_darkest</item>
+        <item name="android:textColor">@color/wc_grey_dark</item>
         <item name="android:drawableStart">@drawable/ic_gridicons_gift</item>
         <item name="android:drawableEnd">@drawable/stats_availability_expander_selector</item>
         <item name="android:paddingStart">@dimen/card_padding_start</item>


### PR DESCRIPTION
This time PR fixes #1395 by modifying the color codes of the stats v4 availability banner and the stats v4 reverted banner. 

### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/22608780/63915419-ade3e200-ca53-11e9-8bee-41c45062279a.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/63915425-afada580-ca53-11e9-81ab-20cf847f93ba.png">

@kyleaparker could I trouble you for a review of this please! Thank you!!

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
