### PR TITLE
Drop the time values in dates before evaluating for TimeGroup

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/TimeGroup.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/TimeGroup.kt
@@ -4,7 +4,6 @@ import androidx.annotation.StringRes
 import com.woocommerce.android.R
 import org.apache.commons.lang3.time.DateUtils
 import org.wordpress.android.util.DateTimeUtils
-import java.util.Calendar
 import java.util.Date
 
 enum class TimeGroup(@StringRes val labelRes: Int) {
@@ -17,18 +16,18 @@ enum class TimeGroup(@StringRes val labelRes: Int) {
 
     companion object {
         fun getTimeGroupForDate(date: Date): TimeGroup {
-            // Normalize the dates to drop time information
-            val dateToday = DateUtils.round(DateTimeUtils.nowUTC(), Calendar.DATE)
-            val dateToCheck = DateUtils.round(date, Calendar.DATE)
+            val dateToday = DateTimeUtils.nowUTC()
 
             return when {
-                dateToCheck.after(dateToday) -> GROUP_FUTURE
-                dateToCheck < DateUtils.addMonths(dateToday, -1) -> GROUP_OLDER_MONTH
-                dateToCheck < DateUtils.addWeeks(dateToday, -1) -> GROUP_OLDER_WEEK
-                dateToCheck < DateUtils.addDays(dateToday, -2) -> GROUP_OLDER_TWO_DAYS
-                DateUtils.isSameDay(DateUtils.addDays(dateToday, -2), dateToCheck) -> GROUP_OLDER_TWO_DAYS
-                DateUtils.isSameDay(DateUtils.addDays(dateToday, -1), dateToCheck) -> GROUP_YESTERDAY
-                else -> GROUP_TODAY
+                date < DateUtils.addMonths(dateToday, -1) -> GROUP_OLDER_MONTH
+                date < DateUtils.addWeeks(dateToday, -1) -> GROUP_OLDER_WEEK
+                date < DateUtils.addDays(dateToday, -2) -> GROUP_OLDER_TWO_DAYS
+                DateUtils.isSameDay(DateUtils.addDays(dateToday, -2), date) -> GROUP_OLDER_TWO_DAYS
+                DateUtils.isSameDay(DateUtils.addDays(dateToday, -1), date) -> GROUP_YESTERDAY
+                DateUtils.isSameDay(dateToday, date) -> GROUP_TODAY
+                else -> {
+                    GROUP_FUTURE
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/TimeGroup.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/TimeGroup.kt
@@ -4,6 +4,7 @@ import androidx.annotation.StringRes
 import com.woocommerce.android.R
 import org.apache.commons.lang3.time.DateUtils
 import org.wordpress.android.util.DateTimeUtils
+import java.util.Calendar
 import java.util.Date
 
 enum class TimeGroup(@StringRes val labelRes: Int) {
@@ -16,14 +17,17 @@ enum class TimeGroup(@StringRes val labelRes: Int) {
 
     companion object {
         fun getTimeGroupForDate(date: Date): TimeGroup {
-            val dateToday = Date()
+            // Normalize the dates to drop time information
+            val dateToday = DateUtils.round(DateTimeUtils.nowUTC(), Calendar.DATE)
+            val dateToCheck = DateUtils.round(date, Calendar.DATE)
+
             return when {
-                date.after(DateTimeUtils.nowUTC()) -> GROUP_FUTURE
-                date < DateUtils.addMonths(dateToday, -1) -> GROUP_OLDER_MONTH
-                date < DateUtils.addWeeks(dateToday, -1) -> GROUP_OLDER_WEEK
-                date < DateUtils.addDays(dateToday, -2) -> GROUP_OLDER_TWO_DAYS
-                DateUtils.isSameDay(DateUtils.addDays(dateToday, -2), date) -> GROUP_OLDER_TWO_DAYS
-                DateUtils.isSameDay(DateUtils.addDays(dateToday, -1), date) -> GROUP_YESTERDAY
+                dateToCheck.after(dateToday) -> GROUP_FUTURE
+                dateToCheck < DateUtils.addMonths(dateToday, -1) -> GROUP_OLDER_MONTH
+                dateToCheck < DateUtils.addWeeks(dateToday, -1) -> GROUP_OLDER_WEEK
+                dateToCheck < DateUtils.addDays(dateToday, -2) -> GROUP_OLDER_TWO_DAYS
+                DateUtils.isSameDay(DateUtils.addDays(dateToday, -2), dateToCheck) -> GROUP_OLDER_TWO_DAYS
+                DateUtils.isSameDay(DateUtils.addDays(dateToday, -1), dateToCheck) -> GROUP_YESTERDAY
                 else -> GROUP_TODAY
             }
         }


### PR DESCRIPTION
Fixes #1692 by dropping the time values from the dates before comparing them to figure out which time group the provided date belongs to. The reason why some dates were getting evaluating as a "FUTURE" date was because the time value was being considered during evaluation but this would cause issues for different timezones.

## TO TEST
1. Submit a new product review on the test store
2. Open the app and verify the review shows up in the "TODAY" group.
3. Change device timezone to a value that would turn the date of the review to show up as tomorrow. 
4. Verify the review still shows up in the "TODAY" group.