### PR TITLE
Login: Add missing error logging where needed

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
@@ -96,7 +96,10 @@ class SitePickerPresenter @Inject constructor(
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onAccountChanged(event: OnAccountChanged) {
-        if (!event.isError && !userIsLoggedIn()) {
+        if (event.isError) {
+            WooLog.e(T.LOGIN, "Account error [type = ${event.causeOfChange}] : " +
+                    "${event.error.type} > ${event.error.message}")
+        } else if (!userIsLoggedIn()) {
             view?.didLogout()
         }
     }
@@ -105,7 +108,9 @@ class SitePickerPresenter @Inject constructor(
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onSiteChanged(event: OnSiteChanged) {
         view?.showSkeleton(false)
-        if (!event.isError) {
+        if (event.isError) {
+            WooLog.e(T.LOGIN, "Site error [${event.error.type}] : ${event.error.message}")
+        } else {
             loadSites()
         }
     }


### PR DESCRIPTION
Closes #1356 

We had a user report that nothing would happen after clicking either of the buttons on the sitepicker view in the final login step and there was nothing in the log to point to what the issue was. I found a couple places where errors were not being logged and added logging so next time we can better troubleshoot something like this.