### PR TITLE
Updates FluxC hash to 1.5.1-beta-2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.5.1-beta-1'
+    fluxCVersion = '1.5.1-beta-2'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
This PR updates FluxC hash to 1.5.1-beta-2 which is tagged as a result of the Gradle 5 upgrade done in this PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1397. Since this is a big upgrade, I wanted to make sure it builds OK in WCAndroid and once I did, I thought I might as well open the PR for it.

Could you please make sure I have the correct release and the label setup for the PR?

**To test:**
I think just building & running the app would be enough for this change.

**Update release notes:**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
