### PR TITLE
Hotfix: v4 revenue stats property change for wc-admin 0.23

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -282,7 +282,7 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
         // There are times when the stats v4 api returns no grossRevenue or ordersCount for a site
         // https://github.com/woocommerce/woocommerce-android/issues/1455#issuecomment-540401646
         this.chartRevenueStats = revenueStatsModel?.getIntervalList()?.map {
-            it.interval!! to (it.subtotals?.grossRevenue ?: 0.0)
+            it.interval!! to (it.subtotals?.totalSales ?: 0.0)
         }?.toMap() ?: mapOf()
 
         this.chartOrderStats = revenueStatsModel?.getIntervalList()?.map {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -330,7 +330,7 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
     private fun updateChartView() {
         val wasEmpty = chart.barData?.let { it.dataSetCount == 0 } ?: true
 
-        val grossRevenue = revenueStatsModel?.getTotal()?.grossRevenue ?: 0.0
+        val grossRevenue = revenueStatsModel?.getTotal()?.totalSales ?: 0.0
         val revenue = formatCurrencyForDisplay(grossRevenue, chartCurrencyCode.orEmpty())
 
         val orderCount = revenueStatsModel?.getTotal()?.ordersCount ?: 0
@@ -339,7 +339,7 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
         fadeInLabelValue(revenue_value, revenue)
         fadeInLabelValue(orders_value, orders)
 
-        if (chartRevenueStats.isEmpty() || revenueStatsModel?.getTotal()?.grossRevenue?.toInt() == 0) {
+        if (chartRevenueStats.isEmpty() || revenueStatsModel?.getTotal()?.totalSales?.toInt() == 0) {
             clearLastUpdated()
             isRequestingStats = false
             return

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '68c9d0483052ced0428d7340e075105ce11ca0ad'
+    fluxCVersion = 'ed2383615bff5243b5c06cb20e4a8b4f35946bd9'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'f51c4837bfa11c6c6ca3398a316bbee8400d84ae'
+    fluxCVersion = '68c9d0483052ced0428d7340e075105ce11ca0ad'
     daggerVersion = '2.22.1'
     glideVersion = '4.9.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Fixes #1681 by updating the FluxC hash to use the fix[ in this PR.](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1446). The latest version of wc-admin renamed the property `gross_revenue` to `total_sales`. This PR updates the code so this beta component will continue to work on the latest version of wc-admin.

## To Test
1. Log into the app with a store running wc-admin v0.23+
2. Verify the **Revenue** field on the stats card is populated with a value higher than $0 for a date range where there would definitely be sales. 
