### PR TITLE
Verify site exists before accessing it to prevent a crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListRepository.kt
@@ -114,8 +114,13 @@ final class ProductListRepository @Inject constructor(
      * Returns all products for the current site that are in the database
      */
     fun getProductList(): List<Product> {
-        val wcProducts = productStore.getProductsForSite(selectedSite.get(), PRODUCT_SORTING)
-        return wcProducts.map { it.toAppModel() }
+        return if (selectedSite.exists()) {
+            val wcProducts = productStore.getProductsForSite(selectedSite.get(), PRODUCT_SORTING)
+            wcProducts.map { it.toAppModel() }
+        } else {
+            WooLog.w(WooLog.T.PRODUCTS, "No site selected - unable to load products")
+            emptyList()
+        }
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
Fixes #1776 I was unable to replicate this crash myself, but these changes will fix it by first checking if `selectedSite.exists()` before calling `selectedSite.get()`.

**Note:** This is a hotfix so please notify me when this is merged so we can make sure it's released. 