### PR TITLE
Order List Management Step 4: Empty states

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListEmptyUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListEmptyUiState.kt
@@ -56,7 +56,6 @@ fun createEmptyUiState(
     isLoadingData: Boolean,
     isListEmpty: Boolean,
     hasOrders: Boolean,
-    isSearchPromptRequired: Boolean,
     isError: Boolean = false,
     fetchFirstPage: () -> Unit
 ): OrderListEmptyUiState {
@@ -73,7 +72,7 @@ fun createEmptyUiState(
             }
             else -> {
                 if (isNetworkAvailable) {
-                    createEmptyListUiState(orderListType, isSearchPromptRequired, hasOrders)
+                    createEmptyListUiState(orderListType, hasOrders)
                 } else {
                     createErrorListUiState(isNetworkAvailable, fetchFirstPage)
                 }
@@ -104,16 +103,11 @@ private fun createErrorListUiState(
  */
 private fun createEmptyListUiState(
     orderListType: OrderListType,
-    isSearchPromptRequired: Boolean,
     hasOrders: Boolean
 ): OrderListEmptyUiState {
     return when (orderListType) {
         SEARCH -> {
-            if (isSearchPromptRequired) {
-                OrderListEmptyUiState.EmptyList(UiStringRes(R.string.orderlist_search_prompt), null)
-            } else {
-                OrderListEmptyUiState.EmptyList(UiStringRes(R.string.orders_empty_message_with_search), null)
-            }
+            OrderListEmptyUiState.EmptyList(UiStringRes(R.string.orders_empty_message_with_search), null)
         }
         PROCESSING -> {
             if (hasOrders) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListEmptyUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListEmptyUiState.kt
@@ -62,7 +62,7 @@ fun createEmptyUiState(
 ): OrderListEmptyUiState {
     return if (isListEmpty) {
         when {
-            isError -> createErrorListUiState(isNetworkAvailable, fetchFirstPage)
+            isError && isListEmpty -> createErrorListUiState(isNetworkAvailable, fetchFirstPage)
             isLoadingData -> {
                 // don't show intermediate screen when loading search results
                 if (orderListType == SEARCH) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListEmptyUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListEmptyUiState.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.ui.orders.list.OrderListType.ALL
+import com.woocommerce.android.ui.orders.list.OrderListType.PROCESSING
 import com.woocommerce.android.ui.orders.list.OrderListType.SEARCH
 
 sealed class OrderListEmptyUiState(
@@ -14,22 +15,28 @@ sealed class OrderListEmptyUiState(
     val onButtonClick: (() -> Unit)? = null,
     val emptyViewVisible: Boolean = true
 ) {
-    class ShareStore(
-        onButtonClick: (() -> Unit)?
-    ) : OrderListEmptyUiState(
-            title = UiStringRes(R.string.waiting_for_customers),
-            imgResId = R.drawable.ic_woo_waiting_customers,
-            buttonText = UiStringRes(R.string.share_store_button),
-            onButtonClick = onButtonClick
-    )
+    /**
+     * Base class for displaying "empty" list results.
+     */
+    class EmptyList(title: UiString, imgResId: Int?) : OrderListEmptyUiState(title, imgResId)
 
-    class EmptyList(title: UiString) : OrderListEmptyUiState(title)
-
+    /**
+     * Use this to hide the empty view when there is data available to view.
+     */
     object DataShown : OrderListEmptyUiState(emptyViewVisible = false)
 
+    /**
+     * The view to display while data is loading. This is the view that should be visible
+     * while orders are being fetched. The next step from here would either be to handle no orders,
+     * or to display the orders fetched.
+     */
     object Loading : OrderListEmptyUiState(title = UiStringRes(R.string.orderlist_fetching))
 
-    class RefreshError(
+    /**
+     * There was an error fetching orders. Display an error message along with a button
+     * to "Retry".
+     */
+    class ErrorWithRetry(
         title: UiString,
         buttonText: UiString? = null,
         onButtonClick: (() -> Unit)? = null
@@ -40,15 +47,18 @@ sealed class OrderListEmptyUiState(
             onButtonClick = onButtonClick)
 }
 
+/**
+ * Use this method as a builder for creating "empty" UI views.
+ */
 fun createEmptyUiState(
     orderListType: OrderListType,
     isNetworkAvailable: Boolean,
     isLoadingData: Boolean,
     isListEmpty: Boolean,
+    hasOrders: Boolean,
     isSearchPromptRequired: Boolean,
     isError: Boolean = false,
-    fetchFirstPage: () -> Unit,
-    shareStoreFunc: (() -> Unit)? = null
+    fetchFirstPage: () -> Unit
 ): OrderListEmptyUiState {
     return if (isListEmpty) {
         when {
@@ -63,7 +73,7 @@ fun createEmptyUiState(
             }
             else -> {
                 if (isNetworkAvailable) {
-                    createEmptyListUiState(orderListType, isSearchPromptRequired, shareStoreFunc)
+                    createEmptyListUiState(orderListType, isSearchPromptRequired, hasOrders)
                 } else {
                     createErrorListUiState(isNetworkAvailable, fetchFirstPage)
                 }
@@ -74,6 +84,9 @@ fun createEmptyUiState(
     }
 }
 
+/**
+ * Takes care of creating empty list error views.
+ */
 private fun createErrorListUiState(
     isNetworkAvailable: Boolean,
     fetchFirstPage: () -> Unit
@@ -83,22 +96,42 @@ private fun createErrorListUiState(
     } else {
         UiStringRes(R.string.error_generic_network)
     }
-    return OrderListEmptyUiState.RefreshError(errorText, UiStringRes(R.string.retry), fetchFirstPage)
+    return OrderListEmptyUiState.ErrorWithRetry(errorText, UiStringRes(R.string.retry), fetchFirstPage)
 }
 
+/**
+ * Takes care of creating empty list views.
+ */
 private fun createEmptyListUiState(
     orderListType: OrderListType,
     isSearchPromptRequired: Boolean,
-    shareStoreFunc: (() -> Unit)? = null
+    hasOrders: Boolean
 ): OrderListEmptyUiState {
     return when (orderListType) {
         SEARCH -> {
             if (isSearchPromptRequired) {
-                OrderListEmptyUiState.EmptyList(UiStringRes(R.string.orderlist_search_prompt))
+                OrderListEmptyUiState.EmptyList(UiStringRes(R.string.orderlist_search_prompt), null)
             } else {
-                OrderListEmptyUiState.EmptyList(UiStringRes(R.string.orders_empty_message_with_search))
+                OrderListEmptyUiState.EmptyList(UiStringRes(R.string.orders_empty_message_with_search), null)
             }
         }
-        ALL -> OrderListEmptyUiState.ShareStore(shareStoreFunc)
+        PROCESSING -> {
+            if (hasOrders) {
+                // User has processed all orders
+                OrderListEmptyUiState.EmptyList(
+                        UiStringRes(R.string.orders_processed_empty_message),
+                        R.drawable.ic_gridicons_checkmark)
+            } else {
+                // Waiting for orders to process
+                OrderListEmptyUiState.EmptyList(
+                        UiStringRes(R.string.orders_empty_message_with_processing),
+                        R.drawable.ic_hourglass_empty)
+            }
+        }
+        ALL -> {
+            OrderListEmptyUiState.EmptyList(
+                    UiStringRes(R.string.orders_empty_message_with_filter),
+                    R.drawable.ic_hourglass_empty)
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -224,10 +224,12 @@ class OrderListFragment : TopLevelFragment(),
 
         tab_layout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
             override fun onTabSelected(tab: TabLayout.Tab) {
-                val previousOrderStatus = orderStatusFilter
+                // Hide the empty view if visible
+                order_list_view.hideEmptyView()
 
                 // Calculate the filter that should be active based on the selected
                 // tab and the state of the list.
+                val previousOrderStatus = orderStatusFilter
                 orderStatusFilter = calculateOrderStatusFilter(tab)
 
                 if (orderStatusFilter != previousOrderStatus) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -662,6 +662,8 @@ class OrderListFragment : TopLevelFragment(),
      * 2. The order status list view is displayed by default
      */
     private fun enableSearchListeners() {
+        order_list_view?.hideEmptyView()
+
         orderListMenu?.findItem(R.id.menu_settings)?.isVisible = false
         orderListMenu?.findItem(R.id.menu_support)?.isVisible = false
         searchMenuItem?.setOnActionExpandListener(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -444,11 +444,6 @@ class OrderListFragment : TopLevelFragment(),
     }
 
     override fun onOrderStatusSelected(orderStatus: String?) {
-        if (orderStatusFilter == orderStatus) {
-            // Filter has not changed. Exit.
-            return
-        }
-
         orderStatusFilter = orderStatus ?: StringUtils.EMPTY
         if (isAdded) {
             AnalyticsTracker.track(
@@ -456,10 +451,16 @@ class OrderListFragment : TopLevelFragment(),
                     mapOf(AnalyticsTracker.KEY_STATUS to orderStatus.orEmpty()))
 
             isRefreshing = true
-            displayFilteredList()
-            order_list_view.clearAdapterData()
 
-            viewModel.loadList(statusFilter = orderStatus, excludeFutureOrders = shouldExcludeFutureOrders())
+            // Display the filtered list view
+            displayFilteredList()
+
+            // Load the filtered list
+            order_list_view.clearAdapterData()
+            viewModel.loadList(
+                    statusFilter = orderStatus,
+                    excludeFutureOrders = shouldExcludeFutureOrders()
+            )
 
             updateActivityTitle()
             searchMenuItem?.isVisible = shouldShowSearchMenuItem()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -37,6 +37,7 @@ import com.woocommerce.android.ui.orders.OrderStatusListView
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.ActivityUtils
+import com.woocommerce.android.util.StringUtils
 import org.wordpress.android.util.ActivityUtils as WPActivityUtils
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.activity_main.*
@@ -60,14 +61,22 @@ class OrderListFragment : TopLevelFragment(),
         const val STATE_KEY_SEARCH_QUERY = "search-query"
         const val STATE_KEY_IS_SEARCHING = "is_searching"
         const val STATE_KEY_IS_FILTER_ENABLED = "is_filter_enabled"
+        const val ARG_ORDER_STATUS_FILTER = "args-order-status-filter"
 
         private const val SEARCH_TYPING_DELAY_MS = 500L
         private const val TAB_INDEX_PROCESSING = 0
         private const val TAB_INDEX_ALL = 1
         private const val ORDER_TAB_DEFAULT = TAB_INDEX_PROCESSING
 
-        fun newInstance(orderStatusFilter: String? = null) =
-            OrderListFragment().apply { this.orderStatusFilter = orderStatusFilter }
+        fun newInstance(orderStatus: String? = null): OrderListFragment {
+            val fragment = OrderListFragment()
+            orderStatus?.let {
+                val args = Bundle()
+                args.putString(ARG_ORDER_STATUS_FILTER, orderStatus)
+                fragment.arguments = args
+            }
+            return fragment
+        }
     }
 
     @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
@@ -80,7 +89,12 @@ class OrderListFragment : TopLevelFragment(),
     }
 
     private var listState: Parcelable? = null // Save the state of the recycler view
-    private var orderStatusFilter: String? = null
+
+    // Alias for interacting with [viewModel.orderStatusFilter] so the value is always
+    // identical to the real value on the UI side.
+    private var orderStatusFilter: String
+        private set(value) { viewModel.orderStatusFilter = value}
+        get() = viewModel.orderStatusFilter
 
     // Alias for interacting with [viewModel.isSearching] so the value is always identical
     // to the real value on the UI side.
@@ -118,10 +132,12 @@ class OrderListFragment : TopLevelFragment(),
         setHasOptionsMenu(true)
         savedInstanceState?.let { bundle ->
             listState = bundle.getParcelable(STATE_KEY_LIST)
-            orderStatusFilter = bundle.getString(STATE_KEY_ACTIVE_FILTER, null)
+            orderStatusFilter = bundle.getString(STATE_KEY_ACTIVE_FILTER, StringUtils.EMPTY)
             isSearching = bundle.getBoolean(STATE_KEY_IS_SEARCHING)
             isFilterEnabled = bundle.getBoolean(STATE_KEY_IS_FILTER_ENABLED)
             searchQuery = bundle.getString(STATE_KEY_SEARCH_QUERY, "")
+        } ?: arguments?.let {
+            orderStatusFilter = it.getString(ARG_ORDER_STATUS_FILTER, StringUtils.EMPTY)
         }
     }
 
@@ -193,7 +209,7 @@ class OrderListFragment : TopLevelFragment(),
 
                     // If this tab is the one that should be active, select it and load
                     // the appropriate list.
-                    if (index == calculateDefaultTabPosition()) {
+                    if (index == calculateStartupTabPosition()) {
                         orderStatusFilter = calculateOrderStatusFilter(tab)
                         tab.select()
                     }
@@ -443,7 +459,7 @@ class OrderListFragment : TopLevelFragment(),
             return
         }
 
-        orderStatusFilter = orderStatus
+        orderStatusFilter = orderStatus ?: StringUtils.EMPTY
         if (isAdded) {
             AnalyticsTracker.track(
                     Stat.ORDERS_LIST_FILTER,
@@ -477,9 +493,11 @@ class OrderListFragment : TopLevelFragment(),
      *
      * @return the index of the tab to be activated
      */
-    private fun calculateDefaultTabPosition(): Int {
+    private fun calculateStartupTabPosition(): Int {
         val orderStatusOptions = getOrderStatusOptions()
-        return if (AppPrefs.hasSelectedOrderListTabPosition()) {
+        return if (orderStatusFilter == PROCESSING.value) {
+            TAB_INDEX_PROCESSING
+        } else if (AppPrefs.hasSelectedOrderListTabPosition()) {
             // If the user has already changed tabs once then select
             // the last tab they had selected.
             AppPrefs.getSelectedOrderListTabPosition()
@@ -493,10 +511,10 @@ class OrderListFragment : TopLevelFragment(),
         }
     }
 
-    private fun getOrderStatusFilterForActiveTab(): String? {
+    private fun getOrderStatusFilterForActiveTab(): String {
         return tab_layout.getTabAt(tab_layout.selectedTabPosition)?.let {
             calculateOrderStatusFilter(it)
-        } ?: null
+        } ?: StringUtils.EMPTY
     }
 
     /**
@@ -505,11 +523,11 @@ class OrderListFragment : TopLevelFragment(),
      * @return If there is an active filter, return that filter. Otherwise, if the "Processing"
      * tab is currently selected, return a filter of "processing", else return null (no filter).
      */
-    private fun calculateOrderStatusFilter(tab: TabLayout.Tab): String? {
+    private fun calculateOrderStatusFilter(tab: TabLayout.Tab): String {
         return when {
             isFilterEnabled -> orderStatusFilter
-            tab.position == 0 -> (tab.tag as? String)?.toLowerCase(Locale.getDefault())
-            else -> null
+            tab.position == 0 -> (tab.tag as? String)?.toLowerCase(Locale.getDefault()) ?: StringUtils.EMPTY
+            else -> StringUtils.EMPTY
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -36,7 +36,6 @@ import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.ui.orders.OrderStatusListView
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.WooAnimUtils
-import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.StringUtils
 import org.wordpress.android.util.ActivityUtils as WPActivityUtils
 import dagger.android.support.AndroidSupportInjection
@@ -93,7 +92,7 @@ class OrderListFragment : TopLevelFragment(),
     // Alias for interacting with [viewModel.orderStatusFilter] so the value is always
     // identical to the real value on the UI side.
     private var orderStatusFilter: String
-        private set(value) { viewModel.orderStatusFilter = value}
+        private set(value) { viewModel.orderStatusFilter = value }
         get() = viewModel.orderStatusFilter
 
     // Alias for interacting with [viewModel.isSearching] so the value is always identical
@@ -407,17 +406,6 @@ class OrderListFragment : TopLevelFragment(),
 
         viewModel.emptyViewState.observe(this, Observer {
             it?.let { emptyViewState -> order_list_view?.updateEmptyViewForState(emptyViewState) }
-        })
-
-        viewModel.shareStore.observe(this, Observer {
-            AnalyticsTracker.track(Stat.ORDERS_LIST_SHARE_YOUR_STORE_BUTTON_TAPPED)
-            selectedSite.getIfExists()?.let { site ->
-                context?.let { ctx ->
-                    selectedSite.getIfExists()?.let {
-                        ActivityUtils.shareStoreUrl(ctx, site.url)
-                    }
-                }
-            }
         })
 
         viewModel.start()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListRepository.kt
@@ -72,6 +72,13 @@ class OrderListRepository @Inject constructor(
         }
     }
 
+    /**
+     * Checks to see if there are any orders in the db for the active store.
+     *
+     * @return True if there are orders in the db, else False
+     */
+    fun hasCachedOrdersForSite() = orderStore.hasCachedOrdersForSite(selectedSite.get())
+
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onOrderStatusOptionsChanged(event: OnOrderStatusOptionsChanged) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListType.kt
@@ -2,5 +2,6 @@ package com.woocommerce.android.ui.orders.list
 
 enum class OrderListType {
     ALL,
+    PROCESSING,
     SEARCH
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListView.kt
@@ -124,7 +124,9 @@ class OrderListView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet?
                 UiHelpers.setTextOrHide(emptyView.title, state.title)
                 UiHelpers.setImageOrHide(emptyView.image, state.imgResId)
                 setupButtonOrHide(emptyView.button, state.buttonText, state.onButtonClick)
-                WooAnimUtils.fadeIn(emptyView, Duration.MEDIUM)
+                if (emptyView.visibility == View.GONE) {
+                    WooAnimUtils.fadeIn(emptyView, Duration.MEDIUM)
+                }
             } else {
                 hideEmptyView()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListView.kt
@@ -13,6 +13,8 @@ import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.UiHelpers
+import com.woocommerce.android.util.WooAnimUtils
+import com.woocommerce.android.util.WooAnimUtils.Duration
 import kotlinx.android.synthetic.main.order_list_view.view.*
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 
@@ -118,7 +120,7 @@ class OrderListView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet?
                 UiHelpers.setTextOrHide(emptyView.title, state.title)
                 UiHelpers.setImageOrHide(emptyView.image, state.imgResId)
                 setupButtonOrHide(emptyView.button, state.buttonText, state.onButtonClick)
-                emptyView.visibility = View.VISIBLE
+                WooAnimUtils.fadeIn(emptyView, Duration.MEDIUM)
             } else {
                 emptyView.visibility = View.GONE
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListView.kt
@@ -114,6 +114,10 @@ class OrderListView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet?
         load_more_progressbar.visibility = if (active) View.VISIBLE else View.GONE
     }
 
+    fun hideEmptyView() {
+        empty_view?.visibility = View.GONE
+    }
+
     fun updateEmptyViewForState(state: OrderListEmptyUiState) {
         empty_view?.let { emptyView ->
             if (state.emptyViewVisible) {
@@ -122,7 +126,7 @@ class OrderListView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet?
                 setupButtonOrHide(emptyView.button, state.buttonText, state.onButtonClick)
                 WooAnimUtils.fadeIn(emptyView, Duration.MEDIUM)
             } else {
-                emptyView.visibility = View.GONE
+                hideEmptyView()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -95,9 +95,6 @@ class OrderListViewModel @Inject constructor(
     }
     val emptyViewState: LiveData<OrderListEmptyUiState> = _emptyViewState
 
-    private val _shareStore = SingleLiveEvent<Unit>()
-    val shareStore: LiveData<Unit> = _shareStore
-
     var isSearching = false
     var searchQuery = ""
     var orderStatusFilter = ""
@@ -191,15 +188,6 @@ class OrderListViewModel @Inject constructor(
     }
 
     /**
-     * Notifies the view to share the store. It's necessary to do this from the fragment because
-     * doing this from here would require using the applicationContext which forces a new activity
-     * to be created.
-     */
-    fun shareStore() {
-        _shareStore.call()
-    }
-
-    /**
      * Reload the orders list with the database available in the database. This is the ideal way to
      * load changes to orders that were initiated from within this app instance. If the change was
      * successfully pushed to the API, then the database would already be updated so there is no
@@ -264,8 +252,8 @@ class OrderListViewModel @Inject constructor(
         _emptyViewState.addSource(pagedListWrapper.listError) { _emptyViewState.postValue(update()) }
     }
 
-    private fun isShowingProcessingTab() = orderStatusFilter.isNotEmpty()
-            && orderStatusFilter.toLowerCase(Locale.ROOT) == CoreOrderStatus.PROCESSING.value.toLowerCase(Locale.ROOT)
+    private fun isShowingProcessingTab() = orderStatusFilter.isNotEmpty() &&
+            orderStatusFilter.toLowerCase(Locale.ROOT) == CoreOrderStatus.PROCESSING.value.toLowerCase(Locale.ROOT)
 
     private fun showOfflineSnack() {
         // Network is not connected

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.orders.list
 
-import android.text.TextUtils
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
@@ -197,8 +196,6 @@ class OrderListViewModel @Inject constructor(
         pagedListWrapper?.invalidateData()
     }
 
-    private fun isEmptySearch() = TextUtils.isEmpty(searchQuery) && isSearching
-
     /**
      * Used to filter out dataset changes that might trigger an empty view when performing a search.
      *
@@ -242,7 +239,6 @@ class OrderListViewModel @Inject constructor(
                         pagedListWrapper.data.value == null,
                 isListEmpty = pagedListWrapper.isEmpty.value ?: true,
                 hasOrders = repository.hasCachedOrdersForSite(),
-                isSearchPromptRequired = isEmptySearch(),
                 isError = pagedListWrapper.listError.value != null,
                 fetchFirstPage = this::fetchOrdersAndOrderStatusOptions)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -98,6 +98,7 @@ class OrderListViewModel @Inject constructor(
 
     var isSearching = false
     var searchQuery = ""
+    var orderStatusFilter = ""
 
     init {
         lifecycleRegistry.markState(Lifecycle.State.CREATED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import java.io.IOException
 
 object StringUtils {
+    const val EMPTY = ""
     private const val ONE_MILLION = 1000000
     private const val ONE_THOUSAND = 1000
 

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'd8e999c70729ddb755e64daa7102c78b7919b000'
+    fluxCVersion = 'eb3fb3f887f373107148de77eff3e8a2ce1e135f'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
This PR fixes #1514 by adding the logic needed to display the appropriate empty list or error views (when the order list is empty) for the order list. These empty states are the same that were previously implemented in #1411. This PR just ensures they are carried over with all the changes. 

## No Orders Yet
These are the empty views for a site that has no orders yet:

**ALL tab**

<img src="https://user-images.githubusercontent.com/5810477/68170779-f8874c00-ff25-11e9-9303-c6a7958c4c1d.png" width="300"/>

**PROCESSING tab**

<img src="https://user-images.githubusercontent.com/5810477/68170829-1eacec00-ff26-11e9-81cf-c9950e795d70.png" width="300"/>

## All orders processed
This is the view displayed when the store has orders, but there are no orders waiting to be processed.

<img src="https://user-images.githubusercontent.com/5810477/68170851-34221600-ff26-11e9-8254-1da40da85430.png" width="300"/>

## Error Views
Error views are only displayed if there are no orders to display. 

**Offline**

<img src="https://user-images.githubusercontent.com/5810477/68170875-53b93e80-ff26-11e9-9441-39794ca033db.png" width="300"/>

**Error Fetching Orders**

<img src="https://user-images.githubusercontent.com/5810477/68170880-561b9880-ff26-11e9-8b27-a19674ff5b55.png" width="300"/>

# Testing

**Test "All orders have been processed" empty view**
1. Login to a store that has orders and has 1 order in the "processing" state.
2. Click on the "Orders" tab
3. Click on the "PROCESSING" tab if it's not already selected
4. Verify the single order is visible. Click on the order and fulfill it. 
5. Go back to the order list. 
6. After the list is finished refreshing, the "All orders have been processed" empty view should appear.

**Test "no orders yet"/"No orders to process yet" empty views**
1. Login to a store that has no orders
2. Click on the orders tab
3. Click on the "PROCESSING" tab, verify the "No orders to process yet" empty view is visible.
4. Click on the "ALL" tab, verify the "No orders yet" empty view is visible.

**Test "offline" error empty view**
1. Login to a store with no orders
2. Click on the "Orders" tab and select the "ALL" tab if needed. 
3. The "No orders yet" empty view should be visible.
4. Turn on airplane mode on the device.
5. Do a "pull-to-refresh" on the order list.
6. Verify the offline error empty view is displayed. 

**Test "error fetching orders" error empty view**
The easiest way to test this is to force the error view to be shown. 
1. manually update [this line](https://github.com/woocommerce/woocommerce-android/blob/fca0ec8c64cd075bf7edf580da4535d1b3302d93/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt#L246) to set `isError = true`.
2. Login to a store with no orders (since the error view will only be shown if there are no orders). 
3. Click the "Orders" tab
4. Verify the error view is shown



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
