### PR TITLE
issue/1709-remember-last-selected-tab-take2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -240,7 +240,12 @@ class MainActivity : AppUpgradeActivity(),
             return
         }
 
-        super.onBackPressed()
+        // if we're not on the dashboard make it active, otherwise allow the OS to leave the app
+        if (bottomNavView.currentPosition != DASHBOARD) {
+            bottomNavView.currentPosition = DASHBOARD
+        } else {
+            super.onBackPressed()
+        }
     }
 
     /**


### PR DESCRIPTION
Closes #1709 - [as discussed here](https://github.com/woocommerce/woocommerce-android/issues/1709#issuecomment-567054754), we've decided to change the back button behavior in the main activity.

Previously, hitting the back button on the main activity would close the app, and the bottom navigation position wouldn't be restored. In this PR, hitting the back button when _not_ viewing the dashboard will navigate to the dashboard. If the dashboard is already active, then the app will close.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
