### PR TITLE
issue/1671-zendesk-3.0.3

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -213,7 +213,7 @@ dependencies {
     androidTestImplementation "androidx.annotation:annotation:1.0.0"
     androidTestImplementation "com.google.code.findbugs:jsr305:2.0.1"
 
-    implementation(group: 'com.zendesk', name: 'support', version: '3.0.1') {
+    implementation(group: 'com.zendesk', name: 'support', version: '3.0.3') {
         exclude group: 'com.google.dagger'
     }
 


### PR DESCRIPTION
Closes #1671 - Updated Zendesk to v3.0.3, resolving [a few bugs](https://developer.zendesk.com/embeddables/docs/android-support-sdk/release_notes) in the version we previously used.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
