### PR TITLE
Issue/1455 stats v4 crash fix

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 -----
 * Fixed missing cursor in order list search
 * See a list of issued refunds inside the order detail screen
+* Fixed rare crash on opening stats page with WooCommerce Admin plugin enabled
  
 2.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreDateRangeView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreDateRangeView.kt
@@ -36,20 +36,25 @@ class MyStoreDateRangeView @JvmOverloads constructor(ctx: Context, attrs: Attrib
         revenueStatsModel: WCRevenueStatsModel?,
         granularity: StatsGranularity
     ) {
-        val startInterval = revenueStatsModel?.getIntervalList()?.first()?.interval
-        val startDate = startInterval?.let { getDateValue(it, granularity) }
+        if (revenueStatsModel?.getIntervalList().isNullOrEmpty()) {
+            dashboard_date_range_value.visibility = View.GONE
+        } else {
+            val startInterval = revenueStatsModel?.getIntervalList()?.first()?.interval
+            val startDate = startInterval?.let { getDateValue(it, granularity) }
 
-        val dateRangeString = when (granularity) {
-            StatsGranularity.WEEKS -> {
-                val endInterval = revenueStatsModel?.getIntervalList()?.last()?.interval
-                val endDate = endInterval?.let { getDateValue(it, granularity) }
-                String.format("%s – %s", startDate, endDate)
+            val dateRangeString = when (granularity) {
+                StatsGranularity.WEEKS -> {
+                    val endInterval = revenueStatsModel?.getIntervalList()?.last()?.interval
+                    val endDate = endInterval?.let { getDateValue(it, granularity) }
+                    String.format("%s – %s", startDate, endDate)
+                }
+                else -> {
+                    startDate
+                }
             }
-            else -> {
-                startDate
-            }
+            dashboard_date_range_value.visibility = View.VISIBLE
+            dashboard_date_range_value.text = dateRangeString
         }
-        dashboard_date_range_value.text = dateRangeString
     }
 
     fun clearDateRangeValues() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -279,12 +279,14 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
         this.revenueStatsModel = revenueStatsModel
         chartCurrencyCode = currencyCode
 
+        // There are times when the stats v4 api returns no grossRevenue or ordersCount for a site
+        // https://github.com/woocommerce/woocommerce-android/issues/1455#issuecomment-540401646
         this.chartRevenueStats = revenueStatsModel?.getIntervalList()?.map {
-            it.interval!! to it.subtotals?.grossRevenue!!
+            it.interval!! to (it.subtotals?.grossRevenue ?: 0.0)
         }?.toMap() ?: mapOf()
 
         this.chartOrderStats = revenueStatsModel?.getIntervalList()?.map {
-            it.interval!! to it.subtotals?.ordersCount!!
+            it.interval!! to (it.subtotals?.ordersCount ?: 0)
         }?.toMap() ?: mapOf()
 
         updateChartView()


### PR DESCRIPTION
Fixes #1455 by adding logic to check if the fields `gross_revenue` or `orders_count` is available in the API response before updating the UI.

#### The API response expected by the app:
```
{
	"data": {
		"totals": {
			"orders_count": 6,
			"num_items_sold": 8,
			"gross_revenue": 253.95,
			"coupons": 0,
			"coupons_count": 0,
			"refunds": 0,
			"taxes": 17.95,
			"shipping": 25,
			"net_revenue": 211,
			"products": 6,
			"segments": []
		},
		"intervals": [{
			"interval": "2019-07-07",
			"date_start": "2019-07-07 00:00:00",
			"date_start_gmt": "2019-07-07 00:00:00",
			"date_end": "2019-07-07 23:59:59",
			"date_end_gmt": "2019-07-07 23:59:59",
			"subtotals": {
				"orders_count": 0,
				"num_items_sold": 0,
				"gross_revenue": 0,
				"coupons": 0,
				"coupons_count": 0,
				"refunds": 0,
				"taxes": 0,
				"shipping": 0,
				"net_revenue": 0,
				"segments": []
			}
		}]
	}
}
```

#### API response received in app for those 6 users experiencing this crash:
```
{
	"data": {
		"totals": {
			"products": 0,
			"coupons_count": 0,
			"segments": []
		},
		"intervals": [{
			"interval": "2019-07-09 23",
			"date_start": "2019-07-09 23:00:00",
			"date_start_gmt": "2019-07-09 21:00:00",
			"date_end": "2019-07-09 23:59:59",
			"date_end_gmt": "2019-07-09 21:59:59",
			"subtotals": {
				"coupons_count": 0,
				"segments": []
			}
		}]
	}
}
```

Notice that the fields: `gross_revenue` and `orders_count` (which are expected by the app, by default are missing in the API response. I am not sure why the api response for certain sites do not include these fields. I have pinged the API team for some answers and will update the app, if needed. In the meantime, I have added a fix to stop the app from crashing. Since the `gross_revenue` and `orders_count` fields are not available, the app displays 0 value, at the moment.

#### Notes
This crash only happens in sites with WooCommerce Admin enabled and the user has opted to try out the new stats UI.

#### Testing
I was not able to reproduce this crash from my test site. I was able to SSP from user's site listed [here](https://sentry.io/organizations/a8c/issues/1263604080/events/) and reproduce this crash.
- Pull changes from the `release/2.8` branch and click on the `TRY IT NOW` button to try out the new stats UI from the app. Notice the app crashes.
- Pull changes from this PR and repeat the above step again. Notice that the stats displays 0 value for revenue and order count but no longer crashes.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


cc @jkmassel since this fix would need to be included in the 2.8 beta release.