### PR TITLE
Issue/1461 add order shiping method

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * Added a new refunding feature that brings the ability to specify the amount to refund
 * Products with multiple images now show all images in a gallery.
 * Bugfix: Fixed a rare crash that would happen in the "Add Order Note" view while saving state when the app is pushed to the background.
+* The order detail view now includes the shipping method of the order.
  
 2.9
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailCustomerInfoView.kt
@@ -111,6 +111,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(ctx: Context, attrs:
         if (!isShippingAvailable(order) || hide) {
             customerInfo_divider.visibility = View.GONE
             customerInfo_shippingSection.visibility = View.GONE
+            customerInfo_shippingMethodSection.visibility = View.GONE
             customerInfo_morePanel.visibility = View.VISIBLE
             formatViewAsShippingOnly()
             customerInfo_viewMore.setOnClickListener(null)
@@ -134,6 +135,14 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(ctx: Context, attrs:
                     customerInfo_viewMoreButtonImage.animate().rotation(0F).setDuration(200).start()
                     customerInfo_viewMoreButtonTitle.text = context.getString(R.string.orderdetail_show_billing)
                 }
+            }
+
+            val shippingMethodList = order.getShippingLineList()
+            if (shippingMethodList.isNullOrEmpty()) {
+                customerInfo_shippingMethodSection.visibility = View.GONE
+            } else {
+                customerInfo_shippingMethodSection.visibility = View.VISIBLE
+                customerInfo_shippingMethod.text = shippingMethodList.first().methodTitle
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -232,10 +232,13 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
             )
 
             // check if product is a virtual product. If it is, hide only the shipping details card
+            val isVirtualProduct = presenter.isVirtualProduct(order)
             orderDetail_customerInfo.initView(
                     order = order,
                     shippingOnly = false,
-                    billingOnly = presenter.isVirtualProduct(order))
+                    billingOnly = isVirtualProduct)
+
+            showOrderShippingNotice(isVirtualProduct, order)
 
             // Populate the Payment Information Card
             orderDetail_paymentInfo.initView(
@@ -254,6 +257,7 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
         // hide the shipping details if products in an order is virtual
         val hideShipping = presenter.isVirtualProduct(order)
         orderDetail_customerInfo.initShippingSection(order, hideShipping)
+        showOrderShippingNotice(hideShipping, order)
     }
 
     override fun showOrderNotes(notes: List<WCOrderNoteModel>) {
@@ -667,5 +671,14 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
                             listener = this)
                     .also { it.show(fragmentManager, OrderStatusSelectorDialog.TAG) }
         }
