### PR TITLE
Release/2.9: Refresh order status list when clearing search filters

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderListFragment.kt
@@ -637,6 +637,7 @@ class OrderListFragment : TopLevelFragment(), OrderListContract.View,
             updateActivityTitle()
             searchMenuItem?.collapseActionView()
             isRefreshing = true
+            refreshOrderStatusOptions()
             presenter.loadOrders(orderStatusFilter, forceRefresh = true)
         }
     }


### PR DESCRIPTION
Fixes #1492. This tiny PR adds the option to refresh the order status list when disabling search. 

### Testing:
- Go to Orders tab, note the total # of orders in "Processing" for the badge.
- Open the search screen. Note the total order count for "processing". Leave this page open.
- Log into the test store's wp-admin. Do a batch update to move all "processing" orders to "waiting approval" (or whatever change you want to make - this just makes it really easy to spot).
- Go back to the app and do a "pull-to-refresh". Notice the badge count updates appropriately.
- Open the search screen. Note the total order count for "processing" has not changed. 
- Pull changes from this PR and follow the above steps again to verify that the order status count is changed.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Note
@jkmassel ,@JavonDavis these changes will require a new release candidate build once they are merged.

