### PR TITLE
Issue/1696 deleted variations remain

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * Fixed bug that could cause stats chart to prevent scrolling vertically
 * Fixed bug that caused reviews to show an incorrect timestamp
 * Fixed rare crash when backing out of an order immediately after changing order status
+* Fixed the sorting in product variations to match the sorting displayed on the web.
  
 3.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -282,7 +282,7 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
         // There are times when the stats v4 api returns no grossRevenue or ordersCount for a site
         // https://github.com/woocommerce/woocommerce-android/issues/1455#issuecomment-540401646
         this.chartRevenueStats = revenueStatsModel?.getIntervalList()?.map {
-            it.interval!! to (it.subtotals?.grossRevenue ?: 0.0)
+            it.interval!! to (it.subtotals?.totalSales ?: 0.0)
         }?.toMap() ?: mapOf()
 
         this.chartOrderStats = revenueStatsModel?.getIntervalList()?.map {
@@ -330,7 +330,7 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
     private fun updateChartView() {
         val wasEmpty = chart.barData?.let { it.dataSetCount == 0 } ?: true
 
-        val grossRevenue = revenueStatsModel?.getTotal()?.grossRevenue ?: 0.0
+        val grossRevenue = revenueStatsModel?.getTotal()?.totalSales ?: 0.0
         val revenue = formatCurrencyForDisplay(grossRevenue, chartCurrencyCode.orEmpty())
 
         val orderCount = revenueStatsModel?.getTotal()?.ordersCount ?: 0
@@ -339,7 +339,7 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
         fadeInLabelValue(revenue_value, revenue)
         fadeInLabelValue(orders_value, orders)
 
-        if (chartRevenueStats.isEmpty() || revenueStatsModel?.getTotal()?.grossRevenue?.toInt() == 0) {
+        if (chartRevenueStats.isEmpty() || revenueStatsModel?.getTotal()?.totalSales?.toInt() == 0) {
             clearLastUpdated()
             isRequestingStats = false
             return

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '7163f9d15473da954b8f7cda56b345c33373c10e'
+    fluxCVersion = 'd68b4fed529256c7305e2651228b8772b5cf2f4d'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'f51c4837bfa11c6c6ca3398a316bbee8400d84ae'
+    fluxCVersion = 'ad5e528ca4615e0b6dd48c3fc5647d246863e84b'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
This PR fixes the following issues:
#### Fixes #1696  
- This PR updates the FluxC hash to the one in [this FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1453), which corrects the "deleted products variations remain in the app" bug. 

##### Testing steps:
- Open the app and go to the Product variation list screen for a product.
- For the same product, go to `wp-admin` and delete some variations.
- Follow step 1 again and verify that the number of variations in the web matches the variations in the app.
- For the same product, go to `wp-admin` and add some more variations to the product.
- Follow step 1 again and verify that the number of variations in the web matches the variations in the app.

#### Fixes #1698
-  updates the FluxC hash to match [this FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1451) which corrects a bug in the sorting of product variations.

##### Testing
- Verify that the sorting in product variation list screen matches the sorting in `wp-admin` for the site.

~~**This PR is in draft till this [FluxC PR ](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1453) and this [Woo PR](https://github.com/woocommerce/woocommerce-android/pull/1700) is merged. Once it is merged, we need to update the base branch of this PR before merging.**~~ 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
