### PR TITLE
Bug fix: Lost Password link on self-hosted credentials screen doesn't work

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -154,9 +154,8 @@ public class LoginUsernamePasswordFragment extends LoginBaseDiscoveryFragment im
         siteAddressView.setText(UrlUtils.removeScheme(UrlUtils.removeXmlrpcSuffix(mInputSiteAddress)));
         siteAddressView.setVisibility(mInputSiteAddress != null ? View.VISIBLE : View.GONE);
 
-        String inputSiteAddressWithoutProtocol = UrlUtils.removeScheme(mInputSiteAddress);
         mInputSiteAddressWithoutSuffix = (mEndpointAddress == null || mEndpointAddress.isEmpty())
-                ? inputSiteAddressWithoutProtocol : UrlUtils.removeXmlrpcSuffix(mEndpointAddress);
+                ? mInputSiteAddress : UrlUtils.removeXmlrpcSuffix(mEndpointAddress);
 
         mUsernameInput = rootView.findViewById(R.id.login_username_row);
         mUsernameInput.setText(mInputUsername);
@@ -192,6 +191,9 @@ public class LoginUsernamePasswordFragment extends LoginBaseDiscoveryFragment im
                     if (mIsWpcom) {
                         mLoginListener.forgotPassword(FORGOT_PASSWORD_URL_WPCOM);
                     } else {
+                        if (!mInputSiteAddressWithoutSuffix.endsWith("/")) {
+                            mInputSiteAddressWithoutSuffix += "/";
+                        }
                         mLoginListener.forgotPassword(mInputSiteAddressWithoutSuffix);
                     }
                 }

--- a/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -22,7 +22,7 @@
     <string name="open_mail">Open mail</string>
     <string name="alternatively">Alternatively:</string>
     <string name="enter_site_address_instead">Log in by entering your site address.</string>
-    <string name="enter_site_credentials_instead">Log in with site credentials</string>
+    <string name="enter_site_credentials_instead">Log in with site credentials.</string>
     <string name="enter_username_instead">Log in with your username.</string>
     <string name="enter_verification_code">Almost there! Please enter the verification code from your Authenticator app.</string>
     <string name="enter_verification_code_sms">We sent a text message to the phone number ending in %s. Please enter the verification code in the SMS.</string>


### PR DESCRIPTION
Fixes #1576.  The forgot password link in the self hosted credentials link was malformed. This PR adds logic to fix this issue.

#### Testing
- Open the app while logged out, and select Log In.
- Enter the URL for a WooCommerce store with Jetpack connected.
- Select the option to "log in with site credentials."
- On the site credentials screen, select "Lost your password?" and note the message that appears.
- Pull changes from this PR and verify that the forgot password link is working.

@rachelmcr, adding you as a reviewer since you caught the bug :)  

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