+    }
+
+    /**
+     * Hide the shipping method warning if order contains only virtual products
+     * or if the order contains only one shipping method
+     * */
+    private fun showOrderShippingNotice(isVirtualProduct: Boolean, order: WCOrderModel) {
+        val hideShippingMethodNotice = isVirtualProduct || !order.isMultiShippingLinesAvailable()
+        orderDetail_shippingMethodNotice.visibility = if (hideShippingMethodNotice) View.GONE else View.VISIBLE
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShippingMethodNoticeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShippingMethodNoticeCard.kt
@@ -1,0 +1,18 @@
+package com.woocommerce.android.ui.orders
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.widget.LinearLayout
+import com.woocommerce.android.R
+
+/**
+ * Order warning card that is displayed if an order contains more than one shipping
+ * method. This can happen by installing shipping related plugins that provide this option
+ */
+class OrderDetailShippingMethodNoticeCard @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
+    : LinearLayout(ctx, attrs) {
+    init {
+        View.inflate(context, R.layout.order_detail_shipping_warning, this)
+    }
+}

--- a/WooCommerce/src/main/res/drawable/ic_gridicons_notice.xml
+++ b/WooCommerce/src/main/res/drawable/ic_gridicons_notice.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#B26200" android:pathData="M12,2C6.477,2 2,6.477 2,12s4.477,10 10,10 10,-4.477 10,-10S17.523,2 12,2zM13,17h-2v-2h2v2zM13,13h-2l-0.5,-6h3l-0.5,6z"/>
+</vector>

--- a/WooCommerce/src/main/res/layout/fragment_order_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_detail.xml
@@ -32,6 +32,17 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"/>
 
+                <!-- Order Shipping method warning card -->
+                <com.woocommerce.android.ui.orders.OrderDetailShippingMethodNoticeCard
+                    android:id="@+id/orderDetail_shippingMethodNotice"
+                    style="@style/Woo.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/margin_large"
+                    android:layout_marginEnd="@dimen/margin_large"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+
                 <!-- Product List -->
                 <com.woocommerce.android.ui.orders.OrderDetailProductListView
                     android:id="@+id/orderDetail_productList"

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -89,6 +89,42 @@
 
         </LinearLayout>
 
+        <!-- Label: Shipping method -->
+        <LinearLayout
+            android:id="@+id/customerInfo_shippingMethodSection"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/card_item_padding_intra_double"
+            android:focusable="true"
+            android:orientation="vertical"
+            tools:visibility="visible"
+            android:visibility="gone">
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginBottom="@dimen/card_item_padding_intra_double"
+                android:background="@color/list_divider"
+                app:srcCompat="@drawable/list_divider"/>
+
+            <TextView
+                android:id="@+id/customerInfo_shippingMethodLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/orderdetail_shipping_method"
+                android:textAppearance="@style/Woo.OrderDetail.TextAppearance.SectionTitle"/>
+
+            <TextView
+                android:id="@+id/customerInfo_shippingMethod"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/card_item_padding_intra_h"
+                android:textAppearance="@style/Woo.OrderDetail.TextAppearance"
+                android:textAlignment="viewStart"
+                tools:text="International Priority Mail Express Flat Rate"/>
+
+        </LinearLayout>
+
         <!-- Billing Section -->
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/customerInfo_morePanel"

--- a/WooCommerce/src/main/res/layout/order_detail_shipping_warning.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_shipping_warning.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <!-- Notice Icon ImageView -->
+        <ImageView
+            android:id="@+id/shipping_method_notice_icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:importantForAccessibility="no"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/ic_gridicons_notice" />
+
+        <!-- Notice Message -->
+        <TextView
+            android:id="@+id/shipping_method_notice_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/card_padding_start"
+            android:layout_marginEnd="@dimen/card_padding_end"
+            android:gravity="start"
+            android:lineSpacingExtra="4sp"
+            android:paddingBottom="@dimen/default_padding"
+            android:text="@string/orderdetail_shipping_notice"
+            android:textAppearance="@style/Woo.TextAppearance"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/shipping_method_notice_icon"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</merge>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -229,6 +229,7 @@
     <string name="orderdetail_copy_tracking_number">Copy tracking number</string>
     <string name="orderdetail_delete_tracking">Delete tracking</string>
     <string name="orderdetail_empty_shipping_address">No address specified.</string>
+    <string name="orderdetail_shipping_notice">This order is using extensions to calculate shipping. The shipping methods shown might be incomplete.</string>
     <string name="orderdetail_issue_refund_button">Issue refund</string>
     <string name="order_begin_fulfillment">Begin fulfillment</string>
     <string name="order_fulfill_mark_complete">Mark Order Complete</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -189,6 +189,7 @@
     <string name="orderdetail_orderstatus_ordernum">Order #%s</string>
     <string name="orderdetail_orderstatus_heading">#%1$s %2$s %3$s</string>
     <string name="orderdetail_orderstatus_created">Created %1$s</string>
+    <string name="orderdetail_shipping_method">Shipping Method</string>
     <string name="orderdetail_shipping_details">Shipping details</string>
     <string name="orderdetail_billing_details">Billing details</string>
     <string name="orderdetail_email_contentdesc">email customer</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -189,7 +189,7 @@
     <string name="orderdetail_orderstatus_ordernum">Order #%s</string>
     <string name="orderdetail_orderstatus_heading">#%1$s %2$s %3$s</string>
     <string name="orderdetail_orderstatus_created">Created %1$s</string>
-    <string name="orderdetail_shipping_method">Shipping Method</string>
+    <string name="orderdetail_shipping_method">Shipping method</string>
     <string name="orderdetail_shipping_details">Shipping details</string>
     <string name="orderdetail_billing_details">Billing details</string>
     <string name="orderdetail_email_contentdesc">email customer</string>

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '764df6ab56b9a07e89cf4156b772a811f58531af'
+    fluxCVersion = 'c419d0ac00ba57e765ce88c561f2ebcc3793dd31'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Fixes #1461. This PR adds the shipping method details to the Order detail and order Fulfill screen. 

### Changes
-  Adds the shipping method below the shipping address details in Order detail and order fulfill screen.
- The shipping card is only displayed for orders containing atleast one virtual product. It should not be displayed for virtual products.
- There are plugins that allow multiple shipping methods for an order. It was decided that we would display a warning notice to the user, if an order contains multiple shipping methods. This warning notice will be displayed only in the Order Detail page.
- Only the first shipping method of an order will be displayed (if there are multiple shipping methods).

### Notes
~~- This [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1416) needs to be reviewed and merged before this PR can be merged.~~

### Screenshots
#### Physical product with single shipping methods in an order
(LEFT: Order Detail . RIGHT: Order Fulfill)
<img width="300" src="https://user-images.githubusercontent.com/22608780/68100350-a1fe1b80-feed-11e9-908c-00e09e1c8e83.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/68100351-a4607580-feed-11e9-819f-9403ccb379f7.png">

#### Physical product with multiple shipping methods in an order
<img width="300" src="https://user-images.githubusercontent.com/22608780/68100373-c1954400-feed-11e9-9b6d-99629cb2bf34.png">

### Testing
- Order with only virtual products - should not display warning - should not display shipping method or warning notice.
- Order with physical + virtual products with single shipping methods - display the shipping method but the shipping warning should not be displayed.
- Order with physical + virtual products with multiple shipping methods - display the shipping method and the shipping warning notice.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
