### PR TITLE
Issue/1698 incorrect product variants sorting fix

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * Fixed bug that could cause stats chart to prevent scrolling vertically
 * Fixed bug that caused reviews to show an incorrect timestamp
 * Fixed rare crash when backing out of an order immediately after changing order status
+* Fixed the sorting in product variations to match the sorting displayed on the web.
  
 3.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -282,7 +282,7 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
         // There are times when the stats v4 api returns no grossRevenue or ordersCount for a site
         // https://github.com/woocommerce/woocommerce-android/issues/1455#issuecomment-540401646
         this.chartRevenueStats = revenueStatsModel?.getIntervalList()?.map {
-            it.interval!! to (it.subtotals?.grossRevenue ?: 0.0)
+            it.interval!! to (it.subtotals?.totalSales ?: 0.0)
         }?.toMap() ?: mapOf()
 
         this.chartOrderStats = revenueStatsModel?.getIntervalList()?.map {
@@ -330,7 +330,7 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
     private fun updateChartView() {
         val wasEmpty = chart.barData?.let { it.dataSetCount == 0 } ?: true
 
-        val grossRevenue = revenueStatsModel?.getTotal()?.grossRevenue ?: 0.0
+        val grossRevenue = revenueStatsModel?.getTotal()?.totalSales ?: 0.0
         val revenue = formatCurrencyForDisplay(grossRevenue, chartCurrencyCode.orEmpty())
 
         val orderCount = revenueStatsModel?.getTotal()?.ordersCount ?: 0
@@ -339,7 +339,7 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
         fadeInLabelValue(revenue_value, revenue)
         fadeInLabelValue(orders_value, orders)
 
-        if (chartRevenueStats.isEmpty() || revenueStatsModel?.getTotal()?.grossRevenue?.toInt() == 0) {
+        if (chartRevenueStats.isEmpty() || revenueStatsModel?.getTotal()?.totalSales?.toInt() == 0) {
             clearLastUpdated()
             isRequestingStats = false
             return

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'f51c4837bfa11c6c6ca3398a316bbee8400d84ae'
+    fluxCVersion = 'ad5e528ca4615e0b6dd48c3fc5647d246863e84b'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Closes #1698  - updates the FluxC hash to match [this FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1451) which corrects a bug in the sorting of product variations.

**Note that this PR is in draft till this [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1451)) is reviewed and merged.**

#### Testing:
- Verify that the sorting in product variation list screen matches the sorting in `wp-admin` for the site.

<img width="671" src="https://user-images.githubusercontent.com/22608780/70771572-9a0c8380-1d97-11ea-9dd1-ebf4a76a2924.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/70771573-9bd64700-1d97-11ea-9bfa-a433c91163de.png">

Update release notes:

[x] I have considered if this change warrants user-facing release notes and have added them to RELEASE-NOTES.txt if necessary.