### PR TITLE
Hide the skeleton once the product review has properly been fetched

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModel.kt
@@ -108,6 +108,7 @@ final class ReviewDetailViewModel @Inject constructor(
                     SUCCESS, NO_ACTION_NEEDED -> {
                         repository.getCachedProductReview(remoteReviewId)?.let { review ->
                             _productReview.value = review
+                            _isSkeletonShown.value = false
                         }
                     }
                     ERROR -> _showSnackbarMessage.value = R.string.wc_load_review_error


### PR DESCRIPTION
Fixes #1463 which is a ticket against the _**beta**_ 2.8 build. This fix is contained in a branch created off of `release/2.8`. Once it has been approved and merged, the changed will need to be merged back into develop as well. 

The bug fixed by this PR was happening when we don't have a copy of a product review in the db so we have to fetch it from the API. The logic was not hiding the loading skeleton once the review has been fetched and return to the UI - so the loading skeleton was covering the review details.