### PR TITLE
Issue/1467 share button reviews

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -266,6 +266,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         REVIEWS_MARK_ALL_READ_FAILED,
         REVIEWS_LIST_PULLED_TO_REFRESH,
         REVIEWS_LIST_MENU_MARK_READ_BUTTON_TAPPED,
+        REVIEWS_LIST_SHARE_YOUR_STORE_BUTTON_TAPPED,
 
         // -- Product Review Detail
         REVIEW_LOADED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.model.ActionStatus
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.reviews.ProductReviewStatus.SPAM
 import com.woocommerce.android.ui.reviews.ProductReviewStatus.TRASH
 import com.woocommerce.android.widgets.AppRatingDialog
@@ -52,6 +53,7 @@ class ReviewListFragment : TopLevelFragment(), ItemDecorationListener, ReviewLis
 
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var uiMessageResolver: UIMessageResolver
+    @Inject lateinit var selectedSite: SelectedSite
 
     private lateinit var viewModel: ReviewListViewModel
     private lateinit var reviewsAdapter: ReviewListAdapter
@@ -293,7 +295,14 @@ class ReviewListFragment : TopLevelFragment(), ItemDecorationListener, ReviewLis
     }
 
     private fun showEmptyView(show: Boolean) {
-        if (show) empty_view.show(R.string.reviews_empty_message) else empty_view.hide()
+        if (show) {
+            empty_view.setSiteToShare(
+                    selectedSite.get(),
+                    Stat.REVIEWS_LIST_SHARE_YOUR_STORE_BUTTON_TAPPED)
+            empty_view.show(R.string.reviews_empty_message)
+        } else {
+            empty_view.hide()
+        }
     }
 
     private fun showMarkAllReadMenuItem(show: Boolean) {


### PR DESCRIPTION
Fixes #1467 by showing the "Share your store" button on the reviews list screen if there are no reviews to show. This also required adding a new track event `_REVIEWS_LIST_SHARE_YOUR_STORE_BUTTON_TAPPED` - which has been validated and registered.

<img src="https://user-images.githubusercontent.com/5810477/66801189-0d476580-eecd-11e9-8214-d788afc65cac.png" width="300"/>

NOTE: once this PR has been reviewed and merged, the changes will need to be merged back into the `develop` branch. 