### PR TITLE
Hide the refunds feature

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 * The bottom navigation bar no longer disappears when scrolling
 * Fixed a rare crash in refunds when custom order numbers are used
 * Fixed a rare crash when updating a product variant in wp-admin and refreshing the same in the app.
+* Temporarily disabled the refunds feature due to a reporting inconsistency issue
  
 3.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPaymentView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPaymentView.kt
@@ -74,11 +74,13 @@ class OrderDetailPaymentView @JvmOverloads constructor(ctx: Context, attrs: Attr
                         order.paymentMethodTitle
                 )
 
-                if (order.total - order.refundTotal > BigDecimal.ZERO) {
-                    paymentInfo_issueRefundButtonSection.show()
-                } else {
-                    paymentInfo_issueRefundButtonSection.hide()
-                }
+                // temporarily disabled in v3.2
+                paymentInfo_issueRefundButtonSection.hide()
+//                if (order.total - order.refundTotal > BigDecimal.ZERO) {
+//                    paymentInfo_issueRefundButtonSection.show()
+//                } else {
+//                    paymentInfo_issueRefundButtonSection.hide()
+//                }
             }
         }
 


### PR DESCRIPTION
This PR temporarily disables issuing refunds by amount by hiding the Issue refund button. The reason for disabling the feature is due to reporting inconsistency issue that must be resolved in the API.

The refunds feature will come back in the next release in the form of refund by items.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

cc: @astralbodies 
