### PR TITLE
issue/1641-hide-optimize-images

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -16,7 +16,7 @@ enum class FeatureFlag {
         return when (this) {
             PRODUCT_RELEASE_TEASER -> AppPrefs.isProductsFeatureEnabled()
             REFUNDS -> BuildConfig.DEBUG
-            PRODUCT_IMAGE_CHOOSER -> BuildConfig.DEBUG
+            PRODUCT_IMAGE_CHOOSER -> BuildConfig.DEBUG && AppPrefs.isProductsFeatureEnabled()
             DB_DOWNGRADE -> {
                 BuildConfig.DEBUG || context != null && PackageUtils.isBetaBuild(context)
             }


### PR DESCRIPTION
Fixes #1641 - Changes the `PRODUCT_IMAGE_CHOOSER` feature flag to only be enabled when the product list is enabled, so the "Optimize images" setting only appears when the product list is enabled.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
