### PR TITLE
Issue/1658 product variation bug fix

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 3.3
 -----
 * In rare situations, the labels on the bottom navigation bar could be cut off
+* Fixed a rare crash when updating a product variant in wp-admin and refreshing the same in the app.
  
 3.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariant.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariant.kt
@@ -13,7 +13,8 @@ data class ProductVariant(
     val stockStatus: ProductStockStatus,
     val stockQuantity: Int,
     val optionName: String,
-    var priceWithCurrency: String? = null
+    var priceWithCurrency: String? = null,
+    val purchasable: Boolean
 )
 
 fun WCProductVariationModel.toAppModel(): ProductVariant {
@@ -24,7 +25,8 @@ fun WCProductVariationModel.toAppModel(): ProductVariant {
         this.price.toBigDecimalOrNull(),
         ProductStockStatus.fromString(this.stockStatus),
         this.stockQuantity,
-        getAttributeOptionName(this.getProductVariantOptions())
+        getAttributeOptionName(this.getProductVariantOptions()),
+        purchasable = this.purchasable
     )
 }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -424,6 +424,8 @@
     <string name="product_search_hint">Search products</string>
     <string name="product_wip_title">Work in progress!</string>
     <string name="product_wip_message">We\'re hard at work on the new Products section so you may see some changes as we get ready for launch 🚀</string>
+    <string name="product_bullet" translatable="false">&#160;\u2022&#160;</string>
+    <string name="product_variant_hidden">Hidden</string>
     <!--
         Product images
     -->


### PR DESCRIPTION
Fixes #1658 and #1661. 

#### Changes:
- Fixes the original issue mentioned in the ticket and displays a variation's visibility if the variant is not enabled.
- While testing, I noticed that the app crashes when updating a product variant in `wp-admin` when in the product variant list screen and initiating PTR. 

#### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/22608780/70498016-18201e80-1b3b-11ea-97a4-f2961bb6e59b.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/70498018-19e9e200-1b3b-11ea-879a-26c62cf1a4dd.png">

#### Testing
**Issue 1:**
- Go to the store's Products section in WP Admin on the web.
- Select a variable product.
- In the Variations section, uncheck the "Enabled" box for one or more variations (to disable them).
- In the app, go to the Products section.
- Select that variable product.
- In the Variations section, note that you can tell whether or not a variation is enabled.

**Issue 2:**
- In the app, go to the Products section -> Select a variable product and click on the `Variants` section.
- In the web, go to the store's Products section in WP Admin.
- Select a variable product.
- Under the `Variations` section, uncheck the "Enabled" box for one or more variations (to disable them).
- In the app, pull to refresh the variations list.
- Notice the app does not crash.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
