### PR TITLE
Updates FluxC hash for LIST_ITEMS_CHANGED event removal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'a782ff3d4827d301ac361c2c866ba86121053ebd'
+    fluxCVersion = '1.5.8'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
This PR updates FluxC hash to the latest tag `1.5.8`. It includes the changes in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1468 which should have no effect in WCAndroid. It also includes a couple Gutenberg related changes. Here is the diff between the current FluxC hash and the new tag: https://github.com/wordpress-mobile/WordPress-FluxC-Android/compare/a782ff3d4827d301ac361c2c866ba86121053ebd...1.5.8

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
