### PR TITLE
Automatic refunds

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 2.9
 -----
+* Added a new refunding feature that brings the ability to specify the amount to refund
  
 2.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/PaymentGateway.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/PaymentGateway.kt
@@ -1,0 +1,25 @@
+package com.woocommerce.android.model
+
+import org.wordpress.android.fluxc.model.gateways.WCGatewayModel
+
+const val REFUNDS_FEATURE = "refunds"
+
+data class PaymentGateway(
+    val title: String = "",
+    val description: String = "",
+    val isEnabled: Boolean = true,
+    val methodTitle: String,
+    val methodDescription: String = "",
+    val supportsRefunds: Boolean = false
+)
+
+fun WCGatewayModel.toAppModel(): PaymentGateway {
+    return PaymentGateway(
+            this.title,
+            this.description,
+            this.enabled,
+            this.methodTitle,
+            this.methodDescription,
+            features.contains(REFUNDS_FEATURE)
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
@@ -15,6 +15,9 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.mystore.RevenueStatsAvailabilityFetcher.RevenueStatsAvailabilityChangeEvent
 import com.woocommerce.android.tools.SelectedSite.SelectedSiteChangedEvent
 import com.woocommerce.android.util.WooLog
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -36,6 +39,7 @@ import org.wordpress.android.fluxc.store.AccountStore.UpdateTokenPayload
 import org.wordpress.android.fluxc.store.NotificationStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
+import org.wordpress.android.fluxc.store.WCGatewayStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload
@@ -52,7 +56,8 @@ class MainPresenter @Inject constructor(
     private val wooCommerceStore: WooCommerceStore,
     private val notificationStore: NotificationStore,
     private val selectedSite: SelectedSite,
-    private val productImageMap: ProductImageMap
+    private val productImageMap: ProductImageMap,
+    private val gatewayStore: WCGatewayStore
 ) : MainContract.Presenter {
     private var mainView: MainContract.View? = null
 
@@ -172,6 +177,14 @@ class MainPresenter @Inject constructor(
             // Magic link login is now complete - notify the activity to set the selected site and proceed with loading UI
             mainView?.updateSelectedSite()
             isHandlingMagicLink = false
+        }
+
+        // prefetch all gateways whenever the site changes
+        GlobalScope.launch(Dispatchers.Default) {
+            val result = gatewayStore.fetchAllGateways(selectedSite.get())
+            if (result.isError) {
+                WooLog.e(WooLog.T.UTILS, "${result.error.type.name}: ${result.error.message}")
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPaymentView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPaymentView.kt
@@ -12,7 +12,6 @@ import com.woocommerce.android.extensions.isEqualTo
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Refund
-import com.woocommerce.android.util.FeatureFlag
 import kotlinx.android.synthetic.main.order_detail_payment_info.view.*
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import java.math.BigDecimal
@@ -25,7 +24,7 @@ class OrderDetailPaymentView @JvmOverloads constructor(ctx: Context, attrs: Attr
 
     init {
         View.inflate(context, R.layout.order_detail_payment_info, this)
-        orientation = LinearLayout.VERTICAL
+        orientation = VERTICAL
     }
 
     fun initView(
@@ -75,7 +74,7 @@ class OrderDetailPaymentView @JvmOverloads constructor(ctx: Context, attrs: Attr
                         order.paymentMethodTitle
                 )
 
-                if (order.total - order.refundTotal > BigDecimal.ZERO && FeatureFlag.REFUNDS.isEnabled()) {
+                if (order.total - order.refundTotal > BigDecimal.ZERO) {
                     paymentInfo_issueRefundButtonSection.show()
                 } else {
                     paymentInfo_issueRefundButtonSection.hide()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundSummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundSummaryFragment.kt
@@ -82,6 +82,14 @@ class RefundSummaryFragment : DaggerFragment(), BackPressListener {
             refundSummary_previouslyRefunded.text = it
         })
 
+        viewModel.refundMethod.observe(this, Observer {
+            refundSummary_method.text = it
+        })
+
+        viewModel.isManualRefundDescriptionVisible.observe(this, Observer { visible ->
+            refundSummary_methodDescription.visibility = if (visible) View.VISIBLE else View.GONE
+        })
+
         viewModel.exitAfterRefund.observe(this, Observer {
             val bundle = Bundle()
             bundle.putBoolean(REFUND_SUCCESS_KEY, it)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -8,13 +8,11 @@ import com.woocommerce.android.BuildConfig
  */
 enum class FeatureFlag {
     PRODUCT_LIST,
-    DB_DOWNGRADE,
-    REFUNDS;
+    DB_DOWNGRADE;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
             PRODUCT_LIST -> BuildConfig.DEBUG
-            REFUNDS -> BuildConfig.DEBUG
             DB_DOWNGRADE -> {
                 BuildConfig.DEBUG || context != null && PackageUtils.isBetaBuild(context)
             }

--- a/WooCommerce/src/main/res/layout/fragment_refund_summary.xml
+++ b/WooCommerce/src/main/res/layout/fragment_refund_summary.xml
@@ -119,6 +119,7 @@
                 android:textAppearance="@style/Woo.TextAppearance.Medium.Purple" />
 
             <TextView
+                android:id="@+id/refundSummary_method"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/card_item_padding_intra_h"
@@ -127,11 +128,13 @@
                 android:textAppearance="@style/Woo.Refunds.TextAppearance" />
 
             <TextView
+                android:id="@+id/refundSummary_methodDescription"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/card_item_padding_intra_h"
                 android:textAppearance="@style/Woo.OrderDetail.TextAppearance"
                 android:text="@string/order_refunds_refund_manual_refund_note"
+                android:lineSpacingMultiplier="1.4"
                 android:textColor="@color/wc_grey_medium"
                 android:textAlignment="viewStart"
                 android:textIsSelectable="true"/>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -271,7 +271,7 @@
     <string name="order_refunds_manual_refund_progress_message">Your refund for %s is being processed. Please wait…</string>
     <string name="order_refunds_manual_refund_successful">The refund was successfully submitted.</string>
     <string name="order_refunds_manual_refund_error">Something went wrong with the refund. Please try again.</string>
-    <string name="order_refunds_refund_manual_refund_note">Currently, only manual refunds are supported. Complete the refund through your payment gateway\'s dashboard, or manually transfer the money to the customer.</string>
+    <string name="order_refunds_refund_manual_refund_note">The payment method does not support automatic refunds. Complete the refund by transferring the money to the customer manually.</string>
     <!--
         Add Order Note
     -->

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.5.1-beta-1'
+    fluxCVersion = '22b7a35ec93729ec8f6201ac4b290a4f005e3814'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Fixes #1478. This PR brings the automatic refund by utilising the payment gateway endpoint. When the app is started (or a site changes), all payment gateways for the site are loaded. During a refund the selected gateway is checked, whether it supports automatic refunds.

The feature flag for issuing refunds has been removed.

<img src="https://user-images.githubusercontent.com/1522856/67111831-22c2d500-f1d6-11e9-9d5c-a2d80e302de5.png" width="300" />

<img src="https://user-images.githubusercontent.com/1522856/67111842-28b8b600-f1d6-11e9-97b9-b01fe19df05e.png" width="300" />

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
