### PR TITLE
Issue/1557 image service upload only

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -188,6 +188,7 @@ class ProductImagesService : JobIntentService() {
         EventBus.getDefault().post(OnProductImagesUpdateCompletedEvent(remoteProductId, isError = false))
         doneSignal.countDown()
         productImageMap.remove(remoteProductId)
+        currentUploads.remove(remoteProductId)
     }
 
     private fun handleFailure(remoteProductId: Long) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -126,7 +126,7 @@ class ProductImagesService : JobIntentService() {
         val payload = UploadMediaPayload(site, media, STRIP_LOCATION)
         dispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload))
 
-        // wait as long as 60 seconds for the two-step process to complete
+        // wait for the two-step process to complete with a timeout
         try {
             doneSignal.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)
         } catch (e: InterruptedException) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -126,7 +126,7 @@ class ProductImagesService : JobIntentService() {
         val payload = UploadMediaPayload(site, media, STRIP_LOCATION)
         dispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload))
 
-        // wait as long as two minutes for the two-step process to complete
+        // wait as long as 60 seconds for the two-step process to complete
         try {
             doneSignal.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)
         } catch (e: InterruptedException) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -44,7 +44,7 @@ class ProductImagesService : JobIntentService() {
         const val KEY_LOCAL_MEDIA_URI = "key_local_media_uri"
 
         private const val STRIP_LOCATION = true
-        private const val TIMEOUT_SECONDS = 60L
+        private const val TIMEOUT_SECONDS = 120L
 
         // array of remoteProductId / localImageUri
         private val currentUploads = LongSparseArray<Uri>()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -26,7 +26,7 @@ import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductImagesChanged
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductImagesPayload
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit.MINUTES
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 /**
@@ -44,7 +44,7 @@ class ProductImagesService : JobIntentService() {
         const val KEY_LOCAL_MEDIA_URI = "key_local_media_uri"
 
         private const val STRIP_LOCATION = true
-        private const val TIMEOUT_MINUTES = 2L
+        private const val TIMEOUT_SECONDS = 60L
 
         // array of remoteProductId / localImageUri
         private val currentUploads = LongSparseArray<Uri>()
@@ -128,7 +128,7 @@ class ProductImagesService : JobIntentService() {
 
         // wait as long as two minutes for the two-step process to complete
         try {
-            doneSignal.await(TIMEOUT_MINUTES, MINUTES)
+            doneSignal.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)
         } catch (e: InterruptedException) {
             WooLog.e(T.MEDIA, "productImagesService > interrupted", e)
             handleFailure(remoteProductId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -36,7 +36,6 @@ class ProductImagesService : JobIntentService() {
         const val KEY_REMOTE_PRODUCT_ID = "key_remote_product_id"
         const val KEY_LOCAL_MEDIA_URI = "key_local_media_uri"
 
-
         private const val STRIP_LOCATION = true
 
         // array of remoteProductId / localImageUri

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesServiceWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesServiceWrapper.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.net.Uri
 import androidx.core.app.JobIntentService
 import com.woocommerce.android.JobServiceIds
-import com.woocommerce.android.media.ProductImagesService.Companion.Action
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -18,23 +17,8 @@ class ProductImagesServiceWrapper
 @Inject constructor(private val context: Context) {
     fun uploadProductMedia(remoteProductId: Long, localMediaUri: Uri) {
         val intent = Intent(context, ProductImagesService::class.java).also {
-            it.putExtra(ProductImagesService.KEY_ACTION, Action.UPLOAD_IMAGE)
             it.putExtra(ProductImagesService.KEY_REMOTE_PRODUCT_ID, remoteProductId)
             it.putExtra(ProductImagesService.KEY_LOCAL_MEDIA_URI, localMediaUri)
-        }
-        JobIntentService.enqueueWork(
-                context,
-                ProductImagesService::class.java,
-                JobServiceIds.JOB_PRODUCT_IMAGES_SERVICE_ID,
-                intent
-        )
-    }
-
-    fun removeProductMedia(remoteProductId: Long, remoteMediaId: Long) {
-        val intent = Intent(context, ProductImagesService::class.java).also {
-            it.putExtra(ProductImagesService.KEY_ACTION, Action.REMOVE_IMAGE)
-            it.putExtra(ProductImagesService.KEY_REMOTE_PRODUCT_ID, remoteProductId)
-            it.putExtra(ProductImagesService.KEY_REMOTE_MEDIA_ID, remoteMediaId)
         }
         JobIntentService.enqueueWork(
                 context,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesUtils.kt
@@ -47,11 +47,9 @@ object ProductImagesUtils {
 
         // optimize the image if the setting is enabled
         if (AppPrefs.getImageOptimizationEnabled()) {
-            getOptimizedImageUri(context, path)?.let { optUri ->
-                MediaUtils.getRealPathFromURI(context, optUri)?.let { optPath ->
-                    path = optPath
-                }
-            }
+            getOptimizedImagePath(context, path)?.let {
+                path = it
+            } ?: WooLog.w(T.MEDIA, "mediaModelFromLocalUri > failed to optimize image")
         }
 
         val file = File(path)
@@ -170,6 +168,15 @@ object ProductImagesUtils {
         }
 
         WooLog.w(T.MEDIA, "getOptimizedMedia > Optimized picture was null!")
+        return null
+    }
+
+    private fun getOptimizedImagePath(context: Context, path: String): String? {
+        getOptimizedImageUri(context, path)?.let { optUri ->
+            MediaUtils.getRealPathFromURI(context, optUri)?.let {
+                return it
+            }
+        }
         return null
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -122,9 +122,9 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
 
         viewModel.isUploadingProductImage.observe(this, Observer {
             if (it) {
-                imageGallery.addPlaceholder()
+                imageGallery.addUploadPlaceholder()
             } else {
-                imageGallery.removePlaceholder()
+                imageGallery.removeUploadPlaceholder()
             }
         })
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.di.UI_THREAD
 import com.woocommerce.android.media.ProductImagesService
-import com.woocommerce.android.media.ProductImagesService.Companion.Action
 import com.woocommerce.android.media.ProductImagesService.Companion.OnProductImagesUpdateCompletedEvent
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.tools.NetworkStatus
@@ -211,11 +210,7 @@ class ProductDetailViewModel @Inject constructor(
     fun onEventMainThread(event: OnProductImagesUpdateCompletedEvent) {
         setIsUploadingImage(false)
         if (event.isError) {
-            _showSnackbarMessage.value = when (event.action) {
-                Action.UPLOAD_IMAGE -> R.string.product_image_service_error_uploading
-                Action.REMOVE_IMAGE -> R.string.product_image_service_error_removing
-                else -> R.string.error_generic_network
-            }
+            _showSnackbarMessage.value = R.string.product_image_service_error_uploading
         } else {
             loadProduct(remoteProductId)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -113,18 +113,9 @@ class ProductImagesFragment : BaseFragment(), OnGalleryImageClickListener {
 
         viewModel.isUploadingProductImage.observe(this, Observer {
             if (it) {
-                imageGallery.addPlaceholder()
+                imageGallery.addUploadPlaceholder()
             } else {
-                imageGallery.removePlaceholder()
-            }
-        })
-
-        viewModel.isRemovingProductImage.observe(this, Observer {
-            val remoteMediaId = viewModel.removingRemoteMediaId
-            if (it) {
-                imageGallery.addPlaceholder(remoteMediaId)
-            } else {
-                imageGallery.removePlaceholder(remoteMediaId)
+                imageGallery.removeUploadPlaceholder()
             }
         })
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesRepository.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.products
 
 import com.woocommerce.android.annotations.OpenClassOnDebug
-import com.woocommerce.android.media.ProductImagesService.Companion.OnProductImagesUpdateCompletedEvent
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
@@ -13,6 +12,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.model.WCProductImageModel
 import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCProductStore.OnProductImagesChanged
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductImagesPayload
 import javax.inject.Inject
 
@@ -73,9 +73,9 @@ class ProductImagesRepository @Inject constructor(
         return true
     }
 
-    @Suppress("unused")
+    @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onEventMainThread(event: OnProductImagesUpdateCompletedEvent) {
+    fun onProductImagesChanged(event: OnProductImagesChanged) {
         // fetch the product again if the update fails - this is to restore any image we removed
         // from SQLite above
         if (event.isError) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesRepository.kt
@@ -1,17 +1,85 @@
 package com.woocommerce.android.ui.products
 
 import com.woocommerce.android.annotations.OpenClassOnDebug
+import com.woocommerce.android.media.ProductImagesService.Companion.OnProductImagesUpdateCompletedEvent
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.WCProductActionBuilder
+import org.wordpress.android.fluxc.model.WCProductImageModel
 import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductImagesPayload
 import javax.inject.Inject
 
 @OpenClassOnDebug
 class ProductImagesRepository @Inject constructor(
+    private val dispatcher: Dispatcher,
     private val productStore: WCProductStore,
     private val selectedSite: SelectedSite
 ) {
+    init {
+        dispatcher.register(this)
+    }
+
+    fun onCleanup() {
+        dispatcher.unregister(this)
+    }
+
     fun getProduct(remoteProductId: Long): Product? =
             productStore.getProductByRemoteId(selectedSite.get(), remoteProductId)?.toAppModel()
+
+    private fun fetchProduct(remoteProductId: Long) {
+        val payload = WCProductStore.FetchSingleProductPayload(selectedSite.get(), remoteProductId)
+        dispatcher.dispatch(WCProductActionBuilder.newFetchSingleProductAction(payload))
+    }
+
+    /**
+     * Dispatches a request to remove a single product image, returns true only if request
+     * was sent
+     */
+    fun removeProductImage(remoteProductId: Long, remoteMediaId: Long): Boolean {
+        val product = getProduct(remoteProductId)
+        if (product == null) {
+            WooLog.w(T.MEDIA, "removeProductImage > product is null")
+            return false
+        }
+
+        // build a new image list containing all the product images except the passed one
+        val imageList = ArrayList<WCProductImageModel>()
+        var removedImage: WCProductImageModel? = null
+        product.images.forEach { image ->
+            if (image.id == remoteMediaId) {
+                removedImage = image
+            } else {
+                imageList.add(image)
+            }
+        }
+        if (removedImage == null) {
+            WooLog.w(T.MEDIA, "removeProductImage > product image not found")
+            return false
+        }
+
+        // remove the image from SQLite so it's no longer available to the ui
+        productStore.deleteProductImage(selectedSite.get(), remoteProductId, remoteMediaId)
+
+        // then dispatch the request to remove it
+        val payload = UpdateProductImagesPayload(selectedSite.get(), remoteProductId, imageList)
+        dispatcher.dispatch(WCProductActionBuilder.newUpdateProductImagesAction(payload))
+        return true
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onEventMainThread(event: OnProductImagesUpdateCompletedEvent) {
+        // fetch the product again if the update fails - this is to restore any image we removed
+        // from SQLite above
+        if (event.isError) {
+            fetchProduct(event.remoteProductId)
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
@@ -92,12 +92,10 @@ class ProductImagesViewModel @Inject constructor(
         if (!checkNetwork()) {
             return
         }
-        if (ProductImagesService.isBusy()) {
-            _showSnackbarMessage.value = R.string.product_image_service_busy
-            return
-        }
-
-        if (!productRepository.removeProductImage(remoteProductId, remoteMediaId)) {
+        if (productRepository.removeProductImage(remoteProductId, remoteMediaId)) {
+            // reload the product to reflect the removed image
+            loadProduct()
+        } else {
             _showSnackbarMessage.value = R.string.product_image_service_error_removing
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.di.UI_THREAD
 import com.woocommerce.android.media.ProductImagesService
-import com.woocommerce.android.media.ProductImagesService.Companion.Action
 import com.woocommerce.android.media.ProductImagesService.Companion.OnProductImagesUpdateCompletedEvent
 import com.woocommerce.android.media.ProductImagesService.Companion.OnProductImagesUpdateStartedEvent
 import com.woocommerce.android.media.ProductImagesServiceWrapper
@@ -30,7 +29,6 @@ class ProductImagesViewModel @Inject constructor(
     private val networkStatus: NetworkStatus
 ) : ScopedViewModel(mainDispatcher) {
     private var remoteProductId = 0L
-    var removingRemoteMediaId = 0L
 
     private val _product = MutableLiveData<Product>()
     val product: LiveData<Product> = _product
@@ -46,9 +44,6 @@ class ProductImagesViewModel @Inject constructor(
 
     private val _isUploadingProductImage = MutableLiveData<Boolean>()
     val isUploadingProductImage: LiveData<Boolean> = _isUploadingProductImage
-
-    private val _isRemovingProductImage = MutableLiveData<Boolean>()
-    val isRemovingProductImage: LiveData<Boolean> = _isRemovingProductImage
 
     private val _exit = SingleLiveEvent<Unit>()
     val exit: LiveData<Unit> = _exit
@@ -101,8 +96,10 @@ class ProductImagesViewModel @Inject constructor(
             _showSnackbarMessage.value = R.string.product_image_service_busy
             return
         }
-        removingRemoteMediaId = remoteMediaId
-        productImagesServiceWrapper.removeProductMedia(remoteProductId, remoteMediaId)
+
+        if (!productRepository.removeProductImage(remoteProductId, remoteMediaId)) {
+            _showSnackbarMessage.value = R.string.product_image_service_error_removing
+        }
     }
 
     private fun checkNetwork(): Boolean {
@@ -119,42 +116,24 @@ class ProductImagesViewModel @Inject constructor(
         }
     }
 
-    private fun setIsRemovingImage(isRemoving: Boolean) {
-        if (isRemoving != _isRemovingProductImage.value) {
-            _isRemovingProductImage.value = isRemoving
-        }
-    }
-
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: OnProductImagesUpdateStartedEvent) {
         if (remoteProductId == event.remoteProductId) {
-            if (event.action == Action.UPLOAD_IMAGE) {
-                setIsUploadingImage(true)
-            } else if (event.action == Action.REMOVE_IMAGE) {
-                setIsRemovingImage(true)
-            }
+            setIsUploadingImage(true)
         }
     }
 
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: OnProductImagesUpdateCompletedEvent) {
-        if (event.action == Action.UPLOAD_IMAGE) {
+        if (remoteProductId == event.remoteProductId) {
             setIsUploadingImage(false)
-        } else if (event.action == Action.REMOVE_IMAGE) {
-            setIsRemovingImage(false)
-            removingRemoteMediaId = 0
-        }
-
-        if (event.isError) {
-            _showSnackbarMessage.value = when (event.action) {
-                Action.UPLOAD_IMAGE -> R.string.product_image_service_error_uploading
-                Action.REMOVE_IMAGE -> R.string.product_image_service_error_removing
-                else -> R.string.error_generic_network
+            if (event.isError) {
+                _showSnackbarMessage.value = R.string.product_image_service_error_uploading
+            } else {
+                loadProduct()
             }
-        } else {
-            loadProduct()
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -155,18 +155,12 @@ class WCProductImageGalleryView @JvmOverloads constructor(
             return true
         }
 
-        private fun indexOfImage(remoteMediaId: Long): Int {
-            for (index in imageList.indices) {
-                if (imageList[index].id == remoteMediaId) {
-                    return index
-                }
-            }
-            return -1
-        }
-
         fun addUploadPlaceholder() {
-            imageList.add(0, WCProductImageModel(UPLOAD_PLACEHOLDER_ID))
-            notifyItemInserted(0)
+            val hasPlaceholder = imageList.size > 0 && isPlaceholder(0)
+            if (!hasPlaceholder) {
+                imageList.add(0, WCProductImageModel(UPLOAD_PLACEHOLDER_ID))
+                notifyItemInserted(0)
+            }
         }
 
         fun removeUploadPlaceholder(remoteMediaId: Long = UPLOAD_PLACEHOLDER_ID) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -8,7 +8,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.ProgressBar
-import androidx.collection.LongSparseArray
 import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -111,19 +110,15 @@ class WCProductImageGalleryView @JvmOverloads constructor(
     }
 
     /**
-     * Adds a placeholder with a progress bar to indicate images that are uploading or being removed.
-     * Pass the remoteMediaId for media being removed, or nothing for media being uploaded (since we
-     * don't know their media id until the upload completes)
+     * Adds a placeholder with a progress bar to indicate images that are uploading
      */
-    fun addPlaceholder(remoteMediaId: Long = UPLOAD_PLACEHOLDER_ID) {
-        if (remoteMediaId == UPLOAD_PLACEHOLDER_ID) {
-            smoothScrollToPosition(0)
-        }
-        adapter.addPlaceholder(remoteMediaId)
+    fun addUploadPlaceholder() {
+        smoothScrollToPosition(0)
+        adapter.addUploadPlaceholder()
     }
 
-    fun removePlaceholder(remoteMediaId: Long = UPLOAD_PLACEHOLDER_ID) {
-        adapter.removePlaceholder(remoteMediaId)
+    fun removeUploadPlaceholder() {
+        adapter.removeUploadPlaceholder()
     }
 
     private fun onImageClicked(position: Int, imageView: View) {
@@ -135,13 +130,17 @@ class WCProductImageGalleryView @JvmOverloads constructor(
 
     private inner class ImageGalleryAdapter : RecyclerView.Adapter<ImageViewHolder>() {
         private val imageList = ArrayList<WCProductImageModel>()
-        private val placeholderIds = LongSparseArray<Boolean>()
 
         fun showImages(images: List<WCProductImageModel>) {
+            val hasPlaceholder = imageList.size > 0 && isPlaceholder(0)
+
             imageList.clear()
             imageList.addAll(images)
-            restorePlaceholders()
             notifyDataSetChanged()
+
+            if (hasPlaceholder) {
+                addUploadPlaceholder()
+            }
         }
 
         fun isSameImageList(images: List<WCProductImageModel>): Boolean {
@@ -165,53 +164,23 @@ class WCProductImageGalleryView @JvmOverloads constructor(
             return -1
         }
 
-        fun addPlaceholder(remoteMediaId: Long = UPLOAD_PLACEHOLDER_ID) {
-            removePlaceholder(remoteMediaId)
-
-            if (remoteMediaId == UPLOAD_PLACEHOLDER_ID) {
-                // if this is an upload placeholder, we add a bogus image to the list with an id of UPLOAD_PLACEHOLDER_ID
-                placeholderIds.put(remoteMediaId, true)
-                imageList.add(0, WCProductImageModel(remoteMediaId))
-                notifyItemInserted(0)
-            } else {
-                // otherwise we locate the passed media id in the list and mark it as being a placeholder
-                val index = indexOfImage(remoteMediaId)
-                if (index > -1) {
-                    placeholderIds.put(remoteMediaId, true)
-                    notifyItemChanged(index)
-                }
-            }
+        fun addUploadPlaceholder() {
+            imageList.add(0, WCProductImageModel(UPLOAD_PLACEHOLDER_ID))
+            notifyItemInserted(0)
         }
 
-        fun removePlaceholder(remoteMediaId: Long = UPLOAD_PLACEHOLDER_ID) {
+        fun removeUploadPlaceholder(remoteMediaId: Long = UPLOAD_PLACEHOLDER_ID) {
             for (index in imageList.indices) {
                 if (imageList[index].id == remoteMediaId) {
                     imageList.removeAt(index)
-                    placeholderIds.delete(remoteMediaId)
                     notifyItemRemoved(index)
                     break
                 }
             }
         }
 
-        fun isPlaceholder(position: Int): Boolean {
-            val mediaId = imageList[position].id
-            return placeholderIds[mediaId] == true
-        }
+        fun isPlaceholder(position: Int) = imageList[position].id == UPLOAD_PLACEHOLDER_ID
 
-        /**
-         * Called after image list has been updated to make sure we restore any existing upload
-         * placeholders (it's not necessary to restore removal placeholders since those contain
-         * actual image ids, whereas upload placeholders do not since we don't know the id until
-         * the upload completes)
-         */
-        private fun restorePlaceholders() {
-            for (index in 0 until placeholderIds.size()) {
-                if (placeholderIds.valueAt(index) && placeholderIds.keyAt(index) == UPLOAD_PLACEHOLDER_ID) {
-                    imageList.add(0, WCProductImageModel(UPLOAD_PLACEHOLDER_ID))
-                }
-            }
-        }
         fun getImage(position: Int) = imageList[position]
 
         override fun getItemCount() = imageList.size


### PR DESCRIPTION
Closes #1557 - this PR updates the product image service so it only handles image uploads and not image removals. Removing a product image is a fairly lightweight call that doesn't require a service, whereas uploading an image can be time-consuming so it should be handled by a service.

This also simplifies the service, hopefully making it easier to add support for multiple uploads without the baggage of handling multiple removals.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
