### PR TITLE
Dark Mode: My Store Stats Card

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -5,7 +5,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewGroup.LayoutParams
 import androidx.core.content.ContextCompat
+import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayout
 import com.woocommerce.android.R
@@ -54,10 +56,14 @@ class MyStoreFragment : TopLevelFragment(),
     private var tabStatsPosition: Int = 0 // Save the current position of stats tab view
     private val activeGranularity: StatsGranularity
         get() {
-            return tab_layout.getTabAt(tabStatsPosition)?.let {
+            return tabLayout.getTabAt(tabStatsPosition)?.let {
                 it.tag as StatsGranularity
             } ?: DEFAULT_STATS_GRANULARITY
         }
+
+    private val tabLayout: TabLayout by lazy {
+        TabLayout(requireContext(), null, R.attr.scrollableTabStyle)
+    }
 
     override fun onAttach(context: Context) {
         AndroidSupportInjection.inject(this)
@@ -104,18 +110,20 @@ class MyStoreFragment : TopLevelFragment(),
 
         empty_view.setSiteToShare(selectedSite.get(), Stat.DASHBOARD_SHARE_YOUR_STORE_BUTTON_TAPPED)
 
+        // Create tabs and add to appbar
         StatsGranularity.values().forEach { granularity ->
-            val tab = tab_layout.newTab().apply {
+            val tab = tabLayout.newTab().apply {
                 setText(my_store_stats.getStringForGranularity(granularity))
                 tag = granularity
             }
-            tab_layout.addTab(tab)
+            tabLayout.addTab(tab)
 
             // Start with the given time period selected
             if (granularity == activeGranularity) {
                 tab.select()
             }
         }
+        addTabLayoutToAppBar(tabLayout)
 
         my_store_date_bar.initView()
         my_store_stats.initView(
@@ -128,7 +136,7 @@ class MyStoreFragment : TopLevelFragment(),
                 selectedSite = selectedSite,
                 formatCurrencyForDisplay = currencyFormatter::formatCurrencyRounded)
 
-        tab_layout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
+        tabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
             override fun onTabSelected(tab: TabLayout.Tab) {
                 tabStatsPosition = tab.position
                 my_store_date_bar.clearDateRangeValues()
@@ -158,8 +166,10 @@ class MyStoreFragment : TopLevelFragment(),
         // silently refresh if this fragment is no longer hidden
         if (!isHidden && !isStatsRefreshed) {
             refreshMyStoreStats(forced = false)
+            addTabLayoutToAppBar(tabLayout)
         } else {
             isStatsRefreshed = false
+            removeTabLayoutFromAppBar(tabLayout)
         }
     }
 
@@ -184,7 +194,7 @@ class MyStoreFragment : TopLevelFragment(),
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         outState.putBoolean(STATE_KEY_REFRESH_PENDING, isRefreshPending)
-        outState.putInt(STATE_KEY_TAB_POSITION, tab_layout.selectedTabPosition)
+        outState.putInt(STATE_KEY_TAB_POSITION, tabLayout.selectedTabPosition)
     }
 
     override fun showStats(
@@ -317,5 +327,16 @@ class MyStoreFragment : TopLevelFragment(),
 
     override fun showEmptyView(show: Boolean) {
         if (show) empty_view.show(R.string.waiting_for_customers) else empty_view.hide()
+    }
+
+    private fun addTabLayoutToAppBar(tabLayout: TabLayout) {
+        (activity?.findViewById<View>(R.id.app_bar_layout) as? AppBarLayout)?.addView(
+                tabLayout,
+                LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
+        )
+    }
+
+    private fun removeTabLayoutFromAppBar(tabLayout: TabLayout) {
+        (activity?.findViewById<View>(R.id.app_bar_layout) as? AppBarLayout)?.removeView(tabLayout)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.util.CurrencyFormatter
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_my_store.*
 import kotlinx.android.synthetic.main.fragment_my_store.view.*
+import kotlinx.android.synthetic.main.my_store_stats.*
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
 import org.wordpress.android.fluxc.model.WCTopEarnerModel
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -199,7 +199,7 @@ class MyStoreStatsView @JvmOverloads constructor(
                 setDrawZeroLine(false)
                 setDrawAxisLine(false)
                 setDrawGridLines(true)
-                gridColor = ContextCompat.getColor(context, R.color.wc_border_color)
+                gridColor = ContextCompat.getColor(context, R.color.graph_grid_color)
                 textColor = ContextCompat.getColor(context, R.color.graph_label_color)
 
                 // Couldn't use the dimension resource here due to the way this component is written :/
@@ -435,7 +435,7 @@ class MyStoreStatsView @JvmOverloads constructor(
         // fade in the new value after fade out finishes
         val delay = duration.toMillis(context) + 100
         fadeHandler.postDelayed({
-            val color = ContextCompat.getColor(context, R.color.default_text_title)
+            val color = ContextCompat.getColor(context, R.color.color_on_surface_high)
             view.setTextColor(color)
             view.text = value
             WooAnimUtils.fadeIn(view, duration)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -38,7 +38,6 @@ import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import org.wordpress.android.util.ActivityUtils as WPActivityUtils
 import dagger.android.support.AndroidSupportInjection
-import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.fragment_order_list.*
 import kotlinx.android.synthetic.main.fragment_order_list.orderRefreshLayout
 import kotlinx.android.synthetic.main.fragment_order_list.view.*
@@ -244,7 +243,6 @@ class OrderListFragment : TopLevelFragment(),
 
         val filterOrSearchEnabled = isFilterEnabled || isSearching
         showTabs(!filterOrSearchEnabled)
-        enableToolbarElevation(filterOrSearchEnabled)
 
         if (isFilterEnabled) {
             viewModel.submitSearchOrFilter(statusFilter = orderStatusFilter)
@@ -282,13 +280,9 @@ class OrderListFragment : TopLevelFragment(),
     override fun onHiddenChanged(hidden: Boolean) {
         super.onHiddenChanged(hidden)
 
-        if (hidden) {
-            // restore the toolbar elevation when the order list screen is hidden
-            enableToolbarElevation(true)
-        } else {
+        if (!hidden) {
             // silently refresh if this fragment is no longer hidden
             val isChildFragmentShowing = isChildFragmentShowing()
-            enableToolbarElevation(isChildFragmentShowing)
             if (!isChildFragmentShowing) {
                 showOptionsMenu(true)
 
@@ -301,7 +295,6 @@ class OrderListFragment : TopLevelFragment(),
 
     override fun onReturnedFromChildFragment() {
         showOptionsMenu(true)
-        enableToolbarElevation(isChildFragmentShowing())
 
         if (isOrderStatusFilterEnabled()) {
             viewModel.reloadListFromCache()
@@ -611,10 +604,6 @@ class OrderListFragment : TopLevelFragment(),
 
     private fun isOrderStatusFilterEnabled() = isFilterEnabled || !isSearching
 
-    private fun enableToolbarElevation(enable: Boolean) {
-        activity?.toolbar?.elevation = if (enable) resources.getDimension(R.dimen.appbar_elevation) else 0f
-    }
-
     private fun showTabs(show: Boolean) {
         if (show && tab_layout.visibility != View.VISIBLE) {
             WooAnimUtils.fadeIn(tab_layout)
@@ -636,7 +625,6 @@ class OrderListFragment : TopLevelFragment(),
         hideOrderStatusListView()
         showTabs(true)
         (activity as? MainActivity)?.showBottomNav()
-        enableToolbarElevation(false)
 
         if (isFilterEnabled) closeFilteredList()
     }
@@ -658,7 +646,6 @@ class OrderListFragment : TopLevelFragment(),
         displayOrderStatusListView()
 
         (activity as? MainActivity)?.hideBottomNav()
-        enableToolbarElevation(true)
     }
 
     /**

--- a/WooCommerce/src/main/res/layout/activity_main.xml
+++ b/WooCommerce/src/main/res/layout/activity_main.xml
@@ -7,10 +7,6 @@
     android:layout_height="match_parent"
     tools:context=".ui.main.MainActivity">
 
-    <include
-        layout="@layout/view_toolbar"
-        android:id="@+id/toolbar"/>
-
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:id="@+id/snack_root"
         android:layout_width="0dp"
@@ -19,11 +15,23 @@
         app:layout_constraintBottom_toTopOf="@+id/offline_bar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/toolbar">
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/app_bar_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:theme="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar">
+
+            <include
+                layout="@layout/view_toolbar"
+                android:id="@+id/toolbar"/>
+        </com.google.android.material.appbar.AppBarLayout>
 
         <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
             <!-- container for top level fragments -->
             <FrameLayout
@@ -38,7 +46,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 app:defaultNavHost="true"
-                app:navGraph="@navigation/nav_graph_main"/>
+                app:navGraph="@navigation/nav_graph_main"
+                tools:layout="@layout/fragment_my_store"/>
         </FrameLayout>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/WooCommerce/src/main/res/layout/dashboard_stats.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_stats.xml
@@ -13,7 +13,7 @@
 
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tab_layout"
-            style="@style/Woo.TabLayout.Scrollable"
+            style="@style/Woo.TabLayout.Surface.Scrollable"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"/>
 

--- a/WooCommerce/src/main/res/layout/dashboard_top_earners.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_top_earners.xml
@@ -8,7 +8,7 @@
 
     <com.google.android.material.tabs.TabLayout
         android:id="@+id/topEarners_tab_layout"
-        style="@style/Woo.TabLayout"
+        style="@style/Woo.TabLayout.Surface.Scrollable"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"/>
 

--- a/WooCommerce/src/main/res/layout/fragment_my_store.xml
+++ b/WooCommerce/src/main/res/layout/fragment_my_store.xml
@@ -45,13 +45,6 @@
                     android:descendantFocusability="blocksDescendants"
                     android:orientation="vertical">
 
-                    <!-- Date bar -->
-                    <com.woocommerce.android.ui.mystore.MyStoreDateRangeView
-                        android:id="@+id/my_store_date_bar"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical"/>
-
                     <!-- Order stats -->
                     <com.woocommerce.android.ui.mystore.MyStoreStatsView
                         android:id="@+id/my_store_stats"

--- a/WooCommerce/src/main/res/layout/fragment_my_store.xml
+++ b/WooCommerce/src/main/res/layout/fragment_my_store.xml
@@ -1,27 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
     android:id="@+id/dashboardStats_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="com.woocommerce.android.ui.mystore.MyStoreFragment">
-
-    <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/app_bar_layout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:fitsSystemWindows="false">
-
-        <!-- Single tab for all stats -->
-        <com.google.android.material.tabs.TabLayout
-            android:id="@+id/tab_layout"
-            style="@style/Woo.TabLayout.Scrollable"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"/>
-
-    </com.google.android.material.appbar.AppBarLayout>
 
     <FrameLayout
         android:layout_width="match_parent"
@@ -73,4 +59,4 @@
 
     </FrameLayout>
 
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/my_store_date_bar.xml
+++ b/WooCommerce/src/main/res/layout/my_store_date_bar.xml
@@ -9,7 +9,7 @@
     <!-- Date bar -->
     <TextView
         android:id="@+id/dashboard_date_range_value"
-        style="@style/Woo.Stats.DateBar"
+        style="@style/Woo.DateBar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="start"

--- a/WooCommerce/src/main/res/layout/my_store_date_bar.xml
+++ b/WooCommerce/src/main/res/layout/my_store_date_bar.xml
@@ -11,8 +11,6 @@
         android:id="@+id/dashboard_date_range_value"
         style="@style/Woo.Stats.DateBar"
         android:layout_width="wrap_content"
-        android:paddingStart="@dimen/card_padding_start"
-        android:paddingEnd="@dimen/card_padding_end"
         android:layout_height="wrap_content"
         android:gravity="start"
         tools:text="June 30-Jul 06"/>

--- a/WooCommerce/src/main/res/layout/my_store_date_bar.xml
+++ b/WooCommerce/src/main/res/layout/my_store_date_bar.xml
@@ -7,7 +7,7 @@
     android:layout_height="match_parent">
 
     <!-- Date bar -->
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/dashboard_date_range_value"
         style="@style/Woo.DateBar"
         android:layout_width="wrap_content"

--- a/WooCommerce/src/main/res/layout/my_store_stats.xml
+++ b/WooCommerce/src/main/res/layout/my_store_stats.xml
@@ -45,7 +45,7 @@
                 tools:visibility="visible"/>
         </FrameLayout>
 
-        <TextView
+        <com.google.android.material.textview.MaterialTextView
             android:id="@+id/dashboard_recency_text"
             style="@style/Woo.TextView.Caption"
             android:layout_width="wrap_content"

--- a/WooCommerce/src/main/res/layout/my_store_stats.xml
+++ b/WooCommerce/src/main/res/layout/my_store_stats.xml
@@ -11,6 +11,13 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
+        <!-- Date bar -->
+        <com.woocommerce.android.ui.mystore.MyStoreDateRangeView
+            android:id="@+id/my_store_date_bar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"/>
+
         <include android:id="@+id/stats_view_row" layout="@layout/dashboard_main_stats_row" />
 
         <FrameLayout

--- a/WooCommerce/src/main/res/layout/my_store_stats.xml
+++ b/WooCommerce/src/main/res/layout/my_store_stats.xml
@@ -6,34 +6,44 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <include android:id="@+id/stats_view_row" layout="@layout/dashboard_main_stats_row" />
-
-    <FrameLayout
-        android:id="@+id/chart_container"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="@dimen/chart_height">
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
-        <com.woocommerce.android.ui.dashboard.DashboardStatsBarChart
-            android:id="@+id/chart"
+        <include android:id="@+id/stats_view_row" layout="@layout/dashboard_main_stats_row" />
+
+        <FrameLayout
+            android:id="@+id/chart_container"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"/>
+            android:layout_height="200dp">
 
-        <ImageView
-            android:id="@+id/dashboard_stats_error"
+            <com.woocommerce.android.ui.dashboard.DashboardStatsBarChart
+                android:id="@+id/chart"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_75"
+                android:layout_marginBottom="@dimen/major_75"/>
+
+            <ImageView
+                android:id="@+id/dashboard_stats_error"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:contentDescription="@string/dashboard_stats_error_content_description"
+                android:visibility="gone"
+                app:srcCompat="@drawable/ic_woo_error_state"
+                tools:visibility="visible"/>
+        </FrameLayout>
+
+        <TextView
+            android:id="@+id/dashboard_recency_text"
+            style="@style/Woo.TextView.Caption"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:contentDescription="@string/dashboard_stats_error_content_description"
-            android:visibility="gone"
-            app:srcCompat="@drawable/ic_woo_error_state"
-            tools:visibility="visible"/>
-    </FrameLayout>
-
-    <TextView
-        android:id="@+id/dashboard_recency_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        tools:text="dashboard_recency_text"/>
-
+            tools:text="dashboard_recency_text"/>
+    </LinearLayout>
 </merge>

--- a/WooCommerce/src/main/res/layout/order_badge_view.xml
+++ b/WooCommerce/src/main/res/layout/order_badge_view.xml
@@ -11,7 +11,7 @@
        note that the DP text size is on purpose to avoid having the text overlap the badge
        if the user adjusted the device's text size
    -->
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/textOrderCount"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/layout/view_toolbar.xml
+++ b/WooCommerce/src/main/res/layout/view_toolbar.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.appbar.MaterialToolbar
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="?attr/actionBarSize"
-    android:theme="@style/Theme.Woo.DayNight.Toolbar"/>
+    android:elevation="@dimen/plane_00"
+    tools:showIn="@layout/activity_main"
+    tools:menu="@menu/menu_action_bar"/>

--- a/WooCommerce/src/main/res/values-night/themes.xml
+++ b/WooCommerce/src/main/res/values-night/themes.xml
@@ -29,14 +29,4 @@
         <!--System/Platform attributes-->
         <item name="android:windowLightStatusBar" tools:ignore="NewApi">false</item>
     </style>
-
-    <style name="Theme.Woo.DayNight.Toolbar" parent="Theme.Woo.Dark.Toolbar"/>
-
-    <style name="Theme.Woo.Dark.Toolbar">
-        <item name="colorPrimary">@color/woo_purple_30</item>
-        <item name="colorPrimaryVariant">@color/woo_purple_50</item>
-        <item name="colorSecondary">@color/woo_pink_30</item>
-        <item name="colorSecondaryVariant">@color/woo_pink_50</item>
-        <item name="colorControlNormal">?attr/colorOnSurface</item>
-    </style>
 </resources>

--- a/WooCommerce/src/main/res/values-night/themes.xml
+++ b/WooCommerce/src/main/res/values-night/themes.xml
@@ -6,10 +6,10 @@
 
     <style name="Theme.Woo.Dark" parent="Theme.Woo">
         <!-- Color -->
-        <item name="colorPrimary">@color/woo_pink_30</item>
-        <item name="colorPrimaryVariant">@color/woo_pink_50</item>
-        <item name="colorSecondary">@color/woo_purple_30</item>
-        <item name="colorSecondaryVariant">@color/woo_purple_50</item>
+        <item name="colorPrimary">@color/woo_purple_30</item>
+        <item name="colorPrimaryVariant">@color/woo_purple_50</item>
+        <item name="colorSecondary">@color/woo_pink_30</item>
+        <item name="colorSecondaryVariant">@color/woo_pink_50</item>
 
         <item name="android:colorBackground">@color/woo_black_90</item>
         <item name="colorSurface">@color/woo_black_90</item>

--- a/WooCommerce/src/main/res/values-night/themes.xml
+++ b/WooCommerce/src/main/res/values-night/themes.xml
@@ -16,6 +16,7 @@
         <item name="colorError">@color/woo_red_30</item>
 
         <item name="colorOnPrimary">@color/woo_black</item>
+        <item name="colorOnPrimarySurface">@color/woo_white</item>
         <item name="colorOnSecondary">@color/woo_black</item>
         <item name="colorOnBackground">@color/woo_white</item>
         <item name="colorOnSurface">@color/woo_white</item>

--- a/WooCommerce/src/main/res/values/attrs.xml
+++ b/WooCommerce/src/main/res/values/attrs.xml
@@ -73,4 +73,14 @@
         Badge attributes for the bottom bar
     -->
     <attr name="badgeTextAppearance" format="reference"/>
+
+    <!--
+        Attribute for defining different types of TabLayout styles
+    -->
+    <attr name="scrollableTabStyle" format="reference"/>
+    <!--
+        General app attributes
+    -->
+    <!-- Sets the thickness of indicators like the tab indicator or new review indicator -->
+    <attr name="lineIndicatorThickness" format="dimension" />
 </resources>

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -77,6 +77,12 @@
         <item name="tabContentStart">92dp</item>
         <item name="tabMode">scrollable</item>
     </style>
+    <!--
+        Stats Styles
+    -->
+    <style name="Woo.Stats.DateBar" parent="Woo.TextView">
+        <item name="android:textAppearance">?attr/textAppearanceSubtitle2</item>
+    </style>
 
     <!--
         Set a custom cursor for search views so they don't inherit colorAccent
@@ -637,12 +643,6 @@
         <item name="android:paddingBottom">@dimen/card_padding_bottom</item>
         <item name="android:drawablePadding">@dimen/card_padding_start</item>
         <item name="android:textAllCaps">false</item>
-    </style>
-
-    <style name="Woo.Stats.DateBar" parent="Woo.TextView">
-        <item name="android:textAppearance">?attr/textAppearanceSubtitle1</item>
-        <item name="android:paddingTop">@dimen/margin_large</item>
-        <item name="android:paddingBottom">@dimen/margin_large</item>
     </style>
 
     <style name="Woo.Products.WIP.CardExtenderButton" parent="Woo.Stats.Availability.CardExtenderButton">

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -22,8 +22,8 @@
     <style name="Widget.Woo.Card" parent="@style/Widget.MaterialComponents.CardView">
         <item name="cardCornerRadius">@dimen/minor_00</item>
         <item name="android:checkable">false</item>
-        <item name="contentPaddingTop">@dimen/major_75</item>
-        <item name="contentPaddingBottom">@dimen/major_75</item>
+        <item name="contentPaddingTop">@dimen/minor_25</item>
+        <item name="contentPaddingBottom">@dimen/minor_25</item>
     </style>
     <style name="Widget.Woo.Card.Tabbed">
         <item name="contentPaddingTop">@dimen/minor_00</item>

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -14,7 +14,7 @@
         Toolbar Styles
     -->
     <style name="Widget.Woo.Toolbar" parent="@style/Widget.MaterialComponents.Toolbar.PrimarySurface">
-        <item name="android:elevation">@dimen/appbar_elevation</item>
+        <item name="android:elevation">@dimen/plane_04</item>
     </style>
     <!--
         Card Styles
@@ -59,16 +59,35 @@
     <!--
         TabLayout Styles
     -->
-    <style name="Woo.TabLayout" parent="@style/Widget.MaterialComponents.TabLayout">
+    <style name="Woo.TabLayout" parent="@style/Widget.MaterialComponents.TabLayout.PrimarySurface">
+        <item name="tabMode">fixed</item>
+        <item name="tabTextAppearance">?attr/textAppearanceButton</item>
+        <item name="tabSelectedTextColor">?attr/colorOnPrimarySurface</item>
+        <item name="tabIndicatorColor">?attr/colorOnPrimarySurface</item>
+        <item name="tabIndicatorHeight">2dp</item>
+        <item name="tabPaddingStart">25dp</item>
+        <item name="tabPaddingEnd">25dp</item>
+        <item name="android:elevation">@dimen/plane_04</item>
+    </style>
+    <style name="Woo.TabLayout.Scrollable">
+        <!--
+        Designs call for a 52dp gap at the start for scrollable Tabs, but Android calculates
+        this number as being (tabContentStart - tabPaddingStart), so you have to add the
+        padding amount of 40dp on top to make sure the tab actually starts at 52dp
+        -->
+        <item name="tabContentStart">92dp</item>
+        <item name="tabMode">scrollable</item>
+    </style>
+    <style name="Woo.TabLayout.Surface" parent="@style/Widget.MaterialComponents.TabLayout">
         <item name="tabMode">fixed</item>
         <item name="tabTextAppearance">?attr/textAppearanceButton</item>
         <item name="tabSelectedTextColor">?attr/colorOnSurface</item>
         <item name="tabIndicatorColor">?attr/colorOnSurface</item>
         <item name="tabIndicatorHeight">2dp</item>
-        <item name="tabPaddingStart">25dp</item>
-        <item name="tabPaddingEnd">25dp</item>
+        <item name="tabPaddingStart">40dp</item>
+        <item name="tabPaddingEnd">40dp</item>
     </style>
-    <style name="Woo.TabLayout.Scrollable">
+    <style name="Woo.TabLayout.Surface.Scrollable">
         <!--
         Designs call for a 52dp gap at the start for scrollable Tabs, but Android calculates
         this number as being (tabContentStart - tabPaddingStart), so you have to add the

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="Woo"/>
+
+    <!--
+        Toolbar Styles
+    -->
+    <style name="Widget.Woo.Toolbar" parent="@style/Widget.MaterialComponents.Toolbar.PrimarySurface"/>
+
+    <!--
+        AppBarLayout Styles
+    -->
+    <style name="Woo.AppBarLayout" parent="@style/Widget.MaterialComponents.AppBarLayout.PrimarySurface">
+        <item name="android:elevation">@dimen/plane_04</item>
+        <item name="android:fitsSystemWindows">false</item>
+    </style>
+
     <!--
         Bottom Bar Styles
     -->
@@ -10,52 +24,7 @@
         <item name="itemTextColor">@color/color_on_surface</item>
         <item name="android:elevation">@dimen/plane_08</item>
     </style>
-    <!--
-        Toolbar Styles
-    -->
-    <style name="Widget.Woo.Toolbar" parent="@style/Widget.MaterialComponents.Toolbar.PrimarySurface">
-        <item name="android:elevation">@dimen/plane_04</item>
-    </style>
-    <!--
-        Card Styles
-    -->
-    <style name="Widget.Woo.Card" parent="@style/Widget.MaterialComponents.CardView">
-        <item name="cardCornerRadius">@dimen/minor_00</item>
-        <item name="android:checkable">false</item>
-        <item name="contentPaddingTop">@dimen/minor_25</item>
-        <item name="contentPaddingBottom">@dimen/minor_25</item>
-    </style>
-    <style name="Widget.Woo.Card.Tabbed">
-        <item name="contentPaddingTop">@dimen/minor_00</item>
-    </style>
-    <style name="Widget.Woo.Card.Expandable">
-        <item name="android:paddingStart">0dp</item>
-        <item name="android:paddingEnd">0dp</item>
-        <item name="android:paddingBottom">0dp</item>
-    </style>
-    <style name="Widget.Woo.Card.WithoutPadding">
-        <item name="android:paddingStart">0dp</item>
-        <item name="android:paddingEnd">0dp</item>
-        <item name="android:paddingTop">0dp</item>
-        <item name="android:paddingBottom">0dp</item>
-    </style>
-    <!--
-        TextView Styles
-    -->
-    <style name="Woo.TextView" parent="@style/Widget.MaterialComponents.TextView">
-        <item name="android:layout_marginStart">@dimen/major_100</item>
-        <item name="android:layout_marginEnd">@dimen/major_100</item>
-        <item name="android:layout_marginTop">@dimen/major_75</item>
-        <item name="android:layout_marginBottom">@dimen/major_75</item>
-    </style>
-    <style name="Woo.TextView.Subtitle2">
-        <item name="android:textAppearance">?attr/textAppearanceSubtitle2</item>
-        <item name="android:textColor">@color/color_on_surface_high</item>
-        <item name="android:gravity">center_horizontal|start</item>
-    </style>
-    <style name="Woo.TextView.Caption">
-        <item name="android:textAppearance">?attr/textAppearanceCaption</item>
-    </style>
+
     <!--
         TabLayout Styles
     -->
@@ -65,9 +34,9 @@
         <item name="tabSelectedTextColor">?attr/colorOnPrimarySurface</item>
         <item name="tabIndicatorColor">?attr/colorOnPrimarySurface</item>
         <item name="tabIndicatorHeight">2dp</item>
-        <item name="tabPaddingStart">40dp</item>
-        <item name="tabPaddingEnd">40dp</item>
-        <item name="android:elevation">@dimen/plane_04</item>
+        <item name="tabPaddingStart">25dp</item>
+        <item name="tabPaddingEnd">25dp</item>
+        <item name="android:elevation">@dimen/plane_00</item>
     </style>
     <style name="Woo.TabLayout.Scrollable">
         <!--
@@ -96,12 +65,64 @@
         <item name="tabContentStart">92dp</item>
         <item name="tabMode">scrollable</item>
     </style>
+
     <!--
-        Stats Styles
+        Card Styles
     -->
-    <style name="Woo.Stats.DateBar" parent="Woo.TextView">
+    <style name="Widget.Woo.Card" parent="@style/Widget.MaterialComponents.CardView">
+        <item name="cardCornerRadius">@dimen/minor_00</item>
+        <item name="android:checkable">false</item>
+        <item name="contentPaddingTop">@dimen/minor_25</item>
+        <item name="contentPaddingBottom">@dimen/minor_25</item>
+    </style>
+    <style name="Widget.Woo.Card.Tabbed">
+        <item name="contentPaddingTop">@dimen/minor_00</item>
+    </style>
+    <style name="Widget.Woo.Card.Expandable">
+        <item name="android:paddingStart">0dp</item>
+        <item name="android:paddingEnd">0dp</item>
+        <item name="android:paddingBottom">0dp</item>
+    </style>
+    <style name="Widget.Woo.Card.WithoutPadding">
+        <item name="android:paddingStart">0dp</item>
+        <item name="android:paddingEnd">0dp</item>
+        <item name="android:paddingTop">0dp</item>
+        <item name="android:paddingBottom">0dp</item>
+    </style>
+
+    <!--
+        TextView Styles
+    -->
+    <style name="Woo.TextView" parent="@style/Widget.MaterialComponents.TextView">
+        <item name="android:layout_marginStart">@dimen/major_100</item>
+        <item name="android:layout_marginEnd">@dimen/major_100</item>
+        <item name="android:layout_marginTop">@dimen/major_75</item>
+        <item name="android:layout_marginBottom">@dimen/major_75</item>
+    </style>
+    <style name="Woo.TextView.Subtitle2">
+        <item name="android:textAppearance">?attr/textAppearanceSubtitle2</item>
+        <item name="android:textColor">@color/color_on_surface_high</item>
+        <item name="android:gravity">center_horizontal|start</item>
+    </style>
+    <style name="Woo.TextView.Caption">
+        <item name="android:textAppearance">?attr/textAppearanceCaption</item>
+    </style>
+
+    <!--
+        Custom TextView Styles
+    -->
+    <style name="Woo.DateBar" parent="Woo.TextView">
         <item name="android:textAppearance">?attr/textAppearanceSubtitle2</item>
     </style>
+
+
+    <!--
+
+        OLD STUFF below this line will eventually be phased out during the course of this
+        project.
+
+    -->
+
 
     <!--
         Set a custom cursor for search views so they don't inherit colorAccent

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -65,7 +65,7 @@
         <item name="materialAlertDialogTheme">@style/ThemeOverlay.MaterialComponents.MaterialAlertDialog</item>
         <item name="tabStyle">@style/Woo.TabLayout</item>
         <item name="scrollableTabStyle">@style/Woo.TabLayout.Scrollable</item>
-        <item name="appBarLayoutStyle">@style/Widget.MaterialComponents.AppBarLayout.PrimarySurface</item>
+        <item name="appBarLayoutStyle">@style/Woo.AppBarLayout</item>
 
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -16,6 +16,7 @@
         <item name="colorError">@color/woo_red_50</item>
 
         <item name="colorOnPrimary">@color/woo_white</item>
+        <item name="colorOnPrimarySurface">@color/woo_white</item>
         <item name="colorOnSecondary">@color/woo_black</item>
         <item name="colorOnBackground">@color/woo_black</item>
         <item name="colorOnSurface">@color/woo_black</item>
@@ -62,6 +63,9 @@
         <item name="toolbarStyle">@style/Widget.Woo.Toolbar</item>
         <item name="chipStyle">@style/Widget.MaterialComponents.Chip.Entry</item>
         <item name="materialAlertDialogTheme">@style/ThemeOverlay.MaterialComponents.MaterialAlertDialog</item>
+        <item name="tabStyle">@style/Woo.TabLayout</item>
+        <item name="scrollableTabStyle">@style/Woo.TabLayout.Scrollable</item>
+        <item name="appBarLayoutStyle">@style/Widget.MaterialComponents.AppBarLayout.PrimarySurface</item>
 
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -75,14 +75,4 @@
         <item name="android:listViewStyle">@style/Woo.List</item>
         <item name="autoCompleteTextViewStyle">@style/SearchViewCursor</item>
     </style>
-
-    <style name="Theme.Woo.DayNight.Toolbar" parent="Theme.Woo.Toolbar"/>
-
-    <style name="Theme.Woo.Toolbar">
-        <item name="colorPrimary">@color/woo_purple_60</item>
-        <item name="colorPrimaryVariant">@color/woo_purple_80</item>
-        <item name="colorSecondary">@color/woo_pink_50</item>
-        <item name="colorSecondaryVariant">@color/woo_pink_70</item>
-        <item name="colorControlNormal">?attr/colorOnPrimary</item>
-    </style>
 </resources>

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -6,10 +6,10 @@
 
     <style name="Theme.Woo" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <!-- Colors -->
-        <item name="colorPrimary">@color/woo_pink_50</item>
-        <item name="colorPrimaryVariant">@color/woo_pink_70</item>
-        <item name="colorSecondary">@color/woo_purple_60</item>
-        <item name="colorSecondaryVariant">@color/woo_purple_80</item>
+        <item name="colorPrimary">@color/woo_purple_60</item>
+        <item name="colorPrimaryVariant">@color/woo_purple_80</item>
+        <item name="colorSecondary">@color/woo_pink_50</item>
+        <item name="colorSecondaryVariant">@color/woo_pink_70</item>
 
         <item name="android:colorBackground">@color/default_window_background</item>
         <item name="colorSurface">@color/woo_white</item>

--- a/WooCommerce/src/main/res/values/type.xml
+++ b/WooCommerce/src/main/res/values/type.xml
@@ -60,7 +60,7 @@
     <style name="TextAppearance.Woo.Subtitle2" parent="TextAppearance.MaterialComponents.Subtitle2">
         <item name="fontFamily">@font/roboto_medium</item>
         <item name="android:textSize">@dimen/text_minor_100</item>
-        <item name="android:textColor">@color/color_on_surface_medium</item>
+        <item name="android:textColor">@color/color_on_surface_high</item>
         <item name="android:textStyle">normal</item>
         <item name="lineHeight">@dimen/line_height_minor_100</item>
     </style>

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'f51c4837bfa11c6c6ca3398a316bbee8400d84ae'
+    fluxCVersion = '4e77f9d9939d2beb30e6598665de6aecc0e1a31b'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Fix #1578 by converting `MyStoreStatsView` over to using material design styles and theming, and implementing dark/light mode on it. This was a really tricky one for me and I spent an unfathomable amount of time trying to figure out how to get the `Toolbar` and `TabLayout` into a single view so they were both at the same exact elevation and the elevation shadow only appears under the `TabLayout`. To get this working I had to:
- Remove the nested `CoordinatorLayout`'s between `activity_main` and `fragment_my_store`
- Put the toolbar in an `AppBarLayout` in `activity_main`
- Remove the `TabLayout` from the `fragment_my_store` layout file and create it programmatically instead. 
- Add the `TabLayout` to the `AppBarLayout` programmatically (this is why it had to be removed from the layout file).
- Add logic to remove the `TabLayout` whenever the My Store view is hidden, and add it back when it becomes unhidden. 

## Screenshots
<img width="1085" alt="Screen Shot 2019-12-31 at 5 43 17 PM" src="https://user-images.githubusercontent.com/5810477/71636961-c75d8c00-2bf5-11ea-819c-9121caf7f8f3.png">

<img width="1095" alt="Screen Shot 2019-12-31 at 5 42 56 PM" src="https://user-images.githubusercontent.com/5810477/71636970-f2e07680-2bf5-11ea-8da8-3e16b2a6d630.png">

## Recommended testing scenarios

- Test on devices running API 29, API 28, and API 21 - make sure the styles don't break between those versions. 
- Test dark and light modes.
- Test navigating to different areas of the app and returning to the stats view. The tablayout should hide and then be added back when the My Store tab is activated.