### PR TITLE
issue/1749-my-store-leak

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -176,6 +176,8 @@ class MyStoreFragment : TopLevelFragment(),
     }
 
     override fun onDestroyView() {
+        my_store_stats.removeListener()
+        my_store_top_earners.removeListener()
         presenter.dropView()
         super.onDestroyView()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -56,7 +56,7 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
     }
 
     private lateinit var activeGranularity: StatsGranularity
-    private lateinit var listener: DashboardStatsListener
+    private var listener: DashboardStatsListener? = null
 
     private lateinit var selectedSite: SelectedSite
     private lateinit var formatCurrencyForDisplay: FormatCurrencyRounded
@@ -112,6 +112,10 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
         }
     }
 
+    fun removeListener() {
+        listener = null
+    }
+
     fun loadDashboardStats(granularity: StatsGranularity) {
         this.activeGranularity = granularity
         // Track range change
@@ -120,7 +124,7 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
                 mapOf(AnalyticsTracker.KEY_RANGE to granularity.toString().toLowerCase()))
 
         isRequestingStats = true
-        listener.onRequestLoadStats(granularity)
+        listener?.onRequestLoadStats(granularity)
     }
 
     override fun onVisibilityChanged(changedView: View, visibility: Int) {
@@ -230,7 +234,7 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
         fadeInLabelValue(visitors_value, chartVisitorStats.values.sum().toString())
 
         // update date bar when unselected
-        listener.onChartValueUnSelected(revenueStatsModel, activeGranularity)
+        listener?.onChartValueUnSelected(revenueStatsModel, activeGranularity)
     }
 
     override fun onValueSelected(e: Entry?, h: Highlight?) {
@@ -255,7 +259,7 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
         }
 
         // update the date bar
-        listener.onChartValueSelected(date, activeGranularity)
+        listener?.onChartValueSelected(date, activeGranularity)
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreTopEarnersView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreTopEarnersView.kt
@@ -33,9 +33,9 @@ class MyStoreTopEarnersView @JvmOverloads constructor(ctx: Context, attrs: Attri
     }
 
     private lateinit var selectedSite: SelectedSite
-    private lateinit var listener: DashboardStatsListener
     private lateinit var formatCurrencyForDisplay: FormatCurrencyRounded
 
+    private var listener: DashboardStatsListener? = null
     private var skeletonView = SkeletonView()
 
     fun initView(
@@ -52,6 +52,10 @@ class MyStoreTopEarnersView @JvmOverloads constructor(ctx: Context, attrs: Attri
         topEarners_recycler.itemAnimator = androidx.recyclerview.widget.DefaultItemAnimator()
     }
 
+    fun removeListener() {
+        listener = null
+    }
+
     /**
      * Load top earners stats when tab is selected in [MyStoreStatsView]
      */
@@ -64,7 +68,7 @@ class MyStoreTopEarnersView @JvmOverloads constructor(ctx: Context, attrs: Attri
         topEarners_recycler.adapter = TopEarnersAdapter(context, formatCurrencyForDisplay, listener)
         showEmptyView(false)
         showErrorView(false)
-        listener.onRequestLoadTopEarnerStats(granularity)
+        listener?.onRequestLoadTopEarnerStats(granularity)
     }
 
     fun showSkeleton(show: Boolean) {
@@ -101,7 +105,7 @@ class MyStoreTopEarnersView @JvmOverloads constructor(ctx: Context, attrs: Attri
     class TopEarnersAdapter(
         context: Context,
         val formatCurrencyForDisplay: FormatCurrencyRounded,
-        val listener: DashboardStatsListener
+        val listener: DashboardStatsListener?
     ) : RecyclerView.Adapter<TopEarnersViewHolder>() {
         private val orderString: String
         private val imageSize: Int
@@ -149,7 +153,7 @@ class MyStoreTopEarnersView @JvmOverloads constructor(ctx: Context, attrs: Attri
 
             holder.itemView.setOnClickListener {
                 AnalyticsTracker.track(TOP_EARNER_PRODUCT_TAPPED)
-                listener.onTopEarnerClicked(topEarner)
+                listener?.onTopEarnerClicked(topEarner)
             }
         }
     }


### PR DESCRIPTION
Fixes #1749 - Leak Canary was reporting a leak whenever the device was rotated. @AmandaRiu did some detective work and thought the leak was in "My Store," and looking into it further I thought the leak may be the stats listeners because they're never released.


![Screenshot_1577038833](https://user-images.githubusercontent.com/3903757/71325980-84e3d300-24c2-11ea-8cd4-52d09104bfbd.png)


This PR now removes the listeners when the fragment is destroyed, and Leak Canary reported no leaks after I made this change.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
