### PR TITLE
Dark Mode: Dashboard Top Performers

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardTopEarnersView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardTopEarnersView.kt
@@ -6,10 +6,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
-import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.annotation.StringRes
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.card.MaterialCardView
 import com.google.android.material.tabs.TabLayout
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -29,8 +29,8 @@ import org.wordpress.android.util.FormatUtils
 import org.wordpress.android.util.PhotonUtils
 import java.io.Serializable
 
-class DashboardTopEarnersView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
-    : LinearLayout(ctx, attrs) {
+class DashboardTopEarnersView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0)
+    : MaterialCardView(ctx, attrs, defStyleAttr) {
     init {
         View.inflate(context, R.layout.dashboard_top_earners, this)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardTopEarnersView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardTopEarnersView.kt
@@ -29,8 +29,11 @@ import org.wordpress.android.util.FormatUtils
 import org.wordpress.android.util.PhotonUtils
 import java.io.Serializable
 
-class DashboardTopEarnersView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0)
-    : MaterialCardView(ctx, attrs, defStyleAttr) {
+class DashboardTopEarnersView @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : MaterialCardView(ctx, attrs, defStyleAttr) {
     init {
         View.inflate(context, R.layout.dashboard_top_earners, this)
     }

--- a/WooCommerce/src/main/res/drawable/list_divider.xml
+++ b/WooCommerce/src/main/res/drawable/list_divider.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <inset
-    xmlns:android="http://schemas.android.com/apk/res/android" android:insetTop="@dimen/list_divider_padding_top" android:insetBottom="@dimen/list_divider_padding_bottom">
+    xmlns:android="http://schemas.android.com/apk/res/android">
     <shape android:shape="rectangle">
         <solid android:color="@color/list_divider"/>
         <size android:height="1dp" android:width="1dp"/>

--- a/WooCommerce/src/main/res/layout/dashboard_notice.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_notice.xml
@@ -2,7 +2,7 @@
 <merge
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    style="@style/Widget.Woo.Card"
+    style="@style/Woo.Card"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 

--- a/WooCommerce/src/main/res/layout/dashboard_stats.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_stats.xml
@@ -54,7 +54,7 @@
                 android:contentDescription="@string/dashboard_stats_error_content_description"
                 android:visibility="gone"
                 app:srcCompat="@drawable/ic_woo_error_state"
-                tools:visibility="visible"/>
+                tools:visibility="gone"/>
         </FrameLayout>
 
         <TextView
@@ -63,6 +63,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            tools:text="dashboard_recency_text"/>
+            tools:text="Updated 3 minutes ago"/>
     </LinearLayout>
 </merge>

--- a/WooCommerce/src/main/res/layout/dashboard_stats.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_stats.xml
@@ -17,12 +17,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"/>
 
-        <FrameLayout
-            android:id="@+id/tab_layout_divider"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="@color/list_divider"
-            app:srcCompat="@drawable/list_divider"/>
+        <View
+            style="@style/Woo.Divider"/>
 
         <!-- Date bar -->
         <TextView
@@ -32,12 +28,8 @@
             android:layout_height="wrap_content"
             tools:text="June 30-Jul 06"/>
 
-        <FrameLayout
-            android:id="@+id/tab_layout_divider_bottom"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="@color/list_divider"
-            app:srcCompat="@drawable/list_divider"/>
+        <View
+            style="@style/Woo.Divider"/>
 
         <include android:id="@+id/stats_view_row" layout="@layout/dashboard_main_stats_row" />
 

--- a/WooCommerce/src/main/res/layout/dashboard_stats.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_stats.xml
@@ -27,7 +27,7 @@
         <!-- Date bar -->
         <TextView
             android:id="@+id/dashboard_date_range_value"
-            style="@style/Woo.TextView.Subtitle2"
+            style="@style/Woo.DateBar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             tools:text="June 30-Jul 06"/>

--- a/WooCommerce/src/main/res/layout/dashboard_top_earners.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_top_earners.xml
@@ -4,93 +4,91 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    tools:context=".ui.dashboard.DashboardFragment">
 
-    <com.google.android.material.tabs.TabLayout
-        android:id="@+id/topEarners_tab_layout"
-        style="@style/Woo.TabLayout.Surface.Scrollable"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
-
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/list_divider"/>
-
-    <TextView
-        android:id="@+id/topEarners_title"
-        style="@style/Woo.TextAppearance.Title.Bold"
-        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:text="@string/dashboard_top_earners_title"/>
+        android:orientation="vertical">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/margin_large"
-        android:layout_marginTop="@dimen/margin_small"
-        android:text="@string/dashboard_top_earners_description"/>
-
-    <FrameLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="start"
-            android:layout_marginBottom="@dimen/margin_large"
-            android:layout_marginTop="@dimen/margin_small"
-            android:text="@string/product"
-            android:textStyle="bold"/>
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:layout_marginBottom="@dimen/margin_large"
-            android:layout_marginTop="@dimen/margin_small"
-            android:text="@string/dashboard_top_earners_total_spend"
-            android:textStyle="bold"/>
-    </FrameLayout>
-
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/list_divider"/>
-
-    <RelativeLayout
-        android:id="@+id/dashboard_top_earners_container"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/topEarners_recycler"
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/topEarners_tab_layout"
+            style="@style/Woo.TabLayout.Surface.Scrollable"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:minHeight="@dimen/top_earner_min_height"
-            tools:listitem="@layout/top_earner_list_item"/>
+            android:layout_height="wrap_content"/>
 
-        <ImageView
-            android:id="@+id/topEarners_error"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:contentDescription="@string/dashboard_stats_error_content_description"
-            android:visibility="gone"
-            app:srcCompat="@drawable/ic_woo_error_state"
-            tools:visibility="visible"/>
+        <View
+            style="@style/Woo.Divider"/>
 
         <TextView
-            android:id="@+id/topEarners_emptyView"
-            style="@style/Woo.Settings.Label"
+            android:id="@+id/topEarners_title"
+            style="@style/Woo.Card.Title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:text="@string/dashboard_top_earners_empty"
-            android:visibility="gone"
-            tools:visibility="visible"/>
-    </RelativeLayout>
+            android:text="@string/dashboard_top_earners_title"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            style="@style/Woo.Card.Body"
+            android:text="@string/dashboard_top_earners_description"/>
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start"
+                style="@style/Woo.Card.ListHeader"
+                android:text="@string/product"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:text="@string/dashboard_top_earners_total_spend"
+                style="@style/Woo.Card.ListHeader"/>
+        </FrameLayout>
+
+        <View
+            style="@style/Woo.Divider"/>
+
+        <RelativeLayout
+            android:id="@+id/dashboard_top_earners_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/topEarners_recycler"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:minHeight="@dimen/top_earner_min_height"
+                tools:listitem="@layout/top_earner_list_item"
+                tools:visibility="visible"/>
+
+            <ImageView
+                android:id="@+id/topEarners_error"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:contentDescription="@string/dashboard_stats_error_content_description"
+                android:visibility="gone"
+                app:srcCompat="@drawable/ic_woo_error_state"
+                tools:visibility="gone"/>
+
+            <TextView
+                android:id="@+id/topEarners_emptyView"
+                style="@style/Woo.Card.EmptyMessage"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:text="@string/dashboard_top_earners_empty"
+                android:visibility="gone"
+                tools:visibility="gone"/>
+        </RelativeLayout>
+    </LinearLayout>
 
 </merge>

--- a/WooCommerce/src/main/res/layout/dashboard_top_earners.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_top_earners.xml
@@ -21,14 +21,14 @@
         <View
             style="@style/Woo.Divider"/>
 
-        <TextView
+        <com.google.android.material.textview.MaterialTextView
             android:id="@+id/topEarners_title"
             style="@style/Woo.Card.Title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/dashboard_top_earners_title"/>
 
-        <TextView
+        <com.google.android.material.textview.MaterialTextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/Woo.Card.Body"
@@ -38,14 +38,14 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-            <TextView
+            <com.google.android.material.textview.MaterialTextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="start"
                 style="@style/Woo.Card.ListHeader"
                 android:text="@string/product"/>
 
-            <TextView
+            <com.google.android.material.textview.MaterialTextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="end"
@@ -79,7 +79,7 @@
                 app:srcCompat="@drawable/ic_woo_error_state"
                 tools:visibility="gone"/>
 
-            <TextView
+            <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/topEarners_emptyView"
                 style="@style/Woo.Card.EmptyMessage"
                 android:layout_width="wrap_content"

--- a/WooCommerce/src/main/res/layout/fragment_dashboard.xml
+++ b/WooCommerce/src/main/res/layout/fragment_dashboard.xml
@@ -43,22 +43,21 @@
                 <!-- Order stats -->
                 <com.woocommerce.android.ui.dashboard.DashboardStatsView
                     android:id="@+id/dashboard_stats"
-                    style="@style/Widget.Woo.Card.Tabbed"
+                    style="@style/Woo.Card.Tabbed"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/minor_00"
                     android:layout_marginEnd="@dimen/minor_00"
                     android:layout_marginTop="@dimen/minor_100"
-                    android:layout_marginBottom="@dimen/minor_100"/>
+                    android:layout_marginBottom="@dimen/major_100"/>
 
                 <!-- Top earner stats -->
                 <com.woocommerce.android.ui.dashboard.DashboardTopEarnersView
                     android:id="@+id/dashboard_top_earners"
-                    style="@style/Widget.Woo.Card"
+                    style="@style/Woo.Card"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_small"
-                    android:orientation="vertical"/>
+                    android:layout_marginTop="@dimen/minor_50"/>
 
             </LinearLayout>
 

--- a/WooCommerce/src/main/res/layout/fragment_dashboard.xml
+++ b/WooCommerce/src/main/res/layout/fragment_dashboard.xml
@@ -28,7 +28,7 @@
                     style="@style/Woo.Stats.Notice.Card"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    tools:visibility="visible"
+                    tools:visibility="gone"
                     android:visibility="gone"/>
 
                 <!-- My Store stats availability notice card -->
@@ -37,7 +37,7 @@
                     style="@style/Woo.Stats.Card.Expandable"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    tools:visibility="visible"
+                    tools:visibility="gone"
                     android:visibility="gone"/>
 
                 <!-- Order stats -->
@@ -49,7 +49,7 @@
                     android:layout_marginStart="@dimen/minor_00"
                     android:layout_marginEnd="@dimen/minor_00"
                     android:layout_marginTop="@dimen/minor_100"
-                    android:layout_marginBottom="@dimen/major_100"/>
+                    android:layout_marginBottom="@dimen/minor_100"/>
 
                 <!-- Top earner stats -->
                 <com.woocommerce.android.ui.dashboard.DashboardTopEarnersView
@@ -57,7 +57,7 @@
                     style="@style/Woo.Card"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/minor_50"/>
+                    tools:visibility="visible"/>
 
             </LinearLayout>
 
@@ -66,7 +66,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:visibility="gone"
-                tools:visibility="visible"/>
+                tools:visibility="gone"/>
 
         </FrameLayout>
 

--- a/WooCommerce/src/main/res/layout/fragment_order_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_detail.xml
@@ -28,14 +28,14 @@
                 <!-- Order Status -->
                 <com.woocommerce.android.ui.orders.OrderDetailOrderStatusView
                     android:id="@+id/orderDetail_orderStatus"
-                    style="@style/Widget.Woo.Card"
+                    style="@style/Woo.Card"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"/>
 
                 <!-- Order Shipping method warning card -->
                 <com.woocommerce.android.ui.orders.OrderDetailShippingMethodNoticeCard
                     android:id="@+id/orderDetail_shippingMethodNotice"
-                    style="@style/Widget.Woo.Card"
+                    style="@style/Woo.Card"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/margin_large"
@@ -46,7 +46,7 @@
                 <!-- Product List -->
                 <com.woocommerce.android.ui.orders.OrderDetailProductListView
                     android:id="@+id/orderDetail_productList"
-                    style="@style/Widget.Woo.Card.WithoutPadding"
+                    style="@style/Woo.Card.WithoutPadding"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:clipToPadding="false"
@@ -55,7 +55,7 @@
                 <!-- Payments -->
                 <com.woocommerce.android.ui.orders.OrderDetailPaymentView
                     android:id="@+id/orderDetail_paymentInfo"
-                    style="@style/Widget.Woo.Card.WithoutPadding"
+                    style="@style/Woo.Card.WithoutPadding"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:animateLayoutChanges="true"
@@ -64,14 +64,14 @@
                 <!-- Customer Info -->
                 <com.woocommerce.android.ui.orders.OrderDetailCustomerInfoView
                     android:id="@+id/orderDetail_customerInfo"
-                    style="@style/Widget.Woo.Card.Expandable"
+                    style="@style/Woo.Card.Expandable"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"/>
 
                 <!-- Shipment Tracking -->
                 <com.woocommerce.android.ui.orders.OrderDetailShipmentTrackingListView
                     android:id="@+id/orderDetail_shipmentList"
-                    style="@style/Widget.Woo.Card.WithoutPadding"
+                    style="@style/Woo.Card.WithoutPadding"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:clipToPadding="false"
@@ -82,7 +82,7 @@
                 <!-- Order Notes -->
                 <com.woocommerce.android.ui.orders.notes.OrderDetailOrderNoteListView
                     android:id="@+id/orderDetail_noteList"
-                    style="@style/Widget.Woo.Card.WithoutPadding"
+                    style="@style/Woo.Card.WithoutPadding"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"/>
             </LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_order_fulfillment.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_fulfillment.xml
@@ -18,28 +18,28 @@
             android:id="@+id/orderFulfill_products"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            style="@style/Widget.Woo.Card.WithoutPadding"/>
+            style="@style/Woo.Card.WithoutPadding"/>
 
         <!-- Customer Provided Note -->
         <com.woocommerce.android.ui.orders.notes.OrderDetailCustomerNoteView
             android:id="@+id/orderFulfill_customerNote"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            style="@style/Widget.Woo.Card"/>
+            style="@style/Woo.Card"/>
 
         <!-- Customer Info -->
         <com.woocommerce.android.ui.orders.OrderDetailCustomerInfoView
             android:id="@+id/orderFulfill_customerInfo"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            style="@style/Widget.Woo.Card.Expandable"/>
+            style="@style/Woo.Card.Expandable"/>
 
         <!-- Add Optional Shipment Tracking -->
         <com.woocommerce.android.ui.orders.OrderDetailShipmentTrackingListView
             android:id="@+id/orderFulfill_addShipmentTracking"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            style="@style/Widget.Woo.Card.WithoutPadding"
+            style="@style/Woo.Card.WithoutPadding"
             android:clipToPadding="false"
             android:paddingBottom="0dp"
             android:contentDescription="@string/order_shipment_tracking_add_label"

--- a/WooCommerce/src/main/res/layout/fragment_order_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_list.xml
@@ -49,7 +49,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
                 android:visibility="gone"
-                style="@style/Widget.Woo.Card.WithoutPadding"
+                style="@style/Woo.Card.WithoutPadding"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"

--- a/WooCommerce/src/main/res/layout/fragment_order_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_product_list.xml
@@ -11,5 +11,5 @@
         android:id="@+id/orderProducts_list"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        style="@style/Widget.Woo.Card.WithoutPadding"/>
+        style="@style/Woo.Card.WithoutPadding"/>
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_refund_by_amount.xml
+++ b/WooCommerce/src/main/res/layout/fragment_refund_by_amount.xml
@@ -3,7 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    style="@style/Widget.Woo.Card"
+    style="@style/Woo.Card"
     tools:context="com.woocommerce.android.ui.refunds.RefundByAmountFragment">
 
     <com.google.android.material.textfield.TextInputLayout

--- a/WooCommerce/src/main/res/layout/fragment_refund_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_refund_detail.xml
@@ -15,7 +15,7 @@
         tools:context="com.woocommerce.android.ui.refunds.RefundByAmountFragment">
 
         <LinearLayout
-            style="@style/Widget.Woo.Card"
+            style="@style/Woo.Card"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
@@ -72,7 +72,7 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/refundDetail_reasonCard"
-            style="@style/Widget.Woo.Card"
+            style="@style/Woo.Card"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 

--- a/WooCommerce/src/main/res/layout/fragment_refund_summary.xml
+++ b/WooCommerce/src/main/res/layout/fragment_refund_summary.xml
@@ -15,7 +15,7 @@
         tools:context="com.woocommerce.android.ui.refunds.RefundByAmountFragment">
 
         <LinearLayout
-            style="@style/Widget.Woo.Card"
+            style="@style/Woo.Card"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
@@ -107,7 +107,7 @@
         </LinearLayout>
 
         <LinearLayout
-            style="@style/Widget.Woo.Card"
+            style="@style/Woo.Card"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">

--- a/WooCommerce/src/main/res/layout/top_earner_list_item.xml
+++ b/WooCommerce/src/main/res/layout/top_earner_list_item.xml
@@ -4,8 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?attr/selectableItemBackground"
-    android:paddingTop="@dimen/margin_large">
+    android:background="?attr/selectableItemBackground">
 
     <FrameLayout
         android:id="@+id/frame_product"
@@ -13,12 +12,13 @@
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
         android:background="@drawable/picture_frame"
+        android:layout_margin="@dimen/major_100"
         android:padding="1dp">
 
         <ImageView
             android:id="@+id/image_product"
-            android:layout_width="@dimen/product_icon_sz"
-            android:layout_height="@dimen/product_icon_sz"
+            android:layout_width="@dimen/image_minor_100"
+            android:layout_height="@dimen/image_minor_100"
             android:contentDescription="@string/product_image_content_description"
             android:scaleType="centerCrop"
             tools:src="@drawable/ic_stats_grey_min_24dp"/>
@@ -29,16 +29,15 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
-        android:layout_marginBottom="@dimen/margin_extra_large"
-        android:layout_marginEnd="@dimen/margin_large"
-        android:layout_marginStart="@dimen/margin_large"
         android:layout_toEndOf="@+id/frame_product"
         android:layout_toStartOf="@+id/text_TotalSpend"
+        android:layout_marginBottom="@dimen/major_100"
+        android:layout_marginTop="@dimen/major_100"
         android:orientation="vertical">
 
         <TextView
             android:id="@+id/text_ProductName"
-            style="@style/Woo.TextAppearance.Large"
+            style="@style/Woo.Card.ListItem.Title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:ellipsize="end"
@@ -47,7 +46,7 @@
 
         <TextView
             android:id="@+id/text_ProductOrders"
-            style="@style/Woo.TextAppearance.Medium"
+            style="@style/Woo.Card.ListItem.Body"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             tools:text="text_ProductOrders"/>
@@ -55,19 +54,17 @@
 
     <TextView
         android:id="@+id/text_TotalSpend"
-        style="@style/Woo.TextAppearance.Large"
+        style="@style/Woo.Card.ListItem.Title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentEnd="true"
+        android:layout_margin="@dimen/major_100"
         tools:text="$150"/>
 
     <View
+        style="@style/Woo.Divider"
         android:id="@+id/divider"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
         android:layout_below="@+id/product_container"
-        android:layout_marginStart="@dimen/margin_large"
-        android:layout_toEndOf="@+id/frame_product"
-        android:background="@color/list_divider"/>
+        android:layout_toEndOf="@+id/frame_product"/>
 
 </RelativeLayout>

--- a/WooCommerce/src/main/res/layout/top_earner_list_item.xml
+++ b/WooCommerce/src/main/res/layout/top_earner_list_item.xml
@@ -35,7 +35,7 @@
         android:layout_marginTop="@dimen/major_100"
         android:orientation="vertical">
 
-        <TextView
+        <com.google.android.material.textview.MaterialTextView
             android:id="@+id/text_ProductName"
             style="@style/Woo.Card.ListItem.Title"
             android:layout_width="wrap_content"
@@ -44,7 +44,7 @@
             android:maxLines="2"
             tools:text="text_ProductName"/>
 
-        <TextView
+        <com.google.android.material.textview.MaterialTextView
             android:id="@+id/text_ProductOrders"
             style="@style/Woo.Card.ListItem.Body"
             android:layout_width="wrap_content"
@@ -52,7 +52,7 @@
             tools:text="text_ProductOrders"/>
     </LinearLayout>
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/text_TotalSpend"
         style="@style/Woo.Card.ListItem.Title"
         android:layout_width="wrap_content"

--- a/WooCommerce/src/main/res/layout/wc_empty_view.xml
+++ b/WooCommerce/src/main/res/layout/wc_empty_view.xml
@@ -11,7 +11,7 @@
 
     <LinearLayout
         android:id="@+id/empty_view_stats_row"
-        style="@style/Widget.Woo.Card.WithoutPadding"
+        style="@style/Woo.Card.WithoutPadding"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/white"
@@ -56,7 +56,7 @@
 
     <LinearLayout
         android:id="@+id/linearLayout2"
-        style="@style/Widget.Woo.Card.WithoutPadding"
+        style="@style/Woo.Card.WithoutPadding"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_below="@+id/empty_view_stats_row"

--- a/WooCommerce/src/main/res/values/dimens.xml
+++ b/WooCommerce/src/main/res/values/dimens.xml
@@ -16,6 +16,7 @@ so that's the baseline as defined in `major_100`.
     <dimen name="minor_00">0dp</dimen>
     <dimen name="minor_25">2dp</dimen>
     <dimen name="minor_50">4dp</dimen>
+    <dimen name="minor_75">6dp</dimen>
     <dimen name="minor_100">8dp</dimen>
 
     <dimen name="major_75">12dp</dimen>
@@ -50,5 +51,8 @@ so that's the baseline as defined in `major_100`.
     <dimen name="line_height_major_100">56dp</dimen>
     <dimen name="line_height_major_150">72dp</dimen>
     <dimen name="line_height_major_200">112dp</dimen>
+
+    <!-- Smaller image sizes (ex. icons) -->
+    <dimen name="image_minor_100">40dp</dimen>
 
 </resources>

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -1,126 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Woo"/>
+    <!--
+        DateBar Style
+    -->
+    <style name="Woo.DateBar" parent="@style/Woo.TextView.Subtitle1"/>
 
     <!--
-        Toolbar Styles
+        Divider Styles
     -->
-    <style name="Widget.Woo.Toolbar" parent="@style/Widget.MaterialComponents.Toolbar.PrimarySurface"/>
-
-    <!--
-        AppBarLayout Styles
-    -->
-    <style name="Woo.AppBarLayout" parent="@style/Widget.MaterialComponents.AppBarLayout.PrimarySurface">
-        <item name="android:elevation">@dimen/plane_04</item>
-        <item name="android:fitsSystemWindows">false</item>
+    <style name="Woo.Divider">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">1dp</item>
+        <item name="android:background">?android:attr/listDivider</item>
     </style>
 
-    <!--
-        Bottom Bar Styles
-    -->
-    <style name="Widget.Woo.BottomNavigationView" parent="@style/Widget.MaterialComponents.BottomNavigationView">
-        <item name="android:background">?attr/colorSurface</item>
-        <item name="itemIconTint">@color/color_on_surface</item>
-        <item name="itemTextColor">@color/color_on_surface</item>
-        <item name="android:elevation">@dimen/plane_08</item>
-    </style>
-
-    <!--
-        TabLayout Styles
-    -->
-    <style name="Woo.TabLayout" parent="@style/Widget.MaterialComponents.TabLayout.PrimarySurface">
-        <item name="tabMode">fixed</item>
-        <item name="tabTextAppearance">?attr/textAppearanceButton</item>
-        <item name="tabSelectedTextColor">?attr/colorOnPrimarySurface</item>
-        <item name="tabIndicatorColor">?attr/colorOnPrimarySurface</item>
-        <item name="tabIndicatorHeight">2dp</item>
-        <item name="tabPaddingStart">25dp</item>
-        <item name="tabPaddingEnd">25dp</item>
-        <item name="android:elevation">@dimen/plane_00</item>
-    </style>
-    <style name="Woo.TabLayout.Scrollable">
-        <!--
-        Designs call for a 52dp gap at the start for scrollable Tabs, but Android calculates
-        this number as being (tabContentStart - tabPaddingStart), so you have to add the
-        padding amount of 40dp on top to make sure the tab actually starts at 52dp
-        -->
-        <item name="tabContentStart">92dp</item>
-        <item name="tabMode">scrollable</item>
-    </style>
-    <style name="Woo.TabLayout.Surface" parent="@style/Widget.MaterialComponents.TabLayout">
-        <item name="tabMode">fixed</item>
-        <item name="tabTextAppearance">?attr/textAppearanceButton</item>
-        <item name="tabSelectedTextColor">?attr/colorOnSurface</item>
-        <item name="tabIndicatorColor">?attr/colorOnSurface</item>
-        <item name="tabIndicatorHeight">2dp</item>
-        <item name="tabPaddingStart">40dp</item>
-        <item name="tabPaddingEnd">40dp</item>
-    </style>
-    <style name="Woo.TabLayout.Surface.Scrollable">
-        <!--
-        Designs call for a 52dp gap at the start for scrollable Tabs, but Android calculates
-        this number as being (tabContentStart - tabPaddingStart), so you have to add the
-        padding amount of 40dp on top to make sure the tab actually starts at 52dp
-        -->
-        <item name="tabContentStart">92dp</item>
-        <item name="tabMode">scrollable</item>
+    <style name="Woo.Divider.Padded">
+        <item name="android:layout_height">17dp</item>
+        <item name="android:paddingTop">@dimen/minor_100</item>
+        <item name="android:paddingBottom">@dimen/minor_100</item>
     </style>
 
     <!--
         Card Styles
     -->
-    <style name="Widget.Woo.Card" parent="@style/Widget.MaterialComponents.CardView">
-        <item name="cardCornerRadius">@dimen/minor_00</item>
-        <item name="android:checkable">false</item>
-        <item name="contentPaddingTop">@dimen/minor_25</item>
-        <item name="contentPaddingBottom">@dimen/minor_25</item>
-    </style>
-    <style name="Widget.Woo.Card.Tabbed">
-        <item name="contentPaddingTop">@dimen/minor_00</item>
-    </style>
-    <style name="Widget.Woo.Card.Expandable">
-        <item name="android:paddingStart">0dp</item>
-        <item name="android:paddingEnd">0dp</item>
-        <item name="android:paddingBottom">0dp</item>
-    </style>
-    <style name="Widget.Woo.Card.WithoutPadding">
-        <item name="android:paddingStart">0dp</item>
-        <item name="android:paddingEnd">0dp</item>
-        <item name="android:paddingTop">0dp</item>
-        <item name="android:paddingBottom">0dp</item>
-    </style>
+    <style name="Woo.Card.Title" parent="@style/Woo.TextView.Subtitle1"/>
 
-    <!--
-        TextView Styles
-    -->
-    <style name="Woo.TextView" parent="@style/Widget.MaterialComponents.TextView">
+    <style name="Woo.Card.Body" parent="@style/Woo.TextView.Body2"/>
+
+    <style name="Woo.Card.EmptyMessage" parent="@style/Woo.TextView.Subtitle1"/>
+
+    <style name="Woo.Card.ListHeader" parent="@style/Woo.TextView.Subtitle2">
+        <item name="android:layout_marginTop">@dimen/major_100</item>
+        <item name="android:layout_marginBottom">@dimen/major_75</item>
         <item name="android:layout_marginStart">@dimen/major_100</item>
         <item name="android:layout_marginEnd">@dimen/major_100</item>
-        <item name="android:layout_marginTop">@dimen/major_75</item>
-        <item name="android:layout_marginBottom">@dimen/major_75</item>
-    </style>
-    <style name="Woo.TextView.Subtitle2">
-        <item name="android:textAppearance">?attr/textAppearanceSubtitle2</item>
-        <item name="android:textColor">@color/color_on_surface_high</item>
-        <item name="android:gravity">center_horizontal|start</item>
-    </style>
-    <style name="Woo.TextView.Caption">
-        <item name="android:textAppearance">?attr/textAppearanceCaption</item>
     </style>
 
-    <!--
-        Custom TextView Styles
-    -->
-    <style name="Woo.DateBar" parent="Woo.TextView">
-        <item name="android:textAppearance">?attr/textAppearanceSubtitle2</item>
+    <style name="Woo.Card.ListItem.Title" parent="@style/Woo.TextView.Subtitle1">
+        <item name="android:layout_margin">@dimen/minor_00</item>
+    </style>
+
+    <style name="Woo.Card.ListItem.Body" parent="@style/Woo.TextView.Body2">
+        <item name="android:layout_margin">@dimen/minor_00</item>
     </style>
 
 
-    <!--
 
-        OLD STUFF below this line will eventually be phased out during the course of this
-        project.
-
+    <!---
+        -
+        -
+        -
+        - OLD STUFF below this line will eventually be phased out during the course of this
+        - project.
+        -
+        -
+        -
     -->
 
 
@@ -658,17 +592,17 @@
     <!--
          Stats
         -->
-    <style name="Woo.Stats.Card" parent="Widget.Woo.Card">
+    <style name="Woo.Stats.Card" parent="Woo.Card">
         <item name="android:layout_marginBottom">@dimen/card_item_padding_intra_h</item>
     </style>
 
-    <style name="Woo.Stats.Notice.Card" parent="Widget.Woo.Card">
+    <style name="Woo.Stats.Notice.Card" parent="Woo.Card">
         <item name="android:paddingEnd">@dimen/margin_small</item>
         <item name="android:paddingBottom">@dimen/default_padding</item>
         <item name="android:layout_marginBottom">@dimen/margin_medium</item>
     </style>
 
-    <style name="Woo.Stats.Card.Expandable" parent="Widget.Woo.Card.Expandable">
+    <style name="Woo.Stats.Card.Expandable" parent="Woo.Card.Expandable">
         <item name="android:paddingTop">0dp</item>
         <item name="android:layout_marginBottom">@dimen/margin_medium</item>
     </style>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -58,7 +58,7 @@ theme across the entire app.
         <item name="tabMode">fixed</item>
         <item name="tabTextAppearance">?attr/textAppearanceButton</item>
         <item name="tabSelectedTextColor">?attr/colorOnSurface</item>
-        <item name="tabIndicatorColor">?attr/colorOnSurface</item>
+        <item name="tabIndicatorColor">?attr/colorPrimary</item>
         <item name="tabIndicatorHeight">2dp</item>
         <item name="tabPaddingStart">40dp</item>
         <item name="tabPaddingEnd">40dp</item>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Base Woo Styles. Use these styles as a base for custom component styles and override only the
+properties necessary. The goal is to make as few modifications as possible to keep a consistent
+theme across the entire app.
+-->
+<resources>
+    <style name="Woo"/>
+
+    <!--
+        Toolbar Style
+    -->
+    <style name="Widget.Woo.Toolbar" parent="@style/Widget.MaterialComponents.Toolbar.PrimarySurface"/>
+
+    <!--
+        AppBarLayout Style
+    -->
+    <style name="Woo.AppBarLayout" parent="@style/Widget.MaterialComponents.AppBarLayout.PrimarySurface">
+        <item name="android:elevation">@dimen/plane_04</item>
+        <item name="android:fitsSystemWindows">false</item>
+    </style>
+
+    <!--
+        Bottom Bar Style
+    -->
+    <style name="Widget.Woo.BottomNavigationView" parent="@style/Widget.MaterialComponents.BottomNavigationView">
+        <item name="android:background">?attr/colorSurface</item>
+        <item name="itemIconTint">@color/color_on_surface</item>
+        <item name="itemTextColor">@color/color_on_surface</item>
+        <item name="android:elevation">@dimen/plane_08</item>
+    </style>
+
+    <!--
+        TabLayout Styles
+    -->
+    <style name="Woo.TabLayout" parent="@style/Widget.MaterialComponents.TabLayout.PrimarySurface">
+        <item name="tabMode">fixed</item>
+        <item name="tabTextAppearance">?attr/textAppearanceButton</item>
+        <item name="tabSelectedTextColor">?attr/colorOnPrimarySurface</item>
+        <item name="tabIndicatorColor">?attr/colorOnPrimarySurface</item>
+        <item name="tabIndicatorHeight">2dp</item>
+        <item name="tabPaddingStart">25dp</item>
+        <item name="tabPaddingEnd">25dp</item>
+        <item name="android:elevation">@dimen/plane_00</item>
+    </style>
+
+    <style name="Woo.TabLayout.Scrollable">
+        <!--
+        Designs call for a 52dp gap at the start for scrollable Tabs, but Android calculates
+        this number as being (tabContentStart - tabPaddingStart), so you have to add the
+        padding amount of 40dp on top to make sure the tab actually starts at 52dp
+        -->
+        <item name="tabContentStart">92dp</item>
+        <item name="tabMode">scrollable</item>
+    </style>
+
+    <style name="Woo.TabLayout.Surface" parent="@style/Widget.MaterialComponents.TabLayout">
+        <item name="tabMode">fixed</item>
+        <item name="tabTextAppearance">?attr/textAppearanceButton</item>
+        <item name="tabSelectedTextColor">?attr/colorOnSurface</item>
+        <item name="tabIndicatorColor">?attr/colorOnSurface</item>
+        <item name="tabIndicatorHeight">2dp</item>
+        <item name="tabPaddingStart">40dp</item>
+        <item name="tabPaddingEnd">40dp</item>
+    </style>
+
+    <style name="Woo.TabLayout.Surface.Scrollable">
+        <!--
+        Designs call for a 52dp gap at the start for scrollable Tabs, but Android calculates
+        this number as being (tabContentStart - tabPaddingStart), so you have to add the
+        padding amount of 40dp on top to make sure the tab actually starts at 52dp
+        -->
+        <item name="tabContentStart">92dp</item>
+        <item name="tabMode">scrollable</item>
+    </style>
+
+    <!--
+        Card Styles
+    -->
+    <style name="Woo.Card" parent="@style/Widget.MaterialComponents.CardView">
+        <item name="cardCornerRadius">@dimen/minor_00</item>
+        <item name="android:checkable">false</item>
+        <item name="contentPaddingTop">@dimen/minor_25</item>
+        <item name="contentPaddingBottom">@dimen/minor_25</item>
+    </style>
+
+    <style name="Woo.Card.Tabbed">
+        <item name="contentPaddingTop">@dimen/minor_00</item>
+    </style>
+
+    <style name="Woo.Card.Expandable">
+        <item name="android:paddingStart">0dp</item>
+        <item name="android:paddingEnd">0dp</item>
+        <item name="android:paddingBottom">0dp</item>
+    </style>
+
+    <style name="Woo.Card.WithoutPadding">
+        <item name="android:paddingStart">0dp</item>
+        <item name="android:paddingEnd">0dp</item>
+        <item name="android:paddingTop">0dp</item>
+        <item name="android:paddingBottom">0dp</item>
+    </style>
+
+    <!--
+        TextView Styles
+    -->
+    <style name="Woo.TextView" parent="@style/Widget.MaterialComponents.TextView">
+        <item name="android:layout_marginStart">@dimen/major_100</item>
+        <item name="android:layout_marginEnd">@dimen/major_100</item>
+        <item name="android:layout_marginTop">@dimen/major_75</item>
+        <item name="android:layout_marginBottom">@dimen/major_75</item>
+    </style>
+
+    <style name="Woo.TextView.Headline1">
+        <item name="android:textAppearance">?attr/textAppearanceHeadline1</item>
+    </style>
+
+    <style name="Woo.TextView.Headline2">
+        <item name="android:textAppearance">?attr/textAppearanceHeadline2</item>
+    </style>
+
+    <style name="Woo.TextView.Headline3">
+        <item name="android:textAppearance">?attr/textAppearanceHeadline3</item>
+    </style>
+
+    <style name="Woo.TextView.Headline4">
+        <item name="android:textAppearance">?attr/textAppearanceHeadline4</item>
+    </style>
+
+    <style name="Woo.TextView.Headline5">
+        <item name="android:textAppearance">?attr/textAppearanceHeadline5</item>
+    </style>
+
+    <style name="Woo.TextView.Headline6">
+        <item name="android:textAppearance">?attr/textAppearanceHeadline6</item>
+    </style>
+
+    <style name="Woo.TextView.Subtitle1">
+        <item name="android:textAppearance">?attr/textAppearanceSubtitle1</item>
+        <item name="android:textColor">@color/color_on_surface_high</item>
+        <item name="android:gravity">center_horizontal|start</item>
+    </style>
+
+    <style name="Woo.TextView.Subtitle2">
+        <item name="android:textAppearance">?attr/textAppearanceSubtitle2</item>
+        <item name="android:textColor">@color/color_on_surface_medium</item>
+        <item name="android:gravity">center_horizontal|start</item>
+    </style>
+
+    <style name="Woo.TextView.Body1">
+        <item name="android:textAppearance">?attr/textAppearanceBody1</item>
+    </style>
+
+    <style name="Woo.TextView.Body2">
+        <item name="android:textAppearance">?attr/textAppearanceBody2</item>
+        <item name="android:textColor">@color/color_on_surface_medium</item>
+        <item name="android:gravity">center_horizontal|start</item>
+        <item name="android:layout_marginTop">@dimen/minor_00</item>
+        <item name="android:layout_marginBottom">@dimen/minor_00</item>
+    </style>
+
+    <style name="Woo.TextView.Caption">
+        <item name="android:textAppearance">?attr/textAppearanceCaption</item>
+    </style>
+
+    <style name="Woo.TextView.Overline">
+        <item name="android:textAppearance">?attr/textAppearanceOverline</item>
+    </style>
+</resources>

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -66,6 +66,7 @@
         <item name="tabStyle">@style/Woo.TabLayout</item>
         <item name="scrollableTabStyle">@style/Woo.TabLayout.Scrollable</item>
         <item name="appBarLayoutStyle">@style/Woo.AppBarLayout</item>
+        <item name="android:listDivider">@drawable/list_divider</item>
 
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '4e77f9d9939d2beb30e6598665de6aecc0e1a31b'
+    fluxCVersion = 'eb346201f539c0e0445edffbcdf7920905478184'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Partially fixes #1765 by implementing dark/light mode styling on the old version of the Top Performers card.  The new top performers card will be covered in a separate PR. This PR is just focusing on this one component, so don't worry about the styling in the rest of the app. It will be fubar'd for a while :)

No functionality changed, this is only styling.

<img width="1657" alt="Screen Shot 2019-12-31 at 9 36 26 PM" src="https://user-images.githubusercontent.com/5810477/71638178-0e5b7980-2c16-11ea-99c3-35c11da7f4c8.png">

## Recommended Testing
- Test on devices running API 21, 28, and 29 just to make sure there aren't any funky issues between the major styling changes included those versions.
- Test light and dark versions. 
