### PR TITLE
Updated Glide to 4.10.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ task installGitHooks(type: Copy) {
 ext {
     fluxCVersion = 'f51c4837bfa11c6c6ca3398a316bbee8400d84ae'
     daggerVersion = '2.25.2'
-    glideVersion = '4.9.0'
+    glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.0.1'
     mockitoKotlinVersion = '2.1.0'


### PR DESCRIPTION
Closes #1685 - updates to v4.10.0 of Glide so we get the [latest bug fixes](https://github.com/bumptech/glide/releases/tag/v4.10.0)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
