### PR TITLE
Kotlin migration update

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
@@ -10,7 +10,7 @@ import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 
-class WooWellSqlConfig(context: Context?) : WellSqlConfig(context, ADDON_WOOCOMMERCE) {
+class WooWellSqlConfig(context: Context) : WellSqlConfig(context, ADDON_WOOCOMMERCE) {
     /**
      * Detect when the database is downgraded in debug and beta builds so we can recreate all the tables.
      * The initial purpose of this was to avoid the hassle of devs switching branches and having to clear
@@ -35,7 +35,7 @@ class WooWellSqlConfig(context: Context?) : WellSqlConfig(context, ADDON_WOOCOMM
 
             // the main activity uses this to determine when it needs to load the site list
             AppPrefs.setDatabaseDowngraded(true)
-            reset(helper)
+            reset()
         } else {
             super.onDowngrade(db, helper, oldVersion, newVersion)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
@@ -35,7 +35,7 @@ class WooWellSqlConfig(context: Context) : WellSqlConfig(context, ADDON_WOOCOMME
 
             // the main activity uses this to determine when it needs to load the site list
             AppPrefs.setDatabaseDowngraded(true)
-            reset()
+            helper?.let { reset(it) }
         } else {
             super.onDowngrade(db, helper, oldVersion, newVersion)
         }

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.5.0'
+    fluxCVersion = 'b960468d646a9430d4ed2be85bf1ec4094fc8acc'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'f7dbf9c34eb1f19ba4e8d79e9e08cd38c81992c9'
+    fluxCVersion = '1.5.1-beta-1'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'b960468d646a9430d4ed2be85bf1ec4094fc8acc'
+    fluxCVersion = 'f7dbf9c34eb1f19ba4e8d79e9e08cd38c81992c9'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
This PR fixes the build after the Kotlin migration update (wordpress-mobile/WordPress-FluxC-Android#1395).

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
