### PR TITLE
Feature/product image capture

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaUploadUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaUploadUtils.kt
@@ -19,16 +19,9 @@ object MediaUploadUtils {
         localUri: Uri,
         mediaStore: MediaStore
     ): MediaModel? {
-        // "fetch" the media - necessary to support choosing from Downloads, Google Photos, etc.
-        val fetchedUri = fetchMedia(context, localUri)
-        if (fetchedUri == null) {
-            WooLog.w(T.MEDIA, "mediaModelFromLocalUri > fetched media path is null or empty")
-            return null
-        }
-
-        val path = MediaUtils.getRealPathFromURI(context, fetchedUri)
+        val path = MediaUtils.getRealPathFromURI(context, localUri)
         if (path == null) {
-            WooLog.w(T.MEDIA, "mediaModelFromLocalUri > failed to get path from uri, $fetchedUri")
+            WooLog.w(T.MEDIA, "mediaModelFromLocalUri > failed to get path from uri, $localUri")
             return null
         }
 
@@ -39,10 +32,10 @@ object MediaUploadUtils {
         }
 
         val media = mediaStore.instantiateMediaModel()
-        var filename = org.wordpress.android.fluxc.utils.MediaUtils.getFileName(fetchedUri.path)
-        var fileExtension: String? = org.wordpress.android.fluxc.utils.MediaUtils.getExtension(fetchedUri.path)
+        var filename = org.wordpress.android.fluxc.utils.MediaUtils.getFileName(localUri.path)
+        var fileExtension: String? = org.wordpress.android.fluxc.utils.MediaUtils.getExtension(localUri.path)
 
-        var mimeType = UrlUtils.getUrlMimeType(fetchedUri.toString())
+        var mimeType = UrlUtils.getUrlMimeType(localUri.toString())
         if (mimeType == null) {
             mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExtension)
             if (mimeType == null) {
@@ -59,7 +52,7 @@ object MediaUploadUtils {
 
         media.fileName = filename
         media.title = filename
-        media.filePath = fetchedUri.path
+        media.filePath = localUri.path
         media.localSiteId = localSiteId
         media.fileExtension = fileExtension
         media.mimeType = mimeType
@@ -78,7 +71,7 @@ object MediaUploadUtils {
      *
      * @return A local {@link Uri} or null if the download failed
      */
-    private fun fetchMedia(context: Context, mediaUri: Uri): Uri? {
+    fun fetchMedia(context: Context, mediaUri: Uri): Uri? {
         if (MediaUtils.isInMediaStore(mediaUri)) {
             return mediaUri
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaUploadUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaUploadUtils.kt
@@ -1,8 +1,11 @@
 package com.woocommerce.android.media
 
 import android.content.Context
+import android.content.Intent
 import android.net.Uri
+import android.os.Environment
 import android.webkit.MimeTypeMap
+import androidx.core.content.FileProvider
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import org.wordpress.android.fluxc.model.MediaModel
@@ -11,6 +14,10 @@ import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.MediaUtils
 import org.wordpress.android.util.UrlUtils
 import java.io.File
+import java.io.IOException
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 object MediaUploadUtils {
     fun mediaModelFromLocalUri(
@@ -19,9 +26,16 @@ object MediaUploadUtils {
         localUri: Uri,
         mediaStore: MediaStore
     ): MediaModel? {
-        val path = MediaUtils.getRealPathFromURI(context, localUri)
+        // "fetch" the media - necessary to support choosing from Downloads, Google Photos, etc.
+        val fetchedUri = fetchMedia(context, localUri)
+        if (fetchedUri == null) {
+            WooLog.w(T.MEDIA, "mediaModelFromLocalUri > fetched media path is null or empty")
+            return null
+        }
+
+        val path = MediaUtils.getRealPathFromURI(context, fetchedUri)
         if (path == null) {
-            WooLog.w(T.MEDIA, "mediaModelFromLocalUri > failed to get path from uri, $localUri")
+            WooLog.w(T.MEDIA, "mediaModelFromLocalUri > failed to get path from uri, $fetchedUri")
             return null
         }
 
@@ -32,10 +46,10 @@ object MediaUploadUtils {
         }
 
         val media = mediaStore.instantiateMediaModel()
-        var filename = org.wordpress.android.fluxc.utils.MediaUtils.getFileName(localUri.path)
-        var fileExtension: String? = org.wordpress.android.fluxc.utils.MediaUtils.getExtension(localUri.path)
+        var filename = org.wordpress.android.fluxc.utils.MediaUtils.getFileName(fetchedUri.path)
+        var fileExtension: String? = org.wordpress.android.fluxc.utils.MediaUtils.getExtension(fetchedUri.path)
 
-        var mimeType = UrlUtils.getUrlMimeType(localUri.toString())
+        var mimeType = UrlUtils.getUrlMimeType(fetchedUri.toString())
         if (mimeType == null) {
             mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExtension)
             if (mimeType == null) {
@@ -52,7 +66,7 @@ object MediaUploadUtils {
 
         media.fileName = filename
         media.title = filename
-        media.filePath = localUri.path
+        media.filePath = fetchedUri.path
         media.localSiteId = localSiteId
         media.fileExtension = fileExtension
         media.mimeType = mimeType
@@ -82,5 +96,46 @@ object MediaUploadUtils {
             WooLog.e(T.MEDIA, "Can't download the image at: $mediaUri", e)
             null
         }
+    }
+
+    /**
+     * Creates a temporary file for storing captured photos
+     */
+    private fun createCaptureImageFile(context: Context): File? {
+        val timeStamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
+        val storageDir = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES)
+        return try {
+            File.createTempFile(
+                    "JPEG_${timeStamp}_",
+                    ".jpg",
+                    storageDir
+            )
+        } catch (ex: IOException) {
+            WooLog.e(T.MEDIA, ex)
+            null
+        }
+    }
+
+    /**
+     * Create an intent for capturing a device photo
+     */
+    fun createCaptureImageIntent(context: Context): Intent? {
+        Intent(android.provider.MediaStore.ACTION_IMAGE_CAPTURE).also { intent ->
+            // Ensure that there's a camera activity to handle the intent
+            intent.resolveActivity(context.packageManager)?.also {
+                createCaptureImageFile(context)?.also { file ->
+                    // capturedPhotoPath = file.absolutePath
+                    val authority = context.applicationContext.packageName + ".provider"
+                    val imageUri = FileProvider.getUriForFile(
+                            context,
+                            authority,
+                            file
+                    )
+                    intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, imageUri)
+                    return intent
+                }
+            }
+        }
+        return null
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -568,7 +568,9 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
      * Triggered by the viewModel when an image is being uploaded or has finished uploading
      */
     private fun showUploadImageProgress(isUploading: Boolean) {
-        // TODO
+        // TODO - for now we simply show a progress spinner in the middle of the gallery, a separate PR
+        // will tackle showing the progress on the image being replaced
+        imageUploadProgess.visibility = if (isUploading) View.VISIBLE else View.GONE
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -40,8 +40,6 @@ import com.woocommerce.android.ui.products.ProductType.GROUPED
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.StringUtils
-import com.woocommerce.android.util.WooLog
-import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.util.WooPermissionUtils
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageClickListener

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -28,6 +28,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_IM
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_SHARE_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_VIEW_AFFILIATE_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_VIEW_EXTERNAL_TAPPED
+import com.woocommerce.android.media.MediaUploadUtils
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -38,6 +39,8 @@ import com.woocommerce.android.ui.products.ProductType.GROUPED
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.StringUtils
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.util.WooPermissionUtils
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageClickListener
@@ -565,7 +568,12 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == REQUEST_CODE_CHOOSE_PHOTO && resultCode == RESULT_OK && data != null) {
             data.data?.let { imageUri ->
-                viewModel.uploadProductMedia(navArgs.remoteProductId, imageUri)
+                // "fetch" the media - necessary to support choosing from Downloads, Google Photos, etc.
+                MediaUploadUtils.fetchMedia(requireActivity(), imageUri)?.let { fetchedUri ->
+                    viewModel.uploadProductMedia(navArgs.remoteProductId, fetchedUri)
+                    return
+                }
+                WooLog.w(T.MEDIA, "mediaModelFromLocalUri > fetched media path is null or empty")
             }
         } else if (requestCode == REQUEST_CODE_CAPTURE_PHOTO) {
             viewModel.uploadCapturedImage(navArgs.remoteProductId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1,12 +1,6 @@
 package com.woocommerce.android.ui.products
 
-import android.content.Context
-import android.content.Intent
 import android.net.Uri
-import android.os.Bundle
-import android.os.Environment
-import android.provider.MediaStore
-import androidx.core.content.FileProvider
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
@@ -20,8 +14,6 @@ import com.woocommerce.android.model.Product
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.WooLog
-import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.SingleLiveEvent
 import kotlinx.coroutines.CoroutineDispatcher
@@ -30,12 +22,7 @@ import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.store.WooCommerceStore
-import java.io.File
-import java.io.IOException
 import java.math.BigDecimal
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 import kotlin.math.roundToInt
@@ -50,10 +37,6 @@ class ProductDetailViewModel @Inject constructor(
     private val currencyFormatter: CurrencyFormatter,
     private val mediaUploadWrapper: MediaUploadWrapper
 ) : ScopedViewModel(mainDispatcher) {
-    companion object {
-        private const val KEY_CURRENT_PHOTO_PATH = "photo_path"
-    }
-
     private var remoteProductId = 0L
 
     private val product = MutableLiveData<Product>()
@@ -71,6 +54,9 @@ class ProductDetailViewModel @Inject constructor(
     private val _chooseProductImage = SingleLiveEvent<Product>()
     val chooseProductImage: LiveData<Product> = _chooseProductImage
 
+    private val _captureProductImage = SingleLiveEvent<Product>()
+    val captureProductImage: LiveData<Product> = _captureProductImage
+
     private val _showSnackbarMessage = SingleLiveEvent<Int>()
     val showSnackbarMessage: LiveData<Int> = _showSnackbarMessage
 
@@ -79,8 +65,6 @@ class ProductDetailViewModel @Inject constructor(
 
     private val _exit = SingleLiveEvent<Unit>()
     val exit: LiveData<Unit> = _exit
-
-    private var capturedPhotoPath: String? = null
 
     init {
         _productData.addSource(product) { prod ->
@@ -97,17 +81,8 @@ class ProductDetailViewModel @Inject constructor(
         EventBus.getDefault().register(this)
     }
 
-    fun start(remoteProductId: Long, savedInstanceState: Bundle? = null) {
+    fun start(remoteProductId: Long) {
         loadProduct(remoteProductId)
-        savedInstanceState?.let { bundle ->
-            capturedPhotoPath = bundle.getString(KEY_CURRENT_PHOTO_PATH)
-        }
-    }
-
-    fun saveState(bundle: Bundle) {
-        capturedPhotoPath?.let {
-            bundle.putString(KEY_CURRENT_PHOTO_PATH, it)
-        }
     }
 
     fun onShareButtonClicked() {
@@ -116,6 +91,10 @@ class ProductDetailViewModel @Inject constructor(
 
     fun onChooseImageClicked() {
         _chooseProductImage.value = product.value
+    }
+
+    fun onCaptureImageClicked() {
+        _captureProductImage.value = product.value
     }
 
     override fun onCleared() {
@@ -215,13 +194,6 @@ class ProductDetailViewModel @Inject constructor(
         }
     }
 
-    fun uploadCapturedImage(remoteProductId: Long) {
-        Uri.parse(capturedPhotoPath)?.let { uri ->
-            uploadProductMedia(remoteProductId, uri)
-        }
-        capturedPhotoPath = null
-    }
-
     fun uploadProductMedia(remoteProductId: Long, localImageUri: Uri) {
         // TODO: at some point we want to support uploading multiple product images
         if (MediaUploadService.isBusy()) {
@@ -231,50 +203,7 @@ class ProductDetailViewModel @Inject constructor(
         _isUploadingProductImage.value = true
         mediaUploadWrapper.uploadProductMedia(remoteProductId, localImageUri)
     }
-    /**
-     * Create an intent for capturing a device photo
-     * TODO: get rid of context
-     */
-    fun createCaptureImageIntent(context: Context): Intent? {
-        Intent(MediaStore.ACTION_IMAGE_CAPTURE).also { intent ->
-            // Ensure that there's a camera activity to handle the intent
-            intent.resolveActivity(context.packageManager)?.also {
-                createCaptureImageFile(context)?.also { file ->
-                    capturedPhotoPath = file.absolutePath
-                    val authority = context.applicationContext.packageName + ".provider"
-                    val imageUri = FileProvider.getUriForFile(
-                            context,
-                            authority,
-                            file
-                    )
-                    intent.putExtra(MediaStore.EXTRA_OUTPUT, imageUri)
-                    return intent
-                }
-            }
-        }
 
-        WooLog.w(T.MEDIA, "ProductDetailViewModel > unable to create capture intent")
-        _showSnackbarMessage.value = R.string.product_image_capture_failed
-        return null
-    }
-
-    /**
-     * Creates a temporary file for captured photos
-     */
-    private fun createCaptureImageFile(context: Context): File? {
-        val timeStamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
-        val storageDir = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES)
-        return try {
-            File.createTempFile(
-                    "JPEG_${timeStamp}_",
-                    ".jpg",
-                    storageDir
-            )
-        } catch (ex: IOException) {
-            WooLog.e(T.MEDIA, ex)
-            null
-        }
-    }
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: OnProductMediaUploadEvent) {

--- a/WooCommerce/src/main/res/layout/fragment_product_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_detail.xml
@@ -63,6 +63,15 @@
                         tools:text="Private" />
                 </FrameLayout>
 
+                <ProgressBar
+                    android:id="@+id/imageUploadProgess"
+                    style="?android:attr/progressBarStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+
                 <View
                     style="@style/Woo.Settings.Divider"
                     android:layout_gravity="bottom" />

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -403,9 +403,10 @@
     <string name="product_list_empty_search">No matching products</string>
     <string name="product_search_hint">Search products</string>
     <string name="product_change_image">Change product image</string>
+    <string name="product_capture_image">Capture product image</string>
     <string name="product_image_upload_error">Error uploading product photo</string>
     <string name="product_image_already_uploading">A product image is already uploading</string>
-
+    <string name="product_image_capture_failed">Failed to capture image</string>
     <!--
         Empty list messages
     -->


### PR DESCRIPTION
This is the second PR related to uploading product images. The first one added support for choosing a product image from the device, and this one adds support for capturing a product image from the device camera.

As with the first PR, this feature is only enabled in `DEBUG` builds and is available from the product detail options menu. This isn't how the final UI will work - that will come later.

![ezgif com-optimize](https://user-images.githubusercontent.com/3903757/67583434-92c2e500-f719-11e9-962e-0ed825c84e42.gif)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
