### PR TITLE
Dark Mode - Step 1 - Base theme and style configurations

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -125,7 +125,7 @@ dependencies {
     implementation "androidx.recyclerview:recyclerview:1.1.0"
     implementation "androidx.multidex:multidex:2.0.1"
     implementation "androidx.appcompat:appcompat:1.1.0"
-    implementation "com.google.android.material:material:1.2.0-alpha02"
+    implementation "com.google.android.material:material:1.1.0-rc01"
     implementation "androidx.cardview:cardview:1.0.0"
     implementation "androidx.browser:browser:1.0.0"
     implementation "androidx.preference:preference:1.1.0"

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -125,7 +125,7 @@ dependencies {
     implementation "androidx.recyclerview:recyclerview:1.1.0"
     implementation "androidx.multidex:multidex:2.0.1"
     implementation "androidx.appcompat:appcompat:1.1.0"
-    implementation "com.google.android.material:material:1.0.0"
+    implementation "com.google.android.material:material:1.2.0-alpha02"
     implementation "androidx.cardview:cardview:1.0.0"
     implementation "androidx.browser:browser:1.0.0"
     implementation "androidx.preference:preference:1.1.0"

--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
         android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/Theme.Woo.DayNight">
 
         <!-- TODO: we eventually want to drop support for Apache, but for now it's used by FluxC -->
         <uses-library android:name="org.apache.http.legacy" android:required="false"/>
@@ -46,7 +46,7 @@
 
         <activity
             android:name=".ui.sitepicker.SitePickerActivity"
-            android:theme="@style/AppTheme.Base"/>
+            android:theme="@style/Theme.Woo.DayNight"/>
 
         <activity android:name=".ui.login.MagicLinkInterceptActivity">
             <intent-filter>
@@ -60,16 +60,18 @@
         </activity>
 
         <activity
-            android:name=".ui.prefs.AppSettingsActivity"/>
+            android:name=".ui.prefs.AppSettingsActivity"
+            android:theme="@style/Theme.Woo.DayNight"/>
 
         <activity
             android:label="@string/logviewer_activity_title"
-            android:name=".support.WooLogViewerActivity"/>
+            android:name=".support.WooLogViewerActivity"
+            android:theme="@style/Theme.Woo.DayNight"/>
 
         <activity
             android:name=".support.HelpActivity"
             android:label="@string/support_help"
-            android:theme="@style/AppTheme" />
+            android:theme="@style/Theme.Woo.DayNight" />
 
         <activity
             android:name=".ui.imageviewer.ImageViewerActivity"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SupportHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SupportHelper.kt
@@ -37,7 +37,7 @@ class SupportHelper {
         val (layout, emailEditText, nameEditText) =
                 supportIdentityInputDialogLayout(context, isNameInputHidden, email, name)
 
-        val dialog = AlertDialog.Builder(ContextThemeWrapper(context, style.AppTheme))
+        val dialog = AlertDialog.Builder(ContextThemeWrapper(context, style.Theme_Woo_DayNight))
                 .setView(layout)
                 .setPositiveButton(android.R.string.ok, null)
                 .setNegativeButton(android.R.string.cancel, null)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.base
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.StringRes
+import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.R
 
@@ -104,8 +105,10 @@ interface UIMessageResolver {
      * @param [stringResId] The string resource id of the base message
      * @param [stringArgs] Optional. One or more format argument stringArgs
      */
+    // BaseTransientBottomBar.LENGTH_LONG is pointing to Snackabr.LENGTH_LONG which confuses checkstyle
+    @Suppress("WrongConstant")
     fun getSnack(@StringRes stringResId: Int, vararg stringArgs: String = arrayOf()) = Snackbar.make(
-            snackbarRoot, snackbarRoot.context.getString(stringResId, *stringArgs), Snackbar.LENGTH_LONG)
+            snackbarRoot, snackbarRoot.context.getString(stringResId, *stringArgs), BaseTransientBottomBar.LENGTH_LONG)
 
     /**
      * Display a snackbar with the provided message.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
@@ -15,6 +15,8 @@ import com.woocommerce.android.R
  *
  * @see com.woocommerce.android.ui.main.MainUIMessageResolver
  */
+// BaseTransientBottomBar.LENGTH_LONG is pointing to Snackabr.LENGTH_LONG which confuses checkstyle
+@Suppress("WrongConstant")
 interface UIMessageResolver {
     /**
      * Set by the implementing class. This is the root view the snackbar should be attached to. To enable
@@ -105,8 +107,6 @@ interface UIMessageResolver {
      * @param [stringResId] The string resource id of the base message
      * @param [stringArgs] Optional. One or more format argument stringArgs
      */
-    // BaseTransientBottomBar.LENGTH_LONG is pointing to Snackabr.LENGTH_LONG which confuses checkstyle
-    @Suppress("WrongConstant")
     fun getSnack(@StringRes stringResId: Int, vararg stringArgs: String = arrayOf()) = Snackbar.make(
             snackbarRoot, snackbarRoot.context.getString(stringResId, *stringArgs), BaseTransientBottomBar.LENGTH_LONG)
 
@@ -115,33 +115,35 @@ interface UIMessageResolver {
      *
      * @param [msg] The message to display in the snackbar
      */
-    fun showSnack(msg: String) = Snackbar.make(snackbarRoot, msg, Snackbar.LENGTH_LONG).show()
+    fun showSnack(msg: String) = Snackbar.make(snackbarRoot, msg, BaseTransientBottomBar.LENGTH_LONG).show()
 
     /**
      * Display a snackbar with the provided string resource.
      *
      * @param [msgId] The resource ID of the message to display in the snackbar
      */
-    fun showSnack(@StringRes msgId: Int) = Snackbar.make(snackbarRoot, msgId, Snackbar.LENGTH_LONG).show()
+    fun showSnack(@StringRes msgId: Int) = Snackbar.make(snackbarRoot, msgId, BaseTransientBottomBar.LENGTH_LONG).show()
 
     /**
      * Display a generic offline message.
      */
-    fun showOfflineSnack() = Snackbar
-            .make(snackbarRoot, snackbarRoot.context.getString(R.string.offline_error), Snackbar.LENGTH_LONG)
-            .show()
+    fun showOfflineSnack() = Snackbar.make(
+            snackbarRoot,
+            snackbarRoot.context.getString(R.string.offline_error),
+            BaseTransientBottomBar.LENGTH_LONG
+    ).show()
 
     private fun getIndefiniteSnackbarWithAction(
         view: View,
         msg: String,
         actionString: String,
         actionListener: View.OnClickListener
-    ) = Snackbar.make(view, msg, Snackbar.LENGTH_INDEFINITE).setAction(actionString, actionListener)
+    ) = Snackbar.make(view, msg, BaseTransientBottomBar.LENGTH_INDEFINITE).setAction(actionString, actionListener)
 
     private fun getSnackbarWithAction(
         view: View,
         msg: String,
         actionString: String,
         actionListener: View.OnClickListener
-    ) = Snackbar.make(view, msg, Snackbar.LENGTH_LONG).setAction(actionString, actionListener)
+    ) = Snackbar.make(view, msg, BaseTransientBottomBar.LENGTH_LONG).setAction(actionString, actionListener)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/imageviewer/ImageViewerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/imageviewer/ImageViewerActivity.kt
@@ -226,7 +226,7 @@ class ImageViewerActivity : AppCompatActivity(), ImageViewerListener {
      */
     private fun confirmRemoveProductImage() {
         isConfirmationShowing = true
-        confirmationDialog = AlertDialog.Builder(ContextThemeWrapper(this, style.AppTheme))
+        confirmationDialog = AlertDialog.Builder(ContextThemeWrapper(this, style.Theme_Woo_DayNight))
                 .setMessage(R.string.product_image_remove_confirmation)
                 .setCancelable(true)
                 .setPositiveButton(R.string.remove) { _, _ ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
@@ -15,6 +15,7 @@ import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
+import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
@@ -209,6 +210,8 @@ class LoginNoJetpackFragment : Fragment() {
         setupObservers()
     }
 
+    // BaseTransientBottomBar.LENGTH_LONG is pointing to Snackabr.LENGTH_LONG which confuses checkstyle
+    @Suppress("WrongConstant")
     private fun setupObservers() {
         viewModel.isLoading.observe(this, Observer {
             showProgressDialog(it)
@@ -220,7 +223,7 @@ class LoginNoJetpackFragment : Fragment() {
                 redirectToSiteCredentialsScreen()
             } else {
                 view?.let { Snackbar.make(
-                        it, getString(R.string.login_jetpack_not_found), Snackbar.LENGTH_LONG
+                        it, getString(R.string.login_jetpack_not_found), BaseTransientBottomBar.LENGTH_LONG
                 ).show() }
             }
         })

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/MagicLinkInterceptFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/MagicLinkInterceptFragment.kt
@@ -12,6 +12,7 @@ import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
+import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -96,6 +97,8 @@ class MagicLinkInterceptFragment : Fragment() {
         authToken?.let { viewModel.updateMagicLinkAuthToken(it) }
     }
 
+    // BaseTransientBottomBar.LENGTH_LONG is pointing to Snackabr.LENGTH_LONG which confuses checkstyle
+    @Suppress("WrongConstant")
     private fun setupObservers() {
         viewModel.isLoading.observe(this, Observer {
             showProgressDialog(it)
@@ -109,7 +112,7 @@ class MagicLinkInterceptFragment : Fragment() {
 
         viewModel.showSnackbarMessage.observe(this, Observer { messageId ->
             view?.let {
-                Snackbar.make(it, getString(messageId), Snackbar.LENGTH_LONG).show()
+                Snackbar.make(it, getString(messageId), BaseTransientBottomBar.LENGTH_LONG).show()
             }
         })
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderTrackingProviderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderTrackingProviderListFragment.kt
@@ -12,6 +12,7 @@ import androidx.appcompat.widget.SearchView.OnQueryTextListener
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.DialogFragment
+import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -172,12 +173,14 @@ class AddOrderTrackingProviderListFragment : DialogFragment(), AddOrderTrackingP
         }
     }
 
+    // BaseTransientBottomBar.LENGTH_LONG is pointing to Snackabr.LENGTH_LONG which confuses checkstyle
+    @Suppress("WrongConstant")
     override fun showProviderListErrorSnack(@StringRes stringResId: Int) {
         dialog?.window?.let {
             Snackbar.make(
                     it.findViewById(android.R.id.content),
                     stringResId,
-                    Snackbar.LENGTH_LONG
+                    BaseTransientBottomBar.LENGTH_LONG
             ).show()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderTrackingProviderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderTrackingProviderListFragment.kt
@@ -73,7 +73,7 @@ class AddOrderTrackingProviderListFragment : DialogFragment(), AddOrderTrackingP
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         listener = targetFragment as AddOrderTrackingProviderActionListener
-        setStyle(STYLE_NORMAL, R.style.AppTheme)
+        setStyle(STYLE_NORMAL, R.style.Theme_Woo_DayNight)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
@@ -9,6 +9,7 @@ import androidx.appcompat.view.ContextThemeWrapper
 import androidx.appcompat.widget.Toolbar
 import androidx.navigation.findNavController
 import androidx.preference.PreferenceManager
+import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
@@ -101,6 +102,8 @@ class AppSettingsActivity : AppCompatActivity(),
      * User switched sites from the main settings fragment, set the result code so the calling activity
      * will know the site changed
      */
+    // BaseTransientBottomBar.LENGTH_LONG is pointing to Snackabr.LENGTH_LONG which confuses checkstyle
+    @Suppress("WrongConstant")
     override fun onSiteChanged() {
         siteChanged = true
         setResult(RESULT_CODE_SITE_CHANGED)
@@ -112,7 +115,7 @@ class AppSettingsActivity : AppCompatActivity(),
             Snackbar.make(
                     main_content,
                     getString(R.string.settings_switch_site_notifs_msg, it.name),
-                    Snackbar.LENGTH_LONG
+                    BaseTransientBottomBar.LENGTH_LONG
             ).show()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
@@ -162,7 +162,7 @@ class AppSettingsActivity : AppCompatActivity(),
                 getString(R.string.settings_confirm_logout),
                 presenter.getAccountDisplayName()
         )
-        AlertDialog.Builder(ContextThemeWrapper(this, R.style.AppTheme))
+        AlertDialog.Builder(ContextThemeWrapper(this, R.style.Theme_Woo_DayNight))
                 .setMessage(message)
                 .setPositiveButton(R.string.signout) { _, _ ->
                     AnalyticsTracker.track(Stat.SETTINGS_LOGOUT_CONFIRMATION_DIALOG_RESULT, mapOf(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -19,6 +19,7 @@ import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
@@ -366,6 +367,8 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         WooUpgradeRequiredDialog().show(supportFragmentManager)
     }
 
+    // BaseTransientBottomBar.LENGTH_LONG is pointing to Snackabr.LENGTH_LONG which confuses checkstyle
+    @Suppress("WrongConstant")
     override fun siteVerificationError(site: SiteModel) {
         progressDialog?.dismiss()
 
@@ -373,7 +376,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         Snackbar.make(
                 site_picker_root as ViewGroup,
                 getString(R.string.login_verifying_site_error, siteName),
-                Snackbar.LENGTH_LONG
+                BaseTransientBottomBar.LENGTH_LONG
         ).show()
     }
 

--- a/WooCommerce/src/main/res/color/color_on_primary_surface_emphasis_disabled.xml
+++ b/WooCommerce/src/main/res/color/color_on_primary_surface_emphasis_disabled.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="?attr/colorOnPrimarySurface" android:alpha="?attr/emphasisDisabledAlphaPrimary" />
+</selector>

--- a/WooCommerce/src/main/res/color/color_on_primary_surface_emphasis_high.xml
+++ b/WooCommerce/src/main/res/color/color_on_primary_surface_emphasis_high.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="?attr/colorOnPrimarySurface" android:alpha="?attr/emphasisHighAlphaPrimary" />
+</selector>

--- a/WooCommerce/src/main/res/color/color_on_primary_surface_emphasis_medium.xml
+++ b/WooCommerce/src/main/res/color/color_on_primary_surface_emphasis_medium.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="?attr/colorOnPrimarySurface" android:alpha="?attr/emphasisMediumAlphaPrimary" />
+</selector>

--- a/WooCommerce/src/main/res/color/color_on_surface_emphasis_disabled.xml
+++ b/WooCommerce/src/main/res/color/color_on_surface_emphasis_disabled.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="?attr/colorOnSurface" android:alpha="?attr/emphasisDisabledAlpha" />
+</selector>

--- a/WooCommerce/src/main/res/color/color_on_surface_emphasis_high.xml
+++ b/WooCommerce/src/main/res/color/color_on_surface_emphasis_high.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="?attr/colorOnSurface" android:alpha="?attr/emphasisHighAlpha" />
+</selector>

--- a/WooCommerce/src/main/res/color/color_on_surface_emphasis_medium.xml
+++ b/WooCommerce/src/main/res/color/color_on_surface_emphasis_medium.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="?attr/colorOnSurface" android:alpha="?attr/emphasisMediumAlpha" />
+</selector>

--- a/WooCommerce/src/main/res/font/roboto_light.xml
+++ b/WooCommerce/src/main/res/font/roboto_light.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<font-family xmlns:app="http://schemas.android.com/apk/res-auto"
+        app:fontProviderAuthority="com.google.android.gms.fonts"
+        app:fontProviderPackage="com.google.android.gms"
+        app:fontProviderQuery="name=Roboto&amp;weight=300"
+        app:fontProviderCerts="@array/com_google_android_gms_fonts_certs">
+</font-family>

--- a/WooCommerce/src/main/res/layout/view_toolbar.xml
+++ b/WooCommerce/src/main/res/layout/view_toolbar.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.appcompat.widget.Toolbar
+<com.google.android.material.appbar.MaterialToolbar
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="?attr/actionBarSize"
-    android:background="?attr/colorPrimary"
-    android:elevation="@dimen/appbar_elevation"
-    style="@style/ToolbarTheme"/>
+    android:layout_height="?attr/actionBarSize"/>

--- a/WooCommerce/src/main/res/values-night/themes.xml
+++ b/WooCommerce/src/main/res/values-night/themes.xml
@@ -5,6 +5,35 @@
     <style name="Theme.Woo.DayNight" parent="Theme.Woo.Dark"/>
 
     <style name="Theme.Woo.Dark" parent="Theme.Woo">
-        <!-- Override dark colors -->
+        <!-- Color -->
+        <item name="colorPrimary">@color/woo_purple_30</item>
+        <item name="colorPrimaryVariant">@color/woo_purple_50</item>
+        <item name="colorSecondary">@color/woo_pink_30</item>
+        <item name="colorSecondaryVariant">@color/woo_pink_50</item>
+
+        <item name="android:colorBackground">@color/woo_black_90</item>
+        <item name="colorSurface">@color/woo_black_90</item>
+        <item name="colorError">@color/woo_red_30</item>
+
+        <item name="colorOnPrimary">@color/woo_black</item>
+        <item name="colorOnSecondary">@color/woo_black</item>
+        <item name="colorOnBackground">@color/woo_white</item>
+        <item name="colorOnSurface">@color/woo_white</item>
+        <item name="colorOnError">@color/woo_black</item>
+
+        <item name="scrimBackground">@color/woo_black_90_alpha_087</item>
+        <item name="android:statusBarColor">@color/woo_black_90_alpha_038</item>
+
+        <item name="elevationOverlayEnabled">true</item>
+
+        <!-- Custom attrs for setting alpha values -->
+        <item name="emphasisHighAlpha">0.87</item>
+        <item name="emphasisMediumAlpha">0.60</item>
+        <item name="emphasisDisabledAlpha">0.38</item>
+
+        <item name="toolbarStyle">@style/Widget.MaterialComponents.Toolbar.Surface</item>
+
+        <!--System/Platform attributes-->
+        <item name="android:windowLightStatusBar" tools:ignore="NewApi">false</item>
     </style>
 </resources>

--- a/WooCommerce/src/main/res/values-night/themes.xml
+++ b/WooCommerce/src/main/res/values-night/themes.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- Final top-level theme -->
+    <style name="Theme.Woo.DayNight" parent="Theme.Woo.Dark"/>
+
+    <style name="Theme.Woo.Dark" parent="Theme.Woo">
+        <!-- Override dark colors -->
+    </style>
+</resources>

--- a/WooCommerce/src/main/res/values/alphas.xml
+++ b/WooCommerce/src/main/res/values/alphas.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <fraction name="alpha_plane_00">0.00</fraction>
+    <fraction name="alpha_plane_01">0.05</fraction>
+    <fraction name="alpha_plane_02">0.07</fraction>
+    <fraction name="alpha_plane_03">0.08</fraction>
+    <fraction name="alpha_plane_04">0.09</fraction>
+    <fraction name="alpha_plane_06">0.11</fraction>
+    <fraction name="alpha_plane_08">0.12</fraction>
+    <fraction name="alpha_plane_12">0.14</fraction>
+    <fraction name="alpha_plane_16">0.14</fraction>
+    <fraction name="alpha_plane_24">0.16</fraction>
+</resources>

--- a/WooCommerce/src/main/res/values/attrs.xml
+++ b/WooCommerce/src/main/res/values/attrs.xml
@@ -65,4 +65,7 @@
     <attr name="emphasisHighAlpha" format="float"/>
     <attr name="emphasisMediumAlpha" format="float"/>
     <attr name="emphasisDisabledAlpha" format="float"/>
+    <attr name="emphasisHighAlphaPrimary" format="float"/>
+    <attr name="emphasisMediumAlphaPrimary" format="float"/>
+    <attr name="emphasisDisabledAlphaPrimary" format="float"/>
 </resources>

--- a/WooCommerce/src/main/res/values/attrs.xml
+++ b/WooCommerce/src/main/res/values/attrs.xml
@@ -57,4 +57,12 @@
         <!-- Required: string text of title -->
         <attr name="aevTitle" format="string"/>
     </declare-styleable>
+
+    <!--
+    Emphasis values are used in combination with each "on" color to create
+    three available levels of emphasis for text and content.
+    -->
+    <attr name="emphasisHighAlpha" format="float"/>
+    <attr name="emphasisMediumAlpha" format="float"/>
+    <attr name="emphasisDisabledAlpha" format="float"/>
 </resources>

--- a/WooCommerce/src/main/res/values/attrs.xml
+++ b/WooCommerce/src/main/res/values/attrs.xml
@@ -17,7 +17,7 @@
         <attr name="tagBorderColor" format="reference|color"/>
     </declare-styleable>
 
-    <declare-styleable name="AppTheme">
+    <declare-styleable name="WooTheme">
         <attr name="tagViewStyle" format="reference"/>
         <attr name="flowLayoutStyle" format="reference"/>
     </declare-styleable>

--- a/WooCommerce/src/main/res/values/colors.xml
+++ b/WooCommerce/src/main/res/values/colors.xml
@@ -1,180 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">@color/wc_purple</color>
-    <color name="colorPrimaryDark">@color/wc_purple_status</color>
-    <color name="colorAccent">@color/wc_purple</color>
-    <!--
-        Default Colors
-    -->
-    <color name="default_window_background">#f7f7f7</color>
-    <color name="default_text_color">@color/wc_grey_dark</color>
-    <color name="default_button_fg_color">@color/colorPrimary</color>
-    <color name="default_text_label_color">@color/colorPrimary</color>
-    <color name="default_card_heading_color">@color/colorPrimary</color>
-    <!--
-        General Color Definitions
-    -->
-    <!-- Primary Greys -->
-    <!-- TODO: Consolidate with rest of wc_greys -->
-    <color name="wc_grey">#999999</color>
-    <color name="wc_grey_darker">#787878</color>
-    <color name="wc_grey_darkest">#2a2a2a</color>
-    <color name="wc_grey_lightest">#f7f7f7</color>
-    <color name="grey_dark_highlight">#333333</color>
+    <color name="woo_purple_30">#B17FD4</color>
+    <color name="woo_purple_50">#7F54B3</color>
+    <color name="woo_purple_60">#674399</color>
+    <color name="woo_purple_80">#3C2861</color>
 
-    <!-- Primary Greens -->
-    <color name="wc_green_light">#d1dcc7</color>
-    <color name="wc_green_lightest">#e9f4db</color>
+    <color name="woo_pink_30">#EB6594</color>
+    <color name="woo_pink_50">#C9356E</color>
+    <color name="woo_pink_70">#8C1749</color>
 
-    <!-- Primary Reds -->
-    <color name="wc_red">#ff0000</color>
-    <color name="wc_red_light">#febdbb</color>
-    <color name="wc_red_lightest">#fededd</color>
+    <color name="woo_red_30">#F86368</color>
+    <color name="woo_red_50">#D63638</color>
 
-    <!-- Primary Blues -->
-    <color name="wc_blue_light">#BCDEEE</color>
-    <color name="wc_blue_lightest">#e8f2f9</color>
+    <color name="woo_white">@android:color/white</color>
+    <color name="woo_white_alpha_038">#61FFFFFF</color>
 
-    <!-- STUDIO 2.0.0 -->
-    <color name="blue_50">#2271b1</color>
-    <color name="black_85">#de000000</color>
+    <color name="woo_black">@android:color/black</color>
+    <color name="woo_black_90">#121212</color>
+    <color name="woo_black_90_alpha_020">#33121212</color>
+    <color name="woo_black_90_alpha_038">#61121212</color>
+    <color name="woo_black_90_alpha_087">#DE121212</color>
 
     <!--
-        Default Global Colors
+        Nav bar color protection for behavior differences between Android P and Q. All sdk
+        levels should draw fullscreen. P should color the nav bar with a translucent background
+        to guard for contrast. Q should have a transparent nav bar as Q will automatically
+        handles contrast by either dynamically coloring the nav bar handle (gesture nav)
+        or automatically applying a translucent background (3-button mode).
     -->
-    <color name="default_window_bg">@color/wc_border_color</color>
-    <color name="default_text">@color/wc_grey_dark</color>
-    <color name="default_text_title">@color/grey_dark_highlight</color>
-    <color name="default_text_title_disabled">@color/wc_grey_17</color>
-    <color name="default_search_hint_text">#c5adc3</color>
-    <!--
-        Default Widget Color Definitions
-    -->
-    <!-- Menu Text Colors -->
-    <color name="menu_title_text">#FFFFFFFF</color>
-    <color name="menu_action_text">#FFFFFFFF</color>
-
-    <!-- Default Card colors -->
-    <color name="card_bgColor">@color/white</color>
-    <color name="card_title_text">@color/default_text_title</color>
-    <color name="card_label_text">@color/default_text_label_color</color>
-    <color name="card_normal_text">@color/default_text_color</color>
-
-    <!-- Tag View default colors -->
-    <color name="tagView_bgColor">#d2d2d2</color>
-    <color name="tagView_fgColor">#a7a7a7</color>
-
-    <!-- Default List colors -->
-    <color name="list_divider">@color/wc_border_color</color>
-    <color name="list_item_text">@color/default_text</color>
-    <color name="list_item_text_title">@color/default_text_title</color>
-    <color name="list_item_bg">@color/white</color>
-    <color name="List_header_text">@color/wc_grey_mid</color>
-    <color name="list_header_bg">@color/wc_grey_light</color>
-    <color name="list_header_border">@color/wc_grey_17</color>
-
-    <!-- Default Tag colors -->
-    <color name="tagView_bg">@color/wc_border_color</color>
-    <color name="tagView_text">@color/default_text_title</color>
-    <color name="tagView_border_bg">@color/wc_grey_darker</color>
-
-    <!-- Default Edit Text -->
-    <color name="edit_text_color_control_activated">@color/grey_dark_highlight</color>
-    <color name="edit_text_color_control_highlight">@color/grey_dark_highlight</color>
-    <color name="edit_text_color_control_normal">@color/wc_grey_39</color>
-    <color name="edit_text_label_text_color">@color/wc_grey_dark</color>
-    <color name="edit_text_text_color">@color/wc_grey_dark</color>
-    <color name="edit_text_text_color_highlight">@color/wc_purple_highlight</color>
-    <color name="edit_text_text_hint_color">@color/wc_grey_dark</color>
-
-    <!-- Default Link Color -->
-    <color name="link_text_color">@color/wc_purple</color>
-
-    <!--
-        Bottom Navigation Bar
-    -->
-    <!-- Bar Background color -->
-    <color name="bottomBar_bg">@color/white</color>
-    <!-- Option icon/text color when NOT selected -->
-    <color name="bottomBar_fg_normal">@color/wc_grey_darker</color>
-    <!-- Option icon/text color when selected -->
-    <color name="bottomBar_fg_checked">@color/colorPrimary</color>
-    <!--
-        Default graph colors
-    -->
-    <color name="graph_no_data_text_color">@color/default_text_color</color>
-    <color name="graph_data_color">@color/wc_grey_mid</color>
-    <color name="graph_grid_color">@color/wc_border_color</color>
-    <color name="graph_highlight_color">@color/wc_purple</color>
-    <!--
-        Order: status tag background colors
-    -->
-    <color name="orderStatus_processing_text">@color/tagView_text</color>
-    <color name="orderStatus_processing_bg">@color/wc_green_lightest</color>
-    <color name="orderStatus_processing_border">@color/wc_green_light</color>
-
-    <color name="orderStatus_pending_text">@color/tagView_text</color>
-    <color name="orderStatus_pending_bg">@color/wc_green_lightest</color>
-    <color name="orderStatus_pending_border">@color/wc_green_light</color>
-
-    <color name="orderStatus_failed_text">@color/tagView_text</color>
-    <color name="orderStatus_failed_bg">@color/wc_red_lightest</color>
-    <color name="orderStatus_failed_border">@color/wc_red_light</color>
-
-    <color name="orderStatus_completed_text">@color/tagView_text</color>
-    <color name="orderStatus_completed_bg">@color/wc_blue_lightest</color>
-    <color name="orderStatus_completed_border">@color/wc_blue_light</color>
-
-    <color name="orderStatus_hold_text">@color/tagView_text</color>
-    <color name="orderStatus_hold_bg">@color/wc_border_color</color>
-    <color name="orderStatus_hold_border">@color/wc_grey_17</color>
-
-    <color name="orderStatus_cancelled_text">@color/tagView_text</color>
-    <color name="orderStatus_cancelled_bg">@color/wc_border_color</color>
-    <color name="orderStatus_cancelled_border">@color/wc_grey_17</color>
-
-    <color name="orderStatus_refunded_text">@color/tagView_text</color>
-    <color name="orderStatus_refunded_bg">@color/wc_red_lightest</color>
-    <color name="orderStatus_refunded_border">@color/wc_red_light</color>
-    <!--
-        Order: Order note icon colors
-    -->
-    <color name="orderNote_private">@color/wc_grey</color>
-    <color name="orderNote_public">@color/wc_blue_light</color>
-    <color name="orderNote_system">@color/wc_purple</color>
-
-    <!-- Login -->
-    <!-- Login uses snake_case instead of CamelCase for the main color palette,
-    this makes sure they're not used accidentally -->
-    <color name="color_primary">@color/colorPrimary</color>
-    <color name="color_primary_dark">@color/colorPrimaryDark</color>
-    <color name="color_accent">@color/colorAccent</color>
-
-    <color name="status_bar">@color/colorPrimaryDark</color>
-    <color name="login_theme_accent_color">@color/colorAccent</color>
-    <color name="login_background_color">@color/wc_grey_light</color>
-
-    <color name="login_toolbar_color">@color/colorPrimary</color>
-    <color name="login_primary_button_normal_color">@color/colorAccent</color>
-    <color name="login_primary_button_text_color">@color/white</color>
-    <color name="login_secondary_button_text_color">@color/colorPrimary</color>
-    <color name="login_google_button_text_color">@color/colorPrimary</color>
-    <color name="login_text_label_text_color">@color/edit_text_label_text_color</color>
-    <color name="login_input_label_static_text_color">@color/wc_grey_39</color>
-    <color name="login_edit_text_color_control_normal">@color/edit_text_color_control_normal</color>
-    <color name="login_edit_text_color_control_activated">@color/edit_text_color_control_activated</color>
-    <color name="login_edit_text_color_control_highlight">@color/edit_text_color_control_highlight</color>
-    <color name="login_edit_text_text_color">@color/edit_text_text_color</color>
-    <color name="login_edit_text_text_hint_color">@color/edit_text_text_hint_color</color>
-    <color name="login_heading_text_color">@color/wc_grey_17</color>
-    <color name="login_subhead_text_color">@color/wc_grey_dark</color>
-    <color name="login_username_text_color">@color/wc_grey_17</color>
-    <color name="login_footnote_text_color">@color/wc_grey_dark</color>
-
-    <color name="login_input_icon_color">@color/wc_grey_30</color>
-    <color name="login_input_password_icon_color">@color/wc_grey_30</color>
-    <color name="login_notification_accent_color">@color/colorPrimary</color>
-
-    <color name="skeleton_color">#16000000</color>
-    <color name="skeleton_color_light">@color/white</color>
+    <color name="nav_bar">@color/woo_black_90_alpha_020</color>
 </resources>

--- a/WooCommerce/src/main/res/values/colors_old.xml
+++ b/WooCommerce/src/main/res/values/colors_old.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="colorPrimary">@color/wc_purple</color>
+    <color name="colorPrimaryDark">@color/wc_purple_status</color>
+    <color name="colorAccent">@color/wc_purple</color>
+    <!--
+        Default Colors
+    -->
+    <color name="default_window_background">#f7f7f7</color>
+    <color name="default_text_color">@color/wc_grey_dark</color>
+    <color name="default_button_fg_color">@color/colorPrimary</color>
+    <color name="default_text_label_color">@color/colorPrimary</color>
+    <color name="default_card_heading_color">@color/colorPrimary</color>
+    <!--
+        General Color Definitions
+    -->
+    <!-- Primary Greys -->
+    <!-- TODO: Consolidate with rest of wc_greys -->
+    <color name="wc_grey">#999999</color>
+    <color name="wc_grey_darker">#787878</color>
+    <color name="wc_grey_darkest">#2a2a2a</color>
+    <color name="wc_grey_lightest">#f7f7f7</color>
+    <color name="grey_dark_highlight">#333333</color>
+
+    <!-- Primary Greens -->
+    <color name="wc_green_light">#d1dcc7</color>
+    <color name="wc_green_lightest">#e9f4db</color>
+
+    <!-- Primary Reds -->
+    <color name="wc_red">#ff0000</color>
+    <color name="wc_red_light">#febdbb</color>
+    <color name="wc_red_lightest">#fededd</color>
+
+    <!-- Primary Blues -->
+    <color name="wc_blue_light">#BCDEEE</color>
+    <color name="wc_blue_lightest">#e8f2f9</color>
+
+    <!-- STUDIO 2.0.0 -->
+    <color name="blue_50">#2271b1</color>
+    <color name="black_85">#de000000</color>
+
+    <!--
+        Default Global Colors
+    -->
+    <color name="default_window_bg">@color/wc_border_color</color>
+    <color name="default_text">@color/wc_grey_dark</color>
+    <color name="default_text_title">@color/grey_dark_highlight</color>
+    <color name="default_text_title_disabled">@color/wc_grey_17</color>
+    <color name="default_search_hint_text">#c5adc3</color>
+    <!--
+        Default Widget Color Definitions
+    -->
+    <!-- Menu Text Colors -->
+    <color name="menu_title_text">#FFFFFFFF</color>
+    <color name="menu_action_text">#FFFFFFFF</color>
+
+    <!-- Default Card colors -->
+    <color name="card_bgColor">@color/white</color>
+    <color name="card_title_text">@color/default_text_title</color>
+    <color name="card_label_text">@color/default_text_label_color</color>
+    <color name="card_normal_text">@color/default_text_color</color>
+
+    <!-- Tag View default colors -->
+    <color name="tagView_bgColor">#d2d2d2</color>
+    <color name="tagView_fgColor">#a7a7a7</color>
+
+    <!-- Default List colors -->
+    <color name="list_divider">@color/wc_border_color</color>
+    <color name="list_item_text">@color/default_text</color>
+    <color name="list_item_text_title">@color/default_text_title</color>
+    <color name="list_item_bg">@color/white</color>
+    <color name="List_header_text">@color/wc_grey_mid</color>
+    <color name="list_header_bg">@color/wc_grey_light</color>
+    <color name="list_header_border">@color/wc_grey_17</color>
+
+    <!-- Default Tag colors -->
+    <color name="tagView_bg">@color/wc_border_color</color>
+    <color name="tagView_text">@color/default_text_title</color>
+    <color name="tagView_border_bg">@color/wc_grey_darker</color>
+
+    <!-- Default Edit Text -->
+    <color name="edit_text_color_control_activated">@color/grey_dark_highlight</color>
+    <color name="edit_text_color_control_highlight">@color/grey_dark_highlight</color>
+    <color name="edit_text_color_control_normal">@color/wc_grey_39</color>
+    <color name="edit_text_label_text_color">@color/wc_grey_dark</color>
+    <color name="edit_text_text_color">@color/wc_grey_dark</color>
+    <color name="edit_text_text_color_highlight">@color/wc_purple_highlight</color>
+    <color name="edit_text_text_hint_color">@color/wc_grey_dark</color>
+
+    <!-- Default Link Color -->
+    <color name="link_text_color">@color/wc_purple</color>
+
+    <!--
+        Bottom Navigation Bar
+    -->
+    <!-- Bar Background color -->
+    <color name="bottomBar_bg">@color/white</color>
+    <!-- Option icon/text color when NOT selected -->
+    <color name="bottomBar_fg_normal">@color/wc_grey_darker</color>
+    <!-- Option icon/text color when selected -->
+    <color name="bottomBar_fg_checked">@color/colorPrimary</color>
+    <!--
+        Default graph colors
+    -->
+    <color name="graph_no_data_text_color">@color/default_text_color</color>
+    <color name="graph_data_color">@color/wc_grey_mid</color>
+    <color name="graph_grid_color">@color/wc_border_color</color>
+    <color name="graph_highlight_color">@color/wc_purple</color>
+    <!--
+        Order: status tag background colors
+    -->
+    <color name="orderStatus_processing_text">@color/tagView_text</color>
+    <color name="orderStatus_processing_bg">@color/wc_green_lightest</color>
+    <color name="orderStatus_processing_border">@color/wc_green_light</color>
+
+    <color name="orderStatus_pending_text">@color/tagView_text</color>
+    <color name="orderStatus_pending_bg">@color/wc_green_lightest</color>
+    <color name="orderStatus_pending_border">@color/wc_green_light</color>
+
+    <color name="orderStatus_failed_text">@color/tagView_text</color>
+    <color name="orderStatus_failed_bg">@color/wc_red_lightest</color>
+    <color name="orderStatus_failed_border">@color/wc_red_light</color>
+
+    <color name="orderStatus_completed_text">@color/tagView_text</color>
+    <color name="orderStatus_completed_bg">@color/wc_blue_lightest</color>
+    <color name="orderStatus_completed_border">@color/wc_blue_light</color>
+
+    <color name="orderStatus_hold_text">@color/tagView_text</color>
+    <color name="orderStatus_hold_bg">@color/wc_border_color</color>
+    <color name="orderStatus_hold_border">@color/wc_grey_17</color>
+
+    <color name="orderStatus_cancelled_text">@color/tagView_text</color>
+    <color name="orderStatus_cancelled_bg">@color/wc_border_color</color>
+    <color name="orderStatus_cancelled_border">@color/wc_grey_17</color>
+
+    <color name="orderStatus_refunded_text">@color/tagView_text</color>
+    <color name="orderStatus_refunded_bg">@color/wc_red_lightest</color>
+    <color name="orderStatus_refunded_border">@color/wc_red_light</color>
+    <!--
+        Order: Order note icon colors
+    -->
+    <color name="orderNote_private">@color/wc_grey</color>
+    <color name="orderNote_public">@color/wc_blue_light</color>
+    <color name="orderNote_system">@color/wc_purple</color>
+
+    <!-- Login -->
+    <!-- Login uses snake_case instead of CamelCase for the main color palette,
+    this makes sure they're not used accidentally -->
+    <color name="color_primary">@color/colorPrimary</color>
+    <color name="color_primary_dark">@color/colorPrimaryDark</color>
+    <color name="color_accent">@color/colorAccent</color>
+
+    <color name="status_bar">@color/colorPrimaryDark</color>
+    <color name="login_theme_accent_color">@color/colorAccent</color>
+    <color name="login_background_color">@color/wc_grey_light</color>
+
+    <color name="login_toolbar_color">@color/colorPrimary</color>
+    <color name="login_primary_button_normal_color">@color/colorAccent</color>
+    <color name="login_primary_button_text_color">@color/white</color>
+    <color name="login_secondary_button_text_color">@color/colorPrimary</color>
+    <color name="login_google_button_text_color">@color/colorPrimary</color>
+    <color name="login_text_label_text_color">@color/edit_text_label_text_color</color>
+    <color name="login_input_label_static_text_color">@color/wc_grey_39</color>
+    <color name="login_edit_text_color_control_normal">@color/edit_text_color_control_normal</color>
+    <color name="login_edit_text_color_control_activated">@color/edit_text_color_control_activated</color>
+    <color name="login_edit_text_color_control_highlight">@color/edit_text_color_control_highlight</color>
+    <color name="login_edit_text_text_color">@color/edit_text_text_color</color>
+    <color name="login_edit_text_text_hint_color">@color/edit_text_text_hint_color</color>
+    <color name="login_heading_text_color">@color/wc_grey_17</color>
+    <color name="login_subhead_text_color">@color/wc_grey_dark</color>
+    <color name="login_username_text_color">@color/wc_grey_17</color>
+    <color name="login_footnote_text_color">@color/wc_grey_dark</color>
+
+    <color name="login_input_icon_color">@color/wc_grey_30</color>
+    <color name="login_input_password_icon_color">@color/wc_grey_30</color>
+    <color name="login_notification_accent_color">@color/colorPrimary</color>
+
+    <color name="skeleton_color">#16000000</color>
+    <color name="skeleton_color_light">@color/white</color>
+</resources>

--- a/WooCommerce/src/main/res/values/elevations.xml
+++ b/WooCommerce/src/main/res/values/elevations.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="plane_00">0dp</dimen>
+    <dimen name="plane_01">1dp</dimen>
+    <dimen name="plane_02">2dp</dimen>
+    <dimen name="plane_03">3dp</dimen>
+    <dimen name="plane_04">4dp</dimen>
+    <dimen name="plane_06">6dp</dimen>
+    <dimen name="plane_08">8dp</dimen>
+    <dimen name="plane_12">12dp</dimen>
+    <dimen name="plane_16">16dp</dimen>
+    <dimen name="plane_24">24dp</dimen>
+</resources>

--- a/WooCommerce/src/main/res/values/preloaded_fonts.xml
+++ b/WooCommerce/src/main/res/values/preloaded_fonts.xml
@@ -2,6 +2,7 @@
 <resources>
     <array name="preloaded_fonts" translatable="false">
         <item>@font/roboto</item>
+        <item>@font/roboto_light</item>
         <item>@font/roboto_medium</item>
     </array>
 </resources>

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -7,32 +7,7 @@
     <style name="SearchViewCursor" parent="Widget.AppCompat.AutoCompleteTextView">
         <item name="android:textCursorDrawable">@drawable/searchview_cursor</item>
     </style>
-
-    <!--
-        Toolbar Theme
-    -->
-    <style name="ToolbarTheme" parent="Theme.AppCompat.Light.DarkActionBar">
-        <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <!-- Tints input fields like checkboxes and text fields -->
-        <item name="colorAccent">@color/colorAccent</item>
-        <!-- Color of the title text in the toolbar -->
-        <item name="android:textColorPrimary">@color/menu_title_text</item>
-        <!-- Applies to views in their normal state. -->
-        <item name="colorControlNormal">#FFFFFFFF</item>
-        <!-- Applies to views in their activated state (i.e checked or switches) -->
-        <item name="colorControlActivated">#FFCCCCCC</item>
-        <!-- Applied to framework control highlights (i.e ripples or list selectors) -->
-        <item name="colorControlHighlight">#3d96588a</item>
-        <!-- Ripple effect when clicking items -->
-        <item name="selectableItemBackground">?android:selectableItemBackground</item>
-        <item name="selectableItemBackgroundBorderless">?android:selectableItemBackground</item>
-        <!-- Light touch feedback for actions -->
-        <item name="android:theme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
-        <!-- Light background for menus -->
-        <item name="popupTheme">@style/ThemeOverlay.AppCompat.Light</item>
-    </style>
-
+    
     <style name="Woo"/>
     <!--
         Text Styles

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -1,39 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <!-- Base application theme. -->
-    <style name="AppTheme.Base" parent="Theme.AppCompat.Light.NoActionBar">
-        <!--
-            Default colors
-        -->
-        <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
-        <item name="android:windowBackground">@color/default_window_bg</item>
-        <item name="colorButtonNormal">@color/light_gray</item>
-
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
-        <item name="android:windowContentTransitions">true</item>
-
-        <!--
-            Default text
-        -->
-        <item name="android:textAppearance">@style/Woo.TextAppearance</item>
-        <!--
-            Widgets
-        -->
-        <item name="tagViewStyle">@style/Woo.Tag</item>
-        <item name="flowLayoutStyle">@style/Woo.FlowLayout</item>
-        <item name="android:listViewStyle">@style/Woo.List</item>
-        <item name="android:alertDialogTheme">@style/Woo.Dialog</item>
-        <item name="autoCompleteTextViewStyle">@style/SearchViewCursor</item>
-    </style>
-
-    <style name="AppTheme" parent="AppTheme.Base">
-        <!-- Overrides for various api levels -->
-    </style>
-
     <!--
         Set a custom cursor for search views so they don't inherit colorAccent
     -->
@@ -538,7 +505,7 @@
         Image viewer
     -->
     <style name="ImageViewer" />
-    <style name="ImageViewer.Activity" parent="AppTheme">
+    <style name="ImageViewer.Activity" parent="Theme.Woo.DayNight">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:windowTranslucentStatus">true</item>
@@ -553,7 +520,7 @@
         <item name="colorAccent">@color/color_accent</item>
     </style>
 
-    <style name="EditText" parent="@style/AppTheme">
+    <style name="EditText" parent="Theme.Woo.DayNight">
         <item name="android:textColor">@color/edit_text_text_color</item>
         <item name="android:textColorHighlight">@color/edit_text_text_color_highlight</item>
         <item name="android:textColorHint">@color/edit_text_text_hint_color</item>

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -31,24 +31,27 @@
         <item name="shapeAppearanceLargeComponent">@style/ShapeAppearance.MaterialComponents.LargeComponent</item>
 
         <!-- Typography -->
-        <!-- TODO: Add typography -->
-        <item name="textAppearanceHeadline2">@style/TextAppearance.MaterialComponents.Headline2</item>
-        <item name="textAppearanceHeadline3">@style/TextAppearance.MaterialComponents.Headline3</item>
-        <item name="textAppearanceHeadline4">@style/TextAppearance.MaterialComponents.Headline4</item>
-        <item name="textAppearanceHeadline5">@style/TextAppearance.MaterialComponents.Headline5</item>
-        <item name="textAppearanceHeadline6">@style/TextAppearance.MaterialComponents.Headline6</item>
-        <item name="textAppearanceSubtitle1">@style/TextAppearance.MaterialComponents.Subtitle1</item>
-        <item name="textAppearanceSubtitle2">@style/TextAppearance.MaterialComponents.Subtitle2</item>
-        <item name="textAppearanceBody1">@style/TextAppearance.MaterialComponents.Body1</item>
-        <item name="textAppearanceBody2">@style/TextAppearance.MaterialComponents.Body2</item>
-        <item name="textAppearanceButton">@style/TextAppearance.MaterialComponents.Button</item>
-        <item name="textAppearanceCaption">@style/TextAppearance.MaterialComponents.Caption</item>
-        <item name="textAppearanceOverline">@style/TextAppearance.MaterialComponents.Overline</item>
+        <item name="textAppearanceHeadline1">@style/TextAppearance.Woo.Headline1</item>
+        <item name="textAppearanceHeadline2">@style/TextAppearance.Woo.Headline2</item>
+        <item name="textAppearanceHeadline3">@style/TextAppearance.Woo.Headline3</item>
+        <item name="textAppearanceHeadline4">@style/TextAppearance.Woo.Headline4</item>
+        <item name="textAppearanceHeadline5">@style/TextAppearance.Woo.Headline5</item>
+        <item name="textAppearanceHeadline6">@style/TextAppearance.Woo.Headline6</item>
+        <item name="textAppearanceSubtitle1">@style/TextAppearance.Woo.Subtitle1</item>
+        <item name="textAppearanceSubtitle2">@style/TextAppearance.Woo.Subtitle2</item>
+        <item name="textAppearanceBody1">@style/TextAppearance.Woo.Body1</item>
+        <item name="textAppearanceBody2">@style/TextAppearance.Woo.Body2</item>
+        <item name="textAppearanceButton">@style/TextAppearance.Woo.Button</item>
+        <item name="textAppearanceCaption">@style/TextAppearance.Woo.Caption</item>
+        <item name="textAppearanceOverline">@style/TextAppearance.Woo.Overline</item>
 
         <!-- Custom attrs for setting alpha values -->
         <item name="emphasisHighAlpha">0.87</item>
         <item name="emphasisMediumAlpha">0.60</item>
         <item name="emphasisDisabledAlpha">0.38</item>
+        <item name="emphasisHighAlphaPrimary">1.00</item>
+        <item name="emphasisMediumAlphaPrimary">0.74</item>
+        <item name="emphasisDisabledAlphaPrimary">0.38</item>
 
         <!-- Styles -->
         <!-- TODO: Configure custom styles -->

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- Final top-level theme -->
+    <style name="Theme.Woo.DayNight" parent="Theme.Woo"/>
+
+    <style name="Theme.Woo" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+        <!--
+            Default colors
+        -->
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
+        <item name="android:windowBackground">@color/default_window_bg</item>
+        <item name="colorButtonNormal">@color/light_gray</item>
+
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:windowContentTransitions">true</item>
+
+        <!--
+            Default text
+        -->
+        <item name="android:textAppearance">@style/Woo.TextAppearance</item>
+        <!--
+            Widgets
+        -->
+        <item name="tagViewStyle">@style/Woo.Tag</item>
+        <item name="flowLayoutStyle">@style/Woo.FlowLayout</item>
+        <item name="android:listViewStyle">@style/Woo.List</item>
+        <item name="android:alertDialogTheme">@style/Woo.Dialog</item>
+        <item name="autoCompleteTextViewStyle">@style/SearchViewCursor</item>
+    </style>
+
+</resources>

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -5,26 +5,72 @@
     <style name="Theme.Woo.DayNight" parent="Theme.Woo"/>
 
     <style name="Theme.Woo" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
-        <!--
-            Default colors
-        -->
-        <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
-        <item name="android:windowBackground">@color/default_window_bg</item>
-        <item name="colorButtonNormal">@color/light_gray</item>
+        <!-- Colors -->
+        <item name="colorPrimary">@color/woo_purple_60</item>
+        <item name="colorPrimaryVariant">@color/woo_purple_80</item>
+        <item name="colorSecondary">@color/woo_pink_50</item>
+        <item name="colorSecondaryVariant">@color/woo_pink_70</item>
 
+        <item name="android:colorBackground">@color/woo_white</item>
+        <item name="colorSurface">@color/woo_white</item>
+        <item name="colorError">@color/woo_red_50</item>
+
+        <item name="colorOnPrimary">@color/woo_white</item>
+        <item name="colorOnSecondary">@color/woo_black</item>
+        <item name="colorOnBackground">@color/woo_black</item>
+        <item name="colorOnSurface">@color/woo_black</item>
+        <item name="colorOnError">@color/woo_white</item>
+
+        <item name="scrimBackground">@color/woo_white_alpha_038</item>
+        <item name="android:statusBarColor">@color/woo_purple_60</item>
+        <item name="android:navigationBarColor">@color/nav_bar</item>
+
+        <!-- TODO: Add ShapeAppearance values -->
+        <item name="shapeAppearanceSmallComponent">@style/ShapeAppearance.MaterialComponents.SmallComponent</item>
+        <item name="shapeAppearanceMediumComponent">@style/ShapeAppearance.MaterialComponents.MediumComponent</item>
+        <item name="shapeAppearanceLargeComponent">@style/ShapeAppearance.MaterialComponents.LargeComponent</item>
+
+        <!-- Typography -->
+        <!-- TODO: Add typography -->
+        <item name="textAppearanceHeadline2">@style/TextAppearance.MaterialComponents.Headline2</item>
+        <item name="textAppearanceHeadline3">@style/TextAppearance.MaterialComponents.Headline3</item>
+        <item name="textAppearanceHeadline4">@style/TextAppearance.MaterialComponents.Headline4</item>
+        <item name="textAppearanceHeadline5">@style/TextAppearance.MaterialComponents.Headline5</item>
+        <item name="textAppearanceHeadline6">@style/TextAppearance.MaterialComponents.Headline6</item>
+        <item name="textAppearanceSubtitle1">@style/TextAppearance.MaterialComponents.Subtitle1</item>
+        <item name="textAppearanceSubtitle2">@style/TextAppearance.MaterialComponents.Subtitle2</item>
+        <item name="textAppearanceBody1">@style/TextAppearance.MaterialComponents.Body1</item>
+        <item name="textAppearanceBody2">@style/TextAppearance.MaterialComponents.Body2</item>
+        <item name="textAppearanceButton">@style/TextAppearance.MaterialComponents.Button</item>
+        <item name="textAppearanceCaption">@style/TextAppearance.MaterialComponents.Caption</item>
+        <item name="textAppearanceOverline">@style/TextAppearance.MaterialComponents.Overline</item>
+
+        <!-- Custom attrs for setting alpha values -->
+        <item name="emphasisHighAlpha">0.87</item>
+        <item name="emphasisMediumAlpha">0.60</item>
+        <item name="emphasisDisabledAlpha">0.38</item>
+
+        <!-- Styles -->
+        <!-- TODO: Configure custom styles -->
+        <item name="bottomAppBarStyle">@style/Widget.MaterialComponents.BottomAppBar.PrimarySurface</item>
+        <item name="bottomSheetStyle">@style/Widget.MaterialComponents.BottomSheet.Modal</item>
+        <item name="navigationViewStyle">@style/Widget.MaterialComponents.NavigationView</item>
+        <item name="toolbarStyle">@style/Widget.MaterialComponents.Toolbar.Primary</item>
+        <item name="chipStyle">@style/Widget.MaterialComponents.Chip.Entry</item>
+
+        <!-- System/Platform attributes -->
+        <item name="android:windowBackground">?android:colorBackground</item>
+        <item name="android:windowLightStatusBar" tools:ignore="NewApi">false</item>
+
+        <!-- TODO: Verify if needed -->
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:windowContentTransitions">true</item>
+        <item name="colorControlNormal">@color/woo_white</item>
 
-        <!--
-            Default text
-        -->
-        <item name="android:textAppearance">@style/Woo.TextAppearance</item>
-        <!--
-            Widgets
-        -->
+        <!-- Custom Widgets -->
+        <!-- TODO: Update styles -->
         <item name="tagViewStyle">@style/Woo.Tag</item>
         <item name="flowLayoutStyle">@style/Woo.FlowLayout</item>
         <item name="android:listViewStyle">@style/Woo.List</item>

--- a/WooCommerce/src/main/res/values/type.xml
+++ b/WooCommerce/src/main/res/values/type.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!--Typography-->
+    <style name="TextAppearance.Woo.Headline1" parent="TextAppearance.MaterialComponents.Headline1">
+        <item name="fontFamily">@font/roboto_light</item>
+        <item name="android:textSize">96sp</item>
+        <item name="android:textColor">@color/color_on_surface_emphasis_high</item>
+        <item name="lineHeight">112sp</item>
+    </style>
+
+    <style name="TextAppearance.Woo.Headline2" parent="TextAppearance.MaterialComponents.Headline2">
+        <item name="fontFamily">@font/roboto_light</item>
+        <item name="android:textSize">60sp</item>
+        <item name="android:textColor">@color/color_on_surface_emphasis_high</item>
+        <item name="lineHeight">72sp</item>
+    </style>
+
+    <style name="TextAppearance.Woo.Headline3" parent="TextAppearance.MaterialComponents.Headline3">
+        <item name="fontFamily">@font/roboto</item>
+        <item name="android:textSize">48sp</item>
+        <item name="android:textColor">@color/color_on_surface_emphasis_high</item>
+        <item name="lineHeight">56sp</item>
+    </style>
+
+    <style name="TextAppearance.Woo.Headline4" parent="TextAppearance.MaterialComponents.Headline4">
+        <item name="fontFamily">@font/roboto</item>
+        <item name="android:textSize">34sp</item>
+        <item name="android:textColor">@color/color_on_surface_emphasis_high</item>
+        <item name="lineHeight">36sp</item>
+    </style>
+
+    <style name="TextAppearance.Woo.Headline5" parent="TextAppearance.MaterialComponents.Headline5">
+        <item name="fontFamily">@font/roboto</item>
+        <item name="android:textSize">24sp</item>
+        <item name="android:textColor">@color/color_on_surface_emphasis_high</item>
+        <item name="lineHeight">24sp</item>
+    </style>
+
+    <style name="TextAppearance.Woo.Headline6" parent="TextAppearance.MaterialComponents.Headline6">
+        <item name="fontFamily">@font/roboto_medium</item>
+        <item name="android:textSize">20sp</item>
+        <item name="android:textColor">@color/color_on_surface_emphasis_high</item>
+        <item name="lineHeight">24sp</item>
+    </style>
+
+    <style name="TextAppearance.Woo.Subtitle1" parent="TextAppearance.MaterialComponents.Subtitle1">
+        <item name="fontFamily">@font/roboto</item>
+        <item name="android:textSize">16sp</item>
+        <item name="android:textColor">@color/color_on_surface_emphasis_high</item>
+        <item name="lineHeight">24sp</item>
+    </style>
+
+    <style name="TextAppearance.Woo.Subtitle2" parent="TextAppearance.MaterialComponents.Subtitle2">
+        <item name="fontFamily">@font/roboto_medium</item>
+        <item name="android:textSize">14dp</item>
+        <item name="android:textColor">@color/color_on_surface_emphasis_high</item>
+        <item name="lineHeight">24sp</item>
+    </style>
+
+    <style name="TextAppearance.Woo.Body1" parent="TextAppearance.MaterialComponents.Body1">
+        <item name="fontFamily">@font/roboto</item>
+        <item name="android:textSize">16sp</item>
+        <item name="android:textColor">@color/color_on_surface_emphasis_high</item>
+        <item name="lineHeight">24sp</item>
+    </style>
+
+    <style name="TextAppearance.Woo.Body2" parent="TextAppearance.MaterialComponents.Body2">
+        <item name="fontFamily">@font/roboto</item>
+        <item name="android:textSize">14sp</item>
+        <item name="android:textColor">@color/color_on_surface_emphasis_high</item>
+        <item name="lineHeight">20sp</item>
+    </style>
+
+    <style name="TextAppearance.Woo.Button" parent="TextAppearance.MaterialComponents.Button">
+        <item name="fontFamily">@font/roboto_medium</item>
+        <item name="android:textSize">14sp</item>
+        <item name="android:textAllCaps">true</item>
+        <item name="android:textColor">@color/color_on_surface_emphasis_high</item>
+        <item name="lineHeight">16sp</item>
+    </style>
+
+    <style name="TextAppearance.Woo.Caption" parent="TextAppearance.MaterialComponents.Caption">
+        <item name="fontFamily">@font/roboto</item>
+        <item name="android:textSize">12sp</item>
+        <item name="android:textColor">@color/color_on_surface_emphasis_high</item>
+        <item name="lineHeight">16sp</item>
+    </style>
+
+    <style name="TextAppearance.Woo.Overline" parent="TextAppearance.MaterialComponents.Overline">
+        <item name="fontFamily">@font/roboto</item>
+        <item name="android:textSize">10sp</item>
+        <item name="android:textAllCaps">true</item>
+        <item name="android:textColor">@color/color_on_surface_emphasis_high</item>
+        <item name="lineHeight">16sp</item>
+    </style>
+</resources>


### PR DESCRIPTION
Fixes #1572 by doing the following:
- Update material dependency
- Create new `themes.xml` resource files and move theme configurations to these files.
- Update theme to use a new `Woo.DayNight` theme
- Add new color palette in `colors.xml` and moved the existing color configurations to `colors_old.xml`
- Add new `roboto-light` downloadable font config
- Add font configurations and apply to theme
- Add resource files for alpha and elevation settings for each material plane

### Misc
- Swapped out `Toolbar` for `MaterialToolbar` while configuring different theme attributes and left it in since it will be changed later anyway. 
- The toolbar will change colors for dark/light mode, but should not be evaluated for completeness as there is still much more to do for this. 

### Testing
There's not really much here to test since styles haven't been applied to anything. Updating the base theme over to using `Theme.MaterialComponents.DayNight.DarkActionBar` did cause some visual changes, but they should be ignored at this point. 
- Build the app and ensure it doesn't crash.