### PR TITLE
Added logic to fetch the correct SiteModel from the local db for the incoming url

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.store.WooCommerceStore.OnApiVersionFetched
+import org.wordpress.android.login.util.SiteUtils
 import javax.inject.Inject
 
 class SitePickerPresenter @Inject constructor(
@@ -91,7 +92,7 @@ class SitePickerPresenter @Inject constructor(
     }
 
     override fun getSiteModelByUrl(url: String): SiteModel? =
-            siteStore.getSitesByNameOrUrlMatching(url).firstOrNull()
+            SiteUtils.getSiteByMatchingUrl(siteStore, url)
 
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/util/SiteUtils.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/util/SiteUtils.java
@@ -22,9 +22,18 @@ public class SiteUtils {
 
     @Nullable
     public static SiteModel getXMLRPCSiteByUrl(SiteStore siteStore, String url) {
-        List<SiteModel> selfhostedSites = siteStore.getSitesAccessedViaXMLRPC();
-        if (selfhostedSites != null && !selfhostedSites.isEmpty()) {
-            for (SiteModel siteModel : selfhostedSites) {
+        return getSiteByMatchingUrl(siteStore.getSitesAccessedViaXMLRPC(), url);
+    }
+
+    @Nullable
+    public static SiteModel getSiteByMatchingUrl(SiteStore siteStore, String url) {
+        return getSiteByMatchingUrl(siteStore.getSites(), url);
+    }
+
+    @Nullable
+    private static SiteModel getSiteByMatchingUrl(List<SiteModel> siteModelList, String url) {
+        if (siteModelList != null && !siteModelList.isEmpty()) {
+            for (SiteModel siteModel : siteModelList) {
                 String storedSiteUrl = UrlUtils.removeScheme(siteModel.getUrl()).replace("/", "");
                 String incomingSiteUrl = UrlUtils.removeScheme(url).replace("/", "");
                 if (storedSiteUrl.equalsIgnoreCase(incomingSiteUrl)) {


### PR DESCRIPTION
Fixes #1730. This PR adds logic to fetch the correct `SiteModel` for the stored site address in the Site Picker screen.

#### Screenshots
(LEFT: Before . RIGHT: After) 
<img width="300" src="https://user-images.githubusercontent.com/22608780/71405521-ae843200-265b-11ea-8980-9b4706e0ec8c.gif"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/71405246-dde66f00-265a-11ea-830f-857a430b1e7d.gif">

#### Testing
- Login to a test site and verify that you are logged in successfully to the correct site.
- Logout of the app.
- Now login to a different test site with a similar name/url to the site entered in step 1.
- Note that you are logged in to the site entered in step 1 when, in fact, you should be redirected to the site in step 3.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
