### PR TITLE
Release/3.2 - products list optimisation changes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -64,6 +64,18 @@ data class Product(
         val options: List<String>,
         val isVisible: Boolean
     ) : Parcelable
+
+    fun isSameProduct(product: Product): Boolean {
+        return remoteId == product.remoteId &&
+                stockQuantity == product.stockQuantity &&
+                stockStatus == product.stockStatus &&
+                status == product.status &&
+                manageStock == product.manageStock &&
+                type == product.type &&
+                numVariations == product.numVariations &&
+                name == product.name &&
+                images == product.images
+    }
 }
 
 fun WCProductModel.toAppModel(): Product {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListAdapter.kt
@@ -9,7 +9,6 @@ import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.core.text.HtmlCompat
 import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.DiffUtil.Callback
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -151,7 +150,7 @@ class ProductListAdapter(
         }
     }
 
-    private class ProductItemDiffUtil(val items: List<Product>, val result: List<Product>) : Callback() {
+    private class ProductItemDiffUtil(val items: List<Product>, val result: List<Product>) : DiffUtil.Callback() {
         override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int) =
                 items[oldItemPosition].remoteId == result[newItemPosition].remoteId
 
@@ -162,28 +161,30 @@ class ProductListAdapter(
         override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
             val oldItem = items[oldItemPosition]
             val newItem = result[newItemPosition]
-            return oldItem.stockQuantity == newItem.stockQuantity &&
-                    oldItem.stockStatus == newItem.stockStatus &&
-                    oldItem.status == newItem.status &&
-                    oldItem.manageStock == newItem.manageStock &&
-                    oldItem.type == newItem.type &&
-                    oldItem.numVariations == newItem.numVariations &&
-                    oldItem.name == newItem.name &&
-                    oldItem.images == newItem.images
+            return oldItem.isSameProduct(newItem)
         }
     }
 
     fun setProductList(products: List<Product>) {
-        val diffResult = DiffUtil.calculateDiff(ProductItemDiffUtil(productList, products))
-        productList.clear()
-        productList.addAll(products)
-        diffResult.dispatchUpdatesTo(this)
-    }
+        fun isSameList(): Boolean {
+            if (products.size != productList.size) {
+                return false
+            }
+            for (index in products.indices) {
+                val oldItem = productList[index]
+                val newItem = products[index]
+                if (!oldItem.isSameProduct(newItem)) {
+                    return false
+                }
+            }
+            return true
+        }
 
