### PR TITLE
issue/3.2 bug crash fixes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 * Added a new variants section in the Product detail screen for variable products
 * The bottom navigation bar no longer disappears when scrolling
 * Fixed a rare crash in refunds when custom order numbers are used
+* Fixed a rare crash when updating a product variant in wp-admin and refreshing the same in the app.
  
 3.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariant.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariant.kt
@@ -13,7 +13,8 @@ data class ProductVariant(
     val stockStatus: ProductStockStatus,
     val stockQuantity: Int,
     val optionName: String,
-    var priceWithCurrency: String? = null
+    var priceWithCurrency: String? = null,
+    val purchasable: Boolean
 )
 
 fun WCProductVariationModel.toAppModel(): ProductVariant {
@@ -24,7 +25,8 @@ fun WCProductVariationModel.toAppModel(): ProductVariant {
         this.price.toBigDecimalOrNull(),
         ProductStockStatus.fromString(this.stockStatus),
         this.stockQuantity,
-        getAttributeOptionName(this.getProductVariantOptions())
+        getAttributeOptionName(this.getProductVariantOptions()),
+        purchasable = this.purchasable
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -228,7 +228,7 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
             val propertyValue = getPropertyValue(properties, R.string.product_property_variant_formatter)
             addPropertyView(
                     DetailCard.Primary,
-                    getString(R.string.product_variants),
+                    getString(R.string.product_variations),
                     propertyValue,
                     LinearLayout.VERTICAL
             )?.setClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductVariantsAdapter.kt
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.DiffUtil.Callback
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.R
 import com.woocommerce.android.di.GlideRequests
+import com.woocommerce.android.extensions.appendWithIfNotEmpty
 import com.woocommerce.android.model.ProductVariant
 import com.woocommerce.android.ui.products.ProductVariantsAdapter.ProductVariantViewHolder
 import kotlinx.android.synthetic.main.product_variant_list_item.view.*
@@ -27,7 +28,7 @@ class ProductVariantsAdapter(
         setHasStableIds(true)
     }
 
-    override fun getItemId(position: Int) = productVariantList[position].remoteProductId
+    override fun getItemId(position: Int) = productVariantList[position].remoteVariationId
 
     override fun getItemCount() = productVariantList.size
 
@@ -43,9 +44,16 @@ class ProductVariantsAdapter(
         val productVariant = productVariantList[position]
 
         holder.txtVariantOptionName.text = productVariant.optionName
-        productVariant.priceWithCurrency?.let {
-            holder.txtVariantOptionPriceAndStock.text = it
+
+        val variantPurchasable = if (!productVariant.purchasable) {
+            context.getString(R.string.product_variant_hidden)
+        } else {
+            null
         }
+
+        holder.txtVariantOptionPriceAndStock.text = StringBuilder()
+                .appendWithIfNotEmpty(variantPurchasable)
+                .appendWithIfNotEmpty(productVariant.priceWithCurrency, context.getString(R.string.product_bullet))
 
         productVariant.imageUrl?.let {
             val imageUrl = PhotonUtils.getPhotonImageUrl(it, imageSize, imageSize)
@@ -60,7 +68,7 @@ class ProductVariantsAdapter(
         val newList: List<ProductVariant>
     ) : Callback() {
         override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int) =
-                oldList[oldItemPosition].remoteProductId == newList[newItemPosition].remoteProductId
+                oldList[oldItemPosition].remoteVariationId == newList[newItemPosition].remoteVariationId
 
         override fun getOldListSize(): Int = oldList.size
 
@@ -72,6 +80,7 @@ class ProductVariantsAdapter(
             return oldItem.stockQuantity == newItem.stockQuantity &&
                     oldItem.remoteVariationId == newItem.remoteVariationId &&
                     oldItem.price == newItem.price &&
+                    oldItem.purchasable == newItem.purchasable &&
                     oldItem.stockStatus == newItem.stockStatus &&
                     oldItem.imageUrl == newItem.imageUrl &&
                     oldItem.optionName == newItem.optionName

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -9,7 +9,6 @@ Language: de
     <string name="magic_link_fetch_account_error">Es gab Probleme beim Abrufen deines Kontos. Du kannst es jetzt oder es schließen und später erneut versuchen.</string>
     <string name="magic_link_update_error">Es ist ein Fehler aufgetreten. Melde dich an, umfortzufahren</string>
     <string name="login_magic_link_token_updating">Verbindung mit deiner Website wird hergestellt…</string>
-    <string name="product_variants">Varianten</string>
     <string name="product_property_edit">Produkt bearbeiten</string>
     <string name="product_variants_fetch_product_variants_error">Fehler beim Abrufen von Produktvarianten</string>
     <string name="my_store_stats_reverted_message">Wir sind zu den alten Statistiken zurückgekehrt. Um die Beta-Statistiken zu verwenden, aktiviere das WooCommerce Admin-Plugin mit Version 0.22 oder höher</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -9,7 +9,6 @@ Language: es
     <string name="magic_link_fetch_account_error">No se ha podido obtener tu cuenta. Puedes intentarlo de nuevo ahora o cerrar e intentarlo más tarde.</string>
     <string name="magic_link_update_error">Se ha producido un error. Accede para continuar</string>
     <string name="login_magic_link_token_updating">Conectando con tu sitio…</string>
-    <string name="product_variants">Variantes</string>
     <string name="product_property_edit">Editar producto</string>
     <string name="product_variants_fetch_product_variants_error">Error al obtener las reseñas de los productos</string>
     <string name="my_store_stats_reverted_message">Hemos cambiado a las antiguas estadísticas. Para usar las estadísticas beta, activa el plugin Administración de WooCommerce con la versión 0.22 o una posterior</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -9,7 +9,6 @@ Language: fr
     <string name="magic_link_fetch_account_error">Une erreur s\'est produite lors de la récupération de votre compte. Vous pouvez recommencer maintenant ou fermer et réessayer ultérieurement.</string>
     <string name="magic_link_update_error">Une erreur inconnue est survenue. Veuillez vous connecter pour continuer.</string>
     <string name="login_magic_link_token_updating">Connexion à votre site en cours…</string>
-    <string name="product_variants">Variantes</string>
     <string name="product_property_edit">Modifier le produit</string>
     <string name="product_variants_fetch_product_variants_error">Erreur lors de la récupération des variations du produit</string>
     <string name="my_store_stats_reverted_message">Nous sommes revenus aux anciennes statistiques. Pour utiliser les statistiques en version bêta, veuillez activer l\'extension d\'administration WooCommerce version 0.22 ou ultérieure.</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -9,7 +9,6 @@ Language: he_IL
     <string name="magic_link_fetch_account_error">אירעה בעיה בהבאת החשבון שלך. אפשר לנסות שוב עכשיו או לסגור את העמוד ולנסות שוב מאוחר יותר.</string>
     <string name="magic_link_update_error">אירעה שגיאה. עליך להתחבר כדי להמשיך</string>
     <string name="login_magic_link_token_updating">מתחבר לאתר שלך…</string>
-    <string name="product_variants">משתנים</string>
     <string name="product_property_edit">עריכת מוצר</string>
     <string name="product_variants_fetch_product_variants_error">שגיאה בהבאת הסוגים של המוצר</string>
     <string name="my_store_stats_reverted_message">שינינו את הנתונים הסטטיסטיים הישנים. כדי להשתמש בנתונים הסטטיסטיים בגרסת ביתא, עליך להפעיל את התוסף של מנהל המערכת של WooCommerce עם גרסה 0.22 ומעלה</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -9,7 +9,6 @@ Language: id
     <string name="magic_link_fetch_account_error">Ada masalah saat mengambil akun Anda. Anda dapat mencoba lagi sekarang atau menutupnya dan mencoba lagi nanti.</string>
     <string name="magic_link_update_error">Terjadi error. Harap login untuk melanjutkan</string>
     <string name="login_magic_link_token_updating">Menyambungkan ke situs Anda…</string>
-    <string name="product_variants">Varian</string>
     <string name="product_property_edit">Sunting produk</string>
     <string name="product_variants_fetch_product_variants_error">Terjadi error saat mengambil variasi produk</string>
     <string name="my_store_stats_reverted_message">Kami telah mengembalikan ke statistik lama. Untuk menggunakan statistik beta, harap aktifkan plugin Admin WooCommerce Admin dengan versi 0.22 atau yang lebih tinggi</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -9,7 +9,6 @@ Language: ja_JP
     <string name="magic_link_fetch_account_error">アカウントの取得時に問題が発生しました。今すぐ再試行するか、閉じてから後で再試行できます。</string>
     <string name="magic_link_update_error">エラーが発生しました。ログインして続行してください</string>
     <string name="login_magic_link_token_updating">サイトに接続しています…</string>
-    <string name="product_variants">バリアント</string>
     <string name="product_property_edit">商品を編集</string>
     <string name="product_variants_fetch_product_variants_error">商品バリエーションを取得する際にエラーが発生しました</string>
     <string name="my_store_stats_reverted_message">従来の統計に戻しました。ベータ統計を使用するには、バージョン0.22以上の WooCommerce Admin プラグインを有効化してください</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -9,7 +9,6 @@ Language: ko_KR
     <string name="magic_link_fetch_account_error">계정을 가져오는 중에 문제가 발생했습니다. 지금 다시 시도하거나 닫고 나중에 다시 시도할 수 있습니다.</string>
     <string name="magic_link_update_error">오류가 발생했습니다. 계속하려면 로그인하세요.</string>
     <string name="login_magic_link_token_updating">사이트에 연결하는 중…</string>
-    <string name="product_variants">변형</string>
     <string name="product_property_edit">제품 편집</string>
     <string name="product_variants_fetch_product_variants_error">제품 변경을 가져오는 중에 오류 발생</string>
     <string name="my_store_stats_reverted_message">이전 통계로 되돌렸습니다. 베타 통계를 사용하려면 버전 0.22 이상으로 WooCommerce Admin 플러그인을 활성화하세요.</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -9,7 +9,6 @@ Language: nl
     <string name="magic_link_fetch_account_error">Er is een probleem opgetreden bij het ophalen van je account. Je kunt het nu opnieuw proberen of het venster sluiten en later opnieuw proberen.</string>
     <string name="magic_link_update_error">Er is een fout opgetreden. Log in om door te gaan</string>
     <string name="login_magic_link_token_updating">Je site wordt gekoppeld …</string>
-    <string name="product_variants">Varianten</string>
     <string name="product_property_edit">Product bewerken</string>
     <string name="product_variants_fetch_product_variants_error">Fout bij ophalen productvariaties</string>
     <string name="my_store_stats_reverted_message">We hebben de oude statistieken hersteld. Om de bèta-statistieken te kunnen gebruiken, moet je de WooCommerce Admin-plugin met versie 0.22 of hoger activeren</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -9,7 +9,6 @@ Language: pt_BR
     <string name="magic_link_fetch_account_error">Ocorreu um problema ao recuperar sua conta. É possível tentar novamente agora ou fechar e tentar novamente mais tarde.</string>
     <string name="magic_link_update_error">Ocorreu um erro. Faça login para continuar</string>
     <string name="login_magic_link_token_updating">Conectando ao seu site…</string>
-    <string name="product_variants">Variantes</string>
     <string name="product_property_edit">Editar produto</string>
     <string name="product_variants_fetch_product_variants_error">Erro ao buscar variantes do produto</string>
     <string name="my_store_stats_reverted_message">Retornamos para as estatísticas antigas. Para usar as estatísticas beta, ative o plugin WooCommerce Admin com a versão 0.22 ou superior</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -9,7 +9,6 @@ Language: ru
     <string name="magic_link_fetch_account_error">При загрузке вашей учетной записи произошла ошибка. Повторите попытку сейчас или закройте и попробуйте позже.</string>
     <string name="magic_link_update_error">Произошла ошибка. Войдите, чтобы продолжить.</string>
     <string name="login_magic_link_token_updating">Подключение к сайту…</string>
-    <string name="product_variants">Варианты</string>
     <string name="product_property_edit">Изменить продукт</string>
     <string name="product_variants_fetch_product_variants_error">Ошибка при получении вариантов продукта</string>
     <string name="my_store_stats_reverted_message">Мы вернулись к старой статистике. Чтобы использовать бета-версию статистики, активируйте плагин администратора WooCommerce 0.22 или более поздней версии.</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -9,7 +9,6 @@ Language: sv_SE
     <string name="magic_link_fetch_account_error">Det uppstod ett fel när ditt konto skulle hämtas. Du kan försöka igen nu eller stänga och försöka igen senare.</string>
     <string name="magic_link_update_error">Ett fel har uppstått. Logga in för att fortsätta</string>
     <string name="login_magic_link_token_updating">Ansluter till din webbplats …</string>
-    <string name="product_variants">Varianter</string>
     <string name="product_property_edit">Redigera produkt</string>
     <string name="product_variants_fetch_product_variants_error">Ett fel uppstod när produktvarianterna skulle hämtas</string>
     <string name="my_store_stats_reverted_message">Vi har återgått till den gamla statistiken. För att använda betastatistiken, aktivera WooCommerce Admin-tillägget med version 0.22 eller senare</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -9,7 +9,6 @@ Language: tr
     <string name="magic_link_fetch_account_error">Hesabınızı alırken bazı sorunlar oluştu. Şimdi yeniden deneyebilir veya kapatıp daha sonra tekrar deneyebilirsiniz.</string>
     <string name="magic_link_update_error">Bir hata oluştu. Devam etmek için lütfen giriş yapın</string>
     <string name="login_magic_link_token_updating">Sitenize bağlanıyor…</string>
-    <string name="product_variants">Varyasyonlar</string>
     <string name="product_property_edit">Ürünü düzenle</string>
     <string name="product_variants_fetch_product_variants_error">Ürün varyasyonları alınırken bir hata oluştu</string>
     <string name="my_store_stats_reverted_message">Eski istatistiklere geri döndük. Beta istatistiklerini kullanmak için lütfen 0.22 veya daha üst sürüm WooCommerce Yönetici eklentisini etkinleştirin</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -9,7 +9,6 @@ Language: zh_CN
     <string name="magic_link_fetch_account_error">获取您的帐户时出现一些问题。您可以立即重试，或关闭并稍后重试。</string>
     <string name="magic_link_update_error">出现错误。请登录以继续</string>
     <string name="login_magic_link_token_updating">正在连接到您的站点…</string>
-    <string name="product_variants">变体</string>
     <string name="product_property_edit">编辑产品</string>
     <string name="product_variants_fetch_product_variants_error">获取产品变体时出错</string>
     <string name="my_store_stats_reverted_message">我们已还原为旧统计信息。要使用测试版统计信息，请激活 0.22 或更高版本的 WooCommerce Admin 插件</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -9,7 +9,6 @@ Language: zh_TW
     <string name="magic_link_fetch_account_error">擷取帳號時發生錯誤。你可以現在重試，或先關閉並稍後再試。</string>
     <string name="magic_link_update_error">發生錯誤。請登入以繼續</string>
     <string name="login_magic_link_token_updating">正在連線至你的網站…</string>
-    <string name="product_variants">型號</string>
     <string name="product_property_edit">編輯商品</string>
     <string name="product_variants_fetch_product_variants_error">擷取產品不同型號時發生錯誤</string>
     <string name="my_store_stats_reverted_message">我們已回復為舊的統計資料。若要使用 Beta 版統計資料，請啟用 0.22 或更新版本的 WooCommerce Admin 外掛程式</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -421,6 +421,8 @@
     <string name="product_search_hint">Search products</string>
     <string name="product_wip_title">Work in progress!</string>
     <string name="product_wip_message">We\'re hard at work on the new Products section so you may see some changes as we get ready for launch 🚀</string>
+    <string name="product_bullet" translatable="false">&#160;\u2022&#160;</string>
+    <string name="product_variant_hidden">Hidden</string>
     <!--
         Empty list messages
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -381,7 +381,6 @@
     <string name="product_property_variant_formatter" translatable="false">%1$s (%2$s options)</string>
     <string name="product_property_edit">Edit product</string>
     <string name="product_inventory">Inventory</string>
-    <string name="product_variants">Variants</string>
     <string name="product_price">Price</string>
     <string name="product_regular_price">Regular price</string>
     <string name="product_sale_price">Sale price</string>

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseDiscoveryFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseDiscoveryFragment.java
@@ -38,6 +38,10 @@ public abstract class LoginBaseDiscoveryFragment extends LoginBaseFormFragment<L
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onDiscoverySucceeded(OnDiscoveryResponse event) {
+        if (mLoginBaseDiscoveryListener == null) {
+            return;
+        }
+
         // hold the URL in a variable to use below otherwise it gets cleared up by endProgress
         // bail if user canceled
         String mRequestedSiteAddress = mLoginBaseDiscoveryListener.getRequestedSiteAddress();


### PR DESCRIPTION
This PR updates some hot fixes that are already merged into the `develop` branch but need to be updated to `release/3.2` branch for a new beta release.

#### Changes
- Fixes #1630 - Updates the variants section heading to `Variations` in the product detail screen.  (Original PR: #1659  )
- Fixes #1658 - Displays a variation's visibility only if the variant is not enabled.  (Original PR: #1662 )
- Fixes #1661 - Crash fix when updating a product variant in `wp-admin` and refreshing the product variant list in the app.  (Original PR: #1662 )
- Fixes #1663 - Crash fix when logging in using self hosted credentials. (Original PR: #1667 )

#### Testing
**Issue 1:** Verify that the title of variants section in the product detail screen is displayed as `Variations`.

**Issue 2:**
- Go to the store's Products section in WP Admin on the web.
- Select a variable product.
- In the Variations section, uncheck the "Enabled" box for one or more variations (to disable them).
- In the app, go to the Products section.
- Select that variable product.
- In the Variations section, note that you can tell whether or not a variation is enabled.

**Issue 3:**
- In the app, go to the Products section -> Select a variable product and click on the `Variants` section.
- In the web, go to the store's Products section in WP Admin.
- Select a variable product.
- Under the `Variations` section, uncheck the "Enabled" box for one or more variations (to disable them).
- In the app, pull to refresh the variations list.
- Notice the app does not crash.

**Issue 4:** Verify that user is able to login using self hosted credentials.

**Note that all the changes in this PR have already been tested and reviewed.** 

@nbradbury I have assigned you as a reviewer since you reviewed most of the original PRs :) 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
