### PR TITLE
Issue/1664 order number crash

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * Added a new option in the Settings page for users to opt in or out of our new Products tab.
 * Added a new variants section in the Product detail screen for variable products
 * The bottom navigation bar no longer disappears when scrolling
+* Fixed a rare crash in refunds when custom order numbers are used
  
 3.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -296,7 +296,7 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
     override fun issueOrderRefund(order: Order) {
         AnalyticsTracker.track(ORDER_DETAIL_ISSUE_REFUND_BUTTON_TAPPED)
 
-        val action = OrderDetailFragmentDirections.actionOrderDetailFragmentToIssueRefund(order.number.toLong())
+        val action = OrderDetailFragmentDirections.actionOrderDetailFragmentToIssueRefund(order.remoteId)
         findNavController().navigate(action)
     }
 


### PR DESCRIPTION
Fixes #1664. Order number was incorrectly being sent to refunds instead of Order remote ID. Most of the time they're the same and the crash is rare, unless someone uses a custom number format.

I'm targeting the 3.2 release to ship the fix ASAP.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
