### PR TITLE
Issue/1423 stats locale crash fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'cdb64c29e1c38dd339051e25e99ccd364895a4f7'
+    fluxCVersion = '7192ea31f7b45f4f14c1535d3bf7b2b733b71e57'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '7192ea31f7b45f4f14c1535d3bf7b2b733b71e57'
+    fluxCVersion = '768c3d3a319dfb8d2b81c21249770086cb8391c5'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Fixes #1423 by updating the FluxC hash that includes the fix.

### Note:
This PR is in draft till this [FluxC PR ](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1387)can be merged.

### Testing Steps:
- Change the device locale to `en_GB`.
- Pull changes from `develop` branch. 
- Install `wc-admin` plugin on a site and open the app.
- Click on the banner at the top of the page and click on `Try it now`.
- Click on `This Week`.
- Notice the app crashes.
- Pull changes from this PR and repeat the steps 4 and 5.
- Notice that the app does not crash.
- Click on other tabs and verify that the date bar displays the correct date (this is just a sanity check).
- Recommend testing for multiple locales as well.

@rachelmcr, I also requested you as a reviewer since you caught the associated bugs and to ensure they are fixed. Thank you 🙏

@loremattei, these changes are targeted for the 2.7 release and will require a new release candidate build once they are merged. Thank you 🙏 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
