### PR TITLE
Issue/1550 add first product image

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/TextViewExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/TextViewExt.kt
@@ -1,11 +1,15 @@
 package com.woocommerce.android.extensions
 
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
 import android.os.Build
 import android.text.Html
 import android.text.SpannableStringBuilder
 import android.text.style.ClickableSpan
 import android.view.View
 import android.widget.TextView
+import androidx.annotation.ColorRes
+import androidx.core.content.ContextCompat
 
 typealias OnLinkClicked = (ClickableSpan) -> Unit
 
@@ -47,5 +51,14 @@ private fun addLinkListener(strBuilder: SpannableStringBuilder, span: ClickableS
     with(strBuilder) {
         setSpan(newSpan, getSpanStart(span), getSpanEnd(span), getSpanFlags(span))
         removeSpan(span)
+    }
+}
+
+/**
+ * Programmatically set the drawable tint (in xml android:drawableTint isn't supported until API 23)
+ */
+fun TextView.setDrawableColor(@ColorRes colorRes: Int) {
+    compoundDrawables.filterNotNull().forEach {
+        it.colorFilter = PorterDuffColorFilter(ContextCompat.getColor(context, colorRes), PorterDuff.Mode.SRC_IN)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -26,6 +26,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_IM
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_SHARE_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_VIEW_AFFILIATE_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_VIEW_EXTERNAL_TAPPED
+import com.woocommerce.android.extensions.setDrawableColor
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -59,7 +60,6 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
 
     private var productTitle = ""
     private var isVariation = false
-    private var imageHeight = 0
     private val skeletonView = SkeletonView()
 
     private val navArgs: ProductDetailFragmentArgs by navArgs()
@@ -88,6 +88,7 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initializeViewModel()
+        textAddImage.setDrawableColor(R.color.grey_darken_10)
     }
 
     private fun initializeViewModel() {
@@ -105,6 +106,10 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
 
         viewModel.productData.observe(this, Observer {
             showProduct(it)
+        })
+
+        viewModel.addProductImage.observe(this, Observer {
+            showProductImages()
         })
 
         viewModel.shareProduct.observe(this, Observer {
@@ -147,7 +152,7 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
     private fun showSkeleton(show: Boolean) {
         if (show) {
             skeletonView.show(productDetail_root, R.layout.skeleton_product_detail, delayed = true)
-            skeletonView.findViewById(R.id.productImage_Skeleton)?.layoutParams?.height = imageHeight
+            skeletonView.findViewById(R.id.productImage_Skeleton)?.layoutParams?.height = imageGallery.height
         } else {
             skeletonView.hide()
         }
@@ -173,7 +178,20 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
         }
 
         updateActivityTitle()
-        imageGallery.showProductImages(product, this)
+
+        if (product.images.isEmpty() && viewModel.isUploadingProductImage.value == false) {
+            imageGallery.visibility = View.GONE
+            if (FeatureFlag.PRODUCT_IMAGE_CHOOSER.isEnabled(requireActivity())) {
+                addImageContainer.visibility = View.VISIBLE
+                addImageContainer.setOnClickListener {
+                    viewModel.onAddImageClicked()
+                }
+            }
+        } else {
+            addImageContainer.visibility = View.GONE
+            imageGallery.visibility = View.VISIBLE
+            imageGallery.showProductImages(product, this)
+        }
 
         isVariation = product.type == ProductType.VARIATION
 
@@ -521,12 +539,16 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
     }
 
     override fun onGalleryImageClicked(imageModel: WCProductImageModel, imageView: View) {
+        showProductImages(imageModel, imageView)
+    }
+
+    private fun showProductImages(imageModel: WCProductImageModel? = null, imageView: View? = null) {
         AnalyticsTracker.track(PRODUCT_DETAIL_IMAGE_TAPPED)
         if (FeatureFlag.PRODUCT_IMAGE_CHOOSER.isEnabled(requireActivity())) {
             val action = ProductDetailFragmentDirections
                     .actionProductDetailFragmentToProductImagesFragment(navArgs.remoteProductId)
             findNavController().navigate(action)
-        } else {
+        } else if (imageModel != null) {
             viewModel.productData.value?.product?.let { product ->
                 ImageViewerActivity.showProductImage(
                         this,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -46,6 +46,9 @@ class ProductDetailViewModel @Inject constructor(
     private val _isSkeletonShown = MutableLiveData<Boolean>()
     val isSkeletonShown: LiveData<Boolean> = _isSkeletonShown
 
+    private val _addProductImage = SingleLiveEvent<Unit>()
+    val addProductImage: LiveData<Unit> = _addProductImage
+
     private val _shareProduct = SingleLiveEvent<Product>()
     val shareProduct: LiveData<Product> = _shareProduct
 
@@ -82,6 +85,10 @@ class ProductDetailViewModel @Inject constructor(
 
     fun onShareButtonClicked() {
         _shareProduct.value = product.value
+    }
+
+    fun onAddImageClicked() {
+        _addProductImage.call()
     }
 
     override fun onCleared() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -104,20 +104,9 @@ class WCProductImageGalleryView @JvmOverloads constructor(
 
     fun showProductImages(product: Product, listener: OnGalleryImageClickListener) {
         this.listener = listener
-        this.visibility = if (product.images.isNotEmpty()) View.VISIBLE else View.GONE
 
-        if (adapter.isSameImageList(product.images)) {
-            return
-        }
-        // if the imageHeight is already known show the images immediately, otherwise invalidate the view
-        // so the imageHeight can be determined and then show the images after a brief delay
-        if (imageHeight > 0) {
+        if (!adapter.isSameImageList(product.images)) {
             adapter.showImages(product.images)
-        } else {
-            invalidate()
-            postDelayed({
-                adapter.showImages(product.images)
-            }, 100)
         }
     }
 

--- a/WooCommerce/src/main/res/drawable/ic_gridicons_add_image.xml
+++ b/WooCommerce/src/main/res/drawable/ic_gridicons_add_image.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M23,4v2h-3v3h-2V6h-3V4h3V1h2v3H23zM14.5,11c0.828,0 1.5,-0.672 1.5,-1.5S15.328,8 14.5,8S13,8.672 13,9.5S13.672,11 14.5,11zM18,14.234l-0.513,-0.57c-0.794,-0.885 -2.181,-0.885 -2.976,0l-0.656,0.731L9,9l-3,3.333V6h7V4H6C4.895,4 4,4.895 4,6v12c0,1.105 0.895,2 2,2h12c1.105,0 2,-0.895 2,-2v-7h-2V14.234z"/>
+</vector>

--- a/WooCommerce/src/main/res/drawable/ripple_grey.xml
+++ b/WooCommerce/src/main/res/drawable/ripple_grey.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@color/grey"
+    android:exitFadeDuration="@android:integer/config_shortAnimTime">
+
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/holo_green_light" />
+        </shape>
+    </item>
+
+</ripple>

--- a/WooCommerce/src/main/res/layout/fragment_product_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_detail.xml
@@ -29,16 +29,38 @@
             <FrameLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@color/white"
+                android:background="@color/grey_light"
                 app:layout_collapseMode="parallax">
 
                 <com.woocommerce.android.widgets.WCProductImageGalleryView
                     android:id="@+id/imageGallery"
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/product_image_gallery_image_height"
                     android:layout_gravity="center_horizontal"
-                    app:isGridView="false"
-                    tools:height="200dp" />
+                    android:background="@color/white"
+                    app:isGridView="false" />
+
+                <FrameLayout
+                    android:id="@+id/addImageContainer"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/product_image_gallery_image_height"
+                    android:background="@drawable/ripple_grey"
+                    android:visibility="gone"
+                    tools:visibility="visible">
+
+                    <TextView
+                        android:id="@+id/textAddImage"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:drawableTop="@drawable/ic_gridicons_add_image"
+                        android:drawablePadding="@dimen/margin_medium"
+                        android:gravity="center"
+                        android:text="@string/product_image_add"
+                        android:textColor="@color/grey_darken_10"
+                        android:textSize="@dimen/text_medium"
+                        tools:drawableTint="@color/grey_darken_10" />
+                </FrameLayout>
 
                 <FrameLayout
                     android:id="@+id/frameStatusBadge"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -428,6 +428,7 @@
     <string name="product_images_title">Photos</string>
     <string name="product_add_photo">Add photo</string>
     <string name="product_remove_photo">Remove photo</string>
+    <string name="product_image_add">Add a product image</string>
     <string name="product_image_service_error_uploading">Error uploading product image</string>
     <string name="product_image_service_error_removing">Error removing product image</string>
     <string name="product_image_service_busy">Please wait for the current operation to complete</string>

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1b71c61ebc318c4d639de2dd080301f647076156'
+    fluxCVersion = 'e9034137c916f052c4283c36fbc2c7c899e40295'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Closes #1550 - enables adding a product image when one isn't already assigned.

![Screenshot_1573667529](https://user-images.githubusercontent.com/3903757/68790181-cdcb8080-0614-11ea-92e5-33ef9993cbf3.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
