### PR TITLE
Issue/1650 product list sorting

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -226,7 +226,7 @@ class IssueRefundViewModel @AssistedInject constructor(
                     ))
 
                     val resultCall = async(dispatchers.io) {
-                        return@async refundStore.createRefund(
+                        return@async refundStore.createAmountRefund(
                                 selectedSite.get(),
                                 order.remoteId,
                                 refundByAmountState.enteredAmount,

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.5.4'
+    fluxCVersion = '473fa32e7d39b8466722de1112a353bfd4ae6018'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Closes #1650 - updates the FluxC hash to match [this FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1439) which corrects a bug in the order products are fetched.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
