### PR TITLE
Check for invalid image index

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -313,7 +313,9 @@ class WCProductImageGalleryView @JvmOverloads constructor(
             }
 
             itemView.setOnClickListener {
-                onImageClicked(adapterPosition, productImageView)
+                if (adapterPosition > NO_POSITION) {
+                    onImageClicked(adapterPosition, productImageView)
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #1717 - the error log for this issue shows "ArrayIndexOutOfBoundsException: length=10; **index=-1**," which can happen if the recycleView is no longer valid. This PR checks for this situation.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
