### PR TITLE
Hotfix/3.1-v4-stats-rename-endpoint-fix

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 3.1
 -----
 * Added a new variants section in the Product detail screen for variable products
-
+* The new beta stats UI now requires WooCommerce Admin plugin version 0.22+
  
 3.0
 -----

--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -60,7 +60,6 @@ Language: ar
     <string name="orderdetail_payment_summary_completed">%1$s عبر %2$s</string>
     <string name="my_store_stats_availability_message">نطرح تحسينات على الإحصاءات الخاصة بالمتاجر باستخدام إضافة مسؤول WooCommerce.</string>
     <string name="my_store_stats_availability_title">تجربة إحصاءاتنا المُحسَّنة</string>
-    <string name="my_store_stats_reverted_message">عدنا إلى الإحصاءات القديمة كما نحن\nتعذر العثور على إضافة مسؤول WooCommerce</string>
     <string name="dashboard_state_no_data">لا توجد أي إيرادات في هذه الفترة</string>
     <string name="no_thanks">لا شكرًا</string>
     <string name="try_it_now">جرّبه الآن</string>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -60,7 +60,6 @@ Language: de
     <string name="orderdetail_payment_summary_completed">%1$s per %2$s</string>
     <string name="my_store_stats_availability_message">Wir werden Verbesserungen an den Statistiken für Shops über das WooCommerce Admin-Plugin einführen</string>
     <string name="my_store_stats_availability_title">Teste unsere verbesserten Statistiken</string>
-    <string name="my_store_stats_reverted_message">Wir sund zu den alten Statistiken zurückgekehrt, da wir\ndas WooCommerce Admin-Plugin nicht finden konnten</string>
     <string name="dashboard_state_no_data">Keine Einnahmen in diesem Zeitraum</string>
     <string name="no_thanks">Nein, danke</string>
     <string name="try_it_now">Jetzt ausprobieren</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -60,7 +60,6 @@ Language: es
     <string name="orderdetail_payment_summary_completed">%1$s a través de %2$s</string>
     <string name="my_store_stats_availability_message">Estamos implementando mejoras en las estadísticas para las tiendas con el plugin de administración de WooCommerce</string>
     <string name="my_store_stats_availability_title">Prueba nuestras mejoras de las estadísticas</string>
-    <string name="my_store_stats_reverted_message">Hemos cambiado a las antiguas estadísticas porque\nno hemos podido encontrar el plugin de administración de WooCommerce</string>
     <string name="dashboard_state_no_data">Sin ingresos durante este periodo</string>
     <string name="no_thanks">No, gracias</string>
     <string name="try_it_now">Probar ahora</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -60,7 +60,6 @@ Language: fr
     <string name="orderdetail_payment_summary_completed">%1$s via %2$s</string>
     <string name="my_store_stats_availability_message">Nous déployons des améliorations afin d\'optimiser les statistiques des boutiques via l\'extension d\'administration WooCommerce</string>
     <string name="my_store_stats_availability_title">Essayer nos statistiques améliorées</string>
-    <string name="my_store_stats_reverted_message">Nous sommes revenus aux anciennes statistiques car nous\nn\'avons pas pu trouver l\'extension d\'administration WooCommerce</string>
     <string name="dashboard_state_no_data">Pas de revenus durant cette période</string>
     <string name="no_thanks">Non merci</string>
     <string name="try_it_now">Essayer maintenant</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -60,7 +60,6 @@ Language: he_IL
     <string name="orderdetail_payment_summary_completed">%1$s דרך %2$s</string>
     <string name="my_store_stats_availability_message">אנחנו מפרסמים שיפורים לנתונים הסטטיסטיים בחנויות באמצעות תוסף הניהול של WooCommerce</string>
     <string name="my_store_stats_availability_title">מומלץ לנסות את הנתונים הסטטיסטיים המשופרים</string>
-    <string name="my_store_stats_reverted_message">החזרנו את הנתונים הסטטיסטיים לגרסה הקודמת מאחר שלא הצלחנו\nלמצוא את תוסף הניהול של WooCommerce</string>
     <string name="dashboard_state_no_data">אין רווחים בתקופה זאת</string>
     <string name="no_thanks">לא תודה</string>
     <string name="try_it_now">כדאי לנסות עכשיו</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -60,7 +60,6 @@ Language: id
     <string name="orderdetail_payment_summary_completed">%1$s melalui %2$s</string>
     <string name="my_store_stats_availability_message">Kami merilis penyempurnaan untuk statistik toko menggunakan plugin Admin WooCommerce</string>
     <string name="my_store_stats_availability_title">Cobalah statistik yang disempurnakan</string>
