### PR TITLE
issue/1736-lateinit-exception-order-list 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -177,6 +177,9 @@ class OrderListFragment : TopLevelFragment(),
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        order_list_view.init(currencyFormatter = currencyFormatter, orderListListener = this)
+        order_status_list_view.init(listener = this)
+
         initializeViewModel()
     }
 
@@ -207,9 +210,6 @@ class OrderListFragment : TopLevelFragment(),
                         tab.select()
                     }
                 }
-
-        order_list_view.init(currencyFormatter = currencyFormatter, orderListListener = this)
-        order_status_list_view.init(listener = this)
 
         listState?.let {
             order_list_view.onFragmentRestoreInstanceState(it)


### PR DESCRIPTION
Fixes #1736 - I couldn't reproduce the exact crash, but when I removed `android:configChanges="orientation|screenSize"` from the main activity in the manifest I could cause the  crash every time the order list was active.

So, to test:

* Remove `android:configChanges="orientation|screenSize"`
* Go to the order list and rotate the device
* Ensure the app doesn't go boom

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
