### PR TITLE
Make sure the fragment is added before updating the order status view

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * Fixed a rare crash when updating a product variant in wp-admin and refreshing the same in the app.
 * Fixed bug that could cause stats chart to prevent scrolling vertically
 * Fixed bug that caused reviews to show an incorrect timestamp
+* Fixed rare crash when backing out of an order immediately after changing order status
  
 3.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -323,15 +323,17 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
     }
 
     override fun setOrderStatus(newStatus: String) {
-        val orderStatus = presenter.getOrderStatusForStatusKey(newStatus)
-        orderDetail_orderStatus.updateStatus(orderStatus)
-        presenter.orderModel?.let {
-            orderDetail_productList.updateView(it, this)
-            orderDetail_paymentInfo.initView(
-                    it.toAppModel(),
-                    currencyFormatter.buildBigDecimalFormatter(it.currency),
-                    this
-            )
+        if (isAdded) {
+            val orderStatus = presenter.getOrderStatusForStatusKey(newStatus)
+            orderDetail_orderStatus.updateStatus(orderStatus)
+            presenter.orderModel?.let {
+                orderDetail_productList.updateView(it, this)
+                orderDetail_paymentInfo.initView(
+                        it.toAppModel(),
+                        currencyFormatter.buildBigDecimalFormatter(it.currency),
+                        this
+                )
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #1665 - As I mentioned on the issue, I'm not able to reproduce this but the most likely cause is that the user changed the order status then backed out of the order detail fragment before the order status change snackbar disappeared. 

We don't change the status until the snackbar goes away, so if they quickly back out of the fragment it will still call `setOrderStatus()`, resulting in this crash because the fragment is no longer added. Simply checking `isAdded` should resolve this.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
