### PR TITLE
Issue/1563 hide inventory variable products

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -476,6 +476,16 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
         return cardView
     }
 
+    /**
+     * Given a map of product properties [properties] and a formatter [propertyValueFormatterId]
+     * returns a String with the property names and corresponding values
+     * Eg:
+     * Regular Price: $20.00
+     * Sale Price: $10.00
+     *      OR
+     * Color: 3 options
+     * Size: 2 options
+     */
     private fun getPropertyValue(
         properties: Map<String, String>,
         @StringRes propertyValueFormatterId: Int = R.string.product_property_default_formatter

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -193,7 +193,12 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
         }
 
         addPrimaryCard(productData)
-        addPricingAndInventoryCard(productData)
+
+        // display pricing/inventory card only if product is not a variable product
+        // since pricing, inventory, shipping and SKU for a variable product can differ per variant
+        if (product.type != VARIABLE) {
+            addPricingAndInventoryCard(productData)
+        }
         addPurchaseDetailsCard(productData)
     }
 


### PR DESCRIPTION
Fixes #1563. This PR adds the following changes to the product detail screen:

- Adds logic to hide the pricing and inventory section for a variable product.
- Adds logic to display the variants section below the reviews section **only if** the product is a variable product and if build is debug build.

#### Screenshots
(LEFT: Variable product . RIGHT: non-variable product)
<img width="300" src="https://user-images.githubusercontent.com/22608780/69024616-8e70ab80-09e9-11ea-9137-7ed41ffc861a.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/69024618-903a6f00-09e9-11ea-9ddc-e3a33c9e9f99.png">

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
