### PR TITLE
Issue/1747 remove config changes

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,8 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <AndroidXmlCodeStyleSettings>
-      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="STATIC_FIELD_NAME_PREFIX" value="s" />

--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -31,8 +31,7 @@
 
         <activity
             android:name=".ui.main.MainActivity"
-            android:windowSoftInputMode="adjustResize"
-            android:configChanges="orientation|screenSize">
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -247,7 +247,7 @@ class OrderListFragment : TopLevelFragment(),
         if (isFilterEnabled) {
             viewModel.submitSearchOrFilter(statusFilter = orderStatusFilter)
         } else if (isSearching) {
-            searchHandler.postDelayed({ searchView?.setQuery(searchQuery, true)}, 100)
+            searchHandler.postDelayed({ searchView?.setQuery(searchQuery, true) }, 100)
         } else {
             loadListForActiveTab()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.orders.list
 
 import android.content.Context
-import android.content.res.Configuration
 import android.graphics.Color
 import android.os.Bundle
 import android.os.Handler
@@ -33,14 +32,12 @@ import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.ui.orders.OrderStatusListView
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowErrorSnack
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.StringUtils
+import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.viewmodel.ViewModelFactory
-import org.wordpress.android.util.ActivityUtils as WPActivityUtils
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.fragment_order_list.*
-import kotlinx.android.synthetic.main.fragment_order_list.orderRefreshLayout
 import kotlinx.android.synthetic.main.fragment_order_list.view.*
 import kotlinx.android.synthetic.main.order_list_view.view.*
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
@@ -48,6 +45,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus.P
 import org.wordpress.android.util.DisplayUtils
 import java.util.Locale
 import javax.inject.Inject
+import org.wordpress.android.util.ActivityUtils as WPActivityUtils
 
 class OrderListFragment : TopLevelFragment(),
         OrderStatusListView.OrderStatusListListener, OnQueryTextListener, OnActionExpandListener, OrderListListener {
@@ -251,11 +249,6 @@ class OrderListFragment : TopLevelFragment(),
         } else if (!isSearching) {
             loadListForActiveTab()
         }
-    }
-
-    override fun onConfigurationChanged(newConfig: Configuration) {
-        super.onConfigurationChanged(newConfig)
-        checkOrientation()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -246,7 +246,9 @@ class OrderListFragment : TopLevelFragment(),
 
         if (isFilterEnabled) {
             viewModel.submitSearchOrFilter(statusFilter = orderStatusFilter)
-        } else if (!isSearching) {
+        } else if (isSearching) {
+            searchHandler.postDelayed({ searchView?.setQuery(searchQuery, true)}, 100)
+        } else {
             loadListForActiveTab()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -132,7 +132,7 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener {
 
     private fun showSkeleton(show: Boolean) {
         if (show) {
-            skeletonView.show(productDetail_root, R.layout.skeleton_product_detail, delayed = true)
+            skeletonView.show(app_bar_layout, R.layout.skeleton_product_detail, delayed = true)
             skeletonView.findViewById(R.id.productImage_Skeleton)?.layoutParams?.height = imageGallery.height
         } else {
             skeletonView.hide()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -42,6 +42,7 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener,
     companion object {
         val TAG: String = ProductListFragment::class.java.simpleName
         const val KEY_LIST_STATE = "list-state"
+        const val KEY_WIP_EXPANDED = "wip_expanded"
         fun newInstance() = ProductListFragment()
     }
 
@@ -73,6 +74,7 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener,
         val activity = requireActivity()
 
         listState = savedInstanceState?.getParcelable(KEY_LIST_STATE)
+        products_wip_card.isExpanded = savedInstanceState?.getBoolean(KEY_WIP_EXPANDED) ?: false
 
         productAdapter = ProductListAdapter(activity, this, this)
         productsRecycler.layoutManager = LinearLayoutManager(activity)
@@ -104,6 +106,7 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener,
 
     override fun onSaveInstanceState(outState: Bundle) {
         outState.putParcelable(KEY_LIST_STATE, productsRecycler.layoutManager?.onSaveInstanceState())
+        outState.putBoolean(KEY_WIP_EXPANDED, products_wip_card.isExpanded)
         super.onSaveInstanceState(outState)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductsWIPNoticeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductsWIPNoticeCard.kt
@@ -14,13 +14,21 @@ class ProductsWIPNoticeCard @JvmOverloads constructor(ctx: Context, attrs: Attri
         View.inflate(context, R.layout.products_wip_notice, this)
     }
 
+    var isExpanded: Boolean = false
+        set(value) {
+            if (value != field) {
+                field = value
+                if (value) {
+                    WooAnimUtils.fadeIn(products_wip_morePanel)
+                } else {
+                    WooAnimUtils.fadeOut(products_wip_morePanel)
+                }
+            }
+        }
+
     fun initView() {
         products_wip_viewMore.setOnCheckedChangeListener { _, isChecked ->
-            if (isChecked) {
-                WooAnimUtils.fadeIn(products_wip_morePanel)
-            } else {
-                WooAnimUtils.fadeOut(products_wip_morePanel)
-            }
+            isExpanded = isChecked
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCEmptyView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCEmptyView.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.widgets
 
 import android.content.Context
-import android.content.res.Configuration
 import android.util.AttributeSet
 import android.view.View
 import android.widget.LinearLayout
@@ -9,12 +8,12 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.extensions.hide
+import com.woocommerce.android.extensions.show
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
-import com.woocommerce.android.extensions.hide
-import com.woocommerce.android.extensions.show
 import kotlinx.android.synthetic.main.dashboard_main_stats_row.view.*
 import kotlinx.android.synthetic.main.wc_empty_view.view.*
 import org.wordpress.android.fluxc.model.SiteModel
@@ -28,11 +27,6 @@ class WCEmptyView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? =
 
     init {
         View.inflate(context, R.layout.wc_empty_view, this)
-        checkOrientation()
-    }
-
-    override fun onConfigurationChanged(newConfig: Configuration?) {
-        super.onConfigurationChanged(newConfig)
         checkOrientation()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCPromoDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCPromoDialog.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.widgets
 
 import android.app.Dialog
 import android.content.Context
-import android.content.res.Configuration
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AlertDialog
@@ -70,11 +69,6 @@ class WCPromoDialog : androidx.fragment.app.DialogFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         dialog?.window?.attributes?.windowAnimations = R.style.Woo_Dialog_Promo
-    }
-
-    override fun onConfigurationChanged(newConfig: Configuration) {
-        super.onConfigurationChanged(newConfig)
-        checkOrientation()
     }
 
     // hide the image in landscape


### PR DESCRIPTION
Closes #1747 and #1731 - This PR removes `android:configChanges="orientation|screenSize"` from the main activity, along with the various instances of `onConfigurationChanged()` that were previously necessary.

In the process I fixed a few bugs that exposed themselves after `configChanges` was removed:

* When opened from the Dashboard, product detail would crash
* Order list search wasn't retained
* Expanded state of the products teaser wasn't retained

To test, install this PR and browse around the app while randomly rotating the device and make sure everything works.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
