### PR TITLE
Update min wc-admin version supported in v4 stats warning string

### DIFF
--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -11,7 +11,7 @@ Language: de
     <string name="login_magic_link_token_updating">Verbindung mit deiner Website wird hergestellt…</string>
     <string name="product_property_edit">Produkt bearbeiten</string>
     <string name="product_variants_fetch_product_variants_error">Fehler beim Abrufen von Produktvarianten</string>
-    <string name="my_store_stats_reverted_message">Wir sind zu den alten Statistiken zurückgekehrt. Um die Beta-Statistiken zu verwenden, aktiviere das WooCommerce Admin-Plugin mit Version 0.22 oder höher</string>
+    <string name="my_store_stats_reverted_message">Wir sind zu den alten Statistiken zurückgekehrt. Um die Beta-Statistiken zu verwenden, aktiviere das WooCommerce Admin-Plugin mit Version 0.23 oder höher</string>
     <string name="login_discovery_error_option_select">Eine Option auswählen</string>
     <string name="login_troubleshooting_tips">Tipps zur Fehlerbehebung lesen</string>
     <string name="login_with_wordpress">Mit WordPress.com anmelden</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -11,7 +11,7 @@ Language: es
     <string name="login_magic_link_token_updating">Conectando con tu sitio…</string>
     <string name="product_property_edit">Editar producto</string>
     <string name="product_variants_fetch_product_variants_error">Error al obtener las reseñas de los productos</string>
-    <string name="my_store_stats_reverted_message">Hemos cambiado a las antiguas estadísticas. Para usar las estadísticas beta, activa el plugin Administración de WooCommerce con la versión 0.22 o una posterior</string>
+    <string name="my_store_stats_reverted_message">Hemos cambiado a las antiguas estadísticas. Para usar las estadísticas beta, activa el plugin Administración de WooCommerce con la versión 0.23 o una posterior</string>
     <string name="login_discovery_error_option_select">Elige una opción</string>
     <string name="login_troubleshooting_tips">Lee nuestros consejos de solución de problemas</string>
     <string name="login_with_wordpress">Inicia sesión con WordPress.com</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -11,7 +11,7 @@ Language: fr
     <string name="login_magic_link_token_updating">Connexion à votre site en cours…</string>
     <string name="product_property_edit">Modifier le produit</string>
     <string name="product_variants_fetch_product_variants_error">Erreur lors de la récupération des variations du produit</string>
-    <string name="my_store_stats_reverted_message">Nous sommes revenus aux anciennes statistiques. Pour utiliser les statistiques en version bêta, veuillez activer l\'extension d\'administration WooCommerce version 0.22 ou ultérieure.</string>
+    <string name="my_store_stats_reverted_message">Nous sommes revenus aux anciennes statistiques. Pour utiliser les statistiques en version bêta, veuillez activer l\'extension d\'administration WooCommerce version 0.23 ou ultérieure.</string>
     <string name="login_discovery_error_option_select">Sélectionner une option</string>
     <string name="login_troubleshooting_tips">Lire les astuces de résolution de problème</string>
     <string name="login_with_wordpress">Se connecter avec WordPress.com</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -11,7 +11,7 @@ Language: he_IL
     <string name="login_magic_link_token_updating">מתחבר לאתר שלך…</string>
     <string name="product_property_edit">עריכת מוצר</string>
     <string name="product_variants_fetch_product_variants_error">שגיאה בהבאת הסוגים של המוצר</string>
-    <string name="my_store_stats_reverted_message">שינינו את הנתונים הסטטיסטיים הישנים. כדי להשתמש בנתונים הסטטיסטיים בגרסת ביתא, עליך להפעיל את התוסף של מנהל המערכת של WooCommerce עם גרסה 0.22 ומעלה</string>
+    <string name="my_store_stats_reverted_message">שינינו את הנתונים הסטטיסטיים הישנים. כדי להשתמש בנתונים הסטטיסטיים בגרסת ביתא, עליך להפעיל את התוסף של מנהל המערכת של WooCommerce עם גרסה 0.23 ומעלה</string>
     <string name="login_discovery_error_option_select">לבחור אפשרות</string>
     <string name="login_troubleshooting_tips">לעיון בעצות שלנו לפתרון בעיות</string>
     <string name="login_with_wordpress">התחברות באמצעות WordPress.com</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -11,7 +11,7 @@ Language: id
     <string name="login_magic_link_token_updating">Menyambungkan ke situs Anda…</string>
     <string name="product_property_edit">Sunting produk</string>
     <string name="product_variants_fetch_product_variants_error">Terjadi error saat mengambil variasi produk</string>
