### PR TITLE
Move SqlScout instantiation to the Application class

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -9,6 +9,7 @@ import androidx.multidex.MultiDexApplication
 import com.android.volley.VolleyLog
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
+import com.idescout.sql.SqlScoutServer
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.di.AppComponent
@@ -72,6 +73,7 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
 
     // Listens for changes in device connectivity
     @Inject lateinit var connectionReceiver: ConnectionChangeReceiver
+
     private var connectionReceiverRegistered = false
 
     open val component: AppComponent by lazy {
@@ -105,6 +107,9 @@ open class WooCommerce : MultiDexApplication(), HasActivityInjector, HasServiceI
         // https://github.com/woocommerce/woocommerce-android/issues/817
         if (!BuildConfig.DEBUG) {
             VolleyLog.DEBUG = false
+        } else {
+            // We are in a debug build. Let's enable sqlScout
+            SqlScoutServer.create(this, getPackageName())
         }
 
         // We init Crash Logging further down using the selected site and account, but we also want to init it here

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -15,7 +15,6 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.findNavController
-import com.idescout.sql.SqlScoutServer
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.R
@@ -115,8 +114,6 @@ class MainActivity : AppUpgradeActivity(),
     private var previousDestinationId: Int? = null
     private var unfilledOrderCount: Int = 0
 
-    private lateinit var sqlScoutServer: SqlScoutServer
-
     private lateinit var bottomNavView: MainBottomNavigationView
     private lateinit var navController: NavController
 
@@ -127,8 +124,6 @@ class MainActivity : AppUpgradeActivity(),
         AndroidInjection.inject(this)
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-
-        sqlScoutServer = SqlScoutServer.create(this, getPackageName())
 
         // Set the toolbar
         setSupportActionBar(toolbar as Toolbar)
@@ -199,7 +194,6 @@ class MainActivity : AppUpgradeActivity(),
 
     override fun onResume() {
         super.onResume()
-        sqlScoutServer.resume()
         AnalyticsTracker.trackViewShown(this)
 
         updateReviewsBadge()
@@ -209,7 +203,6 @@ class MainActivity : AppUpgradeActivity(),
     }
 
     override fun onPause() {
-        sqlScoutServer.pause()
         super.onPause()
     }
 
@@ -221,7 +214,6 @@ class MainActivity : AppUpgradeActivity(),
     }
 
     public override fun onDestroy() {
-        sqlScoutServer.destroy()
         presenter.dropView()
         super.onDestroy()
     }


### PR DESCRIPTION
This PR effects an optional Android Studio plugin named [SqlScout](https://plugins.jetbrains.com/plugin/8322-sqlscout-sqlite-support-) which enables a developer to connect to the db on their test device via Android Studio. This small change moves the SqlScout server instantiation to the Application class to prevent the constant errors generated by SqlScout in Logcat while testing the app. SqlScout recommends instantiating the server in the main Activity (`MainActivity`), but this leads to annoying logcat errors because the LifeCycle of that Activity is causing SqlScout to stop, destroy, and restart over and over. After some research I found several articles that recommend moving it to the Application class to prevent this constant tear-down/rebuild error cycle. 

