### PR TITLE
Issue/1567 multiple image uploads

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -109,7 +109,7 @@ class ProductImagesService : JobIntentService() {
         val localUriList = intent.getParcelableArrayListExtra<Uri>(KEY_LOCAL_URI_LIST)
         if (localUriList.isNullOrEmpty()) {
             WooLog.w(T.MEDIA, "productImagesService > null media list")
-            handleFailure(remoteProductId)
+            EventBus.getDefault().post(OnProductImagesUpdateCompletedEvent(remoteProductId))
             return
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -30,13 +30,7 @@ import java.util.concurrent.TimeUnit.SECONDS
 import javax.inject.Inject
 
 /**
- * Service which adds a product image via a two-step process:
- *
- *      1. Uploads the image to the WP media library
- *      2. When the upload completes, adds the uploaded media to the product
- *
- * For now the service only supports uploading a single image, but down the road
- * we can extend it to support multiple uploads.
+ * Service which uploads device images to the WP media library and assigns them to a product
  */
 class ProductImagesService : JobIntentService() {
     companion object {
@@ -69,9 +63,7 @@ class ProductImagesService : JobIntentService() {
 
         fun isBusy() = !currentUploads.isEmpty
 
-        fun getUploadCountForProduct(remoteProductId: Long): Int {
-            return currentUploads.get(remoteProductId, 0)
-        }
+        fun getUploadCountForProduct(remoteProductId: Long) = currentUploads.get(remoteProductId, 0)
     }
 
     @Inject lateinit var dispatcher: Dispatcher
@@ -102,14 +94,12 @@ class ProductImagesService : JobIntentService() {
 
         val remoteProductId = intent.getLongExtra(KEY_REMOTE_PRODUCT_ID, 0L)
         if (!networkStatus.isConnected()) {
-            handleFailure(remoteProductId)
             return
         }
 
         val localUriList = intent.getParcelableArrayListExtra<Uri>(KEY_LOCAL_URI_LIST)
         if (localUriList.isNullOrEmpty()) {
             WooLog.w(T.MEDIA, "productImagesService > null media list")
-            EventBus.getDefault().post(OnProductImagesUpdateCompletedEvent(remoteProductId))
             return
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -137,8 +137,8 @@ class ProductImagesService : JobIntentService() {
             media.setUploadState(MediaModel.MediaUploadState.UPLOADING)
 
             // dispatch the upload request
-            val site = siteStore.getSiteByLocalId(media.localSiteId)
-            val payload = UploadMediaPayload(site, media, STRIP_LOCATION)
+            WooLog.d(T.MEDIA, "productImagesService > Dispatching request to upload $localUri")
+            val payload = UploadMediaPayload(selectedSite.get(), media, STRIP_LOCATION)
             dispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload))
         }
 
@@ -220,9 +220,12 @@ class ProductImagesService : JobIntentService() {
 
     private fun decUploadCount(remoteProductId: Long) {
         val count = currentUploads.get(remoteProductId, 0)
-        if (count > 0) {
-            currentUploads.put(remoteProductId, count - 1)
+        // we're done if this was the last image to be uploaded, otherwise simply decrement the count
+        if (count == 1) {
+            currentUploads.remove(remoteProductId)
             doneSignal.countDown()
+        } else {
+            currentUploads.put(remoteProductId, count - 1)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -90,7 +90,7 @@ class ProductImagesService : JobIntentService() {
         WooLog.i(T.MEDIA, "productImagesService > onHandleWork")
 
         val remoteProductId = intent.getLongExtra(KEY_REMOTE_PRODUCT_ID, 0L)
-        val localUriList = intent.getSerializableExtra(KEY_LOCAL_MEDIA_URI_LIST) as List<Uri>
+        val localUriList = intent.getSerializableExtra(KEY_LOCAL_MEDIA_URI_LIST) as ArrayList<Uri>
         if (localUriList.isNullOrEmpty()) {
             WooLog.w(T.MEDIA, "productImagesService > null localMediaUri")
             handleFailure(remoteProductId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -63,7 +63,7 @@ class ProductImagesService : JobIntentService() {
 
         fun isBusy() = !currentUploads.isEmpty
 
-        fun getUploadCountForProduct(remoteProductId: Long) = currentUploads.get(remoteProductId, 0)
+        fun getUploadCountForProduct(remoteProductId: Long): Int = currentUploads.get(remoteProductId, 0)
     }
 
     @Inject lateinit var dispatcher: Dispatcher

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesServiceWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesServiceWrapper.kt
@@ -18,7 +18,7 @@ class ProductImagesServiceWrapper
     fun uploadProductMedia(remoteProductId: Long, localMediaUriList: ArrayList<Uri>) {
         val intent = Intent(context, ProductImagesService::class.java).also {
             it.putExtra(ProductImagesService.KEY_REMOTE_PRODUCT_ID, remoteProductId)
-            it.putParcelableArrayListExtra(ProductImagesService.KEY_LOCAL_MEDIA_URI_LIST, localMediaUriList)
+            it.putParcelableArrayListExtra(ProductImagesService.KEY_LOCAL_URI_LIST, localMediaUriList)
         }
         JobIntentService.enqueueWork(
                 context,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesServiceWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesServiceWrapper.kt
@@ -18,7 +18,7 @@ class ProductImagesServiceWrapper
     fun uploadProductMedia(remoteProductId: Long, localMediaUriList: ArrayList<Uri>) {
         val intent = Intent(context, ProductImagesService::class.java).also {
             it.putExtra(ProductImagesService.KEY_REMOTE_PRODUCT_ID, remoteProductId)
-            it.putExtra(ProductImagesService.KEY_LOCAL_MEDIA_URI_LIST, localMediaUriList)
+            it.putParcelableArrayListExtra(ProductImagesService.KEY_LOCAL_MEDIA_URI_LIST, localMediaUriList)
         }
         JobIntentService.enqueueWork(
                 context,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesServiceWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesServiceWrapper.kt
@@ -16,9 +16,14 @@ import javax.inject.Singleton
 class ProductImagesServiceWrapper
 @Inject constructor(private val context: Context) {
     fun uploadProductMedia(remoteProductId: Long, localMediaUri: Uri) {
+        val uriList = ArrayList<Uri>().also { it.add(localMediaUri) }
+        uploadProductMedia(remoteProductId, uriList)
+    }
+
+    fun uploadProductMedia(remoteProductId: Long, localMediaUriList: ArrayList<Uri>) {
         val intent = Intent(context, ProductImagesService::class.java).also {
             it.putExtra(ProductImagesService.KEY_REMOTE_PRODUCT_ID, remoteProductId)
-            it.putExtra(ProductImagesService.KEY_LOCAL_MEDIA_URI, localMediaUri)
+            it.putExtra(ProductImagesService.KEY_LOCAL_MEDIA_URI_LIST, localMediaUriList)
         }
         JobIntentService.enqueueWork(
                 context,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesServiceWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesServiceWrapper.kt
@@ -15,11 +15,6 @@ import javax.inject.Singleton
 @Singleton
 class ProductImagesServiceWrapper
 @Inject constructor(private val context: Context) {
-    fun uploadProductMedia(remoteProductId: Long, localMediaUri: Uri) {
-        val uriList = ArrayList<Uri>().also { it.add(localMediaUri) }
-        uploadProductMedia(remoteProductId, uriList)
-    }
-
     fun uploadProductMedia(remoteProductId: Long, localMediaUriList: ArrayList<Uri>) {
         val intent = Intent(context, ProductImagesService::class.java).also {
             it.putExtra(ProductImagesService.KEY_REMOTE_PRODUCT_ID, remoteProductId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/imageviewer/ImageViewerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/imageviewer/ImageViewerViewModel.kt
@@ -7,7 +7,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.di.UI_THREAD
-import com.woocommerce.android.media.ProductImagesService.Companion.OnProductImagesUpdateCompletedEvent
+import com.woocommerce.android.media.ProductImagesService.Companion.OnProductImageUploaded
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -78,7 +78,7 @@ class ImageViewerViewModel @Inject constructor(
 
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onEventMainThread(event: OnProductImagesUpdateCompletedEvent) {
+    fun onEventMainThread(event: OnProductImageUploaded) {
         if (remoteProductId == event.remoteProductId) {
             if (event.isError) {
                 _showSnackbarMessage.value = R.string.product_image_error_removing

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -175,7 +175,7 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
 
         updateActivityTitle()
 
-        if (product.images.isEmpty() && viewModel.isUploading()) {
+        if (product.images.isEmpty() && !viewModel.isUploading()) {
             imageGallery.visibility = View.GONE
             if (FeatureFlag.PRODUCT_IMAGE_CHOOSER.isEnabled(requireActivity())) {
                 addImageContainer.visibility = View.VISIBLE

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -120,12 +120,8 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
             uiMessageResolver.showSnack(it)
         })
 
-        viewModel.isUploadingProductImage.observe(this, Observer {
-            if (it) {
-                imageGallery.addUploadPlaceholder()
-            } else {
-                imageGallery.removeUploadPlaceholder()
-            }
+        viewModel.uploadingImageCount.observe(this, Observer {
+            imageGallery.setPlaceholderCount(it)
         })
 
         viewModel.exit.observe(this, Observer {
@@ -179,7 +175,7 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
 
         updateActivityTitle()
 
-        if (product.images.isEmpty() && viewModel.isUploadingProductImage.value == false) {
+        if (product.images.isEmpty() && viewModel.isUploading()) {
             imageGallery.visibility = View.GONE
             if (FeatureFlag.PRODUCT_IMAGE_CHOOSER.isEnabled(requireActivity())) {
                 addImageContainer.visibility = View.VISIBLE

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -113,12 +113,8 @@ class ProductImagesFragment : BaseFragment(), OnGalleryImageClickListener {
             captureProductImage()
         })
 
-        viewModel.isUploadingProductImage.observe(this, Observer {
-            if (it) {
-                imageGallery.addUploadPlaceholder()
-            } else {
-                imageGallery.removeUploadPlaceholder()
-            }
+        viewModel.uploadingImageCount.observe(this, Observer {
+            imageGallery.setPlaceholderCount(it)
         })
 
         viewModel.exit.observe(this, Observer {
@@ -232,7 +228,7 @@ class ProductImagesFragment : BaseFragment(), OnGalleryImageClickListener {
                             Stat.PRODUCT_IMAGE_ADDED,
                             mapOf(AnalyticsTracker.KEY_IMAGE_SOURCE to AnalyticsTracker.IMAGE_SOURCE_DEVICE)
                     )
-                    viewModel.uploadProductMedia(navArgs.remoteProductId, uriList)
+                    viewModel.uploadProductImages(navArgs.remoteProductId, uriList)
                 }
                 REQUEST_CODE_CAPTURE_PHOTO -> capturedPhotoUri?.let { imageUri ->
                     AnalyticsTracker.track(
@@ -240,7 +236,7 @@ class ProductImagesFragment : BaseFragment(), OnGalleryImageClickListener {
                             mapOf(AnalyticsTracker.KEY_IMAGE_SOURCE to AnalyticsTracker.IMAGE_SOURCE_CAMERA)
                     )
                     val uriList = ArrayList<Uri>().also { it.add(imageUri) }
-                    viewModel.uploadProductMedia(navArgs.remoteProductId, uriList)
+                    viewModel.uploadProductImages(navArgs.remoteProductId, uriList)
                 }
                 REQUEST_CODE_IMAGE_VIEWER -> data?.let { bundle ->
                     if (bundle.getBooleanExtra(ImageViewerActivity.KEY_DID_REMOVE_IMAGE, false)) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -25,6 +25,8 @@ import com.woocommerce.android.media.ProductImagesUtils
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.imageviewer.ImageViewerActivity
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.util.WooPermissionUtils
 import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageClickListener
 import dagger.android.support.AndroidSupportInjection
@@ -178,8 +180,10 @@ class ProductImagesFragment : BaseFragment(), OnGalleryImageClickListener {
         // permission and do nothing else - this will be called again if the user then agrees to allow
         // storage permission
         if (requestStoragePermission()) {
-            val intent = Intent(Intent.ACTION_GET_CONTENT)
-            intent.type = "image/*"
+            val intent = Intent(Intent.ACTION_GET_CONTENT).also {
+                it.type = "image/*"
+                it.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+            }
             val chooser = Intent.createChooser(intent, null)
             activity?.startActivityFromFragment(this, chooser, REQUEST_CODE_CHOOSE_PHOTO)
         }
@@ -205,20 +209,38 @@ class ProductImagesFragment : BaseFragment(), OnGalleryImageClickListener {
 
         if (resultCode == Activity.RESULT_OK) {
             when (requestCode) {
-                REQUEST_CODE_CHOOSE_PHOTO -> data?.data?.let { imageUri ->
+                REQUEST_CODE_CHOOSE_PHOTO -> data?.let {
+                    val uriList = ArrayList<Uri>()
+                    val clipData = it.clipData
+                    if (clipData != null) {
+                        // handle multiple images
+                        for (i in 0 until clipData.itemCount) {
+                            val uri = clipData.getItemAt(i).uri
+                            uriList.add(uri)
+                        }
+                    } else {
+                        // handle single image
+                        it.data?.let { uri ->
+                            uriList.add(uri)
+                        }
+                    }
+                    if (uriList.isEmpty()) {
+                        WooLog.w(T.MEDIA, "Photo chooser returned empty list")
+                        return
+                    }
                     AnalyticsTracker.track(
                             Stat.PRODUCT_IMAGE_ADDED,
                             mapOf(AnalyticsTracker.KEY_IMAGE_SOURCE to AnalyticsTracker.IMAGE_SOURCE_DEVICE)
                     )
-                    viewModel.uploadProductMedia(navArgs.remoteProductId, imageUri)
+                    viewModel.uploadProductMedia(navArgs.remoteProductId, uriList)
                 }
                 REQUEST_CODE_CAPTURE_PHOTO -> capturedPhotoUri?.let { imageUri ->
                     AnalyticsTracker.track(
                             Stat.PRODUCT_IMAGE_ADDED,
                             mapOf(AnalyticsTracker.KEY_IMAGE_SOURCE to AnalyticsTracker.IMAGE_SOURCE_CAMERA)
                     )
-                    AnalyticsTracker.track(Stat.PRODUCT_IMAGE_ADDED)
-                    viewModel.uploadProductMedia(navArgs.remoteProductId, imageUri)
+                    val uriList = ArrayList<Uri>().also { it.add(imageUri) }
+                    viewModel.uploadProductMedia(navArgs.remoteProductId, uriList)
                 }
                 REQUEST_CODE_IMAGE_VIEWER -> data?.let { bundle ->
                     if (bundle.getBooleanExtra(ImageViewerActivity.KEY_DID_REMOVE_IMAGE, false)) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
@@ -77,7 +77,7 @@ class ProductImagesViewModel @Inject constructor(
         _captureProductImage.call()
     }
 
-    fun uploadProductMedia(remoteProductId: Long, localImageUri: Uri) {
+    fun uploadProductMedia(remoteProductId: Long, localMediaUriList: ArrayList<Uri>) {
         if (!checkNetwork()) {
             return
         }
@@ -85,7 +85,7 @@ class ProductImagesViewModel @Inject constructor(
             _showSnackbarMessage.value = R.string.product_image_service_busy
             return
         }
-        productImagesServiceWrapper.uploadProductMedia(remoteProductId, localImageUri)
+        productImagesServiceWrapper.uploadProductMedia(remoteProductId, localMediaUriList)
     }
 
     private fun checkNetwork(): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -150,8 +150,6 @@ class ProductListViewModel @Inject constructor(
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: OnProductImagesUpdateCompletedEvent) {
-        if (!event.isError) {
-            loadProducts()
-        }
+        loadProducts()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -137,12 +137,34 @@ class WCProductImageGalleryView @JvmOverloads constructor(
             setPlaceholderCount(count)
         }
 
-        fun isSameImageList(images: List<WCProductImageModel>): Boolean {
-            if (images.size != imageList.size) {
+        /**
+         * Returns the list of images without placeholders
+         */
+        private fun getActualImages(): List<WCProductImageModel> {
+            if (placeholderCount == 0) {
+                return imageList
+            }
+            val images = ArrayList<WCProductImageModel>()
+            for (index in imageList.indices) {
+                if (!isPlaceholder(index)) {
+                    images.add(imageList[index])
+                }
+            }
+            return images
+        }
+
+        /**
+         * Returns true if the passed list of images is the same as the adapter's list, taking
+         * placeholders into account
+         */
+        private fun isSameImageList(images: List<WCProductImageModel>): Boolean {
+            val actualImages = getActualImages()
+            if (images.size != actualImages.size) {
                 return false
             }
+
             for (index in images.indices) {
-                if (images[index].id != imageList[index].id) {
+                if (images[index].id != actualImages[index].id) {
                     return false
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -101,10 +101,7 @@ class WCProductImageGalleryView @JvmOverloads constructor(
 
     fun showProductImages(product: Product, listener: OnGalleryImageClickListener) {
         this.listener = listener
-
-        if (!adapter.isSameImageList(product.images)) {
-            adapter.showImages(product.images)
-        }
+        adapter.showImages(product.images)
     }
 
     /**
@@ -126,6 +123,10 @@ class WCProductImageGalleryView @JvmOverloads constructor(
         private var placeholderCount = 0
 
         fun showImages(images: List<WCProductImageModel>) {
+            if (isSameImageList(images)) {
+                return
+            }
+
             val count = placeholderCount
             placeholderCount = 0
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -127,6 +127,7 @@ class WCProductImageGalleryView @JvmOverloads constructor(
 
         fun showImages(images: List<WCProductImageModel>) {
             val count = placeholderCount
+            placeholderCount = 0
 
             imageList.clear()
             imageList.addAll(images)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -155,9 +155,7 @@ class WCProductImageGalleryView @JvmOverloads constructor(
             }
 
             // remove existing placeholders
-            for (index in 1..placeholderCount) {
-                imageList.removeAt(index)
-            }
+            clearPlaceholders()
 
             // add the new ones
             for (index in 1..count) {
@@ -168,6 +166,13 @@ class WCProductImageGalleryView @JvmOverloads constructor(
 
             placeholderCount = count
             notifyDataSetChanged()
+        }
+
+        private fun clearPlaceholders() {
+            while (itemCount > 0 && isPlaceholder(0)) {
+                imageList.removeAt(0)
+            }
+            placeholderCount = 0
         }
 
         fun isPlaceholder(position: Int) = imageList[position].id < 0

--- a/WooCommerce/src/main/res/layout/fragment_product_images.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_images.xml
@@ -13,7 +13,7 @@
         style="@style/Woo.Button.Bordered"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/product_add_photo" />
+        android:text="@string/product_add_photos" />
 
     <View
         android:id="@+id/divider"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -426,7 +426,7 @@
         Product images
     -->
     <string name="product_images_title">Photos</string>
-    <string name="product_add_photo">Add photo</string>
+    <string name="product_add_photos">Add photos</string>
     <string name="product_remove_photo">Remove photo</string>
     <string name="product_image_add">Add a product image</string>
     <string name="product_image_error_removing">Error removing product image</string>


### PR DESCRIPTION
Closes #1567 - adds the ability to select multiple images from the device picker and upload them all. To select multiple images, simply long press in the device picker to begin the multi-select process.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
