### PR TITLE
Add a note after a refund

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNoteRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNoteRepository.kt
@@ -1,0 +1,34 @@
+package com.woocommerce.android.ui.orders
+
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_NOTE_ADD
+import com.woocommerce.android.annotations.OpenClassOnDebug
+import com.woocommerce.android.tools.SelectedSite
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
+import org.wordpress.android.fluxc.model.WCOrderNoteModel
+import org.wordpress.android.fluxc.model.order.OrderIdentifier
+import org.wordpress.android.fluxc.store.WCOrderStore
+import javax.inject.Inject
+
+@OpenClassOnDebug
+class OrderNoteRepository @Inject constructor(
+    private val dispatcher: Dispatcher,
+    private val orderStore: WCOrderStore,
+    private val selectedSite: SelectedSite
+) {
+    fun createOrderNote(orderId: OrderIdentifier, noteText: String, isCustomerNote: Boolean): Boolean {
+        val order = orderStore.getOrderByIdentifier(orderId) ?: return false
+
+        AnalyticsTracker.track(ORDER_NOTE_ADD, mapOf(AnalyticsTracker.KEY_PARENT_ID to order.remoteOrderId))
+
+        val noteModel = WCOrderNoteModel()
+        noteModel.isCustomerNote = isCustomerNote
+        noteModel.note = noteText
+
+        val payload = WCOrderStore.PostOrderNotePayload(order, selectedSite.get(), noteModel)
+        dispatcher.dispatch(WCOrderActionBuilder.newPostOrderNoteAction(payload))
+
+        return true
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.extensions.isEqualTo
+import com.woocommerce.android.ui.orders.OrderNoteRepository
 import com.woocommerce.android.ui.refunds.IssueRefundViewModel.InputValidationState.TOO_HIGH
 import com.woocommerce.android.ui.refunds.IssueRefundViewModel.InputValidationState.TOO_LOW
 import com.woocommerce.android.ui.refunds.IssueRefundViewModel.InputValidationState.VALID
@@ -47,7 +48,8 @@ class IssueRefundViewModel @Inject constructor(
     private val selectedSite: SelectedSite,
     private val networkStatus: NetworkStatus,
     private val currencyFormatter: CurrencyFormatter,
-    private val resourceProvider: ResourceProvider
+    private val resourceProvider: ResourceProvider,
+    private val noteRepository: OrderNoteRepository
 ) : ScopedViewModel(mainDispatcher) {
     companion object {
         private const val DEFAULT_DECIMAL_PRECISION = 2
@@ -174,6 +176,7 @@ class IssueRefundViewModel @Inject constructor(
                                 reason
                         )
                     }
+
                     val result = resultCall.await()
 
                     if (result.isError) {
@@ -190,6 +193,8 @@ class IssueRefundViewModel @Inject constructor(
                         AnalyticsTracker.track(Stat.REFUND_CREATE_SUCCESS, mapOf(
                                 AnalyticsTracker.KEY_ID to result.model?.id
                         ))
+                        
+                        noteRepository.createOrderNote(order.identifier, reason, true)
 
                         _showSnackbarMessage.value = resourceProvider.getString(
                                 R.string.order_refunds_manual_refund_successful

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -193,8 +193,10 @@ class IssueRefundViewModel @Inject constructor(
                         AnalyticsTracker.track(Stat.REFUND_CREATE_SUCCESS, mapOf(
                                 AnalyticsTracker.KEY_ID to result.model?.id
                         ))
-                        
-                        noteRepository.createOrderNote(order.identifier, reason, true)
+
+                        if (reason.isNotBlank()) {
+                            noteRepository.createOrderNote(order.identifier, reason, true)
+                        }
 
                         _showSnackbarMessage.value = resourceProvider.getString(
                                 R.string.order_refunds_manual_refund_successful


### PR DESCRIPTION
After a successful refund, an order note with a reason is sent to the customer.

<img src="https://user-images.githubusercontent.com/1522856/66297470-04183080-e8f0-11e9-883e-3eea9f2d1473.png" width="300" />

<img src="https://user-images.githubusercontent.com/1522856/66297484-0aa6a800-e8f0-11e9-9267-98e520aef1c9.png" width="300" />

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
