### PR TITLE
check if listener is null before handling discovery error

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseDiscoveryFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseDiscoveryFragment.java
@@ -38,6 +38,10 @@ public abstract class LoginBaseDiscoveryFragment extends LoginBaseFormFragment<L
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onDiscoverySucceeded(OnDiscoveryResponse event) {
+        if (mLoginBaseDiscoveryListener == null) {
+            return;
+        }
+
         // hold the URL in a variable to use below otherwise it gets cleared up by endProgress
         // bail if user canceled
         String mRequestedSiteAddress = mLoginBaseDiscoveryListener.getRequestedSiteAddress();


### PR DESCRIPTION
Fixes #1663. 

I have not been able to reproduce this crash but I believe it can happen when `mLoginBaseDiscoveryListener` [here](https://github.com/woocommerce/woocommerce-android/blob/d8f27b82031a4036e524c1c5cb80f5b6baa241a9/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseDiscoveryFragment.java#L47) is `null`. This happens when the fragment is detached from the activity. My assumption is that the response is received from the API right at the moment when the fragment is detached which is causing the `NullPointerException`.

This PR adds a fix to check if the `mLoginBaseDiscoveryListener` is null before handling the discovery changes.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
