### PR TITLE
Ensure popup works on Lollipop

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -12,6 +12,7 @@ import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewGroup.LayoutParams
 import android.widget.PopupWindow
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -150,8 +151,7 @@ class ProductImagesFragment : BaseFragment(), OnGalleryImageClickListener {
             }
         }
 
-        imageSourcePopup = PopupWindow(requireActivity()).also {
-            it.contentView = contentView
+        imageSourcePopup = PopupWindow(contentView, LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT).also {
             it.elevation = resources.getDimensionPixelSize(R.dimen.appbar_elevation).toFloat()
             it.setBackgroundDrawable(null)
             it.isFocusable = true


### PR DESCRIPTION
Fixes #1595 - previously the popup window enabling the user to choose the image source wouldn't appear on Lollipop. This PR corrects this.

![Screenshot_1574353408](https://user-images.githubusercontent.com/3903757/69356869-25d83780-0c52-11ea-9cac-727258d23bed.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
