### PR TITLE
Dark Mode: My Store Tab - Misc

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsAvailabilityCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsAvailabilityCard.kt
@@ -3,15 +3,18 @@ package com.woocommerce.android.ui.mystore
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
-import android.widget.LinearLayout
+import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.util.WooAnimUtils
 import kotlinx.android.synthetic.main.my_store_stats_availability_notice.view.*
 
-class MyStoreStatsAvailabilityCard @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
-    : LinearLayout(ctx, attrs) {
+class MyStoreStatsAvailabilityCard @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttrs: Int = 0
+) : MaterialCardView(ctx, attrs, defStyleAttrs) {
     init {
         View.inflate(context, R.layout.my_store_stats_availability_notice, this)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsRevertedNoticeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsRevertedNoticeCard.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.ui.mystore
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
-import android.widget.LinearLayout
+import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
@@ -14,8 +14,11 @@ import kotlinx.android.synthetic.main.my_store_stats_reverted_notice.view.*
  * Dashboard card that displays a reverted notice message if the WooCommerce Admin plugin
  * is disabled/uninstalled from a site but the v4 stats is already displayed to the user
  */
-class MyStoreStatsRevertedNoticeCard @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
-    : LinearLayout(ctx, attrs) {
+class MyStoreStatsRevertedNoticeCard @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : MaterialCardView(ctx, attrs, defStyleAttr) {
     init {
         View.inflate(context, R.layout.my_store_stats_reverted_notice, this)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCEmptyView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCEmptyView.kt
@@ -4,9 +4,9 @@ import android.content.Context
 import android.content.res.Configuration
 import android.util.AttributeSet
 import android.view.View
-import android.widget.LinearLayout
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.util.ActivityUtils
@@ -21,7 +21,11 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.util.DisplayUtils
 import java.util.Date
 
-class WCEmptyView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null) : LinearLayout(ctx, attrs) {
+class WCEmptyView @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : MaterialCardView(ctx, attrs, defStyleAttr) {
     private var showNoCustomersImage = true
     private var siteModel: SiteModel? = null
     private var shareTracksEvent: AnalyticsTracker.Stat? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCEmptyView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCEmptyView.kt
@@ -4,9 +4,9 @@ import android.content.Context
 import android.content.res.Configuration
 import android.util.AttributeSet
 import android.view.View
+import android.widget.LinearLayout
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.util.ActivityUtils
@@ -25,7 +25,7 @@ class WCEmptyView @JvmOverloads constructor(
     ctx: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
-) : MaterialCardView(ctx, attrs, defStyleAttr) {
+) : LinearLayout(ctx, attrs, defStyleAttr) {
     private var showNoCustomersImage = true
     private var siteModel: SiteModel? = null
     private var shareTracksEvent: AnalyticsTracker.Stat? = null

--- a/WooCommerce/src/main/res/color-v23/button_text_color_selector.xml
+++ b/WooCommerce/src/main/res/color-v23/button_text_color_selector.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="1.00" android:color="?attr/colorSecondary" android:state_checkable="true" android:state_checked="true" android:state_enabled="true"/>
+    <item android:alpha="0.60" android:color="?attr/colorOnSurface" android:state_checkable="true" android:state_checked="false" android:state_enabled="true"/>
+    <item android:alpha="1.00" android:color="?attr/colorSecondary" android:state_enabled="true"/>
+    <item android:alpha="0.38" android:color="?attr/colorOnSurface"/>
+</selector>

--- a/WooCommerce/src/main/res/color/button_colored_bg_selector.xml
+++ b/WooCommerce/src/main/res/color/button_colored_bg_selector.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/button_colored_bg_tint" android:state_enabled="true"/>
+    <item android:color="@color/color_on_surface_disabled"/>
+</selector>

--- a/WooCommerce/src/main/res/color/button_text_color_selector.xml
+++ b/WooCommerce/src/main/res/color/button_text_color_selector.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/color_secondary" android:state_checkable="true" android:state_checked="true" android:state_enabled="true"/>
+    <item android:color="@color/color_on_surface_high" android:state_checkable="true" android:state_checked="false" android:state_enabled="true"/>
+    <item android:color="@color/color_secondary" android:state_enabled="true"/>
+    <item android:color="@color/color_on_surface"/>
+</selector>

--- a/WooCommerce/src/main/res/drawable/button_bordered_bg.xml
+++ b/WooCommerce/src/main/res/drawable/button_bordered_bg.xml
@@ -3,7 +3,7 @@
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
             <corners android:radius="1dp" />
-            <solid android:color="@color/grey_lighten_30" />
+            <solid android:color="@color/color_on_surface_medium" />
             <padding android:bottom="8dp" android:left="16dp" android:right="16dp" android:top="8dp" />
         </shape>
     </item>

--- a/WooCommerce/src/main/res/drawable/ic_arrow_down.xml
+++ b/WooCommerce/src/main/res/drawable/ic_arrow_down.xml
@@ -4,6 +4,6 @@
         android:viewportWidth="24.0"
         android:viewportHeight="24.0">
     <path
-        android:fillColor="#96588A"
+        android:fillColor="@color/color_on_surface_high"
         android:pathData="M7.41,7.84L12,12.42l4.59,-4.58L18,9.25l-6,6 -6,-6z"/>
 </vector>

--- a/WooCommerce/src/main/res/drawable/ic_arrow_down_black.xml
+++ b/WooCommerce/src/main/res/drawable/ic_arrow_down_black.xml
@@ -1,5 +1,0 @@
-<vector android:autoMirrored="true" android:height="24dp"
-    android:tint="#3C3C3C" android:viewportHeight="24.0"
-    android:viewportWidth="24.0" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#FF000000" android:pathData="M7.41,7.84L12,12.42l4.59,-4.58L18,9.25l-6,6 -6,-6z"/>
-</vector>

--- a/WooCommerce/src/main/res/drawable/ic_arrow_up.xml
+++ b/WooCommerce/src/main/res/drawable/ic_arrow_up.xml
@@ -4,6 +4,6 @@
         android:viewportWidth="24.0"
         android:viewportHeight="24.0">
     <path
-        android:fillColor="#96588A"
+        android:fillColor="@color/color_on_surface_high"
         android:pathData="M7.41,15.41L12,10.83l4.59,4.58L18,14l-6,-6 -6,6z"/>
 </vector>

--- a/WooCommerce/src/main/res/drawable/ic_arrow_up_black.xml
+++ b/WooCommerce/src/main/res/drawable/ic_arrow_up_black.xml
@@ -1,5 +1,0 @@
-<vector android:autoMirrored="true" android:height="24dp"
-    android:tint="#3C3C3C" android:viewportHeight="24.0"
-    android:viewportWidth="24.0" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#FF000000" android:pathData="M7.41,15.41L12,10.83l4.59,4.58L18,14l-6,-6 -6,6z"/>
-</vector>

--- a/WooCommerce/src/main/res/drawable/ic_gridicons_gift.xml
+++ b/WooCommerce/src/main/res/drawable/ic_gridicons_gift.xml
@@ -1,7 +1,7 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android" android:width="24dp"
         android:height="24dp" android:autoMirrored="true"
         android:viewportHeight="24" android:viewportWidth="24">
-    <path android:fillColor="#FF000000"
+    <path android:fillColor="@color/color_on_surface_high"
           android:pathData="M22,6h-4.8c0.5,-0.5 0.8,-1.2 0.8,-2 0,-1.7 -1.3,-3 -3,-3s-3,1.3 -3,3c0,-1.7 -1.3,-3 -3,-3S6,2.3 6,4c0,0.8 0.3,1.5 0.8,2L2,6v6h1v8c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2v-8h1L22,6zM20,10h-7L13,8h7v2zM15,3c0.6,0 1,0.4 1,1s-0.4,1 -1,1 -1,-0.4 -1,-1 0.4,-1 1,-1zM9,3c0.6,0 1,0.4 1,1s-0.4,1 -1,1 -1,-0.4 -1,-1 0.4,-1 1,-1zM4,8h7v2L4,10L4,8zM5,12h6v8L5,20v-8zM19,20h-6v-8h6v8z"/>
     <group android:pivotX="12"
            android:pivotY="12"

--- a/WooCommerce/src/main/res/drawable/stats_availability_expander_selector.xml
+++ b/WooCommerce/src/main/res/drawable/stats_availability_expander_selector.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@drawable/ic_arrow_up_black" android:state_checked="true"/>
-    <item android:drawable="@drawable/ic_arrow_down_black"/>
-</selector>

--- a/WooCommerce/src/main/res/layout/dashboard_main_stats_row.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_main_stats_row.xml
@@ -6,6 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:baselineAligned="false"
+    android:layout_marginTop="@dimen/major_100"
     android:gravity="center_horizontal"
     android:orientation="horizontal">
 

--- a/WooCommerce/src/main/res/layout/dashboard_main_stats_row.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_main_stats_row.xml
@@ -5,7 +5,6 @@
     android:id="@+id/label_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginTop="16dp"
     android:baselineAligned="false"
     android:gravity="center_horizontal"
     android:orientation="horizontal">

--- a/WooCommerce/src/main/res/layout/fragment_dashboard.xml
+++ b/WooCommerce/src/main/res/layout/fragment_dashboard.xml
@@ -25,7 +25,7 @@
                 <!-- My Store stats reverted notice card -->
                 <com.woocommerce.android.ui.mystore.MyStoreStatsRevertedNoticeCard
                     android:id="@+id/dashboard_stats_reverted_card"
-                    style="@style/Woo.Stats.Notice.Card"
+                    style="@style/Woo.Card"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     tools:visibility="gone"

--- a/WooCommerce/src/main/res/layout/fragment_dashboard.xml
+++ b/WooCommerce/src/main/res/layout/fragment_dashboard.xml
@@ -2,6 +2,7 @@
 <com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/dashboard_refresh_layout"
     android:background="@color/default_window_background"
     android:layout_width="match_parent"
@@ -14,7 +15,7 @@
 
         <FrameLayout android:layout_width="match_parent" android:layout_height="match_parent">
 
-            <LinearLayout
+            <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/dashboard_view"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -29,16 +30,24 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:visibility="gone"
-                    tools:visibility="visible"/>
+                    app:layout_constraintBottom_toTopOf="@+id/dashboard_stats_availability_card"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:visibility="visible" />
 
                 <!-- My Store stats availability notice card -->
                 <com.woocommerce.android.ui.mystore.MyStoreStatsAvailabilityCard
                     android:id="@+id/dashboard_stats_availability_card"
-                    style="@style/Woo.Stats.Card.Expandable"
+                    style="@style/Woo.Card.Expandable"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:visibility="gone"
-                    tools:visibility="visible"/>
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/dashboard_stats_reverted_card"
+                    app:layout_constraintBottom_toTopOf="@+id/dashboard_stats"
+                    tools:visibility="visible" />
 
                 <!-- Order stats -->
                 <com.woocommerce.android.ui.dashboard.DashboardStatsView
@@ -46,10 +55,10 @@
                     style="@style/Woo.Card.Tabbed"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/minor_00"
-                    android:layout_marginEnd="@dimen/minor_00"
-                    android:layout_marginTop="@dimen/minor_100"
-                    android:layout_marginBottom="@dimen/minor_100"/>
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/dashboard_stats_availability_card"
+                    app:layout_constraintBottom_toTopOf="@+id/dashboard_top_earners"/>
 
                 <!-- Top earner stats -->
                 <com.woocommerce.android.ui.dashboard.DashboardTopEarnersView
@@ -57,9 +66,13 @@
                     style="@style/Woo.Card"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/dashboard_stats"
+                    app:layout_constraintBottom_toBottomOf="parent"
                     tools:visibility="visible"/>
 
-            </LinearLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
             <com.woocommerce.android.widgets.WCEmptyView
                 android:id="@+id/empty_view"

--- a/WooCommerce/src/main/res/layout/fragment_dashboard.xml
+++ b/WooCommerce/src/main/res/layout/fragment_dashboard.xml
@@ -28,8 +28,8 @@
                     style="@style/Woo.Card"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    tools:visibility="gone"
-                    android:visibility="gone"/>
+                    android:visibility="gone"
+                    tools:visibility="visible"/>
 
                 <!-- My Store stats availability notice card -->
                 <com.woocommerce.android.ui.mystore.MyStoreStatsAvailabilityCard
@@ -37,8 +37,8 @@
                     style="@style/Woo.Stats.Card.Expandable"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    tools:visibility="gone"
-                    android:visibility="gone"/>
+                    android:visibility="gone"
+                    tools:visibility="visible"/>
 
                 <!-- Order stats -->
                 <com.woocommerce.android.ui.dashboard.DashboardStatsView

--- a/WooCommerce/src/main/res/layout/fragment_dashboard.xml
+++ b/WooCommerce/src/main/res/layout/fragment_dashboard.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/dashboard_refresh_layout"
-    android:background="@color/default_window_background"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -13,7 +12,9 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <FrameLayout android:layout_width="match_parent" android:layout_height="match_parent">
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/dashboard_view"
@@ -80,9 +81,7 @@
                 android:layout_height="match_parent"
                 android:visibility="gone"
                 tools:visibility="gone"/>
-
         </FrameLayout>
-
     </androidx.core.widget.NestedScrollView>
 
 </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>

--- a/WooCommerce/src/main/res/layout/fragment_my_store.xml
+++ b/WooCommerce/src/main/res/layout/fragment_my_store.xml
@@ -9,54 +9,47 @@
     android:layout_height="match_parent"
     tools:context="com.woocommerce.android.ui.mystore.MyStoreFragment">
 
-    <FrameLayout
+    <com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout
+        android:id="@+id/dashboard_refresh_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        <com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout
-            android:id="@+id/dashboard_refresh_layout"
+        <androidx.core.widget.NestedScrollView
+            android:id="@+id/scroll_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-            <androidx.core.widget.NestedScrollView
-                android:id="@+id/scroll_view"
+            <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="match_parent">
+                android:layout_height="wrap_content"
+                android:animateLayoutChanges="true"
+                android:descendantFocusability="blocksDescendants"
+                android:orientation="vertical">
 
-                <LinearLayout
+                <!-- Order stats -->
+                <com.woocommerce.android.ui.mystore.MyStoreStatsView
+                    android:id="@+id/my_store_stats"
+                    style="@style/Woo.Card"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:animateLayoutChanges="true"
-                    android:descendantFocusability="blocksDescendants"
-                    android:orientation="vertical">
+                    android:orientation="vertical"/>
 
-                    <!-- Order stats -->
-                    <com.woocommerce.android.ui.mystore.MyStoreStatsView
-                        android:id="@+id/my_store_stats"
-                        style="@style/Woo.Card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical"/>
+                <!-- Top earner stats -->
+                <com.woocommerce.android.ui.mystore.MyStoreTopEarnersView
+                    android:id="@+id/my_store_top_earners"
+                    style="@style/Woo.Card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"/>
 
-                    <!-- Top earner stats -->
-                    <com.woocommerce.android.ui.mystore.MyStoreTopEarnersView
-                        android:id="@+id/my_store_top_earners"
-                        style="@style/Woo.Card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical"/>
+            </LinearLayout>
+        </androidx.core.widget.NestedScrollView>
+    </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
 
-                </LinearLayout>
-            </androidx.core.widget.NestedScrollView>
-        </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
-
-        <com.woocommerce.android.widgets.WCEmptyView
-            android:id="@+id/empty_view"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:visibility="gone"/>
-
-    </FrameLayout>
-
+    <com.woocommerce.android.widgets.WCEmptyView
+        android:id="@+id/empty_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"/>
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_order_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_detail.xml
@@ -46,7 +46,6 @@
                 <!-- Product List -->
                 <com.woocommerce.android.ui.orders.OrderDetailProductListView
                     android:id="@+id/orderDetail_productList"
-                    style="@style/Woo.Card.WithoutPadding"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:clipToPadding="false"
@@ -55,7 +54,6 @@
                 <!-- Payments -->
                 <com.woocommerce.android.ui.orders.OrderDetailPaymentView
                     android:id="@+id/orderDetail_paymentInfo"
-                    style="@style/Woo.Card.WithoutPadding"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:animateLayoutChanges="true"
@@ -64,14 +62,12 @@
                 <!-- Customer Info -->
                 <com.woocommerce.android.ui.orders.OrderDetailCustomerInfoView
                     android:id="@+id/orderDetail_customerInfo"
-                    style="@style/Woo.Card.Expandable"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"/>
 
                 <!-- Shipment Tracking -->
                 <com.woocommerce.android.ui.orders.OrderDetailShipmentTrackingListView
                     android:id="@+id/orderDetail_shipmentList"
-                    style="@style/Woo.Card.WithoutPadding"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:clipToPadding="false"
@@ -82,7 +78,6 @@
                 <!-- Order Notes -->
                 <com.woocommerce.android.ui.orders.notes.OrderDetailOrderNoteListView
                     android:id="@+id/orderDetail_noteList"
-                    style="@style/Woo.Card.WithoutPadding"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"/>
             </LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_order_fulfillment.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_fulfillment.xml
@@ -17,15 +17,13 @@
         <com.woocommerce.android.ui.orders.OrderDetailProductListView
             android:id="@+id/orderFulfill_products"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            style="@style/Woo.Card.WithoutPadding"/>
+            android:layout_height="wrap_content"/>
 
         <!-- Customer Provided Note -->
         <com.woocommerce.android.ui.orders.notes.OrderDetailCustomerNoteView
             android:id="@+id/orderFulfill_customerNote"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            style="@style/Woo.Card"/>
+            android:layout_height="wrap_content"/>
 
         <!-- Customer Info -->
         <com.woocommerce.android.ui.orders.OrderDetailCustomerInfoView
@@ -39,7 +37,6 @@
             android:id="@+id/orderFulfill_addShipmentTracking"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            style="@style/Woo.Card.WithoutPadding"
             android:clipToPadding="false"
             android:paddingBottom="0dp"
             android:contentDescription="@string/order_shipment_tracking_add_label"

--- a/WooCommerce/src/main/res/layout/fragment_order_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_list.xml
@@ -49,7 +49,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
                 android:visibility="gone"
-                style="@style/Woo.Card.WithoutPadding"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"

--- a/WooCommerce/src/main/res/layout/fragment_order_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_product_list.xml
@@ -10,6 +10,5 @@
     <com.woocommerce.android.ui.orders.OrderDetailProductListView
         android:id="@+id/orderProducts_list"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        style="@style/Woo.Card.WithoutPadding"/>
+        android:layout_height="wrap_content"/>
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout/my_store_date_bar.xml
+++ b/WooCommerce/src/main/res/layout/my_store_date_bar.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -12,14 +11,9 @@
         style="@style/Woo.DateBar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:gravity="start"
         tools:text="June 30-Jul 06"/>
 
-    <FrameLayout
-        android:id="@+id/tab_layout_divider_bottom"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/list_divider"
-        app:srcCompat="@drawable/list_divider"/>
+    <View
+        style="@style/Woo.Divider"/>
 
 </merge>

--- a/WooCommerce/src/main/res/layout/my_store_stats_availability_notice.xml
+++ b/WooCommerce/src/main/res/layout/my_store_stats_availability_notice.xml
@@ -1,82 +1,75 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <!-- VIEW MORE Button -->
+    <ToggleButton
+        android:id="@+id/my_store_availability_viewMore"
+        style="@style/Woo.Stats.Availability.CardExtenderButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:background="@null"
+        android:textOff="@string/my_store_stats_availability_title"
+        android:textOn="@string/my_store_stats_availability_title"/>
 
-        <!-- VIEW MORE Button -->
-        <ToggleButton
-            android:id="@+id/my_store_availability_viewMore"
-            style="@style/Woo.Stats.Availability.CardExtenderButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@null"
-            android:textOff="@string/my_store_stats_availability_title"
-            android:textOn="@string/my_store_stats_availability_title"/>
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/my_store_availability_morePanel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingBottom="@dimen/default_padding"
+        android:paddingTop="@dimen/default_padding"
+        android:paddingStart="@dimen/card_padding_start"
+        android:layout_marginStart="9dp"
+        android:paddingEnd="0dp"
+        android:visibility="gone"
+        tools:visibility="visible">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/my_store_availability_morePanel"
-            android:layout_width="match_parent"
+        <!-- Message -->
+        <TextView
+            android:id="@+id/my_store_availability_message"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_extra_large"
+            android:gravity="start"
+            android:lineSpacingExtra="4sp"
             android:paddingBottom="@dimen/default_padding"
-            android:paddingTop="@dimen/default_padding"
+            android:paddingEnd="@dimen/card_padding_end"
             android:paddingStart="@dimen/card_padding_start"
-            android:layout_marginStart="9dp"
-            android:paddingEnd="0dp"
-            android:visibility="gone"
-            tools:visibility="visible">
+            android:text="@string/my_store_stats_availability_message"
+            android:textAppearance="@style/Woo.TextAppearance.Medium.Grey"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"/>
 
-            <!-- Message -->
-            <TextView
-                android:id="@+id/my_store_availability_message"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/margin_extra_large"
-                android:gravity="start"
-                android:lineSpacingExtra="4sp"
-                android:paddingBottom="@dimen/default_padding"
-                android:paddingEnd="@dimen/card_padding_end"
-                android:paddingStart="@dimen/card_padding_start"
-                android:text="@string/my_store_stats_availability_message"
-                android:textAppearance="@style/Woo.TextAppearance.Medium.Grey"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"/>
+        <!-- TRY IT NOW button -->
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_try"
+            style="@style/Woo.Button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:text="@string/try_it_now"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/my_store_availability_message"/>
 
-            <!-- TRY IT NOW button -->
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/btn_try"
-                style="@style/Woo.Button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:text="@string/try_it_now"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/my_store_availability_message"/>
+        <!-- NO THANKS button -->
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_no_thanks"
+            style="@style/Woo.Button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:text="@string/no_thanks"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/btn_try"
+            app:layout_constraintTop_toBottomOf="@+id/my_store_availability_message"/>
 
-            <!-- NO THANKS button -->
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/btn_no_thanks"
-                style="@style/Woo.Button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:text="@string/no_thanks"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toStartOf="@+id/btn_try"
-                app:layout_constraintTop_toBottomOf="@+id/my_store_availability_message"/>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-    </LinearLayout>
-
-</merge>
-
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/my_store_stats_availability_notice.xml
+++ b/WooCommerce/src/main/res/layout/my_store_stats_availability_notice.xml
@@ -30,7 +30,7 @@
             tools:visibility="visible">
 
             <!-- Message -->
-            <TextView
+            <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/my_store_availability_message"
                 style="@style/Woo.Card.Body"
                 android:layout_width="0dp"
@@ -42,7 +42,7 @@
                 app:layout_constraintTop_toTopOf="parent"/>
 
             <!-- TRY IT NOW button -->
-            <androidx.appcompat.widget.AppCompatButton
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/btn_try"
                 style="@style/Woo.Card.Button"
                 android:layout_width="wrap_content"
@@ -54,7 +54,7 @@
                 app:layout_constraintTop_toBottomOf="@+id/my_store_availability_message"/>
 
             <!-- NO THANKS button -->
-            <androidx.appcompat.widget.AppCompatButton
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/btn_no_thanks"
                 style="@style/Woo.Card.Button"
                 android:layout_width="wrap_content"

--- a/WooCommerce/src/main/res/layout/my_store_stats_availability_notice.xml
+++ b/WooCommerce/src/main/res/layout/my_store_stats_availability_notice.xml
@@ -1,75 +1,72 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
+<merge
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    tools:context=".ui.dashboard.DashboardFragment">
 
-    <!-- VIEW MORE Button -->
-    <ToggleButton
-        android:id="@+id/my_store_availability_viewMore"
-        style="@style/Woo.Stats.Availability.CardExtenderButton"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@null"
-        android:textOff="@string/my_store_stats_availability_title"
-        android:textOn="@string/my_store_stats_availability_title"/>
+        android:orientation="vertical">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/my_store_availability_morePanel"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingBottom="@dimen/default_padding"
-        android:paddingTop="@dimen/default_padding"
-        android:paddingStart="@dimen/card_padding_start"
-        android:layout_marginStart="9dp"
-        android:paddingEnd="0dp"
-        android:visibility="gone"
-        tools:visibility="visible">
-
-        <!-- Message -->
-        <TextView
-            android:id="@+id/my_store_availability_message"
-            android:layout_width="0dp"
+        <!-- VIEW MORE Button -->
+        <ToggleButton
+            android:id="@+id/my_store_availability_viewMore"
+            style="@style/Woo.Card.ExpanderButton"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/margin_extra_large"
-            android:gravity="start"
-            android:lineSpacingExtra="4sp"
-            android:paddingBottom="@dimen/default_padding"
-            android:paddingEnd="@dimen/card_padding_end"
-            android:paddingStart="@dimen/card_padding_start"
-            android:text="@string/my_store_stats_availability_message"
-            android:textAppearance="@style/Woo.TextAppearance.Medium.Grey"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"/>
+            android:textOff="@string/my_store_stats_availability_title"
+            android:textOn="@string/my_store_stats_availability_title"
+            android:drawableStart="@drawable/ic_gridicons_gift"/>
 
-        <!-- TRY IT NOW button -->
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/btn_try"
-            style="@style/Woo.Button"
-            android:layout_width="wrap_content"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/my_store_availability_morePanel"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:text="@string/try_it_now"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/my_store_availability_message"/>
+            android:visibility="gone"
+            tools:visibility="visible">
 
-        <!-- NO THANKS button -->
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/btn_no_thanks"
-            style="@style/Woo.Button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:text="@string/no_thanks"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/btn_try"
-            app:layout_constraintTop_toBottomOf="@+id/my_store_availability_message"/>
+            <!-- Message -->
+            <TextView
+                android:id="@+id/my_store_availability_message"
+                style="@style/Woo.Card.Body"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/minor_100"
+                android:text="@string/my_store_stats_availability_message"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"/>
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <!-- TRY IT NOW button -->
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btn_try"
+                style="@style/Woo.Card.Button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:text="@string/try_it_now"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/my_store_availability_message"/>
 
-</LinearLayout>
+            <!-- NO THANKS button -->
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btn_no_thanks"
+                style="@style/Woo.Card.Button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_marginEnd="@dimen/minor_100"
+                android:text="@string/no_thanks"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/btn_try"
+                app:layout_constraintTop_toBottomOf="@+id/my_store_availability_message"/>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </LinearLayout>
+
+</merge>

--- a/WooCommerce/src/main/res/layout/my_store_stats_reverted_notice.xml
+++ b/WooCommerce/src/main/res/layout/my_store_stats_reverted_notice.xml
@@ -2,8 +2,10 @@
 <merge
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    tools:context=".ui.dashboard.DashboardFragment">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/layout/my_store_stats_reverted_notice.xml
+++ b/WooCommerce/src/main/res/layout/my_store_stats_reverted_notice.xml
@@ -14,6 +14,7 @@
             android:id="@+id/my_store_info_icon"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_margin="@dimen/major_100"
             android:importantForAccessibility="no"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
@@ -22,10 +23,10 @@
         <!-- Message -->
         <TextView
             android:id="@+id/my_store_reverted_title"
+            style="@style/Woo.Card.Body"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/default_padding"
-            android:paddingBottom="@dimen/default_padding"
+            android:layout_marginTop="@dimen/major_100"
             android:gravity="start"
             android:lineSpacingExtra="4sp"
             android:text="@string/my_store_stats_reverted_message"
@@ -35,11 +36,12 @@
             app:layout_constraintTop_toTopOf="parent"/>
 
         <!-- LEARN MORE button -->
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_learn_more"
             style="@style/Woo.Button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/major_100"
             android:layout_gravity="center_vertical"
             android:text="@string/learn_more"
             app:layout_constraintBottom_toBottomOf="parent"
@@ -47,11 +49,12 @@
             app:layout_constraintTop_toBottomOf="@+id/my_store_reverted_title"/>
 
         <!-- DISMISS button -->
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_dismiss"
             style="@style/Woo.Button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_margin="@dimen/minor_75"
             android:layout_gravity="center_vertical"
             android:text="@string/dismiss"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/WooCommerce/src/main/res/layout/my_store_stats_reverted_notice.xml
+++ b/WooCommerce/src/main/res/layout/my_store_stats_reverted_notice.xml
@@ -23,7 +23,7 @@
             app:srcCompat="@drawable/ic_error_grey"/>
 
         <!-- Message -->
-        <TextView
+        <com.google.android.material.textview.MaterialTextView
             android:id="@+id/my_store_reverted_title"
             style="@style/Woo.Card.Body"
             android:layout_width="0dp"

--- a/WooCommerce/src/main/res/layout/my_store_top_earners.xml
+++ b/WooCommerce/src/main/res/layout/my_store_top_earners.xml
@@ -12,7 +12,6 @@
         style="@style/Woo.Card.Title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
         android:text="@string/dashboard_top_earners_title"/>
 
     <TextView

--- a/WooCommerce/src/main/res/layout/wc_empty_view.xml
+++ b/WooCommerce/src/main/res/layout/wc_empty_view.xml
@@ -26,7 +26,7 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
 
-                <TextView
+                <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/date_title"
                     style="@style/Woo.Card.Title"
                     android:layout_width="wrap_content"
@@ -43,7 +43,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/major_100"/>
 
-                <TextView
+                <com.google.android.material.textview.MaterialTextView
                     style="@style/Woo.TextView.Caption"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -75,7 +75,7 @@
                 android:importantForAccessibility="no"
                 app:srcCompat="@drawable/ic_woo_waiting_customers"/>
 
-            <TextView
+            <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/empty_view_text"
                 style="@style/Woo.Card.EmptyMessage"
                 android:layout_width="wrap_content"

--- a/WooCommerce/src/main/res/layout/wc_empty_view.xml
+++ b/WooCommerce/src/main/res/layout/wc_empty_view.xml
@@ -82,7 +82,7 @@
                 android:layout_height="wrap_content"
                 tools:text="@string/waiting_for_customers"/>
 
-            <androidx.appcompat.widget.AppCompatButton
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/empty_view_share_button"
                 style="@style/Woo.Button.Colored"
                 android:layout_width="wrap_content"

--- a/WooCommerce/src/main/res/layout/wc_empty_view.xml
+++ b/WooCommerce/src/main/res/layout/wc_empty_view.xml
@@ -4,66 +4,63 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <LinearLayout
+        <com.google.android.material.card.MaterialCardView
             android:id="@+id/empty_view_stats_row"
+            style="@style/Woo.Card"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:gravity="center"
-            android:orientation="vertical"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintBottom_toTopOf="@+id/empty_container">
 
-            <TextView
-                android:id="@+id/date_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="start"
-                android:layout_marginStart="@dimen/margin_extra_large"
-                android:layout_marginTop="@dimen/margin_extra_large"
-                android:text="@string/dashboard_stats_todays_stats"
-                android:textColor="@color/wc_grey_medium"
-                android:textSize="@dimen/text_medium"
-                android:textStyle="bold"/>
-
-            <View
-                android:id="@+id/divider1"
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_marginTop="@dimen/margin_extra_large"
-                android:background="@color/list_divider"/>
-
-            <include
-                android:id="@+id/empty_view_row"
-                layout="@layout/dashboard_main_stats_row"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_extra_large"/>
+                android:orientation="vertical">
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_extra_large"
-                android:text="@string/dashboard_stats_updated_now"
-                android:textColor="@color/wc_grey_mid"
-                android:textSize="@dimen/text_caption"/>
+                <TextView
+                    android:id="@+id/date_title"
+                    style="@style/Woo.Card.Title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/dashboard_stats_todays_stats"/>
 
-        </LinearLayout>
+                <View
+                    style="@style/Woo.Divider"/>
+
+                <include
+                    android:id="@+id/empty_view_row"
+                    layout="@layout/dashboard_main_stats_row"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/major_100"/>
+
+                <TextView
+                    style="@style/Woo.TextView.Caption"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:text="@string/dashboard_stats_updated_now"/>
+
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
 
         <LinearLayout
             android:id="@+id/empty_container"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_below="@+id/empty_view_stats_row"
             android:gravity="center"
             android:orientation="vertical"
+            android:elevation="@dimen/minor_00"
             app:layout_constraintTop_toBottomOf="@+id/empty_view_stats_row"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
@@ -80,18 +77,17 @@
 
             <TextView
                 android:id="@+id/empty_view_text"
-                style="@style/Woo.TextAppearance.Bold"
+                style="@style/Woo.Card.EmptyMessage"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_large"
                 tools:text="@string/waiting_for_customers"/>
 
             <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/empty_view_share_button"
-                style="@style/Woo.Button.Purple"
+                style="@style/Woo.Button.Colored"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_large"
+                android:layout_marginTop="@dimen/major_75"
                 android:text="@string/share_store_button"/>
 
         </LinearLayout>

--- a/WooCommerce/src/main/res/layout/wc_empty_view.xml
+++ b/WooCommerce/src/main/res/layout/wc_empty_view.xml
@@ -1,93 +1,100 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
+<merge
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/empty_view_container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/default_window_background"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <LinearLayout
-        android:id="@+id/empty_view_stats_row"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@color/white"
-        android:gravity="center"
-        android:orientation="vertical">
+        android:layout_height="wrap_content">
 
-        <TextView
-            android:id="@+id/date_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="start"
-            android:layout_marginStart="@dimen/margin_extra_large"
-            android:layout_marginTop="@dimen/margin_extra_large"
-            android:text="@string/dashboard_stats_todays_stats"
-            android:textColor="@color/wc_grey_medium"
-            android:textSize="@dimen/text_medium"
-            android:textStyle="bold"/>
-
-        <View
-            android:id="@+id/divider1"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginTop="@dimen/margin_extra_large"
-            android:background="@color/list_divider"/>
-
-        <include
-            android:id="@+id/empty_view_row"
-            layout="@layout/dashboard_main_stats_row"
+        <LinearLayout
+            android:id="@+id/empty_view_stats_row"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_extra_large"/>
+            android:gravity="center"
+            android:orientation="vertical"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/empty_container">
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_extra_large"
-            android:text="@string/dashboard_stats_updated_now"
-            android:textColor="@color/wc_grey_mid"
-            android:textSize="@dimen/text_caption"/>
+            <TextView
+                android:id="@+id/date_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start"
+                android:layout_marginStart="@dimen/margin_extra_large"
+                android:layout_marginTop="@dimen/margin_extra_large"
+                android:text="@string/dashboard_stats_todays_stats"
+                android:textColor="@color/wc_grey_medium"
+                android:textSize="@dimen/text_medium"
+                android:textStyle="bold"/>
 
-    </LinearLayout>
+            <View
+                android:id="@+id/divider1"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginTop="@dimen/margin_extra_large"
+                android:background="@color/list_divider"/>
 
-    <LinearLayout
-        android:id="@+id/linearLayout2"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_below="@+id/empty_view_stats_row"
-        android:background="@color/white"
-        android:gravity="center"
-        android:orientation="vertical">
+            <include
+                android:id="@+id/empty_view_row"
+                layout="@layout/dashboard_main_stats_row"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_extra_large"/>
 
-        <ImageView
-            android:id="@+id/empty_view_image"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:contentDescription="@string/waiting_for_customers_contentdesc"
-            android:importantForAccessibility="no"
-            app:srcCompat="@drawable/ic_woo_waiting_customers"/>
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_extra_large"
+                android:text="@string/dashboard_stats_updated_now"
+                android:textColor="@color/wc_grey_mid"
+                android:textSize="@dimen/text_caption"/>
 
-        <TextView
-            android:id="@+id/empty_view_text"
-            style="@style/Woo.TextAppearance.Bold"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_large"
-            tools:text="@string/waiting_for_customers"/>
+        </LinearLayout>
 
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/empty_view_share_button"
-            style="@style/Woo.Button.Purple"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_large"
-            android:text="@string/share_store_button"/>
+        <LinearLayout
+            android:id="@+id/empty_container"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_below="@+id/empty_view_stats_row"
+            android:gravity="center"
+            android:orientation="vertical"
+            app:layout_constraintTop_toBottomOf="@+id/empty_view_stats_row"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent">
 
-    </LinearLayout>
+            <ImageView
+                android:id="@+id/empty_view_image"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:contentDescription="@string/waiting_for_customers_contentdesc"
+                android:importantForAccessibility="no"
+                app:srcCompat="@drawable/ic_woo_waiting_customers"/>
 
+            <TextView
+                android:id="@+id/empty_view_text"
+                style="@style/Woo.TextAppearance.Bold"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_large"
+                tools:text="@string/waiting_for_customers"/>
 
-</RelativeLayout>
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/empty_view_share_button"
+                style="@style/Woo.Button.Purple"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_large"
+                android:text="@string/share_store_button"/>
+
+        </LinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</merge>

--- a/WooCommerce/src/main/res/layout/wc_empty_view.xml
+++ b/WooCommerce/src/main/res/layout/wc_empty_view.xml
@@ -11,7 +11,6 @@
 
     <LinearLayout
         android:id="@+id/empty_view_stats_row"
-        style="@style/Woo.Card.WithoutPadding"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/white"
@@ -56,7 +55,6 @@
 
     <LinearLayout
         android:id="@+id/linearLayout2"
-        style="@style/Woo.Card.WithoutPadding"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_below="@+id/empty_view_stats_row"

--- a/WooCommerce/src/main/res/values-night/colors.xml
+++ b/WooCommerce/src/main/res/values-night/colors.xml
@@ -3,8 +3,11 @@
     <!--
         General colors
     -->
+    <color name="color_primary">@color/woo_purple_30</color>
+    <color name="color_secondary">@color/woo_pink_30</color>
     <color name="color_on_surface_high">@color/woo_white_alpha_087</color>
     <color name="color_on_surface_medium">@color/woo_white_alpha_060</color>
+    <color name="color_on_surface_disabled">@color/woo_white_alpha_038</color>
     <!--
         App colors
     -->

--- a/WooCommerce/src/main/res/values/colors.xml
+++ b/WooCommerce/src/main/res/values/colors.xml
@@ -10,6 +10,11 @@
     <color name="color_on_primary_medium">@color/woo_white_alpha_060</color>
     <color name="color_on_surface_disabled">@color/woo_black_90_alpha_038</color>
     <!--
+        Custom widget tint
+    -->
+    <color name="button_colored_bg_tint">@color/color_secondary</color>
+
+    <!--
         App colors
     -->
     <color name="default_window_background">#f7f7f7</color>

--- a/WooCommerce/src/main/res/values/colors.xml
+++ b/WooCommerce/src/main/res/values/colors.xml
@@ -3,8 +3,11 @@
     <!--
         General colors
     -->
+    <color name="color_primary">@color/woo_purple_60</color>
+    <color name="color_secondary">@color/woo_pink_50</color>
     <color name="color_on_surface_high">@color/woo_black_90_alpha_087</color>
     <color name="color_on_surface_medium">@color/woo_black_90_alpha_060</color>
+    <color name="color_on_surface_disabled">@color/woo_black_90_alpha_038</color>
     <!--
         App colors
     -->

--- a/WooCommerce/src/main/res/values/colors_old.xml
+++ b/WooCommerce/src/main/res/values/colors_old.xml
@@ -127,7 +127,6 @@
     <!-- Login -->
     <!-- Login uses snake_case instead of CamelCase for the main color palette,
     this makes sure they're not used accidentally -->
-    <color name="color_primary">@color/colorPrimary</color>
     <color name="color_primary_dark">@color/colorPrimaryDark</color>
     <color name="color_accent">@color/colorAccent</color>
 

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -1,51 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+Use this file to override styles in the styles_base.xml file.
+-->
 <resources>
     <!--
         DateBar Style
     -->
     <style name="Woo.DateBar" parent="@style/Woo.TextView.Subtitle1"/>
-
-    <!--
-        Divider Styles
-    -->
-    <style name="Woo.Divider">
-        <item name="android:layout_width">match_parent</item>
-        <item name="android:layout_height">1dp</item>
-        <item name="android:background">?android:attr/listDivider</item>
-    </style>
-
-    <style name="Woo.Divider.Padded">
-        <item name="android:layout_height">17dp</item>
-        <item name="android:paddingTop">@dimen/minor_100</item>
-        <item name="android:paddingBottom">@dimen/minor_100</item>
-    </style>
-
-    <!--
-        Card Styles
-    -->
-    <style name="Woo.Card.Title" parent="@style/Woo.TextView.Subtitle1">
-        <item name="android:textAlignment">viewStart</item>
-    </style>
-
-    <style name="Woo.Card.Body" parent="@style/Woo.TextView.Body2"/>
-
-    <style name="Woo.Card.EmptyMessage" parent="@style/Woo.TextView.Subtitle1"/>
-
-    <style name="Woo.Card.ListHeader" parent="@style/Woo.TextView.Subtitle2">
-        <item name="android:layout_marginTop">@dimen/major_100</item>
-        <item name="android:layout_marginBottom">@dimen/major_75</item>
-        <item name="android:layout_marginStart">@dimen/major_100</item>
-        <item name="android:layout_marginEnd">@dimen/major_100</item>
-    </style>
-
-    <style name="Woo.Card.ListItem.Title" parent="@style/Woo.TextView.Subtitle1">
-        <item name="android:layout_margin">@dimen/minor_00</item>
-    </style>
-
-    <style name="Woo.Card.ListItem.Body" parent="@style/Woo.TextView.Body2">
-        <item name="android:layout_margin">@dimen/minor_00</item>
-    </style>
-
 
 
     <!---

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -165,9 +165,7 @@
     <!--
         Button Styles
     -->
-    <style name="Woo.Button.Bordered" parent="Woo.Button">
-        <item name="android:background">@drawable/button_bordered_bg</item>
-    </style>
+
 
     <style name="Woo.Button.Lowercase">
         <item name="android:textAllCaps">false</item>

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -23,7 +23,9 @@
     <!--
         Card Styles
     -->
-    <style name="Woo.Card.Title" parent="@style/Woo.TextView.Subtitle1"/>
+    <style name="Woo.Card.Title" parent="@style/Woo.TextView.Subtitle1">
+        <item name="android:textAlignment">viewStart</item>
+    </style>
 
     <style name="Woo.Card.Body" parent="@style/Woo.TextView.Body2"/>
 
@@ -603,7 +605,7 @@
         <item name="android:background">@drawable/button_white_bg</item>
         <item name="android:textColor">@color/wc_grey_dark</item>
         <item name="android:drawableStart">@drawable/ic_gridicons_gift</item>
-        <item name="android:drawableEnd">@drawable/stats_availability_expander_selector</item>
+        <item name="android:drawableEnd">@drawable/card_expander_selector</item>
         <item name="android:paddingStart">@dimen/card_padding_start</item>
         <item name="android:paddingTop">@dimen/card_padding_top</item>
         <item name="android:paddingBottom">@dimen/card_padding_bottom</item>

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -6,7 +6,9 @@ Use this file to override styles in the styles_base.xml file.
     <!--
         DateBar Style
     -->
-    <style name="Woo.DateBar" parent="@style/Woo.TextView.Subtitle1"/>
+    <style name="Woo.DateBar" parent="@style/Woo.TextView.Subtitle1">
+        <item name="android:gravity">start</item>
+    </style>
 
 
     <!---

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -163,14 +163,6 @@
     <!--
         Button Styles
     -->
-    <style name="Woo.Button" parent="Widget.AppCompat.Button.Borderless">
-        <item name="android:textColor">@color/wc_purple</item>
-        <item name="android:textAllCaps">true</item>
-        <item name="android:paddingStart">16dp</item>
-        <item name="android:paddingEnd">16dp</item>
-        <item name="android:textSize">@dimen/text_large</item>
-    </style>
-
     <style name="Woo.Button.Bordered" parent="Woo.Button">
         <item name="android:background">@drawable/button_bordered_bg</item>
     </style>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -2,7 +2,7 @@
 <!--
 Base Woo Styles. Use these styles as a base for custom component styles and override only the
 properties necessary. The goal is to make as few modifications as possible to keep a consistent
-theme across the entire app.
+theme across the entire app. Overridden versions should be added to the styles.xml file.
 -->
 <resources xmlns:tools="http://schemas.android.com/tools">
     <style name="Woo"/>
@@ -113,6 +113,29 @@ theme across the entire app.
         <item name="android:layout_marginTop">@dimen/major_100</item>
     </style>
 
+    <style name="Woo.Card.Title" parent="@style/Woo.TextView.Subtitle1">
+        <item name="android:textAlignment">viewStart</item>
+    </style>
+
+    <style name="Woo.Card.Body" parent="@style/Woo.TextView.Body2"/>
+
+    <style name="Woo.Card.EmptyMessage" parent="@style/Woo.TextView.Subtitle1"/>
+
+    <style name="Woo.Card.ListHeader" parent="@style/Woo.TextView.Subtitle2">
+        <item name="android:layout_marginTop">@dimen/major_100</item>
+        <item name="android:layout_marginBottom">@dimen/major_75</item>
+        <item name="android:layout_marginStart">@dimen/major_100</item>
+        <item name="android:layout_marginEnd">@dimen/major_100</item>
+    </style>
+
+    <style name="Woo.Card.ListItem.Title" parent="@style/Woo.TextView.Subtitle1">
+        <item name="android:layout_margin">@dimen/minor_00</item>
+    </style>
+
+    <style name="Woo.Card.ListItem.Body" parent="@style/Woo.TextView.Body2">
+        <item name="android:layout_margin">@dimen/minor_00</item>
+    </style>
+
     <!--
         TextView Styles
     -->
@@ -193,5 +216,14 @@ theme across the entire app.
     <style name="Woo.Button.Colored" parent="@style/Widget.AppCompat.Button.Colored">
         <item name="android:paddingStart">@dimen/major_100</item>
         <item name="android:paddingEnd">@dimen/major_100</item>
+    </style>
+
+    <!--
+        Divider Style
+    -->
+    <style name="Woo.Divider">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">1dp</item>
+        <item name="android:background">?android:attr/listDivider</item>
     </style>
 </resources>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -215,6 +215,9 @@ theme across the entire app. Overridden versions should be added to the styles.x
     <style name="Woo.Button.Colored" parent="@style/Widget.MaterialComponents.Button">
         <item name="android:paddingStart">@dimen/major_100</item>
         <item name="android:paddingEnd">@dimen/major_100</item>
+        <item name="android:layout_marginTop">@dimen/major_100</item>
+        <item name="android:layout_marginBottom">@dimen/major_100</item>
+        <item name="android:backgroundTint">@color/button_colored_bg_selector</item>
     </style>
 
     <!--

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -4,7 +4,7 @@ Base Woo Styles. Use these styles as a base for custom component styles and over
 properties necessary. The goal is to make as few modifications as possible to keep a consistent
 theme across the entire app.
 -->
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <style name="Woo"/>
 
     <!--
@@ -90,9 +90,27 @@ theme across the entire app.
     </style>
 
     <style name="Woo.Card.Expandable">
-        <item name="android:paddingStart">0dp</item>
-        <item name="android:paddingEnd">0dp</item>
-        <item name="android:paddingBottom">0dp</item>
+        <item name="contentPaddingBottom">@dimen/minor_00</item>
+    </style>
+
+    <style name="Woo.Card.ExpanderButton" parent="@style/Widget.MaterialComponents.Button.TextButton">
+        <item name="android:textAppearance">?attr/textAppearanceSubtitle1</item>
+        <item name="android:drawableTint" tools:targetApi="m">@color/color_on_surface_high</item>
+        <item name="android:gravity">start|center_vertical</item>
+        <item name="android:textColor">@color/color_on_surface_high</item>
+        <item name="android:paddingEnd">@dimen/major_100</item>
+        <item name="android:paddingStart">@dimen/major_100</item>
+        <item name="android:background">?android:attr/selectableItemBackgroundBorderless</item>
+        <item name="android:drawableEnd">@drawable/card_expander_selector</item>
+        <item name="android:foregroundTint">@color/color_on_surface_high</item>
+        <item name="android:drawablePadding">@dimen/major_100</item>
+        <item name="android:textAllCaps">false</item>
+    </style>
+
+    <style name="Woo.Card.Button" parent="Woo.Button">
+        <item name="android:layout_marginStart">@dimen/major_100</item>
+        <item name="android:layout_marginEnd">@dimen/major_100</item>
+        <item name="android:layout_marginTop">@dimen/major_100</item>
     </style>
 
     <!--
@@ -132,13 +150,13 @@ theme across the entire app.
     <style name="Woo.TextView.Subtitle1">
         <item name="android:textAppearance">?attr/textAppearanceSubtitle1</item>
         <item name="android:textColor">@color/color_on_surface_high</item>
-        <item name="android:gravity">center_horizontal|start</item>
+        <item name="android:gravity">center_vertical|start</item>
     </style>
 
     <style name="Woo.TextView.Subtitle2">
         <item name="android:textAppearance">?attr/textAppearanceSubtitle2</item>
         <item name="android:textColor">@color/color_on_surface_medium</item>
-        <item name="android:gravity">center_horizontal|start</item>
+        <item name="android:gravity">center_vertical|start</item>
     </style>
 
     <style name="Woo.TextView.Body1">

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -95,13 +95,6 @@ theme across the entire app.
         <item name="android:paddingBottom">0dp</item>
     </style>
 
-    <style name="Woo.Card.WithoutPadding">
-        <item name="android:paddingStart">0dp</item>
-        <item name="android:paddingEnd">0dp</item>
-        <item name="android:paddingTop">0dp</item>
-        <item name="android:paddingBottom">0dp</item>
-    </style>
-
     <!--
         TextView Styles
     -->

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -212,7 +212,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:background">@drawable/button_bordered_bg</item>
     </style>
 
-    <style name="Woo.Button.Colored" parent="@style/Widget.AppCompat.Button.Colored">
+    <style name="Woo.Button.Colored" parent="@style/Widget.MaterialComponents.Button">
         <item name="android:paddingStart">@dimen/major_100</item>
         <item name="android:paddingEnd">@dimen/major_100</item>
     </style>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -95,7 +95,6 @@ theme across the entire app. Overridden versions should be added to the styles.x
 
     <style name="Woo.Card.ExpanderButton" parent="@style/Widget.MaterialComponents.Button.TextButton">
         <item name="android:textAppearance">?attr/textAppearanceSubtitle1</item>
-        <item name="android:drawableTint" tools:targetApi="m">@color/color_on_surface_high</item>
         <item name="android:gravity">start|center_vertical</item>
         <item name="android:textColor">@color/color_on_surface_high</item>
         <item name="android:paddingEnd">@dimen/major_100</item>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -166,4 +166,11 @@ theme across the entire app.
     <style name="Woo.TextView.Overline">
         <item name="android:textAppearance">?attr/textAppearanceOverline</item>
     </style>
+
+    <!--
+        Button Styles
+    -->
+    <style name="Woo.Button" parent="@style/Widget.MaterialComponents.Button.TextButton">
+        <item name="android:textColor">@color/button_text_color_selector</item>
+    </style>
 </resources>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -185,4 +185,13 @@ theme across the entire app.
     <style name="Woo.Button" parent="@style/Widget.MaterialComponents.Button.TextButton">
         <item name="android:textColor">@color/button_text_color_selector</item>
     </style>
+
+    <style name="Woo.Button.Bordered">
+        <item name="android:background">@drawable/button_bordered_bg</item>
+    </style>
+
+    <style name="Woo.Button.Colored" parent="@style/Widget.AppCompat.Button.Colored">
+        <item name="android:paddingStart">@dimen/major_100</item>
+        <item name="android:paddingEnd">@dimen/major_100</item>
+    </style>
 </resources>

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -67,6 +67,7 @@
         <item name="scrollableTabStyle">@style/Woo.TabLayout.Scrollable</item>
         <item name="appBarLayoutStyle">@style/Woo.AppBarLayout</item>
         <item name="borderlessButtonStyle">@style/Woo.Button</item>
+        <item name="materialCardViewStyle">@style/Woo.Card</item>
         <item name="android:listDivider">@drawable/list_divider</item>
 
         <item name="windowActionBar">false</item>

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -66,6 +66,7 @@
         <item name="tabStyle">@style/Woo.TabLayout</item>
         <item name="scrollableTabStyle">@style/Woo.TabLayout.Scrollable</item>
         <item name="appBarLayoutStyle">@style/Woo.AppBarLayout</item>
+        <item name="borderlessButtonStyle">@style/Woo.Button</item>
         <item name="android:listDivider">@drawable/list_divider</item>
 
         <item name="windowActionBar">false</item>


### PR DESCRIPTION
Fixes #1767 by completing the following:
- Apply dark/light styling to `MyStatsStoreAvailabilityCard`
- Apply dark/light styling to `WCEmptyView`
- Apply dark/light styling to `MyStoreStatsRevertedNoticeCard` 
- Cleanup style definitions and associated layout files
- Add Card Expander styles
- Add Button styles

## Waiting for Customers
### API 21
![Screen Shot 2020-01-02 at 11 27 12 PM](https://user-images.githubusercontent.com/5810477/71710039-80b78f80-2db7-11ea-898f-af8aa918b5a1.png)
### API 28
![Screen Shot 2020-01-02 at 11 27 40 PM](https://user-images.githubusercontent.com/5810477/71710044-82815300-2db7-11ea-9a48-3d7d22bbac10.png)

## Try our improved stats
### API 21
![stats-avail-21-collapsed](https://user-images.githubusercontent.com/5810477/71710171-2834c200-2db8-11ea-84c4-e59c56569e07.png)
![stats-avail-21-expanded](https://user-images.githubusercontent.com/5810477/71710173-2a971c00-2db8-11ea-9292-298417d3975b.png)
### API 28
![stats-avail-28-collapsed](https://user-images.githubusercontent.com/5810477/71710177-308cfd00-2db8-11ea-9af2-fda31a960307.png)
![stats-avail-28-expanded](https://user-images.githubusercontent.com/5810477/71710180-3256c080-2db8-11ea-97b8-2fad45ac9347.png)

## Stats Reverted
### API 21
![stats-reverted-21](https://user-images.githubusercontent.com/5810477/71710359-1869ad80-2db9-11ea-927c-e1443ac33974.png)
### API 28
![stats-reverted-28](https://user-images.githubusercontent.com/5810477/71710363-1dc6f800-2db9-11ea-93f0-c776f7d54766.png)