-    <string name="my_store_stats_reverted_message">Kami telah mengembalikan ke statistik lama. Untuk menggunakan statistik beta, harap aktifkan plugin Admin WooCommerce Admin dengan versi 0.22 atau yang lebih tinggi</string>
+    <string name="my_store_stats_reverted_message">Kami telah mengembalikan ke statistik lama. Untuk menggunakan statistik beta, harap aktifkan plugin Admin WooCommerce Admin dengan versi 0.23 atau yang lebih tinggi</string>
     <string name="login_discovery_error_option_select">Tentukan pilihan</string>
     <string name="login_troubleshooting_tips">Baca tips pemecahan masalah kami</string>
     <string name="login_with_wordpress">Masuk dengan WordPress.com</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -11,7 +11,7 @@ Language: ja_JP
     <string name="login_magic_link_token_updating">サイトに接続しています…</string>
     <string name="product_property_edit">商品を編集</string>
     <string name="product_variants_fetch_product_variants_error">商品バリエーションを取得する際にエラーが発生しました</string>
-    <string name="my_store_stats_reverted_message">従来の統計に戻しました。ベータ統計を使用するには、バージョン0.22以上の WooCommerce Admin プラグインを有効化してください</string>
+    <string name="my_store_stats_reverted_message">従来の統計に戻しました。ベータ統計を使用するには、バージョン0.23以上の WooCommerce Admin プラグインを有効化してください</string>
     <string name="login_discovery_error_option_select">オプションを選択してください</string>
     <string name="login_troubleshooting_tips">トラブルシューティングのヒントを参照してください</string>
     <string name="login_with_wordpress">WordPress.com アカウントでログイン</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -11,7 +11,7 @@ Language: ko_KR
     <string name="login_magic_link_token_updating">사이트에 연결하는 중…</string>
     <string name="product_property_edit">제품 편집</string>
     <string name="product_variants_fetch_product_variants_error">제품 변경을 가져오는 중에 오류 발생</string>
-    <string name="my_store_stats_reverted_message">이전 통계로 되돌렸습니다. 베타 통계를 사용하려면 버전 0.22 이상으로 WooCommerce Admin 플러그인을 활성화하세요.</string>
+    <string name="my_store_stats_reverted_message">이전 통계로 되돌렸습니다. 베타 통계를 사용하려면 버전 0.23 이상으로 WooCommerce Admin 플러그인을 활성화하세요.</string>
     <string name="login_discovery_error_option_select">옵션 선택</string>
     <string name="login_troubleshooting_tips">문제 해결 팁 읽기</string>
     <string name="login_with_wordpress">워드프레스닷컴으로 로그인</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -11,7 +11,7 @@ Language: nl
     <string name="login_magic_link_token_updating">Je site wordt gekoppeld …</string>
     <string name="product_property_edit">Product bewerken</string>
     <string name="product_variants_fetch_product_variants_error">Fout bij ophalen productvariaties</string>
-    <string name="my_store_stats_reverted_message">We hebben de oude statistieken hersteld. Om de bèta-statistieken te kunnen gebruiken, moet je de WooCommerce Admin-plugin met versie 0.22 of hoger activeren</string>
+    <string name="my_store_stats_reverted_message">We hebben de oude statistieken hersteld. Om de bèta-statistieken te kunnen gebruiken, moet je de WooCommerce Admin-plugin met versie 0.23 of hoger activeren</string>
     <string name="login_discovery_error_option_select">Selecteer een optie</string>
     <string name="login_troubleshooting_tips">Bekijk onze tips voor probleemoplossing</string>
     <string name="login_with_wordpress">Aanmelden via WordPress.com</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -11,7 +11,7 @@ Language: pt_BR
     <string name="login_magic_link_token_updating">Conectando ao seu site…</string>
     <string name="product_property_edit">Editar produto</string>
     <string name="product_variants_fetch_product_variants_error">Erro ao buscar variantes do produto</string>
-    <string name="my_store_stats_reverted_message">Retornamos para as estatísticas antigas. Para usar as estatísticas beta, ative o plugin WooCommerce Admin com a versão 0.22 ou superior</string>
+    <string name="my_store_stats_reverted_message">Retornamos para as estatísticas antigas. Para usar as estatísticas beta, ative o plugin WooCommerce Admin com a versão 0.23 ou superior</string>
     <string name="login_discovery_error_option_select">Selecionar uma opção</string>
     <string name="login_troubleshooting_tips">Ler nossas dicas de solução de problemas</string>
     <string name="login_with_wordpress">Entrar usando o WordPress.com</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -11,7 +11,7 @@ Language: ru
     <string name="login_magic_link_token_updating">Подключение к сайту…</string>
     <string name="product_property_edit">Изменить продукт</string>
     <string name="product_variants_fetch_product_variants_error">Ошибка при получении вариантов продукта</string>
-    <string name="my_store_stats_reverted_message">Мы вернулись к старой статистике. Чтобы использовать бета-версию статистики, активируйте плагин администратора WooCommerce 0.22 или более поздней версии.</string>
+    <string name="my_store_stats_reverted_message">Мы вернулись к старой статистике. Чтобы использовать бета-версию статистики, активируйте плагин администратора WooCommerce 0.23 или более поздней версии.</string>
     <string name="login_discovery_error_option_select">Выберите вариант.</string>
     <string name="login_troubleshooting_tips">Просмотрите советы по устранению неполадок</string>
     <string name="login_with_wordpress">Войти с помощью WordPress.com</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -11,7 +11,7 @@ Language: sv_SE
     <string name="login_magic_link_token_updating">Ansluter till din webbplats …</string>
     <string name="product_property_edit">Redigera produkt</string>
     <string name="product_variants_fetch_product_variants_error">Ett fel uppstod när produktvarianterna skulle hämtas</string>
