### PR TITLE
Issue/1556 product image tracks events

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -264,6 +264,10 @@ class AnalyticsTracker private constructor(private val context: Context) {
         PRODUCT_VARIANTS_LOADED,
         PRODUCT_VARIANTS_LOAD_ERROR,
 
+        // -- Product images
+        PRODUCT_IMAGE_ADDED,
+        PRODUCT_IMAGE_REMOVED,
+
         // -- Help & Support
         SUPPORT_HELP_CENTER_VIEWED(siteless = true),
         SUPPORT_IDENTITY_SET(siteless = true),
@@ -477,11 +481,14 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_LAST_KNOWN_VERSION_CODE = "last_known_version_code"
         const val KEY_REVIEW_ID = "review_id"
         const val KEY_NOTE_ID = "note_id"
+        const val KEY_IMAGE_SOURCE = "source"
 
         const val VALUE_ORDER = "order"
         const val VALUE_REVIEW = "review"
         const val VALUE_ORDER_DETAIL = "order_detail"
         const val VALUE_ORDER_FULFILL = "order_fulfill"
+        const val IMAGE_SOURCE_CAMERA = "camera"
+        const val IMAGE_SOURCE_DEVICE = "device"
 
         const val KEY_REFUND_IS_FULL = "is_full"
         const val KEY_REFUND_TYPE = "method"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -19,6 +19,7 @@ import androidx.lifecycle.ViewModelProviders
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_IMAGE_TAPPED
 import com.woocommerce.android.media.ProductImagesUtils
 import com.woocommerce.android.ui.base.BaseFragment
@@ -214,14 +215,24 @@ class ProductImagesFragment : BaseFragment(), OnGalleryImageClickListener {
         if (resultCode == Activity.RESULT_OK) {
             when (requestCode) {
                 REQUEST_CODE_CHOOSE_PHOTO -> data?.data?.let { imageUri ->
+                    AnalyticsTracker.track(
+                            Stat.PRODUCT_IMAGE_ADDED,
+                            mapOf(AnalyticsTracker.KEY_IMAGE_SOURCE to AnalyticsTracker.IMAGE_SOURCE_DEVICE)
+                    )
                     viewModel.uploadProductMedia(navArgs.remoteProductId, imageUri)
                 }
                 REQUEST_CODE_CAPTURE_PHOTO -> capturedPhotoUri?.let { imageUri ->
+                    AnalyticsTracker.track(
+                            Stat.PRODUCT_IMAGE_ADDED,
+                            mapOf(AnalyticsTracker.KEY_IMAGE_SOURCE to AnalyticsTracker.IMAGE_SOURCE_CAMERA)
+                    )
+                    AnalyticsTracker.track(Stat.PRODUCT_IMAGE_ADDED)
                     viewModel.uploadProductMedia(navArgs.remoteProductId, imageUri)
                 }
                 REQUEST_CODE_IMAGE_VIEWER -> data?.let { intent ->
                     val remoteMediaId = intent.getLongExtra(ImageViewerActivity.EXTRA_REMOVE_REMOTE_IMAGE_ID, 0)
                     if (remoteMediaId > 0) {
+                        AnalyticsTracker.track(Stat.PRODUCT_IMAGE_REMOVED)
                         viewModel.removeProductMedia(navArgs.remoteProductId, remoteMediaId)
                     }
                 }


### PR DESCRIPTION
Closes #1556 - adds tracks events for adding and removing a product image. Both events have already been validated.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
