### PR TITLE
Spike: Aztec integration with image support

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/BitmapExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/BitmapExt.kt
@@ -1,0 +1,11 @@
+package com.woocommerce.android.extensions
+
+import android.graphics.Bitmap
+
+internal fun Bitmap.upscaleTo(desiredWidth: Int): Bitmap {
+    val ratio = this.height.toFloat() / this.width.toFloat()
+    val proportionateHeight = ratio * desiredWidth
+    val finalHeight = Math.rint(proportionateHeight.toDouble()).toInt()
+
+    return Bitmap.createScaledBitmap(this, desiredWidth, finalHeight, true)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/MediaToolbarAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/MediaToolbarAction.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.ui.aztec
+
+import com.woocommerce.android.R
+import org.wordpress.aztec.AztecTextFormat
+import org.wordpress.aztec.ITextFormat
+import org.wordpress.aztec.toolbar.IToolbarAction
+import org.wordpress.aztec.toolbar.ToolbarActionType
+
+enum class MediaToolbarAction constructor(override val buttonId: Int, override val actionType: ToolbarActionType,
+    override val textFormats: Set<ITextFormat> = setOf()) : IToolbarAction {
+    GALLERY(R.id.media_bar_button_gallery, ToolbarActionType.OTHER, setOf(AztecTextFormat.FORMAT_NONE)),
+    CAMERA(R.id.media_bar_button_camera, ToolbarActionType.OTHER, setOf(AztecTextFormat.FORMAT_NONE))
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/MediaToolbarCameraButton.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/MediaToolbarCameraButton.kt
@@ -1,0 +1,37 @@
+package com.woocommerce.android.ui.aztec
+
+import android.view.KeyEvent
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.woocommerce.android.R
+import org.wordpress.aztec.plugins.IMediaToolbarButton
+import org.wordpress.aztec.toolbar.AztecToolbar
+import org.wordpress.aztec.toolbar.IToolbarAction
+
+class MediaToolbarCameraButton(val toolbar: AztecToolbar) : IMediaToolbarButton {
+    private var clickListener: IMediaToolbarButton.IMediaToolbarClickListener? = null
+
+    override val action: IToolbarAction = MediaToolbarAction.CAMERA
+    override val context = toolbar.context!!
+
+    override fun setMediaToolbarButtonClickListener(clickListener: IMediaToolbarButton.IMediaToolbarClickListener) {
+        this.clickListener = clickListener
+    }
+
+    override fun toggle() {
+        clickListener?.onClick(toolbar.findViewById(action.buttonId))
+    }
+
+    override fun matchesKeyShortcut(keyCode: Int, event: KeyEvent): Boolean {
+        return false
+    }
+
+    override fun inflateButton(parent: ViewGroup) {
+        LayoutInflater.from(context).inflate(R.layout.aztec_media_toobar_camera_button, parent)
+    }
+
+    override fun toolbarStateAboutToChange(toolbar: AztecToolbar, enable: Boolean) {
+        toolbar.findViewById<View>(action.buttonId).isEnabled = enable
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/MediaToolbarGalleryButton.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/MediaToolbarGalleryButton.kt
@@ -1,0 +1,37 @@
+package com.woocommerce.android.ui.aztec
+
+import android.view.KeyEvent
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.woocommerce.android.R
+import org.wordpress.aztec.plugins.IMediaToolbarButton
+import org.wordpress.aztec.toolbar.AztecToolbar
+import org.wordpress.aztec.toolbar.IToolbarAction
+
+class MediaToolbarGalleryButton(val toolbar: AztecToolbar) : IMediaToolbarButton {
+    private var clickListener: IMediaToolbarButton.IMediaToolbarClickListener? = null
+
+    override val action: IToolbarAction = MediaToolbarAction.GALLERY
+    override val context = toolbar.context!!
+
+    override fun setMediaToolbarButtonClickListener(clickListener: IMediaToolbarButton.IMediaToolbarClickListener) {
+        this.clickListener = clickListener
+    }
+
+    override fun toggle() {
+        clickListener?.onClick(toolbar.findViewById(action.buttonId))
+    }
+
+    override fun matchesKeyShortcut(keyCode: Int, event: KeyEvent): Boolean {
+        return false
+    }
+
+    override fun inflateButton(parent: ViewGroup) {
+        LayoutInflater.from(context).inflate(R.layout.aztec_media_toobar_gallery_button, parent)
+    }
+
+    override fun toolbarStateAboutToChange(toolbar: AztecToolbar, enable: Boolean) {
+        toolbar.findViewById<View>(action.buttonId).isEnabled = enable
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/AztecEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/AztecEditorFragment.kt
@@ -40,6 +40,7 @@ class AztecEditorFragment : BaseFragment(), IAztecToolbarClickListener,
         OnRequestPermissionsResultCallback {
     companion object {
         const val TAG: String = "AztecEditorFragment"
+        private const val FIELD_DESC_TEXT = "desc_text"
         private const val MEDIA_CAMERA_PHOTO_PERMISSION_REQUEST_CODE: Int = 1001
         private const val MEDIA_PHOTOS_PERMISSION_REQUEST_CODE: Int = 1003
         private const val REQUEST_MEDIA_CAMERA_PHOTO: Int = 2001
@@ -84,10 +85,20 @@ class AztecEditorFragment : BaseFragment(), IAztecToolbarClickListener,
                 .addPlugin(galleryButton)
                 .addPlugin(cameraButton)
 
-        aztec.visualEditor.fromHtml(navArgs.productDescription)
-        aztec.sourceEditor?.displayStyledAndFormattedHtml(navArgs.productDescription)
+        savedInstanceState?.getString(FIELD_DESC_TEXT)?.let {
+            aztec.visualEditor.fromHtml(it)
+            aztec.sourceEditor?.displayStyledAndFormattedHtml(it)
+        } ?: run {
+            aztec.visualEditor.fromHtml(navArgs.productDescription)
+            aztec.sourceEditor?.displayStyledAndFormattedHtml(navArgs.productDescription)
+        }
 
         aztec.initSourceEditorHistory()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putString(FIELD_DESC_TEXT, aztec.visualEditor.text.toString())
     }
 
     override fun onToolbarCollapseButtonClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/AztecEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/AztecEditorFragment.kt
@@ -8,6 +8,7 @@ import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.main.MainActivity
+import com.woocommerce.android.util.GlideImageLoader
 import kotlinx.android.synthetic.main.fragment_aztec_editor.*
 import org.wordpress.aztec.Aztec
 import org.wordpress.aztec.ITextFormat
@@ -38,10 +39,12 @@ class AztecEditorFragment : BaseFragment(), IAztecToolbarClickListener {
         (activity as? MainActivity)?.hideBottomNav()
 
         aztec = Aztec.with(visualEditor, sourceEditor, aztecToolbar, this)
-        aztec.initSourceEditorHistory()
+                .setImageGetter(GlideImageLoader(requireContext()))
 
         aztec.visualEditor.fromHtml(navArgs.productDescription)
         aztec.sourceEditor?.displayStyledAndFormattedHtml(navArgs.productDescription)
+
+        aztec.initSourceEditorHistory()
     }
 
     override fun onToolbarCollapseButtonClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/AztecEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/AztecEditorFragment.kt
@@ -1,22 +1,49 @@
 package com.woocommerce.android.ui.products
 
+import android.Manifest
+import android.annotation.SuppressLint
+import android.app.Activity.RESULT_OK
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.drawable.BitmapDrawable
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.util.DisplayMetrics
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.app.ActivityCompat.OnRequestPermissionsResultCallback
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.aztec.MediaToolbarCameraButton
+import com.woocommerce.android.ui.aztec.MediaToolbarGalleryButton
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.util.GlideImageLoader
 import kotlinx.android.synthetic.main.fragment_aztec_editor.*
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.ImageUtils
+import org.wordpress.android.util.PermissionUtils
+import org.wordpress.android.util.ToastUtils
 import org.wordpress.aztec.Aztec
+import org.wordpress.aztec.AztecAttributes
 import org.wordpress.aztec.ITextFormat
+import org.wordpress.aztec.plugins.IMediaToolbarButton.IMediaToolbarClickListener
 import org.wordpress.aztec.toolbar.IAztecToolbarClickListener
+import java.util.Random
 
-class AztecEditorFragment : BaseFragment(), IAztecToolbarClickListener {
+class AztecEditorFragment : BaseFragment(), IAztecToolbarClickListener,
+        OnRequestPermissionsResultCallback {
     companion object {
         const val TAG: String = "AztecEditorFragment"
+        private const val MEDIA_CAMERA_PHOTO_PERMISSION_REQUEST_CODE: Int = 1001
+        private const val MEDIA_PHOTOS_PERMISSION_REQUEST_CODE: Int = 1003
+        private const val REQUEST_MEDIA_CAMERA_PHOTO: Int = 2001
+        private const val REQUEST_MEDIA_PHOTO: Int = 2003
     }
 
     private lateinit var aztec: Aztec
@@ -38,8 +65,24 @@ class AztecEditorFragment : BaseFragment(), IAztecToolbarClickListener {
         super.onActivityCreated(savedInstanceState)
         (activity as? MainActivity)?.hideBottomNav()
 
+        val galleryButton = MediaToolbarGalleryButton(aztecToolbar)
+        galleryButton.setMediaToolbarButtonClickListener(object : IMediaToolbarClickListener {
+            override fun onClick(view: View) {
+                onPhotosMediaOptionSelected()
+            }
+        })
+
+        val cameraButton = MediaToolbarCameraButton(aztecToolbar)
+        cameraButton.setMediaToolbarButtonClickListener(object : IMediaToolbarClickListener {
+            override fun onClick(view: View) {
+                onCameraPhotoMediaOptionSelected()
+            }
+        })
+
         aztec = Aztec.with(visualEditor, sourceEditor, aztecToolbar, this)
                 .setImageGetter(GlideImageLoader(requireContext()))
+                .addPlugin(galleryButton)
+                .addPlugin(cameraButton)
 
         aztec.visualEditor.fromHtml(navArgs.productDescription)
         aztec.sourceEditor?.displayStyledAndFormattedHtml(navArgs.productDescription)
@@ -73,5 +116,159 @@ class AztecEditorFragment : BaseFragment(), IAztecToolbarClickListener {
 
     override fun onToolbarMediaButtonClicked(): Boolean {
         return false
+    }
+
+    /**
+     * TODO: TEMP code added just for testing media support in Aztec
+     * This code will be removed once Image upload is integrated
+     */
+    private lateinit var mediaFile: String
+    private lateinit var mediaPath: String
+
+    private fun onCameraPhotoMediaOptionSelected() {
+        // TODO: handle camera functionality
+    }
+
+    @SuppressLint("ObsoleteSdkInt")
+    private fun onPhotosMediaOptionSelected() {
+        if (PermissionUtils.checkAndRequestStoragePermission(
+                        this,
+                        MEDIA_PHOTOS_PERMISSION_REQUEST_CODE
+                )) {
+            val intent: Intent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                Intent(Intent.ACTION_OPEN_DOCUMENT)
+            } else {
+                Intent.createChooser(
+                        Intent(Intent.ACTION_GET_CONTENT),
+                        getString(R.string.title_select_photo)
+                )
+            }
+
+            intent.addCategory(Intent.CATEGORY_OPENABLE)
+            intent.type = "image/*"
+
+            try {
+                startActivityForResult(intent, REQUEST_MEDIA_PHOTO)
+            } catch (exception: ActivityNotFoundException) {
+                AppLog.e(AppLog.T.EDITOR, exception.message)
+                ToastUtils.showToast(
+                        requireContext(),
+                        getString(R.string.error_chooser_photo),
+                        ToastUtils.Duration.LONG
+                )
+                        .show()
+            }
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        if (resultCode == RESULT_OK) {
+            when (requestCode) {
+                REQUEST_MEDIA_CAMERA_PHOTO -> {
+                    // By default, BitmapFactory.decodeFile sets the bitmap's density to the device default so, we need
+                    //  to correctly set the input density to 160 ourselves.
+                    val options = BitmapFactory.Options()
+                    options.inDensity = DisplayMetrics.DENSITY_DEFAULT
+                    val bitmap = BitmapFactory.decodeFile(mediaPath, options)
+                    insertImageAndSimulateUpload(bitmap, mediaPath)
+                }
+                REQUEST_MEDIA_PHOTO -> {
+                    mediaPath = data?.data.toString()
+                    val stream = requireActivity().contentResolver.openInputStream(Uri.parse(mediaPath))
+                    // By default, BitmapFactory.decodeFile sets the bitmap's density to the device default so, we need
+                    //  to correctly set the input density to 160 ourselves.
+                    val options = BitmapFactory.Options()
+                    options.inDensity = DisplayMetrics.DENSITY_DEFAULT
+                    val bitmap = BitmapFactory.decodeStream(stream, null, options)
+
+                    insertImageAndSimulateUpload(bitmap, mediaPath)
+                }
+            }
+        }
+
+        super.onActivityResult(requestCode, resultCode, data)
+    }
+
+    private fun insertImageAndSimulateUpload(bitmap: Bitmap?, mediaPath: String) {
+        val bitmapResized = ImageUtils.getScaledBitmapAtLongestSide(bitmap, aztec.visualEditor.maxImagesWidth)
+        val (id, attrs) = generateAttributesForMedia(mediaPath)
+        aztec.visualEditor.insertImage(BitmapDrawable(resources, bitmapResized), attrs)
+
+        // TODO: upload the image to media library in backend
+//        insertMediaAndSimulateUpload(id, attrs)
+
+        aztec.visualEditor.refreshText()
+        aztec.toolbar.toggleMediaToolbar()
+    }
+
+    private fun generateAttributesForMedia(mediaPath: String): Pair<String, AztecAttributes> {
+        val id = Random().nextInt(Integer.MAX_VALUE).toString()
+        val attrs = AztecAttributes()
+        attrs.setValue("src", mediaPath) // Temporary source value.  Replace with URL after uploaded.
+        attrs.setValue("id", id)
+        attrs.setValue("uploading", "true")
+        return Pair(id, attrs)
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
+        when (requestCode) {
+            MEDIA_CAMERA_PHOTO_PERMISSION_REQUEST_CODE -> {
+                var isPermissionDenied = false
+
+                for (i in grantResults.indices) {
+                    when (permissions[i]) {
+                        Manifest.permission.CAMERA -> {
+                            if (grantResults[i] == PackageManager.PERMISSION_DENIED) {
+                                isPermissionDenied = true
+                            }
+                        }
+                        Manifest.permission.WRITE_EXTERNAL_STORAGE -> {
+                            if (grantResults[i] == PackageManager.PERMISSION_DENIED) {
+                                isPermissionDenied = true
+                            }
+                        }
+                    }
+                }
+
+                if (isPermissionDenied) {
+                    // TODO: handle permission denied
+//                    ToastUtils.showToast(this, getString(R.string.permission_required_media_camera))
+                } else {
+                    when (requestCode) {
+                        MEDIA_CAMERA_PHOTO_PERMISSION_REQUEST_CODE -> {
+                            onCameraPhotoMediaOptionSelected()
+                        }
+                    }
+                }
+            }
+            MEDIA_PHOTOS_PERMISSION_REQUEST_CODE -> {
+                var isPermissionDenied = false
+
+                for (i in grantResults.indices) {
+                    when (permissions[i]) {
+                        Manifest.permission.WRITE_EXTERNAL_STORAGE -> {
+                            if (grantResults[i] == PackageManager.PERMISSION_DENIED) {
+                                isPermissionDenied = true
+                            }
+                        }
+                    }
+                }
+
+                when (requestCode) {
+                    MEDIA_PHOTOS_PERMISSION_REQUEST_CODE -> {
+                        if (isPermissionDenied) {
+                            // TODO: handle permission denied
+//                            ToastUtils.showToast(this, getString(R.string.permission_required_media_photos))
+                        } else {
+                            onPhotosMediaOptionSelected()
+                        }
+                    }
+                }
+            }
+            else -> {
+            }
+        }
+
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/GlideImageLoader.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/GlideImageLoader.kt
@@ -1,0 +1,69 @@
+package com.woocommerce.android.util
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.util.DisplayMetrics
+import com.bumptech.glide.Glide
+import com.bumptech.glide.request.Request
+import com.bumptech.glide.request.target.SizeReadyCallback
+import com.bumptech.glide.request.target.Target
+import com.bumptech.glide.request.transition.Transition
+import com.woocommerce.android.extensions.upscaleTo
+import org.wordpress.aztec.Html
+
+class GlideImageLoader(private val context: Context) : Html.ImageGetter {
+    override fun loadImage(source: String, callbacks: Html.ImageGetter.Callbacks, maxWidth: Int) {
+        loadImage(source, callbacks, maxWidth, 0)
+    }
+
+    override fun loadImage(source: String, callbacks: Html.ImageGetter.Callbacks, maxWidth: Int, minWidth: Int) {
+        Glide.with(context).asBitmap().load(source).into(object : Target<Bitmap> {
+            override fun onLoadStarted(placeholder: Drawable?) {
+                callbacks.onImageLoading(placeholder)
+            }
+
+            override fun onLoadFailed(errorDrawable: Drawable?) {
+                callbacks.onImageFailed()
+            }
+
+            override fun onResourceReady(resource: Bitmap, transition: Transition<in Bitmap>?) {
+                // This should probably be done somewhere more appropriate for Glide (?)
+                if (resource.width < minWidth) {
+                    return callbacks.onImageLoaded(BitmapDrawable(context.resources, resource.upscaleTo(minWidth)))
+                }
+
+                // By default, BitmapFactory.decodeFile sets the bitmap's density to the device default so, we need
+                // to correctly set the input density to 160 ourselves.
+                resource.density = DisplayMetrics.DENSITY_DEFAULT
+                callbacks.onImageLoaded(BitmapDrawable(context.resources, resource))
+            }
+
+            override fun onLoadCleared(placeholder: Drawable?) {}
+
+            override fun getSize(cb: SizeReadyCallback) {
+                cb.onSizeReady(maxWidth, Target.SIZE_ORIGINAL)
+            }
+
+            override fun removeCallback(cb: SizeReadyCallback) {
+            }
+
+            override fun setRequest(request: Request?) {
+            }
+
+            override fun getRequest(): Request? {
+                return null
+            }
+
+            override fun onStart() {
+            }
+
+            override fun onStop() {
+            }
+
+            override fun onDestroy() {
+            }
+        })
+    }
+}

--- a/WooCommerce/src/main/res/drawable/media_bar_button_camera.xml
+++ b/WooCommerce/src/main/res/drawable/media_bar_button_camera.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+
+    <path
+        android:fillColor="#ff4f748e"
+        android:pathData="M29,24c0,1.7-1.3,3-3,3s-3-1.3-3-3s1.3-3,3-3S29,22.3,29,24zM34,19v11c0,1.1-0.9,2-2,2H16c-1.1,0-2-0.9-2-2V19c0-1.1,0.9-2,2-2v-1h4v1h2l1-2h6l1,2h2C33.1,17,34,17.9,34,19zM19.5,21c0-0.8-0.7-1.5-1.5-1.5s-1.5,0.7-1.5,1.5s0.7,1.5,1.5,1.5S19.5,21.8,19.5,21z M31,24c0-2.8-2.2-5-5-5s-5,2.2-5,5s2.2,5,5,5S31,26.8,31,24z" />
+
+</vector>

--- a/WooCommerce/src/main/res/drawable/media_bar_button_camera_disabled.xml
+++ b/WooCommerce/src/main/res/drawable/media_bar_button_camera_disabled.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+
+    <path
+        android:fillColor="#ffc8d7e1"
+        android:pathData="M29,24c0,1.7-1.3,3-3,3s-3-1.3-3-3s1.3-3,3-3S29,22.3,29,24zM34,19v11c0,1.1-0.9,2-2,2H16c-1.1,0-2-0.9-2-2V19c0-1.1,0.9-2,2-2v-1h4v1h2l1-2h6l1,2h2C33.1,17,34,17.9,34,19zM19.5,21c0-0.8-0.7-1.5-1.5-1.5s-1.5,0.7-1.5,1.5s0.7,1.5,1.5,1.5S19.5,21.8,19.5,21z M31,24c0-2.8-2.2-5-5-5s-5,2.2-5,5s2.2,5,5,5S31,26.8,31,24z" />
+
+</vector>

--- a/WooCommerce/src/main/res/drawable/media_bar_button_camera_highlighted.xml
+++ b/WooCommerce/src/main/res/drawable/media_bar_button_camera_highlighted.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+
+    <path
+        android:fillColor="#ff11181D"
+        android:pathData="M29,24c0,1.7-1.3,3-3,3s-3-1.3-3-3s1.3-3,3-3S29,22.3,29,24zM34,19v11c0,1.1-0.9,2-2,2H16c-1.1,0-2-0.9-2-2V19c0-1.1,0.9-2,2-2v-1h4v1h2l1-2h6l1,2h2C33.1,17,34,17.9,34,19zM19.5,21c0-0.8-0.7-1.5-1.5-1.5s-1.5,0.7-1.5,1.5s0.7,1.5,1.5,1.5S19.5,21.8,19.5,21z M31,24c0-2.8-2.2-5-5-5s-5,2.2-5,5s2.2,5,5,5S31,26.8,31,24z" />
+</vector>

--- a/WooCommerce/src/main/res/drawable/media_bar_button_camera_selector.xml
+++ b/WooCommerce/src/main/res/drawable/media_bar_button_camera_selector.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:drawable="@drawable/media_bar_button_camera_disabled" android:state_enabled="false" />
+    <item android:drawable="@drawable/media_bar_button_camera_highlighted" android:state_focused="true" />
+    <item android:drawable="@drawable/media_bar_button_camera" />
+
+</selector>

--- a/WooCommerce/src/main/res/drawable/media_bar_button_image_multiple.xml
+++ b/WooCommerce/src/main/res/drawable/media_bar_button_image_multiple.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+
+    <path
+        android:fillColor="#ff4f748e"
+        android:pathData="M27,19.5c0-0.8,0.7-1.5,1.5-1.5s1.5,0.7,1.5,1.5S29.3,21,28.5,21S27,20.3,27,19.5z M16,32h14c0,1.1-0.9,2-2,2H16 c-1.1,0-2-0.9-2-2V20c0-1.1,0.9-2,2-2V32z M34,16v12c0,1.1-0.9,2-2,2H20c-1.1,0-2-0.9-2-2V16c0-1.1,0.9-2,2-2h12 C33.1,14,34,14.9,34,16z M20,16v6.3l3-3.3l4.9,5.4l0.7-0.7c0.8-0.9,2.2-0.9,3,0l0.5,0.6V16H20z" />
+
+</vector>

--- a/WooCommerce/src/main/res/drawable/media_bar_button_image_multiple_disabled.xml
+++ b/WooCommerce/src/main/res/drawable/media_bar_button_image_multiple_disabled.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+
+    <path
+        android:fillColor="#ffc8d7e1"
+        android:pathData="M27,19.5c0-0.8,0.7-1.5,1.5-1.5s1.5,0.7,1.5,1.5S29.3,21,28.5,21S27,20.3,27,19.5z M16,32h14c0,1.1-0.9,2-2,2H16 c-1.1,0-2-0.9-2-2V20c0-1.1,0.9-2,2-2V32z M34,16v12c0,1.1-0.9,2-2,2H20c-1.1,0-2-0.9-2-2V16c0-1.1,0.9-2,2-2h12 C33.1,14,34,14.9,34,16z M20,16v6.3l3-3.3l4.9,5.4l0.7-0.7c0.8-0.9,2.2-0.9,3,0l0.5,0.6V16H20z" />
+</vector>

--- a/WooCommerce/src/main/res/drawable/media_bar_button_image_multiple_highlighted.xml
+++ b/WooCommerce/src/main/res/drawable/media_bar_button_image_multiple_highlighted.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+
+    <path
+        android:fillColor="#ff11181D"
+        android:pathData="M27,19.5c0-0.8,0.7-1.5,1.5-1.5s1.5,0.7,1.5,1.5S29.3,21,28.5,21S27,20.3,27,19.5z M16,32h14c0,1.1-0.9,2-2,2H16 c-1.1,0-2-0.9-2-2V20c0-1.1,0.9-2,2-2V32z M34,16v12c0,1.1-0.9,2-2,2H20c-1.1,0-2-0.9-2-2V16c0-1.1,0.9-2,2-2h12 C33.1,14,34,14.9,34,16z M20,16v6.3l3-3.3l4.9,5.4l0.7-0.7c0.8-0.9,2.2-0.9,3,0l0.5,0.6V16H20z" />
+</vector>

--- a/WooCommerce/src/main/res/drawable/media_bar_button_image_multiple_selector.xml
+++ b/WooCommerce/src/main/res/drawable/media_bar_button_image_multiple_selector.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/media_bar_button_image_multiple_disabled" android:state_enabled="false"/>
+    <item android:drawable="@drawable/media_bar_button_image_multiple_highlighted" android:state_focused="true"/>
+    <item android:drawable="@drawable/media_bar_button_image_multiple"/>
+</selector>

--- a/WooCommerce/src/main/res/layout/aztec_media_toobar_camera_button.xml
+++ b/WooCommerce/src/main/res/layout/aztec_media_toobar_camera_button.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<org.wordpress.aztec.toolbar.RippleToggleButton
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/media_bar_button_camera"
+    style="@style/FormatBarButton"
+    android:layout_width="wrap_content"
+    android:layout_height="fill_parent"
+    android:background="@drawable/media_bar_button_camera_selector"
+    android:contentDescription="@string/media_bar_description_camera">
+</org.wordpress.aztec.toolbar.RippleToggleButton>

--- a/WooCommerce/src/main/res/layout/aztec_media_toobar_gallery_button.xml
+++ b/WooCommerce/src/main/res/layout/aztec_media_toobar_gallery_button.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<org.wordpress.aztec.toolbar.RippleToggleButton
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/media_bar_button_gallery"
+    style="@style/FormatBarButton"
+    android:layout_width="wrap_content"
+    android:layout_height="fill_parent"
+    android:background="@drawable/media_bar_button_image_multiple_selector"
+    android:contentDescription="@string/media_bar_description_gallery">
+</org.wordpress.aztec.toolbar.RippleToggleButton>

--- a/WooCommerce/src/main/res/layout/fragment_aztec_editor.xml
+++ b/WooCommerce/src/main/res/layout/fragment_aztec_editor.xml
@@ -13,7 +13,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:mediaToolbarAvailable="false" />
+        app:mediaToolbarAvailable="true" />
 
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"


### PR DESCRIPTION
This PR adds support to display/add images in the Aztec editor.

### Changes:
- Adds support to display an image from a product description.
- Add support to upload image to the Aztec editor.

### Pending tasks:
- This PR just integrates the Aztec editor to the app and displays the current description of a product.
- The option to update the product description will take place in another PR.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.