### PR TITLE
issue/1676-review-detail-dates

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * In rare situations, the labels on the bottom navigation bar could be cut off
 * Fixed a rare crash when updating a product variant in wp-admin and refreshing the same in the app.
 * Fixed bug that could cause stats chart to prevent scrolling vertically
+* Fixed bug that caused reviews to show an incorrect timestamp
  
 3.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
@@ -146,7 +146,7 @@ class ReviewDetailFragment : BaseFragment() {
                 .circleCrop()
                 .into(review_gravatar)
         review_user_name.text = review.reviewerName
-        review_time.text = DateTimeUtils.timeSpanFromTimestamp(review.dateCreated.time, activity as Context)
+        review_time.text = DateTimeUtils.javaDateToTimeSpan(review.dateCreated, requireActivity())
 
         // Populate reviewed product info
         review.product?.let { product ->


### PR DESCRIPTION
Fixes #1676 - prior to this PR, reviews always showed "Now" as their timespan. This PR corrects this by showing the right timespan. To test:

* On the web, submit a product review whose text contains the current date & time
* Go to the app and verify that the timespan for that review is "Now"
* Wait a few minutes, refresh reviews, and open that review again
* Verify the timespan is correct

![Screenshot_1576074040](https://user-images.githubusercontent.com/3903757/70631598-61d03e00-1bfb-11ea-9ed2-c9f35d465730.png)

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
