### PR TITLE
Refund by items: Variable products fix - Step 9

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/RefundsExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/RefundsExt.kt
@@ -9,10 +9,10 @@ fun List<RefundListItem>.calculateTotals(): Pair<BigDecimal, BigDecimal> {
     var subtotal = BigDecimal.ZERO
     this.forEach { item ->
         val quantity = item.quantity.toBigDecimal()
-        subtotal += quantity.times(item.product.price)
+        subtotal += quantity.times(item.orderItem.price)
 
-        val singleItemTax = item.product.totalTax.divide(
-                item.product.quantity.toBigDecimal(),
+        val singleItemTax = item.orderItem.totalTax.divide(
+                item.orderItem.quantity.toBigDecimal(),
                 HALF_UP
         )
         taxes += quantity.times(singleItemTax)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.model.Order.Address
 import com.woocommerce.android.model.Order.Address.Type.BILLING
 import com.woocommerce.android.model.Order.Address.Type.SHIPPING
 import com.woocommerce.android.model.Order.Item
+import kotlinx.android.parcel.IgnoredOnParcel
 import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
@@ -53,7 +54,10 @@ data class Order(
         val totalTax: BigDecimal,
         val total: BigDecimal,
         val variationId: Long
-    ) : Parcelable
+    ) : Parcelable {
+        @IgnoredOnParcel
+        val uniqueId: String = productId.toString() + variationId.toString()
+    }
 
     @Parcelize
     data class Address(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.model.Order.Address
 import com.woocommerce.android.model.Order.Address.Type.BILLING
 import com.woocommerce.android.model.Order.Address.Type.SHIPPING
 import com.woocommerce.android.model.Order.Item
+import com.woocommerce.android.ui.products.ProductHelper
 import kotlinx.android.parcel.IgnoredOnParcel
 import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.fluxc.model.WCOrderModel
@@ -56,7 +57,7 @@ data class Order(
         val variationId: Long
     ) : Parcelable {
         @IgnoredOnParcel
-        val uniqueId: String = productId.toString() + variationId.toString()
+        val uniqueId: Long = ProductHelper.productOrVariationId(productId, variationId)
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.model
 
 import android.os.Parcelable
 import com.woocommerce.android.extensions.roundError
+import com.woocommerce.android.ui.products.ProductHelper
 import kotlinx.android.parcel.IgnoredOnParcel
 import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel
@@ -32,7 +33,7 @@ data class Refund(
         val price: BigDecimal = BigDecimal.ZERO
     ) : Parcelable {
         @IgnoredOnParcel
-        val uniqueId: String = productId.toString() + variationId.toString()
+        val uniqueId: Long = ProductHelper.productOrVariationId(productId, variationId)
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.model
 
 import android.os.Parcelable
 import com.woocommerce.android.extensions.roundError
+import kotlinx.android.parcel.IgnoredOnParcel
 import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel.WCRefundItem
@@ -29,7 +30,10 @@ data class Refund(
         val totalTax: BigDecimal = BigDecimal.ZERO,
         val sku: String = "",
         val price: BigDecimal = BigDecimal.ZERO
-    ) : Parcelable
+    ) : Parcelable {
+        @IgnoredOnParcel
+        val uniqueId: String = productId.toString() + variationId.toString()
+    }
 }
 
 fun WCRefundModel.toAppModel(): Refund {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -47,7 +47,7 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
     companion object {
         const val ARG_DID_MARK_COMPLETE = "did_mark_complete"
         const val STATE_KEY_REFRESH_PENDING = "is-refresh-pending"
-        private const val REFUNDS_REFRESH_DELAY = 1000L
+        private const val REFUNDS_REFRESH_DELAY = 2000L
     }
 
     @Inject lateinit var presenter: OrderDetailContract.Presenter

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPaymentView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPaymentView.kt
@@ -126,7 +126,7 @@ class OrderDetailPaymentView @JvmOverloads constructor(ctx: Context, attrs: Attr
         paymentInfo_refundTotalSection.hide()
 
         var availableRefundQuantity = order.items.sumBy { it.quantity }
-        refunds.flatMap { it.items }.groupBy { it.productId }.forEach { productRefunds ->
+        refunds.flatMap { it.items }.groupBy { it.uniqueId }.forEach { productRefunds ->
             val refundedCount = productRefunds.value.sumBy { it.quantity }
             availableRefundQuantity -= refundedCount
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundFragment.kt
@@ -44,7 +44,10 @@ class IssueRefundFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        parentFragmentManager.beginTransaction().replace(R.id.issueRefund_frame, RefundByItemsFragment()).commit()
+        childFragmentManager
+                .beginTransaction()
+                .replace(R.id.issueRefund_frame, RefundByItemsFragment())
+                .commit()
 
         // TODO: Temporary; it will be used again in a future release - do not remove
 //        initializeViews(viewModel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -111,13 +111,13 @@ class IssueRefundViewModel @AssistedInject constructor(
     private val refunds: List<Refund>
 
     private val maxRefund: BigDecimal
-    private val maxQuantities: Map<Long, Int>
+    private val maxQuantities: Map<String, Int>
     private val formatCurrency: (BigDecimal) -> String
     private val gateway: PaymentGateway
     private val arguments: RefundsArgs by savedState.navArgs()
 
-    private val selectedQuantities: MutableMap<Long, Int> by lazy {
-        val quantities = savedState.get<MutableMap<Long, Int>>(SELECTED_QUANTITIES_KEY) ?: mutableMapOf()
+    private val selectedQuantities: MutableMap<String, Int> by lazy {
+        val quantities = savedState.get<MutableMap<String, Int>>(SELECTED_QUANTITIES_KEY) ?: mutableMapOf()
         savedState[SELECTED_QUANTITIES_KEY] = quantities
         quantities
     }
@@ -179,8 +179,8 @@ class IssueRefundViewModel @AssistedInject constructor(
         }
 
         val items = order.items.map {
-            val maxQuantity = maxQuantities[it.productId] ?: 0
-            val selectedQuantity = min(selectedQuantities[it.productId] ?: 0, maxQuantity)
+            val maxQuantity = maxQuantities[it.uniqueId] ?: 0
+            val selectedQuantity = min(selectedQuantities[it.uniqueId] ?: 0, maxQuantity)
             RefundListItem(it, maxQuantity, selectedQuantity)
         }
         updateRefundItems(items)
@@ -389,8 +389,8 @@ class IssueRefundViewModel @AssistedInject constructor(
         refundContinuation?.resume(false)
     }
 
-    fun onRefundQuantityTapped(productId: Long) {
-        _refundItems.value?.firstOrNull { it.product.productId == productId }?.let {
+    fun onRefundQuantityTapped(uniqueId: String) {
+        _refundItems.value?.firstOrNull { it.orderItem.uniqueId == uniqueId }?.let {
             triggerEvent(ShowNumberPicker(it))
         }
 
@@ -422,11 +422,11 @@ class IssueRefundViewModel @AssistedInject constructor(
         )
     }
 
-    fun onRefundQuantityChanged(productId: Long, newQuantity: Int) {
-        val newItems = getUpdatedItemList(productId, newQuantity)
+    fun onRefundQuantityChanged(uniqueId: String, newQuantity: Int) {
+        val newItems = getUpdatedItemList(uniqueId, newQuantity)
         updateRefundItems(newItems)
 
-        selectedQuantities[productId] = newQuantity
+        selectedQuantities[uniqueId] = newQuantity
 
         val (subtotal, taxes) = newItems.calculateTotals()
         val productsRefund = min(max(subtotal + taxes, BigDecimal.ZERO), maxRefund)
@@ -446,14 +446,14 @@ class IssueRefundViewModel @AssistedInject constructor(
         )
     }
 
-    private fun getUpdatedItemList(productId: Long, newQuantity: Int): MutableList<RefundListItem> {
+    private fun getUpdatedItemList(uniqueId: String, newQuantity: Int): MutableList<RefundListItem> {
         val newItems = mutableListOf<RefundListItem>()
         _refundItems.value?.forEach {
-            if (it.product.productId == productId) {
+            if (it.orderItem.uniqueId == uniqueId) {
                 newItems.add(
                         it.copy(
                                 quantity = newQuantity,
-                                maxQuantity = maxQuantities[productId] ?: 0
+                                maxQuantity = maxQuantities[uniqueId] ?: 0
                         )
                 )
             } else {
@@ -466,11 +466,11 @@ class IssueRefundViewModel @AssistedInject constructor(
     fun onSelectButtonTapped() {
         if (areAllItemsSelected) {
             _refundItems.value?.forEach {
-                onRefundQuantityChanged(it.product.productId, 0)
+                onRefundQuantityChanged(it.orderItem.uniqueId, 0)
             }
         } else {
             _refundItems.value?.forEach {
-                onRefundQuantityChanged(it.product.productId, it.maxQuantity)
+                onRefundQuantityChanged(it.orderItem.uniqueId, it.maxQuantity)
             }
         }
 
@@ -512,11 +512,11 @@ class IssueRefundViewModel @AssistedInject constructor(
     }
 
     // calculate the max quantity for each item by subtracting the number of already-refunded items
-    private fun getMaxQuantities(): Map<Long, Int> {
-        val map = mutableMapOf<Long, Int>()
-        val groupedRefunds = refunds.flatMap { it.items }.groupBy { it.productId }
+    private fun getMaxQuantities(): Map<String, Int> {
+        val map = mutableMapOf<String, Int>()
+        val groupedRefunds = refunds.flatMap { it.items }.groupBy { it.uniqueId }
         order.items.map { item ->
-            map[item.productId] = item.quantity - (groupedRefunds[item.productId]?.sumBy { it.quantity } ?: 0)
+            map[item.uniqueId] = item.quantity - (groupedRefunds[item.uniqueId]?.sumBy { it.quantity } ?: 0)
         }
         return map
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -111,13 +111,13 @@ class IssueRefundViewModel @AssistedInject constructor(
     private val refunds: List<Refund>
 
     private val maxRefund: BigDecimal
-    private val maxQuantities: Map<String, Int>
+    private val maxQuantities: Map<Long, Int>
     private val formatCurrency: (BigDecimal) -> String
     private val gateway: PaymentGateway
     private val arguments: RefundsArgs by savedState.navArgs()
 
-    private val selectedQuantities: MutableMap<String, Int> by lazy {
-        val quantities = savedState.get<MutableMap<String, Int>>(SELECTED_QUANTITIES_KEY) ?: mutableMapOf()
+    private val selectedQuantities: MutableMap<Long, Int> by lazy {
+        val quantities = savedState.get<MutableMap<Long, Int>>(SELECTED_QUANTITIES_KEY) ?: mutableMapOf()
         savedState[SELECTED_QUANTITIES_KEY] = quantities
         quantities
     }
@@ -389,7 +389,7 @@ class IssueRefundViewModel @AssistedInject constructor(
         refundContinuation?.resume(false)
     }
 
-    fun onRefundQuantityTapped(uniqueId: String) {
+    fun onRefundQuantityTapped(uniqueId: Long) {
         _refundItems.value?.firstOrNull { it.orderItem.uniqueId == uniqueId }?.let {
             triggerEvent(ShowNumberPicker(it))
         }
@@ -422,7 +422,7 @@ class IssueRefundViewModel @AssistedInject constructor(
         )
     }
 
-    fun onRefundQuantityChanged(uniqueId: String, newQuantity: Int) {
+    fun onRefundQuantityChanged(uniqueId: Long, newQuantity: Int) {
         val newItems = getUpdatedItemList(uniqueId, newQuantity)
         updateRefundItems(newItems)
 
@@ -446,7 +446,7 @@ class IssueRefundViewModel @AssistedInject constructor(
         )
     }
 
-    private fun getUpdatedItemList(uniqueId: String, newQuantity: Int): MutableList<RefundListItem> {
+    private fun getUpdatedItemList(uniqueId: Long, newQuantity: Int): MutableList<RefundListItem> {
         val newItems = mutableListOf<RefundListItem>()
         _refundItems.value?.forEach {
             if (it.orderItem.uniqueId == uniqueId) {
@@ -512,8 +512,8 @@ class IssueRefundViewModel @AssistedInject constructor(
     }
 
     // calculate the max quantity for each item by subtracting the number of already-refunded items
-    private fun getMaxQuantities(): Map<String, Int> {
-        val map = mutableMapOf<String, Int>()
+    private fun getMaxQuantities(): Map<Long, Int> {
+        val map = mutableMapOf<Long, Int>()
         val groupedRefunds = refunds.flatMap { it.items }.groupBy { it.uniqueId }
         order.items.map { item ->
             map[item.uniqueId] = item.quantity - (groupedRefunds[item.uniqueId]?.sumBy { it.quantity } ?: 0)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByItemsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByItemsFragment.kt
@@ -74,7 +74,7 @@ class RefundByItemsFragment : BaseFragment() {
                         currencyFormatter.buildBigDecimalFormatter(new.currency),
                         imageMap,
                         false,
-                        { productId -> viewModel.onRefundQuantityTapped(productId) }
+                        { uniqueId -> viewModel.onRefundQuantityTapped(uniqueId) }
                 )
             }
             new.isNextButtonEnabled?.takeIfNotEqualTo(old?.isNextButtonEnabled) {
@@ -115,7 +115,7 @@ class RefundByItemsFragment : BaseFragment() {
                 is ShowNumberPicker -> {
                     val action = IssueRefundFragmentDirections.actionIssueRefundFragmentToRefundItemsPickerDialog(
                             getString(R.string.order_refunds_select_quantity),
-                            event.refundItem.product.productId,
+                            event.refundItem.orderItem.uniqueId,
                             event.refundItem.maxQuantity,
                             event.refundItem.quantity
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundDetailViewModel.kt
@@ -65,7 +65,7 @@ class RefundDetailViewModel @AssistedInject constructor(
         if (refund.items.isNotEmpty()) {
             val items = refund.items.map { refundItem ->
                 RefundListItem(
-                    order.items.first { it.productId == refundItem.productId },
+                    order.items.first { it.uniqueId == refundItem.uniqueId },
                     quantity = refundItem.quantity
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundItemsPickerDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundItemsPickerDialog.kt
@@ -26,7 +26,7 @@ class RefundItemsPickerDialog : NumberPickerDialog(), HasAndroidInjector {
     }
 
     override fun returnResult(selectedValue: Int) {
-        viewModel.onRefundQuantityChanged(navArgs.productId, selectedValue)
+        viewModel.onRefundQuantityChanged(navArgs.uniqueId, selectedValue)
     }
 
     override fun androidInjector(): AndroidInjector<Any> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundProductListAdapter.kt
@@ -23,7 +23,7 @@ class RefundProductListAdapter(
     private val formatCurrency: (BigDecimal) -> String,
     private val imageMap: ProductImageMap,
     private val isReadOnly: Boolean,
-    private val onRefundQuantityClicked: (String) -> Unit = { }
+    private val onRefundQuantityClicked: (Long) -> Unit = { }
 ) : RecyclerView.Adapter<RefundProductListAdapter.ViewHolder>() {
     private var items = mutableListOf<RefundListItem>()
 
@@ -48,7 +48,7 @@ class RefundProductListAdapter(
         parent: ViewGroup,
         @LayoutRes layout: Int,
         private val formatCurrency: (BigDecimal) -> String,
-        private val onRefundQuantityClicked: (String) -> Unit,
+        private val onRefundQuantityClicked: (Long) -> Unit,
         private val imageMap: ProductImageMap
     ) : RecyclerView.ViewHolder(
             LayoutInflater.from(parent.context).inflate(layout, parent, false)

--- a/WooCommerce/src/main/res/navigation/nav_graph_refunds.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_refunds.xml
@@ -37,8 +37,8 @@
             android:name="title"
             app:argType="string" />
         <argument
-            android:name="productId"
-            app:argType="long" />
+            android:name="uniqueId"
+            app:argType="string" />
         <argument
             android:name="maxValue"
             app:argType="integer" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_refunds.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_refunds.xml
@@ -38,7 +38,7 @@
             app:argType="string" />
         <argument
             android:name="uniqueId"
-            app:argType="string" />
+            app:argType="long" />
         <argument
             android:name="maxValue"
             app:argType="integer" />


### PR DESCRIPTION
This PR fixes the support for refunding variable products. 

The **productId** was assumed to be unique, but variable products have the same product ID for all variations. Therefore, there is a new `Order.Item.uniqueId` and `Refund.Item.uniqueId` which, is a concatenation of productId & variationId.

**To test:**
1. Create an order with at least 2 different variations the same product
2. Go to order details and tap the Issue refund button
3. Select the refund quantity of an item and notice only that item's quantity is changed
4. Issue a refund
5. Verify that the refund was issued and the proper item was refunded