### PR TITLE
Issue/1577 image upload placeholder previews

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesNotificationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesNotificationHandler.kt
@@ -15,8 +15,7 @@ import java.util.Random
  */
 class ProductImagesNotificationHandler(
     val service: ProductImagesService,
-    val remoteProductId: Long,
-    totalUploads: Int
+    val remoteProductId: Long
 ) {
     companion object {
         private const val CHANNEL_ID = "image_upload_channel"
@@ -25,6 +24,7 @@ class ProductImagesNotificationHandler(
     private val context: Context = service.baseContext.applicationContext
     private val notificationId: Int
     private val notificationManager: NotificationManager
+    private val notificationBuilder: NotificationCompat.Builder
 
     init {
         notificationManager = SystemServiceFactory.get(
@@ -34,20 +34,13 @@ class ProductImagesNotificationHandler(
 
         createChannel()
 
-        val title = if (totalUploads == 1) {
-            context.getString(R.string.product_images_uploading_single_notif_message)
-        } else {
-            context.getString(R.string.product_images_uploading_multi_notif_message)
-        }
-
-        val notificationBuilder = NotificationCompat.Builder(
+        notificationBuilder = NotificationCompat.Builder(
                 context,
                 CHANNEL_ID
         ).also {
             it.color = ContextCompat.getColor(context, R.color.grey_50)
             it.setSmallIcon(android.R.drawable.stat_sys_upload)
             it.setOnlyAlertOnce(true)
-            it.setContentTitle(title)
             it.setOngoing(true)
             it.setProgress(0, 0, true)
         }
@@ -56,6 +49,22 @@ class ProductImagesNotificationHandler(
         notificationId = (Random()).nextInt()
         service.startForeground(notificationId, notification)
         notificationManager.notify(notificationId, notification)
+    }
+
+    fun setProgress(progress: Int) {
+        notificationBuilder.setProgress(100, progress, false)
+        notificationManager.notify(notificationId, notificationBuilder.build())
+    }
+
+    fun update(currentUpload: Int, totalUploads: Int) {
+        val title = if (totalUploads == 1) {
+            context.getString(R.string.product_images_uploading_single_notif_message)
+        } else {
+            context.getString(R.string.product_images_uploading_multi_notif_message, currentUpload, totalUploads)
+        }
+
+        notificationBuilder.setContentTitle(title)
+        notificationManager.notify(notificationId, notificationBuilder.build())
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -147,8 +147,16 @@ class ProductImagesService : JobIntentService() {
                 WooLog.e(T.MEDIA, "productImagesService > interrupted", e)
             }
 
-            // remove this uri from the list of uploads for this product and notify that this upload completed
-            currentUploads.get(remoteProductId)?.remove(localUri)
+            // remove this uri from the list of uploads for this product
+            currentUploads.get(remoteProductId)?.let{ oldList ->
+                val newList = ArrayList<Uri>().also {
+                    it.addAll(oldList)
+                    it.remove(localUri)
+                }
+                currentUploads.put(remoteProductId, newList)
+            }
+
+            // notify that this upload completed
             EventBus.getDefault().post(OnProductImageUploaded(remoteProductId, isError = didLastUploadFail))
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -193,9 +193,11 @@ class ProductImagesService : JobIntentService() {
                 handleFailure()
             }
             event.completed -> {
+                // the image uploaded successfully, so assign it to the product
                 dispatchAddMediaAction(event.media)
                 WooLog.i(T.MEDIA, "productImagesService > uploaded media ${event.media?.id}")
             } else -> {
+                // otherwise this is an upload progress event, so update the notification progress
                 val progress = (event.progress * 100).toInt()
                 notifHandler.setProgress(progress)
             }
@@ -240,11 +242,15 @@ class ProductImagesService : JobIntentService() {
 
     private fun handleSuccess() {
         didLastUploadFail = false
-        doneSignal.countDown()
+        if (doneSignal.count > 0) {
+            doneSignal.countDown()
+        }
     }
 
     private fun handleFailure() {
         didLastUploadFail = true
-        doneSignal.countDown()
+        if (doneSignal.count > 0) {
+            doneSignal.countDown()
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -76,7 +76,7 @@ class ProductImagesService : JobIntentService() {
     @Inject lateinit var productImageMap: ProductImageMap
     @Inject lateinit var networkStatus: NetworkStatus
 
-    private val doneSignal = CountDownLatch(1)
+    private var doneSignal: CountDownLatch? = null
     private var didLastUploadFail = false
 
     private lateinit var notifHandler: ProductImagesNotificationHandler
@@ -143,7 +143,8 @@ class ProductImagesService : JobIntentService() {
 
                 // wait for the upload to complete
                 try {
-                    doneSignal.await(TIMEOUT_PER_UPLOAD, SECONDS)
+                    doneSignal = CountDownLatch(1)
+                    doneSignal!!.await(TIMEOUT_PER_UPLOAD, SECONDS)
                 } catch (e: InterruptedException) {
                     WooLog.e(T.MEDIA, "productImagesService > interrupted", e)
                 }
@@ -241,15 +242,11 @@ class ProductImagesService : JobIntentService() {
 
     private fun handleSuccess() {
         didLastUploadFail = false
-        if (doneSignal.count > 0) {
-            doneSignal.countDown()
-        }
+        doneSignal?.countDown()
     }
 
     private fun handleFailure() {
         didLastUploadFail = true
-        if (doneSignal.count > 0) {
-            doneSignal.countDown()
-        }
+        doneSignal?.countDown()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -151,7 +151,7 @@ class ProductImagesService : JobIntentService() {
             }
 
             // remove this uri from the list of uploads for this product
-            currentUploads.get(remoteProductId)?.let{ oldList ->
+            currentUploads.get(remoteProductId)?.let { oldList ->
                 val newList = ArrayList<Uri>().also {
                     it.addAll(oldList)
                     it.remove(localUri)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -116,9 +116,12 @@ class ProductImagesService : JobIntentService() {
         EventBus.getDefault().post(event)
 
         val totalUploads = localUriList.size
-        notifHandler = ProductImagesNotificationHandler(this, remoteProductId, totalUploads)
+        notifHandler = ProductImagesNotificationHandler(this, remoteProductId)
 
-        localUriList.forEach loop@{ localUri ->
+        for (index in 0 until totalUploads) {
+            notifHandler.update(index + 1, totalUploads)
+            val localUri = localUriList[index]
+
             // create a media model from this local image uri
             val media = ProductImagesUtils.mediaModelFromLocalUri(
                     this,
@@ -129,7 +132,7 @@ class ProductImagesService : JobIntentService() {
             if (media == null) {
                 WooLog.w(T.MEDIA, "productImagesService > null media")
                 handleFailure()
-                return@loop
+                continue
             }
 
             media.postId = remoteProductId
@@ -192,6 +195,9 @@ class ProductImagesService : JobIntentService() {
             event.completed -> {
                 dispatchAddMediaAction(event.media)
                 WooLog.i(T.MEDIA, "productImagesService > uploaded media ${event.media?.id}")
+            } else -> {
+                val progress = (event.progress * 100).toInt()
+                notifHandler.setProgress(progress)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -132,22 +132,21 @@ class ProductImagesService : JobIntentService() {
             if (media == null) {
                 WooLog.w(T.MEDIA, "productImagesService > null media")
                 handleFailure()
-                continue
-            }
+            } else {
+                media.postId = remoteProductId
+                media.setUploadState(MediaModel.MediaUploadState.UPLOADING)
 
-            media.postId = remoteProductId
-            media.setUploadState(MediaModel.MediaUploadState.UPLOADING)
+                // dispatch the upload request
+                WooLog.d(T.MEDIA, "productImagesService > Dispatching request to upload $localUri")
+                val payload = UploadMediaPayload(selectedSite.get(), media, STRIP_LOCATION)
+                dispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload))
 
-            // dispatch the upload request
-            WooLog.d(T.MEDIA, "productImagesService > Dispatching request to upload $localUri")
-            val payload = UploadMediaPayload(selectedSite.get(), media, STRIP_LOCATION)
-            dispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload))
-
-            // wait for the upload to complete
-            try {
-                doneSignal.await(TIMEOUT_PER_UPLOAD, SECONDS)
-            } catch (e: InterruptedException) {
-                WooLog.e(T.MEDIA, "productImagesService > interrupted", e)
+                // wait for the upload to complete
+                try {
+                    doneSignal.await(TIMEOUT_PER_UPLOAD, SECONDS)
+                } catch (e: InterruptedException) {
+                    WooLog.e(T.MEDIA, "productImagesService > interrupted", e)
+                }
             }
 
             // remove this uri from the list of uploads for this product

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -242,11 +242,19 @@ class ProductImagesService : JobIntentService() {
 
     private fun handleSuccess() {
         didLastUploadFail = false
-        doneSignal?.countDown()
+        countDown()
     }
 
     private fun handleFailure() {
         didLastUploadFail = true
-        doneSignal?.countDown()
+        countDown()
+    }
+
+    private fun countDown() {
+        doneSignal?.let {
+            if (it.count > 0) {
+                it.countDown()
+            }
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -120,8 +120,8 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
             uiMessageResolver.showSnack(it)
         })
 
-        viewModel.uploadingImageCount.observe(this, Observer {
-            imageGallery.setPlaceholderCount(it)
+        viewModel.uploadingImageUris.observe(this, Observer {
+            imageGallery.setPlaceholderImageUris(it)
         })
 
         viewModel.exit.observe(this, Observer {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.products
 
+import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
@@ -54,8 +55,8 @@ class ProductDetailViewModel @Inject constructor(
     private val _showSnackbarMessage = SingleLiveEvent<Int>()
     val showSnackbarMessage: LiveData<Int> = _showSnackbarMessage
 
-    private val _uploadingImageCount = SingleLiveEvent<Int>()
-    val uploadingImageCount: LiveData<Int> = _uploadingImageCount
+    private val _uploadingImageUris = MutableLiveData<List<Uri>>()
+    val uploadingImageUris: LiveData<List<Uri>> = _uploadingImageUris
 
     private val _exit = SingleLiveEvent<Unit>()
     val exit: LiveData<Unit> = _exit
@@ -77,7 +78,7 @@ class ProductDetailViewModel @Inject constructor(
 
     fun start(remoteProductId: Long) {
         loadProduct(remoteProductId)
-        checkUploadCount()
+        checkUploads()
     }
 
     fun onShareButtonClicked() {
@@ -140,11 +141,8 @@ class ProductDetailViewModel @Inject constructor(
 
     fun isUploading() = ProductImagesService.isUploadingForProduct(remoteProductId)
 
-    private fun checkUploadCount() {
-        val count = ProductImagesService.getUploadCountForProduct(remoteProductId)
-        if (_uploadingImageCount.value != count) {
-            _uploadingImageCount.value = count
-        }
+    private fun checkUploads() {
+        _uploadingImageUris.value = ProductImagesService.getUploadingImageUrisForProduct(remoteProductId)
     }
 
     private fun formatCurrency(amount: BigDecimal?, currencyCode: String?): String {
@@ -214,6 +212,6 @@ class ProductDetailViewModel @Inject constructor(
         } else {
             loadProduct(remoteProductId)
         }
-        checkUploadCount()
+        checkUploads()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -30,7 +30,9 @@ import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.util.WooPermissionUtils
 import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageClickListener
 import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.fragment_product_detail.*
 import kotlinx.android.synthetic.main.fragment_product_images.*
+import kotlinx.android.synthetic.main.fragment_product_images.imageGallery
 import org.wordpress.android.fluxc.model.WCProductImageModel
 import javax.inject.Inject
 
@@ -113,8 +115,8 @@ class ProductImagesFragment : BaseFragment(), OnGalleryImageClickListener {
             captureProductImage()
         })
 
-        viewModel.uploadingImageCount.observe(this, Observer {
-            imageGallery.setPlaceholderCount(it)
+        viewModel.uploadingImageUris.observe(this, Observer {
+            imageGallery.setPlaceholderImageUris(it)
         })
 
         viewModel.exit.observe(this, Observer {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -30,9 +30,7 @@ import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.util.WooPermissionUtils
 import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageClickListener
 import dagger.android.support.AndroidSupportInjection
-import kotlinx.android.synthetic.main.fragment_product_detail.*
 import kotlinx.android.synthetic.main.fragment_product_images.*
-import kotlinx.android.synthetic.main.fragment_product_images.imageGallery
 import org.wordpress.android.fluxc.model.WCProductImageModel
 import javax.inject.Inject
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -12,6 +12,7 @@ import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewGroup.LayoutParams
 import android.widget.PopupWindow
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -150,8 +151,7 @@ class ProductImagesFragment : BaseFragment(), OnGalleryImageClickListener {
             }
         }
 
-        imageSourcePopup = PopupWindow(requireActivity()).also {
-            it.contentView = contentView
+        imageSourcePopup = PopupWindow(contentView, LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT).also {
             it.elevation = resources.getDimensionPixelSize(R.dimen.appbar_elevation).toFloat()
             it.setBackgroundDrawable(null)
             it.isFocusable = true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
@@ -8,6 +8,8 @@ import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.di.UI_THREAD
 import com.woocommerce.android.media.ProductImagesService
 import com.woocommerce.android.media.ProductImagesService.Companion.OnProductImageUploaded
+import com.woocommerce.android.media.ProductImagesService.Companion.OnProductImagesUpdateCompletedEvent
+import com.woocommerce.android.media.ProductImagesService.Companion.OnProductImagesUpdateStartedEvent
 import com.woocommerce.android.media.ProductImagesServiceWrapper
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.tools.NetworkStatus
@@ -95,6 +97,29 @@ class ProductImagesViewModel @Inject constructor(
 
     private fun checkUploads() {
         _uploadingImageUris.value = ProductImagesService.getUploadingImageUrisForProduct(remoteProductId)
+    }
+
+    /**
+     * The list of images has started uploaded
+     */
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onEventMainThread(event: OnProductImagesUpdateStartedEvent) {
+        if (remoteProductId == event.remoteProductId) {
+            checkUploads()
+        }
+    }
+
+    /**
+     * The list of images has finished uploading
+     */
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onEventMainThread(event: OnProductImagesUpdateCompletedEvent) {
+        if (remoteProductId == event.remoteProductId) {
+            loadProduct()
+            checkUploads()
+        }
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -117,6 +117,7 @@ class WCProductImageGalleryView @JvmOverloads constructor(
                 it.src = imageUriList[index].toString()
             })
         }
+        adapter.setPlaceholderImages(placeholders)
     }
 
     private fun onImageClicked(position: Int, imageView: View) {
@@ -189,20 +190,31 @@ class WCProductImageGalleryView @JvmOverloads constructor(
             return true
         }
 
-        fun setPlaceholderImages(images: List<WCProductImageModel>) {
+        fun setPlaceholderImages(placeholders: List<WCProductImageModel>) {
             // remove existing placeholders
-            clearPlaceholders()
+           var didChange = clearPlaceholders()
 
             // add the new ones to the top of the list
-            imageList.addAll(0, images)
+            if (placeholders.size > 0) {
+                imageList.addAll(0, placeholders)
+                didChange = true
+            }
 
-            notifyDataSetChanged()
+            if (didChange) {
+                notifyDataSetChanged()
+            }
         }
 
-        private fun clearPlaceholders() {
+        /**
+         * Removes all placeholders, returns true only if any were removed
+         */
+        private fun clearPlaceholders(): Boolean {
+            var result = false
             while (itemCount > 0 && isPlaceholder(0)) {
                 imageList.removeAt(0)
+                result = true
             }
+            return result
         }
 
         fun isPlaceholder(position: Int) = imageList[position].id < 0

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -142,7 +142,7 @@ class WCProductImageGalleryView @JvmOverloads constructor(
             imageList.addAll(images)
             notifyDataSetChanged()
 
-            if (placeholders.size > 0) {
+            if (placeholders.isNotEmpty()) {
                 setPlaceholderImages(placeholders)
             }
         }
@@ -196,7 +196,7 @@ class WCProductImageGalleryView @JvmOverloads constructor(
             var didChange = clearPlaceholders()
 
             // add the new ones to the top of the list
-            if (placeholders.size > 0) {
+            if (placeholders.isNotEmpty()) {
                 imageList.addAll(0, placeholders)
                 didChange = true
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -112,8 +112,9 @@ class WCProductImageGalleryView @JvmOverloads constructor(
         val placeholders = ArrayList<WCProductImageModel>()
         for (index in imageUriList.indices) {
             // use a negative id so we can check it in isPlaceholder() below
-            val id = -(index - 1).toLong()
+            val id = (-index - 1).toLong()
             placeholders.add(0, WCProductImageModel(id).also {
+                // set the image src to this uri so we can preview it while uploading
                 it.src = imageUriList[index].toString()
             })
         }
@@ -239,9 +240,11 @@ class WCProductImageGalleryView @JvmOverloads constructor(
 
             if (viewType == VIEW_TYPE_PLACEHOLDER) {
                 holder.imageView.layoutParams.width = placeholderWidth
+                holder.imageView.alpha = 0.5F
                 holder.uploadProgress.visibility = View.VISIBLE
             } else {
                 holder.imageView.layoutParams.width = ViewGroup.LayoutParams.WRAP_CONTENT
+                holder.imageView.alpha = 1.0F
                 holder.uploadProgress.visibility = View.GONE
             }
 
@@ -249,8 +252,11 @@ class WCProductImageGalleryView @JvmOverloads constructor(
         }
 
         override fun onBindViewHolder(holder: ImageViewHolder, position: Int) {
-            if (getItemViewType(position) == VIEW_TYPE_IMAGE) {
-                val photonUrl = PhotonUtils.getPhotonImageUrl(getImage(position).src, 0, imageHeight)
+            val src = getImage(position).src
+            if (getItemViewType(position) == VIEW_TYPE_PLACEHOLDER) {
+                holder.imageView.setImageURI(Uri.parse(src))
+            } else {
+                val photonUrl = PhotonUtils.getPhotonImageUrl(src, 0, imageHeight)
                 request.load(photonUrl).into(holder.imageView)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.widgets
 
-import android.content.ContentResolver
 import android.content.Context
 import android.graphics.drawable.Drawable
 import android.net.Uri
@@ -48,8 +47,6 @@ class WCProductImageGalleryView @JvmOverloads constructor(
     private val placeholderWidth: Int
     private val adapter: ImageGalleryAdapter
     private val layoutInflater: LayoutInflater
-    private val contentResolver: ContentResolver
-
     private val request: GlideRequest<Drawable>
 
     private lateinit var listener: OnGalleryImageClickListener
@@ -74,7 +71,6 @@ class WCProductImageGalleryView @JvmOverloads constructor(
 
         itemAnimator = DefaultItemAnimator()
         layoutInflater = LayoutInflater.from(context)
-        contentResolver = context.contentResolver
 
         setHasFixedSize(false)
         setItemViewCacheSize(0)
@@ -197,7 +193,7 @@ class WCProductImageGalleryView @JvmOverloads constructor(
 
         fun setPlaceholderImages(placeholders: List<WCProductImageModel>) {
             // remove existing placeholders
-           var didChange = clearPlaceholders()
+            var didChange = clearPlaceholders()
 
             // add the new ones to the top of the list
             if (placeholders.size > 0) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.widgets
 
+import android.content.ContentResolver
 import android.content.Context
 import android.graphics.drawable.Drawable
 import android.net.Uri
@@ -46,8 +47,10 @@ class WCProductImageGalleryView @JvmOverloads constructor(
 
     private val placeholderWidth: Int
     private val adapter: ImageGalleryAdapter
-    private val request: GlideRequest<Drawable>
     private val layoutInflater: LayoutInflater
+    private val contentResolver: ContentResolver
+
+    private val request: GlideRequest<Drawable>
 
     private lateinit var listener: OnGalleryImageClickListener
 
@@ -71,6 +74,7 @@ class WCProductImageGalleryView @JvmOverloads constructor(
 
         itemAnimator = DefaultItemAnimator()
         layoutInflater = LayoutInflater.from(context)
+        contentResolver = context.contentResolver
 
         setHasFixedSize(false)
         setItemViewCacheSize(0)
@@ -254,7 +258,7 @@ class WCProductImageGalleryView @JvmOverloads constructor(
         override fun onBindViewHolder(holder: ImageViewHolder, position: Int) {
             val src = getImage(position).src
             if (getItemViewType(position) == VIEW_TYPE_PLACEHOLDER) {
-                holder.imageView.setImageURI(Uri.parse(src))
+                request.load(Uri.parse(src)).into(holder.imageView)
             } else {
                 val photonUrl = PhotonUtils.getPhotonImageUrl(src, 0, imageHeight)
                 request.load(photonUrl).into(holder.imageView)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -239,11 +239,9 @@ class WCProductImageGalleryView @JvmOverloads constructor(
             )
 
             if (viewType == VIEW_TYPE_PLACEHOLDER) {
-                holder.imageView.layoutParams.width = placeholderWidth
                 holder.imageView.alpha = 0.5F
                 holder.uploadProgress.visibility = View.VISIBLE
             } else {
-                holder.imageView.layoutParams.width = ViewGroup.LayoutParams.WRAP_CONTENT
                 holder.imageView.alpha = 1.0F
                 holder.uploadProgress.visibility = View.GONE
             }
@@ -254,7 +252,7 @@ class WCProductImageGalleryView @JvmOverloads constructor(
         override fun onBindViewHolder(holder: ImageViewHolder, position: Int) {
             val src = getImage(position).src
             if (getItemViewType(position) == VIEW_TYPE_PLACEHOLDER) {
-                request.load(Uri.parse(src)).centerCrop().into(holder.imageView)
+                request.load(Uri.parse(src)).into(holder.imageView)
             } else {
                 val photonUrl = PhotonUtils.getPhotonImageUrl(src, 0, imageHeight)
                 request.load(photonUrl).into(holder.imageView)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -254,7 +254,7 @@ class WCProductImageGalleryView @JvmOverloads constructor(
         override fun onBindViewHolder(holder: ImageViewHolder, position: Int) {
             val src = getImage(position).src
             if (getItemViewType(position) == VIEW_TYPE_PLACEHOLDER) {
-                request.load(Uri.parse(src)).into(holder.imageView)
+                request.load(Uri.parse(src)).centerCrop().into(holder.imageView)
             } else {
                 val photonUrl = PhotonUtils.getPhotonImageUrl(src, 0, imageHeight)
                 request.load(photonUrl).into(holder.imageView)

--- a/WooCommerce/src/main/res/layout/image_gallery_item.xml
+++ b/WooCommerce/src/main/res/layout/image_gallery_item.xml
@@ -16,10 +16,9 @@
         tools:layout_height="200dp"
         tools:src="@drawable/ic_product" />
 
-
     <ProgressBar
         android:id="@+id/uploadProgess"
-        style="?android:attr/progressBarStyleSmall"
+        style="?android:attr/progressBarStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"

--- a/WooCommerce/src/main/res/layout/image_gallery_item.xml
+++ b/WooCommerce/src/main/res/layout/image_gallery_item.xml
@@ -19,7 +19,7 @@
 
     <ProgressBar
         android:id="@+id/uploadProgess"
-        style="?android:attr/progressBarStyle"
+        style="?android:attr/progressBarStyleSmall"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -436,7 +436,7 @@
     <string name="product_image_remove_confirmation">Remove this image from the product?</string>
     <string name="product_images_camera_error">Unable to access camera</string>
     <string name="product_images_uploading_single_notif_message">Uploading image…</string>
-    <string name="product_images_uploading_multi_notif_message">Uploading images…</string>
+    <string name="product_images_uploading_multi_notif_message">Uploading images…%d of %d</string>
     <string name="product_images_upload_channel_title">Uploads</string>
     <string name="image_source_title">Select an upload method</string>
     <string name="image_source_device_chooser">Choose from device</string>


### PR DESCRIPTION
Closes #1577 - adds a preview of uploading images, and updates the upload notification to show the number of images being uploaded and the upload progress for each image.

One change I made in this PR was that previously multiple uploads were dispatched concurrently, but now they're uploaded in order. This enables showing an accurate upload process, and more importantly the previous approach seemed too resource-intense.

![placeholder](https://user-images.githubusercontent.com/3903757/69271449-e0a8fc80-0ba2-11ea-9803-94f0a012c125.png)

![notif](https://user-images.githubusercontent.com/3903757/69271456-e3a3ed00-0ba2-11ea-80b4-a64a5877fe36.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
