### PR TITLE
Hotfix: Fix UninitializedPropertyAccessException for ordersAdapter

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -177,6 +177,8 @@ class OrderListFragment : TopLevelFragment(),
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        order_list_view.init(currencyFormatter = currencyFormatter, orderListListener = this)
+        order_status_list_view.init(listener = this)
         initializeViewModel()
     }
 
@@ -207,9 +209,6 @@ class OrderListFragment : TopLevelFragment(),
                         tab.select()
                     }
                 }
-
-        order_list_view.init(currencyFormatter = currencyFormatter, orderListListener = this)
-        order_status_list_view.init(listener = this)
 
         listState?.let {
             order_list_view.onFragmentRestoreInstanceState(it)


### PR DESCRIPTION
Fixes #1728  by initializing the order lists in the same lifecycle method as the viewModel initialization. In some scenarios the `onActivityCreated` and `onViewCreated` lifecycle methods may fire in a different order. The order status list is populated when the viewModel is initialized so if the associated ordersAdapter hasn't been initialized we'll see this failure. I wasn't able to replicate this crash, but I'm 98.99% certain this was the problem and so handling the initialization of the lists and viewModel in the same lifecycle method should resolve the issue.

## To Test
- load the orders list, switching to search and filtering by a status. There should be no crash.
- Close the app and open a new order notification. Rotate the device. Click back to go back to the order list. There should be no crash.

**Note**: this is a hotfix. Please notify me when this is merged so I can cut another beta release binary.