### PR TITLE
Upgrade to latest navigation library version, use FragmentContainerView

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -126,9 +126,6 @@ class MainActivity : AppUpgradeActivity(),
 
         presenter.takeView(this)
 
-        navController = findNavController(R.id.nav_host_fragment_main)
-        navController.addOnDestinationChangedListener(this)
-
         bottomNavView = bottom_nav.also { it.init(supportFragmentManager, this) }
 
         // Verify authenticated session
@@ -165,6 +162,13 @@ class MainActivity : AppUpgradeActivity(),
         if (!BuildConfig.DEBUG) {
             checkForAppUpdates()
         }
+    }
+
+    override fun onPostCreate(savedInstanceState: Bundle?) {
+        super.onPostCreate(savedInstanceState)
+
+        navController = findNavController(R.id.nav_host_fragment_main)
+        navController.addOnDestinationChangedListener(this)
     }
 
     override fun hideProgressDialog() {

--- a/WooCommerce/src/main/res/layout/activity_app_settings.xml
+++ b/WooCommerce/src/main/res/layout/activity_app_settings.xml
@@ -15,7 +15,7 @@
         android:layout_height="match_parent"
         android:fillViewport="true">
 
-        <fragment
+        <androidx.fragment.app.FragmentContainerView
             android:id="@+id/nav_host_fragment"
             android:name="androidx.navigation.fragment.NavHostFragment"
             android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/layout/activity_main.xml
+++ b/WooCommerce/src/main/res/layout/activity_main.xml
@@ -35,7 +35,7 @@
                 android:layout_height="match_parent"/>
 
             <!-- container for child fragments in the nav graph -->
-            <fragment
+            <androidx.fragment.app.FragmentContainerView
                 android:id="@+id/nav_host_fragment_main"
                 android:name="androidx.navigation.fragment.NavHostFragment"
                 android:layout_width="match_parent"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.kotlinVersion = '1.3.60'
-    ext.navigationVersion = '2.2.0-rc02'
+    ext.navigationVersion = '2.2.0-rc03'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.kotlinVersion = '1.3.60'
-    ext.navigationVersion = '2.2.0-rc03'
+    ext.navigationVersion = '2.2.0-rc04'
 
     repositories {
         google()


### PR DESCRIPTION
Possibly fixes #1719 by using the FragmentContainerView instead of the fragment element as the navigation host container to ensure fragment transactions are properly handled and no timing issues
creep up. The `FragmentContainerView` was broken in `2.2.0-rc02` version of the androidx navigation library ([see bug](https://issuetracker.google.com/issues/143752103)), but was fixed in `2.2.0-rc03`. This PR does the following:
- upgrades the androidx.navigation library to `2.2.0-rc03`
- swaps out the use of `<fragment/>` as the navhost container with `<FragmentContainerView/>`

Since I was never able to reproduce the issue I'm unsure how to test if this will _fix_ things, but at the very least it's the proper implementation of the feature so now Google fixed we should use it. 😏 

### Recommended Testing Areas
- Test opening child fragments and performing configuration changes (example - Orders -> Order Detail -> Order Fulfillment -> minimize app and reopen) : "Don't keep activities" should be enabled in dev options. 
- Test clicking through setting screens and rotating the device. 
