### PR TITLE
Issue/1459 request permissions

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,8 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <AndroidXmlCodeStyleSettings>
+      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
+    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="STATIC_FIELD_NAME_PREFIX" value="s" />
@@ -85,6 +88,7 @@
               <match>
                 <AND>
                   <NAME>xmlns:android</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
@@ -95,6 +99,7 @@
               <match>
                 <AND>
                   <NAME>xmlns:.*</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
@@ -106,6 +111,7 @@
               <match>
                 <AND>
                   <NAME>.*:id</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
                 </AND>
               </match>
@@ -116,6 +122,7 @@
               <match>
                 <AND>
                   <NAME>.*:name</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
                 </AND>
               </match>
@@ -126,6 +133,7 @@
               <match>
                 <AND>
                   <NAME>name</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
@@ -136,6 +144,7 @@
               <match>
                 <AND>
                   <NAME>style</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
@@ -146,6 +155,7 @@
               <match>
                 <AND>
                   <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
@@ -156,53 +166,12 @@
             <rule>
               <match>
                 <AND>
-                  <NAME>.*:layout_width</NAME>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
                 </AND>
               </match>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:layout_height</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:layout_.*</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:width</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:height</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
+              <order>ANDROID_ATTRIBUTE_ORDER</order>
             </rule>
           </section>
           <section>
@@ -210,17 +179,7 @@
               <match>
                 <AND>
                   <NAME>.*</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>.*</XML_NAMESPACE>
                 </AND>
               </match>

--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -6,6 +6,9 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
 
     <!-- Dangerous permissions, access must be requested at runtime -->
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -57,8 +57,7 @@ object AppPrefs {
         // The app update for this version was cancelled by the user
         CANCELLED_APP_VERSION_CODE,
         // Application permissions
-        ASKED_PERMISSION_STORAGE_READ,
-        ASKED_PERMISSION_STORAGE_WRITE,
+        ASKED_PERMISSION_STORAGE,
         ASKED_PERMISSION_CAMERA,
     }
 
