### PR TITLE
issue/1509-string-out-of-bounds-autofill

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * In rare situations, the labels on the bottom navigation bar could be cut off
 * Fixed a rare crash when updating a product variant in wp-admin and refreshing the same in the app.
+* Fixed potential crash on Android Oreo after clicking on an email address field
  
 3.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.PackageUtils
 import dagger.android.AndroidInjection

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -11,7 +11,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.PackageUtils
 import dagger.android.AndroidInjection

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SupportHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SupportHelper.kt
@@ -10,6 +10,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.view.ContextThemeWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.R.style
+import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.StringUtils
 import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.model.SiteModel
@@ -42,8 +43,9 @@ class SupportHelper {
                 .setPositiveButton(android.R.string.ok, null)
                 .setNegativeButton(android.R.string.cancel, null)
                 .create()
+        ActivityUtils.disableAutofillIfNecessary(dialog)
         dialog.setOnShowListener {
-            val button = (dialog as AlertDialog).getButton(AlertDialog.BUTTON_POSITIVE)
+            val button = dialog.getButton(AlertDialog.BUTTON_POSITIVE)
             button.setOnClickListener { _ ->
                 val newEmail = emailEditText.text.toString()
                 val newName = nameEditText.text.toString()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -6,8 +6,8 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
-import com.automattic.android.tracks.CrashLogging.CrashLogging
 import androidx.fragment.app.Fragment
+import com.automattic.android.tracks.CrashLogging.CrashLogging
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -63,6 +63,7 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
 
     override fun onCreate(savedInstanceState: Bundle?) {
         AndroidInjection.inject(this)
+        ActivityUtils.disableAutofillIfNecessary(this)
         super.onCreate(savedInstanceState)
 
         setContentView(R.layout.activity_login)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ActivityUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ActivityUtils.kt
@@ -96,7 +96,7 @@ object ActivityUtils {
     @SuppressLint("NewApi")
     fun disableAutofillIfNecessary(activity: Activity) {
         if (VERSION.SDK_INT == VERSION_CODES.O || VERSION.SDK_INT == VERSION_CODES.O_MR1) {
-           activity.window.decorView.importantForAutofill = View.IMPORTANT_FOR_AUTOFILL_NO_EXCLUDE_DESCENDANTS
+            activity.window.decorView.importantForAutofill = View.IMPORTANT_FOR_AUTOFILL_NO_EXCLUDE_DESCENDANTS
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ActivityUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ActivityUtils.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.util
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Context
@@ -8,8 +9,10 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
+import android.view.View
 import android.view.WindowManager
 import androidx.annotation.ColorRes
+import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import com.woocommerce.android.R
 import com.woocommerce.android.util.WooLog.T
@@ -81,6 +84,29 @@ object ActivityUtils {
             window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
             window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
             window.statusBarColor = ContextCompat.getColor(activity, colorRes)
+        }
+    }
+
+    /**
+     * Disables autofill on Oreo since it can cause crashes on API 26 & 27 - must be called in the
+     * activity's onCreate() - note that this also impacts any fragments hosted by the activity
+     * but it does not impact dialogs displayed from the activity or its fragments
+     * https://developer.android.com/guide/topics/text/autofill-optimize#autofill_causes_apps_to_crash_on_android_80_81
+     */
+    @SuppressLint("NewApi")
+    fun disableAutofillIfNecessary(activity: Activity) {
+        if (VERSION.SDK_INT == VERSION_CODES.O || VERSION.SDK_INT == VERSION_CODES.O_MR1) {
+           activity.window.decorView.importantForAutofill = View.IMPORTANT_FOR_AUTOFILL_NO_EXCLUDE_DESCENDANTS
+        }
+    }
+
+    /**
+     * Same as the above but for dialogs - must be called after the dialog builder's create()
+     */
+    @SuppressLint("NewApi")
+    fun disableAutofillIfNecessary(dialog: AlertDialog) {
+        if (VERSION.SDK_INT == VERSION_CODES.O || VERSION.SDK_INT == VERSION_CODES.O_MR1) {
+            dialog.window?.decorView?.importantForAutofill = View.IMPORTANT_FOR_AUTOFILL_NO_EXCLUDE_DESCENDANTS
         }
     }
 }


### PR DESCRIPTION
Possibly fixes #1509 - the `StringOutOfBounds` exception described in the issue is due to a bug in APis 26 & 27 that causes this crash was an autofill text field is focused, as documented by Google [here](https://developer.android.com/guide/topics/text/autofill-optimize#autofill_causes_apps_to_crash_on_android_80_81):

> Autofill causes apps to crash on Android 8.0, 8.1
In Android 8.0 (API level 26) and 8.1 (API level 27), autofill can cause your app to crash in certain scenarios. To work around any potential issues, you should tag any views that are not autofilled with importantForAutofill=no. You can also tag the whole activity with importantForAutofill=noExcludeDescendants. Note that these practices are generally recommended for any views that don't need to be autofilled.

To fix the crash, we have to disable autofill in text fields on API 26 & 27. The Sentry crash logs all have a `siteId` of zero, which means the crash is happening during login. For this reason I disabled autofill for the entire login activity on those APIs just to be safe, but it looks like autofill was already disabled in XML. 

My assumption is that there would be far more crash reports if the crashes were happening during the login flow itself. We'd also have similar crash reports for WPAndroid, but there aren't any.

Instead, I believe the source of the problem is the support email dialog which has autofill for the email address. The users are having trouble logging in, tap the HELP link, and then the support email dialog pops up and crashes when they focus the email field. So, I've disabled autofill for that dialog on APIs 26 & 27.

To test:

* Run this branch on an Oreo device
* Go to the Help & Support screen
* Tap Contact Email
* Tap on the Email field and ensure autofill doesn't appear

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
