### PR TITLE
Add a WIP banner to product list

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -277,6 +277,7 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener,
 
     private fun showSkeleton(show: Boolean) {
         if (show) {
+            showProductWIPNoticeCard(false)
             skeletonView.show(productsRecycler, R.layout.skeleton_product_list, delayed = true)
         } else {
             skeletonView.hide()
@@ -289,6 +290,16 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener,
 
     private fun showProductList(products: List<Product>) {
         productAdapter.setProductList(products)
+        showProductWIPNoticeCard(true)
+    }
+
+    private fun showProductWIPNoticeCard(show: Boolean) {
+        if (show) {
+            products_wip_card.visibility = View.VISIBLE
+            products_wip_card.initView()
+        } else {
+            products_wip_card.visibility = View.GONE
+        }
     }
 
     override fun onProductClick(remoteProductId: Long) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -86,7 +86,7 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener,
                     ContextCompat.getColor(activity, R.color.colorAccent),
                     ContextCompat.getColor(activity, R.color.colorPrimaryDark)
             )
-            scrollUpChild = productsRecycler
+            scrollUpChild = scroll_view
             setOnRefreshListener {
                 viewModel.onRefreshRequested()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductsWIPNoticeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductsWIPNoticeCard.kt
@@ -1,0 +1,27 @@
+package com.woocommerce.android.ui.products
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.widget.LinearLayout
+import com.woocommerce.android.R
+import com.woocommerce.android.util.WooAnimUtils
+import kotlinx.android.synthetic.main.my_store_stats_availability_notice.view.*
+import kotlinx.android.synthetic.main.products_wip_notice.view.*
+
+class ProductsWIPNoticeCard @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
+    : LinearLayout(ctx, attrs) {
+    init {
+        View.inflate(context, R.layout.products_wip_notice, this)
+    }
+
+    fun initView() {
+        products_wip_viewMore.setOnCheckedChangeListener { _, isChecked ->
+            if (isChecked) {
+                WooAnimUtils.fadeIn(my_store_availability_morePanel)
+            } else {
+                WooAnimUtils.fadeOut(my_store_availability_morePanel)
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductsWIPNoticeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductsWIPNoticeCard.kt
@@ -6,7 +6,6 @@ import android.view.View
 import android.widget.LinearLayout
 import com.woocommerce.android.R
 import com.woocommerce.android.util.WooAnimUtils
-import kotlinx.android.synthetic.main.my_store_stats_availability_notice.view.*
 import kotlinx.android.synthetic.main.products_wip_notice.view.*
 
 class ProductsWIPNoticeCard @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
@@ -18,9 +17,9 @@ class ProductsWIPNoticeCard @JvmOverloads constructor(ctx: Context, attrs: Attri
     fun initView() {
         products_wip_viewMore.setOnCheckedChangeListener { _, isChecked ->
             if (isChecked) {
-                WooAnimUtils.fadeIn(my_store_availability_morePanel)
+                WooAnimUtils.fadeIn(products_wip_morePanel)
             } else {
-                WooAnimUtils.fadeOut(my_store_availability_morePanel)
+                WooAnimUtils.fadeOut(products_wip_morePanel)
             }
         }
     }

--- a/WooCommerce/src/main/res/drawable/ic_gridicons_tools.xml
+++ b/WooCommerce/src/main/res/drawable/ic_gridicons_tools.xml
@@ -1,0 +1,9 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#000000" android:pathData="M14.5,11.5C15.1,11.8 15.8,12 16.5,12C19,12 21,10 21,7.5C21,6.8 20.8,6.1 20.5,5.5L17,9L15,7L18.5,3.5C17.9,3.2 17.2,3 16.5,3C14,3 12,5 12,7.5C12,8.2 12.2,8.9 12.5,9.5L2,20L4,22L10.8,15.2L13.1,12.9L14.5,11.5Z"/>
+    <group>
+        <clip-path android:pathData="M14.5,11.5C15.1,11.8 15.8,12 16.5,12C19,12 21,10 21,7.5C21,6.8 20.8,6.1 20.5,5.5L17,9L15,7L18.5,3.5C17.9,3.2 17.2,3 16.5,3C14,3 12,5 12,7.5C12,8.2 12.2,8.9 12.5,9.5L2,20L4,22L10.8,15.2L13.1,12.9L14.5,11.5Z M 0,0"/>
+        <path android:fillColor="#A2AAB2" android:pathData="M0,0h24v24h-24z"/>
+    </group>
+</vector>

--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -12,10 +12,20 @@
         android:clickable="true"
         android:focusable="true">
 
+        <!-- Products work in progress notice card -->
+        <com.woocommerce.android.ui.products.ProductsWIPNoticeCard
+            android:id="@+id/products_wip_card"
+            style="@style/Woo.Stats.Card.Expandable"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            tools:visibility="visible"
+            android:visibility="gone"/>
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/productsRecycler"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/products_wip_card"/>
 
         <com.woocommerce.android.widgets.WCEmptyView
             android:id="@+id/empty_view"

--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -9,6 +9,7 @@
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/default_window_background"
         android:clickable="true"
         android:focusable="true">
 
@@ -18,19 +19,21 @@
             style="@style/Woo.Stats.Card.Expandable"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            tools:visibility="visible"
-            android:visibility="gone"/>
+            android:layout_marginBottom="@dimen/margin_large"
+            android:visibility="gone"
+            tools:visibility="visible" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/productsRecycler"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/products_wip_card"/>
+            android:layout_below="@+id/products_wip_card" />
 
         <com.woocommerce.android.widgets.WCEmptyView
             android:id="@+id/empty_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:layout_below="@+id/products_wip_card"
             android:visibility="gone" />
 
         <ProgressBar

--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -6,45 +6,52 @@
     android:layout_height="match_parent"
     tools:context="com.woocommerce.android.ui.products.ProductListFragment">
 
-    <RelativeLayout
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/scroll_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/default_window_background"
-        android:clickable="true"
-        android:focusable="true">
+        android:fillViewport="true">
 
-        <!-- Products work in progress notice card -->
-        <com.woocommerce.android.ui.products.ProductsWIPNoticeCard
-            android:id="@+id/products_wip_card"
-            style="@style/Woo.Stats.Card.Expandable"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/margin_large"
-            android:visibility="gone"
-            tools:visibility="visible" />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/productsRecycler"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/products_wip_card" />
-
-        <com.woocommerce.android.widgets.WCEmptyView
-            android:id="@+id/empty_view"
+        <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_below="@+id/products_wip_card"
-            android:visibility="gone" />
+            android:background="@color/default_window_background"
+            android:clickable="true"
+            android:focusable="true">
 
-        <ProgressBar
-            android:id="@+id/loadMoreProgress"
-            style="?android:attr/progressBarStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
-            android:layout_centerHorizontal="true"
-            android:layout_marginBottom="@dimen/margin_large"
-            android:visibility="gone"
-            tools:visibility="visible" />
-    </RelativeLayout>
+            <!-- Products work in progress notice card -->
+            <com.woocommerce.android.ui.products.ProductsWIPNoticeCard
+                android:id="@+id/products_wip_card"
+                style="@style/Woo.Stats.Card.Expandable"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/margin_large"
+                android:visibility="gone"
+                tools:visibility="visible" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/productsRecycler"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_below="@+id/products_wip_card" />
+
+            <com.woocommerce.android.widgets.WCEmptyView
+                android:id="@+id/empty_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_below="@+id/products_wip_card"
+                android:visibility="gone" />
+
+            <ProgressBar
+                android:id="@+id/loadMoreProgress"
+                style="?android:attr/progressBarStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentBottom="true"
+                android:layout_centerHorizontal="true"
+                android:layout_marginBottom="@dimen/margin_large"
+                android:visibility="gone"
+                tools:visibility="visible" />
+        </RelativeLayout>
+    </androidx.core.widget.NestedScrollView>
 </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -33,6 +33,7 @@
                 android:id="@+id/productsRecycler"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:background="@color/card_bgColor"
                 android:layout_below="@+id/products_wip_card" />
 
             <com.woocommerce.android.widgets.WCEmptyView

--- a/WooCommerce/src/main/res/layout/products_wip_notice.xml
+++ b/WooCommerce/src/main/res/layout/products_wip_notice.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <!-- VIEW MORE Button -->
+        <ToggleButton
+            android:id="@+id/products_wip_viewMore"
+            style="@style/Woo.Products.WIP.CardExtenderButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@null"
+            android:textOff="@string/product_wip_title"
+            android:textOn="@string/product_wip_title" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/products_wip_morePanel"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="9dp"
+            android:paddingStart="@dimen/card_padding_start"
+            android:paddingTop="@dimen/default_padding"
+            android:paddingEnd="0dp"
+            android:paddingBottom="@dimen/default_padding"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <!-- Message -->
+            <TextView
+                android:id="@+id/products_wip_message"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_extra_large"
+                android:gravity="start"
+                android:lineSpacingExtra="4sp"
+                android:paddingStart="@dimen/card_padding_start"
+                android:paddingEnd="@dimen/card_padding_end"
+                android:paddingBottom="@dimen/default_padding"
+                android:text="@string/product_wip_message"
+                android:textAppearance="@style/Woo.TextAppearance.Medium.Grey"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </LinearLayout>
+
+</merge>
+

--- a/WooCommerce/src/main/res/layout/products_wip_notice.xml
+++ b/WooCommerce/src/main/res/layout/products_wip_notice.xml
@@ -43,7 +43,7 @@
                 android:paddingEnd="@dimen/card_padding_end"
                 android:paddingBottom="@dimen/default_padding"
                 android:text="@string/product_wip_message"
-                android:textAppearance="@style/Woo.TextAppearance.Medium.Grey"
+                android:textAppearance="@style/Woo.TextAppearance.Medium.Black"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />

--- a/WooCommerce/src/main/res/layout/products_wip_notice.xml
+++ b/WooCommerce/src/main/res/layout/products_wip_notice.xml
@@ -26,7 +26,6 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="9dp"
             android:paddingStart="@dimen/card_padding_start"
-            android:paddingTop="@dimen/default_padding"
             android:paddingEnd="0dp"
             android:paddingBottom="@dimen/default_padding"
             android:visibility="gone"

--- a/WooCommerce/src/main/res/values/colors.xml
+++ b/WooCommerce/src/main/res/values/colors.xml
@@ -37,6 +37,7 @@
 
     <!-- STUDIO 2.0.0 -->
     <color name="blue_50">#2271b1</color>
+    <color name="black_85">#de000000</color>
 
     <!--
         Default Global Colors

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -420,6 +420,8 @@
     <string name="product_list_empty">No products yet</string>
     <string name="product_list_empty_search">No matching products</string>
     <string name="product_search_hint">Search products</string>
+    <string name="product_wip_title">Work in progress!</string>
+    <string name="product_wip_message">We\'re hard at work on the new products section so you may see some changes as we get ready for launch \u00F0\009F\u009A\u0080</string>
     <!--
         Empty list messages
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -421,7 +421,7 @@
     <string name="product_list_empty_search">No matching products</string>
     <string name="product_search_hint">Search products</string>
     <string name="product_wip_title">Work in progress!</string>
-    <string name="product_wip_message">We\'re hard at work on the new products section so you may see some changes as we get ready for launch \u00F0\009F\u009A\u0080</string>
+    <string name="product_wip_message">We\'re hard at work on the new products section so you may see some changes as we get ready for launch &#x1f680;</string>
     <!--
         Empty list messages
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -421,7 +421,7 @@
     <string name="product_list_empty_search">No matching products</string>
     <string name="product_search_hint">Search products</string>
     <string name="product_wip_title">Work in progress!</string>
-    <string name="product_wip_message">We\'re hard at work on the new products section so you may see some changes as we get ready for launch &#x1f680;</string>
+    <string name="product_wip_message">We\'re hard at work on the new Products section so you may see some changes as we get ready for launch &#x1f680;</string>
     <!--
         Empty list messages
     -->

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -109,6 +109,11 @@
         <item name="android:textSize">@dimen/text_medium</item>
     </style>
 
+    <style name="Woo.TextAppearance.Medium.Black">
+        <item name="android:textColor">@color/black_85</item>
+        <item name="android:textSize">@dimen/text_medium</item>
+    </style>
+
     <style name="Woo.TextAppearance.Medium.Grey">
         <item name="android:textColor">@color/wc_grey_medium</item>
     </style>
@@ -680,6 +685,8 @@
 
     <style name="Woo.Products.WIP.CardExtenderButton" parent="Woo.Stats.Availability.CardExtenderButton">
         <item name="android:drawableStart">@drawable/ic_gridicons_tools</item>
+        <item name="android:textSize">@dimen/text_large</item>
+        <item name="android:textColor">@color/black_85</item>
     </style>
 
 </resources>

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -678,4 +678,8 @@
         <item name="android:paddingBottom">@dimen/margin_large</item>
     </style>
 
+    <style name="Woo.Products.WIP.CardExtenderButton" parent="Woo.Stats.Availability.CardExtenderButton">
+        <item name="android:drawableStart">@drawable/ic_gridicons_tools</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Fixes #1602 . This PR adds a new work in progress banner to the product list screen.

### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/22608780/69403328-4a024a00-0d20-11ea-9cf1-cf60dc0e64ab.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/69403334-4bcc0d80-0d20-11ea-917d-849bcd64000f.png">

#### Empty product state
<img width="300" src="https://user-images.githubusercontent.com/22608780/69403821-9601be80-0d21-11ea-8bb2-3315fb629720.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/69403826-97cb8200-0d21-11ea-857f-37ab7dd69225.png">

### Testing:
- Verify that the WIP banner is only displayed when the product is list loaded (and not when skeleton view is displayed).
- Verify that the banner is displayed even when there are no products in the store.
- Verify that the banner is displayed correctly in lollipop devices.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
