### PR TITLE
Jetpack sign in - Step 1: Fetch Jetpack e-mail address for flowing through Magic Links

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -268,9 +268,7 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
         // Save site address to app prefs so it's available to MainActivity regardless of how the user
         // logs into the app.
         siteAddress?.let { AppPrefs.setLoginSiteAddress(it) }
-
-        val loginEmailFragment = getLoginEmailFragment() ?: LoginEmailFragment.newInstance(true, siteAddress)
-        slideInFragment(loginEmailFragment as Fragment, true, LoginEmailFragment.TAG)
+        showEmailLoginScreen(siteAddress)
     }
 
     override fun gotConnectedSiteInfo(siteAddress: String, redirectUrl: String?, hasJetpack: Boolean) {
@@ -447,8 +445,8 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
         startActivity(HelpActivity.createIntent(this, Origin.LOGIN_CONNECTED_EMAIL_HELP, null))
     }
 
-    override fun showEmailLoginScreen(siteAddress: String) {
-        val loginEmailFragment = getLoginEmailFragment() ?: LoginEmailFragment.newInstance(true, siteAddress)
+    override fun showEmailLoginScreen(siteAddress: String?) {
+        val loginEmailFragment = getLoginEmailFragment() ?: LoginEmailFragment.newInstance(false, siteAddress)
         slideInFragment(loginEmailFragment as Fragment, true, LoginEmailFragment.TAG)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -9,7 +9,6 @@ import androidx.appcompat.app.AppCompatActivity
 import com.automattic.android.tracks.CrashLogging.CrashLogging
 import androidx.fragment.app.Fragment
 import com.woocommerce.android.AppPrefs
-import com.woocommerce.android.ui.login.LoginJetpackRequiredFragment.LoginJetpackRequiredListener
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
@@ -47,7 +46,7 @@ import kotlin.text.RegexOption.IGNORE_CASE
 
 @Suppress("SameParameterValue")
 class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, PrologueFinishedListener,
-        HasSupportFragmentInjector, LoginJetpackRequiredListener, LoginEmailHelpDialogFragment.Listener {
+        HasSupportFragmentInjector, LoginNoJetpackListener, LoginEmailHelpDialogFragment.Listener {
     companion object {
         private const val FORGOT_PASSWORD_URL_SUFFIX = "wp-login.php?action=lostpassword"
     }
@@ -299,9 +298,9 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
     }
 
     /**
-     * Method call when Login with Site credentials link is clicked in the [LoginEmailFragment]
+     * Method called when Login with Site credentials link is clicked in the [LoginEmailFragment]
      * This method is called instead of [LoginListener.gotXmlRpcEndpoint] since calling that method overrides
-     * the already saved [inputSiteAddress] to AppPrefs without the protocol with the same site address but with
+     * the already saved [inputSiteAddress] without the protocol, with the same site address but with
      * the protocol. This may cause issues when attempting to match the url to the authenticated account later
      * in the login process.
      */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -377,6 +377,22 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
         viewHelpAndSupport(Origin.LOGIN_USERNAME_PASSWORD)
     }
 
+    override fun helpNoJetpackScreen(
+        siteAddress: String,
+        endpointAddress: String?,
+        username: String,
+        password: String,
+        userAvatarUrl: String?
+    ) {
+        val jetpackReqFragment = LoginNoJetpackFragment.newInstance(
+                siteAddress, endpointAddress, username, password, userAvatarUrl
+        )
+        slideInFragment(
+                fragment = jetpackReqFragment as Fragment,
+                shouldAddToBackStack = true,
+                tag = LoginJetpackRequiredFragment.TAG)
+    }
+
     // SmartLock
 
     override fun saveCredentialsInSmartLock(
@@ -454,5 +470,16 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
         val loginEmailFragment = getLoginEmailFragment()
                 ?: LoginEmailFragment.newInstance(siteAddress, siteXmlRpcAddress)
         slideInFragment(loginEmailFragment as Fragment, true, LoginEmailFragment.TAG)
+    }
+
+    override fun showUsernamePasswordScreen(
+        siteAddress: String?,
+        endpointAddress: String?,
+        inputUsername: String?,
+        inputPassword: String?
+    ) {
+        val loginUsernamePasswordFragment = LoginUsernamePasswordFragment.newInstance(
+                siteAddress, endpointAddress, null, null, inputUsername, inputPassword, false)
+        slideInFragment(loginUsernamePasswordFragment, true, LoginUsernamePasswordFragment.TAG)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -294,6 +294,33 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
         }
     }
 
+    override fun gotXmlRpcEndpoint(
+        inputSiteAddress: String,
+        endpointAddress: String?,
+        hasJetpack: Boolean
+    ) {
+        // Save site address to app prefs so it's available to MainActivity regardless of how the user
+        // logs into the app. If the redirect url is available, use that as the preferred url. Strip the
+        // protocol from this url string prior to saving to AppPrefs since it's not needed and may cause issues
+        // when attempting to match the url to the authenticated account later in the login process.
+        val protocolRegex = Regex("^(http[s]?://)", IGNORE_CASE)
+        AppPrefs.setLoginSiteAddress(inputSiteAddress.replaceFirst(protocolRegex, ""))
+
+        if (hasJetpack) {
+            showEmailLoginScreen(inputSiteAddress, endpointAddress)
+        } else {
+            // hide the keyboard
+            org.wordpress.android.util.ActivityUtils.hideKeyboard(this)
+
+            // Show the 'Jetpack required' fragment
+            val jetpackReqFragment = LoginJetpackRequiredFragment.newInstance(inputSiteAddress, endpointAddress)
+            slideInFragment(
+                    fragment = jetpackReqFragment as Fragment,
+                    shouldAddToBackStack = true,
+                    tag = LoginJetpackRequiredFragment.TAG)
+        }
+    }
+
     override fun gotXmlRpcEndpoint(inputSiteAddress: String?, endpointAddress: String?) {
         // Save site address to app prefs so it's available to MainActivity regardless of how the user
         // logs into the app.
@@ -445,8 +472,9 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
         startActivity(HelpActivity.createIntent(this, Origin.LOGIN_CONNECTED_EMAIL_HELP, null))
     }
 
-    override fun showEmailLoginScreen(siteAddress: String?) {
-        val loginEmailFragment = getLoginEmailFragment() ?: LoginEmailFragment.newInstance(false, siteAddress)
+    override fun showEmailLoginScreen(siteAddress: String?, siteXmlRpcAddress: String?) {
+        val loginEmailFragment = getLoginEmailFragment()
+                ?: LoginEmailFragment.newInstance(siteAddress, siteXmlRpcAddress)
         slideInFragment(loginEmailFragment as Fragment, true, LoginEmailFragment.TAG)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -271,31 +271,9 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
         showEmailLoginScreen(siteAddress)
     }
 
-    override fun gotConnectedSiteInfo(siteAddress: String, redirectUrl: String?, hasJetpack: Boolean) {
-        // Save site address to app prefs so it's available to MainActivity regardless of how the user
-        // logs into the app. If the redirect url is available, use that as the preferred url. Strip the
-        // protocol from this url string prior to saving to AppPrefs since it's not needed and may cause issues
-        // when attempting to match the url to the authenticated account later in the login process.
-        val protocolRegex = Regex("^(http[s]?://)", IGNORE_CASE)
-        AppPrefs.setLoginSiteAddress((redirectUrl ?: siteAddress).replaceFirst(protocolRegex, ""))
-
-        if (hasJetpack) {
-            showEmailLoginScreen(siteAddress)
-        } else {
-            // hide the keyboard
-            org.wordpress.android.util.ActivityUtils.hideKeyboard(this)
-
-            // Show the 'Jetpack required' fragment
-            val jetpackReqFragment = LoginJetpackRequiredFragment.newInstance(siteAddress)
-            slideInFragment(
-                    fragment = jetpackReqFragment as Fragment,
-                    shouldAddToBackStack = true,
-                    tag = LoginJetpackRequiredFragment.TAG)
-        }
-    }
-
-    override fun gotXmlRpcEndpoint(
-        inputSiteAddress: String,
+    override fun gotConnectedSiteInfo(
+        siteAddress: String,
+        redirectUrl: String?,
         endpointAddress: String?,
         hasJetpack: Boolean
     ) {
@@ -304,16 +282,16 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
         // protocol from this url string prior to saving to AppPrefs since it's not needed and may cause issues
         // when attempting to match the url to the authenticated account later in the login process.
         val protocolRegex = Regex("^(http[s]?://)", IGNORE_CASE)
-        AppPrefs.setLoginSiteAddress(inputSiteAddress.replaceFirst(protocolRegex, ""))
+        AppPrefs.setLoginSiteAddress((redirectUrl ?: siteAddress).replaceFirst(protocolRegex, ""))
 
         if (hasJetpack) {
-            showEmailLoginScreen(inputSiteAddress, endpointAddress)
+            showEmailLoginScreen(siteAddress, endpointAddress)
         } else {
             // hide the keyboard
             org.wordpress.android.util.ActivityUtils.hideKeyboard(this)
 
             // Show the 'Jetpack required' fragment
-            val jetpackReqFragment = LoginJetpackRequiredFragment.newInstance(inputSiteAddress, endpointAddress)
+            val jetpackReqFragment = LoginJetpackRequiredFragment.newInstance(siteAddress, endpointAddress)
             slideInFragment(
                     fragment = jetpackReqFragment as Fragment,
                     shouldAddToBackStack = true,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -271,12 +271,7 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
         showEmailLoginScreen(siteAddress)
     }
 
-    override fun gotConnectedSiteInfo(
-        siteAddress: String,
-        redirectUrl: String?,
-        endpointAddress: String?,
-        hasJetpack: Boolean
-    ) {
+    override fun gotConnectedSiteInfo(siteAddress: String, redirectUrl: String?, hasJetpack: Boolean) {
         // Save site address to app prefs so it's available to MainActivity regardless of how the user
         // logs into the app. If the redirect url is available, use that as the preferred url. Strip the
         // protocol from this url string prior to saving to AppPrefs since it's not needed and may cause issues
@@ -285,13 +280,13 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
         AppPrefs.setLoginSiteAddress((redirectUrl ?: siteAddress).replaceFirst(protocolRegex, ""))
 
         if (hasJetpack) {
-            showEmailLoginScreen(siteAddress, endpointAddress)
+            showEmailLoginScreen(siteAddress)
         } else {
             // hide the keyboard
             org.wordpress.android.util.ActivityUtils.hideKeyboard(this)
 
             // Show the 'Jetpack required' fragment
-            val jetpackReqFragment = LoginJetpackRequiredFragment.newInstance(siteAddress, endpointAddress)
+            val jetpackReqFragment = LoginJetpackRequiredFragment.newInstance(siteAddress)
             slideInFragment(
                     fragment = jetpackReqFragment as Fragment,
                     shouldAddToBackStack = true,
@@ -466,9 +461,8 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
         startActivity(HelpActivity.createIntent(this, Origin.LOGIN_CONNECTED_EMAIL_HELP, null))
     }
 
-    override fun showEmailLoginScreen(siteAddress: String?, siteXmlRpcAddress: String?) {
-        val loginEmailFragment = getLoginEmailFragment()
-                ?: LoginEmailFragment.newInstance(siteAddress, siteXmlRpcAddress)
+    override fun showEmailLoginScreen(siteAddress: String?) {
+        val loginEmailFragment = getLoginEmailFragment() ?: LoginEmailFragment.newInstance(siteAddress)
         slideInFragment(loginEmailFragment as Fragment, true, LoginEmailFragment.TAG)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginJetpackRequiredFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginJetpackRequiredFragment.kt
@@ -48,6 +48,12 @@ class LoginJetpackRequiredFragment : Fragment() {
         fun showJetpackInstructions()
         fun showWhatIsJetpackDialog()
         fun showEmailLoginScreen(siteAddress: String?, siteXmlRpcAddress: String? = null)
+        fun showUsernamePasswordScreen(
+            siteAddress: String?,
+            endpointAddress: String?,
+            inputUsername: String?,
+            inputPassword: String?
+        )
     }
 
     private var loginListener: LoginListener? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginJetpackRequiredFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginJetpackRequiredFragment.kt
@@ -42,20 +42,8 @@ class LoginJetpackRequiredFragment : Fragment() {
         }
     }
 
-    interface LoginJetpackRequiredListener {
-        fun showJetpackInstructions()
-        fun showWhatIsJetpackDialog()
-        fun showEmailLoginScreen(siteAddress: String?)
-        fun showUsernamePasswordScreen(
-            siteAddress: String?,
-            endpointAddress: String?,
-            inputUsername: String?,
-            inputPassword: String?
-        )
-    }
-
     private var loginListener: LoginListener? = null
-    private var jetpackLoginListener: LoginJetpackRequiredListener? = null
+    private var jetpackLoginListener: LoginNoJetpackListener? = null
     private var siteAddress: String? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -143,7 +131,13 @@ class LoginJetpackRequiredFragment : Fragment() {
 
         // this will throw if parent activity doesn't implement the login listener interface
         loginListener = context as? LoginListener
-        jetpackLoginListener = context as? LoginJetpackRequiredListener
+        jetpackLoginListener = context as? LoginNoJetpackListener
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        loginListener = null
+        jetpackLoginListener = null
     }
 
     override fun onResume() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginJetpackRequiredFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginJetpackRequiredFragment.kt
@@ -45,7 +45,7 @@ class LoginJetpackRequiredFragment : Fragment() {
     interface LoginJetpackRequiredListener {
         fun showJetpackInstructions()
         fun showWhatIsJetpackDialog()
-        fun showEmailLoginScreen(siteAddress: String)
+        fun showEmailLoginScreen(siteAddress: String?)
     }
 
     private var loginListener: LoginListener? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginJetpackRequiredFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginJetpackRequiredFragment.kt
@@ -32,13 +32,11 @@ class LoginJetpackRequiredFragment : Fragment() {
     companion object {
         const val TAG = "LoginJetpackRequiredFragment"
         const val ARG_SITE_ADDRESS = "SITE-ADDRESS"
-        const val ARG_SITE_XMLRPC_ADDRESS = "SITE-XMLRPC-ADDRESS"
 
-        fun newInstance(siteAddress: String, endpointAddress: String? = null): LoginJetpackRequiredFragment {
+        fun newInstance(siteAddress: String): LoginJetpackRequiredFragment {
             val fragment = LoginJetpackRequiredFragment()
             val args = Bundle()
             args.putString(ARG_SITE_ADDRESS, siteAddress)
-            args.putString(ARG_SITE_XMLRPC_ADDRESS, endpointAddress)
             fragment.arguments = args
             return fragment
         }
@@ -47,7 +45,7 @@ class LoginJetpackRequiredFragment : Fragment() {
     interface LoginJetpackRequiredListener {
         fun showJetpackInstructions()
         fun showWhatIsJetpackDialog()
-        fun showEmailLoginScreen(siteAddress: String?, siteXmlRpcAddress: String? = null)
+        fun showEmailLoginScreen(siteAddress: String?)
         fun showUsernamePasswordScreen(
             siteAddress: String?,
             endpointAddress: String?,
@@ -59,14 +57,12 @@ class LoginJetpackRequiredFragment : Fragment() {
     private var loginListener: LoginListener? = null
     private var jetpackLoginListener: LoginJetpackRequiredListener? = null
     private var siteAddress: String? = null
-    private var siteXmlRpcAddress: String? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         arguments?.let {
             siteAddress = it.getString(ARG_SITE_ADDRESS, null)
-            siteXmlRpcAddress = it.getString(ARG_SITE_XMLRPC_ADDRESS, null)
         }
     }
 
@@ -116,7 +112,7 @@ class LoginJetpackRequiredFragment : Fragment() {
                         AppPrefs.setLoginUserBypassedJetpackRequired()
 
                         // Display the login by email screen
-                        jetpackLoginListener?.showEmailLoginScreen(siteAddress.orEmpty(), siteXmlRpcAddress.orEmpty())
+                        jetpackLoginListener?.showEmailLoginScreen(siteAddress.orEmpty())
                     },
                     (jetpackInstalledText.length - signInText.length),
                     jetpackInstalledText.length,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginJetpackRequiredFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginJetpackRequiredFragment.kt
@@ -32,11 +32,13 @@ class LoginJetpackRequiredFragment : Fragment() {
     companion object {
         const val TAG = "LoginJetpackRequiredFragment"
         const val ARG_SITE_ADDRESS = "SITE-ADDRESS"
+        const val ARG_SITE_XMLRPC_ADDRESS = "SITE-XMLRPC-ADDRESS"
 
-        fun newInstance(siteAddress: String): LoginJetpackRequiredFragment {
+        fun newInstance(siteAddress: String, endpointAddress: String? = null): LoginJetpackRequiredFragment {
             val fragment = LoginJetpackRequiredFragment()
             val args = Bundle()
             args.putString(ARG_SITE_ADDRESS, siteAddress)
+            args.putString(ARG_SITE_XMLRPC_ADDRESS, endpointAddress)
             fragment.arguments = args
             return fragment
         }
@@ -45,18 +47,20 @@ class LoginJetpackRequiredFragment : Fragment() {
     interface LoginJetpackRequiredListener {
         fun showJetpackInstructions()
         fun showWhatIsJetpackDialog()
-        fun showEmailLoginScreen(siteAddress: String?)
+        fun showEmailLoginScreen(siteAddress: String?, siteXmlRpcAddress: String? = null)
     }
 
     private var loginListener: LoginListener? = null
     private var jetpackLoginListener: LoginJetpackRequiredListener? = null
     private var siteAddress: String? = null
+    private var siteXmlRpcAddress: String? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         arguments?.let {
             siteAddress = it.getString(ARG_SITE_ADDRESS, null)
+            siteXmlRpcAddress = it.getString(ARG_SITE_XMLRPC_ADDRESS, null)
         }
     }
 
@@ -106,7 +110,7 @@ class LoginJetpackRequiredFragment : Fragment() {
                         AppPrefs.setLoginUserBypassedJetpackRequired()
 
                         // Display the login by email screen
-                        jetpackLoginListener?.showEmailLoginScreen(siteAddress.orEmpty())
+                        jetpackLoginListener?.showEmailLoginScreen(siteAddress.orEmpty(), siteXmlRpcAddress.orEmpty())
                     },
                     (jetpackInstalledText.length - signInText.length),
                     jetpackInstalledText.length,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
@@ -16,8 +16,10 @@ import androidx.fragment.app.Fragment
 import com.woocommerce.android.R
 import com.woocommerce.android.R.layout
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.di.GlideApp
 import com.woocommerce.android.ui.login.LoginJetpackRequiredFragment.LoginJetpackRequiredListener
 import com.woocommerce.android.widgets.WooClickableSpan
+import kotlinx.android.synthetic.main.fragment_login_no_jetpack.*
 import kotlinx.android.synthetic.main.view_login_epilogue_button_bar.*
 import kotlinx.android.synthetic.main.view_login_no_stores.*
 import org.wordpress.android.login.LoginListener
@@ -27,14 +29,16 @@ class LoginNoJetpackFragment : Fragment() {
         const val TAG = "LoginNoJetpackFragment"
         private const val ARG_SITE_ADDRESS = "SITE-ADDRESS"
         private const val ARG_SITE_XMLRPC_ADDRESS = "SITE-XMLRPC-ADDRESS"
-        private val ARG_INPUT_USERNAME = "ARG_INPUT_USERNAME"
-        private val ARG_INPUT_PASSWORD = "ARG_INPUT_PASSWORD"
+        private const val ARG_INPUT_USERNAME = "ARG_INPUT_USERNAME"
+        private const val ARG_INPUT_PASSWORD = "ARG_INPUT_PASSWORD"
+        private const val ARG_USER_AVATAR_URL = "ARG_USER_AVATAR_URL"
 
         fun newInstance(
             siteAddress: String,
             endpointAddress: String?,
             inputUsername: String,
-            inputPassword: String
+            inputPassword: String,
+            userAvatarUrl: String?
         ): LoginNoJetpackFragment {
             val fragment = LoginNoJetpackFragment()
             val args = Bundle()
@@ -42,6 +46,7 @@ class LoginNoJetpackFragment : Fragment() {
             args.putString(ARG_SITE_XMLRPC_ADDRESS, endpointAddress)
             args.putString(ARG_INPUT_USERNAME, inputUsername)
             args.putString(ARG_INPUT_PASSWORD, inputPassword)
+            args.putString(ARG_USER_AVATAR_URL, userAvatarUrl)
             fragment.arguments = args
             return fragment
         }
@@ -53,6 +58,7 @@ class LoginNoJetpackFragment : Fragment() {
     private var siteXmlRpcAddress: String? = null
     private var mInputUsername: String? = null
     private var mInputPassword: String? = null
+    private var userAvatarUrl: String? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -62,6 +68,7 @@ class LoginNoJetpackFragment : Fragment() {
             siteXmlRpcAddress = it.getString(ARG_SITE_XMLRPC_ADDRESS, null)
             mInputUsername = it.getString(ARG_INPUT_USERNAME, null)
             mInputPassword = it.getString(ARG_INPUT_PASSWORD, null)
+            userAvatarUrl = it.getString(ARG_USER_AVATAR_URL, null)
         }
     }
 
@@ -77,7 +84,23 @@ class LoginNoJetpackFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        text_displayname.text = mInputUsername
+        with(text_username) {
+            val logOutText = getString(R.string.signout)
+            val usernameText = getString(R.string.login_no_jetpack_username, mInputUsername, logOutText)
+            text = usernameText
+        }
+
+        userAvatarUrl?.let {
+            GlideApp.with(this)
+                    .load(it)
+                    .placeholder(R.drawable.ic_placeholder_gravatar_grey_lighten_20_100dp)
+                    .circleCrop()
+                    .into(image_avatar)
+        }
+
         with(no_stores_view) {
+            visibility = View.VISIBLE
             val refreshAppText = getString(R.string.login_refresh_app_continue)
             val notConnectedText = getString(
                     R.string.login_not_connected_jetpack,
@@ -89,7 +112,9 @@ class LoginNoJetpackFragment : Fragment() {
             spannable.setSpan(
                     WooClickableSpan {
                         // TODO: add event here to track when refresh link is clicked
-                        // TODO: call the username password fragment
+                        jetpackLoginListener?.showUsernamePasswordScreen(
+                                siteAddress, siteXmlRpcAddress, mInputUsername, mInputPassword
+                        )
                     },
                     (notConnectedText.length - refreshAppText.length),
                     notConnectedText.length,
@@ -102,16 +127,19 @@ class LoginNoJetpackFragment : Fragment() {
         with(button_primary) {
             text = getString(R.string.login_jetpack_view_setup_instructions)
             setOnClickListener {
-                // Add event here to track when primary button is clicked
+                // TODO: Add event here to track when primary button is clicked
                 jetpackLoginListener?.showJetpackInstructions()
             }
         }
 
         with(button_secondary) {
+            visibility = View.VISIBLE
             text = getString(R.string.try_again)
             setOnClickListener {
-                // Add event here to track when secondary button is clicked
-                // TODO: call the username password fragment
+                // TODO: Add event here to track when secondary button is clicked
+                jetpackLoginListener?.showUsernamePasswordScreen(
+                        siteAddress, siteXmlRpcAddress, mInputUsername, mInputPassword
+                )
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
@@ -1,0 +1,147 @@
+package com.woocommerce.android.ui.login
+
+import android.content.Context
+import android.os.Bundle
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.method.LinkMovementMethod
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import com.woocommerce.android.R
+import com.woocommerce.android.R.layout
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.ui.login.LoginJetpackRequiredFragment.LoginJetpackRequiredListener
+import com.woocommerce.android.widgets.WooClickableSpan
+import kotlinx.android.synthetic.main.view_login_epilogue_button_bar.*
+import kotlinx.android.synthetic.main.view_login_no_stores.*
+import org.wordpress.android.login.LoginListener
+
+class LoginNoJetpackFragment : Fragment() {
+    companion object {
+        const val TAG = "LoginNoJetpackFragment"
+        private const val ARG_SITE_ADDRESS = "SITE-ADDRESS"
+        private const val ARG_SITE_XMLRPC_ADDRESS = "SITE-XMLRPC-ADDRESS"
+        private val ARG_INPUT_USERNAME = "ARG_INPUT_USERNAME"
+        private val ARG_INPUT_PASSWORD = "ARG_INPUT_PASSWORD"
+
+        fun newInstance(
+            siteAddress: String,
+            endpointAddress: String?,
+            inputUsername: String,
+            inputPassword: String
+        ): LoginNoJetpackFragment {
+            val fragment = LoginNoJetpackFragment()
+            val args = Bundle()
+            args.putString(ARG_SITE_ADDRESS, siteAddress)
+            args.putString(ARG_SITE_XMLRPC_ADDRESS, endpointAddress)
+            args.putString(ARG_INPUT_USERNAME, inputUsername)
+            args.putString(ARG_INPUT_PASSWORD, inputPassword)
+            fragment.arguments = args
+            return fragment
+        }
+    }
+
+    private var loginListener: LoginListener? = null
+    private var jetpackLoginListener: LoginJetpackRequiredListener? = null
+    private var siteAddress: String? = null
+    private var siteXmlRpcAddress: String? = null
+    private var mInputUsername: String? = null
+    private var mInputPassword: String? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        arguments?.let {
+            siteAddress = it.getString(ARG_SITE_ADDRESS, null)
+            siteXmlRpcAddress = it.getString(ARG_SITE_XMLRPC_ADDRESS, null)
+            mInputUsername = it.getString(ARG_INPUT_USERNAME, null)
+            mInputPassword = it.getString(ARG_INPUT_PASSWORD, null)
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        setHasOptionsMenu(true)
+        return inflater.inflate(layout.fragment_login_no_jetpack, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        with(no_stores_view) {
+            val refreshAppText = getString(R.string.login_refresh_app_continue)
+            val notConnectedText = getString(
+                    R.string.login_not_connected_jetpack,
+                    siteAddress,
+                    refreshAppText
+            )
+
+            val spannable = SpannableString(notConnectedText)
+            spannable.setSpan(
+                    WooClickableSpan {
+                        // TODO: add event here to track when refresh link is clicked
+                        // TODO: call the username password fragment
+                    },
+                    (notConnectedText.length - refreshAppText.length),
+                    notConnectedText.length,
+                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+
+            setText(spannable, TextView.BufferType.SPANNABLE)
+            movementMethod = LinkMovementMethod.getInstance()
+        }
+
+        with(button_primary) {
+            text = getString(R.string.login_jetpack_view_setup_instructions)
+            setOnClickListener {
+                // Add event here to track when primary button is clicked
+                jetpackLoginListener?.showJetpackInstructions()
+            }
+        }
+
+        with(button_secondary) {
+            text = getString(R.string.try_again)
+            setOnClickListener {
+                // Add event here to track when secondary button is clicked
+                // TODO: call the username password fragment
+            }
+        }
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu?, inflater: MenuInflater) {
+        super.onCreateOptionsMenu(menu, inflater)
+        inflater.inflate(R.menu.menu_login, menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == R.id.help) {
+            // TODO: add tracking here when help is clicked
+            loginListener?.helpSiteAddress(siteAddress)
+            return true
+        }
+
+        return false
+    }
+
+    override fun onAttach(context: Context?) {
+        super.onAttach(context)
+
+        // this will throw if parent activity doesn't implement the login listener interface
+        loginListener = context as? LoginListener
+        jetpackLoginListener = context as? LoginJetpackRequiredListener
+    }
+
+    override fun onResume() {
+        super.onResume()
+        AnalyticsTracker.trackViewShown(this)
+        // TODO: add tracking here on which screen is viewed
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
@@ -1,14 +1,13 @@
 package com.woocommerce.android.ui.login
 
+import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
@@ -23,6 +22,7 @@ import kotlinx.android.synthetic.main.fragment_login_no_jetpack.*
 import kotlinx.android.synthetic.main.view_login_epilogue_button_bar.*
 import kotlinx.android.synthetic.main.view_login_no_stores.*
 import org.wordpress.android.login.LoginListener
+import org.wordpress.android.login.LoginMode
 
 class LoginNoJetpackFragment : Fragment() {
     companion object {
@@ -89,6 +89,23 @@ class LoginNoJetpackFragment : Fragment() {
             val logOutText = getString(R.string.signout)
             val usernameText = getString(R.string.login_no_jetpack_username, mInputUsername, logOutText)
             text = usernameText
+
+            val spannable = SpannableString(usernameText)
+            spannable.setSpan(
+                    WooClickableSpan {
+                        // TODO: add event here to track when logout is clicked
+                        activity?.setResult(Activity.RESULT_CANCELED)
+                        val intent = Intent(activity, LoginActivity::class.java)
+                        LoginMode.WOO_LOGIN_MODE.putInto(intent)
+                        startActivity(intent)
+                        activity?.finish()
+                    },
+                    (usernameText.length - logOutText.length),
+                    usernameText.length,
+                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+
+            setText(spannable, TextView.BufferType.SPANNABLE)
+            movementMethod = LinkMovementMethod.getInstance()
         }
 
         userAvatarUrl?.let {
@@ -101,27 +118,7 @@ class LoginNoJetpackFragment : Fragment() {
 
         with(no_stores_view) {
             visibility = View.VISIBLE
-            val refreshAppText = getString(R.string.login_refresh_app_continue)
-            val notConnectedText = getString(
-                    R.string.login_not_connected_jetpack,
-                    siteAddress,
-                    refreshAppText
-            )
-
-            val spannable = SpannableString(notConnectedText)
-            spannable.setSpan(
-                    WooClickableSpan {
-                        // TODO: add event here to track when refresh link is clicked
-                        jetpackLoginListener?.showUsernamePasswordScreen(
-                                siteAddress, siteXmlRpcAddress, mInputUsername, mInputPassword
-                        )
-                    },
-                    (notConnectedText.length - refreshAppText.length),
-                    notConnectedText.length,
-                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
-
-            setText(spannable, TextView.BufferType.SPANNABLE)
-            movementMethod = LinkMovementMethod.getInstance()
+            text = getString(R.string.login_no_jetpack, siteAddress)
         }
 
         with(button_primary) {
@@ -142,21 +139,13 @@ class LoginNoJetpackFragment : Fragment() {
                 )
             }
         }
-    }
 
-    override fun onCreateOptionsMenu(menu: Menu?, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
-        inflater.inflate(R.menu.menu_login, menu)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        if (item.itemId == R.id.help) {
-            // TODO: add tracking here when help is clicked
-            loginListener?.helpSiteAddress(siteAddress)
-            return true
+        with(button_help) {
+            setOnClickListener {
+                // TODO: add tracking here when help is clicked
+                loginListener?.helpSiteAddress(siteAddress)
+            }
         }
-
-        return false
     }
 
     override fun onAttach(context: Context?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
@@ -16,7 +16,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.R.layout
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.di.GlideApp
-import com.woocommerce.android.ui.login.LoginJetpackRequiredFragment.LoginJetpackRequiredListener
 import com.woocommerce.android.widgets.WooClickableSpan
 import kotlinx.android.synthetic.main.fragment_login_no_jetpack.*
 import kotlinx.android.synthetic.main.view_login_epilogue_button_bar.*
@@ -53,7 +52,7 @@ class LoginNoJetpackFragment : Fragment() {
     }
 
     private var loginListener: LoginListener? = null
-    private var jetpackLoginListener: LoginJetpackRequiredListener? = null
+    private var jetpackLoginListener: LoginNoJetpackListener? = null
     private var siteAddress: String? = null
     private var siteXmlRpcAddress: String? = null
     private var mInputUsername: String? = null
@@ -153,7 +152,13 @@ class LoginNoJetpackFragment : Fragment() {
 
         // this will throw if parent activity doesn't implement the login listener interface
         loginListener = context as? LoginListener
-        jetpackLoginListener = context as? LoginJetpackRequiredListener
+        jetpackLoginListener = context as? LoginNoJetpackListener
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        loginListener = null
+        jetpackLoginListener = null
     }
 
     override fun onResume() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackListener.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackListener.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.ui.login
+
+interface LoginNoJetpackListener {
+    fun showJetpackInstructions()
+    fun showWhatIsJetpackDialog()
+    fun showEmailLoginScreen(siteAddress: String?)
+    fun showUsernamePasswordScreen(
+        siteAddress: String?,
+        endpointAddress: String?,
+        inputUsername: String?,
+        inputPassword: String?
+    )
+}

--- a/WooCommerce/src/main/res/layout/fragment_login_no_jetpack.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_no_jetpack.xml
@@ -5,8 +5,7 @@
     android:id="@+id/site_picker_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:visibility="visible">
+    android:orientation="vertical">
 
     <ScrollView
         android:layout_width="match_parent"
@@ -17,8 +16,7 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@color/wc_grey_light"
-            tools:visibility="visible">
+            android:background="@color/wc_grey_light">
 
             <Button
                 android:id="@+id/button_help"
@@ -46,6 +44,7 @@
                 android:layout_height="wrap_content"
                 android:textColor="@color/grey_dark"
                 android:textSize="@dimen/text_large"
+                android:gravity="center"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/text_displayname"
@@ -67,9 +66,7 @@
                 android:id="@+id/user_info_group"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:visibility="gone"
-                app:constraint_referenced_ids="image_avatar,text_displayname,text_username"
-                tools:visibility="visible" />
+                app:constraint_referenced_ids="image_avatar,text_displayname,text_username"/>
 
             <include layout="@layout/view_login_no_stores" />
 

--- a/WooCommerce/src/main/res/layout/fragment_login_no_jetpack.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_no_jetpack.xml
@@ -2,7 +2,6 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/site_picker_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -61,12 +60,6 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/image_avatar"
                 tools:text="droidtester2018" />
-
-            <androidx.constraintlayout.widget.Group
-                android:id="@+id/user_info_group"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:constraint_referenced_ids="image_avatar,text_displayname,text_username"/>
 
             <include layout="@layout/view_login_no_stores" />
 

--- a/WooCommerce/src/main/res/layout/fragment_login_no_jetpack.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_no_jetpack.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/site_picker_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:visibility="visible">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:fillViewport="true">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/wc_grey_light"
+            tools:visibility="visible">
+
+            <Button
+                android:id="@+id/button_help"
+                style="@style/Woo.Button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/help"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageView
+                android:id="@+id/image_avatar"
+                android:layout_width="@dimen/login_avatar_size"
+                android:layout_height="@dimen/login_avatar_size"
+                android:layout_marginTop="40dp"
+                android:contentDescription="@string/login_avatar_content_description"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:srcCompat="@drawable/ic_placeholder_gravatar_grey_lighten_20_100dp" />
+
+            <TextView
+                android:id="@+id/text_username"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/grey_dark"
+                android:textSize="@dimen/text_large"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/text_displayname"
+                tools:text="\@droidtester2018" />
+
+            <TextView
+                android:id="@+id/text_displayname"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_large"
+                android:textColor="@color/grey_dark"
+                android:textSize="@dimen/text_extra_large"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/image_avatar"
+                tools:text="droidtester2018" />
+
+            <androidx.constraintlayout.widget.Group
+                android:id="@+id/user_info_group"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                app:constraint_referenced_ids="image_avatar,text_displayname,text_username"
+                tools:visibility="visible" />
+
+            <include layout="@layout/view_login_no_stores" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
+
+    <View
+        android:id="@+id/view6"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/appbar_elevation"
+        android:background="@drawable/shadow_top" />
+
+    <include layout="@layout/view_login_epilogue_button_bar" />
+</LinearLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -100,6 +100,7 @@
     <string name="cant_open_url">Unable to open the link</string>
     <string name="already_logged_in_wpcom">You\'re already logged in a WordPress.com account, you can\'t add a WordPress.com site bound to another account.</string>
     <string name="at_username">\@%s</string>
+    <string name="login_no_jetpack_username">Signed in as \@1%s\nWrong account? %2$s</string>
     <string name="login_jetpack_required">This app requires Jetpack to connect to your store.</string>
     <string name="login">Log in</string>
     <string name="login_prologue_banner">Manage orders, track sales, and monitor store activity with real-time alerts.</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
     <string name="login_try_another_store">Try another store</string>
     <string name="login_not_woo_store">It looks like %1$s is not a WooCommerce site. Install the WooCommerce plugin on your site and then %2$s</string>
     <string name="login_not_connected_jetpack">To use this app for %1$s you\'ll need to have the Jetpack plugin setup and connected to this account. \n\nOnce setup, %2$s</string>
+    <string name="login_no_jetpack">To use this app for %1$s you\'ll need to have the Jetpack plugin setup and connected to a WordPress.com account</string>
     <string name="login_refresh_app">refresh the app</string>
     <string name="login_refresh_app_continue">refresh the app to continue</string>
     <string name="login_refresh_app_progress">Checking for WooCommerce...</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -494,7 +494,6 @@
     <string name="invalid_verification_code">Invalid verification code</string>
     <string name="send_link">Send link</string>
     <string name="enter_your_password_instead">Enter your password instead</string>
-    <string name="username" content_override="true">WordPress.com username</string>
     <string name="password">Password</string>
     <string name="log_in">Log In</string>
     <string name="login_promo_text_onthego">Publish from the park. Blog from the bus. Comment from the café. WordPress goes where you go.</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -72,6 +72,7 @@
     <string name="database_downgraded">Database downgraded, recreating tables and loading stores</string>
     <string name="button_not_now">Not now</string>
     <string name="unknown">Unknown</string>
+    <string name="try_again">Try again</string>
     <!--
         Date/Time Labels
     -->
@@ -125,6 +126,7 @@
     <string name="login_view_connected_stores">View connected stores</string>
     <string name="login_jetpack_required_msg">To use the WooCommerce app you’ll need to set up the Jetpack plugin on your site</string>
     <string name="login_jetpack_view_instructions">View instructions</string>
+    <string name="login_jetpack_view_setup_instructions">View setup instructions</string>
     <string name="login_jetpack_what_is">What is Jetpack?</string>
     <string name="login_jetpack_what_is_description">Jetpack is a free WordPress plugin that connects your store with the tools needed to give you the best mobile experience, including push notifications and stats</string>
     <string name="login_jetpack_installed_sign_in">Already have Jetpack? %1$s</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -100,7 +100,7 @@
     <string name="cant_open_url">Unable to open the link</string>
     <string name="already_logged_in_wpcom">You\'re already logged in a WordPress.com account, you can\'t add a WordPress.com site bound to another account.</string>
     <string name="at_username">\@%s</string>
-    <string name="login_no_jetpack_username">Signed in as \@1%s\nWrong account? %2$s</string>
+    <string name="login_no_jetpack_username">Signed in as \@%1$s\nWrong account? %2$s</string>
     <string name="login_jetpack_required">This app requires Jetpack to connect to your store.</string>
     <string name="login">Log in</string>
     <string name="login_prologue_banner">Manage orders, track sales, and monitor store activity with real-time alerts.</string>

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseDiscoveryFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseDiscoveryFragment.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Intent;
 
 import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentManager;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -63,7 +64,10 @@ public abstract class LoginBaseDiscoveryFragment extends LoginBaseFormFragment<L
     private void askForHttpAuthCredentials(@NonNull final String url) {
         LoginHttpAuthDialogFragment loginHttpAuthDialogFragment = LoginHttpAuthDialogFragment.newInstance(url);
         loginHttpAuthDialogFragment.setTargetFragment(this, LoginHttpAuthDialogFragment.DO_HTTP_AUTH);
-        loginHttpAuthDialogFragment.show(getFragmentManager(), LoginHttpAuthDialogFragment.TAG);
+        FragmentManager fragmentManager = getFragmentManager();
+        if (fragmentManager != null) {
+            loginHttpAuthDialogFragment.show(getFragmentManager(), LoginHttpAuthDialogFragment.TAG);
+        }
     }
 
     @SuppressWarnings("unused")

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseDiscoveryFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseDiscoveryFragment.java
@@ -1,0 +1,143 @@
+package org.wordpress.android.login;
+
+import android.app.Activity;
+import android.content.Intent;
+
+import androidx.annotation.NonNull;
+
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
+import org.wordpress.android.fluxc.network.HTTPAuthManager;
+import org.wordpress.android.fluxc.network.MemorizingTrustManager;
+import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder.DiscoveryError;
+import org.wordpress.android.fluxc.store.AccountStore.OnDiscoveryResponse;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.NetworkUtils;
+
+import javax.inject.Inject;
+
+public abstract class LoginBaseDiscoveryFragment extends LoginBaseFormFragment<LoginListener> {
+    @Inject HTTPAuthManager mHTTPAuthManager;
+    @Inject MemorizingTrustManager mMemorizingTrustManager;
+
+    LoginBaseDiscoveryListener mLoginBaseDiscoveryListener;
+
+    public interface LoginBaseDiscoveryListener {
+        String getRequestedSiteAddress();
+        void showDiscoveryError(int messageId);
+        void handleWpComDiscoveryError(String failedEndpoint);
+        void handleDiscoverySuccess(String endpointAddress);
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        mLoginBaseDiscoveryListener = null;
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (requestCode == LoginHttpAuthDialogFragment.DO_HTTP_AUTH && resultCode == Activity.RESULT_OK) {
+            String url = data.getStringExtra(LoginHttpAuthDialogFragment.ARG_URL);
+            String httpUsername = data.getStringExtra(LoginHttpAuthDialogFragment.ARG_USERNAME);
+            String httpPassword = data.getStringExtra(LoginHttpAuthDialogFragment.ARG_PASSWORD);
+            mHTTPAuthManager.addHTTPAuthCredentials(httpUsername, httpPassword, url, null);
+            initiateDiscovery();
+        }
+    }
+
+    void initiateDiscovery() {
+        if (!NetworkUtils.checkConnection(getActivity())) {
+            return;
+        }
+
+        // Start the discovery process
+        mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(
+                mLoginBaseDiscoveryListener.getRequestedSiteAddress()));
+    }
+
+    private void askForHttpAuthCredentials(@NonNull final String url) {
+        LoginHttpAuthDialogFragment loginHttpAuthDialogFragment = LoginHttpAuthDialogFragment.newInstance(url);
+        loginHttpAuthDialogFragment.setTargetFragment(this, LoginHttpAuthDialogFragment.DO_HTTP_AUTH);
+        loginHttpAuthDialogFragment.show(getFragmentManager(), LoginHttpAuthDialogFragment.TAG);
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onDiscoverySucceeded(OnDiscoveryResponse event) {
+        // hold the URL in a variable to use below otherwise it gets cleared up by endProgress
+        // bail if user canceled
+        String mRequestedSiteAddress = mLoginBaseDiscoveryListener.getRequestedSiteAddress();
+        if (mRequestedSiteAddress == null) {
+            return;
+        }
+
+        if (!isAdded()) {
+            return;
+        }
+
+        if (event.isError()) {
+            if (isInProgress()) {
+                endProgress();
+            }
+
+            mAnalyticsListener.trackLoginFailed(event.getClass().getSimpleName(),
+                    event.error.name(), event.error.toString());
+
+            AppLog.e(T.API, "onDiscoveryResponse has error: " + event.error.name()
+                            + " - " + event.error.toString());
+            handleDiscoveryError(event.error, event.failedEndpoint);
+            return;
+        }
+
+        AppLog.i(T.NUX, "Discovery succeeded, endpoint: " + event.xmlRpcEndpoint);
+        mLoginBaseDiscoveryListener.handleDiscoverySuccess(event.xmlRpcEndpoint);
+    }
+
+    private void handleDiscoveryError(DiscoveryError error, final String failedEndpoint) {
+        switch (error) {
+            case ERRONEOUS_SSL_CERTIFICATE:
+                mLoginListener.handleSslCertificateError(mMemorizingTrustManager,
+                        new LoginListener.SelfSignedSSLCallback() {
+                            @Override
+                            public void certificateTrusted() {
+                                if (failedEndpoint == null) {
+                                    return;
+                                }
+                                // retry site lookup
+                                initiateDiscovery();
+                            }
+                        });
+                break;
+            case HTTP_AUTH_REQUIRED:
+                askForHttpAuthCredentials(failedEndpoint);
+                break;
+            case NO_SITE_ERROR:
+                mLoginBaseDiscoveryListener.showDiscoveryError(R.string.no_site_error);
+                break;
+            case INVALID_URL:
+                mLoginBaseDiscoveryListener.showDiscoveryError(R.string.invalid_site_url_message);
+                mAnalyticsListener.trackInsertedInvalidUrl();
+                break;
+            case MISSING_XMLRPC_METHOD:
+                mLoginBaseDiscoveryListener.showDiscoveryError(R.string.xmlrpc_missing_method_error);
+                break;
+            case XMLRPC_BLOCKED:
+                mLoginBaseDiscoveryListener.showDiscoveryError(R.string.xmlrpc_post_blocked_error);
+                break;
+            case XMLRPC_FORBIDDEN:
+                mLoginBaseDiscoveryListener.showDiscoveryError(R.string.xmlrpc_endpoint_forbidden_error);
+                break;
+            case GENERIC_ERROR:
+                mLoginBaseDiscoveryListener.showDiscoveryError(R.string.error_generic);
+                break;
+            case WORDPRESS_COM_SITE:
+                mLoginBaseDiscoveryListener.handleWpComDiscoveryError(failedEndpoint);
+                break;
+        }
+    }
+}

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -185,7 +185,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
                     if (loginMode == LoginMode.JETPACK_STATS) {
                         mLoginListener.loginViaWpcomUsernameInstead();
                     } else if (loginMode == LoginMode.WOO_LOGIN_MODE) {
-                        mLoginListener.gotXmlRpcEndpoint(mLoginSiteUrl, null);
+                        mLoginListener.loginViaSiteCredentials(mLoginSiteUrl);
                     } else {
                         mLoginListener.loginViaSiteAddress();
                     }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -187,8 +187,11 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
                 @Override
                 public void onClick(View view) {
                     if (mLoginListener != null) {
-                        if (mLoginListener.getLoginMode() == LoginMode.JETPACK_STATS) {
+                        LoginMode loginMode = mLoginListener.getLoginMode();
+                        if (loginMode == LoginMode.JETPACK_STATS) {
                             mLoginListener.loginViaWpcomUsernameInstead();
+                        } else if (loginMode == LoginMode.WOO_LOGIN_MODE) {
+                            // TODO: add logic to login via self hosted credentials
                         } else {
                             mLoginListener.loginViaSiteAddress();
                         }
@@ -201,9 +204,12 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
         TextView siteLoginButtonText = rootView.findViewById(R.id.login_site_button_text);
 
         switch (mLoginListener.getLoginMode()) {
+            case WOO_LOGIN_MODE:
+                siteLoginButtonIcon.setImageResource(R.drawable.ic_domains_grey_24dp);
+                siteLoginButtonText.setText(R.string.enter_site_credentials_instead);
+                break;
             case FULL:
             case WPCOM_LOGIN_ONLY:
-            case WOO_LOGIN_MODE:
             case SHARE_INTENT:
                 siteLoginButtonIcon.setImageResource(R.drawable.ic_domains_grey_24dp);
                 siteLoginButtonText.setText(R.string.enter_site_address_instead);

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -69,7 +69,6 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     private static final int EMAIL_CREDENTIALS_REQUEST_CODE = 25100;
 
     private static final String ARG_LOGIN_SITE_URL = "ARG_LOGIN_SITE_URL";
-    private static final String ARG_LOGIN_SITE_XMLRPC_URL = "ARG_LOGIN_SITE_XMLRPC_URL";
 
     public static final String TAG = "login_email_fragment_tag";
     public static final int MAX_EMAIL_LENGTH = 100;
@@ -84,13 +83,11 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     protected boolean mHasDismissedEmailHints;
     protected boolean mIsDisplayingEmailHints;
     protected String mLoginSiteUrl;
-    protected String mLoginSiteXmlRpcUrl;
 
-    public static LoginEmailFragment newInstance(String url, String endpointAddress) {
+    public static LoginEmailFragment newInstance(String url) {
         LoginEmailFragment fragment = new LoginEmailFragment();
         Bundle args = new Bundle();
         args.putString(ARG_LOGIN_SITE_URL, url);
-        args.putString(ARG_LOGIN_SITE_XMLRPC_URL, endpointAddress);
         fragment.setArguments(args);
         return fragment;
     }
@@ -188,11 +185,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
                     if (loginMode == LoginMode.JETPACK_STATS) {
                         mLoginListener.loginViaWpcomUsernameInstead();
                     } else if (loginMode == LoginMode.WOO_LOGIN_MODE) {
-                        if (mLoginSiteXmlRpcUrl == null || mLoginSiteXmlRpcUrl.isEmpty()) {
-                            mLoginListener.loginViaWpcomUsernameInstead();
-                        } else {
-                            mLoginListener.gotXmlRpcEndpoint(mLoginSiteUrl, mLoginSiteXmlRpcUrl);
-                        }
+                        mLoginListener.gotXmlRpcEndpoint(mLoginSiteUrl, null);
                     } else {
                         mLoginListener.loginViaSiteAddress();
                     }
@@ -284,7 +277,6 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
         Bundle args = getArguments();
         if (args != null) {
             mLoginSiteUrl = args.getString(ARG_LOGIN_SITE_URL, "");
-            mLoginSiteXmlRpcUrl = args.getString(ARG_LOGIN_SITE_XMLRPC_URL, "");
         }
     }
 

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -60,6 +60,8 @@ public interface LoginListener {
                                     @NonNull String displayName, @Nullable Uri profilePicture);
     void loggedInViaUsernamePassword(ArrayList<Integer> oldSitesIds);
     void helpUsernamePassword(String url, String username, boolean isWpcom);
+    void helpNoJetpackScreen(String siteAddress, String endpointAddress, String username,
+                             String password, String userAvatarUrl);
 
     // Login 2FA screen callbacks
     void help2FaScreen(String email);

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -48,8 +48,7 @@ public interface LoginListener {
     // Login Site Address input callbacks
     void alreadyLoggedInWpcom(ArrayList<Integer> oldSitesIds);
     void gotWpcomSiteInfo(String siteAddress, String siteName, String siteIconUrl);
-    void gotConnectedSiteInfo(@NonNull String siteAddress, @Nullable String redirectUrl,
-                              @Nullable String endpointAddress, boolean hasJetpack);
+    void gotConnectedSiteInfo(@NonNull String siteAddress, @Nullable String redirectUrl, boolean hasJetpack);
     void gotXmlRpcEndpoint(String inputSiteAddress, String endpointAddress);
     void handleSslCertificateError(MemorizingTrustManager memorizingTrustManager, SelfSignedSSLCallback callback);
     void helpSiteAddress(String url);

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -23,6 +23,7 @@ public interface LoginListener {
     void loginViaSocialAccount(String email, String idToken, String service, boolean isPasswordRequired);
     void loggedInViaSocialAccount(ArrayList<Integer> oldSiteIds, boolean doLoginUpdate);
     void loginViaWpcomUsernameInstead();
+    void loginViaSiteCredentials(String inputSiteAddress);
     void helpEmailScreen(String email);
     void helpSocialEmailScreen(String email);
     void addGoogleLoginFragment();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -48,9 +48,9 @@ public interface LoginListener {
     // Login Site Address input callbacks
     void alreadyLoggedInWpcom(ArrayList<Integer> oldSitesIds);
     void gotWpcomSiteInfo(String siteAddress, String siteName, String siteIconUrl);
-    void gotConnectedSiteInfo(@NonNull String siteAddress, @Nullable String redirectUrl, boolean hasJetpack);
+    void gotConnectedSiteInfo(@NonNull String siteAddress, @Nullable String redirectUrl,
+                              @Nullable String endpointAddress, boolean hasJetpack);
     void gotXmlRpcEndpoint(String inputSiteAddress, String endpointAddress);
-    void gotXmlRpcEndpoint(String inputSiteAddress, String endpointAddress, boolean hasJetpack);
     void handleSslCertificateError(MemorizingTrustManager memorizingTrustManager, SelfSignedSSLCallback callback);
     void helpSiteAddress(String url);
     void helpFindingSiteAddress(String username, SiteStore siteStore);

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -50,6 +50,7 @@ public interface LoginListener {
     void gotWpcomSiteInfo(String siteAddress, String siteName, String siteIconUrl);
     void gotConnectedSiteInfo(@NonNull String siteAddress, @Nullable String redirectUrl, boolean hasJetpack);
     void gotXmlRpcEndpoint(String inputSiteAddress, String endpointAddress);
+    void gotXmlRpcEndpoint(String inputSiteAddress, String endpointAddress, boolean hasJetpack);
     void handleSslCertificateError(MemorizingTrustManager memorizingTrustManager, SelfSignedSSLCallback callback);
     void helpSiteAddress(String url);
     void helpFindingSiteAddress(String username, SiteStore siteStore);

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -374,7 +374,7 @@ public class LoginSiteAddressFragment extends LoginBaseFormFragment<LoginListene
                     mLoginListener.alreadyLoggedInWpcom(oldSitesIDs);
                 } else if (mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE) {
                     // Woo login: if jetpack is not installed/active/connected, redirect to Jetpack required
-                    mLoginListener.gotXmlRpcEndpoint(event.failedEndpoint, null, mHasJetpack);
+                    mLoginListener.gotConnectedSiteInfo(event.failedEndpoint, null, null, mHasJetpack);
                 } else {
                     mLoginListener.gotWpcomSiteInfo(event.failedEndpoint, null, null);
                 }
@@ -392,7 +392,7 @@ public class LoginSiteAddressFragment extends LoginBaseFormFragment<LoginListene
 
         // Woo login: if jetpack is not installed/active/connected, redirect to Jetpack required
         if (mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE) {
-            mLoginListener.gotXmlRpcEndpoint(requestedSiteAddress, event.xmlRpcEndpoint, mHasJetpack);
+            mLoginListener.gotConnectedSiteInfo(requestedSiteAddress, null, event.xmlRpcEndpoint, mHasJetpack);
             return;
         }
 
@@ -462,6 +462,7 @@ public class LoginSiteAddressFragment extends LoginBaseFormFragment<LoginListene
                 mLoginListener.gotConnectedSiteInfo(
                         event.info.url,
                         event.info.urlAfterRedirects,
+                        null,
                         hasJetpack);
             }
         }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -317,6 +317,8 @@ public class LoginSiteAddressFragment extends LoginBaseFormFragment<LoginListene
             // Woo Login: verify if Jetpack is installed/active/connected
             if (mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE) {
                 mHasJetpack = event.site.isJetpackInstalled() && event.site.isJetpackConnected();
+                mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(mRequestedSiteAddress));
+                return;
             }
 
             if (event.site.isJetpackInstalled() && mLoginListener.getLoginMode() != LoginMode.WPCOM_LOGIN_ONLY) {
@@ -328,12 +330,6 @@ public class LoginSiteAddressFragment extends LoginBaseFormFragment<LoginListene
             }
 
             endProgress();
-
-            // Woo login: if jetpack is not installed/active/connected, redirect to Jetpack required
-            if (mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE) {
-                mLoginListener.gotConnectedSiteInfo(event.site.getUrl(), null, mHasJetpack);
-                return;
-            }
 
             // it's a wp.com site so, treat it as such.
             mLoginListener.gotWpcomSiteInfo(
@@ -396,7 +392,7 @@ public class LoginSiteAddressFragment extends LoginBaseFormFragment<LoginListene
 
         // Woo login: if jetpack is not installed/active/connected, redirect to Jetpack required
         if (mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE) {
-            mLoginListener.gotConnectedSiteInfo(requestedSiteAddress, null, mHasJetpack);
+            mLoginListener.gotConnectedSiteInfo(requestedSiteAddress, event.xmlRpcEndpoint, mHasJetpack);
             return;
         }
 

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -374,7 +374,7 @@ public class LoginSiteAddressFragment extends LoginBaseFormFragment<LoginListene
                     mLoginListener.alreadyLoggedInWpcom(oldSitesIDs);
                 } else if (mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE) {
                     // Woo login: if jetpack is not installed/active/connected, redirect to Jetpack required
-                    mLoginListener.gotConnectedSiteInfo(event.failedEndpoint, null, mHasJetpack);
+                    mLoginListener.gotXmlRpcEndpoint(event.failedEndpoint, null, mHasJetpack);
                 } else {
                     mLoginListener.gotWpcomSiteInfo(event.failedEndpoint, null, null);
                 }
@@ -392,7 +392,7 @@ public class LoginSiteAddressFragment extends LoginBaseFormFragment<LoginListene
 
         // Woo login: if jetpack is not installed/active/connected, redirect to Jetpack required
         if (mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE) {
-            mLoginListener.gotConnectedSiteInfo(requestedSiteAddress, event.xmlRpcEndpoint, mHasJetpack);
+            mLoginListener.gotXmlRpcEndpoint(requestedSiteAddress, event.xmlRpcEndpoint, mHasJetpack);
             return;
         }
 

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -152,7 +152,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseDiscoveryFragment im
         siteAddressView.setVisibility(mInputSiteAddress != null ? View.VISIBLE : View.GONE);
 
         String inputSiteAddressWithoutProtocol = UrlUtils.removeScheme(mInputSiteAddress);
-        mInputSiteAddressWithoutSuffix = mEndpointAddress.isEmpty()
+        mInputSiteAddressWithoutSuffix = (mEndpointAddress == null || mEndpointAddress.isEmpty())
                 ? inputSiteAddressWithoutProtocol : UrlUtils.removeXmlrpcSuffix(mEndpointAddress);
 
         mUsernameInput = rootView.findViewById(R.id.login_username_row);
@@ -224,7 +224,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseDiscoveryFragment im
         super.onCreate(savedInstanceState);
 
         mInputSiteAddress = getArguments().getString(ARG_INPUT_SITE_ADDRESS);
-        mEndpointAddress = getArguments().getString(ARG_ENDPOINT_ADDRESS, "");
+        mEndpointAddress = getArguments().getString(ARG_ENDPOINT_ADDRESS, null);
         mSiteName = getArguments().getString(ARG_SITE_NAME);
         mSiteIconUrl = getArguments().getString(ARG_SITE_ICON_URL);
         mInputUsername = getArguments().getString(ARG_INPUT_USERNAME);
@@ -569,7 +569,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseDiscoveryFragment im
                                 lastAddedXMLRPCSite.getXmlRpcUrl(), lastAddedXMLRPCSite.getUsername(),
                                 lastAddedXMLRPCSite.getPassword(), mAccountStore.getAccount().getAvatarUrl());
                     } else {
-                        mLoginListener.gotWpcomEmail(lastAddedXMLRPCSite.getJetpackUserEmail());
+                        mLoginListener.gotWpcomEmail(userEmail);
                     }
                 } else {
                     // Initiate the wp.getOptions endpoint to fetch the jetpack user email

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -150,6 +150,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
         siteAddressView.setText(UrlUtils.removeScheme(UrlUtils.removeXmlrpcSuffix(mInputSiteAddress)));
         siteAddressView.setVisibility(mInputSiteAddress != null ? View.VISIBLE : View.GONE);
 
+        // TODO: mEndpointAddress is null since discovery process has not yet taken place for the Woo APP
         mInputSiteAddressWithoutSuffix = UrlUtils.removeXmlrpcSuffix(mEndpointAddress);
 
         mUsernameInput = rootView.findViewById(R.id.login_username_row);
@@ -221,7 +222,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
         super.onCreate(savedInstanceState);
 
         mInputSiteAddress = getArguments().getString(ARG_INPUT_SITE_ADDRESS);
-        mEndpointAddress = getArguments().getString(ARG_ENDPOINT_ADDRESS);
+        mEndpointAddress = getArguments().getString(ARG_ENDPOINT_ADDRESS, "");
         mSiteName = getArguments().getString(ARG_SITE_NAME);
         mSiteIconUrl = getArguments().getString(ARG_SITE_ICON_URL);
         mInputUsername = getArguments().getString(ARG_INPUT_USERNAME);

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -379,14 +379,6 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
         return null;
     }
 
-    private @Nullable SiteModel getLastAddedXMLRPCSite() {
-        List<SiteModel> selfhostedSites = mSiteStore.getSitesAccessedViaXMLRPC();
-        if (selfhostedSites != null && !selfhostedSites.isEmpty()) {
-            return selfhostedSites.get(selfhostedSites.size() - 1);
-        }
-        return null;
-    }
-
     @Override
     protected void endProgress() {
         super.endProgress();
@@ -527,7 +519,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
         }
 
         if (mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE) {
-            SiteModel lastAddedXMLRPCSite = getLastAddedXMLRPCSite();
+            SiteModel lastAddedXMLRPCSite = SiteUtils.getXMLRPCSiteByUrl(mSiteStore, mInputSiteAddress);
             if (lastAddedXMLRPCSite != null) {
                 // the wp.getOptions endpoint is already called
                 // verify if jetpack user email is available.

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -115,7 +115,9 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
 
     @Override
     protected void setupLabel(@NonNull TextView label) {
-        // no label in this screen
+        if (mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE) {
+            label.setText(getString(R.string.enter_credentials_for_site, mInputSiteAddress));
+        }
     }
 
     @Override
@@ -127,6 +129,8 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
         rootView.findViewById(R.id.login_site_title_static).setVisibility(mIsWpcom ? View.GONE : View.VISIBLE);
         rootView.findViewById(R.id.login_blavatar_static).setVisibility(mIsWpcom ? View.GONE : View.VISIBLE);
         rootView.findViewById(R.id.login_blavatar).setVisibility(mIsWpcom ? View.VISIBLE : View.GONE);
+        rootView.findViewById(R.id.label).setVisibility(
+                (mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE) ? View.VISIBLE : View.GONE);
 
         if (mSiteIconUrl != null) {
             Glide.with(this)

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -154,7 +154,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
 
         mUsernameInput = rootView.findViewById(R.id.login_username_row);
         mUsernameInput.setText(mInputUsername);
-        if (BuildConfig.DEBUG) {
+        if (BuildConfig.DEBUG && mInputUsername == null) {
             mUsernameInput.getEditText().setText(BuildConfig.DEBUG_WPCOM_LOGIN_USERNAME);
         }
         mUsernameInput.addTextChangedListener(this);
@@ -168,7 +168,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
 
         mPasswordInput = rootView.findViewById(R.id.login_password_row);
         mPasswordInput.setText(mInputPassword);
-        if (BuildConfig.DEBUG) {
+        if (BuildConfig.DEBUG && mInputPassword == null) {
             mPasswordInput.getEditText().setText(BuildConfig.DEBUG_WPCOM_LOGIN_PASSWORD);
         }
         mPasswordInput.addTextChangedListener(this);
@@ -535,8 +535,11 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
                 if (mGetSiteOptionsInitiated) {
                     endProgress();
                     mGetSiteOptionsInitiated = false;
-                    if (lastAddedXMLRPCSite.getJetpackUserEmail() == null) {
-                        // TODO: redirect to jetpack required screen
+                    String userEmail = lastAddedXMLRPCSite.getJetpackUserEmail();
+                    if (userEmail == null || userEmail.isEmpty()) {
+                        mLoginListener.helpNoJetpackScreen(lastAddedXMLRPCSite.getUrl(),
+                                lastAddedXMLRPCSite.getXmlRpcUrl(), lastAddedXMLRPCSite.getUsername(),
+                                lastAddedXMLRPCSite.getPassword(), mAccountStore.getAccount().getAvatarUrl());
                     } else {
                         mLoginListener.gotWpcomEmail(lastAddedXMLRPCSite.getJetpackUserEmail());
                     }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -355,8 +355,8 @@ public class LoginUsernamePasswordFragment extends LoginBaseDiscoveryFragment im
 
     @Override
     public void handleWpComDiscoveryError(String failedEndpoint) {
-        // Used only by wp-android as Woo already uses the Connect-Inf-url to check
-        // if site is a wp.com site
+        AppLog.e(T.API, "Inputted a wpcom address in site address screen. Redirecting to Email screen");
+        mLoginListener.gotWpcomSiteInfo(UrlUtils.removeScheme(failedEndpoint), null, null);
     }
 
     @Override

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -150,8 +150,9 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
         siteAddressView.setText(UrlUtils.removeScheme(UrlUtils.removeXmlrpcSuffix(mInputSiteAddress)));
         siteAddressView.setVisibility(mInputSiteAddress != null ? View.VISIBLE : View.GONE);
 
-        // TODO: mEndpointAddress is null since discovery process has not yet taken place for the Woo APP
-        mInputSiteAddressWithoutSuffix = UrlUtils.removeXmlrpcSuffix(mEndpointAddress);
+        String inputSiteAddressWithoutProtocol = UrlUtils.removeScheme(mInputSiteAddress);
+        mInputSiteAddressWithoutSuffix = mEndpointAddress.isEmpty()
+                ? inputSiteAddressWithoutProtocol : UrlUtils.removeXmlrpcSuffix(mEndpointAddress);
 
         mUsernameInput = rootView.findViewById(R.id.login_username_row);
         mUsernameInput.setText(mInputUsername);

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -37,6 +37,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 import org.wordpress.android.login.util.SiteUtils;
 import org.wordpress.android.login.widgets.WPLoginInputRow;
 import org.wordpress.android.login.widgets.WPLoginInputRow.OnEditorCommitListener;
+import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.EditTextUtils;
@@ -562,6 +563,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseDiscoveryFragment im
                     endProgress();
                     mGetSiteOptionsInitiated = false;
                     String userEmail = lastAddedXMLRPCSite.getJetpackUserEmail();
+                    ActivityUtils.hideKeyboard(getActivity());
                     if (userEmail == null || userEmail.isEmpty()) {
                         mLoginListener.helpNoJetpackScreen(lastAddedXMLRPCSite.getUrl(),
                                 lastAddedXMLRPCSite.getXmlRpcUrl(), lastAddedXMLRPCSite.getUsername(),

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/util/SiteUtils.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/util/SiteUtils.java
@@ -1,7 +1,10 @@
 package org.wordpress.android.login.util;
 
+import androidx.annotation.Nullable;
+
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.util.UrlUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,5 +18,20 @@ public class SiteUtils {
         }
 
         return siteIDs;
+    }
+
+    @Nullable
+    public static SiteModel getXMLRPCSiteByUrl(SiteStore siteStore, String url) {
+        List<SiteModel> selfhostedSites = siteStore.getSitesAccessedViaXMLRPC();
+        if (selfhostedSites != null && !selfhostedSites.isEmpty()) {
+            for (SiteModel siteModel : selfhostedSites) {
+                String storedSiteUrl = UrlUtils.removeScheme(siteModel.getUrl()).replace("/", "");
+                String incomingSiteUrl = UrlUtils.removeScheme(url).replace("/", "");
+                if (storedSiteUrl.equalsIgnoreCase(incomingSiteUrl)) {
+                    return siteModel;
+                }
+            }
+        }
+        return null;
     }
 }

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/login_username_password_screen.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/login_username_password_screen.xml
@@ -11,6 +11,18 @@
     android:paddingEnd="@dimen/margin_extra_large"
     android:layout_marginBottom="@dimen/margin_extra_large">
 
+    <TextView
+        style="@style/LoginTheme.TextLabel"
+        android:id="@+id/label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_extra_large"
+        android:textAlignment="viewStart"
+        android:gravity="start"
+        android:visibility="gone"
+        android:layout_marginBottom="@dimen/margin_extra_large"
+        tools:text="@string/enter_credentials_for_site" />
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="open_mail">Open mail</string>
     <string name="alternatively">Alternatively:</string>
     <string name="enter_site_address_instead">Log in by entering your site address.</string>
+    <string name="enter_site_credentials_instead">Log in with site credentials</string>
     <string name="enter_username_instead">Log in with your username.</string>
     <string name="enter_verification_code">Almost there! Please enter the verification code from your Authenticator app.</string>
     <string name="enter_verification_code_sms">We sent a text message to the phone number ending in %s. Please enter the verification code in the SMS.</string>

--- a/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="login_promo_text_jetpack">Manage your Jetpack-powered site on the go — you\'ve got WordPress in your pocket.</string>
     <string name="enter_email_wordpress_com">Log in to WordPress.com using an email address to manage all your WordPress sites.</string>
     <string name="enter_email_for_site">Log in with WordPress.com to connect to %1$s</string>
+    <string name="enter_credentials_for_site">Log in with your %1$s site credentials</string>
     <string name="next">Next</string>
     <string name="open_mail">Open mail</string>
     <string name="alternatively">Alternatively:</string>


### PR DESCRIPTION
Partially fixes #1482. This PR completes the first step of the Jetpack sign in with self credentials as defined in the master thread. 

### Changes
- ~~Revert existing logic of validating site url from `FETCH_CONNECT_SITE_INFO` endpoint and use the `FETCH_WPCOM_SITE_BY_URL` endpoint and initiate the discovery process.~~ Since using the discovery endpoint to validate the site would interfere with the existing logic of logging in using wp.com credentials, I've moved the discovery process to initiate only when the user enters their username + password in the `LoginUsernamePasswordFragment`.
- Added a new button to `LoginEmailFragment`: `Login via site credentials`.
- Design changes:
  - Added label to the top of the `LoginUsernamePasswordFragment`.
  - Change hint text of `username` in `LoginUsernamePasswordFragment`.
- When site credentials are clicked:
  - Initialise the discovery process which will let us know if the XMLRPC endpoint is supported by the site. **Note that the error handling during the discovery process will take place in another PR.**
   - If jetpack is installed/active/connected: call the `wp.getOptions` endpoint to fetch the `jetpack_user_email` and store in `SiteModel` and redirect to the request magic link screen.
   - If jetpack NOT installed/active/connected: Redirect to a new fragment called `LoginNoJetpackFragment`. 


### Notes:
- This PR handles only the redirection to the magic link login. The design changes required in the magic link login will take place in another PR.
- Since this PR adds logic to initiate the discovery process, there are new error messages and error scenarios that need to be incorporated. This will likely take place in another PR.
- ~Since this PR removes the logic to validate site address using the `FETCH_CONNECT_SITE_INFO` endpoint, there are some events that will likely be invalidated once this feature is merged.~
   - `LOGIN_CONNECTED_SITE_INFO_FAILED`
   - `LOGIN_CONNECTED_SITE_INFO_SUCCEEDED` 
- The are TODO's added to the PR to add events to the button clicks. This will take place in another PR.
- Note that this PR is to be merged to a feature branch. 


### Deviations from design:
- The username hint in `LoginUsernamePasswordFragment` is set to just `Username` rather than just `Username or Email` because there is no option to pass email address via the API, just the username.

### Behaviour
(LEFT: Login with self hosted site with Jetpack . RIGHT: Login with self hosted site without Jetpack)
<img width="300" src="https://user-images.githubusercontent.com/22608780/67195788-3c9f2a80-f417-11e9-97ba-7fb73e6e826a.gif"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/67195794-3f018480-f417-11e9-8897-8afac854b4a2.gif">

##### Entering a non existent site:
<img width="300" src="https://user-images.githubusercontent.com/22608780/67195997-a4ee0c00-f417-11e9-9e75-c3da2669b6ad.gif">

#### Testing
- Verify that existing flow works as expected.
- Enter a non existent site and verify that an error message is displayed.
- Enter a non jetpack site and verify that Jetpack required screen is displayed.
  - Click on `Sign in` at the bottom of the screen.
  - Verify that the Email screen is displayed. Click on `Login with site credentials`.
  - Enter username + password and click on `Next`.
  - Verify that you are redirected to Jetpack needed screen.
  - Install, activate and connect Jetpack on your test site while in the app.
  - Click on `Refresh the app` link. Notice that you are redirected to the Site credentials screen.
  - Click on `Next` and verify that you are redirected to the Magic link sign in screen.
- Enter a jetpack site and verify that you are redirect to the email screen.
  - Click on `Login with site credentials`.
  - Enter username + password and click on `Next` and verify that you are redirected to the Magic link sign in screen.
  

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
