### PR TITLE
Issue/1648 bottom nav labels cut off

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 3.3
 -----
+* In rare situations, the labels on the bottom navigation bar could be cut off
  
 3.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -85,13 +85,9 @@ class MainBottomNavigationView @JvmOverloads constructor(
         active(DASHBOARD.position)
     }
 
-    fun refreshProductsTab() {
-        if (FeatureFlag.PRODUCT_RELEASE_TEASER.isEnabled()) {
-            detectLabelVisibilityMode()
-            menu.findItem(R.id.products)?.isVisible = true
-        } else {
-            menu.findItem(R.id.products)?.isVisible = false
-        }
+    private fun refreshProductsTab() {
+        menu.findItem(R.id.products)?.isVisible = FeatureFlag.PRODUCT_RELEASE_TEASER.isEnabled()
+        detectLabelVisibilityMode()
     }
 
     /**
@@ -122,8 +118,9 @@ class MainBottomNavigationView @JvmOverloads constructor(
         labelVisibilityMode = LabelVisibilityMode.LABEL_VISIBILITY_LABELED
 
         val displayWidth = DisplayUtils.getDisplayPixelWidth(context)
+        val numCells = if (FeatureFlag.PRODUCT_RELEASE_TEASER.isEnabled()) menu.size() else menu.size() - 1
         val cellMargin = resources.getDimensionPixelSize(R.dimen.design_bottom_navigation_margin)
-        val cellWidth = (displayWidth / menu.size()) - (cellMargin * 3)
+        val cellWidth = (displayWidth / numCells) - (cellMargin * 3)
 
         // create a paint object whose text size matches the bottom navigation active text size - note that
         // we have to use the active size since it's 2sp larger than inactive

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -119,30 +119,42 @@ class MainBottomNavigationView @JvmOverloads constructor(
         // get the menu view
         val menuView = getChildAt(0) as BottomNavigationMenuView
 
+        val textSizeNormal = resources.getDimensionPixelSize(R.dimen.design_bottom_navigation_text_size).toFloat()
+        val textSizeActive = resources.getDimensionPixelSize(R.dimen.design_bottom_navigation_active_text_size).toFloat()
+
         // iterate through the menu items
         for (index in 0 until menuView.childCount) {
             val child = menuView.getChildAt(index)
-            // find the textView showing the caption and add a layout listener to it so we can detect how many
-            // lines of text there are after layout
-            child.findViewById<TextView>(R.id.smallLabel)?.addOnLayoutChangeListener(object : OnLayoutChangeListener {
-                override fun onLayoutChange(
-                    view: View,
-                    left: Int,
-                    top: Int,
-                    right: Int,
-                    bottom: Int,
-                    oldLeft: Int,
-                    oldTop: Int,
-                    oldRight: Int,
-                    oldBottom: Int
-                ) {
-                    view.removeOnLayoutChangeListener(this)
-                    // if there are multiple lines, revert to showing labels for just the active tab
-                    if ((view as TextView).lineCount > 1) {
-                        labelVisibilityMode = LabelVisibilityMode.LABEL_VISIBILITY_AUTO
+            // find the textView showing the caption
+            child.findViewById<TextView>(R.id.smallLabel)?.let { textView ->
+                // set text size to active size so we can measure it as active (active is 2sp larger than normal)
+                textView.textSize = textSizeActive
+
+                // add a layout listener to it so we can detect how many lines of text there are after layout
+                textView.addOnLayoutChangeListener(object : OnLayoutChangeListener {
+                    override fun onLayoutChange(
+                        view: View,
+                        left: Int,
+                        top: Int,
+                        right: Int,
+                        bottom: Int,
+                        oldLeft: Int,
+                        oldTop: Int,
+                        oldRight: Int,
+                        oldBottom: Int
+                    ) {
+                        view.removeOnLayoutChangeListener(this)
+
+                        // if there are multiple lines, revert to showing labels for just the active tab
+                        if ((view as TextView).lineCount > 1) {
+                            labelVisibilityMode = LabelVisibilityMode.LABEL_VISIBILITY_AUTO
+                        }
+
+                        // restore normal text size
+                        view.textSize = textSizeNormal
                     }
-                }
-            })
+                })
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -118,9 +118,10 @@ class MainBottomNavigationView @JvmOverloads constructor(
         labelVisibilityMode = LabelVisibilityMode.LABEL_VISIBILITY_LABELED
 
         val displayWidth = DisplayUtils.getDisplayPixelWidth(context)
-        val numCells = if (FeatureFlag.PRODUCT_RELEASE_TEASER.isEnabled()) menu.size() else menu.size() - 1
-        val cellMargin = resources.getDimensionPixelSize(R.dimen.design_bottom_navigation_margin)
-        val cellWidth = (displayWidth / numCells) - (cellMargin * 3)
+        val numItems = if (FeatureFlag.PRODUCT_RELEASE_TEASER.isEnabled()) menu.size() else menu.size() - 1
+        val itemMargin = resources.getDimensionPixelSize(R.dimen.design_bottom_navigation_margin)
+        val itemMaxWidth = resources.getDimensionPixelSize(R.dimen.design_bottom_navigation_item_max_width)
+        val itemWidth = Math.min(itemMaxWidth, (displayWidth / numItems) - (itemMargin * 3))
 
         // create a paint object whose text size matches the bottom navigation active text size - note that
         // we have to use the active size since it's 2sp larger than inactive
@@ -128,30 +129,16 @@ class MainBottomNavigationView @JvmOverloads constructor(
             paint.textSize = resources.getDimension(R.dimen.design_bottom_navigation_active_text_size)
         }
 
-        addOnLayoutChangeListener(object : OnLayoutChangeListener {
-            override fun onLayoutChange(
-                view: View,
-                left: Int,
-                top: Int,
-                right: Int,
-                bottom: Int,
-                oldLeft: Int,
-                oldTop: Int,
-                oldRight: Int,
-                oldBottom: Int
-            ) {
-                view.removeOnLayoutChangeListener(this)
-
-                for (index in 0 until menu.size()) {
-                    val bounds = Rect()
-                    val title = menu.getItem(index).title.toString()
-                    textPaint.getTextBounds(title, 0, title.length, bounds)
-                    if (bounds.width() > cellWidth) {
-                        labelVisibilityMode = LabelVisibilityMode.LABEL_VISIBILITY_AUTO
-                    }
-                }
+        // iterate through the menu items and determine whether they can all fit their space
+        for (index in 0 until menu.size()) {
+            val bounds = Rect()
+            val title = menu.getItem(index).title.toString()
+            textPaint.getTextBounds(title, 0, title.length, bounds)
+            if (bounds.width() > itemWidth) {
+                labelVisibilityMode = LabelVisibilityMode.LABEL_VISIBILITY_AUTO
+                break
             }
-        })
+        }
     }
 
     fun getFragment(navPos: BottomNavigationPosition): TopLevelFragment = navAdapter.getFragment(navPos)

--- a/WooCommerce/src/main/res/values/dimens.xml
+++ b/WooCommerce/src/main/res/values/dimens.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <dimen name="min_tap_target">48dp</dimen>
 
     <!--
@@ -179,4 +179,11 @@
     -->
     <dimen name="image_border_size">1dp</dimen>
     <dimen name="image_border_radius">2dp</dimen>
+
+    <!--
+        Overide the bottom nav's text size - these are the same as default and are simply here
+        so we can access them at runtime (they're a private resource otherwise)
+    -->
+    <dimen name="design_bottom_navigation_text_size" tools:override="true">12sp</dimen>
+    <dimen name="design_bottom_navigation_active_text_size" tools:override="true">14sp</dimen>
 </resources>

--- a/WooCommerce/src/main/res/values/dimens.xml
+++ b/WooCommerce/src/main/res/values/dimens.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
     <dimen name="min_tap_target">48dp</dimen>
 
     <!--
@@ -179,11 +179,4 @@
     -->
     <dimen name="image_border_size">1dp</dimen>
     <dimen name="image_border_radius">2dp</dimen>
-
-    <!--
-        Overide the bottom nav's text size - these are the same as default and are simply here
-        so we can access them at runtime (they're a private resource otherwise)
-    -->
-    <dimen name="design_bottom_navigation_text_size" tools:override="true">12sp</dimen>
-    <dimen name="design_bottom_navigation_active_text_size" tools:override="true">14sp</dimen>
 </resources>


### PR DESCRIPTION
Fixes #1648 - in rare cases, the labels in the bottom navigation view could be truncated. This was due to measuring the label text using the inactive label size rather than the active size. The active size is 2sp larger, and this minor difference could result in the active item's text to be cut off.

As part of this, I rewrote how we measure the items. Previously we relied on a global layout listener, but this was unnecessary since we can determine the item width using the bottom nav's resources.

The screenshot below is from a 4" emulator with a display size of 480x800 and font size set to the largest.

![Screenshot_1575817105](https://user-images.githubusercontent.com/3903757/70391621-1ae90b00-19a5-11ea-9c0b-ff3638e1a347.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
