### PR TITLE
Product Reviews: Mark all as read

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -46,7 +46,6 @@ import com.woocommerce.android.ui.orders.OrderDetailFragmentDirections
 import com.woocommerce.android.ui.orders.OrderListFragment
 import com.woocommerce.android.ui.prefs.AppSettingsActivity
 import com.woocommerce.android.ui.products.ProductDetailFragmentDirections
-import com.woocommerce.android.ui.reviews.ReviewListFragment
 import com.woocommerce.android.ui.sitepicker.SitePickerActivity
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListAdapter.kt
@@ -256,8 +256,7 @@ class ReviewListAdapter(
      * property to true and feeding the updated list back into the adapter.
      */
     fun markAllReviewsAsRead() {
-        val newList = mutableListOf<ProductReview>()
-                .apply { addAll(reviewList) }.applyTransform { it.apply { read = true } }
+        val newList = reviewList.map { it.copy() }.applyTransform { it.apply { read = true } }
 
         setReviews(newList)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -16,6 +16,7 @@ import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.extensions.onScrollDown
 import com.woocommerce.android.extensions.onScrollUp
 import com.woocommerce.android.model.ProductReview
@@ -147,6 +148,17 @@ class ReviewListFragment : TopLevelFragment(), ItemDecorationListener, ReviewLis
         super.onPrepareOptionsMenu(menu)
     }
 
+    override fun onOptionsItemSelected(item: MenuItem?): Boolean {
+        return when (item?.itemId) {
+            R.id.menu_mark_all_read -> {
+                AnalyticsTracker.track(Stat.NOTIFICATIONS_LIST_MENU_MARK_READ_BUTTON_TAPPED)
+                viewModel.markAllReviewsAsRead()
+                true
+            }
+            else -> return super.onOptionsItemSelected(item)
+        }
+    }
+
     override fun onAttach(context: Context?) {
         AndroidSupportInjection.inject(this)
         super.onAttach(context)
@@ -201,6 +213,13 @@ class ReviewListFragment : TopLevelFragment(), ItemDecorationListener, ReviewLis
 
         viewModel.showSnackbarMessage.observe(this, Observer {
             uiMessageResolver.showSnack(it)
+        })
+
+        viewModel.isMarkingAllAsRead.observe(this, Observer {
+            when (it) {
+                true -> menuMarkAllRead?.actionView = layoutInflater.inflate(R.layout.action_menu_progress, null)
+                false -> menuMarkAllRead?.actionView = null
+            }
         })
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -22,6 +22,9 @@ import com.woocommerce.android.extensions.onScrollUp
 import com.woocommerce.android.model.ProductReview
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.reviews.ReviewListViewModel.ActionStatus.COMPLETE
+import com.woocommerce.android.ui.reviews.ReviewListViewModel.ActionStatus.ERROR
+import com.woocommerce.android.ui.reviews.ReviewListViewModel.ActionStatus.PROCESSING
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.UnreadItemDecoration
 import com.woocommerce.android.widgets.UnreadItemDecoration.ItemDecorationListener
@@ -217,8 +220,12 @@ class ReviewListFragment : TopLevelFragment(), ItemDecorationListener, ReviewLis
 
         viewModel.isMarkingAllAsRead.observe(this, Observer {
             when (it) {
-                true -> menuMarkAllRead?.actionView = layoutInflater.inflate(R.layout.action_menu_progress, null)
-                false -> menuMarkAllRead?.actionView = null
+                PROCESSING -> menuMarkAllRead?.actionView = layoutInflater.inflate(R.layout.action_menu_progress, null)
+                COMPLETE -> {
+                    menuMarkAllRead?.actionView = null
+                    reviewsAdapter.markAllReviewsAsRead()
+                }
+                ERROR -> menuMarkAllRead?.actionView = null
             }
         })
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.extensions.onScrollDown
 import com.woocommerce.android.extensions.onScrollUp
 import com.woocommerce.android.model.ProductReview
+import com.woocommerce.android.push.NotificationHandler
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.reviews.ReviewListViewModel.ActionStatus.COMPLETE
@@ -223,11 +224,18 @@ class ReviewListFragment : TopLevelFragment(), ItemDecorationListener, ReviewLis
                 PROCESSING -> menuMarkAllRead?.actionView = layoutInflater.inflate(R.layout.action_menu_progress, null)
                 COMPLETE -> {
                     menuMarkAllRead?.actionView = null
-                    reviewsAdapter.markAllReviewsAsRead()
+                    markAllReviewsAsReadSuccess()
                 }
                 ERROR -> menuMarkAllRead?.actionView = null
             }
         })
