### PR TITLE
Issue/1705 current day order

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemDataSource.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.ui.orders.list.OrderListItemIdentifier.SectionHea
 import com.woocommerce.android.ui.orders.list.OrderListItemUIType.LoadingItem
 import com.woocommerce.android.ui.orders.list.OrderListItemUIType.OrderListItemUI
 import com.woocommerce.android.ui.orders.list.OrderListItemUIType.SectionHeader
+import com.woocommerce.android.util.DateUtils
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
@@ -110,7 +111,7 @@ class OrderListItemDataSource(
             // Check if future-dated orders should be excluded from the results list.
             if (listDescriptor.excludeFutureOrders) {
                 val currentUtcDate = DateTimeUtils.nowUTC()
-                if (date.after(currentUtcDate)) {
+                if (DateUtils.isAfterDate(currentUtcDate, date)) {
                     // This order is dated for the future so skip adding it to the list
                     return@forEach
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.text.format.DateFormat
 import com.woocommerce.android.R
 import com.woocommerce.android.model.TimeGroup
+import org.apache.commons.lang3.time.DateUtils
 import org.wordpress.android.util.DateTimeUtils
 import java.text.DateFormatSymbols
 import java.text.SimpleDateFormat
@@ -314,5 +315,19 @@ object DateUtils {
     fun getDayOfWeekWithMonthAndDayFromDate(date: Date): String {
         val dateFormat = SimpleDateFormat("EEEE, MMM dd", Locale.US)
         return dateFormat.format(date)
+    }
+
+    /**
+     * Compares two dates to determine if [date2] is after [Date1]. Note that
+     * this method strips the time information from the comparison and is only comparing
+     * the dates.
+     *
+     * @param date1 the base date for comparison
+     * @param date2 the date to determine if after [date1]
+     */
+    fun isAfterDate(date1: Date, date2: Date): Boolean {
+        val dateOnly1 = DateUtils.round(date1, Calendar.DATE)
+        val dateOnly2 = DateUtils.round(date2, Calendar.DATE)
+        return dateOnly2.after(dateOnly1)
     }
 }


### PR DESCRIPTION
Fixes #1705 - I had fixed the `TimeGroup` logic for determining future-dated orders in #1699 but missed the logic in `OrderListItemDatasource` which was still using the faulty logic for working with UTC dates. Updated and should now be fixed. 