-    <string name="my_store_stats_reverted_message">Vi har återgått till den gamla statistiken. För att använda betastatistiken, aktivera WooCommerce Admin-tillägget med version 0.22 eller senare</string>
+    <string name="my_store_stats_reverted_message">Vi har återgått till den gamla statistiken. För att använda betastatistiken, aktivera WooCommerce Admin-tillägget med version 0.23 eller senare</string>
     <string name="login_discovery_error_option_select">Välj ett alternativ</string>
     <string name="login_troubleshooting_tips">Läs våra felsökningstips</string>
     <string name="login_with_wordpress">Logga in med WordPress.com</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -11,7 +11,7 @@ Language: tr
     <string name="login_magic_link_token_updating">Sitenize bağlanıyor…</string>
     <string name="product_property_edit">Ürünü düzenle</string>
     <string name="product_variants_fetch_product_variants_error">Ürün varyasyonları alınırken bir hata oluştu</string>
-    <string name="my_store_stats_reverted_message">Eski istatistiklere geri döndük. Beta istatistiklerini kullanmak için lütfen 0.22 veya daha üst sürüm WooCommerce Yönetici eklentisini etkinleştirin</string>
+    <string name="my_store_stats_reverted_message">Eski istatistiklere geri döndük. Beta istatistiklerini kullanmak için lütfen 0.23 veya daha üst sürüm WooCommerce Yönetici eklentisini etkinleştirin</string>
     <string name="login_discovery_error_option_select">Bir seçenek seçin</string>
     <string name="login_troubleshooting_tips">Sorun giderme ipuçlarımızı okuyun</string>
     <string name="login_with_wordpress">WordPress.com ile Giriş Yap</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -11,7 +11,7 @@ Language: zh_CN
     <string name="login_magic_link_token_updating">正在连接到您的站点…</string>
     <string name="product_property_edit">编辑产品</string>
     <string name="product_variants_fetch_product_variants_error">获取产品变体时出错</string>
-    <string name="my_store_stats_reverted_message">我们已还原为旧统计信息。要使用测试版统计信息，请激活 0.22 或更高版本的 WooCommerce Admin 插件</string>
+    <string name="my_store_stats_reverted_message">我们已还原为旧统计信息。要使用测试版统计信息，请激活 0.23 或更高版本的 WooCommerce Admin 插件</string>
     <string name="login_discovery_error_option_select">选择一个选项</string>
     <string name="login_troubleshooting_tips">了解我们的故障排除技巧</string>
     <string name="login_with_wordpress">通过 WordPress.com 登录</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -11,7 +11,7 @@ Language: zh_TW
     <string name="login_magic_link_token_updating">正在連線至你的網站…</string>
     <string name="product_property_edit">編輯商品</string>
     <string name="product_variants_fetch_product_variants_error">擷取產品不同型號時發生錯誤</string>
-    <string name="my_store_stats_reverted_message">我們已回復為舊的統計資料。若要使用 Beta 版統計資料，請啟用 0.22 或更新版本的 WooCommerce Admin 外掛程式</string>
+    <string name="my_store_stats_reverted_message">我們已回復為舊的統計資料。若要使用 Beta 版統計資料，請啟用 0.23 或更新版本的 WooCommerce Admin 外掛程式</string>
     <string name="login_discovery_error_option_select">選取一個選項</string>
     <string name="login_troubleshooting_tips">閱讀疑難排解提示</string>
     <string name="login_with_wordpress">透過 WordPress.com 登入</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -178,7 +178,7 @@
     <string name="dashboard_fulfill_order_title_multiple">You have %1$d orders to fulfill</string>
     <string name="dashboard_fulfill_orders_msg">Review, prepare, and ship these pending orders</string>
 
-    <string name="my_store_stats_reverted_message">We have reverted to the old stats. To use the beta stats, please activate the WooCommerce Admin plugin with version 0.22 or higher</string>
+    <string name="my_store_stats_reverted_message">We have reverted to the old stats. To use the beta stats, please activate the WooCommerce Admin plugin with version 0.23 or higher</string>
     <string name="my_store_stats_availability_title">Try our improved stats</string>
     <string name="my_store_stats_availability_message">We\'re rolling out improvements to stats for  stores using the WooCommerce Admin plugin</string>
     <!--


### PR DESCRIPTION
Fixes #1688  by updating the string displayed to the users to:

> We have reverted to the old stats. To use the beta stats, please activate the WooCommerce Admin plugin with version 0.23 or higher

This is a hotfix for the 3.2 release.