### PR TITLE
Ux audit/stats

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -12,6 +12,7 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
+import com.github.mikephil.charting.charts.Chart
 import com.github.mikephil.charting.components.AxisBase
 import com.github.mikephil.charting.components.XAxis.XAxisPosition
 import com.github.mikephil.charting.data.BarData
@@ -226,6 +227,7 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
             isDragEnabled = true
 
             setNoDataTextColor(ContextCompat.getColor(context, R.color.graph_no_data_text_color))
+            getPaint(Chart.PAINT_INFO).textSize = context.resources.getDimension(R.dimen.text_large)
         }
 
         chart.setOnChartValueSelectedListener(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -198,9 +198,9 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
                 valueFormatter = StartEndDateAxisFormatter()
             }
 
-            axisLeft.isEnabled = false
+            axisRight.isEnabled = false
 
-            with(axisRight) {
+            with(axisLeft) {
                 setDrawZeroLine(false)
                 setDrawAxisLine(false)
                 setDrawGridLines(true)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -12,6 +12,7 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
+import com.github.mikephil.charting.charts.Chart
 import com.github.mikephil.charting.components.AxisBase
 import com.github.mikephil.charting.components.XAxis.XAxisPosition
 import com.github.mikephil.charting.data.BarData
@@ -213,6 +214,7 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
             isDragEnabled = true
 
             setNoDataTextColor(ContextCompat.getColor(context, R.color.graph_no_data_text_color))
+            getPaint(Chart.PAINT_INFO).textSize = context.resources.getDimension(R.dimen.text_large)
         }
         chart.setOnChartValueSelectedListener(this)
         chart.onChartGestureListener = this

--- a/WooCommerce/src/main/res/layout/dashboard_stats.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_stats.xml
@@ -61,6 +61,7 @@
     </FrameLayout>
 
     <TextView
+        android:paddingTop="@dimen/card_padding_top"
         android:id="@+id/dashboard_recency_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/layout/my_store_stats.xml
+++ b/WooCommerce/src/main/res/layout/my_store_stats.xml
@@ -30,6 +30,7 @@
     </FrameLayout>
 
     <TextView
+        android:paddingTop="@dimen/card_padding_top"
         android:id="@+id/dashboard_recency_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/layout/wc_empty_view.xml
+++ b/WooCommerce/src/main/res/layout/wc_empty_view.xml
@@ -45,6 +45,7 @@
             android:layout_marginTop="@dimen/margin_extra_large"/>
 
         <TextView
+            android:paddingBottom="@dimen/card_padding_bottom"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_extra_large"

--- a/WooCommerce/src/main/res/values/integers.xml
+++ b/WooCommerce/src/main/res/values/integers.xml
@@ -5,5 +5,5 @@
     <integer name="stats_label_count_days">6</integer>
     <integer name="stats_label_count_weeks">6</integer>
     <integer name="stats_label_count_months">6</integer>
-    <integer name="stats_label_count_years">4</integer>
+    <integer name="stats_label_count_years">6</integer>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'eb346201f539c0e0445edffbcdf7920905478184'
+    fluxCVersion = '9300c686789edcc5ec95260499268c6c541e1c38'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '9300c686789edcc5ec95260499268c6c541e1c38'
+    fluxCVersion = 'a782ff3d4827d301ac361c2c866ba86121053ebd'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '4e77f9d9939d2beb30e6598665de6aecc0e1a31b'
+    fluxCVersion = '862bcdbcc752233b3fd04795b1c0e411c6960182'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '862bcdbcc752233b3fd04795b1c0e411c6960182'
+    fluxCVersion = 'eb346201f539c0e0445edffbcdf7920905478184'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Fixes #1758. 

This PR addresses 3 issues:
- Update the top and bottom vertical padding for the “Updated moments ago” text to 16px. -  dafc4d0
<img width="300" src="https://user-images.githubusercontent.com/22608780/71458274-00e26180-27c8-11ea-877d-f6a6d2d81d9e.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/71458276-02ac2500-27c8-11ea-9af9-3a323ec7d25e.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/71458277-0475e880-27c8-11ea-83d0-939e639e0950.png">

- The x axis in the Revenue data graph for “This Week” needs to display all the day of the week and the column width of the daily revenue should stay consistent along the week (currently changes depending on how many days have passed in the week) - This is a purely FluxC fix and this commit 8374f16 updates the FluxC hash.
(LEFT: Before the fix . RIGHT: After the fix)
<img width="300" src="https://user-images.githubusercontent.com/22608780/71458358-73534180-27c8-11ea-9f70-a09d3c94d65f.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/71458359-73ebd800-27c8-11ea-8028-eb7fa4c1484c.png">

- Increases the font size of empty chart text to match the top earners empty text size -  5ce69b4
<img width="300" src="https://user-images.githubusercontent.com/22608780/71458479-e8bf1200-27c8-11ea-899c-c0b567d85cb4.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/71458480-e8bf1200-27c8-11ea-9a0c-d2254f9de427.png">

~**Note that this PR is in draft till this [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1464) can be reviewed and merged**~

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
