### PR TITLE
Fix typo in release notes tooling

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -357,7 +357,7 @@ end
       f.puts("<en-US>")
       f.puts("#{options[:version_name]}:")
       f.puts(File.open(en_release_notes_path).read)
-      f.puts("/<en-US>")
+      f.puts("</en-US>")
     }
   end
 


### PR DESCRIPTION
This PR fixes a typo in Fastfile that causes an error in the xml file that contains the translated release notes.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
