### PR TITLE
issue/1474-filtered-order-list-not-clickable-fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -483,6 +483,7 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
                     mapOf(AnalyticsTracker.KEY_STATUS to orderStatus.orEmpty())
             )
 
+            isRefreshing = true
             enableFilterListeners()
             order_list_view.clearAdapterData()
             presenter.loadOrders(orderStatusFilter, true)
@@ -701,7 +702,6 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
      */
     private fun enableFilterListeners() {
         isFilterEnabled = true
-        isRefreshing = true
         hideOrderStatusListView()
         searchView?.queryHint = getString(R.string.orders)
                 .plus(orderStatusFilter?.let { filter ->


### PR DESCRIPTION
Fixes #1474 . This tiny PR fixes the logic where `isRefreshing` was getting set to true, which was the reason the filtered order list item was not redirecting to the Order Detail page. 

### Testing Steps
- Click on the search icon in `My Orders` tab.
- Click on any one of the statuses such as `Refunded`.
- Click on an order item from the list of refunded items.
- Click back from the Order detail screen.
- Click on another item from the order list and notice that it is not clickable.
- Pull changes from this PR and follow the above steps again to verify that the order list item is clickable.

### Behaviour
(LEFT: Before the fix . RIGHT: After the fix)
<img width="300" src="https://user-images.githubusercontent.com/22608780/66911450-287db680-f02e-11e9-8ab0-b7acf039b9cf.gif"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/66915519-d9884f00-f036-11e9-9f7f-8d6585526408.gif">

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
