### PR TITLE
Issue/1625 fix chart scrolling

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * In rare situations, the labels on the bottom navigation bar could be cut off
 * Fixed a rare crash when updating a product variant in wp-admin and refreshing the same in the app.
+* Fixed bug that could cause stats chart to prevent scrolling vertically
  
 3.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsBarChart.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsBarChart.kt
@@ -71,7 +71,8 @@ class DashboardStatsBarChart(context: Context?, attrs: AttributeSet?) : BarChart
                             Math.abs(event.getX().toInt() - startTouchPoint.x),
                             Math.abs(event.getY().toInt() - startTouchPoint.y)
                     )
-                    // swallow the event if this is a horizontal scrub
+                    // swallow the event if this is a horizontal scrub, which we determine by
+                    // checking if the vertical motion is less than the horizontal motion
                     if (movement.y < movement.x) {
                         // see https://github.com/PhilJay/MPAndroidChart/issues/925
                         parent.requestDisallowInterceptTouchEvent(true)
@@ -79,6 +80,9 @@ class DashboardStatsBarChart(context: Context?, attrs: AttributeSet?) : BarChart
                         return true
                     }
                 }
+                // according to the docs, we must make sure to reset the intercept setting
+                // when the user ends this event
+                MotionEvent.ACTION_CANCEL,
                 MotionEvent.ACTION_UP -> {
                     parent.requestDisallowInterceptTouchEvent(false)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsBarChart.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsBarChart.kt
@@ -7,6 +7,7 @@ import android.util.AttributeSet
 import android.view.MotionEvent
 import com.github.mikephil.charting.charts.BarChart
 import com.github.mikephil.charting.data.BarEntry
+import kotlin.math.abs
 
 /**
  * Creating a custom BarChart to fix this issue:
@@ -63,13 +64,13 @@ class DashboardStatsBarChart(context: Context?, attrs: AttributeSet?) : BarChart
                 MotionEvent.ACTION_DOWN -> {
                     offsetX = 0
                     offsetY = 0
-                    startTouchPoint.x = event.getX().toInt()
-                    startTouchPoint.y = event.getY().toInt()
+                    startTouchPoint.x = event.x.toInt()
+                    startTouchPoint.y = event.y.toInt()
                 }
                 MotionEvent.ACTION_MOVE -> {
                     val movement = Point(
-                            Math.abs(event.getX().toInt() - startTouchPoint.x),
-                            Math.abs(event.getY().toInt() - startTouchPoint.y)
+                            abs(event.x.toInt() - startTouchPoint.x),
+                            abs(event.y.toInt() - startTouchPoint.y)
                     )
                     // swallow the event if this is a horizontal scrub, which we determine by
                     // checking if the vertical motion is less than the horizontal motion

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsBarChart.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsBarChart.kt
@@ -17,8 +17,6 @@ class DashboardStatsBarChart(context: Context?, attrs: AttributeSet?) : BarChart
         context,
         attrs
 ) {
-    private var offsetX = 0
-    private var offsetY = 0
     private val startTouchPoint = Point(0, 0)
 
     // Overriding this method from the Chart.java: line 719
@@ -62,8 +60,6 @@ class DashboardStatsBarChart(context: Context?, attrs: AttributeSet?) : BarChart
         if (data != null) {
             when (event.action) {
                 MotionEvent.ACTION_DOWN -> {
-                    offsetX = 0
-                    offsetY = 0
                     startTouchPoint.x = event.x.toInt()
                     startTouchPoint.y = event.y.toInt()
                 }


### PR DESCRIPTION
Fixes #1625 - prior to this PR, scrolling the dashboard vertically could be tricky because the stats chart would intercept the motion event so users could "scrub" between bars. This PR corrects this by only intercepting (swallowing) the event when the user swipes horizontally.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
