### PR TITLE
Refund by items: Show item list in refund details - Step 8

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/RefundsExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/RefundsExt.kt
@@ -1,0 +1,21 @@
+package com.woocommerce.android.extensions
+
+import com.woocommerce.android.ui.refunds.RefundProductListAdapter.RefundListItem
+import java.math.BigDecimal
+import java.math.RoundingMode.HALF_UP
+
+fun List<RefundListItem>.calculateTotals(): Pair<BigDecimal, BigDecimal> {
+    var taxes = BigDecimal.ZERO
+    var subtotal = BigDecimal.ZERO
+    this.forEach { item ->
+        val quantity = item.quantity.toBigDecimal()
+        subtotal += quantity.times(item.product.price)
+
+        val singleItemTax = item.product.totalTax.divide(
+                item.product.quantity.toBigDecimal(),
+                HALF_UP
+        )
+        taxes += quantity.times(singleItemTax)
+    }
+    return Pair(subtotal, taxes)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.REFUND_CREATE_SUC
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.di.ViewModelAssistedFactory
+import com.woocommerce.android.extensions.calculateTotals
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.NetworkStatus
@@ -428,7 +429,7 @@ class IssueRefundViewModel @AssistedInject constructor(
 
         selectedQuantities[productId] = newQuantity
 
-        val (taxes, subtotal) = calculateTotals(newItems)
+        val (subtotal, taxes) = newItems.calculateTotals()
         val productsRefund = min(max(subtotal + taxes, BigDecimal.ZERO), maxRefund)
 
         val selectButtonTitle = if (areAllItemsSelected)
@@ -444,22 +445,6 @@ class IssueRefundViewModel @AssistedInject constructor(
                 isNextButtonEnabled = productsRefund > BigDecimal.ZERO,
                 selectButtonTitle = selectButtonTitle
         )
-    }
-
-    private fun calculateTotals(newItems: MutableList<RefundListItem>): Pair<BigDecimal, BigDecimal> {
-        var taxes = BigDecimal.ZERO
-        var subtotal = BigDecimal.ZERO
-        newItems.forEach { item ->
-            val quantity = item.quantity.toBigDecimal()
-            subtotal += quantity.times(item.product.price)
-
-            val singleItemTax = item.product.totalTax.divide(
-                    item.product.quantity.toBigDecimal(),
-                    HALF_UP
-            )
-            taxes += quantity.times(singleItemTax)
-        }
-        return Pair(taxes, subtotal)
     }
 
     private fun getUpdatedItemList(productId: Long, newQuantity: Int): MutableList<RefundListItem> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -59,7 +59,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCRefundStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
-import java.math.RoundingMode.HALF_UP
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByItemsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByItemsFragment.kt
@@ -72,8 +72,9 @@ class RefundByItemsFragment : BaseFragment() {
             new.currency?.takeIfNotEqualTo(old?.currency) {
                 issueRefund_products.adapter = RefundProductListAdapter(
                         currencyFormatter.buildBigDecimalFormatter(new.currency),
-                        { productId -> viewModel.onRefundQuantityTapped(productId) },
-                        imageMap
+                        imageMap,
+                        false,
+                        { productId -> viewModel.onRefundQuantityTapped(productId) }
                 )
             }
             new.isNextButtonEnabled?.takeIfNotEqualTo(old?.isNextButtonEnabled) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundDetailFragment.kt
@@ -5,20 +5,26 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Observer
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import kotlinx.android.synthetic.main.fragment_refund_detail.*
-import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.show
+import com.woocommerce.android.extensions.takeIfNotEqualTo
+import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.ViewModelFactory
+import kotlinx.android.synthetic.main.refund_by_items_products.*
 import javax.inject.Inject
 
 class RefundDetailFragment : BaseFragment() {
     @Inject lateinit var viewModelFactory: ViewModelFactory
+    @Inject lateinit var currencyFormatter: CurrencyFormatter
+    @Inject lateinit var imageMap: ProductImageMap
 
-    private val navArgs: RefundDetailFragmentArgs by navArgs()
     private val viewModel: RefundDetailViewModel by viewModels { viewModelFactory }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -34,21 +40,59 @@ class RefundDetailFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        initializeViews()
         setupObservers(viewModel)
-        viewModel.start(navArgs.orderId, navArgs.refundId)
+    }
+
+    private fun initializeViews() {
+        issueRefund_products.layoutManager = LinearLayoutManager(context)
+        issueRefund_products.setHasFixedSize(true)
     }
 
     private fun setupObservers(viewModel: RefundDetailViewModel) {
-        viewModel.viewStateData.observe(viewLifecycleOwner) { _, data ->
-            activity?.title = data.screenTitle
-            refundDetail_refundAmount.text = data.refundAmount
-            refundDetail_refundMethod.text = data.refundMethod
-            if (data.refundReason.isNullOrEmpty()) {
+        viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
+            new.screenTitle?.takeIfNotEqualTo(old?.screenTitle) {
+                activity?.title = new.screenTitle
+            }
+            new.refundAmount?.takeIfNotEqualTo(old?.refundAmount) {
+                refundDetail_refundAmount.text = new.refundAmount
+                issueRefund_productsTotal.text = new.refundAmount
+            }
+            new.subtotal?.takeIfNotEqualTo(old?.subtotal) {
+                issueRefund_subtotal.text = new.subtotal
+            }
+            new.taxes?.takeIfNotEqualTo(old?.taxes) {
+                issueRefund_taxesTotal.text = new.taxes
+            }
+            new.refundMethod?.takeIfNotEqualTo(old?.refundMethod) {
+                refundDetail_refundMethod.text = new.refundMethod
+            }
+            new.currency?.takeIfNotEqualTo(old?.currency) {
+                issueRefund_products.adapter = RefundProductListAdapter(
+                        currencyFormatter.buildBigDecimalFormatter(new.currency),
+                        imageMap,
+                        true
+                )
+            }
+            new.areItemsVisible?.takeIfNotEqualTo(old?.areItemsVisible) { isVisible ->
+                if (isVisible) {
+                    refundDetail_refundItems.show()
+                } else {
+                    refundDetail_refundItems.hide()
+                }
+            }
+
+            if (new.refundReason.isNullOrEmpty()) {
                 refundDetail_reasonCard.hide()
             } else {
                 refundDetail_reasonCard.show()
-                refundDetail_refundReason.text = data.refundReason
+                refundDetail_refundReason.text = new.refundReason
             }
         }
+
+        viewModel.refundItems.observe(viewLifecycleOwner, Observer { list ->
+            val adapter = issueRefund_products.adapter as RefundProductListAdapter
+            adapter.update(list)
+        })
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundDetailModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundDetailModule.kt
@@ -16,8 +16,8 @@ abstract class RefundDetailModule {
     companion object {
         @JvmStatic
         @Provides
-        fun provideDefaultArgs(): Bundle? {
-            return null
+        fun provideDefaultArgs(fragment: RefundDetailFragment): Bundle? {
+            return fragment.arguments
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundDetailViewModel.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.ui.refunds
 
 import android.os.Parcelable
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
@@ -11,6 +13,7 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Refund
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.refunds.RefundProductListAdapter.RefundListItem
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.LiveDataDelegate
@@ -21,12 +24,13 @@ import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCRefundStore
 import java.math.BigDecimal
+import com.woocommerce.android.extensions.calculateTotals
 
 @OpenClassOnDebug
 class RefundDetailViewModel @AssistedInject constructor(
     @Assisted savedState: SavedStateWithArgs,
     dispatchers: CoroutineDispatchers,
-    private val orderStore: WCOrderStore,
+    orderStore: WCOrderStore,
     private val selectedSite: SelectedSite,
     private val currencyFormatter: CurrencyFormatter,
     private val resourceProvider: ResourceProvider,
@@ -35,13 +39,18 @@ class RefundDetailViewModel @AssistedInject constructor(
     final val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 
+    private val _refundItems = MutableLiveData<List<RefundListItem>>()
+    final val refundItems: LiveData<List<RefundListItem>> = _refundItems
+
     private lateinit var formatCurrency: (BigDecimal) -> String
 
-    fun start(orderId: Long, refundId: Long) {
-        orderStore.getOrderByIdentifier(OrderIdentifier(selectedSite.get().id, orderId))
+    private val navArgs: RefundDetailFragmentArgs by savedState.navArgs()
+
+    init {
+        orderStore.getOrderByIdentifier(OrderIdentifier(selectedSite.get().id, navArgs.orderId))
                 ?.toAppModel()?.let { order ->
             formatCurrency = currencyFormatter.buildBigDecimalFormatter(order.currency)
-            refundStore.getRefund(selectedSite.get(), orderId, refundId)?.toAppModel()?.let { refund ->
+            refundStore.getRefund(selectedSite.get(), navArgs.orderId, navArgs.refundId)?.toAppModel()?.let { refund ->
                 displayRefundDetails(refund, order)
             }
         }
@@ -52,6 +61,27 @@ class RefundDetailViewModel @AssistedInject constructor(
             order.paymentMethodTitle
         else
             "${resourceProvider.getString(R.string.order_refunds_manual_refund)} - ${order.paymentMethodTitle}"
+
+        if (refund.items.isNotEmpty()) {
+            val items = refund.items.map { refundItem ->
+                RefundListItem(
+                    order.items.first { it.productId == refundItem.productId },
+                    quantity = refundItem.quantity
+                )
+            }
+
+            val (subtotal, taxes) = items.calculateTotals()
+            viewState = viewState.copy(
+                    currency = order.currency,
+                    areItemsVisible = true,
+                    subtotal = formatCurrency(subtotal),
+                    taxes = formatCurrency(taxes)
+            )
+
+            _refundItems.value = items
+        } else {
+            viewState = viewState.copy(areItemsVisible = false)
+        }
 
         viewState = viewState.copy(
                 screenTitle = "${resourceProvider.getString(R.string.order_refunds_refund)} #${refund.id}",
@@ -65,8 +95,12 @@ class RefundDetailViewModel @AssistedInject constructor(
     data class ViewState(
         val screenTitle: String? = null,
         val refundAmount: String? = null,
+        val subtotal: String? = null,
+        val taxes: String? = null,
         val refundMethod: String? = null,
-        val refundReason: String? = null
+        val refundReason: String? = null,
+        val currency: String? = null,
+        val areItemsVisible: Boolean? = null
     ) : Parcelable
 
     @AssistedInject.Factory

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundProductListAdapter.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.annotation.LayoutRes
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.DiffUtil.Callback
 import androidx.recyclerview.widget.RecyclerView
@@ -20,13 +21,15 @@ import java.math.BigDecimal
 
 class RefundProductListAdapter(
     private val formatCurrency: (BigDecimal) -> String,
-    private val onRefundQuantityClicked: (Long) -> Unit,
-    private val imageMap: ProductImageMap
+    private val imageMap: ProductImageMap,
+    private val isReadOnly: Boolean,
+    private val onRefundQuantityClicked: (Long) -> Unit = { }
 ) : RecyclerView.Adapter<RefundProductListAdapter.ViewHolder>() {
     private var items = mutableListOf<RefundListItem>()
 
     override fun onCreateViewHolder(parent: ViewGroup, itemType: Int): ViewHolder {
-        return ViewHolder(parent, formatCurrency, onRefundQuantityClicked, imageMap)
+        val layout = if (isReadOnly) R.layout.refunds_detail_product_list_item else R.layout.refunds_product_list_item
+        return ViewHolder(parent, layout, formatCurrency, onRefundQuantityClicked, imageMap)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
@@ -43,11 +46,12 @@ class RefundProductListAdapter(
 
     class ViewHolder(
         parent: ViewGroup,
+        @LayoutRes layout: Int,
         private val formatCurrency: (BigDecimal) -> String,
         private val onRefundQuantityClicked: (Long) -> Unit,
         private val imageMap: ProductImageMap
     ) : RecyclerView.ViewHolder(
-            LayoutInflater.from(parent.context).inflate(R.layout.refunds_product_list_item, parent, false)
+            LayoutInflater.from(parent.context).inflate(layout, parent, false)
     ) {
         private val nameTextView: TextView = itemView.findViewById(R.id.refundItem_productName)
         private val descriptionTextView: TextView = itemView.findViewById(R.id.refundItem_description)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundProductListAdapter.kt
@@ -86,7 +86,7 @@ class RefundProductListAdapter(
     @Parcelize
     data class RefundListItem(
         val product: Order.Item,
-        val maxQuantity: Int,
+        val maxQuantity: Int = 0,
         val quantity: Int = 0
     ) : Parcelable {
         fun toDataModel(): WCRefundItem {

--- a/WooCommerce/src/main/res/layout/fragment_refund_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_refund_detail.xml
@@ -14,6 +14,47 @@
         android:background="@color/default_window_background"
         tools:context="com.woocommerce.android.ui.refunds.RefundByAmountFragment">
 
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/refundDetail_refundItems"
+            style="@style/Woo.Card.WithoutPadding"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/refundDetail_productTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/card_padding_start"
+                android:layout_marginEnd="@dimen/card_padding_end"
+                android:textAppearance="@style/Woo.TextAppearance.Title"
+                android:text="@string/product"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@id/refundDetail_quantityTitle"
+                app:layout_constraintBottom_toTopOf="@id/issueRefund_productsList" />
+
+            <TextView
+                android:id="@+id/refundDetail_quantityTitle"
+                android:textAppearance="@style/Woo.TextAppearance.Title"
+                android:layout_marginStart="@dimen/card_padding_start"
+                android:layout_marginEnd="@dimen/card_padding_end"
+                android:layout_marginTop="@dimen/card_padding_top"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/orderdetail_product_qty"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <include
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:id="@+id/issueRefund_productsList"
+                layout="@layout/refund_by_items_products"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/refundDetail_quantityTitle" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
         <LinearLayout
             style="@style/Woo.Card"
             android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/layout/refunds_detail_product_list_item.xml
+++ b/WooCommerce/src/main/res/layout/refunds_detail_product_list_item.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/card_padding_top"
+    android:layout_marginBottom="@dimen/card_padding_bottom">
+
+    <FrameLayout
+        android:id="@+id/refundItem_iconFrame"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:background="@drawable/picture_frame"
+        android:padding="1dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/refundItem_icon"
+            android:layout_width="@dimen/product_icon_sz"
+            android:layout_height="@dimen/product_icon_sz"
+            android:contentDescription="@string/orderdetail_product_image_contentdesc"
+            android:scaleType="centerCrop"
+            app:srcCompat="@drawable/ic_product"
+            tools:visibility="visible"/>
+
+    </FrameLayout>
+
+    <TextView
+        android:id="@+id/refundItem_productName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/margin_extra_large"
+        android:layout_marginStart="@dimen/margin_extra_large"
+        android:layout_marginTop="1dp"
+        android:includeFontPadding="false"
+        android:textSize="@dimen/text_medium"
+        android:maxLines="2"
+        android:textAppearance="@style/Woo.TextAppearance.ListItem.Title"
+        app:layout_constrainedWidth="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toEndOf="@+id/refundItem_iconFrame"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Awesome Sauce" />
+
+    <TextView
+        android:id="@+id/refundItem_description"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="1dp"
+        android:textAppearance="@style/Woo.TextAppearance.Medium.Grey"
+        app:layout_constraintEnd_toEndOf="@+id/refundItem_productName"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="@+id/refundItem_productName"
+        app:layout_constraintTop_toBottomOf="@+id/refundItem_productName"
+        tools:text="2 x $15.00 each" />
+
+    <TextView
+        android:id="@+id/refundItem_quantity"
+        android:layout_width="42dp"
+        android:layout_height="32dp"
+        android:layout_gravity="center"
+        android:gravity="end"
+        android:textAppearance="@style/Woo.OrderDetail.TextAppearance.Heading"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="2" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This PR adds the refund item list to order details. Previously, only the total amount was shown, now the refunds with items are shown in a list.

![image](https://user-images.githubusercontent.com/1522856/70805876-4a8b7f00-1dba-11ea-9455-2b8ac583d774.png)

To test:
1. Go to an order with a refund (with refunded items)
2. Tap on the View details button of the refund
3. Notice the refund items are shown in the detail

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
