### PR TITLE
Update fastlane and release-toolkit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org" do 
   gem 'nokogiri'
-  gem "fastlane", "2.127.2"
+  gem "fastlane", "2.133.0"
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,11 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 21400012da8c2ceafa8ea2ce23d8a88233a97838
-  ref: 0.7.2
+  revision: c8007b8c11c282ea3e9f97f722d1971271959770
+  ref: 0.8.0
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.7.2)
+    fastlane-plugin-wpmreleasetoolkit (0.8.0)
+      activesupport (~> 4)
+      chroma (= 0.2.0)
       diffy (~> 3.3)
       git (~> 1.3)
       jsonlint
@@ -17,16 +19,23 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.0)
+    CFPropertyList (3.0.1)
+    activesupport (4.2.11.1)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     atomos (0.1.3)
-    babosa (1.0.2)
+    babosa (1.0.3)
+    chroma (0.2.0)
     claide (1.0.3)
     colored (1.2)
     colored2 (3.1.2)
     commander-fastlane (4.4.6)
       highline (~> 1.7.2)
+    concurrent-ruby (1.1.5)
     declarative (0.0.10)
     declarative-option (0.1.0)
     diffy (3.3.0)
@@ -35,7 +44,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.5)
     emoji_regex (1.0.1)
-    excon (0.66.0)
+    excon (0.67.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)
@@ -43,8 +52,8 @@ GEM
       http-cookie (~> 1.0.0)
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
-    fastimage (2.1.5)
-    fastlane (2.127.2)
+    fastimage (2.1.7)
+    fastlane (2.133.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -54,9 +63,9 @@ GEM
       dotenv (>= 2.1.1, < 3.0.0)
       emoji_regex (>= 0.1, < 2.0)
       excon (>= 0.45.0, < 1.0.0)
-      faraday (~> 0.9)
+      faraday (< 0.16.0)
       faraday-cookie_jar (~> 0.0.6)
-      faraday_middleware (~> 0.9)
+      faraday_middleware (< 0.16.0)
       fastimage (>= 2.1.0, < 3.0.0)
       gh_inspector (>= 1.1.2, < 2.0.0)
       google-api-client (>= 0.21.2, < 0.24.0)
@@ -69,7 +78,7 @@ GEM
       multipart-post (~> 2.0.0)
       plist (>= 3.1.0, < 4.0.0)
       public_suffix (~> 2.0.0)
-      rubyzip (>= 1.2.2, < 2.0.0)
+      rubyzip (>= 1.3.0, < 2.0.0)
       security (= 0.1.3)
       simctl (~> 1.6.3)
       slack-notifier (>= 2.0.0, < 3.0.0)
@@ -91,9 +100,9 @@ GEM
       representable (~> 3.0)
       retriable (>= 2.0, < 4.0)
       signet (~> 0.9)
-    google-cloud-core (1.3.0)
+    google-cloud-core (1.3.1)
       google-cloud-env (~> 1.0)
-    google-cloud-env (1.2.0)
+    google-cloud-env (1.2.1)
       faraday (~> 0.11)
     google-cloud-storage (1.16.0)
       digest-crc (~> 0.4)
@@ -111,17 +120,20 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.8.3)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
     json (2.2.0)
     jsonlint (0.3.0)
       oj (~> 3)
       optimist (~> 3)
     jwt (2.1.0)
     memoist (0.16.0)
-    mime-types (3.2.2)
+    mime-types (3.3)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.0331)
+    mime-types-data (3.2019.1009)
     mini_magick (4.9.5)
     mini_portile2 (2.4.0)
+    minitest (5.12.2)
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -131,18 +143,18 @@ GEM
       mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.9.0)
+    oj (3.9.2)
     optimist (3.0.0)
     options (2.3.2)
     os (1.0.1)
-    parallel (1.17.0)
+    parallel (1.18.0)
     plist (3.5.0)
     progress_bar (1.3.0)
       highline (>= 1.6, < 3)
       options (~> 2.3.0)
     public_suffix (2.0.5)
     rake (12.3.3)
-    rake-compiler (1.0.7)
+    rake-compiler (1.0.8)
       rake
     representable (3.0.4)
       declarative (< 0.1.0)
@@ -150,7 +162,7 @@ GEM
       uber (< 0.2.0)
     retriable (3.1.2)
     rouge (2.0.7)
-    rubyzip (1.2.3)
+    rubyzip (1.3.0)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
@@ -160,24 +172,27 @@ GEM
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
-    simctl (1.6.5)
+    simctl (1.6.6)
       CFPropertyList
       naturally
     slack-notifier (2.3.2)
     terminal-notifier (2.0.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    thread_safe (0.3.6)
     tty-cursor (0.7.0)
     tty-screen (0.7.0)
     tty-spinner (0.9.1)
       tty-cursor (~> 0.7)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
     uber (0.1.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
     unicode-display_width (1.6.0)
     word_wrap (1.0.0)
-    xcodeproj (1.11.0)
+    xcodeproj (1.12.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -192,9 +207,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fastlane (= 2.127.2)!
+  fastlane (= 2.133.0)!
   fastlane-plugin-wpmreleasetoolkit!
   nokogiri!
 
 BUNDLED WITH
-   1.17.3
+   2.0.2

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,5 +2,5 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref:'0.7.2'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref:'0.8.0'
 


### PR DESCRIPTION
This PR updates fastlane to get rid of the security warning about rubyzip.
It also updates release-toolkit to import the latest improvements in the release tools.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
