### PR TITLE
Release/2.9 - Order list redesign bug fixes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -433,6 +433,11 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
     override fun refreshFragmentState() {
         if (isActive) {
             refreshOrders()
+        } else {
+            // refresh order status options in the background even when order list is hidden
+            // This is so that when an order status change takes place, we need to refresh the order
+            // status count in the local cache
+            refreshOrderStatusOptions()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -725,7 +725,6 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
 
     /**
      * Method called when user clicks on the back button after selecting an order status.
-     * The order list for the currently displayed tab should be refreshed only if [isFilterEnabled] is true
      * 1. Hide the order status view
      * 2. Enable search again and update the hint query
      */
@@ -741,7 +740,6 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
             val tabPosition = getTabPosition()
             orderStatusFilter = tab_layout.getTabAt(tabPosition)?.let { getOrderStatusByTab(it) }
 
-            presenter.loadOrders(orderStatusFilter, forceRefresh = true)
             (activity as? MainActivity)?.hideBottomNav()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -636,6 +636,7 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
             disableSearchListeners()
             updateActivityTitle()
             searchMenuItem?.collapseActionView()
+            isRefreshing = true
             presenter.loadOrders(orderStatusFilter, forceRefresh = true)
         }
     }
@@ -738,7 +739,10 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
             searchView?.queryHint = getString(R.string.orderlist_search_hint)
 
             val tabPosition = getTabPosition()
-            orderStatusFilter = tab_layout.getTabAt(tabPosition)?.let { getOrderStatusByTab(it) }
+            orderStatusFilter = tab_layout.getTabAt(tabPosition)?.let {
+                it.select()
+                getOrderStatusByTab(it)
+            }
 
             (activity as? MainActivity)?.hideBottomNav()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -677,6 +677,7 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
         hideOrderStatusListView()
         showTabs(true)
         (activity as? MainActivity)?.showBottomNav()
