### PR TITLE
Order List redesign - Step 1: Added TabLayout to the order list 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 2.7
 -----
+* Revamped the order list page by providing a new tab for unfulfilled orders
  
 2.6
 -----

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockedActivityBindingModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockedActivityBindingModule.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.MagicLinkInterceptActivity
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MockedMainModule
+import com.woocommerce.android.ui.mystore.MyStoreModule
 import com.woocommerce.android.ui.notifications.NotifsListModule
 import com.woocommerce.android.ui.notifications.ReviewDetailModule
 import com.woocommerce.android.ui.orders.MockedAddOrderShipmentTrackingModule
@@ -33,6 +34,7 @@ abstract class MockedActivityBindingModule {
     @ContributesAndroidInjector(modules = arrayOf(
             MockedMainModule::class,
             MockedDashboardModule::class,
+            MyStoreModule::class,
             MockedOrderListModule::class,
             MockedOrderDetailModule::class,
             MockedOrderProductListModule::class,

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/MockedOrderListModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/MockedOrderListModule.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders
 
 import android.content.Context
 import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.whenever
@@ -11,6 +12,7 @@ import com.woocommerce.android.tools.SelectedSite
 import dagger.Module
 import dagger.Provides
 import dagger.android.ContributesAndroidInjector
+import org.mockito.ArgumentMatchers.anyString
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
@@ -57,7 +59,7 @@ abstract class MockedOrderListModule {
              */
             doReturn(true).whenever(mockedOrderListPresenter).isOrderStatusOptionsRefreshing()
             doReturn(orderStatusList).whenever(mockedOrderListPresenter).getOrderStatusOptions()
-            doReturn(orders).whenever(mockedOrderListPresenter).fetchOrdersFromDb(null, false)
+            doReturn(orders).whenever(mockedOrderListPresenter).fetchOrdersFromDb(anyString(), eq(false))
             return mockedOrderListPresenter
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -32,7 +32,8 @@ object AppPrefs {
         SHOULD_DISPLAY_V4_STATS_AVAILABILITY_BANNER,
         SHOULD_DISPLAY_V4_STATS_REVERTED_BANNER,
         IS_V4_STATS_UI_ENABLED,
-        LOGIN_USER_BYPASSED_JETPACK_REQUIRED
+        LOGIN_USER_BYPASSED_JETPACK_REQUIRED,
+        SELECTED_ORDER_LIST_TAB_POSITION
     }
 
     /**
@@ -225,6 +226,13 @@ object AppPrefs {
     fun setDatabaseDowngraded(value: Boolean) {
         setBoolean(DATABASE_DOWNGRADED, value)
     }
+
+    fun setSelectedOrderListTab(selectedOrderListTabPosition: Int) {
+        setInt(DeletablePrefKey.SELECTED_ORDER_LIST_TAB_POSITION, selectedOrderListTabPosition)
+    }
+
+    fun getSelectedOrderListTabPosition() =
+            getInt(DeletablePrefKey.SELECTED_ORDER_LIST_TAB_POSITION, 0)
 
     /**
      * Remove all user-related preferences.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListAdapter.kt
@@ -25,7 +25,7 @@ import javax.inject.Inject
  * Adapter serves up list of [WCOrderModel] items grouped by the appropriate [TimeGroup].
  */
 class OrderListAdapter @Inject constructor(
-    val presenter: OrderListContract.Presenter,
+    val listener: OrderListListener,
     val currencyFormatter: CurrencyFormatter
 )
     : SectionedRecyclerViewAdapter() {
@@ -44,7 +44,7 @@ class OrderListAdapter @Inject constructor(
 
     fun setOrders(orders: List<WCOrderModel>, filterByStatus: String? = null) {
         orderStatusFilter = filterByStatus
-        orderStatusOptionsMap = presenter.getOrderStatusOptions()
+        orderStatusOptionsMap = listener.getOrderStatusOptions()
 
         // clear all the current data from the adapter
         removeAllSections()
@@ -249,7 +249,7 @@ class OrderListAdapter @Inject constructor(
             itemHolder.rootView.tag = order
             itemHolder.rootView.setOnClickListener {
                 val orderItem = it.tag as WCOrderModel
-                presenter.openOrderDetail(orderItem)
+                listener.openOrderDetail(orderItem)
             }
             // clear existing tags and add new ones
             itemHolder.orderTagList.removeAllViews()
@@ -259,7 +259,7 @@ class OrderListAdapter @Inject constructor(
         }
 
         private fun refreshOrderStatusOptionsAndCreateTemp(status: String): WCOrderStatusModel {
-            presenter.refreshOrderStatusOptions()
+            listener.refreshOrderStatusOptions()
             return WCOrderStatusModel().apply {
                 statusKey = status
                 label = status

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -238,7 +238,8 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
                     }
                     tab_layout.addTab(tab)
 
-                    // Start with the given time period selected
+                    // Start with the tab user had previously selected
+                    // if no tab is selected, default to the `Processing` Tab
                     if (index == tabPosition) {
                         orderStatusFilter = getOrderStatusByTab(tab)
                         tab.select()
@@ -275,7 +276,9 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
 
             override fun onTabUnselected(tab: TabLayout.Tab) {}
 
-            override fun onTabReselected(tab: TabLayout.Tab) {}
+            override fun onTabReselected(tab: TabLayout.Tab) {
+                order_list_view.scrollToTop()
+            }
         })
 
         // set activity toolbar elevation to 0

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -260,9 +260,10 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
 
         tab_layout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
             override fun onTabSelected(tab: TabLayout.Tab) {
+                val previousOrderStatus = orderStatusFilter
                 orderStatusFilter = getOrderStatusByTab(tab)
 
-                if (orderStatusFilter != order_list_view.getOrderListStatusFilter()) {
+                if (orderStatusFilter != previousOrderStatus) {
                     // store the selected tab in SharedPrefs
                     // clear the adapter data
                     // load orders based on the order status
@@ -276,6 +277,9 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
 
             override fun onTabReselected(tab: TabLayout.Tab) {}
         })
+
+        // set activity toolbar elevation to 0
+        activity?.toolbar?.elevation = 0f
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -355,7 +359,6 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
 
         if (isActive) {
             updateActivityTitle()
-            activity?.toolbar?.elevation = 0f
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -281,7 +281,7 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
             }
         })
 
-        // set activity toolbar elevation to 0
+        // As part of the new order list design changes, there is no elevation of the toolbar
         activity?.toolbar?.elevation = 0f
     }
 
@@ -307,8 +307,11 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
         super.onHiddenChanged(hidden)
 
         if (hidden) {
+            // restore the toolbar elevation when the order list screen is hidden
+            activity?.toolbar?.elevation = resources.getDimension(R.dimen.appbar_elevation)
             disableSearchListeners()
         } else {
+            activity?.toolbar?.elevation = 0f
             enableSearchListeners()
 
             // silently refresh if this fragment is no longer hidden

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -380,6 +380,8 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
         return !isSearching && orderStatusFilter.isNullOrEmpty()
     }
 
+    private fun isShowingProcessingOrders() = tab_layout.selectedTabPosition == 0
+
     /**
      * shows the view that appears for stores that have have no orders matching the current filter
      */
@@ -403,14 +405,15 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
                     showShareButton = true
                     messageId = R.string.waiting_for_customers
                 }
+                isShowingProcessingOrders() -> {
+                    showImage = false
+                    showShareButton = false
+                    messageId = R.string.orders_empty_message_with_processing
+                }
                 else -> {
                     showImage = true
                     showShareButton = true
-                    // display "No orders to process" only if the current tab is `Processing`
-                    // otherwise display the default "No orders" message
-                    messageId = if (tab_layout.selectedTabPosition == 0) {
-                        R.string.orders_empty_message_with_processing
-                    } else R.string.orders_empty_message_with_filter
+                    messageId = R.string.orders_empty_message_with_filter
                 }
             }
             order_list_view.showEmptyView(messageId, showImage, showShareButton)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -349,16 +349,17 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
     }
 
     override fun showOrders(orders: List<WCOrderModel>, filterByStatus: String?, isFreshData: Boolean) {
-        orderStatusFilter = filterByStatus
+        // Only update the order list view if the new filter match the currently selected order status
+        if (orderStatusFilter == filterByStatus) {
+            order_list_view.showOrders(orders, filterByStatus, isFreshData)
 
-        order_list_view.showOrders(orders, filterByStatus, isFreshData)
+            if (isFreshData) {
+                isRefreshPending = false
+            }
 
-        if (isFreshData) {
-            isRefreshPending = false
-        }
-
-        if (isActive) {
-            updateActivityTitle()
+            if (isActive) {
+                updateActivityTitle()
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -405,7 +405,11 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
                 else -> {
                     showImage = true
                     showShareButton = true
-                    messageId = R.string.orders_empty_message_with_filter
+                    // display "No orders to process" only if the current tab is `Processing`
+                    // otherwise display the default "No orders" message
+                    messageId = if (tab_layout.selectedTabPosition == 0) {
+                        R.string.orders_empty_message_with_processing
+                    } else R.string.orders_empty_message_with_filter
                 }
             }
             order_list_view.showEmptyView(messageId, showImage, showShareButton)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListListener.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListListener.kt
@@ -1,0 +1,12 @@
+package com.woocommerce.android.ui.orders
+
+import org.wordpress.android.fluxc.model.WCOrderModel
+import org.wordpress.android.fluxc.model.WCOrderStatusModel
+
+interface OrderListListener {
+    fun getOrderStatusOptions(): Map<String, WCOrderStatusModel>
+    fun refreshOrderStatusOptions()
+    fun openOrderDetail(wcOrderModel: WCOrderModel)
+    fun onFragmentScrollDown()
+    fun onFragmentScrollUp()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListView.kt
@@ -126,7 +126,7 @@ class OrderListView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet?
 
     fun showSkeleton(show: Boolean) {
         if (show) {
-            skeletonView.show(ordersView, R.layout.skeleton_order_list, delayed = true)
+            skeletonView.show(ordersList, R.layout.skeleton_order_list, delayed = true)
         } else {
             skeletonView.hide()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListView.kt
@@ -1,0 +1,157 @@
+package com.woocommerce.android.ui.orders
+
+import android.content.Context
+import android.os.Parcelable
+import android.util.AttributeSet
+import android.view.View
+import android.widget.LinearLayout
+import androidx.annotation.StringRes
+import androidx.recyclerview.widget.RecyclerView
+import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.widgets.SkeletonView
+import kotlinx.android.synthetic.main.order_list_view.view.*
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCOrderModel
+import org.wordpress.android.fluxc.model.WCOrderStatusModel
+
+class OrderListView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
+    : LinearLayout(ctx, attrs) {
+    init {
+        View.inflate(context, R.layout.order_list_view, this)
+    }
+
+    lateinit var ordersAdapter: OrderListAdapter
+    private lateinit var listener: OrderListListener
+
+    private val skeletonView = SkeletonView()
+
+    fun init(
+        currencyFormatter: CurrencyFormatter,
+        orderListListener: OrderListListener
+    ) {
+        this.listener = orderListListener
+        this.ordersAdapter = OrderListAdapter(orderListListener, currencyFormatter)
+
+        // Set the divider decoration for the list
+        val ordersDividerDecoration = androidx.recyclerview.widget.DividerItemDecoration(
+                context,
+                androidx.recyclerview.widget.DividerItemDecoration.VERTICAL
+        )
+
+        ordersList.apply {
+            layoutManager = androidx.recyclerview.widget.LinearLayoutManager(context)
+            itemAnimator = androidx.recyclerview.widget.DefaultItemAnimator()
+            setHasFixedSize(true)
+            addItemDecoration(ordersDividerDecoration)
+            adapter = ordersAdapter
+            addOnScrollListener(object : RecyclerView.OnScrollListener() {
+                override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+                    if (dy > 0) {
+                        listener.onFragmentScrollDown()
+                    } else if (dy < 0) {
+                        listener.onFragmentScrollUp()
+                    }
+                }
+            })
+        }
+    }
+
+    /**
+     * order list adapter method
+     * set order status options to the order list adapter
+     */
+    fun setOrderStatusOptions(orderStatusOptions: Map<String, WCOrderStatusModel>) {
+        ordersAdapter.setOrderStatusOptions(orderStatusOptions)
+    }
+
+    /**
+     * order list adapter method
+     * get order status options from the order list adapter
+     */
+    fun getOrderListStatusFilter() = ordersAdapter.orderStatusFilter
+
+    /**
+     * order list adapter method
+     * get order list item count from the order list adapter
+     */
+    fun getOrderListItemCount() = ordersAdapter.itemCount
+
+    /**
+     * order list adapter method
+     * set orders to the order list adapter
+     */
+    fun setOrders(orders: List<WCOrderModel>) {
+        ordersAdapter.setOrders(orders)
+    }
+
+    /**
+     * order list adapter method
+     * add orders to the order list adapter
+     */
+    fun addOrders(orders: List<WCOrderModel>) {
+        ordersAdapter.addOrders(orders)
+    }
+
+    /**
+     * clear order list adapter data
+     */
+    fun clearAdapterData() {
+        ordersAdapter.clearAdapterData()
+    }
+
+    /**
+     * scroll to the top of the order list
+     */
+    fun scrollToTop() {
+        ordersList.smoothScrollToPosition(0)
+    }
+
+    /**
+     * save the order list on configuration change
+     */
+    fun onFragmentSavedInstanceState() = ordersList.layoutManager?.onSaveInstanceState()
+
+    /**
+     * restore the order list on configuration change
+     */
+    fun onFragmentRestoreInstanceState(listState: Parcelable) {
+        ordersList.layoutManager?.onRestoreInstanceState(listState)
+    }
+
+    fun setLoadingMoreIndicator(active: Boolean) {
+        load_more_progressbar.visibility = if (active) View.VISIBLE else View.GONE
+    }
+
+    fun showSkeleton(show: Boolean) {
+        if (show) {
+            skeletonView.show(ordersView, R.layout.skeleton_order_list, delayed = true)
+        } else {
+            skeletonView.hide()
+        }
+    }
+
+    fun showOrders(orders: List<WCOrderModel>, filterByStatus: String?, isFreshData: Boolean) {
+        ordersList?.let {
+            if (isFreshData) {
+                ordersList.scrollToPosition(0)
+            }
+            ordersAdapter.setOrders(orders, filterByStatus)
+        }
+    }
+
+    fun initEmptyView(siteModel: SiteModel) {
+        empty_view.setSiteToShare(siteModel, Stat.ORDERS_LIST_SHARE_YOUR_STORE_BUTTON_TAPPED)
+    }
+
+    fun showEmptyView(@StringRes messageId: Int, showImage: Boolean, showShareButton: Boolean) {
+        empty_view.show(messageId, showImage, showShareButton)
+    }
+
+    fun hideEmptyView() {
+        empty_view.hide()
+    }
+
+    fun isEmptyViewDisplayed() = empty_view.visibility == View.VISIBLE
+}

--- a/WooCommerce/src/main/res/layout/fragment_order_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_list.xml
@@ -1,46 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/orderRefreshLayout"
+    android:id="@+id/order_list_root"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    tools:context="com.woocommerce.android.ui.mystore.MyStoreFragment">
 
-    <RelativeLayout
-        android:id="@+id/ordersContainer"
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="false">
+
+        <!-- Single tab for all stats -->
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tab_layout"
+            style="@style/Woo.OrderList.TabLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout
+        android:id="@+id/orderRefreshLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:clickable="true"
-        android:focusable="true">
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        <!-- Orders List View -->
-        <LinearLayout
-            android:id="@+id/ordersView"
+        <com.woocommerce.android.ui.orders.OrderListView
+            android:id="@+id/order_list_view"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical">
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/ordersList"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
-        </LinearLayout>
-
-        <com.woocommerce.android.widgets.WCEmptyView
-            android:id="@+id/empty_view"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:visibility="gone"/>
-
-        <ProgressBar
-            android:id="@+id/load_more_progressbar"
-            style="?android:attr/progressBarStyle"
-            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
-            android:layout_centerHorizontal="true"
-            android:layout_marginBottom="@dimen/margin_large"
-            android:visibility="gone"
-            tools:visibility="visible"/>
-    </RelativeLayout>
-</com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
+            android:orientation="vertical"/>
+
+    </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WooCommerce/src/main/res/layout/order_list_view.xml
+++ b/WooCommerce/src/main/res/layout/order_list_view.xml
@@ -13,17 +13,10 @@
         android:focusable="true">
 
         <!-- Orders List View -->
-        <LinearLayout
-            android:id="@+id/ordersView"
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/ordersList"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical">
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/ordersList"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
-        </LinearLayout>
+            android:layout_height="match_parent"/>
 
         <com.woocommerce.android.widgets.WCEmptyView
             android:id="@+id/empty_view"

--- a/WooCommerce/src/main/res/layout/order_list_view.xml
+++ b/WooCommerce/src/main/res/layout/order_list_view.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <RelativeLayout
+        android:id="@+id/ordersContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clickable="true"
+        android:focusable="true">
+
+        <!-- Orders List View -->
+        <LinearLayout
+            android:id="@+id/ordersView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/ordersList"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
+        </LinearLayout>
+
+        <com.woocommerce.android.widgets.WCEmptyView
+            android:id="@+id/empty_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone"/>
+
+        <ProgressBar
+            android:id="@+id/load_more_progressbar"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:layout_centerHorizontal="true"
+            android:layout_marginBottom="@dimen/margin_large"
+            android:visibility="gone"
+            tools:visibility="visible"/>
+    </RelativeLayout>
+
+</merge>

--- a/WooCommerce/src/main/res/layout/wc_empty_view.xml
+++ b/WooCommerce/src/main/res/layout/wc_empty_view.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -16,11 +16,7 @@
         android:layout_height="wrap_content"
         android:background="@color/white"
         android:gravity="center"
-        android:orientation="vertical"
-        app:layout_constraintBottom_toTopOf="@+id/linearLayout2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:orientation="vertical">
 
         <TextView
             android:id="@+id/date_title"
@@ -31,8 +27,8 @@
             android:layout_marginTop="@dimen/margin_extra_large"
             android:text="@string/dashboard_stats_todays_stats"
             android:textColor="@color/wc_grey_medium"
-            android:textStyle="bold"
-            android:textSize="@dimen/text_medium"/>
+            android:textSize="@dimen/text_medium"
+            android:textStyle="bold"/>
 
         <View
             android:id="@+id/divider1"
@@ -62,12 +58,11 @@
         android:id="@+id/linearLayout2"
         style="@style/Woo.Card.List"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/default_padding"
+        android:layout_height="match_parent"
+        android:layout_below="@+id/empty_view_stats_row"
         android:background="@color/white"
         android:gravity="center"
-        android:orientation="vertical"
-        app:layout_constraintTop_toBottomOf="@id/empty_view_stats_row">
+        android:orientation="vertical">
 
         <ImageView
             android:id="@+id/empty_view_image"
@@ -97,4 +92,4 @@
     </LinearLayout>
 
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</RelativeLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -365,6 +365,7 @@
     <string name="waiting_for_customers">Waiting for customers</string>
     <string name="waiting_for_customers_contentdesc">Waiting for customers image</string>
     <string name="orders_empty_message_with_filter">No orders</string>
+    <string name="orders_empty_message_with_processing">No orders to process</string>
     <string name="orders_empty_message_with_search">No matching orders</string>
     <string name="reviews_empty_message">No reviews yet!</string>
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -259,6 +259,15 @@
     <string name="add_order_note_error">Unable to add note</string>
     <string name="add_order_note_confirm_discard">Discard this note?</string>
     <string name="add_order_note_invalid_order">Invalid order</string>
+
+    <!--
+    Order List Tab Labels
+    -->
+    <string-array name="order_list_tabs">
+        <item>Processing</item>
+        <item>All Orders</item>
+    </string-array>
+
     <!--
         Order Status Labels
     -->

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -342,6 +342,19 @@
     <style name="Woo.OrderList.TextAppearance.ListItem.Title.Bold">
         <item name="android:textStyle">bold</item>
     </style>
+    <style name="Woo.OrderList.TabLayout" parent="Woo.TabLayout">
+        <item name="android:background">@color/colorPrimary</item>
+        <item name="android:elevation">@dimen/tablayout_elevation</item>
+        <item name="tabGravity">fill</item>
+        <item name="tabMaxWidth">0dp</item>
+        <item name="tabMode">fixed</item>
+        <item name="tabPaddingStart">25dp</item>
+        <item name="tabPaddingEnd">25dp</item>
+        <item name="tabIndicatorHeight">2.5dp</item>
+        <item name="tabTextColor">@color/white_translucent_65</item>
+        <item name="tabSelectedTextColor">@color/white</item>
+        <item name="tabIndicatorColor">@color/white</item>
+    </style>
     <!--
         OrderDetail Styles
     -->


### PR DESCRIPTION
Fixes #1399. This PR completes the first step of the Stats Improvements Project as defined in the master thread [here](https://github.com/woocommerce/woocommerce-android/issues/1398). 

### Changes
- Added a new class `OrderListView` that handles the order list related logic such as populating the `RecyclerView`, displaying empty view.
- Added `TabLayout` with `Processing` and `All Orders` tab and anchor the `TabLayout` to the top of the view when scrolled.
- Added logic to remember the last selected tab and default to that when order list screen is loaded.

### Notes
- The filter option will be removed in a separate PR when addressing #1400. 
- The search revamp will take place in a separate PR when addressing #1400.  
- Requires a design review from @kyleaparker before PR can be merged.
- **Note that this PR is to be merged to a feature branch.**

### Testing
- Run `OrderListItemTest`
- Test marking an order as complete from the `Processing` tab.
- Test changing an order status from the `All Orders` tab.
- Test pagination working as expected for both tabs.
- Search should work as it is currently.

### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/22608780/64146200-a64c8080-ce39-11e9-9eb8-8a022d59ba1a.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/64146202-a8aeda80-ce39-11e9-85df-a92d41b84970.png">

#### Empty View
<img width="300" src="https://user-images.githubusercontent.com/22608780/64146226-c11ef500-ce39-11e9-9f9f-cf5c057b6070.png">

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
