### PR TITLE
Issue/1446 login lib merge

### DIFF
--- a/WordPressLoginFlow/build.gradle
+++ b/WordPressLoginFlow/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'com.android.library'
 repositories {
     google()
     jcenter()
-    maven { url "https://jitpack.io" }
+    maven { url "https://www.jitpack.io" }
 }
 
 android {

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -52,9 +52,9 @@ import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import dagger.android.support.AndroidSupportInjection;
-
 import static android.app.Activity.RESULT_OK;
+
+import dagger.android.support.AndroidSupportInjection;
 
 public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> implements TextWatcher,
         OnEditorCommitListener, ConnectionCallbacks, OnConnectionFailedListener {
@@ -280,12 +280,27 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
             mHideLoginWithSiteOption = args.getBoolean(ARG_HIDE_LOGIN_BY_SITE_OPTION, false);
             mLoginSiteUrl = args.getString(ARG_LOGIN_SITE_URL, "");
         }
+    }
 
+    @Override
+    public void onStart() {
+        super.onStart();
         mGoogleApiClient = new GoogleApiClient.Builder(getActivity())
                 .addConnectionCallbacks(LoginEmailFragment.this)
                 .enableAutoManage(getActivity(), GOOGLE_API_CLIENT_ID, LoginEmailFragment.this)
                 .addApi(Auth.CREDENTIALS_API)
                 .build();
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        if (mGoogleApiClient != null) {
+            mGoogleApiClient.stopAutoManage(getActivity());
+            if (mGoogleApiClient.isConnected()) {
+                mGoogleApiClient.disconnect();
+            }
+        }
     }
 
     @Override
@@ -333,11 +348,6 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     public void onDetach() {
         super.onDetach();
         mLoginListener = null;
-
-        mGoogleApiClient.stopAutoManage(getActivity());
-        if (mGoogleApiClient.isConnected()) {
-            mGoogleApiClient.disconnect();
-        }
     }
 
     private String getCleanedEmail() {

--- a/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupEmailFragment.java
+++ b/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupEmailFragment.java
@@ -45,9 +45,9 @@ import org.wordpress.android.util.NetworkUtils;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import dagger.android.support.AndroidSupportInjection;
-
 import static android.app.Activity.RESULT_OK;
+
+import dagger.android.support.AndroidSupportInjection;
 
 public class SignupEmailFragment extends LoginBaseFormFragment<LoginListener> implements TextWatcher,
         OnEditorCommitListener, ConnectionCallbacks, OnConnectionFailedListener {
@@ -143,14 +143,24 @@ public class SignupEmailFragment extends LoginBaseFormFragment<LoginListener> im
         super.onAttach(context);
     }
 
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    @Override public void onStart() {
+        super.onStart();
         mGoogleApiClient = new GoogleApiClient.Builder(getActivity())
                 .addConnectionCallbacks(SignupEmailFragment.this)
                 .enableAutoManage(getActivity(), GOOGLE_API_CLIENT_ID, SignupEmailFragment.this)
                 .addApi(Auth.CREDENTIALS_API)
                 .build();
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        if (mGoogleApiClient != null) {
+            mGoogleApiClient.stopAutoManage(getActivity());
+            if (mGoogleApiClient.isConnected()) {
+                mGoogleApiClient.disconnect();
+            }
+        }
     }
 
     @Override
@@ -190,11 +200,6 @@ public class SignupEmailFragment extends LoginBaseFormFragment<LoginListener> im
     public void onDetach() {
         super.onDetach();
         mLoginListener = null;
-
-        if (mGoogleApiClient.isConnected()) {
-            mGoogleApiClient.stopAutoManage(getActivity());
-            mGoogleApiClient.disconnect();
-        }
     }
 
     private String getCleanedEmail() {


### PR DESCRIPTION
Fixes #1446 by merging the login library changes to move GoogleApiClient.Builder to onStart/Stop methods. This change was originally done for WPAndroid and this PR is just to synchronize those changes to woo.

To test:
- Test Login and Signup
- Try to move the app to the background in the middle of the process and come back