### PR TITLE
Issue/1397 product list skeleton

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListAdapter.kt
@@ -171,6 +171,6 @@ class ProductListAdapter(
     class ProductViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val imgProduct: ImageView = view.productImage
         val txtProductName: TextView = view.productName
-        val txtProductStockAndStatus: TextView = view.productStockAndStaus
+        val txtProductStockAndStatus: TextView = view.productStockAndStatus
     }
 }

--- a/WooCommerce/src/main/res/layout/product_list_item.xml
+++ b/WooCommerce/src/main/res/layout/product_list_item.xml
@@ -34,12 +34,12 @@
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/margin_extra_large"
         android:layout_marginStart="@dimen/margin_extra_large"
-        android:maxLines="2"
         android:layout_marginTop="1dp"
-        android:textAppearance="@style/Woo.TextAppearance.ListItem.Title"
         android:includeFontPadding="false"
+        android:maxLines="2"
+        android:textAppearance="@style/Woo.TextAppearance.ListItem.Title"
         app:layout_constrainedWidth="true"
-        app:layout_constraintBottom_toTopOf="@+id/productStockAndStaus"
+        app:layout_constraintBottom_toTopOf="@+id/productStockAndStatus"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toEndOf="@+id/productImageFrame"
@@ -47,10 +47,10 @@
         tools:text="Awesome Sauce" />
 
     <TextView
-        android:id="@+id/productStockAndStaus"
+        android:id="@+id/productStockAndStatus"
         android:layout_width="wrap_content"
-        android:layout_marginTop="1dp"
         android:layout_height="wrap_content"
+        android:layout_marginTop="1dp"
         android:textAppearance="@style/Woo.TextAppearance.Medium.Grey"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="@+id/productName"

--- a/WooCommerce/src/main/res/layout/product_list_item.xml
+++ b/WooCommerce/src/main/res/layout/product_list_item.xml
@@ -36,14 +36,14 @@
         app:layout_constrainedWidth="true"
         android:maxLines="2"
         android:textAppearance="@style/Woo.TextAppearance.ListItem.Title"
-        app:layout_constraintBottom_toTopOf="@+id/productStockAndStaus"
+        app:layout_constraintBottom_toTopOf="@+id/productStockAndStatus"
         app:layout_constraintStart_toEndOf="@+id/productImageFrame"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         tools:text="Awesome Sauce" />
 
     <TextView
-        android:id="@+id/productStockAndStaus"
+        android:id="@+id/productStockAndStatus"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textAppearance="@style/Woo.TextAppearance.Medium.Grey"

--- a/WooCommerce/src/main/res/layout/skeleton_order_product_list.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_order_product_list.xml
@@ -34,6 +34,22 @@
 
     <include layout="@layout/skeleton_order_product_list_item"/>
 
+    <include layout="@layout/skeleton_order_product_list_item"/>
+
+    <include layout="@layout/skeleton_order_product_list_item"/>
+
+    <include layout="@layout/skeleton_order_product_list_item"/>
+
+    <include layout="@layout/skeleton_order_product_list_item"/>
+
+    <include layout="@layout/skeleton_order_product_list_item"/>
+
+    <include layout="@layout/skeleton_order_product_list_item"/>
+
+    <include layout="@layout/skeleton_order_product_list_item"/>
+
+    <include layout="@layout/skeleton_order_product_list_item"/>
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/layout/skeleton_order_product_list_item.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_order_product_list_item.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/white"
+    android:paddingBottom="@dimen/settings_padding"
+    android:paddingTop="@dimen/settings_padding">
+
+    <View
+        android:id="@+id/product_gravatar"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_marginEnd="@dimen/margin_large"
+        android:layout_marginStart="@dimen/margin_large"
+        android:background="@drawable/skeleton_background"/>
+
+    <View
+        android:id="@+id/product_name"
+        android:layout_width="200dp"
+        android:layout_height="@dimen/text_medium"
+        android:layout_marginTop="@dimen/margin_large"
+        android:layout_toEndOf="@+id/product_gravatar"
+        android:background="@drawable/skeleton_background"/>
+
+    <View
+        android:layout_width="30dp"
+        android:layout_height="@dimen/text_large"
+        android:layout_alignParentEnd="true"
+        android:layout_marginEnd="@dimen/margin_large"
+        android:layout_marginTop="@dimen/margin_large"
+        android:background="@drawable/skeleton_background"/>
+
+</RelativeLayout>

--- a/WooCommerce/src/main/res/layout/skeleton_product_list_item.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_product_list_item.xml
@@ -1,34 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/linearLayout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@color/white"
-    android:paddingBottom="@dimen/settings_padding"
-    android:paddingTop="@dimen/settings_padding">
+    android:background="@color/list_item_bg"
+    android:padding="@dimen/margin_extra_large">
 
     <View
-        android:id="@+id/product_gravatar"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
-        android:layout_marginEnd="@dimen/margin_large"
-        android:layout_marginStart="@dimen/margin_large"
-        android:background="@drawable/skeleton_background"/>
+        android:id="@+id/productImage"
+        android:layout_width="@dimen/product_icon_sz"
+        android:layout_height="@dimen/product_icon_sz"
+        android:background="@color/skeleton_color"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <View
-        android:id="@+id/product_name"
-        android:layout_width="200dp"
-        android:layout_height="@dimen/text_medium"
-        android:layout_marginTop="@dimen/margin_large"
-        android:layout_toEndOf="@+id/product_gravatar"
-        android:background="@drawable/skeleton_background"/>
+        android:id="@+id/productName"
+        android:layout_width="wrap_content"
+        android:layout_height="@dimen/skeleton_default_text_height"
+        android:layout_marginEnd="@dimen/margin_extra_large"
+        android:layout_marginStart="@dimen/margin_extra_large"
+        android:background="@color/skeleton_color"
+        app:layout_constrainedWidth="true"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toEndOf="@+id/productImage"
+        app:layout_constraintTop_toTopOf="@+id/productImage" />
+
+    <Space
+        android:id="@+id/spacer"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/margin_small"
+        app:layout_constraintTop_toBottomOf="@+id/productName" />
 
     <View
-        android:layout_width="30dp"
-        android:layout_height="@dimen/text_large"
-        android:layout_alignParentEnd="true"
-        android:layout_marginEnd="@dimen/margin_large"
-        android:layout_marginTop="@dimen/margin_large"
-        android:background="@drawable/skeleton_background"/>
+        android:id="@+id/productStockAndStatus"
+        android:layout_width="wrap_content"
+        android:layout_height="@dimen/skeleton_default_text_height"
+        android:background="@color/skeleton_color"
+        app:layout_constraintEnd_toEndOf="@+id/productName"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="@+id/productName"
+        app:layout_constraintTop_toBottomOf="@+id/spacer" />
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Fixes #1397 - the original product list re-used the skeleton from the order detail product list, which didn't work very well. This PR adds a skeleton solely for the product list.

To simplify testing, I recommend replacing [this block of code](https://github.com/woocommerce/woocommerce-android/blob/feature/simple-product-list-master/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt#L60-L64) with this line to ensure the skeleton appears when refreshing.

```
_isSkeletonShown.value = true
```

Before:

![before](https://user-images.githubusercontent.com/3903757/64191255-12cd7c80-ce46-11e9-91d5-3473fc65ea66.gif)

After:

![after](https://user-images.githubusercontent.com/3903757/64191271-1c56e480-ce46-11e9-94e0-e2354d973b1b.gif)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