+    }
+
+    private fun markAllReviewsAsReadSuccess() {
+        reviewsAdapter.markAllReviewsAsRead()
+
+        // Remove all active notifications from the system bar
+        context?.let { NotificationHandler.removeAllReviewNotifsFromSystemBar(it) }
     }
 
     private fun showReviewList(reviews: List<ProductReview>) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModel.kt
@@ -47,6 +47,9 @@ class ReviewListViewModel @Inject constructor(
     private val _isRefreshing = MutableLiveData<Boolean>()
     val isRefreshing: LiveData<Boolean> = _isRefreshing
 
+    private val _hasUnreadReviews = MutableLiveData<Boolean>()
+    val hasUnreadReviews: LiveData<Boolean> = _hasUnreadReviews
+
     fun start() {
         dispatcher.register(this)
         loadReviews()
@@ -85,6 +88,12 @@ class ReviewListViewModel @Inject constructor(
         _isRefreshing.value = true
         launch {
             fetchReviewList(loadMore = false)
+        }
+    }
+    
+    fun checkForUnreadReviews() {
+        launch {
+            _hasUnreadReviews.value = reviewRepository.getHasUnreadReviews()
         }
     }
 

--- a/WooCommerce/src/main/res/layout/action_menu_progress.xml
+++ b/WooCommerce/src/main/res/layout/action_menu_progress.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="56dp"
+    android:layout_height="wrap_content"
+    android:minWidth="56dp">
+
+    <ProgressBar
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_gravity="center"
+        android:padding="4dp"
+        android:indeterminateTint="@color/white"/>
+</FrameLayout>

--- a/WooCommerce/src/main/res/menu/menu_reviews_list_fragment.xml
+++ b/WooCommerce/src/main/res/menu/menu_reviews_list_fragment.xml
@@ -7,5 +7,6 @@
         android:id="@+id/menu_mark_all_read"
         android:icon="@drawable/ic_menu_check"
         android:title="@string/wc_mark_all_read"
+        android:visible="false"
         app:showAsAction="always"/>
 </menu>


### PR DESCRIPTION
This PR fixes #1389 by implementing the "Mark all as read" functionality in the Product Reviews tab. This includes:

- Adding the menu option
- Hiding/showing menu option depending on if there are any unread reviews
- Fetching notifications from the API and matching them to the product review to determine  `read` status
- If a product review does not exist in the notifications table it's assumed it's been read.
- Error handling

We used to superficially mark all the notifications as read and then process the result of the network action to mark all as read. If there was an error, we'd revert the superficial change and show an error message. This didn't seem ideal and with MVVM also just felt wrong. I've updated the design to show a "refreshing" icon in the toolbar while the request is being processed, and then handle the real results. The nice thing about this is the user doesn't have to stick around and wait for it to finish. They can navigate around the app and return to this view and if it's finished, the list will be appropriately updated. They will also get the success snack message no matter where they are in the app as long as they don't leave the main activity (like going to settings). 

Here's a preview. This PR needs a design review before being approved. @kyleaparker 

<img src="https://user-images.githubusercontent.com/5810477/64144407-49b17d00-cdc9-11e9-9ccb-8d68709202f9.gif" width="350"/>

PR #1402 needs to be approved and merged before this PR will be ready for review.
