### PR TITLE
Check addNote_switch is not null before accessing isChecked

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 3.0
 -----
 * Added a new refunding feature that brings the ability to specify the amount to refund
+* Bugfix: Fixed a rare crash that would happen in the "Add Order Note" view while saving state when the app is pushed to the background.
  
 2.9
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteFragment.kt
@@ -145,7 +145,7 @@ class AddOrderNoteFragment : BaseFragment(), AddOrderNoteContract.View, BackPres
 
     override fun onSaveInstanceState(outState: Bundle) {
         outState.putString(FIELD_NOTE_TEXT, getNoteText())
-        outState.putBoolean(FIELD_IS_CUSTOMER_NOTE, addNote_switch.isChecked)
+        outState.putBoolean(FIELD_IS_CUSTOMER_NOTE, addNote_switch?.isChecked ?: false)
         outState.putBoolean(FIELD_IS_CONFIRMING_DISCARD, isConfirmingDiscard)
         super.onSaveInstanceState(outState)
     }


### PR DESCRIPTION
Fixes #1507 by first checking if `addNote_switch` is null before attempting to access the `isChecked` property. If it is null, we default to `false` since that is the default for the view. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
