### PR TITLE
issue/1470 product detail crash fix take2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
@@ -6,8 +6,10 @@ import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.suspendCancellableCoroutineWithTimeout
 import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.CancellationException
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.fluxc.Dispatcher
@@ -39,11 +41,16 @@ class ProductDetailRepository @Inject constructor(
     }
 
     suspend fun fetchProduct(remoteProductId: Long): Product? {
-        suspendCancellableCoroutineWithTimeout<Boolean>(ACTION_TIMEOUT) {
-            continuation = it
+        try {
+            continuation?.cancel()
+            suspendCancellableCoroutineWithTimeout<Boolean>(ACTION_TIMEOUT) {
+                continuation = it
 
-            val payload = WCProductStore.FetchSingleProductPayload(selectedSite.get(), remoteProductId)
-            dispatcher.dispatch(WCProductActionBuilder.newFetchSingleProductAction(payload))
+                val payload = WCProductStore.FetchSingleProductPayload(selectedSite.get(), remoteProductId)
+                dispatcher.dispatch(WCProductActionBuilder.newFetchSingleProductAction(payload))
+            }
+        } catch (e: CancellationException) {
+            WooLog.d(WooLog.T.PRODUCTS, "CancellationException while fetching single product")
         }
 
         continuation = null
@@ -57,13 +64,11 @@ class ProductDetailRepository @Inject constructor(
     @Subscribe(threadMode = MAIN)
     fun onProductChanged(event: OnProductChanged) {
         if (event.causeOfChange == FETCH_SINGLE_PRODUCT) {
-            if (continuation?.isActive == true) {
-                if (event.isError) {
-                    continuation?.resume(false)
-                } else {
-                    AnalyticsTracker.track(PRODUCT_DETAIL_LOADED)
-                    continuation?.resume(true)
-                }
+            if (event.isError) {
+                continuation?.resume(false)
+            } else {
+                AnalyticsTracker.track(PRODUCT_DETAIL_LOADED)
+                continuation?.resume(true)
             }
         }
     }


### PR DESCRIPTION
Tries to fix #1470. There is a crash that happens when the `continuation` in `ProductDetailRepository` is resumed a second time which results in `IllegalStateException`. There was a fix for this in PR #1473 by setting the `continuation` to `null` when `ProductDetailRepository` is cleaned up. But the crash continues to happen.

I have not been able to replicate the crash this time but this PR attempts to fix the crash by checking if the `continuation` is `active` before resuming it based on the docs [here](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-cancellable-continuation/). To be honest, I'm not sure if there is a better solution available and definitely open to any solutions from reviewers :) 

Marking the PR as draft since this [PR](https://github.com/woocommerce/woocommerce-android/pull/1674) on product list optimisation needs to be merged before this PR can be merged.  Note that the base branch needs to be changed to `release/3.2` before merging this PR.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
