### PR TITLE
Issue/1632 product list search fails

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListRepository.kt
@@ -85,11 +85,12 @@ final class ProductListRepository @Inject constructor(
     /**
      * Submits a fetch request to get a page of products for the current site matching the passed
      * query and returns only that page of products - note that this returns null if the search
-     * is interrupted (which means the user submitted another search while this was running)
+     * is interrupted (which means the user submitted another search while this was running) or
+     * if products are currently being loaded
      */
     suspend fun searchProductList(searchQuery: String, loadMore: Boolean = false): List<Product>? {
         if (isLoadingProducts) {
-            return emptyList()
+            return null
         }
 
         try {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListRepository.kt
@@ -84,9 +84,10 @@ final class ProductListRepository @Inject constructor(
 
     /**
      * Submits a fetch request to get a page of products for the current site matching the passed
-     * query and returns only that page of products
+     * query and returns only that page of products - note that this returns null if the search
+     * is interrupted (which means the user submitted another search while this was running)
      */
-    suspend fun searchProductList(searchQuery: String, loadMore: Boolean = false): List<Product> {
+    suspend fun searchProductList(searchQuery: String, loadMore: Boolean = false): List<Product>? {
         if (isLoadingProducts) {
             return emptyList()
         }
@@ -110,7 +111,7 @@ final class ProductListRepository @Inject constructor(
             return products ?: emptyList()
         } catch (e: CancellationException) {
             WooLog.e(WooLog.T.PRODUCTS, "CancellationException while searching products", e)
-            return emptyList()
+            return null
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -158,22 +158,24 @@ class ProductListViewModel @AssistedInject constructor(
             if (searchQuery.isNullOrEmpty()) {
                 _productList.value = productRepository.fetchProductList(loadMore)
             } else {
-                val fetchedProducts = productRepository.searchProductList(searchQuery, loadMore)
-                // make sure the search query hasn't changed while the fetch was processing
-                if (searchQuery == productRepository.lastSearchQuery) {
-                    if (loadMore) {
-                        _productList.value = _productList.value.orEmpty() + fetchedProducts
+                productRepository.searchProductList(searchQuery, loadMore)?.let { fetchedProducts ->
+                    // make sure the search query hasn't changed while the fetch was processing
+                    if (searchQuery == productRepository.lastSearchQuery) {
+                        if (loadMore) {
+                            _productList.value = _productList.value.orEmpty() + fetchedProducts
+                        } else {
+                            _productList.value = fetchedProducts
+                        }
                     } else {
-                        _productList.value = fetchedProducts
+                        WooLog.d(WooLog.T.PRODUCTS, "Search query changed")
                     }
-                } else {
-                    WooLog.d(WooLog.T.PRODUCTS, "Search query changed")
+
+                    viewState = viewState.copy(
+                            canLoadMore = productRepository.canLoadMoreProducts,
+                            isEmptyViewVisible = _productList.value?.isEmpty() == true
+                    )
                 }
             }
-            viewState = viewState.copy(
-                    canLoadMore = productRepository.canLoadMoreProducts,
-                    isEmptyViewVisible = _productList.value?.isEmpty() == true
-            )
         } else {
             triggerEvent(ShowSnackbar(R.string.offline_error))
         }


### PR DESCRIPTION
Closes #1632 - prior to this PR, typing slowly in the product list search field could cause "No matching products" to be shown even when matches should be found. This would happen when an existing search request was already in process, resulting in the previous search `continuation` being cancelled and returning an empty search.

The fix was to return `null` when a prior search is cancelled, and ignoring a `null` result in the UI.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
