### PR TITLE
Update FluxC hash to latest tag for release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'd68b4fed529256c7305e2651228b8772b5cf2f4d'
+    fluxCVersion = '1.5.5'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Updates the FluxC hash to `1.5.5` for release prep