-    fun clearAdapterData() {
-        if (productList.isNotEmpty()) {
+        if (!isSameList()) {
+            val diffResult = DiffUtil.calculateDiff(ProductItemDiffUtil(productList, products))
             productList.clear()
-            notifyDataSetChanged()
+            productList.addAll(products)
+            diffResult.dispatchUpdatesTo(this)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -91,7 +91,7 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener,
                     ContextCompat.getColor(activity, R.color.colorAccent),
                     ContextCompat.getColor(activity, R.color.colorPrimaryDark)
             )
-            scrollUpChild = scroll_view
+            scrollUpChild = productsRecycler
             setOnRefreshListener {
                 viewModel.onRefreshRequested()
             }
@@ -138,6 +138,10 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener,
 
     override fun onReturnedFromChildFragment() {
         showOptionsMenu(true)
+
+        if (!viewModel.isSearching()) {
+            viewModel.loadProducts()
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListRepository.kt
@@ -8,7 +8,8 @@ import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.WooLog
-import com.woocommerce.android.util.suspendCoroutineWithTimeout
+import com.woocommerce.android.util.suspendCancellableCoroutineWithTimeout
+import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CancellationException
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -20,7 +21,6 @@ import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductsSearched
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
 import javax.inject.Inject
-import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 
 @OpenClassOnDebug
@@ -35,10 +35,9 @@ final class ProductListRepository @Inject constructor(
         private val PRODUCT_SORTING = ProductSorting.TITLE_ASC
     }
 
-    private var loadContinuation: Continuation<Boolean>? = null
-    private var searchContinuation: Continuation<List<Product>>? = null
+    private var loadContinuation: CancellableContinuation<Boolean>? = null
+    private var searchContinuation: CancellableContinuation<List<Product>>? = null
     private var offset = 0
-    private var isLoadingProducts = false
 
     final var canLoadMoreProducts = true
         private set
@@ -59,24 +58,21 @@ final class ProductListRepository @Inject constructor(
      * list of products from the database
      */
     suspend fun fetchProductList(loadMore: Boolean = false): List<Product> {
-        if (!isLoadingProducts) {
-            try {
-                suspendCoroutineWithTimeout<Boolean>(ACTION_TIMEOUT) {
-                    offset = if (loadMore) offset + PRODUCT_PAGE_SIZE else 0
-                    loadContinuation = it
-                    isLoadingProducts = true
-                    lastSearchQuery = null
-                    val payload = WCProductStore.FetchProductsPayload(
-                            selectedSite.get(),
-                            PRODUCT_PAGE_SIZE,
-                            offset,
-                            PRODUCT_SORTING
-                    )
-                    dispatcher.dispatch(WCProductActionBuilder.newFetchProductsAction(payload))
-                }
-            } catch (e: CancellationException) {
-                WooLog.e(WooLog.T.PRODUCTS, "CancellationException while fetching products", e)
+        try {
+            suspendCancellableCoroutineWithTimeout<Boolean>(ACTION_TIMEOUT) {
+                offset = if (loadMore) offset + PRODUCT_PAGE_SIZE else 0
+                loadContinuation = it
+                lastSearchQuery = null
+                val payload = WCProductStore.FetchProductsPayload(
+                        selectedSite.get(),
+                        PRODUCT_PAGE_SIZE,
+                        offset,
+                        PRODUCT_SORTING
+                )
+                dispatcher.dispatch(WCProductActionBuilder.newFetchProductsAction(payload))
             }
+        } catch (e: CancellationException) {
+            WooLog.e(WooLog.T.PRODUCTS, "CancellationException while fetching products", e)
         }
 
         return getProductList()
@@ -84,18 +80,18 @@ final class ProductListRepository @Inject constructor(
 
     /**
      * Submits a fetch request to get a page of products for the current site matching the passed
-     * query and returns only that page of products
+     * query and returns only that page of products - note that this returns null if the search
+     * is interrupted (which means the user submitted another search while this was running)
      */
     suspend fun searchProductList(searchQuery: String, loadMore: Boolean = false): List<Product> {
-        if (isLoadingProducts) {
-            return emptyList()
-        }
+        // cancel any existing load or search
+        loadContinuation?.cancel()
+        searchContinuation?.cancel()
 
         try {
-            val products = suspendCoroutineWithTimeout<List<Product>>(ACTION_TIMEOUT) {
+            val products = suspendCancellableCoroutineWithTimeout<List<Product>>(ACTION_TIMEOUT) {
                 offset = if (loadMore) offset + PRODUCT_PAGE_SIZE else 0
                 searchContinuation = it
-                isLoadingProducts = true
                 lastSearchQuery = searchQuery
                 val payload = WCProductStore.SearchProductsPayload(
                         selectedSite.get(),
@@ -109,7 +105,7 @@ final class ProductListRepository @Inject constructor(
 
             return products ?: emptyList()
         } catch (e: CancellationException) {
-            WooLog.e(WooLog.T.PRODUCTS, "CancellationException while searching products", e)
+            WooLog.d(WooLog.T.PRODUCTS, "CancellationException while searching products")
             return emptyList()
         }
     }
@@ -126,7 +122,6 @@ final class ProductListRepository @Inject constructor(
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onProductChanged(event: OnProductChanged) {
         if (event.causeOfChange == FETCH_PRODUCTS) {
-            isLoadingProducts = false
             if (event.isError) {
                 loadContinuation?.resume(false)
                 AnalyticsTracker.track(
@@ -147,7 +142,6 @@ final class ProductListRepository @Inject constructor(
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onProductsSearched(event: OnProductsSearched) {
-        isLoadingProducts = false
         if (event.isError) {
             searchContinuation?.resume(emptyList())
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -226,7 +226,7 @@ class IssueRefundViewModel @AssistedInject constructor(
                     ))
 
                     val resultCall = async(dispatchers.io) {
-                        return@async refundStore.createRefund(
+                        return@async refundStore.createAmountRefund(
                                 selectedSite.get(),
                                 order.remoteId,
                                 refundByAmountState.enteredAmount,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CoroutineHelpers.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CoroutineHelpers.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.util
 
+import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -15,6 +16,18 @@ import kotlin.coroutines.Continuation
 suspend inline fun <T> suspendCoroutineWithTimeout(
     timeout: Long,
     crossinline block: (Continuation<T>) -> Unit
+) = coroutineScope {
+    withTimeoutOrNull(timeout) {
+        suspendCancellableCoroutine(block = block)
+    }
+}
+
+/**
+ * Similar to the above but returns a cancellable continuation
+ */
+suspend inline fun <T> suspendCancellableCoroutineWithTimeout(
+    timeout: Long,
+    crossinline block: (CancellableContinuation<T>) -> Unit
 ) = coroutineScope {
     withTimeoutOrNull(timeout) {
         suspendCancellableCoroutine(block = block)

--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -1,58 +1,61 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/productsRefreshLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="com.woocommerce.android.ui.products.ProductListFragment">
 
-    <androidx.core.widget.NestedScrollView
-        android:id="@+id/scroll_view"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:fillViewport="true">
+        android:background="@color/default_window_background">
 
-        <RelativeLayout
+        <!-- Products work in progress notice card -->
+        <com.woocommerce.android.ui.products.ProductsWIPNoticeCard
+            android:id="@+id/products_wip_card"
+            style="@style/Woo.Stats.Card.Expandable"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="@color/default_window_background"
-            android:clickable="true"
-            android:focusable="true">
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:visibility="visible" />
 
-            <!-- Products work in progress notice card -->
-            <com.woocommerce.android.ui.products.ProductsWIPNoticeCard
-                android:id="@+id/products_wip_card"
-                style="@style/Woo.Stats.Card.Expandable"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/margin_large"
-                android:visibility="gone"
-                tools:visibility="visible" />
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/productsRecycler"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:background="@color/card_bgColor"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/products_wip_card" />
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/productsRecycler"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:background="@color/card_bgColor"
-                android:layout_below="@+id/products_wip_card" />
+        <com.woocommerce.android.widgets.WCEmptyView
+            android:id="@+id/empty_view"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/products_wip_card" />
 
-            <com.woocommerce.android.widgets.WCEmptyView
-                android:id="@+id/empty_view"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_below="@+id/products_wip_card"
-                android:visibility="gone" />
-
-            <ProgressBar
-                android:id="@+id/loadMoreProgress"
-                style="?android:attr/progressBarStyle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentBottom="true"
-                android:layout_centerHorizontal="true"
-                android:layout_marginBottom="@dimen/margin_large"
-                android:visibility="gone"
-                tools:visibility="visible" />
-        </RelativeLayout>
-    </androidx.core.widget.NestedScrollView>
+        <ProgressBar
+            android:id="@+id/loadMoreProgress"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:layout_centerHorizontal="true"
+            android:layout_marginBottom="@dimen/margin_large"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            tools:visibility="visible" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>

--- a/WooCommerce/src/main/res/layout/products_wip_notice.xml
+++ b/WooCommerce/src/main/res/layout/products_wip_notice.xml
@@ -50,6 +50,16 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/list_divider" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/margin_medium"
+            android:background="@color/default_window_background" />
+
     </LinearLayout>
 
 </merge>

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.5.4'
+    fluxCVersion = 'f51c4837bfa11c6c6ca3398a316bbee8400d84ae'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
This PR updates some hot fixes for the product list screen that are already merged into the `develop` branch but need to be updated to `release/3.2` branch for a new beta release.

#### Changes
- Fixes #1650 - Updates the FluxC hash that includes the fix for incorrect product sorting.
- Fixes #1631 - Updates the FluxC hash, which corrects the "deleted products remain" bug.
- Fixes #1652 - Fixes product list scroll slow/lagging due to a bug introduced when adding the WIP banner.

#### Testing
- Verify that product list is displayed as expected.
- Pagination works as expected without any issues.
- The product list count in app matches the product list count in web.
- Product search works as expected.
- Product list is sorted correctly according to Product title ASC.

cc @nbradbury since you implemented the original PR fixes 😄 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
