### PR TITLE
3.4 Hotfix: Update FluxC commit hash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.5.8'
+    fluxCVersion = '1.5.9'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Fixes #1815 by processing SQL requests for records in batches of 200 at a time. The crash was due to a limitation in the amount of query variables allowed in SQLite. Batching these queries and limiting the variables fixes the issue. 

## To Test
- Open the orders list and keep scrolling to force a "more" fetch over and over. I tested by scrolling to the end of my test data (880 orders). There should be no crashes. 