### PR TITLE
Hotfix: Evaluating date for time grouping

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/TimeGroup.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/TimeGroup.kt
@@ -15,19 +15,18 @@ enum class TimeGroup(@StringRes val labelRes: Int) {
     GROUP_OLDER_MONTH(R.string.date_timeframe_older_month);
 
     companion object {
-        fun getTimeGroupForDate(date: Date): TimeGroup {
+        fun getTimeGroupForDate(localDate: Date): TimeGroup {
+            val utcDate = DateTimeUtils.localDateToUTC(localDate)
             val dateToday = DateTimeUtils.nowUTC()
 
             return when {
-                date < DateUtils.addMonths(dateToday, -1) -> GROUP_OLDER_MONTH
-                date < DateUtils.addWeeks(dateToday, -1) -> GROUP_OLDER_WEEK
-                date < DateUtils.addDays(dateToday, -2) -> GROUP_OLDER_TWO_DAYS
-                DateUtils.isSameDay(DateUtils.addDays(dateToday, -2), date) -> GROUP_OLDER_TWO_DAYS
-                DateUtils.isSameDay(DateUtils.addDays(dateToday, -1), date) -> GROUP_YESTERDAY
-                DateUtils.isSameDay(dateToday, date) -> GROUP_TODAY
-                else -> {
-                    GROUP_FUTURE
-                }
+                utcDate < DateUtils.addMonths(dateToday, -1) -> GROUP_OLDER_MONTH
+                utcDate < DateUtils.addWeeks(dateToday, -1) -> GROUP_OLDER_WEEK
+                utcDate < DateUtils.addDays(dateToday, -2) -> GROUP_OLDER_TWO_DAYS
+                DateUtils.isSameDay(DateUtils.addDays(dateToday, -2), utcDate) -> GROUP_OLDER_TWO_DAYS
+                DateUtils.isSameDay(DateUtils.addDays(dateToday, -1), utcDate) -> GROUP_YESTERDAY
+                DateUtils.isSameDay(dateToday, utcDate) -> GROUP_TODAY
+                else -> GROUP_FUTURE
             }
         }
     }


### PR DESCRIPTION
Fixes #1825 by converting the date provided to `TimeGroup.getTimeGroupForDate(...)` to UTC prior to evaluation. What was happening was:
- The `dateCreated` for both order and product review was already in UTC.
- Passing the UTC date string to `DateTimeUtils.dateUTCFromIso8601(...)` to convert it to a `Date` object using the timezone of "UTC". The result is a `Date` object that reflects the correct conversion to the local device datetime. 
- We then use that date to compare it to `todayUTC` but only one is in UTC so the grouping is all wrong. 

It looks like this bug was inserted in [this commit](https://github.com/woocommerce/woocommerce-android/commit/8912b75b6cb3b7558e779d004d9fbaba1d441fe2) a month ago, but is probably only being caught now because I happened to be testing later in the evening when the local and UTC date wouldn't land on the same day. 

Screenshots of fix (compare with the ones in the bug ticket):

<img src="https://user-images.githubusercontent.com/5810477/72488151-58735c00-37cd-11ea-9488-422a88089ab3.png" width="300"/> <img src="https://user-images.githubusercontent.com/5810477/72488166-66c17800-37cd-11ea-9214-5a19a566c9c1.png" width="300"/>
<img src="https://user-images.githubusercontent.com/5810477/72488170-688b3b80-37cd-11ea-8900-988b82cdae92.png" width="300"/>
