### PR TITLE
Extract lists to separate LiveData properties

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -305,8 +305,8 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener,
         productAdapter.setProductList(products)
         listState?.let {
             productsRecycler.layoutManager?.onRestoreInstanceState(it)
+            listState = null
         }
-
         showProductWIPNoticeCard(true)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -232,10 +232,9 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener,
     }
 
     private fun setupObservers(viewModel: ProductListViewModel) {
-        viewModel.viewStateLiveData.observe(this) { old, new ->
+        viewModel.viewStateLiveData.observe(viewLifecycleOwner) { old, new ->
             new.isSkeletonShown?.takeIfNotEqualTo(old?.isSkeletonShown) { showSkeleton(it) }
             new.isLoadingMore?.takeIfNotEqualTo(old?.isLoadingMore) { showLoadMoreProgress(it) }
-            new.productList?.takeIfNotEqualTo(old?.productList) { showProductList(it) }
             new.isRefreshing?.takeIfNotEqualTo(old?.isRefreshing) { productsRefreshLayout.isRefreshing = it }
             new.isEmptyViewVisible?.takeIfNotEqualTo(old?.isEmptyViewVisible) { isEmptyViewVisible ->
                 if (isEmptyViewVisible) {
@@ -256,7 +255,11 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener,
             }
         }
 
-        viewModel.event.observe(this, Observer { event ->
+        viewModel.productList.observe(viewLifecycleOwner, Observer {
+            showProductList(it)
+        })
+
+        viewModel.event.observe(viewLifecycleOwner, Observer { event ->
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.products
 
 import android.content.Context
 import android.os.Bundle
+import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
@@ -41,6 +42,7 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener,
         OnActionExpandListener {
     companion object {
         val TAG: String = ProductListFragment::class.java.simpleName
+        const val KEY_LIST_STATE = "list-state"
         fun newInstance() = ProductListFragment()
     }
 
@@ -48,6 +50,7 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener,
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     private lateinit var productAdapter: ProductListAdapter
+    private var listState: Parcelable? = null
 
     private val viewModel: ProductListViewModel by viewModels { viewModelFactory }
 
@@ -69,6 +72,8 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener,
         super.onActivityCreated(savedInstanceState)
 
         val activity = requireActivity()
+
+        listState = savedInstanceState?.getParcelable(KEY_LIST_STATE)
 
         productAdapter = ProductListAdapter(activity, this, this)
         productsRecycler.layoutManager = LinearLayoutManager(activity)
@@ -96,6 +101,11 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener,
     override fun onAttach(context: Context) {
         AndroidSupportInjection.inject(this)
         super.onAttach(context)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putParcelable(KEY_LIST_STATE, productsRecycler.layoutManager?.onSaveInstanceState())
+        super.onSaveInstanceState(outState)
     }
 
     override fun onDestroyView() {
@@ -292,6 +302,9 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener,
 
     private fun showProductList(products: List<Product>) {
         productAdapter.setProductList(products)
+        listState?.let {
+            productsRecycler.layoutManager?.onRestoreInstanceState(it)
+        }
     }
 
     override fun onProductClick(remoteProductId: Long) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.reviews
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Bundle
 import android.os.Parcelable
@@ -144,11 +143,6 @@ class ReviewListFragment : TopLevelFragment(), ItemDecorationListener, ReviewLis
                 viewModel.forceRefreshReviews()
             }
         }
-
-        listState?.let {
-            reviewsList.layoutManager?.onRestoreInstanceState(listState)
-            listState = null
-        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -219,11 +213,8 @@ class ReviewListFragment : TopLevelFragment(), ItemDecorationListener, ReviewLis
         super.onDestroyView()
     }
 
-    @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
-    @SuppressLint("InflateParams")
     private fun setupObservers() {
-        viewModel.viewStateData.observe(this) { old, new ->
-            new.reviewList?.let { showReviewList(it) }
+        viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
             new.isSkeletonShown?.takeIfNotEqualTo(old?.isSkeletonShown) { showSkeleton(it) }
             new.hasUnreadReviews?.takeIfNotEqualTo(old?.hasUnreadReviews) { showMarkAllReadMenuItem(it) }
             new.isRefreshing?.takeIfNotEqualTo(old?.isRefreshing) {
@@ -233,15 +224,19 @@ class ReviewListFragment : TopLevelFragment(), ItemDecorationListener, ReviewLis
             new.isLoadingMore?.takeIfNotEqualTo(old?.isLoadingMore) { showLoadMoreProgress(it) }
         }
 
-        viewModel.event.observe(this, Observer { event ->
+        viewModel.event.observe(viewLifecycleOwner, Observer { event ->
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is MarkAllAsRead -> handleMarkAllAsReadEvent(event.status)
             }
         })
 
-        viewModel.moderateProductReview.observe(this, Observer {
+        viewModel.moderateProductReview.observe(viewLifecycleOwner, Observer {
             it?.let { request -> handleReviewModerationRequest(request) }
+        })
+
+        viewModel.reviewList.observe(viewLifecycleOwner, Observer {
+            showReviewList(it)
         })
     }
 
@@ -265,6 +260,10 @@ class ReviewListFragment : TopLevelFragment(), ItemDecorationListener, ReviewLis
     private fun showReviewList(reviews: List<ProductReview>) {
         if (isActive) {
             reviewsAdapter.setReviews(reviews)
+            listState?.let {
+                reviewsList.layoutManager?.onRestoreInstanceState(listState)
+            }
+            
             showEmptyView(reviews.isEmpty())
         } else {
             newDataAvailable = true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -263,7 +263,6 @@ class ReviewListFragment : TopLevelFragment(), ItemDecorationListener, ReviewLis
             listState?.let {
                 reviewsList.layoutManager?.onRestoreInstanceState(listState)
             }
-            
             showEmptyView(reviews.isEmpty())
         } else {
             newDataAvailable = true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -262,6 +262,7 @@ class ReviewListFragment : TopLevelFragment(), ItemDecorationListener, ReviewLis
             reviewsAdapter.setReviews(reviews)
             listState?.let {
                 reviewsList.layoutManager?.onRestoreInstanceState(listState)
+                listState = null
             }
             showEmptyView(reviews.isEmpty())
         } else {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
@@ -51,17 +51,15 @@ class ProductListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Displays the product list view correctly`() {
-        doReturn(productList).whenever(productRepository).getProductList()
+    fun `Displays the product list view correctly`() = test {
+        doReturn(productList).whenever(productRepository).fetchProductList()
 
         createViewModel()
 
         val products = ArrayList<Product>()
-        viewModel.viewStateLiveData.observeForever { old, new ->
-            if (old?.productList != new.productList)
-                new.productList?.let { products.addAll(it) } }
-
-        viewModel.loadProducts()
+        viewModel.productList.observeForever {
+            it?.let { products.addAll(it) }
+        }
 
         assertThat(products).isEqualTo(productList)
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModelTest.kt
@@ -77,13 +77,13 @@ class ReviewListViewModelTest : BaseUnitTest() {
         val reviewList = ArrayList<ProductReview>()
         var hasUnread = false
         val skeletonShown = mutableListOf<Boolean>()
+        viewModel.reviewList.observeForever {
+            // We know this will be called twice because the request to fetch the reviews
+            // from the API will also result in passing results from db to the UI.
+            reviewList.clear()
+            reviewList.addAll(it)
+        }
         viewModel.viewStateData.observeForever { old, new ->
-            new.reviewList?.takeIfNotEqualTo(old?.reviewList) {
-                // We know this will be called twice because the request to fetch the reviews
-                // from the API will also result in passing results from db to the UI.
-                reviewList.clear()
-                reviewList.addAll(it)
-            }
             new.isSkeletonShown?.takeIfNotEqualTo(old?.isSkeletonShown) { skeletonShown.add(it) }
             new.hasUnreadReviews?.takeIfNotEqualTo(old?.hasUnreadReviews) { hasUnread = it }
         }
@@ -130,13 +130,13 @@ class ReviewListViewModelTest : BaseUnitTest() {
         val reviewList = ArrayList<ProductReview>()
         var hasUnread = false
         val skeletonShown = mutableListOf<Boolean>()
+        viewModel.reviewList.observeForever {
+            // We know this will be called twice because the request to fetch the reviews
+            // from the API will also result in passing results from db to the UI.
+            reviewList.clear()
+            reviewList.addAll(it)
+        }
         viewModel.viewStateData.observeForever { old, new ->
-            new.reviewList?.takeIfNotEqualTo(old?.reviewList) {
-                // We know this will be called twice because the request to fetch the reviews
-                // from the API will also result in passing results from db to the UI.
-                reviewList.clear()
-                reviewList.addAll(it)
-            }
             new.isSkeletonShown?.takeIfNotEqualTo(old?.isSkeletonShown) { skeletonShown.add(it) }
             new.hasUnreadReviews?.takeIfNotEqualTo(old?.hasUnreadReviews) { hasUnread = it }
         }


### PR DESCRIPTION
SavedState is intended to store light data only and it's not suitable for lists. So product list and review list have been extracted into separate `LiveData` properties and scroll state is saved the old way.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
