### PR TITLE
Issue/1631 deleted products remain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '9b48738b0acef79db09ac7b1cbb3ad31d4510b52'
+    fluxCVersion = 'f51c4837bfa11c6c6ca3398a316bbee8400d84ae'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '473fa32e7d39b8466722de1112a353bfd4ae6018'
+    fluxCVersion = '9b48738b0acef79db09ac7b1cbb3ad31d4510b52'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Fixes #1631 - this PR simply updates the FluxC hash to the one in [this FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1445), which corrects the "deleted products remain" bug.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