-    <string name="my_store_stats_reverted_message">Kami mengembalikan ke statistik lama karena\ntidak dapat menemukan Plugin Admin WooCommerce</string>
     <string name="dashboard_state_no_data">Tidak ada pendapatan dalam periode ini</string>
     <string name="no_thanks">Tidak, terima kasih</string>
     <string name="try_it_now">Coba sekarang</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -60,7 +60,6 @@ Language: it
     <string name="orderdetail_payment_summary_completed">%1$s tramite %2$s</string>
     <string name="my_store_stats_availability_message">Stiamo distribuendo miglioramenti alle statistiche per i negozi che utilizzano il plugin WooCommerce Admin</string>
     <string name="my_store_stats_availability_title">Prova le nostre statistiche migliorate</string>
-    <string name="my_store_stats_reverted_message">Abbiamo ripristinato le vecchie statistiche perché\nnon siamo riusciti a trovare il plugin WooCommerce Admin</string>
     <string name="dashboard_state_no_data">Nessuna entrata per questo periodo</string>
     <string name="no_thanks">No, grazie</string>
     <string name="try_it_now">Prova ora</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -60,7 +60,6 @@ Language: ja_JP
     <string name="orderdetail_payment_summary_completed">%2$s により %1$s</string>
     <string name="my_store_stats_availability_message">WooCommerce Admin プラグインでストアに強化された統計機能を提供開始します</string>
     <string name="my_store_stats_availability_title">強化された統計機能をお試しください</string>
-    <string name="my_store_stats_reverted_message">WooCommerce Admin プラグインが見つからないため、\n従来の統計機能に戻しました</string>
     <string name="dashboard_state_no_data">この期間には収益がありません</string>
     <string name="no_thanks">結構です</string>
     <string name="try_it_now">今すぐお試しください</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -60,7 +60,6 @@ Language: ko_KR
     <string name="orderdetail_payment_summary_completed">%2$s을(를) 통한 %1$s</string>
     <string name="my_store_stats_availability_message">WooCommerce 관리자 플러그인을 사용하여 스토어 통계 개선을 점진적으로 실시합니다.</string>
     <string name="my_store_stats_availability_title">향상된 통계를 사용해 보세요.</string>
-    <string name="my_store_stats_reverted_message">WooCommerce 관리자 플러그인을 찾을 수 없어\n이전 통계로 되돌렸습니다.</string>
     <string name="dashboard_state_no_data">이 기간에 해당하는 수익이 없습니다.</string>
     <string name="no_thanks">괜찮습니다.</string>
     <string name="try_it_now">지금 사용해 보기</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -60,7 +60,6 @@ Language: nl
     <string name="orderdetail_payment_summary_completed">%1$s via %2$s</string>
     <string name="my_store_stats_availability_message">We voeren verbeteringen aan statistieken voor winkels door, via de WooCommerce Admin-plugin</string>
     <string name="my_store_stats_availability_title">Probeer onze verbeterde statistieken</string>
-    <string name="my_store_stats_reverted_message">We hebben de oude statistieken hersteld, want we\nkonden de WooCommerce Admin-plugin niet vinden</string>
     <string name="dashboard_state_no_data">Geen omzet deze periode</string>
     <string name="no_thanks">Nee, liever niet</string>
     <string name="try_it_now">Probeer het nu</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -60,7 +60,6 @@ Language: pt_BR
     <string name="orderdetail_payment_summary_completed">%1$s via %2$s</string>
     <string name="my_store_stats_availability_message">Estamos aprimorando estatísticas para lojas que usam o plugin WooCommerce Admin</string>
     <string name="my_store_stats_availability_title">Experimente nossas estatísticas aprimoradas</string>
-    <string name="my_store_stats_reverted_message">Retornamos para as estatísticas antigas, já que\nnão encontramos o plugin WooCommerce Admin</string>
     <string name="dashboard_state_no_data">Nenhuma receita para esse período</string>
     <string name="no_thanks">Não, obrigado</string>
     <string name="try_it_now">Experimente já</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -60,7 +60,6 @@ Language: ru
     <string name="orderdetail_payment_summary_completed">%1$s через %2$s</string>
     <string name="my_store_stats_availability_message">Представляем вам улучшенную статистику для магазинов, использующих плагин администратора WooCommerce</string>
     <string name="my_store_stats_availability_title">Оцените улучшенный раздел статистики</string>
-    <string name="my_store_stats_reverted_message">Восстановлен прежний формат статистики, поскольку\nплагин администратора WooCommerce не обнаружен</string>
     <string name="dashboard_state_no_data">Нет доходов за указанный период</string>
     <string name="no_thanks">Нет, спасибо</string>
     <string name="try_it_now">Попробовать</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -60,7 +60,6 @@ Language: sv_SE
     <string name="orderdetail_payment_summary_completed">%1$s via %2$s</string>
     <string name="my_store_stats_availability_message">Vi lanserar förbättrad statistik för butiker med hjälp av adminplugin-programmet WooCommerce</string>
     <string name="my_store_stats_availability_title">Prova vår förbättrade statistik</string>
