### PR TITLE
Feature/read only product variants

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+3.1
+-----
+* Added a new variants section in the Product detail screen for variable products
+
 3.0
 -----
 * Added a new refunding feature that brings the ability to specify the amount to refund

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -238,6 +238,12 @@ class AnalyticsTracker private constructor(private val context: Context) {
         PRODUCT_DETAIL_SHARE_BUTTON_TAPPED,
         PRODUCT_DETAIL_VIEW_EXTERNAL_TAPPED,
         PRODUCT_DETAIL_VIEW_AFFILIATE_TAPPED,
+        PRODUCT_DETAIL_VIEW_PRODUCT_VARIANTS_TAPPED,
+
+        // -- Product variants
+        PRODUCT_VARIANTS_PULLED_TO_REFRESH,
+        PRODUCT_VARIANTS_LOADED,
+        PRODUCT_VARIANTS_LOAD_ERROR,
 
         // -- Help & Support
         SUPPORT_HELP_CENTER_VIEWED(siteless = true),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ActivityBindingModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ActivityBindingModule.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.ui.prefs.MainSettingsModule
 import com.woocommerce.android.ui.prefs.PrivacySettingsModule
 import com.woocommerce.android.ui.products.ProductDetailModule
 import com.woocommerce.android.ui.products.ProductListModule
+import com.woocommerce.android.ui.products.ProductVariantsModule
 import com.woocommerce.android.ui.refunds.RefundsModule
 import com.woocommerce.android.ui.reviews.ReviewDetailModule
 import com.woocommerce.android.ui.reviews.ReviewListModule
@@ -45,6 +46,7 @@ abstract class ActivityBindingModule {
             AddOrderNoteModule::class,
             ProductDetailModule::class,
             ProductListModule::class,
+            ProductVariantsModule::class,
             ReviewListModule::class,
             ReviewDetailModule::class,
             SitePickerModule::class,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ViewModelModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ViewModelModule.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.woocommerce.android.ui.products.ProductDetailViewModel
 import com.woocommerce.android.ui.products.ProductListViewModel
+import com.woocommerce.android.ui.products.ProductVariantsViewModel
 import com.woocommerce.android.ui.refunds.IssueRefundViewModel
 import com.woocommerce.android.ui.refunds.RefundDetailViewModel
 import com.woocommerce.android.viewmodel.ViewModelFactory
@@ -25,6 +26,11 @@ internal abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(ProductListViewModel::class)
     internal abstract fun pluginProductListViewModel(viewModel: ProductListViewModel): ViewModel
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(ProductVariantsViewModel::class)
+    internal abstract fun pluginProductVariantsViewModel(viewModel: ProductVariantsViewModel): ViewModel
 
     @Binds
     @IntoMap

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.ui.products.ProductStockStatus
 import com.woocommerce.android.ui.products.ProductType
 import org.wordpress.android.fluxc.model.WCProductImageModel
 import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.model.WCProductModel.ProductAttribute
 import org.wordpress.android.util.DateTimeUtils
 import java.math.BigDecimal
 import java.util.Date
@@ -44,7 +45,8 @@ data class Product(
     val downloadExpiry: Int,
     val purchaseNote: String,
     val numVariations: Int,
-    val images: List<WCProductImageModel>
+    val images: List<WCProductImageModel>,
+    val attributes: List<ProductAttribute>
 )
 
 fun WCProductModel.toAppModel(): Product {
@@ -82,7 +84,8 @@ fun WCProductModel.toAppModel(): Product {
         this.downloadExpiry,
         this.purchaseNote,
         this.getNumVariations(),
-        this.getImages()
+        this.getImages(),
+        this.getAttributes()
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariant.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariant.kt
@@ -37,9 +37,9 @@ private fun getAttributeOptionName(variantOptions: List<ProductVariantOption>): 
     for (variantOption in variantOptions) {
         if (!variantOption.option.isNullOrEmpty()) {
             if (optionName.isNotEmpty()) {
-                optionName += "-"
+                optionName += " - "
             }
-            optionName += " ${variantOption.option} "
+            optionName += "${variantOption.option}"
         }
     }
     return optionName

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariant.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariant.kt
@@ -1,0 +1,45 @@
+package com.woocommerce.android.model
+
+import com.woocommerce.android.ui.products.ProductStockStatus
+import org.wordpress.android.fluxc.model.WCProductVariationModel
+import org.wordpress.android.fluxc.model.WCProductVariationModel.ProductVariantOption
+import java.math.BigDecimal
+
+data class ProductVariant(
+    val remoteProductId: Long,
+    val remoteVariationId: Long,
+    val imageUrl: String?,
+    val price: BigDecimal?,
+    val stockStatus: ProductStockStatus,
+    val stockQuantity: Int,
+    val attributes: String?
+)
+
+fun WCProductVariationModel.toAppModel(): ProductVariant {
+    return ProductVariant(
+        this.remoteProductId,
+        this.remoteVariationId,
+        this.imageUrl,
+        this.price.toBigDecimalOrNull(),
+        ProductStockStatus.fromString(this.stockStatus),
+        this.stockQuantity,
+        getAttributeOptionName(this.getProductVariantOptions())
+    )
+}
+
+/**
+ * Given a list of [ProductVariantOption]
+ * returns the product variant combination name in the format {option1} - {option2}
+ */
+private fun getAttributeOptionName(variantOptions: List<ProductVariantOption>): String? {
+    var optionName = ""
+    for (variantOption in variantOptions) {
+        if (!variantOption.option.isNullOrEmpty()) {
+            if (optionName.isNotEmpty()) {
+                optionName += "-"
+            }
+            optionName += " ${variantOption.option} "
+        }
+    }
+    return optionName
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariant.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariant.kt
@@ -12,7 +12,8 @@ data class ProductVariant(
     val price: BigDecimal?,
     val stockStatus: ProductStockStatus,
     val stockQuantity: Int,
-    val attributes: String?
+    val optionName: String,
+    var priceWithCurrency: String? = null
 )
 
 fun WCProductVariationModel.toAppModel(): ProductVariant {
@@ -31,7 +32,7 @@ fun WCProductVariationModel.toAppModel(): ProductVariant {
  * Given a list of [ProductVariantOption]
  * returns the product variant combination name in the format {option1} - {option2}
  */
-private fun getAttributeOptionName(variantOptions: List<ProductVariantOption>): String? {
+private fun getAttributeOptionName(variantOptions: List<ProductVariantOption>): String {
     var optionName = ""
     for (variantOption in variantOptions) {
         if (!variantOption.option.isNullOrEmpty()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -282,6 +282,7 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
             val productVariantFormatter = R.string.product_property_variant_formatter
             if (FeatureFlag.PRODUCT_VARIANTS.isEnabled(context)) {
                 addPropertyGroup(pricingCard, R.string.product_variants, group, productVariantFormatter) {
+                    AnalyticsTracker.track(Stat.PRODUCT_DETAIL_VIEW_PRODUCT_VARIANTS_TAPPED)
                     showProductVariations(product.remoteId)
                 }
             } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -35,6 +35,7 @@ import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductWithPar
 import com.woocommerce.android.ui.products.ProductType.EXTERNAL
 import com.woocommerce.android.ui.products.ProductType.GROUPED
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.util.WooPermissionUtils
 import com.woocommerce.android.widgets.SkeletonView
@@ -277,9 +278,14 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
             for (attribute in product.attributes) {
                 group[attribute.name] = attribute.options.size.toString()
             }
-            addPropertyGroup(pricingCard, R.string.product_variants, group, R.string.product_property_variant_formatter
-            ) {
-                showProductVariations(product.remoteId)
+
+            val productVariantFormatter = R.string.product_property_variant_formatter
+            if (FeatureFlag.PRODUCT_VARIANTS.isEnabled(context)) {
+                addPropertyGroup(pricingCard, R.string.product_variants, group, productVariantFormatter) {
+                    showProductVariations(product.remoteId)
+                }
+            } else {
+                addPropertyGroup(pricingCard, R.string.product_variants, group, productVariantFormatter)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -18,6 +18,7 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -272,11 +273,14 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
 
         // show product variants only if product type is variable
         if (product.type == VARIABLE) {
-            var group = mutableMapOf<String, String>()
+            val group = mutableMapOf<String, String>()
             for (attribute in product.attributes) {
                 group[attribute.name] = attribute.options.size.toString()
             }
             addPropertyGroup(pricingCard, R.string.product_variants, group, R.string.product_property_variant_formatter)
+            {
+                showProductVariations(product.remoteId)
+            }
         }
     }
 
@@ -371,7 +375,8 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
         card: DetailCard,
         @StringRes groupTitleId: Int,
         properties: Map<String, String>,
-        @StringRes propertyValueFormatterId: Int = R.string.product_property_default_formatter
+        @StringRes propertyValueFormatterId: Int = R.string.product_property_default_formatter,
+        propertyGroupClickListener: ((view: View) -> Unit)? = null
     ): WCProductPropertyView? {
         var propertyValue = ""
         properties.forEach { property ->
@@ -382,7 +387,9 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
                 propertyValue += getString(propertyValueFormatterId, property.key, property.value)
             }
         }
-        return addPropertyView(card, getString(groupTitleId), propertyValue, LinearLayout.VERTICAL)
+        return addPropertyView(card, getString(groupTitleId), propertyValue, LinearLayout.VERTICAL)?.also {
+            it.setClickListener(propertyGroupClickListener)
+        }
     }
 
     /**
@@ -486,6 +493,12 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
         }
         val title = resources.getText(R.string.product_share_dialog_title)
         startActivity(Intent.createChooser(shareIntent, title))
+    }
+
+    private fun showProductVariations(remoteId: Long) {
+        val action = ProductDetailFragmentDirections
+                .actionProductDetailFragmentToProductVariantsFragment(remoteId)
+        findNavController().navigate(action)
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -269,6 +269,15 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
         } else {
             addPropertyView(pricingCard, R.string.product_sku, product.sku, LinearLayout.VERTICAL)
         }
+
+        // show product variants only if product type is variable
+        if (product.type == VARIABLE) {
+            var group = mutableMapOf<String, String>()
+            for (attribute in product.attributes) {
+                group[attribute.name] = attribute.options.size.toString()
+            }
+            addPropertyGroup(pricingCard, R.string.product_variants, group, R.string.product_property_variant_formatter)
+        }
     }
 
     private fun addPurchaseDetailsCard(productData: ProductWithParameters) {
@@ -361,7 +370,8 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
     private fun addPropertyGroup(
         card: DetailCard,
         @StringRes groupTitleId: Int,
-        properties: Map<String, String>
+        properties: Map<String, String>,
+        @StringRes propertyValueFormatterId: Int = R.string.product_property_default_formatter
     ): WCProductPropertyView? {
         var propertyValue = ""
         properties.forEach { property ->
@@ -369,7 +379,7 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
                 if (propertyValue.isNotEmpty()) {
                     propertyValue += "\n"
                 }
-                propertyValue += "${property.key}: ${property.value}"
+                propertyValue += getString(propertyValueFormatterId, property.key, property.value)
             }
         }
         return addPropertyView(card, getString(groupTitleId), propertyValue, LinearLayout.VERTICAL)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -277,8 +277,8 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
             for (attribute in product.attributes) {
                 group[attribute.name] = attribute.options.size.toString()
             }
-            addPropertyGroup(pricingCard, R.string.product_variants, group, R.string.product_property_variant_formatter)
-            {
+            addPropertyGroup(pricingCard, R.string.product_variants, group, R.string.product_property_variant_formatter
+            ) {
                 showProductVariations(product.remoteId)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsAdapter.kt
@@ -1,0 +1,87 @@
+package com.woocommerce.android.ui.products
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.DiffUtil.Callback
+import androidx.recyclerview.widget.RecyclerView
+import com.woocommerce.android.R
+import com.woocommerce.android.di.GlideApp
+import com.woocommerce.android.model.ProductVariant
+import com.woocommerce.android.ui.products.ProductVariantsAdapter.ProductVariantViewHolder
+import kotlinx.android.synthetic.main.product_variant_list_item.view.*
+import org.wordpress.android.util.PhotonUtils
+
+class ProductVariantsAdapter(
+    private val context: Context
+) : RecyclerView.Adapter<ProductVariantViewHolder>() {
+    private val imageSize = context.resources.getDimensionPixelSize(R.dimen.product_icon_sz)
+    private val productVariantList = ArrayList<ProductVariant>()
+
+    override fun getItemId(position: Int) = productVariantList[position].remoteProductId
+
+    override fun getItemCount() = productVariantList.size
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProductVariantViewHolder {
+        val holder = ProductVariantViewHolder(LayoutInflater.from(context).inflate(R.layout.product_variant_list_item, parent, false))
+        holder.imgVariantOption.clipToOutline = true
+        return holder
+    }
+
+    override fun onBindViewHolder(holder: ProductVariantViewHolder, position: Int) {
+        val productVariant = productVariantList[position]
+
+        holder.txtVariantOptionName.text = productVariant.optionName
+        productVariant.priceWithCurrency?.let {
+            holder.txtVariantOptionPriceAndStock.text = it
+        }
+
+        productVariant.imageUrl?.let {
+            val imageUrl = PhotonUtils.getPhotonImageUrl(it, imageSize, imageSize)
+            GlideApp.with(context)
+                    .load(imageUrl)
+                    .placeholder(R.drawable.ic_product)
+                    .into(holder.imgVariantOption)
+        } ?: holder.imgVariantOption.setImageResource(R.drawable.ic_product)
+    }
+
+    private class ProductVariantItemDiffUtil(
+        val items: List<ProductVariant>,
+        val result: List<ProductVariant>
+    ) : Callback() {
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int) =
+                items[oldItemPosition].remoteProductId == result[newItemPosition].remoteProductId
+
+        override fun getOldListSize(): Int = items.size
+
+        override fun getNewListSize(): Int = result.size
+
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            val oldItem = items[oldItemPosition]
+            val newItem = result[newItemPosition]
+            return oldItem.stockQuantity == newItem.stockQuantity &&
+                    oldItem.stockStatus == newItem.stockStatus &&
+                    oldItem.imageUrl == newItem.imageUrl &&
+                    oldItem.optionName == newItem.optionName
+        }
+    }
+
+    fun setProductVariantList(productVariants: List<ProductVariant>) {
+        val diffResult = DiffUtil.calculateDiff(
+                ProductVariantItemDiffUtil(productVariantList, productVariants)
+        )
+        productVariantList.clear()
+        productVariantList.addAll(productVariants)
+        diffResult.dispatchUpdatesTo(this)
+    }
+
+    class ProductVariantViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val imgVariantOption: ImageView = view.variantOptionImage
+        val txtVariantOptionName: TextView = view.variantOptionName
+        val txtVariantOptionPriceAndStock: TextView = view.variantOptionPriceAndStock
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsAdapter.kt
@@ -27,7 +27,9 @@ class ProductVariantsAdapter(
     override fun getItemCount() = productVariantList.size
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProductVariantViewHolder {
-        val holder = ProductVariantViewHolder(LayoutInflater.from(context).inflate(R.layout.product_variant_list_item, parent, false))
+        val holder = ProductVariantViewHolder(
+                LayoutInflater.from(context).inflate(R.layout.product_variant_list_item, parent, false)
+        )
         holder.imgVariantOption.clipToOutline = true
         return holder
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsAdapter.kt
@@ -22,6 +22,10 @@ class ProductVariantsAdapter(
     private val imageSize = context.resources.getDimensionPixelSize(R.dimen.product_icon_sz)
     private val productVariantList = ArrayList<ProductVariant>()
 
+    init {
+        setHasStableIds(true)
+    }
+
     override fun getItemId(position: Int) = productVariantList[position].remoteProductId
 
     override fun getItemCount() = productVariantList.size
@@ -52,19 +56,19 @@ class ProductVariantsAdapter(
     }
 
     private class ProductVariantItemDiffUtil(
-        val items: List<ProductVariant>,
-        val result: List<ProductVariant>
+        val oldList: List<ProductVariant>,
+        val newList: List<ProductVariant>
     ) : Callback() {
         override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int) =
-                items[oldItemPosition].remoteProductId == result[newItemPosition].remoteProductId
+                oldList[oldItemPosition].remoteProductId == newList[newItemPosition].remoteProductId
 
-        override fun getOldListSize(): Int = items.size
+        override fun getOldListSize(): Int = oldList.size
 
-        override fun getNewListSize(): Int = result.size
+        override fun getNewListSize(): Int = newList.size
 
         override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-            val oldItem = items[oldItemPosition]
-            val newItem = result[newItemPosition]
+            val oldItem = oldList[oldItemPosition]
+            val newItem = newList[newItemPosition]
             return oldItem.stockQuantity == newItem.stockQuantity &&
                     oldItem.stockStatus == newItem.stockStatus &&
                     oldItem.imageUrl == newItem.imageUrl &&

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsAdapter.kt
@@ -70,6 +70,7 @@ class ProductVariantsAdapter(
             val oldItem = oldList[oldItemPosition]
             val newItem = newList[newItemPosition]
             return oldItem.stockQuantity == newItem.stockQuantity &&
+                    oldItem.remoteVariationId == newItem.remoteVariationId &&
                     oldItem.price == newItem.price &&
                     oldItem.stockStatus == newItem.stockStatus &&
                     oldItem.imageUrl == newItem.imageUrl &&

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsAdapter.kt
@@ -10,14 +10,15 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.DiffUtil.Callback
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.R
-import com.woocommerce.android.di.GlideApp
+import com.woocommerce.android.di.GlideRequests
 import com.woocommerce.android.model.ProductVariant
 import com.woocommerce.android.ui.products.ProductVariantsAdapter.ProductVariantViewHolder
 import kotlinx.android.synthetic.main.product_variant_list_item.view.*
 import org.wordpress.android.util.PhotonUtils
 
 class ProductVariantsAdapter(
-    private val context: Context
+    private val context: Context,
+    private val glideRequest: GlideRequests
 ) : RecyclerView.Adapter<ProductVariantViewHolder>() {
     private val imageSize = context.resources.getDimensionPixelSize(R.dimen.product_icon_sz)
     private val productVariantList = ArrayList<ProductVariant>()
@@ -48,8 +49,7 @@ class ProductVariantsAdapter(
 
         productVariant.imageUrl?.let {
             val imageUrl = PhotonUtils.getPhotonImageUrl(it, imageSize, imageSize)
-            GlideApp.with(context)
-                    .load(imageUrl)
+            glideRequest.load(imageUrl)
                     .placeholder(R.drawable.ic_product)
                     .into(holder.imgVariantOption)
         } ?: holder.imgVariantOption.setImageResource(R.drawable.ic_product)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsAdapter.kt
@@ -70,6 +70,7 @@ class ProductVariantsAdapter(
             val oldItem = oldList[oldItemPosition]
             val newItem = newList[newItemPosition]
             return oldItem.stockQuantity == newItem.stockQuantity &&
+                    oldItem.price == newItem.price &&
                     oldItem.stockStatus == newItem.stockStatus &&
                     oldItem.imageUrl == newItem.imageUrl &&
                     oldItem.optionName == newItem.optionName

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsFragment.kt
@@ -1,0 +1,138 @@
+package com.woocommerce.android.ui.products
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProviders
+import androidx.navigation.fragment.navArgs
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.model.ProductVariant
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.widgets.AlignedDividerDecoration
+import com.woocommerce.android.widgets.SkeletonView
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.fragment_product_variants.*
+import javax.inject.Inject
+
+class ProductVariantsFragment: BaseFragment() {
+    companion object {
+        const val TAG: String = "ProductVariantsFragment"
+    }
+
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    @Inject lateinit var uiMessageResolver: UIMessageResolver
+
+    private lateinit var viewModel: ProductVariantsViewModel
+    private lateinit var productVariantsAdapter: ProductVariantsAdapter
+
+    private val skeletonView = SkeletonView()
+
+    private val navArgs: ProductVariantsFragmentArgs by navArgs()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        setHasOptionsMenu(true)
+        return inflater.inflate(R.layout.fragment_product_variants, container, false)
+    }
+
+    override fun onAttach(context: Context?) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onDestroyView() {
+        // hide the skeleton view if fragment is destroyed
+        skeletonView.hide()
+        super.onDestroyView()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        AnalyticsTracker.trackViewShown(this)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initializeViewModel()
+    }
+
+    private fun initializeViewModel() {
+        viewModel = ViewModelProviders.of(this, viewModelFactory).get(ProductVariantsViewModel::class.java).also {
+            setupObservers(it)
+        }
+
+        viewModel.start(navArgs.remoteProductId)
+    }
+
+    private fun setupObservers(viewModel: ProductVariantsViewModel) {
+        viewModel.isSkeletonShown.observe(this, Observer {
+            showSkeleton(it)
+        })
+
+        viewModel.productVariantList.observe(this, Observer {
+            showProductVariants(it)
+        })
+
+        viewModel.showSnackbarMessage.observe(this, Observer {
+            uiMessageResolver.showSnack(it)
+        })
+
+        viewModel.exit.observe(this, Observer {
+            activity?.onBackPressed()
+        })
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+
+        val activity = requireActivity()
+
+        productVariantsAdapter = ProductVariantsAdapter(activity)
+        with(productVariantsList) {
+            layoutManager = LinearLayoutManager(activity)
+            adapter = productVariantsAdapter
+            addItemDecoration(AlignedDividerDecoration(
+                    activity, DividerItemDecoration.VERTICAL, R.id.variantOptionName, clipToMargin = false
+            ))
+        }
+
+        productVariantsRefreshLayout?.apply {
+            setColorSchemeColors(
+                    ContextCompat.getColor(activity, R.color.colorPrimary),
+                    ContextCompat.getColor(activity, R.color.colorAccent),
+                    ContextCompat.getColor(activity, R.color.colorPrimaryDark)
+            )
+            scrollUpChild = productVariantsList
+            setOnRefreshListener {
+                // TODO: add event here for ptr in a different commit
+                // TODO: refresh product
+            }
+        }
+    }
+
+    override fun getFragmentTitle() = getString(R.string.product_variations)
+
+    private fun showSkeleton(show: Boolean) {
+        if (show) {
+            skeletonView.show(productVariantsList, R.layout.skeleton_product_list, delayed = true)
+        } else {
+            skeletonView.hide()
+        }
+    }
+
+    private fun showProductVariants(productVariants: List<ProductVariant>) {
+        productVariantsAdapter.setProductVariantList(productVariants)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsFragment.kt
@@ -89,6 +89,10 @@ class ProductVariantsFragment: BaseFragment() {
             uiMessageResolver.showSnack(it)
         })
 
+        viewModel.isRefreshing.observe(this, Observer {
+            productVariantsRefreshLayout.isRefreshing = it
+        })
+
         viewModel.exit.observe(this, Observer {
             activity?.onBackPressed()
         })
@@ -117,7 +121,7 @@ class ProductVariantsFragment: BaseFragment() {
             scrollUpChild = productVariantsList
             setOnRefreshListener {
                 // TODO: add event here for ptr in a different commit
-                // TODO: refresh product
+                viewModel.refreshProductVariants(navArgs.remoteProductId)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsFragment.kt
@@ -14,6 +14,7 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.model.ProductVariant
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -120,7 +121,7 @@ class ProductVariantsFragment : BaseFragment() {
             )
             scrollUpChild = productVariantsList
             setOnRefreshListener {
-                // TODO: add event here for ptr in a different commit
+                AnalyticsTracker.track(Stat.PRODUCT_VARIANTS_PULLED_TO_REFRESH)
                 viewModel.refreshProductVariants(navArgs.remoteProductId)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsFragment.kt
@@ -15,6 +15,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.di.GlideApp
 import com.woocommerce.android.model.ProductVariant
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -104,7 +105,7 @@ class ProductVariantsFragment : BaseFragment() {
 
         val activity = requireActivity()
 
-        productVariantsAdapter = ProductVariantsAdapter(activity)
+        productVariantsAdapter = ProductVariantsAdapter(activity, GlideApp.with(this))
         with(productVariantsList) {
             layoutManager = LinearLayoutManager(activity)
             adapter = productVariantsAdapter

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsFragment.kt
@@ -23,7 +23,7 @@ import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_product_variants.*
 import javax.inject.Inject
 
-class ProductVariantsFragment: BaseFragment() {
+class ProductVariantsFragment : BaseFragment() {
     companion object {
         const val TAG: String = "ProductVariantsFragment"
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsModule.kt
@@ -1,0 +1,10 @@
+package com.woocommerce.android.ui.products
+
+import dagger.Module
+import dagger.android.ContributesAndroidInjector
+
+@Module
+internal abstract class ProductVariantsModule {
+    @ContributesAndroidInjector
+    abstract fun productVariantsFragment(): ProductVariantsFragment
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsRepository.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.CancellationException
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.WCProductAction.FETCHED_PRODUCT_VARIATIONS
+import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_VARIATIONS
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
@@ -79,7 +79,7 @@ class ProductVariantsRepository @Inject constructor(
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onProductChanged(event: OnProductChanged) {
-        if (event.causeOfChange == FETCHED_PRODUCT_VARIATIONS) {
+        if (event.causeOfChange == FETCH_PRODUCT_VARIATIONS) {
             isLoadingProductVariants = false
             if (event.isError) {
                 loadContinuation?.resume(false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsRepository.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.action.WCProductAction.FETCHED_PRODUCT_VARIAT
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
+import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
@@ -20,6 +21,7 @@ import kotlin.coroutines.resume
 class ProductVariantsRepository @Inject constructor(
     private val dispatcher: Dispatcher,
     private val productStore: WCProductStore,
+    private val wooCommerceStore: WooCommerceStore,
     private val selectedSite: SelectedSite
 ) {
     companion object {
@@ -65,9 +67,14 @@ class ProductVariantsRepository @Inject constructor(
      * Returns all product variants for a product and current site that are in the database
      */
     fun getProductVariantList(remoteProductId: Long): List<ProductVariant> {
-        val wcProducts = productStore.getVariationsForProduct(selectedSite.get(), remoteProductId)
-        return wcProducts.map { it.toAppModel() }
+        return productStore.getVariationsForProduct(selectedSite.get(), remoteProductId)
+                .map { it.toAppModel() }
     }
+
+    /**
+     * Returns the currency code for the site
+     */
+    fun getCurrencyCode() = wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyCode
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsRepository.kt
@@ -1,0 +1,87 @@
+package com.woocommerce.android.ui.products
+
+import com.woocommerce.android.model.ProductVariant
+import com.woocommerce.android.model.toAppModel
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.suspendCoroutineWithTimeout
+import kotlinx.coroutines.CancellationException
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.WCProductAction.FETCHED_PRODUCT_VARIATIONS
+import org.wordpress.android.fluxc.generated.WCProductActionBuilder
+import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
+import javax.inject.Inject
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+
+class ProductVariantsRepository @Inject constructor(
+    private val dispatcher: Dispatcher,
+    private val productStore: WCProductStore,
+    private val selectedSite: SelectedSite
+) {
+    companion object {
+        private const val ACTION_TIMEOUT = 10L * 1000
+    }
+
+    private var loadContinuation: Continuation<Boolean>? = null
+    private var isLoadingProductVariants = false
+
+    init {
+        dispatcher.register(this)
+    }
+
+    fun onCleanup() {
+        dispatcher.unregister(this)
+    }
+
+    /**
+     * Submits a fetch request to get a list of products variants for the current site and productId
+     * and returns the full list of product variants from the database
+     */
+    suspend fun fetchProductVariants(remoteProductId: Long): List<ProductVariant> {
+        if (!isLoadingProductVariants) {
+            try {
+                suspendCoroutineWithTimeout<Boolean>(ACTION_TIMEOUT) {
+                    loadContinuation = it
+                    isLoadingProductVariants = true
+                    val payload = WCProductStore.FetchProductVariationsPayload(
+                            selectedSite.get(),
+                            remoteProductId
+                    )
+                    dispatcher.dispatch(WCProductActionBuilder.newFetchProductVariationsAction(payload))
+                }
+            } catch (e: CancellationException) {
+                WooLog.e(WooLog.T.PRODUCTS, "CancellationException while fetching product variants", e)
+            }
+        }
+
+        return getProductVariantList(remoteProductId)
+    }
+
+    /**
+     * Returns all product variants for a product and current site that are in the database
+     */
+    fun getProductVariantList(remoteProductId: Long): List<ProductVariant> {
+        val wcProducts = productStore.getVariationsForProduct(selectedSite.get(), remoteProductId)
+        return wcProducts.map { it.toAppModel() }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onProductChanged(event: OnProductChanged) {
+        if (event.causeOfChange == FETCHED_PRODUCT_VARIATIONS) {
+            isLoadingProductVariants = false
+            if (event.isError) {
+                loadContinuation?.resume(false)
+                // TODO: add analytics here in a different commit
+            } else {
+                // TODO: add analytics here in a different commit
+                loadContinuation?.resume(true)
+            }
+            loadContinuation = null
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsRepository.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.products
 
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.model.ProductVariant
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
@@ -83,9 +85,14 @@ class ProductVariantsRepository @Inject constructor(
             isLoadingProductVariants = false
             if (event.isError) {
                 loadContinuation?.resume(false)
-                // TODO: add analytics here in a different commit
+                AnalyticsTracker.track(
+                        Stat.PRODUCT_VARIANTS_LOAD_ERROR,
+                        this.javaClass.simpleName,
+                        event.error.type.toString(),
+                        event.error.message
+                )
             } else {
-                // TODO: add analytics here in a different commit
+                AnalyticsTracker.track(Stat.PRODUCT_VARIANTS_LOADED)
                 loadContinuation?.resume(true)
             }
             loadContinuation = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsViewModel.kt
@@ -40,12 +40,17 @@ class ProductVariantsViewModel @Inject constructor(
         loadProductVariants(remoteProductId)
     }
 
+    fun refreshProductVariants(remoteProductId: Long) {
+        _isRefreshing.value = true
+        loadProductVariants(remoteProductId, forceRefresh = true)
+    }
+
     override fun onCleared() {
         super.onCleared()
         productVariantsRepository.onCleanup()
     }
 
-    private fun loadProductVariants(remoteProductId: Long) {
+    private fun loadProductVariants(remoteProductId: Long, forceRefresh: Boolean = false) {
         val shouldFetch = remoteProductId != this.remoteProductId
         this.remoteProductId = remoteProductId
 
@@ -56,11 +61,10 @@ class ProductVariantsViewModel @Inject constructor(
                 fetchProductVariants(remoteProductId)
             } else {
                 productVariantList.value = combineData(variantsInDb)
-                if (shouldFetch) {
+                if (shouldFetch || forceRefresh) {
                     fetchProductVariants(remoteProductId)
                 }
             }
-            _isSkeletonShown.value = false
         }
     }
 
@@ -75,8 +79,9 @@ class ProductVariantsViewModel @Inject constructor(
             }
         } else {
             _showSnackbarMessage.value = R.string.offline_error
-            _isSkeletonShown.value = false
         }
+        _isRefreshing.value = false
+        _isSkeletonShown.value = false
     }
 
     private fun combineData(productVariants: List<ProductVariant>): List<ProductVariant> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsViewModel.kt
@@ -1,0 +1,78 @@
+package com.woocommerce.android.ui.products
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.woocommerce.android.R
+import com.woocommerce.android.di.UI_THREAD
+import com.woocommerce.android.model.ProductVariant
+import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.SingleLiveEvent
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Named
+
+class ProductVariantsViewModel @Inject constructor(
+    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
+    private val productVariantsRepository: ProductVariantsRepository,
+    private val networkStatus: NetworkStatus
+) : ScopedViewModel(mainDispatcher) {
+    private var remoteProductId = 0L
+    val productVariantList = MutableLiveData<List<ProductVariant>>()
+
+    private val _isSkeletonShown = MutableLiveData<Boolean>()
+    val isSkeletonShown: LiveData<Boolean> = _isSkeletonShown
+
+    private val _showSnackbarMessage = SingleLiveEvent<Int>()
+    val showSnackbarMessage: LiveData<Int> = _showSnackbarMessage
+
+    private val _isRefreshing = MutableLiveData<Boolean>()
+    val isRefreshing: LiveData<Boolean> = _isRefreshing
+
+    private val _exit = SingleLiveEvent<Unit>()
+    val exit: LiveData<Unit> = _exit
+
+    fun start(remoteProductId: Long) {
+        loadProductVariants(remoteProductId)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        productVariantsRepository.onCleanup()
+    }
+
+    fun loadProductVariants(remoteProductId: Long) {
+        val shouldFetch = remoteProductId != this.remoteProductId
+        this.remoteProductId = remoteProductId
+
+        launch {
+            val variantsInDb = productVariantsRepository.getProductVariantList(remoteProductId)
+            if (variantsInDb.isNullOrEmpty()) {
+                _isSkeletonShown.value = true
+                fetchProductVariants(remoteProductId)
+            } else {
+                productVariantList.value = variantsInDb
+                if (shouldFetch) {
+                    fetchProductVariants(remoteProductId)
+                }
+            }
+            _isSkeletonShown.value = false
+        }
+    }
+
+    private suspend fun fetchProductVariants(remoteProductId: Long) {
+        if (networkStatus.isConnected()) {
+            val fetchedVariants = productVariantsRepository.fetchProductVariants(remoteProductId)
+            if (fetchedVariants.isNullOrEmpty()) {
+                _showSnackbarMessage.value = R.string.product_variants_fetch_product_variants_error
+                _exit.call()
+            } else {
+                productVariantList.value = fetchedVariants
+            }
+        } else {
+            _showSnackbarMessage.value = R.string.offline_error
+            _isSkeletonShown.value = false
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyView.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.products
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
+import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.RatingBar
 import android.widget.TextView
@@ -19,6 +20,7 @@ class WCProductPropertyView @JvmOverloads constructor(
     defStyle: Int = 0
 ) : ConstraintLayout(context, attrs, defStyle) {
     private var view: View? = null
+    private var propertyGroupImg: ImageView? = null
     private var propertyNameText: TextView? = null
     private var propertyValueText: TextView? = null
     private var ratingBar: RatingBar? = null
@@ -31,6 +33,16 @@ class WCProductPropertyView @JvmOverloads constructor(
             propertyValueText?.visibility = View.GONE
         } else {
             propertyValueText?.text = detail
+        }
+    }
+
+    /**
+     * Adds a click listener to the property view
+     */
+    fun setClickListener(onClickListener: ((view: View) -> Unit)? = null) {
+        onClickListener?.let {
+            propertyGroupImg?.visibility = View.VISIBLE
+            view?.setOnClickListener(onClickListener)
         }
     }
 
@@ -52,6 +64,7 @@ class WCProductPropertyView @JvmOverloads constructor(
             } else {
                 View.inflate(context, R.layout.product_property_view_horz, this)
             }
+            propertyGroupImg = view?.findViewById(R.id.imgProperty)
             propertyNameText = view?.findViewById(R.id.textPropertyName)
             propertyValueText = view?.findViewById(R.id.textPropertyValue)
             ratingBar = view?.findViewById(R.id.ratingBar)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -8,11 +8,13 @@ import com.woocommerce.android.BuildConfig
  */
 enum class FeatureFlag {
     PRODUCT_LIST,
+    PRODUCT_VARIANTS,
     DB_DOWNGRADE,
     REFUNDS;
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
             PRODUCT_LIST -> BuildConfig.DEBUG
+            PRODUCT_VARIANTS -> BuildConfig.DEBUG
             REFUNDS -> BuildConfig.DEBUG
             DB_DOWNGRADE -> {
                 BuildConfig.DEBUG || context != null && PackageUtils.isBetaBuild(context)

--- a/WooCommerce/src/main/res/layout/fragment_product_variants.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_variants.xml
@@ -7,8 +7,14 @@
     android:layout_height="match_parent"
     tools:context="com.woocommerce.android.ui.products.ProductVariantsFragment">
 
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/productVariantsList"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
+
+    </FrameLayout>
 </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_variants.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_variants.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/productVariantsRefreshLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.woocommerce.android.ui.products.ProductVariantsFragment">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/productVariantsList"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+</com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>

--- a/WooCommerce/src/main/res/layout/product_property_view_vert.xml
+++ b/WooCommerce/src/main/res/layout/product_property_view_vert.xml
@@ -3,6 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/product_property_vert_root"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground">
@@ -55,6 +56,19 @@
         app:layout_constraintTop_toBottomOf="@+id/textPropertyName"
         tools:rating="3"
         tools:visibility="visible"/>
+
+    <ImageView
+        android:id="@+id/imgProperty"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/margin_large"
+        android:background="@drawable/ic_arrow_right_grey"
+        android:contentDescription="@string/product_property_edit"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible" />
 
     <View
         android:id="@+id/divider"

--- a/WooCommerce/src/main/res/layout/product_variant_list_item.xml
+++ b/WooCommerce/src/main/res/layout/product_variant_list_item.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/list_item_bg"
+    android:padding="@dimen/margin_extra_large">
+
+    <FrameLayout
+        android:id="@+id/variantOptionImageFrame"
+        android:layout_width="@dimen/product_icon_sz"
+        android:layout_height="@dimen/product_icon_sz"
+        android:background="@drawable/picture_frame"
+        android:padding="1dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/variantOptionImage"
+            android:layout_width="@dimen/product_icon_sz"
+            android:layout_height="@dimen/product_icon_sz"
+            android:layout_gravity="center"
+            android:background="@drawable/picture_corners"
+            android:contentDescription="@string/product_image_content_description"
+            android:scaleType="centerCrop"
+            tools:src="@drawable/ic_product" />
+    </FrameLayout>
+
+    <TextView
+        android:id="@+id/variantOptionName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin_extra_large"
+        android:layout_marginTop="1dp"
+        android:layout_marginEnd="@dimen/margin_extra_large"
+        android:includeFontPadding="false"
+        android:maxLines="2"
+        android:textAppearance="@style/Woo.TextAppearance.ListItem.Title"
+        app:layout_constrainedWidth="true"
+        app:layout_constraintBottom_toTopOf="@+id/variantOptionPriceAndStock"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toEndOf="@+id/variantOptionImageFrame"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Blue - Wool" />
+
+    <TextView
+        android:id="@+id/variantOptionPriceAndStock"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="1dp"
+        android:textAppearance="@style/Woo.TextAppearance.Medium.Grey"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/variantOptionName"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="@+id/variantOptionName"
+        app:layout_constraintTop_toBottomOf="@+id/variantOptionName"
+        tools:text="Out of stock" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -12,6 +12,11 @@
             android:name="remoteProductId"
             app:argType="long"
             android:defaultValue="0L"/>
+        <action
+            android:id="@+id/action_productDetailFragment_to_productVariantsFragment"
+            app:destination="@id/productVariantsFragment"
+            app:enterAnim="@anim/activity_fade_in"
+            app:popExitAnim="@anim/activity_fade_out"/>
     </fragment>
     <fragment
         android:id="@+id/rootFragment"
@@ -174,6 +179,15 @@
             android:defaultValue="0L"/>
         <argument
             android:name="refundId"
+            app:argType="long"
+            android:defaultValue="0L"/>
+    </fragment>
+    <fragment
+        android:id="@+id/productVariantsFragment"
+        android:name="com.woocommerce.android.ui.products.ProductVariantsFragment"
+        tools:layout="@layout/fragment_product_variants">
+        <argument
+            android:name="remoteProductId"
             app:argType="long"
             android:defaultValue="0L"/>
     </fragment>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="this_year">This Year</string>
     <string name="discard">Discard</string>
     <string name="products">Products</string>
+    <string name="product_variations">Variations</string>
     <string name="review_notifications">Reviews</string>
     <string name="version_with_name_param">Version %s</string>
     <string name="share_store_button">Share your store</string>
@@ -368,6 +369,7 @@
     <string name="product_pricing_and_inventory">Pricing and inventory</string>
     <string name="product_property_default_formatter" translatable="false">%1$s: %2$s</string>
     <string name="product_property_variant_formatter" translatable="false">%1$s (%2$s options)</string>
+    <string name="product_property_edit">Edit product</string>
     <string name="product_inventory">Inventory</string>
     <string name="product_variants">Variants</string>
     <string name="product_price">Price</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -365,7 +365,10 @@
     <string name="product_name">Title</string>
     <string name="product_purchase_note">Purchase note</string>
     <string name="product_pricing_and_inventory">Pricing and inventory</string>
+    <string name="product_property_default_formatter" translatable="false">%1$s: %2$s</string>
+    <string name="product_property_variant_formatter" translatable="false">%1$s (%2$s options)</string>
     <string name="product_inventory">Inventory</string>
+    <string name="product_variants">Variants</string>
     <string name="product_price">Price</string>
     <string name="product_regular_price">Regular price</string>
     <string name="product_sale_price">Sale price</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -362,6 +362,7 @@
     -->
     <string name="product_image_content_description">Product image</string>
     <string name="product_detail_fetch_product_error">Error fetching product</string>
+    <string name="product_variants_fetch_product_variants_error">Error fetching product variations</string>
     <string name="product_name">Title</string>
     <string name="product_purchase_note">Purchase note</string>
     <string name="product_pricing_and_inventory">Pricing and inventory</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -26,6 +26,7 @@ object ProductTestUtils {
             width = "2"
             height = "3"
             variations = "[]"
+            attributes = "[]"
         }.toAppModel()
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -57,7 +57,7 @@ object ProductTestUtils {
 
     fun generateProductVariantList(productId: Long = 1L): List<ProductVariant> {
         with(ArrayList<ProductVariant>()) {
-            add(generateProductVariant(productId,1))
+            add(generateProductVariant(productId, 1))
             add(generateProductVariant(productId, 2))
             add(generateProductVariant(productId, 3))
             add(generateProductVariant(productId, 4))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -1,8 +1,10 @@
 package com.woocommerce.android.ui.products
 
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.model.ProductVariant
 import com.woocommerce.android.model.toAppModel
 import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.model.WCProductVariationModel
 
 object ProductTestUtils {
     fun generateProduct(productId: Long = 1L): Product {
@@ -34,6 +36,32 @@ object ProductTestUtils {
             add(generateProduct(3))
             add(generateProduct(4))
             add(generateProduct(5))
+            return this
+        }
+    }
+
+    private fun generateProductVariant(
+        productId: Long = 1L,
+        variantId: Long = 1L
+    ): ProductVariant {
+        return WCProductVariationModel(2).apply {
+            dateCreated = "2018-01-05T05:14:30Z"
+            localSiteId = 1
+            remoteProductId = productId
+            remoteVariationId = variantId
+            price = "10.00"
+            imageUrl = ""
+            attributes = ""
+        }.toAppModel().also { it.priceWithCurrency = "$10.00" }
+    }
+
+    fun generateProductVariantList(productId: Long = 1L): List<ProductVariant> {
+        with(ArrayList<ProductVariant>()) {
+            add(generateProductVariant(productId,1))
+            add(generateProductVariant(productId, 2))
+            add(generateProductVariant(productId, 3))
+            add(generateProductVariant(productId, 4))
+            add(generateProductVariant(productId, 5))
             return this
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductVariantsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductVariantsViewModelTest.kt
@@ -1,0 +1,95 @@
+package com.woocommerce.android.ui.products
+
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.spy
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import com.woocommerce.android.R
+import com.woocommerce.android.R.string
+import com.woocommerce.android.model.ProductVariant
+import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.test
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+
+class ProductVariantsViewModelTest : BaseUnitTest() {
+    private val networkStatus: NetworkStatus = mock()
+    private val productVariantsRepository: ProductVariantsRepository = mock()
+    private val currencyFormatter: CurrencyFormatter = mock()
+
+    private val productRemoteId = 1L
+    private lateinit var viewModel: ProductVariantsViewModel
+    private val productVariants = ProductTestUtils.generateProductVariantList(productRemoteId)
+
+    @Before
+    fun setup() {
+        viewModel = spy(
+                ProductVariantsViewModel(
+                        Dispatchers.Unconfined,
+                        productVariantsRepository,
+                        networkStatus,
+                        currencyFormatter
+                )
+        )
+
+        doReturn(true).whenever(networkStatus).isConnected()
+    }
+
+    @Test
+    fun `Displays the product variant list view correctly`() {
+        doReturn(productVariants).whenever(productVariantsRepository).getProductVariantList(productRemoteId)
+
+        val fetchedProductVariantList = ArrayList<ProductVariant>()
+        viewModel.productVariantList.observeForever { fetchedProductVariantList.addAll(it) }
+
+        viewModel.start(productRemoteId)
+        assertThat(fetchedProductVariantList).isEqualTo(productVariants)
+    }
+
+    @Test
+    fun `Do not fetch product variants from api when not connected`() = test {
+        doReturn(false).whenever(networkStatus).isConnected()
+
+        var message: Int? = null
+        viewModel.showSnackbarMessage.observeForever { message = it }
+
+        viewModel.start(productRemoteId)
+
+        verify(productVariantsRepository, times(1)).getProductVariantList(productRemoteId)
+        verify(productVariantsRepository, times(0)).fetchProductVariants(productRemoteId)
+
+        assertThat(message).isEqualTo(string.offline_error)
+    }
+
+    @Test
+    fun `Shows and hides product variants skeleton correctly`() = test {
+        doReturn(emptyList<ProductVariant>()).whenever(productVariantsRepository).getProductVariantList(productRemoteId)
+
+        val isSkeletonShown = ArrayList<Boolean>()
+        viewModel.isSkeletonShown.observeForever { isSkeletonShown.add(it) }
+
+        viewModel.start(productRemoteId)
+        assertThat(isSkeletonShown).containsExactly(true, false)
+    }
+
+    @Test
+    fun `Display error message on fetch product variants error`() = test {
+        whenever(productVariantsRepository.fetchProductVariants(productRemoteId)).thenReturn(null)
+        whenever(productVariantsRepository.getProductVariantList(productRemoteId)).thenReturn(null)
+
+        var message: Int? = null
+        viewModel.showSnackbarMessage.observeForever { message = it }
+
+        viewModel.start(productRemoteId)
+
+        verify(productVariantsRepository, times(1)).fetchProductVariants(productRemoteId)
+
+        assertThat(message).isEqualTo(R.string.product_variants_fetch_product_variants_error)
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'c419d0ac00ba57e765ce88c561f2ebcc3793dd31'
+    fluxCVersion = '4882c2223e534afffe331d93b899522a5291cdfb'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '4882c2223e534afffe331d93b899522a5291cdfb'
+    fluxCVersion = '73ea2194e343ff6871e876e306ca3134baf85f41'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '73ea2194e343ff6871e876e306ca3134baf85f41'
+    fluxCVersion = '1b71c61ebc318c4d639de2dd080301f647076156'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Fixes #1540 by adding the read only product variant list to the product detail screen. 

### Notes:
- I followed the MVVM pattern.
- I've used the existing color palette in the app, rather than the ones specified in the design (since that will be handled separately).
- The product variant section will be displayed to all users once this PR is merged. But it is only clickable in debug builds. 
- Unit tests are added to `ProductVariantsViewModelTest`.

### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/22608780/68450473-3bd90780-0211-11ea-8dd8-316689634659.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/68450481-3f6c8e80-0211-11ea-8a68-ba26cef56d68.png">

### Events
The following events have been added to the PR:
- `PRODUCT_DETAIL_VIEW_PRODUCT_VARIANTS_TAPPED` - User clicked on the variants section in the product detail screen.
- `PRODUCT_VARIANTS_LOADED` - The variants associated with a product was fetched successfully from the API.
- `PRODUCT_VARIANTS_LOAD_ERROR` - The request to fetch variants associated with a product from the API failed.
- `PRODUCT_VARIANTS_PULLED_TO_REFRESH` -  The user is viewing the product variants list and pulled to refresh.

These events have been added to the spreadsheet and will be validated/registered.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
