### PR TITLE
issue/1470-product-repository-crash-fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
@@ -36,7 +36,6 @@ class ProductDetailRepository @Inject constructor(
 
     fun onCleanup() {
         dispatcher.unregister(this)
-        continuation = null
     }
 
     suspend fun fetchProduct(remoteProductId: Long): Product? {
@@ -47,6 +46,7 @@ class ProductDetailRepository @Inject constructor(
             dispatcher.dispatch(WCProductActionBuilder.newFetchSingleProductAction(payload))
         }
 
+        continuation = null
         return getProduct(remoteProductId)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
@@ -36,6 +36,7 @@ class ProductDetailRepository @Inject constructor(
 
     fun onCleanup() {
         dispatcher.unregister(this)
+        continuation = null
     }
 
     suspend fun fetchProduct(remoteProductId: Long): Product? {


### PR DESCRIPTION
Fixes #1470. The app is crashing when the user clicks the back button in Product detail page, right when the product detail page API responds with a result.

### Changes
This tiny PR sets the `Continuation` variable to `null` when `ProductDetailRepository` is cleaned up.

### Testing
I was able to intermittently reproduce this crash by:

- Clicking on any product from the `My Store` top earners tab.
- Click on back button before the screen is fully loaded.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
