### PR TITLE
Issue/1534 product detail upload progress

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -116,6 +116,14 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
             uiMessageResolver.showSnack(it)
         })
 
+        viewModel.isUploadingProductImage.observe(this, Observer {
+            if (it) {
+                imageGallery.addPlaceholder()
+            } else {
+                imageGallery.removePlaceholder()
+            }
+        })
+
         viewModel.exit.observe(this, Observer {
             activity?.onBackPressed()
         })
@@ -504,7 +512,7 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
         } else {
             viewModel.productData.value?.product?.let { product ->
                 ImageViewerActivity.showProductImage(
-                        ProductDetailFragment@this,
+                        this,
                         product,
                         imageModel,
                         sharedElement = imageView

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -41,7 +41,6 @@ import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageC
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_product_detail.*
 import org.wordpress.android.fluxc.model.WCProductImageModel
-import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.HtmlUtils
 import javax.inject.Inject
 
@@ -127,16 +126,6 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
         viewModel.exit.observe(this, Observer {
             activity?.onBackPressed()
         })
-    }
-
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-
-        // make image height a percentage of screen height, adjusting for landscape
-        val displayHeight = DisplayUtils.getDisplayPixelHeight(activity!!)
-        val multiplier = if (DisplayUtils.isLandscape(activity!!)) 0.5f else 0.3f
-        imageHeight = (displayHeight * multiplier).toInt()
-        imageGallery.layoutParams.height = imageHeight
     }
 
     override fun onCreateOptionsMenu(menu: Menu?, inflater: MenuInflater?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.MutableLiveData
 import com.woocommerce.android.R
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.di.UI_THREAD
+import com.woocommerce.android.media.ProductImagesService.Companion.OnProductImagesUpdateCompletedEvent
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
@@ -14,6 +15,9 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.SingleLiveEvent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
+import org.greenrobot.eventbus.EventBus
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 import javax.inject.Inject
@@ -60,6 +64,8 @@ class ProductDetailViewModel @Inject constructor(
                 _productData.value = combineData(prod, params)
             }
         }
+
+        EventBus.getDefault().register(this)
     }
 
     fun start(remoteProductId: Long) {
@@ -72,8 +78,8 @@ class ProductDetailViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
-
         productRepository.onCleanup()
+        EventBus.getDefault().unregister(this)
     }
 
     private fun loadProduct(remoteProductId: Long) {
@@ -174,4 +180,18 @@ class ProductDetailViewModel @Inject constructor(
         val salePriceWithCurrency: String,
         val regularPriceWithCurrency: String
     )
+
+    /**
+     * This event may happen if the user uploads or removes an image from the images fragment and returns
+     * to the detail fragment before the requesrs completes
+     */
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onEventMainThread(event: OnProductImagesUpdateCompletedEvent) {
+        if (event.isError) {
+            _showSnackbarMessage.value = R.string.product_image_service_error
+        } else {
+            loadProduct(remoteProductId)
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -197,7 +197,7 @@ class ProductDetailViewModel @Inject constructor(
 
     /**
      * This event may happen if the user uploads or removes an image from the images fragment and returns
-     * to the detail fragment before the requesrs completes
+     * to the detail fragment before the request completes
      */
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.di.UI_THREAD
 import com.woocommerce.android.media.ProductImagesService
+import com.woocommerce.android.media.ProductImagesService.Companion.Action
 import com.woocommerce.android.media.ProductImagesService.Companion.OnProductImagesUpdateCompletedEvent
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.tools.NetworkStatus
@@ -203,7 +204,11 @@ class ProductDetailViewModel @Inject constructor(
     fun onEventMainThread(event: OnProductImagesUpdateCompletedEvent) {
         setIsUploadingImage(false)
         if (event.isError) {
-            _showSnackbarMessage.value = R.string.product_image_service_error
+            _showSnackbarMessage.value = when (event.action) {
+                Action.UPLOAD_IMAGE -> R.string.product_image_service_error_uploading
+                Action.REMOVE_IMAGE -> R.string.product_image_service_error_removing
+                else -> R.string.error_generic_network
+            }
         } else {
             loadProduct(remoteProductId)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -6,7 +6,6 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.ViewTreeObserver.OnGlobalLayoutListener
 import android.widget.ImageView
 import android.widget.ProgressBar
 import androidx.collection.LongSparseArray
@@ -37,6 +36,7 @@ class WCProductImageGalleryView @JvmOverloads constructor(
         private const val VIEW_TYPE_PLACEHOLDER = 1
 
         private const val UPLOAD_PLACEHOLDER_ID = -1L
+        private const val NUM_COLUMNS = 2
     }
 
     interface OnGalleryImageClickListener {
@@ -63,11 +63,10 @@ class WCProductImageGalleryView @JvmOverloads constructor(
             }
         }
 
-        val numColumns = if (DisplayUtils.isLandscape(context)) 3 else 2
-        placeholderWidth = DisplayUtils.getDisplayPixelWidth(context) / numColumns
+        placeholderWidth = DisplayUtils.getDisplayPixelWidth(context) / NUM_COLUMNS
 
         layoutManager = if (isGridView) {
-            GridLayoutManager(context, numColumns)
+            GridLayoutManager(context, NUM_COLUMNS)
         } else {
             LinearLayoutManager(context, HORIZONTAL, false)
         }
@@ -96,15 +95,11 @@ class WCProductImageGalleryView @JvmOverloads constructor(
                 .placeholder(R.drawable.product_detail_image_background)
                 .transition(DrawableTransitionOptions.withCrossFade())
 
-        // if this is showing a grid make images a percentage of the view's height, otherwise make
-        // images fit the entire height of the view
-        viewTreeObserver.addOnGlobalLayoutListener(object : OnGlobalLayoutListener {
-            override fun onGlobalLayout() {
-                viewTreeObserver.removeOnGlobalLayoutListener(this)
-                val height = this@WCProductImageGalleryView.height
-                imageHeight = if (isGridView) height / 3 else height
-            }
-        })
+        imageHeight = if (isGridView) {
+            context.resources.getDimensionPixelSize(R.dimen.product_image_gallery_image_height_grid)
+        } else {
+            context.resources.getDimensionPixelSize(R.dimen.product_image_gallery_image_height)
+        }
     }
 
     fun showProductImages(product: Product, listener: OnGalleryImageClickListener) {

--- a/WooCommerce/src/main/res/values/dimens.xml
+++ b/WooCommerce/src/main/res/values/dimens.xml
@@ -165,6 +165,8 @@
     <dimen name="product_icon_sz">40dp</dimen>
     <dimen name="product_detail_card_divider_height">16dp</dimen>
     <dimen name="product_detail_property_margin">@dimen/settings_padding</dimen>
+    <dimen name="product_image_gallery_image_height">200dp</dimen>
+    <dimen name="product_image_gallery_image_height_grid">140dp</dimen>
 
     <!--
         Shipment Trackings


### PR DESCRIPTION
Fixes #1534 - Ensures that if an image upload is still in progress when the user returns to the product detail screen, a progress bar is shown until the upload completes.

![Untitled2 2019-11-08 17_03_11](https://user-images.githubusercontent.com/3903757/68513689-ab6ae900-0249-11ea-8044-899e577bbade.gif)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