-    <string name="my_store_stats_reverted_message">Vi har återgått till gammal statistik eftersom vi\ninte kunde hitta adminplugin-programmet WooCommerce</string>
     <string name="dashboard_state_no_data">Inga inkomster denna period</string>
     <string name="no_thanks">Nej tack</string>
     <string name="try_it_now">Prova nu</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -60,7 +60,6 @@ Language: tr
     <string name="orderdetail_payment_summary_completed">%2$s üzerinden %1$s</string>
     <string name="my_store_stats_availability_message">WooCommerce Yönetici eklentisini kullanan mağazalar için istatistiklerde geliştirmeler yapıyoruz</string>
     <string name="my_store_stats_availability_title">Geliştirilmiş istatistiklerimizi deneyin</string>
-    <string name="my_store_stats_reverted_message">Eski istatistiklere geri döndük, çünkü\nWooCommerce Yönetici Eklentisi bulunamadı</string>
     <string name="dashboard_state_no_data">Bu dönemde hiç gelir yok</string>
     <string name="no_thanks">Hayır, teşekkürler</string>
     <string name="try_it_now">Şimdi deneyin</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -60,7 +60,6 @@ Language: zh_CN
     <string name="orderdetail_payment_summary_completed">%1$s（通过 %2$s）</string>
     <string name="my_store_stats_availability_message">我们正面向使用了 WooCommerce Admin 插件的商店推出经改进的统计页面</string>
     <string name="my_store_stats_availability_title">试用经改进的统计页面</string>
-    <string name="my_store_stats_reverted_message">由于无法找到 WooCommerce Admin 插件，\n因此已恢复旧版统计页面</string>
     <string name="dashboard_state_no_data">此时间段内没有收入</string>
     <string name="no_thanks">不用了，谢谢</string>
     <string name="try_it_now">立即试用</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -60,7 +60,6 @@ Language: zh_TW
     <string name="orderdetail_payment_summary_completed">%1$s，付款方式：%2$s</string>
     <string name="my_store_stats_availability_message">我們即將為使用 WooCommerce 管理員外掛程式的商店推出統計資料改善功能</string>
     <string name="my_store_stats_availability_title">體驗我們改善的統計資料效能</string>
-    <string name="my_store_stats_reverted_message">我們已回復為舊的統計資料，因為我們\n找不到 WooCommerce 管理員外掛程式</string>
     <string name="dashboard_state_no_data">此期間沒有收益</string>
     <string name="no_thanks">不用了，謝謝</string>
     <string name="try_it_now">立即試試</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -178,7 +178,7 @@
     <string name="dashboard_fulfill_order_title_multiple">You have %1$d orders to fulfill</string>
     <string name="dashboard_fulfill_orders_msg">Review, prepare, and ship these pending orders</string>
 
-    <string name="my_store_stats_reverted_message">We have reverted to the old stats as we\ncouldn\'t find the WooCommerce Admin Plugin</string>
+    <string name="my_store_stats_reverted_message">We have reverted to the old stats. To use the beta stats, please activate the WooCommerce Admin plugin with version 0.22 or higher</string>
     <string name="my_store_stats_availability_title">Try our improved stats</string>
     <string name="my_store_stats_availability_message">We\'re rolling out improvements to stats for  stores using the WooCommerce Admin plugin</string>
     <!--

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.5.3'
+    fluxCVersion = '74a02ba1390517a344c4c8ce884464bfa3c3ccd7'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '74a02ba1390517a344c4c8ce884464bfa3c3ccd7'
+    fluxCVersion = '8c05cd4576232ab80d0fad93797708f1afc14690'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Fixes #1570. 

This PR adds the following changes:
- Update the endpoint for stats v4 to use the new namespace. This is done on the FluxC side.
- Update the banner reverted message that we show when the user had opted in to the new stats but the `wc-admin` is no longer available (could be because the plugin is uninstalled or using a version < v0.22).

#### Notes
~- Note that this [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1430) needs to be merged and the hash updated to this PR before this PR can be merged.~

#### Testing
##### Scenario I:
- Use a test site with the latest version of `wc-admin` installed. 
- Pull changes from this PR and verify that you are able to see the new stats UI (or opt in to see the new stats UI).
- Download a previous version of `wc-admin` from this [link](https://wordpress.org/plugins/woocommerce-admin/advanced/). Ensure that the version downloaded is less than v0.22. Update this version to your test site. 
- Pull to refresh in the app and verify that you are able to see the stats reverted banner with the updated message.

##### Scenario II:
- Use a test site with the latest version of `wc-admin` installed. 
- Pull changes from this PR and verify that you are able to see the new stats UI (or opt in to see the new stats UI).
- Deactivate the `wc-admin` plugin from the test site.
- Pull to refresh in the app and verify that you are able to see the stats reverted banner with the updated message.

#### Screenshots
(LEFT: latest wc-admin installed . RIGHT: older version of wc-admin installed)
<img width="300" src="https://user-images.githubusercontent.com/22608780/69119627-35724780-0abd-11ea-8a12-c47c33ca7eb5.gif"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/69119708-6a7e9a00-0abd-11ea-8f0c-415366fe69e0.gif">

@JavonDavis, just a heads up that once this PR is approved, we would need another beta release for 3.1. Thank you!! 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
