### PR TITLE
Issue/1680 update androidx

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,8 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <AndroidXmlCodeStyleSettings>
-      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="STATIC_FIELD_NAME_PREFIX" value="s" />

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -122,13 +122,13 @@ dependencies {
     // Support library
     implementation "androidx.legacy:legacy-support-v4:1.0.0"
     implementation "androidx.constraintlayout:constraintlayout:1.1.3"
-    implementation "androidx.recyclerview:recyclerview:1.0.0"
+    implementation "androidx.recyclerview:recyclerview:1.1.0"
     implementation "androidx.multidex:multidex:2.0.1"
-    implementation "androidx.appcompat:appcompat:1.0.2"
+    implementation "androidx.appcompat:appcompat:1.1.0"
     implementation "com.google.android.material:material:1.0.0"
     implementation "androidx.cardview:cardview:1.0.0"
     implementation "androidx.browser:browser:1.0.0"
-    implementation "androidx.preference:preference:1.0.0"
+    implementation "androidx.preference:preference:1.1.0"
 
     implementation "androidx.navigation:navigation-fragment-ktx:$navigationVersion"
     implementation "androidx.navigation:navigation-ui-ktx:$navigationVersion"
@@ -210,7 +210,7 @@ dependencies {
     androidTestCompileOnly("com.squareup.inject:assisted-inject-annotations-dagger2:0.3.3")
 
     // Resolve conflicts between main and test APK
-    androidTestImplementation "androidx.annotation:annotation:1.0.0"
+    androidTestImplementation "androidx.annotation:annotation:1.1.0"
     androidTestImplementation "com.google.code.findbugs:jsr305:2.0.1"
 
     implementation(group: 'com.zendesk', name: 'support', version: '3.0.1') {

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -221,7 +221,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-extensions:$archComponentsVersion"
     implementation "androidx.fragment:fragment-ktx:1.1.0"
     implementation "androidx.activity:activity-ktx:1.1.0-rc02"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:1.0.0-rc02"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:1.0.0-beta01"
 
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -221,7 +221,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-extensions:$archComponentsVersion"
     implementation "androidx.fragment:fragment-ktx:1.1.0"
     implementation "androidx.activity:activity-ktx:1.1.0-rc02"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:1.0.0-beta01"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:1.0.0-rc02"
 
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.kotlinVersion = '1.3.50'
-    ext.navigationVersion = '2.0.0'
+    ext.navigationVersion = '2.1.0'
 
     repositories {
         google()


### PR DESCRIPTION
Closes #1680 - this PR updates the following AndroidX libraries:

* recyclerview 1.1.0 - https://developer.android.com/jetpack/androidx/releases/recyclerview#1.1.0
* appcompat 1.1.0 - https://developer.android.com/jetpack/androidx/releases/appcompat#1.1.0
* preference 1.1.0 - https://developer.android.com/jetpack/androidx/releases/preference#1.1.0
* annotation 1.1.0 - https://developer.android.com/jetpack/androidx/releases/annotation#1.1.0

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
