### PR TITLE
issue/1565-sentry-plugin-deprecation-warning

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     dependencies {
         classpath 'com.google.gms:google-services:3.2.0'
         classpath 'se.bjurr.violations:violation-comments-to-github-gradle-plugin:1.51'
-        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.16'
+        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.28'
     }
 }
 


### PR DESCRIPTION
Closes #1565 - this PR gets rid of the "WARNING: API 'variantOutput.getProcessManifest()' is obsolete and has been replaced with 'variantOutput.getProcessManifestProvider()'. It will be removed at the end of 2019" build warning. The cause was an outdated version of the Sentry plugin - upgrading to the latest does away with the warning.

Note: I checked with the Platform team whether it was okay to upgrade the plugin, and they said it was fine.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
