### PR TITLE
issue/1695-add-product-list-loading-indicator

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -147,6 +147,7 @@ class ProductListViewModel @AssistedInject constructor(
                     if (productsInDb.isEmpty()) {
                         viewState = viewState.copy(isSkeletonShown = true)
                     } else {
+                        viewState = viewState.copy(isRefreshing = true)
                         _productList.value = productsInDb
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -146,8 +146,6 @@ class ProductListViewModel @AssistedInject constructor(
 
             loadJob = launch {
                 viewState = viewState.copy(isLoadingMore = loadMore)
-
-                println("@#@#I@#@#@${viewState.isLoadingMore}")
                 if (!loadMore) {
                     // if this is the initial load, first get the products from the db and if there are any show
                     // them immediately, otherwise make sure the skeleton shows
@@ -155,7 +153,6 @@ class ProductListViewModel @AssistedInject constructor(
                     if (productsInDb.isEmpty()) {
                         viewState = viewState.copy(isSkeletonShown = true)
                     } else {
-                        viewState = viewState.copy(isRefreshing = true)
                         _productList.value = productsInDb
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -66,6 +66,8 @@ class ProductListViewModel @AssistedInject constructor(
 
     private fun isLoadingMore() = viewState.isLoadingMore == true
 
+    private fun isRefreshing() = viewState.isRefreshing == true
+
     fun onSearchQueryChanged(query: String) {
         viewState = viewState.copy(query = query, isEmptyViewVisible = false)
 
@@ -121,6 +123,11 @@ class ProductListViewModel @AssistedInject constructor(
             return
         }
 
+        if (loadMore && isRefreshing()) {
+            WooLog.d(WooLog.T.PRODUCTS, "already refreshing products")
+            return
+        }
+
         if (isSearching()) {
             // cancel any existing search, then start a new one after a brief delay so we don't actually perform
             // the fetch until the user stops typing
@@ -140,6 +147,7 @@ class ProductListViewModel @AssistedInject constructor(
             loadJob = launch {
                 viewState = viewState.copy(isLoadingMore = loadMore)
 
+                println("@#@#I@#@#@${viewState.isLoadingMore}")
                 if (!loadMore) {
                     // if this is the initial load, first get the products from the db and if there are any show
                     // them immediately, otherwise make sure the skeleton shows


### PR DESCRIPTION
Fixes #1695. 

#### Changes
- This tiny PR adds logic to display the PTR refresh indicator when the product list loaded for the first time.  
- Another change added to the PR was to stop the product list from loading more products when the product list is refreshing. This was because I noticed that when there is only one product in the list (which is loaded from the db), there is another `loadMore` products API call being initiated while the product list is still being fetched.

#### Screenshots
LEFT: before the fix . RIGHT: after the fix
<img width="300" src="https://user-images.githubusercontent.com/22608780/70787444-aa7f2700-1db4-11ea-943d-a73099d52ac0.gif"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/70790656-8d018b80-1dbb-11ea-82e2-953444b781bf.gif">

#### Testing
- Click on any order with a product OR click on any product in the Top Earners tab. The product detail screen is displayed. 
- Click on Products tab now.
- Notice there is one product in the list and there is no loading indicator.
- Wait a while and the product list is loaded with the fetched data. 
- Pull changes from this PR and notice the refresh indicator displayed when the product is being fetched in the previous step.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
