### PR TITLE
Add/Edit Products Release 1 - Update Product Inventory - Step 1

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
@@ -17,6 +17,8 @@ fun Date.formatToDD(): String = SimpleDateFormat("d", Locale.getDefault()).forma
 
 fun Date.formatToMMMdd(): String = SimpleDateFormat("MMM d", Locale.getDefault()).format(this)
 
+fun Date.formatToMMMddYYYY(): String = SimpleDateFormat("MMM d, YYYY", Locale.getDefault()).format(this)
+
 fun Date.formatToEEEEMMMddhha(): String {
     val symbols = DateFormatSymbols(Locale.getDefault())
     symbols.amPmStrings = arrayOf("am", "pm")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringDateFormatExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringDateFormatExt.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.extensions
 
 import java.text.DateFormatSymbols
 import java.text.SimpleDateFormat
+import java.util.Date
 import java.util.GregorianCalendar
 import java.util.Locale
 
@@ -119,5 +120,22 @@ fun String.formatToMonthDateOnly(): String {
         date.formatToMMMdd()
     } catch (e: Exception) {
         throw IllegalArgumentException("Date string argument is not of format yyyy-MM-dd: $this")
+    }
+}
+
+/**
+ * Method to convert month string from yyyy-MM-dd'T'hh:mm:ss format to MMM dd
+ * i.e. 2018-08-08T08:12:03 is formatted to Aug 08
+ */
+@Throws(IllegalArgumentException::class)
+fun String?.formatDateToISO8601Format(): Date? {
+    return try {
+        if (!this.isNullOrEmpty()) {
+            val originalFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault())
+            return originalFormat.parse(this)
+        }
+        null
+    } catch (e: Exception) {
+        throw IllegalArgumentException("Date string argument is not of format yyyy-MM-dd'T'HH:mm:ss: $this")
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.model
 
 import android.os.Parcelable
+import com.woocommerce.android.extensions.formatDateToISO8601Format
 import com.woocommerce.android.extensions.roundError
 import com.woocommerce.android.ui.products.ProductBackorderStatus
 import com.woocommerce.android.ui.products.ProductStatus
@@ -49,7 +50,9 @@ data class Product(
     val purchaseNote: String,
     val numVariations: Int,
     val images: List<Image>,
-    val attributes: List<Attribute>
+    val attributes: List<Attribute>,
+    val dateOnSaleTo: Date?,
+    val dateOnSaleFrom: Date?
 ) : Parcelable {
     @Parcelize
     data class Image(
@@ -162,7 +165,9 @@ fun WCProductModel.toAppModel(): Product {
                     it.options,
                     it.visible
             )
-        }
+        },
+        this.dateOnSaleTo.formatDateToISO8601Format(),
+        this.dateOnSaleFrom.formatDateToISO8601Format()
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -256,7 +256,7 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener, Navig
         // display pricing/inventory card only if product is not a variable product
         // since pricing, inventory, shipping and SKU for a variable product can differ per variant
         if (product.type != VARIABLE) {
-            if (FeatureFlag.ADD_EDIT_PRODUCT_RELEASE_1.isEnabled()) {
+            if (isAddEditProductRelease1Enabled(product.type)) {
                 addSecondaryCard(productData)
             } else {
                 addPricingAndInventoryCard(productData)
@@ -268,7 +268,7 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener, Navig
     private fun addPrimaryCard(productData: ViewState) {
         val product = requireNotNull(productData.product)
 
-        if (FeatureFlag.ADD_EDIT_PRODUCT_RELEASE_1.isEnabled()) {
+        if (isAddEditProductRelease1Enabled(product.type)) {
             addEditableView(DetailCard.Primary, R.string.product_detail_title_hint, product.name)?.also { view ->
                 view.setOnTextChangedListener { viewModel.updateProductDraft(title = it.toString()) }
             }
@@ -276,7 +276,7 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener, Navig
             addPropertyView(DetailCard.Primary, R.string.product_name, productTitle, LinearLayout.VERTICAL)
         }
 
-        if (FeatureFlag.ADD_EDIT_PRODUCT_RELEASE_1.isEnabled()) {
+        if (isAddEditProductRelease1Enabled(product.type)) {
             val productDescription = product.description
             val showCaption = !productDescription.isEmpty()
             val description = if (productDescription.isEmpty()) {
@@ -833,4 +833,10 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener, Navig
                 .actionProductDetailFragmentToProductImagesFragment(navArgs.remoteProductId)
         findNavController().navigate(action)
     }
+
+    /**
+     * Add/Edit Product Release 1 is enabled only for debug users for SIMPLE products only
+     */
+    private fun isAddEditProductRelease1Enabled(productType: ProductType) =
+            FeatureFlag.ADD_EDIT_PRODUCT_RELEASE_1.isEnabled() && productType == ProductType.SIMPLE
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -279,7 +279,7 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener, Navig
 
         if (isAddEditProductRelease1Enabled(product.type)) {
             val productDescription = product.description
-            val showCaption = !productDescription.isEmpty()
+            val showCaption = productDescription.isNotEmpty()
             val description = if (productDescription.isEmpty()) {
                 getString(R.string.product_description_empty)
             } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -58,6 +58,7 @@ import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageClickListener
 import kotlinx.android.synthetic.main.fragment_product_detail.*
 import org.wordpress.android.util.ActivityUtils
+import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.HtmlUtils
 import java.lang.ref.WeakReference
 import java.util.Date
@@ -381,10 +382,7 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener, Navig
             }
             val saleDates = when {
                 (dateOnSaleFrom != null && dateOnSaleTo != null) -> {
-                    getString(R.string.product_sale_date_from_to,
-                            dateOnSaleFrom.formatToMMMdd(),
-                            dateOnSaleTo.formatToMMMddYYYY()
-                    )
+                    getProductSaleDates(dateOnSaleFrom, dateOnSaleTo)
                 }
                 (dateOnSaleFrom != null && dateOnSaleTo == null) -> {
                     getString(R.string.product_sale_date_from, dateOnSaleFrom.formatToMMMddYYYY())
@@ -775,6 +773,15 @@ class ProductDetailFragment : BaseFragment(), OnGalleryImageClickListener, Navig
                 .actionProductDetailFragmentToAztecEditorFragment(
                         productDescription, getString(R.string.product_description
                 )))
+    }
+
+    private fun getProductSaleDates(dateOnSaleFrom: Date, dateOnSaleTo: Date): String {
+        val formattedFromDate = if (DateTimeUtils.isSameYear(dateOnSaleFrom, dateOnSaleTo)) {
+            dateOnSaleFrom.formatToMMMdd()
+        } else {
+            dateOnSaleFrom.formatToMMMddYYYY()
+        }
+        return getString(R.string.product_sale_date_from_to, formattedFromDate, dateOnSaleTo.formatToMMMddYYYY())
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyView.kt
@@ -7,6 +7,7 @@ import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.RatingBar
 import android.widget.TextView
+import androidx.annotation.DrawableRes
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.woocommerce.android.R
 import com.woocommerce.android.util.WooLog
@@ -21,14 +22,27 @@ class WCProductPropertyView @JvmOverloads constructor(
 ) : ConstraintLayout(context, attrs, defStyle) {
     private var view: View? = null
     private var propertyGroupImg: ImageView? = null
+    private var propertyGroupIcon: ImageView? = null
     private var propertyNameText: TextView? = null
     private var propertyValueText: TextView? = null
     private var ratingBar: RatingBar? = null
 
-    fun show(orientation: Int, caption: String, detail: CharSequence?) {
+    fun show(
+        orientation: Int,
+        caption: String,
+        detail: CharSequence?,
+        @DrawableRes propertyIcon: Int? = null
+    ) {
         ensureViewCreated(orientation)
 
         propertyNameText?.text = caption
+
+        if (propertyIcon != null) {
+            propertyGroupIcon?.visibility = View.VISIBLE
+            propertyGroupIcon?.setImageDrawable(context.getDrawable(propertyIcon))
+        } else {
+            propertyGroupIcon?.visibility = View.GONE
+        }
 
         if (detail.isNullOrEmpty()) {
             propertyValueText?.visibility = View.GONE
@@ -74,6 +88,7 @@ class WCProductPropertyView @JvmOverloads constructor(
                 View.inflate(context, R.layout.product_property_view_horz, this)
             }
             propertyGroupImg = view?.findViewById(R.id.imgProperty)
+            propertyGroupIcon = view?.findViewById(R.id.imgPropertyIcon)
             propertyNameText = view?.findViewById(R.id.textPropertyName)
             propertyValueText = view?.findViewById(R.id.textPropertyValue)
             ratingBar = view?.findViewById(R.id.ratingBar)

--- a/WooCommerce/src/main/res/drawable/ic_gridicons_list_checkmark.xml
+++ b/WooCommerce/src/main/res/drawable/ic_gridicons_list_checkmark.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#99000000" android:pathData="M9.5,15.5L5,20l-2.5,-2.5 1.06,-1.06L5,17.88l3.44,-3.44L9.5,15.5zM10,5v2h11L21,5L10,5zM10,19h11v-2L10,17v2zM10,13h11v-2L10,11v2zM8.44,8.44L5,11.88l-1.44,-1.44L2.5,11.5 5,14l4.5,-4.5 -1.06,-1.06zM8.44,2.44L5,5.88 3.56,4.44 2.5,5.5 5,8l4.5,-4.5 -1.06,-1.06z"/>
+</vector>

--- a/WooCommerce/src/main/res/drawable/ic_gridicons_money.xml
+++ b/WooCommerce/src/main/res/drawable/ic_gridicons_money.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#99000000" android:pathData="M2,5v14h20L22,5L2,5zM7,17c0,-1.657 -1.343,-3 -3,-3v-4c1.657,0 3,-1.343 3,-3h10c0,1.657 1.343,3 3,3v4c-1.657,0 -3,1.343 -3,3L7,17zM12,9c1.1,0 2,1.3 2,3s-0.9,3 -2,3 -2,-1.3 -2,-3 0.9,-3 2,-3z"/>
+</vector>

--- a/WooCommerce/src/main/res/layout/product_property_view_vert.xml
+++ b/WooCommerce/src/main/res/layout/product_property_view_vert.xml
@@ -8,6 +8,19 @@
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground">
 
+    <ImageView
+        android:id="@+id/imgPropertyIcon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin_large"
+        android:contentDescription="@string/product_property_edit"
+        android:src="@drawable/ic_gridicons_list_checkmark"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible" />
+
     <TextView
         android:id="@+id/textPropertyName"
         android:layout_width="wrap_content"
@@ -17,7 +30,7 @@
         android:layout_marginTop="@dimen/product_detail_property_margin"
         android:textColor="@color/wc_black_darker"
         android:textSize="@dimen/text_large"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/imgPropertyIcon"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="textPropertyName"/>
 
@@ -37,7 +50,7 @@
         android:layout_gravity="start"
         android:textAlignment="viewStart"
         app:layout_constraintBottom_toTopOf="@id/divider"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/imgPropertyIcon"
         app:layout_constraintEnd_toStartOf="@+id/imgProperty"
         app:layout_constraintTop_toBottomOf="@+id/textPropertyName"
         tools:text="textPropertyValue"/>

--- a/WooCommerce/src/main/res/layout/product_property_view_vert.xml
+++ b/WooCommerce/src/main/res/layout/product_property_view_vert.xml
@@ -17,15 +17,14 @@
         android:src="@drawable/ic_gridicons_list_checkmark"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        android:layout_marginTop="@dimen/product_detail_property_margin"
         tools:visibility="visible" />
 
     <TextView
         android:id="@+id/textPropertyName"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-
         android:layout_marginStart="@dimen/product_detail_property_margin"
         android:layout_marginTop="@dimen/product_detail_property_margin"
         android:textColor="@color/wc_black_darker"
@@ -38,21 +37,21 @@
         android:id="@+id/textPropertyValue"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/product_detail_property_margin"
-        android:layout_marginEnd="@dimen/product_detail_property_margin"
+        android:layout_gravity="start"
         android:layout_marginStart="@dimen/product_detail_property_margin"
         android:layout_marginTop="@dimen/margin_small"
-        app:layout_goneMarginTop="@dimen/product_detail_property_margin"
+        android:layout_marginEnd="@dimen/product_detail_property_margin"
+        android:layout_marginBottom="@dimen/product_detail_property_margin"
         android:ellipsize="end"
         android:lineSpacingExtra="2dp"
+        android:textAlignment="viewStart"
         android:textColor="@color/wc_black_lighter"
         android:textSize="@dimen/text_medium"
-        android:layout_gravity="start"
-        android:textAlignment="viewStart"
-        app:layout_constraintBottom_toTopOf="@id/divider"
-        app:layout_constraintStart_toEndOf="@+id/imgPropertyIcon"
         app:layout_constraintEnd_toStartOf="@+id/imgProperty"
+        app:layout_constraintStart_toEndOf="@+id/imgPropertyIcon"
         app:layout_constraintTop_toBottomOf="@+id/textPropertyName"
+        app:layout_goneMarginTop="@dimen/product_detail_property_margin"
+        app:layout_constraintBottom_toTopOf="@id/ratingBar"
         tools:text="textPropertyValue"/>
 
     <RatingBar
@@ -60,17 +59,17 @@
         style="@style/Base.Widget.AppCompat.RatingBar.Small"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_margin="@dimen/product_detail_property_margin"
         android:isIndicator="true"
         android:numStars="5"
         android:progressTint="@color/grey_darken_30"
         android:rating="0"
         android:stepSize="1"
         android:visibility="gone"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textPropertyName"
+        app:layout_constraintBottom_toTopOf="@id/divider"
+        app:layout_constraintStart_toStartOf="@+id/textPropertyName"
+        app:layout_constraintTop_toBottomOf="@+id/textPropertyValue"
         tools:rating="3"
-        tools:visibility="visible"/>
+        tools:visibility="visible" />
 
     <ImageView
         android:id="@+id/imgProperty"
@@ -80,9 +79,9 @@
         android:background="@drawable/ic_arrow_right_grey"
         android:contentDescription="@string/product_property_edit"
         android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         tools:visibility="visible" />
 
     <View
@@ -91,6 +90,6 @@
         android:layout_marginTop="@dimen/product_detail_property_margin"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"/>
+        app:layout_constraintStart_toStartOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -404,6 +404,8 @@
     <string name="product_regular_price">Regular price</string>
     <string name="product_sale_price">Sale price</string>
     <string name="product_sale_dates">Sale dates</string>
+    <string name="product_sale_date_from_to">%1$s - %2$s</string>
+    <string name="product_sale_date_from">From %1$s</string>
     <string name="product_sku">SKU</string>
     <string name="product_stock_status">Stock status</string>
     <string name="product_stock_quantity">Stock quantity</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -397,10 +397,13 @@
     <string name="product_property_variant_formatter" translatable="false">%1$s (%2$s options)</string>
     <string name="product_property_edit">Edit product</string>
     <string name="product_inventory">Inventory</string>
+    <string name="product_inventory_empty">Add inventory</string>
     <string name="product_variants">Variants</string>
     <string name="product_price">Price</string>
+    <string name="product_price_empty">Add price</string>
     <string name="product_regular_price">Regular price</string>
     <string name="product_sale_price">Sale price</string>
+    <string name="product_sale_dates">Sale dates</string>
     <string name="product_sku">SKU</string>
     <string name="product_stock_status">Stock status</string>
     <string name="product_stock_quantity">Stock quantity</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -405,7 +405,7 @@
     <string name="product_sale_price">Sale price</string>
     <string name="product_sale_dates">Sale dates</string>
     <string name="product_sale_date_from_to">%1$s - %2$s</string>
-    <string name="product_sale_date_from">From %1$s</string>
+    <string name="product_sale_date_from">from %1$s</string>
     <string name="product_sku">SKU</string>
     <string name="product_stock_status">Stock status</string>
     <string name="product_stock_quantity">Stock quantity</string>


### PR DESCRIPTION
I split up the Update product inventory task into smaller PRs since it was such a big change. This PR addresses step 1 of #1614 by adding the new designs for displaying product inventory and pricing options. 

#### Notes
- This PR targets `develop` branch since this change only affects debug users.
- As per discussion, this new UI is enabled only for debug users and for SIMPLE products. 
- As per discussion, the sale dates for a product is displayed based on the following logic:
  - if a start date is not entered, but an end date is entered, the start date would default to today. 
  - If a start date is entered but not an end date, display the start date alone, assuming store owners want the sale to last indefinitely from a particular day. 

#### Screenshots
(LEFT: No Start or end date available . RIGHT: Both sale dates available)
<img width="300" src="https://user-images.githubusercontent.com/22608780/72133239-efdc4780-33a6-11ea-8c62-c6d6a41afdd6.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/72133241-efdc4780-33a6-11ea-8df3-d743374c5d04.png"> 

(LEFT: No Start date available . RIGHT: No end date available)
<img width="300" src="https://user-images.githubusercontent.com/22608780/72133244-f074de00-33a6-11ea-83b2-b850cae6b85b.png"> . <img width="300" src="https://user-images.githubusercontent.com/22608780/72133245-f074de00-33a6-11ea-8d2b-cd9d193870bd.png">

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