+        enableToolbarElevation(false)
     }
 
     /**
@@ -693,6 +694,7 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
         displayOrderStatusListView()
         order_status_list_view.updateOrderStatusListView(presenter.getOrderStatusList())
         (activity as? MainActivity)?.hideBottomNav()
+        enableToolbarElevation(true)
     }
 
     /**
@@ -747,13 +749,11 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
     private fun displayOrderStatusListView() {
         order_status_list_view.visibility = View.VISIBLE
         orderRefreshLayout.isEnabled = false
-        enableToolbarElevation(true)
     }
 
     private fun hideOrderStatusListView() {
         order_status_list_view.visibility = View.GONE
         orderRefreshLayout.isEnabled = true
-        enableToolbarElevation(false)
     }
 
     private fun checkOrientation() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListPresenter.kt
@@ -293,9 +293,10 @@ class OrderListPresenter @Inject constructor(
     override fun fetchAndLoadOrdersFromDb(orderStatusFilter: String?, isForceRefresh: Boolean, isFirstRun: Boolean) {
         val orders = fetchOrdersFromDb(orderStatusFilter, isForceRefresh)
         orderView?.let { view ->
+            // if the order list is empty, hide the empty view before displaying new orders
+            orderView?.showEmptyView(false)
             val currentOrders = removeFutureOrders(orders)
             if (currentOrders.count() > 0) {
-                view.showEmptyView(false)
                 view.showOrders(currentOrders, orderStatusFilter, isForceRefresh)
 
                 // load shipment tracking providers list only if order list is fetched and displayed.

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenterTest.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.NotificationStore
 import org.wordpress.android.fluxc.store.WCOrderStore
@@ -38,7 +39,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.OrderError
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderStatusPayload
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCRefundStore
-import org.wordpress.android.fluxc.store.WCRefundStore.RefundResult
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -81,7 +81,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Displays the order detail view correctly`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         presenter.takeView(orderDetailView)
         doReturn(order).whenever(orderStore).getOrderByIdentifier(any())
@@ -91,7 +91,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Displays the order notes view correctly`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         // Presenter should dispatch FETCH_ORDER_NOTES once order detail is fetched
         // from the order store
@@ -110,7 +110,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Display error message on fetch order notes error`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         presenter.takeView(orderDetailView)
         doReturn(order).whenever(orderStore).getOrderByIdentifier(any())
@@ -129,7 +129,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Mark order complete - Displays undo snackbar correctly`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         presenter.takeView(orderDetailView)
         doReturn(order).whenever(orderStore).getOrderByIdentifier(any())
@@ -141,7 +141,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Mark order complete - Processes success correctly`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         doReturn(order).whenever(presenter).orderModel
         doReturn(order).whenever(orderStore).getOrderByIdentifier(any())
@@ -158,7 +158,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Display error message on mark order complete error`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         doReturn(order).whenever(presenter).orderModel
         doReturn(order).whenever(orderStore).getOrderByIdentifier(any())
@@ -178,7 +178,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Mark order complete - Reverts status after failure correctly`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         doReturn(order).whenever(presenter).orderModel
         doReturn(order).whenever(orderStore).getOrderByIdentifier(any())
@@ -198,7 +198,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Do not mark order complete and just show offline message`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         presenter.takeView(orderDetailView)
         doReturn(false).whenever(networkStatus).isConnected()
@@ -210,7 +210,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Do not request order notes from api when not connected`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         presenter.takeView(orderDetailView)
         doReturn(order).whenever(presenter).orderModel
@@ -224,7 +224,7 @@ class OrderDetailPresenterTest {
     @Test
     fun `Request fresh notes from api on network connected event if using non-updated cached data`() =
             test {
-                doReturn(RefundResult(emptyList<WCRefundModel>()))
+                doReturn(WooResult(emptyList<WCRefundModel>()))
                         .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
                 doReturn(true).whenever(presenter).isUsingCachedNotes
                 doReturn(order).whenever(presenter).orderModel
@@ -237,7 +237,7 @@ class OrderDetailPresenterTest {
     @Test
     fun `Do not refresh notes on network connected event if cached data already refreshed`() =
             test {
-                doReturn(RefundResult(emptyList<WCRefundModel>()))
+                doReturn(WooResult(emptyList<WCRefundModel>()))
                         .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
                 doReturn(false).whenever(presenter).isUsingCachedNotes
                 doReturn(order).whenever(presenter).orderModel
@@ -249,7 +249,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Shows and hides the note list skeleton correctly`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         presenter.takeView(orderDetailView)
         doReturn(order).whenever(orderStore).getOrderByIdentifier(any())
@@ -264,7 +264,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Request order shipment trackings from api and load cached from db`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         doReturn(order).whenever(presenter).orderModel
         doReturn(true).whenever(networkStatus).isConnected()
@@ -277,7 +277,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Do not request order shipment trackings from api when not connected`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         doReturn(order).whenever(presenter).orderModel
         doReturn(false).whenever(networkStatus).isConnected()
@@ -291,7 +291,7 @@ class OrderDetailPresenterTest {
     @Test
     fun `Request fresh shipment tracking from api on network connected event if using non-updated cached data`() =
             test {
-                doReturn(RefundResult(emptyList<WCRefundModel>()))
+                doReturn(WooResult(emptyList<WCRefundModel>()))
                         .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
                 doReturn(true).whenever(presenter).isUsingCachedShipmentTrackings
                 doReturn(order).whenever(presenter).orderModel
@@ -304,7 +304,7 @@ class OrderDetailPresenterTest {
     @Test
     fun `Do not refresh shipment trackings on network connected event if cached data already refreshed`() =
             test {
-                doReturn(RefundResult(emptyList<WCRefundModel>()))
+                doReturn(WooResult(emptyList<WCRefundModel>()))
                         .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
                 doReturn(false).whenever(presenter).isUsingCachedShipmentTrackings
                 doReturn(order).whenever(presenter).orderModel
@@ -316,7 +316,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Do not request delete shipment tracking when network is not available`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         doReturn(false).whenever(networkStatus).isConnected()
         doReturn(order).whenever(presenter).orderModel
@@ -340,7 +340,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Request delete shipment tracking when network is available - error`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         doReturn(order).whenever(presenter).orderModel
         presenter.takeView(orderDetailView)
@@ -368,7 +368,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Request delete shipment tracking when network is available - success`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         doReturn(order).whenever(presenter).orderModel
         presenter.takeView(orderDetailView)
@@ -392,7 +392,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Add order shipment tracking when network is available - success`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         presenter.takeView(orderDetailView)
         doReturn(order).whenever(presenter).orderModel
@@ -408,7 +408,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Add order shipment tracking when network is available - error`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         doReturn(order).whenever(presenter).orderModel
         presenter.takeView(orderDetailView)
@@ -428,7 +428,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Verify product is virtual for a single product in an order`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         order.lineItems = Gson().toJson(listOf(mapOf("product_id" to "290")))
         val products = listOf(WCProductModel(1).apply { virtual = true })
@@ -444,7 +444,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Verify product is not virtual for a single product in an order`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         order.lineItems = Gson().toJson(listOf(mapOf("product_id" to "290")))
         val products = listOf(WCProductModel(1))
@@ -460,7 +460,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Verify product is not virtual for multiple products in an order`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         order.lineItems = Gson().toJson(
                 listOf(
@@ -486,7 +486,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Verify product is not virtual for empty products in an order`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         doReturn(emptyList<WCProductModel>()).whenever(productStore)
                 .getProductsByRemoteIds(any(), any())
@@ -502,7 +502,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Verify product is not virtual for empty productIds in an order`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         order.lineItems = Gson().toJson(listOf(mapOf(), mapOf(), mapOf("product_id" to null)))
         doReturn(emptyList<WCProductModel>()).whenever(productStore)
@@ -518,7 +518,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Request order detail refresh when network available - success`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         presenter.takeView(orderDetailView)
         doReturn(order).whenever(presenter).orderModel
@@ -553,7 +553,7 @@ class OrderDetailPresenterTest {
 
     @Test
     fun `Request order detail refresh when network available - error`() = test {
-        doReturn(RefundResult(emptyList<WCRefundModel>()))
+        doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         doReturn(order).whenever(presenter).orderModel
         presenter.takeView(orderDetailView)


### PR DESCRIPTION
Fixes #1488 , #1489, #1490 . This PR fixes the following bugs in the order list redesign changes.

### Fixes:
- #1488  - The order status list count is not updated when an order status is changed. This was happening because the call to refresh order status list count was not called, because the fragment was not active. Fixed in 01aee2b by refreshing the order status list count in the background.
- #1489 - The order list is displayed even when search/filter is enabled. This only happens when screen is rotated from landscape to portrait while search is enabled. This was because there was a call to refresh the order list which was updating the UI. Fixed in 84d2c14.
- #1490 - Processing shows all orders instead of empty message after viewing order status filters. This was because there is logic in place to display the `All Orders` tab by default when there are no Processing orders. But the `TabLayout` was not updated of this change. Fixed in b23490f.
- Added option to enable/disable toolbar elevation when search is enabled/disabled in c5ac27a.
- Added option to hide the empty view, before fetching the order list in 5c3fa5e. This was to avoid displaying the empty view for a second before the loading was displayed.

### Testing:
- #1488 
  - Go to the Orders section.
  - Check the count for Processing orders on the Orders badge.
  - Tap the search icon and note that the count next to Processing matches.
  - Go to the Processing tab in Orders and fulfill an order.
  - Note that the Orders badge count is updated (decreased by 1).
  - Tap the search icon and note that the count next to Processing is unchanged.
  - Close and relaunch the app, and note that when you tap the search icon the count next to Processing is updated to match the Orders badge count.
  - Pull changes from this PR and follow the above steps to verify that the order status count is updated.

- #1489 
  - Go to the Orders section.
  - Tap on the search icon.
  - Select a status from the Order status list.
  - Rotate your device to landscape.
  - Tap the back arrow to go back to the Search orders screen.
  - Rotate your device back to portrait.
  - Result: An order appears at the bottom of the Order status list.
  - Pull changes from this PR and follow the above steps to verify that the order list is not displayed behind the order status list.

- #1490 
  - Open a store in the app with no orders with the Processing status.
  - Go to the Orders section.
  - Confirm the Processing tab shows the "All orders have been processed" message.
  - Tap the search icon.
  - Select an Order status filter.
  - Tap the back arrow twice to exit the search and return to the Processing tab. Note that the tab now shows all orders.
  - Pull to refresh and note that the tab doesn't change.
  - Switch to All Orders and back to Processing and note that the Processing tab now shows the correct message.
  - Pull changes from this PR and follow the above steps to verify that the Processing tab does not display orders from other statuses.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Note
@loremattei, @JavonDavis these changes will require a new release candidate build once they are merged.

@rachelmcr, I also requested you as a reviewer since you caught the associated bugs and to ensure they are fixed.