@@ -294,12 +293,10 @@ object AppPrefs {
      * key in shared preferences which stores a boolean telling whether the app has already
      * asked for the passed permission
      */
-    fun getPermissionAskedKey(permission: String): AppPrefs.PrefKey? {
+    fun getPermissionAskedKey(permission: String): PrefKey? {
         when (permission) {
             android.Manifest.permission.WRITE_EXTERNAL_STORAGE ->
-                return UndeletablePrefKey.ASKED_PERMISSION_STORAGE_WRITE
-            android.Manifest.permission.READ_EXTERNAL_STORAGE ->
-                return UndeletablePrefKey.ASKED_PERMISSION_STORAGE_READ
+                return UndeletablePrefKey.ASKED_PERMISSION_STORAGE
             android.Manifest.permission.CAMERA ->
                 return UndeletablePrefKey.ASKED_PERMISSION_CAMERA
             else -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -291,6 +291,10 @@ class AnalyticsTracker private constructor(private val context: Context) {
         // -- Order status changes
         SET_ORDER_STATUS_DIALOG_APPLY_BUTTON_TAPPED,
 
+        // -- Application permissions
+        APP_PERMISSION_GRANTED,
+        APP_PERMISSION_DENIED,
+
         // -- Other
         UNFULFILLED_ORDERS_LOADED,
         TOP_EARNER_PRODUCT_TAPPED

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -600,7 +600,8 @@ class ProductDetailFragment : BaseFragment(), RequestListener<Drawable> {
     }
 
     override fun onRequestPermissionsResult(
-        requestCode: Int, permissions: Array<String>,
+        requestCode: Int,
+        permissions: Array<String>,
         grantResults: IntArray
     ) {
         if (!isAdded) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -564,31 +564,41 @@ class ProductDetailFragment : BaseFragment(), RequestListener<Drawable> {
         return false
     }
 
-    private fun requestStoragePermission() {
-        if (!isAdded || WooPermissionUtils.hasStoragePermission(activity!!)) {
-            return
+    /**
+     * Requests storage permission, returns true only if permission is already available
+     */
+    private fun requestStoragePermission(): Boolean {
+        if (!isAdded) {
+            return false
+        } else if (WooPermissionUtils.hasStoragePermission(activity!!)) {
+            return true
         }
 
         val permissions = arrayOf(permission.READ_EXTERNAL_STORAGE)
         requestPermissions(
                 permissions, WooPermissionUtils.STORAGE_PERMISSION_REQUEST_CODE
         )
+        return false
     }
 
-    private fun requestCameraPermission() {
+    /**
+     * Requests camera & storage permissions, returns true only if permissions are already
+     * available. Note that we need to ask for both permissions because we also need storage
+     * permission to store media from the camera.
+     */
+    private fun requestCameraPermission(): Boolean {
         if (!isAdded) {
-            return
+            return false
         }
 
-        // in addition to CAMERA permission we also need a storage permission to store media from the camera
-        val hasWriteStorage = WooPermissionUtils.hasStoragePermission(activity!!)
+        val hasStorage = WooPermissionUtils.hasStoragePermission(activity!!)
         val hasCamera = WooPermissionUtils.hasCameraPermission(activity!!)
-        if (hasWriteStorage && hasCamera) {
-            return
+        if (hasStorage && hasCamera) {
+            return true
         }
 
         val permissions = when {
-            hasWriteStorage -> arrayOf(permission.CAMERA)
+            hasStorage -> arrayOf(permission.CAMERA)
             hasCamera -> arrayOf(permission.WRITE_EXTERNAL_STORAGE)
             else -> arrayOf(permission.CAMERA, permission.WRITE_EXTERNAL_STORAGE)
         }
@@ -597,6 +607,7 @@ class ProductDetailFragment : BaseFragment(), RequestListener<Drawable> {
                 permissions,
                 WooPermissionUtils.CAMERA_PERMISSION_REQUEST_CODE
         )
+        return false
     }
 
     override fun onRequestPermissionsResult(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.products
 
+import android.Manifest.permission
 import android.content.Context
 import android.content.Intent
 import android.graphics.drawable.Drawable
@@ -18,6 +19,7 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
+import androidx.navigation.fragment.navArgs
 import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
@@ -34,10 +36,12 @@ import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.imageviewer.ImageViewerActivity
+import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductWithParameters
 import com.woocommerce.android.ui.products.ProductType.EXTERNAL
 import com.woocommerce.android.ui.products.ProductType.GROUPED
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
 import com.woocommerce.android.util.StringUtils
+import com.woocommerce.android.util.WooPermissionUtils
 import com.woocommerce.android.widgets.SkeletonView
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_product_detail.*
@@ -46,8 +50,6 @@ import org.wordpress.android.util.HtmlUtils
 import org.wordpress.android.util.PhotonUtils
 import javax.inject.Inject
 import kotlin.math.max
-import androidx.navigation.fragment.navArgs
-import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductWithParameters
 
 class ProductDetailFragment : BaseFragment(), RequestListener<Drawable> {
     private enum class DetailCard {
@@ -560,5 +562,58 @@ class ProductDetailFragment : BaseFragment(), RequestListener<Drawable> {
             }
         }
         return false
+    }
+
+    private fun requestStoragePermission() {
+        if (!isAdded || WooPermissionUtils.hasStoragePermission(activity!!)) {
+            return
+        }
+
+        val permissions = arrayOf(permission.READ_EXTERNAL_STORAGE)
+        requestPermissions(
+                permissions, WooPermissionUtils.STORAGE_PERMISSION_REQUEST_CODE
+        )
+    }
+
+    private fun requestCameraPermission() {
+        if (!isAdded) {
+            return
+        }
+
+        // in addition to CAMERA permission we also need a storage permission to store media from the camera
+        val hasWriteStorage = WooPermissionUtils.hasStoragePermission(activity!!)
+        val hasCamera = WooPermissionUtils.hasCameraPermission(activity!!)
+        if (hasWriteStorage && hasCamera) {
+            return
+        }
+
+        val permissions = when {
+            hasWriteStorage -> arrayOf(permission.CAMERA)
+            hasCamera -> arrayOf(permission.WRITE_EXTERNAL_STORAGE)
+            else -> arrayOf(permission.CAMERA, permission.WRITE_EXTERNAL_STORAGE)
+        }
+
+        requestPermissions(
+                permissions,
+                WooPermissionUtils.CAMERA_PERMISSION_REQUEST_CODE
+        )
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int, permissions: Array<String>,
+        grantResults: IntArray
+    ) {
+        if (!isAdded) {
+            return
+        }
+
+        val checkForAlwaysDenied = requestCode == WooPermissionUtils.CAMERA_PERMISSION_REQUEST_CODE
+        val allGranted = WooPermissionUtils.setPermissionListAsked(
+                activity!!, requestCode, permissions, grantResults, checkForAlwaysDenied
+        )
+
+        if (allGranted && requestCode == WooPermissionUtils.CAMERA_PERMISSION_REQUEST_CODE) {
+            // TODO: show camera once we add this feature
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooPermissionUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooPermissionUtils.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.util
 
+import android.Manifest.permission
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
@@ -18,9 +19,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import java.util.HashMap
 
 object WooPermissionUtils {
-    const val READ_STORAGE_PERMISSION_REQUEST_CODE = 10
-    const val WRITE_STORAGE_PERMISSION_REQUEST_CODE = 20
-    const val CAMERA_PERMISSION_REQUEST_CODE = 30
+    const val STORAGE_PERMISSION_REQUEST_CODE = 10
+    const val CAMERA_PERMISSION_REQUEST_CODE = 20
 
     /**
      * called by the onRequestPermissionsResult() of various activities and fragments - tracks
@@ -129,13 +129,12 @@ object WooPermissionUtils {
     /*
      * returns the name to display for a permission, ex: "permission.WRITE_EXTERNAL_STORAGE" > "Storage"
      */
-    fun getPermissionName(context: Context, permission: String): String {
+    private fun getPermissionName(context: Context, permission: String): String {
         return when (permission) {
-            android.Manifest.permission.WRITE_EXTERNAL_STORAGE,
-            android.Manifest.permission.READ_EXTERNAL_STORAGE -> context.getString(
-                    R.string.permission_storage
-            )
-            android.Manifest.permission.CAMERA -> context.getString(R.string.permission_camera)
+            android.Manifest.permission.WRITE_EXTERNAL_STORAGE ->
+                context.getString(R.string.permission_storage)
+            android.Manifest.permission.CAMERA ->
+                context.getString(R.string.permission_camera)
             else -> {
                 WooLog.w(WooLog.T.UTILS, "No name for requested permission")
                 context.getString(R.string.unknown)
@@ -176,5 +175,17 @@ object WooPermissionUtils {
         intent.data = uri
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         context.startActivity(intent)
+    }
+
+    fun hasStoragePermission(context: Context): Boolean {
+        return ContextCompat.checkSelfPermission(
+                context, permission.WRITE_EXTERNAL_STORAGE
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    fun hasCameraPermission(context: Context): Boolean {
+        return ContextCompat.checkSelfPermission(
+                context, permission.CAMERA
+        ) == PackageManager.PERMISSION_GRANTED
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooPermissionUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooPermissionUtils.kt
@@ -1,0 +1,180 @@
+package com.woocommerce.android.util
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.provider.Settings
+import android.view.ContextThemeWrapper
+import androidx.appcompat.app.AlertDialog
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.core.text.HtmlCompat
+import androidx.core.text.HtmlCompat.FROM_HTML_MODE_LEGACY
+import com.woocommerce.android.AppPrefs
+import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
+import java.util.HashMap
+
+object WooPermissionUtils {
+    const val READ_STORAGE_PERMISSION_REQUEST_CODE = 10
+    const val WRITE_STORAGE_PERMISSION_REQUEST_CODE = 20
+    const val CAMERA_PERMISSION_REQUEST_CODE = 30
+
+    /**
+     * called by the onRequestPermissionsResult() of various activities and fragments - tracks
+     * the permission results, remembers that the permissions have been asked for, and optionally
+     * shows a dialog enabling the user to edit permissions if any are always denied
+     *
+     * @param activity host activity
+     * @param requestCode request code passed to ContextCompat.checkSelfPermission
+     * @param permissions list of permissions
+     * @param grantResults list of results for above permissions
+     * @param checkForAlwaysDenied show dialog if any permissions always denied
+     * @return true if all permissions granted
+     */
+    fun setPermissionListAsked(
+        activity: Activity,
+        requestCode: Int,
+        permissions: Array<String>,
+        grantResults: IntArray,
+        checkForAlwaysDenied: Boolean
+    ): Boolean {
+        for (i in permissions.indices) {
+            AppPrefs.getPermissionAskedKey(permissions[i])?.let { key ->
+                val isFirstTime = !AppPrefs.exists(key)
+                trackPermissionResult(requestCode, permissions[i], grantResults[i], isFirstTime)
+                AppPrefs.setBoolean(key, true)
+            }
+        }
+
+        var allGranted = true
+        for (i in grantResults.indices) {
+            if (grantResults[i] == PackageManager.PERMISSION_DENIED) {
+                allGranted = false
+                if (checkForAlwaysDenied && !ActivityCompat
+                                .shouldShowRequestPermissionRationale(activity, permissions[i])) {
+                    showPermissionAlwaysDeniedDialog(activity, permissions[i])
+                    break
+                }
+            }
+        }
+
+        return allGranted
+    }
+
+    /*
+     * returns true if we know the app has asked for the passed permission
+     */
+    private fun isPermissionAsked(context: Context, permission: String): Boolean {
+        val key = AppPrefs.getPermissionAskedKey(permission) ?: return false
+
+        // if the key exists, we've already stored whether this permission has been asked for
+        if (AppPrefs.exists(key)) {
+            return AppPrefs.getBoolean(key, false)
+        }
+
+        // otherwise, check whether permission has already been granted - if so we know it has
+        // been asked
+        if (ContextCompat.checkSelfPermission(
+                        context,
+                        permission
+                ) == PackageManager.PERMISSION_GRANTED) {
+            AppPrefs.setBoolean(key, true)
+            return true
+        }
+
+        return false
+    }
+
+    /*
+     * returns true if the passed permission has been denied AND the user checked "never show again"
+     * in the native permission dialog
+     */
+    fun isPermissionAlwaysDenied(activity: Activity, permission: String): Boolean {
+        // shouldShowRequestPermissionRationale returns false if the permission has been permanently
+        // denied, but it also returns false if the app has never requested that permission - so we
+        // check it only if we know we've asked for this permission
+        if (isPermissionAsked(activity, permission) && ContextCompat.checkSelfPermission(
+                        activity,
+                        permission
+                ) == PackageManager.PERMISSION_DENIED) {
+            val shouldShow = ActivityCompat
+                    .shouldShowRequestPermissionRationale(activity, permission)
+            return !shouldShow
+        }
+
+        return false
+    }
+
+    private fun trackPermissionResult(
+        requestCode: Int,
+        permission: String,
+        result: Int,
+        isFirstTime: Boolean
+    ) {
+        val props = HashMap<String, String>()
+        props["permission"] = permission
+        props["request_code"] = requestCode.toString()
+        props["is_first_time"] = java.lang.Boolean.toString(isFirstTime)
+
+        if (result == PackageManager.PERMISSION_GRANTED) {
+            AnalyticsTracker.track(AnalyticsTracker.Stat.APP_PERMISSION_GRANTED, props)
+        } else if (result == PackageManager.PERMISSION_DENIED) {
+            AnalyticsTracker.track(AnalyticsTracker.Stat.APP_PERMISSION_DENIED, props)
+        }
+    }
+
+    /*
+     * returns the name to display for a permission, ex: "permission.WRITE_EXTERNAL_STORAGE" > "Storage"
+     */
+    fun getPermissionName(context: Context, permission: String): String {
+        return when (permission) {
+            android.Manifest.permission.WRITE_EXTERNAL_STORAGE,
+            android.Manifest.permission.READ_EXTERNAL_STORAGE -> context.getString(
+                    R.string.permission_storage
+            )
+            android.Manifest.permission.CAMERA -> context.getString(R.string.permission_camera)
+            else -> {
+                WooLog.w(WooLog.T.UTILS, "No name for requested permission")
+                context.getString(R.string.unknown)
+            }
+        }
+    }
+
+    /*
+     * called when the app detects that the user has permanently denied a permission, shows a dialog
+     * alerting them to this fact and enabling them to visit the app settings to edit permissions
+     */
+    private fun showPermissionAlwaysDeniedDialog(
+        activity: Activity,
+        permission: String
+    ) {
+        val message = String.format(
+                activity.getString(R.string.permissions_denied_message),
+                getPermissionName(activity, permission)
+        )
+
+        val builder = AlertDialog.Builder(ContextThemeWrapper(activity, R.style.Woo_Dialog))
+                .setTitle(activity.getString(R.string.permissions_denied_title))
+                .setMessage(HtmlCompat.fromHtml(message, FROM_HTML_MODE_LEGACY))
+                .setPositiveButton(
+                        R.string.button_edit_permissions
+                ) { dialog, which -> showAppSettings(activity) }
+                .setNegativeButton(R.string.button_not_now, null)
+        builder.show()
+    }
+
+    /*
+     * open the device's settings page for this app so the user can edit permissions
+     */
+    private fun showAppSettings(context: Context) {
+        val intent = Intent()
+        intent.action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+        val uri = Uri.fromParts("package", context.packageName, null)
+        intent.data = uri
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        context.startActivity(intent)
+    }
+}

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -70,6 +70,8 @@
     <string name="error_copy_to_clipboard">Error copying to clipboard</string>
     <string name="read_more">Read more</string>
     <string name="database_downgraded">Database downgraded, recreating tables and loading stores</string>
+    <string name="button_not_now">Not now</string>
+    <string name="unknown">Unknown</string>
     <!--
         Date/Time Labels
     -->
@@ -620,6 +622,13 @@
     <string name="product_status_private">Private</string>
     <string name="product_status_pending">Pending</string>
     <string name="product_status_draft">Draft</string>
+
+    <!-- permissions -->
+    <string name="permissions_denied_title">Permissions</string>
+    <string name="permissions_denied_message">It looks like you turned off permissions required for this feature.&lt;br/&gt;&lt;br/&gt;To change this, edit your permissions and make sure &lt;strong&gt;%s&lt;/strong&gt; is enabled.</string>
+    <string name="permission_storage">Storage</string>
+    <string name="permission_camera">Camera</string>
+    <string name="button_edit_permissions">Edit permissions</string>
 
     <!-- Other -->
     <string name="shared_element_transition" translatable="false">shared_element</string>


### PR DESCRIPTION
Closes #1459 - adds support for requesting storage & camera  permissions, which we'll need in order to enable users to select/capture product images.

To test, add this line to the end of `onActivityCreated()` in `ProductDetailFragment`:

```
requestCameraPermission()
```

Then when you visit product detail, you should see this system permission dialog:

![Screenshot_1570800488](https://user-images.githubusercontent.com/3903757/66655680-7cd9fe00-ec0a-11e9-9f90-c621e823732b.png)

* Choose "Allow" and verify the dialog doesn't show again the next time you run the app
* Reset permissions for the app
* Choose "Deny" and verify the dialog **does** show again the next time you run the app
* Reset permissions for the app
* Choose "Deny & don't ask again" and verify the dialog below appears:

![Screenshot_1570800659](https://user-images.githubusercontent.com/3903757/66655888-e9ed9380-ec0a-11e9-8d08-55ed3d555b96.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
