### PR TITLE
Issue/1640 glide disk cache

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/WooCommerceGlideModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/WooCommerceGlideModule.kt
@@ -1,15 +1,22 @@
 package com.woocommerce.android.di
 
 import android.content.Context
+import android.os.Build
+import android.os.storage.StorageManager
 import com.android.volley.RequestQueue
 import com.bumptech.glide.Glide
 import com.bumptech.glide.GlideBuilder
 import com.bumptech.glide.Registry
 import com.bumptech.glide.annotation.GlideModule
 import com.bumptech.glide.integration.volley.VolleyUrlLoader
+import com.bumptech.glide.load.engine.cache.DiskCache
+import com.bumptech.glide.load.engine.cache.InternalCacheDiskCacheFactory
 import com.bumptech.glide.load.model.GlideUrl
 import com.bumptech.glide.module.AppGlideModule
 import com.woocommerce.android.WooCommerce
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T
+import java.io.IOException
 import java.io.InputStream
 import javax.inject.Inject
 import javax.inject.Named
@@ -21,12 +28,38 @@ import javax.inject.Named
 class WooCommerceGlideModule : AppGlideModule() {
     @field:[Inject Named("custom-ssl")] internal lateinit var requestQueue: RequestQueue
 
-    override fun applyOptions(context: Context, builder: GlideBuilder) {}
+    override fun applyOptions(context: Context, builder: GlideBuilder) {
+        initGlideCache(context, builder)
+    }
 
     override fun isManifestParsingEnabled(): Boolean = false
 
     override fun registerComponents(context: Context, glide: Glide, registry: Registry) {
         (context as WooCommerce).membersInjector.injectMembers(this)
         glide.registry.replace(GlideUrl::class.java, InputStream::class.java, VolleyUrlLoader.Factory(requestQueue))
+    }
+
+    /**
+     * Reduces the size of the disk cache if Android tells us our cache quota is smaller than Glide's
+     * default cache size. Note that this only affects devices running API 26 or later since earlier
+     *  APIs don't support getCacheQuotaBytes().
+     */
+    private fun initGlideCache(context: Context, builder: GlideBuilder) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val appContext = context.applicationContext
+            val storageManager = appContext.getSystemService(Context.STORAGE_SERVICE) as StorageManager
+            try {
+                val uuid = storageManager.getUuidForPath(appContext.getCacheDir())
+                val quota = storageManager.getCacheQuotaBytes(uuid)
+                if (quota > 0 && quota < DiskCache.Factory.DEFAULT_DISK_CACHE_SIZE) {
+                    val cacheFactory = InternalCacheDiskCacheFactory(appContext, quota)
+                    builder.setDiskCache(cacheFactory)
+                    val diff = DiskCache.Factory.DEFAULT_DISK_CACHE_SIZE - quota
+                    WooLog.d(T.UTILS, "Reduced size of image disk cache by $diff bytes")
+                }
+            } catch (e: IOException) {
+                WooLog.e(T.UTILS, "Unable to change image cache size", e)
+            }
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/WooCommerceGlideModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/WooCommerceGlideModule.kt
@@ -55,7 +55,7 @@ class WooCommerceGlideModule : AppGlideModule() {
                 //     "This method may take several seconds to complete, so it
                 //      should only be called from a worker thread."
                 GlobalScope.launch {
-                    val uuid = storageManager.getUuidForPath(context.getCacheDir())
+                    val uuid = storageManager.getUuidForPath(context.cacheDir)
                     val quota = storageManager.getCacheQuotaBytes(uuid)
 
                     if (quota > 0 && quota < DiskCache.Factory.DEFAULT_DISK_CACHE_SIZE) {


### PR DESCRIPTION
Addresses #1640 - Glide's memory cache is smart enough to take device memory into account, but the disk cache is fixed at 250MB.

While it's true that the OS will remove older cached items if disk space runs low, it still seems excessive to cache up to 250MB of images given that WCAndroid isn't an image-heavy app.

This PR changes this to base the disk cache size on [getCacheQuotaBytes()](https://developer.android.com/reference/android/os/storage/StorageManager.html#getCacheQuotaBytes(java.util.UUID)) on Android O and later.

Note: I'm not convinced this PR is even necessary, so feel free to chime in if you think we can do without this change.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
