### PR TITLE
offline handling for new order list management

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -237,7 +237,15 @@ object AppPrefs {
     }
 
     fun getSelectedOrderListTabPosition() =
-            getInt(DeletablePrefKey.SELECTED_ORDER_LIST_TAB_POSITION, 0)
+            getInt(DeletablePrefKey.SELECTED_ORDER_LIST_TAB_POSITION, -1)
+
+    /**
+     * Checks if the user has a saved order list tab position yet. If no position has been saved,
+     * then the value will be the default of -1.
+     *
+     * @return True if the saved position is not the default -1, else false
+     */
+    fun hasSelectedOrderListTabPosition() = getSelectedOrderListTabPosition() > -1
 
     /**
      * Remove all user-related preferences.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderFetcher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderFetcher.kt
@@ -78,12 +78,8 @@ class OrderFetcher @Inject constructor(
     fun onOrdersFetchedById(event: OnOrdersFetchedByIds) {
         if (event.isError) {
             WooLog.e(WooLog.T.ORDERS, "$TAG: Error fetching orders by remoteOrderId: ${event.error.message}")
-
             // FIXME: Add error handling
-
             // FIXME: Possible add new tracks event to track error fetching order list data "order_list_load_failed"
-
-            return
         }
         ongoingRequests.removeAll(event.orderIds)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -707,11 +707,13 @@ class OrderListFragment : TopLevelFragment(),
 
     private fun displayOrderStatusListView() {
         order_status_list_view.visibility = View.VISIBLE
+        order_list_view.visibility = View.GONE
         orderRefreshLayout.isEnabled = false
     }
 
     private fun hideOrderStatusListView() {
         order_status_list_view.visibility = View.GONE
+        order_list_view.visibility = View.VISIBLE
         orderRefreshLayout.isEnabled = true
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -479,10 +479,17 @@ class OrderListFragment : TopLevelFragment(),
      */
     private fun calculateDefaultTabPosition(): Int {
         val orderStatusOptions = getOrderStatusOptions()
-        return if (orderStatusOptions.isEmpty() || orderStatusOptions[PROCESSING.value]?.statusCount == 0) {
-            ORDER_TAB_DEFAULT
-        } else {
+        return if (AppPrefs.hasSelectedOrderListTabPosition()) {
+            // If the user has already changed tabs once then select
+            // the last tab they had selected.
             AppPrefs.getSelectedOrderListTabPosition()
+        } else if (orderStatusOptions.isEmpty() || orderStatusOptions[PROCESSING.value]?.statusCount == 0) {
+            // There are no "processing" orders to display, show all.
+            TAB_INDEX_ALL
+        } else {
+            // Default to the "processing" tab if there are orders to
+            // process.
+            TAB_INDEX_PROCESSING
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -193,7 +193,7 @@ class OrderListFragment : TopLevelFragment(),
 
                     // If this tab is the one that should be active, select it and load
                     // the appropriate list.
-                    if (index == calculateTabPosition()) {
+                    if (index == calculateDefaultTabPosition()) {
                         orderStatusFilter = calculateOrderStatusFilter(tab)
                         tab.select()
                     }
@@ -477,13 +477,19 @@ class OrderListFragment : TopLevelFragment(),
      *
      * @return the index of the tab to be activated
      */
-    private fun calculateTabPosition(): Int {
+    private fun calculateDefaultTabPosition(): Int {
         val orderStatusOptions = getOrderStatusOptions()
         return if (orderStatusOptions.isEmpty() || orderStatusOptions[PROCESSING.value]?.statusCount == 0) {
             ORDER_TAB_DEFAULT
         } else {
             AppPrefs.getSelectedOrderListTabPosition()
         }
+    }
+
+    private fun getOrderStatusFilterForActiveTab(): String? {
+        return tab_layout.getTabAt(tab_layout.selectedTabPosition)?.let {
+            calculateOrderStatusFilter(it)
+        } ?: null
     }
 
     /**
@@ -563,6 +569,7 @@ class OrderListFragment : TopLevelFragment(),
             updateActivityTitle()
             searchMenuItem?.collapseActionView()
 
+            orderStatusFilter = getOrderStatusFilterForActiveTab()
             viewModel.loadList(orderStatusFilter, excludeFutureOrders = shouldExcludeFutureOrders())
         }
     }
@@ -693,9 +700,6 @@ class OrderListFragment : TopLevelFragment(),
                 it.isEnabled = true
             }
             searchView?.queryHint = getString(R.string.orderlist_search_hint)
-
-            val tabPosition = calculateTabPosition()
-            tab_layout.getTabAt(tabPosition)?.select()
 
             (activity as? MainActivity)?.hideBottomNav()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -60,7 +60,7 @@ class OrderListViewModel @Inject constructor(
 
     private var pagedListWrapper: PagedListWrapper<OrderListItemUIType>? = null
     private val dataSource by lazy {
-        OrderListItemDataSource(dispatcher, orderStore, lifecycle)
+        OrderListItemDataSource(dispatcher, orderStore, networkStatus, lifecycle)
     }
 
     private var isStarted = false
@@ -303,6 +303,11 @@ class OrderListViewModel @Inject constructor(
             if (isRefreshPending) {
                 pagedListWrapper?.fetchFirstPage()
             }
+        } else {
+            // Invalidate the list data so that orders that have not
+            // yet been downloaded (the "loading" items) can be removed
+            // from the current list view.
+            pagedListWrapper?.invalidateData()
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '10568dbd36e3955ce77f4c88b7549b11d79ea694'
+    fluxCVersion = '33c4df4b402b2e6db56771e986979b2fe09a0e34'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '33c4df4b402b2e6db56771e986979b2fe09a0e34'
+    fluxCVersion = 'd8e999c70729ddb755e64daa7102c78b7919b000'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
This PR fixes #1495 by adding the logic needed for properly handling offline scenarios. This PR includes the following:
* Hide items in “loading” state if the device is offline
	* Previously, if the device went offline while fetching missing orders the “loading” view would just be shown indefinitely. To get past this, if the device goes offline we immediately invalidate the current list data and the `OrderListItemDatasource` will only return orders that exist in the db.
* Fixed a bug where the orders list for the tab selected was not reloading with all items after canceling out of search/filter.
* Refresh the order list view when the device comes back online

## Device goes offline while fetching missing orders

The device goes offline right in the middle of fetching orders. The orders in a "loading" state are removed from the list.

<img src="https://user-images.githubusercontent.com/5810477/67832691-ae264b00-fa9f-11e9-857c-abbf7f245e9a.gif" width="300"/>

## Device connection restored

The devices goes back online and the missing items are immediately fetched.

<img src="https://user-images.githubusercontent.com/5810477/67832906-4e7c6f80-faa0-11e9-9445-42eed8b0a71f.gif" width="300"/>


**NOTE**: [This PR](https://github.com/woocommerce/woocommerce-android/pull/1510) must be reviewed and approved before this PR since it relies on the code changes in that PR.  This [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1412) must be merged before this PR can be merged. 

## Testing Shortcuts

To turn airplane mode on and off quickly you can use adb:

**Airplane Mode ON**
```
adb shell settings put global airplane_mode_on 1
adb shell am broadcast -a android.intent.action.AIRPLANE_MODE
```

**Airplane Mode OFF**
```
adb shell settings put global airplane_mode_on 0
adb shell am broadcast -a android.intent.action.AIRPLANE_MODE
```