### PR TITLE
Issue/1719 unknown navigation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NavControllerExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NavControllerExt.kt
@@ -1,16 +1,32 @@
 package com.woocommerce.android.extensions
 
+import androidx.annotation.IdRes
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections
 import androidx.navigation.Navigator
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 
+/**
+ * If a user accidentally navigates twice quickly (for example, tapping a button twice), the app may
+ * crash with "IllegalArgumentException: navigation destination is unknown to this NavController."
+ * We prevent this by catching and ignoring the exception.
+ *
+ * https://github.com/woocommerce/woocommerce-android/issues/1719
+ */
 fun NavController.navigateSafely(directions: NavDirections, extras: Navigator.Extras? = null) {
     try {
         extras?.let {
             navigate(directions, it)
         } ?: navigate(directions)
+    } catch (e: IllegalArgumentException) {
+        WooLog.e(T.UTILS, e)
+    }
+}
+
+fun NavController.navigateSafely(@IdRes resId: Int) {
+    try {
+        navigate(resId, null)
     } catch (e: IllegalArgumentException) {
         WooLog.e(T.UTILS, e)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NavControllerExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NavControllerExt.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.extensions
 import androidx.annotation.IdRes
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections
-import androidx.navigation.Navigator
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 
@@ -14,11 +13,9 @@ import com.woocommerce.android.util.WooLog.T
  *
  * https://github.com/woocommerce/woocommerce-android/issues/1719
  */
-fun NavController.navigateSafely(directions: NavDirections, extras: Navigator.Extras? = null) {
+fun NavController.navigateSafely(directions: NavDirections) {
     try {
-        extras?.let {
-            navigate(directions, it)
-        } ?: navigate(directions)
+        navigate(directions)
     } catch (e: IllegalArgumentException) {
         WooLog.e(T.UTILS, e)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NavControllerExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NavControllerExt.kt
@@ -1,0 +1,17 @@
+package com.woocommerce.android.extensions
+
+import androidx.navigation.NavController
+import androidx.navigation.NavDirections
+import androidx.navigation.Navigator
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T
+
+fun NavController.navigateSafely(directions: NavDirections, extras: Navigator.Extras? = null) {
+    try {
+        extras?.let {
+            navigate(directions, it)
+        } ?: navigate(directions)
+    } catch (e: IllegalArgumentException) {
+        WooLog.e(T.UTILS, e)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.extensions.active
 import com.woocommerce.android.extensions.getCommentId
 import com.woocommerce.android.extensions.getRemoteOrderId
 import com.woocommerce.android.extensions.getWooType
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.push.NotificationHandler
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
@@ -717,7 +718,7 @@ class MainActivity : AppUpgradeActivity(),
     override fun showProductDetail(remoteProductId: Long) {
         showBottomNav()
         val action = ProductDetailFragmentDirections.actionGlobalProductDetailFragment(remoteProductId)
-        navController.navigate(action)
+        navController.navigateSafely(action)
     }
 
     override fun showReviewDetail(remoteReviewId: Long, tempStatus: String?) {
@@ -730,7 +731,7 @@ class MainActivity : AppUpgradeActivity(),
         val action = ReviewDetailFragmentDirections.actionGlobalReviewDetailFragment(
                 remoteReviewId,
                 tempStatus)
-        navController.navigate(action)
+        navController.navigateSafely(action)
     }
 
     override fun showOrderDetail(localSiteId: Int, remoteOrderId: Long, remoteNoteId: Long, markComplete: Boolean) {
@@ -753,7 +754,7 @@ class MainActivity : AppUpgradeActivity(),
 
         val orderId = OrderIdentifier(localSiteId, remoteOrderId)
         val action = OrderDetailFragmentDirections.actionGlobalOrderDetailFragment(orderId, remoteNoteId, markComplete)
-        navController.navigate(action)
+        navController.navigateSafely(action)
     }
 
     override fun updateOfflineStatusBar(isConnected: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_DETAIL_TRAC
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_DETAIL_TRACKING_DELETE_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_DETAIL_VIEW_REFUND_DETAILS_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SNACK_ORDER_MARKED_COMPLETE_UNDO_BUTTON_TAPPED
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Refund
 import com.woocommerce.android.model.toAppModel
@@ -290,14 +291,14 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
                 order.number,
                 presenter.isShipmentTrackingsFetched
         )
-        findNavController().navigate(action)
+        findNavController().navigateSafely(action)
     }
 
     override fun issueOrderRefund(order: Order) {
         AnalyticsTracker.track(ORDER_DETAIL_ISSUE_REFUND_BUTTON_TAPPED)
 
         val action = OrderDetailFragmentDirections.actionOrderDetailFragmentToIssueRefund(order.remoteId)
-        findNavController().navigate(action)
+        findNavController().navigateSafely(action)
     }
 
     override fun showRefundDetail(orderId: Long, refundId: Long) {
@@ -307,7 +308,7 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
         ))
 
         val action = OrderDetailFragmentDirections.actionOrderDetailFragmentToRefundDetailFragment(orderId, refundId)
-        findNavController().navigate(action)
+        findNavController().navigateSafely(action)
     }
 
     override fun openOrderProductList(order: WCOrderModel) {
@@ -315,7 +316,7 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
                 order.getIdentifier(),
                 order.number
         )
-        findNavController().navigate(action)
+        findNavController().navigateSafely(action)
     }
 
     override fun openOrderProductDetail(remoteProductId: Long) {
@@ -469,7 +470,7 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
                 order.getIdentifier(),
                 order.number
         )
-        findNavController().navigate(action)
+        findNavController().navigateSafely(action)
     }
 
     override fun showAddOrderNoteErrorSnack() {
@@ -571,7 +572,7 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
                     orderTrackingProvider = AppPrefs.getSelectedShipmentTrackingProviderName(),
                     isCustomProvider = AppPrefs.getIsSelectedShipmentTrackingProviderCustom()
             )
-            findNavController().navigate(action)
+            findNavController().navigateSafely(action)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragment.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_FULFILLMENT_MARK_ORDER_COMPLETE_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_FULFILLMENT_TRACKING_ADD_TRACKING_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_FULFILLMENT_TRACKING_DELETE_BUTTON_TAPPED
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.base.BaseFragment
@@ -214,7 +215,7 @@ class OrderFulfillmentFragment : BaseFragment(), OrderFulfillmentContract.View, 
                             orderTrackingProvider = AppPrefs.getSelectedShipmentTrackingProviderName(),
                             isCustomProvider = AppPrefs.getIsSelectedShipmentTrackingProviderCustom()
                     )
-            findNavController().navigate(action)
+            findNavController().navigateSafely(action)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -29,6 +29,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SETTINGS_PRIVACY_
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SETTINGS_SELECTED_SITE_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SETTINGS_WE_ARE_HIRING_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SETTING_CHANGE
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.sitepicker.SitePickerActivity
 import com.woocommerce.android.util.AnalyticsUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
@@ -155,12 +156,12 @@ class MainSettingsFragment : androidx.fragment.app.Fragment(), MainSettingsContr
 
         textBetaFeatures.setOnClickListener {
             AnalyticsTracker.track(SETTINGS_BETA_FEATURES_BUTTON_TAPPED)
-            findNavController().navigate(R.id.action_mainSettingsFragment_to_betaFeaturesFragment)
+            findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_betaFeaturesFragment)
         }
 
         textPrivacySettings.setOnClickListener {
             AnalyticsTracker.track(SETTINGS_PRIVACY_SETTINGS_BUTTON_TAPPED)
-            findNavController().navigate(R.id.action_mainSettingsFragment_to_privacySettingsFragment)
+            findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_privacySettingsFragment)
         }
 
         textFeatureRequests.setOnClickListener {
@@ -170,12 +171,12 @@ class MainSettingsFragment : androidx.fragment.app.Fragment(), MainSettingsContr
 
         textAbout.setOnClickListener {
             AnalyticsTracker.track(SETTINGS_ABOUT_WOOCOMMERCE_LINK_TAPPED)
-            findNavController().navigate(R.id.action_mainSettingsFragment_to_aboutFragment)
+            findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_aboutFragment)
         }
 
         textLicenses.setOnClickListener {
             AnalyticsTracker.track(SETTINGS_ABOUT_OPEN_SOURCE_LICENSES_LINK_TAPPED)
-            findNavController().navigate(R.id.action_mainSettingsFragment_to_licensesFragment)
+            findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_licensesFragment)
         }
 
         if (presenter.hasMultipleStores()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -24,6 +24,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_SHARE_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_VIEW_AFFILIATE_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_VIEW_EXTERNAL_TAPPED
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.base.BaseFragment
@@ -521,7 +522,7 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
     private fun showProductVariations(remoteId: Long) {
         val action = ProductDetailFragmentDirections
                 .actionProductDetailFragmentToProductVariantsFragment(remoteId)
-        findNavController().navigate(action)
+        findNavController().navigateSafely(action)
     }
 
     /**
@@ -568,6 +569,6 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
     private fun showImageChooser() {
         val action = ProductDetailFragmentDirections
                 .actionProductDetailFragmentToProductImagesFragment(navArgs.remoteProductId)
-        findNavController().navigate(action)
+        findNavController().navigateSafely(action)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundFragment.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.UIMessageResolver
 import javax.inject.Inject
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.refunds.IssueRefundViewModel.IssueRefundEvent.ShowRefundSummary
@@ -84,7 +85,7 @@ class IssueRefundFragment : BaseFragment() {
             when (event) {
                 is ShowRefundSummary -> {
                     val action = IssueRefundFragmentDirections.actionIssueRefundFragmentToRefundSummaryFragment()
-                    findNavController().navigate(action)
+                    findNavController().navigateSafely(action)
                 }
                 else -> event.isHandled = false
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByItemsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByItemsFragment.kt
@@ -10,6 +10,7 @@ import androidx.navigation.navGraphViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.base.BaseFragment
@@ -119,7 +120,7 @@ class RefundByItemsFragment : BaseFragment() {
                             event.refundItem.maxQuantity,
                             event.refundItem.quantity
                     )
-                    findNavController().navigate(action)
+                    findNavController().navigateSafely(action)
                 }
                 is ShowRefundAmountDialog -> {
                     val action = IssueRefundFragmentDirections.actionIssueRefundFragmentToRefundAmountDialog(
@@ -129,7 +130,7 @@ class RefundByItemsFragment : BaseFragment() {
                             BigDecimal.ZERO,
                             event.message
                     )
-                    findNavController().navigate(action)
+                    findNavController().navigateSafely(action)
                 }
                 else -> event.isHandled = false
             }


### PR DESCRIPTION
Fixes #1719 - If a user accidentally causes navigation to happen twice very quickly (for example, by tapping twice on a button), the app may crash with "IllegalArgumentException: navigation destination is unknown to this NavController." This PR resolves this by catching the exception.

Ref: https://blog.jakelee.co.uk/resolving-crash-illegalargumentexception-x-is-unknown-to-this-navcontroller/

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
