### PR TITLE
Dark Mode: Top Performers v4 Card

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreTopEarnersView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreTopEarnersView.kt
@@ -6,9 +6,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
-import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
@@ -26,8 +26,8 @@ import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.util.FormatUtils
 import org.wordpress.android.util.PhotonUtils
 
-class MyStoreTopEarnersView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
-    : LinearLayout(ctx, attrs) {
+class MyStoreTopEarnersView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0)
+    : MaterialCardView(ctx, attrs, defStyleAttr) {
     init {
         View.inflate(context, R.layout.my_store_top_earners, this)
     }

--- a/WooCommerce/src/main/res/layout/fragment_my_store.xml
+++ b/WooCommerce/src/main/res/layout/fragment_my_store.xml
@@ -34,7 +34,7 @@
                     <!-- Order stats -->
                     <com.woocommerce.android.ui.mystore.MyStoreStatsView
                         android:id="@+id/my_store_stats"
-                        style="@style/Woo.Stats.Card"
+                        style="@style/Woo.Card"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="vertical"/>
@@ -42,7 +42,7 @@
                     <!-- Top earner stats -->
                     <com.woocommerce.android.ui.mystore.MyStoreTopEarnersView
                         android:id="@+id/my_store_top_earners"
-                        style="@style/Woo.Stats.Card"
+                        style="@style/Woo.Card"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="vertical"/>

--- a/WooCommerce/src/main/res/layout/my_store_top_earners.xml
+++ b/WooCommerce/src/main/res/layout/my_store_top_earners.xml
@@ -7,7 +7,7 @@
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/topEarners_title"
         style="@style/Woo.Card.Title"
         android:layout_width="wrap_content"
@@ -15,7 +15,7 @@
         android:layout_marginTop="16dp"
         android:text="@string/dashboard_top_earners_title"/>
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         style="@style/Woo.Card.Body"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -25,14 +25,14 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <TextView
+        <com.google.android.material.textview.MaterialTextView
             style="@style/Woo.Card.ListHeader"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="start"
             android:text="@string/product"/>
 
-        <TextView
+        <com.google.android.material.textview.MaterialTextView
             style="@style/Woo.Card.ListHeader"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -65,7 +65,7 @@
             app:srcCompat="@drawable/ic_woo_error_state"
             tools:visibility="visible"/>
 
-        <TextView
+        <com.google.android.material.textview.MaterialTextView
             android:id="@+id/topEarners_emptyView"
             style="@style/Woo.Card.EmptyMessage"
             android:layout_width="wrap_content"

--- a/WooCommerce/src/main/res/layout/my_store_top_earners.xml
+++ b/WooCommerce/src/main/res/layout/my_store_top_earners.xml
@@ -9,17 +9,16 @@
 
     <TextView
         android:id="@+id/topEarners_title"
-        style="@style/Woo.TextAppearance.Title.Bold"
+        style="@style/Woo.Card.Title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
         android:text="@string/dashboard_top_earners_title"/>
 
     <TextView
-        android:layout_width="wrap_content"
+        style="@style/Woo.Card.Body"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/margin_large"
-        android:layout_marginTop="@dimen/margin_small"
         android:text="@string/dashboard_top_earners_description"/>
 
     <FrameLayout
@@ -27,28 +26,22 @@
         android:layout_height="wrap_content">
 
         <TextView
+            style="@style/Woo.Card.ListHeader"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="start"
-            android:layout_marginBottom="@dimen/margin_large"
-            android:layout_marginTop="@dimen/margin_small"
-            android:text="@string/product"
-            android:textStyle="bold"/>
+            android:text="@string/product"/>
 
         <TextView
+            style="@style/Woo.Card.ListHeader"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="end"
-            android:layout_marginBottom="@dimen/margin_large"
-            android:layout_marginTop="@dimen/margin_small"
-            android:text="@string/dashboard_top_earners_total_spend"
-            android:textStyle="bold"/>
+            android:text="@string/dashboard_top_earners_total_spend"/>
     </FrameLayout>
 
     <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/list_divider"/>
+        style="@style/Woo.Divider"/>
 
     <RelativeLayout
         android:id="@+id/dashboard_top_earners_container"
@@ -74,7 +67,7 @@
 
         <TextView
             android:id="@+id/topEarners_emptyView"
-            style="@style/Woo.Settings.Label"
+            style="@style/Woo.Card.EmptyMessage"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerInParent="true"

--- a/WooCommerce/src/main/res/layout/my_store_top_earners.xml
+++ b/WooCommerce/src/main/res/layout/my_store_top_earners.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
 
     <TextView
         android:id="@+id/topEarners_title"
@@ -82,4 +83,4 @@
             tools:visibility="visible"/>
     </RelativeLayout>
 
-</merge>
+</LinearLayout>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -82,6 +82,7 @@ theme across the entire app.
         <item name="android:checkable">false</item>
         <item name="contentPaddingTop">@dimen/minor_25</item>
         <item name="contentPaddingBottom">@dimen/minor_25</item>
+        <item name="android:layout_marginBottom">@dimen/minor_100</item>
     </style>
 
     <style name="Woo.Card.Tabbed">


### PR DESCRIPTION
Fixes #1765 by implementing dark/light mode styling on the Top Performers v2 card. 
- Updated to use `MaterialCardView`
- Applied appropriate styles

![Screen Shot 2020-01-02 at 5 35 40 PM](https://user-images.githubusercontent.com/5810477/71701382-5e594e00-2d86-11ea-989e-d54e8f16703b.png)

![Screen Shot 2020-01-02 at 5 41 01 PM](https://user-images.githubusercontent.com/5810477/71701516-1555c980-2d87-11ea-9610-fc69ca432179.png)


## Recommended Testing
- Test on API versions 21, 28 and 29 to make sure the styles are properly applied since those versions mark the major style changes. 
- Verify light and dark designs.
