### PR TITLE
Add a feature flag for refund flow

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,6 @@
 2.8
 -----
 * Fixed missing cursor in order list search
-* A new manual refund feature, which lets you specify the refunded amount for an order
 * See a list of issued refunds inside the order detail screen
  
 2.7

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPaymentView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPaymentView.kt
@@ -6,6 +6,7 @@ import android.util.AttributeSet
 import android.view.View
 import android.widget.LinearLayout
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.isEqualTo
@@ -74,7 +75,7 @@ class OrderDetailPaymentView @JvmOverloads constructor(ctx: Context, attrs: Attr
                         order.paymentMethodTitle
                 )
 
-                if (order.total - order.refundTotal > BigDecimal.ZERO) {
+                if (order.total - order.refundTotal > BigDecimal.ZERO && BuildConfig.DEBUG) {
                     paymentInfo_issueRefundButtonSection.show()
                 } else {
                     paymentInfo_issueRefundButtonSection.hide()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPaymentView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPaymentView.kt
@@ -75,6 +75,7 @@ class OrderDetailPaymentView @JvmOverloads constructor(ctx: Context, attrs: Attr
                         order.paymentMethodTitle
                 )
 
+                // for now, refunds are only enabled in debug builds
                 if (order.total - order.refundTotal > BigDecimal.ZERO && BuildConfig.DEBUG) {
                     paymentInfo_issueRefundButtonSection.show()
                 } else {


### PR DESCRIPTION
This PR hides the manual refund flow behind a flag, making it available only in the debug builds. It's been decided that it should be made available only after automatic refunds are implemented.

The read-only refund details can be released as is.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
