### PR TITLE
Dark Mode: Privacy Settings Page

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsFragment.kt
@@ -41,10 +41,10 @@ class PrivacySettingsFragment : androidx.fragment.app.Fragment(), PrivacySetting
         presenter.takeView(this)
 
         switchSendStats.isChecked = presenter.getSendUsageStats()
-        switchSendStats.setOnCheckedChangeListener { _, _ ->
+        switchSendStats.setOnCheckedChangeListener { _, isChecked ->
             AnalyticsTracker.track(PRIVACY_SETTINGS_COLLECT_INFO_TOGGLED, mapOf(
                     AnalyticsTracker.KEY_STATE to AnalyticsUtils.getToggleStateLabel(switchSendStats.isChecked)))
-            presenter.setSendUsageStats(switchSendStats.isChecked)
+            presenter.setSendUsageStats(isChecked)
         }
 
         buttonLearnMore.setOnClickListener {
@@ -61,11 +61,11 @@ class PrivacySettingsFragment : androidx.fragment.app.Fragment(), PrivacySetting
         }
 
         switchCrashReporting.isChecked = presenter.getCrashReportingEnabled()
-        switchCrashReporting.setOnCheckedChangeListener { _, _ ->
+        switchCrashReporting.setOnCheckedChangeListener { _, isChecked ->
             AnalyticsTracker.track(
                     PRIVACY_SETTINGS_CRASH_REPORTING_TOGGLED, mapOf(
                     AnalyticsTracker.KEY_STATE to AnalyticsUtils.getToggleStateLabel(switchCrashReporting.isChecked)))
-            presenter.setCrashReportingEnabled(activity!!, switchCrashReporting.isChecked)
+            presenter.setCrashReportingEnabled(activity!!, isChecked)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsFragment.kt
@@ -41,7 +41,7 @@ class PrivacySettingsFragment : androidx.fragment.app.Fragment(), PrivacySetting
         presenter.takeView(this)
 
         switchSendStats.isChecked = presenter.getSendUsageStats()
-        switchSendStats.setOnClickListener {
+        switchSendStats.setOnCheckedChangeListener { _, _ ->
             AnalyticsTracker.track(PRIVACY_SETTINGS_COLLECT_INFO_TOGGLED, mapOf(
                     AnalyticsTracker.KEY_STATE to AnalyticsUtils.getToggleStateLabel(switchSendStats.isChecked)))
             presenter.setSendUsageStats(switchSendStats.isChecked)
@@ -61,7 +61,7 @@ class PrivacySettingsFragment : androidx.fragment.app.Fragment(), PrivacySetting
         }
 
         switchCrashReporting.isChecked = presenter.getCrashReportingEnabled()
-        switchCrashReporting.setOnClickListener {
+        switchCrashReporting.setOnCheckedChangeListener { _, _ ->
             AnalyticsTracker.track(
                     PRIVACY_SETTINGS_CRASH_REPORTING_TOGGLED, mapOf(
                     AnalyticsTracker.KEY_STATE to AnalyticsUtils.getToggleStateLabel(switchCrashReporting.isChecked)))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/WCSettingsCategoryHeaderView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/WCSettingsCategoryHeaderView.kt
@@ -1,0 +1,14 @@
+package com.woocommerce.android.ui.prefs
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.annotation.StyleRes
+import com.google.android.material.textview.MaterialTextView
+import com.woocommerce.android.R
+
+class WCSettingsCategoryHeaderView @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = R.attr.settingsCategoryHeaderStyle,
+    @StyleRes defStyleRes: Int = R.style.Woo_TextView_Subtitle1
+) : MaterialTextView(ctx, attrs, defStyleAttr, defStyleRes)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/WCSettingsOptionValueView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/WCSettingsOptionValueView.kt
@@ -6,6 +6,7 @@ import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.View
 import android.widget.LinearLayout
+import androidx.annotation.StyleRes
 import com.woocommerce.android.R
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.util.StyleAttrUtils
@@ -19,7 +20,8 @@ import kotlinx.android.synthetic.main.view_option_with_active_setting.view.*
 class WCSettingsOptionValueView @JvmOverloads constructor(
     ctx: Context,
     attrs: AttributeSet? = null,
-    defStyleAttr: Int = 0
+    defStyleAttr: Int = R.attr.settingsOptionValueStyle,
+    @StyleRes defStyleRes: Int = 0
 ) : LinearLayout(ctx, attrs, defStyleAttr) {
     init {
         View.inflate(context, R.layout.view_option_with_active_setting, this)
@@ -33,7 +35,8 @@ class WCSettingsOptionValueView @JvmOverloads constructor(
         setBackgroundResource(outValue.resourceId)
 
         if (attrs != null) {
-            val a = context.obtainStyledAttributes(attrs, R.styleable.WCSettingsOptionValueView)
+            val a = context
+                    .obtainStyledAttributes(attrs, R.styleable.WCSettingsOptionValueView, defStyleAttr, defStyleRes)
             try {
                 // Set the view title and style
                 option_title.text = StyleAttrUtils.getString(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/WCSettingsToggleOptionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/WCSettingsToggleOptionView.kt
@@ -64,6 +64,8 @@ class WCSettingsToggleOptionView @JvmOverloads constructor(
                         R.styleable.WCSettingsToggleOptionView_toggleOptionChecked,
                         R.styleable.WCSettingsToggleOptionView_tools_toggleOptionIcon
                 )
+
+                setOnClickListener { toggle() }
             } finally {
                 a.recycle()
             }
@@ -91,6 +93,7 @@ class WCSettingsToggleOptionView @JvmOverloads constructor(
 
     override fun toggle() {
         checkable.toggle()
+        onCheckChanged()
     }
 
     override fun setChecked(checked: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/WCSettingsToggleOptionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/WCSettingsToggleOptionView.kt
@@ -11,6 +11,7 @@ import android.view.accessibility.AccessibilityNodeInfo
 import android.widget.Checkable
 import android.widget.CompoundButton
 import android.widget.CompoundButton.OnCheckedChangeListener
+import androidx.annotation.StyleRes
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.woocommerce.android.R
 import com.woocommerce.android.util.StyleAttrUtils
@@ -20,7 +21,8 @@ import kotlinx.android.synthetic.main.view_settings_toggle_option.view.*
 class WCSettingsToggleOptionView @JvmOverloads constructor(
     ctx: Context,
     attrs: AttributeSet? = null,
-    defStyleAttr: Int = 0
+    defStyleAttr: Int = R.attr.settingsToggleOptionStyle,
+    @StyleRes defStyleRes: Int = 0
 ) : ConstraintLayout(ctx, attrs, defStyleAttr), Checkable {
     init {
         View.inflate(context, R.layout.view_settings_toggle_option, this)
@@ -31,7 +33,8 @@ class WCSettingsToggleOptionView @JvmOverloads constructor(
         setBackgroundResource(outValue.resourceId)
 
         if (attrs != null) {
-            val a = context.obtainStyledAttributes(attrs, R.styleable.WCSettingsToggleOptionView)
+            val a = context
+                    .obtainStyledAttributes(attrs, R.styleable.WCSettingsToggleOptionView, defStyleAttr, defStyleRes)
             try {
                 // Set the view title
                 StyleAttrUtils.getString(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/WCSettingsToggleOptionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/WCSettingsToggleOptionView.kt
@@ -1,0 +1,130 @@
+package com.woocommerce.android.ui.prefs
+
+import android.R.attr
+import android.content.Context
+import android.graphics.drawable.Drawable
+import android.util.AttributeSet
+import android.util.TypedValue
+import android.view.View
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
+import android.widget.Checkable
+import android.widget.CompoundButton
+import android.widget.CompoundButton.OnCheckedChangeListener
+import androidx.constraintlayout.widget.ConstraintLayout
+import com.woocommerce.android.R
+import com.woocommerce.android.util.StyleAttrUtils
+import com.woocommerce.android.util.UiHelpers
+import kotlinx.android.synthetic.main.view_settings_toggle_option.view.*
+
+class WCSettingsToggleOptionView @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : ConstraintLayout(ctx, attrs, defStyleAttr), Checkable {
+    init {
+        View.inflate(context, R.layout.view_settings_toggle_option, this)
+
+        // Sets the selectable background
+        val outValue = TypedValue()
+        context.theme.resolveAttribute(attr.selectableItemBackground, outValue, true)
+        setBackgroundResource(outValue.resourceId)
+
+        if (attrs != null) {
+            val a = context.obtainStyledAttributes(attrs, R.styleable.WCSettingsToggleOptionView)
+            try {
+                // Set the view title
+                StyleAttrUtils.getString(
+                        a,
+                        isInEditMode,
+                        R.styleable.WCSettingsToggleOptionView_toggleOptionTitle,
+                        R.styleable.WCSettingsToggleOptionView_tools_toggleOptionTitle
+                ).let { UiHelpers.setTextOrHide(toggleSetting_title, it) }
+
+                // Set the view description if it exists, or hide
+                StyleAttrUtils.getString(
+                        a,
+                        isInEditMode,
+                        R.styleable.WCSettingsToggleOptionView_toggleOptionDesc,
+                        R.styleable.WCSettingsToggleOptionView_tools_toggleOptionDesc
+                ).let { UiHelpers.setTextOrHide(toggleSetting_desc, it) }
+
+                // Set the view icon if exists, or hide
+                StyleAttrUtils.getResourceId(
+                        a,
+                        isInEditMode,
+                        R.styleable.WCSettingsToggleOptionView_toggleOptionIcon,
+                        R.styleable.WCSettingsToggleOptionView_tools_toggleOptionIcon
+                ).let { UiHelpers.setImageOrHide(toggleSetting_icon, it, setInvisible = true) }
+
+                // Set the view checked state
+                toggleSetting_switch.isChecked = StyleAttrUtils.getBoolean(
+                        a,
+                        isInEditMode,
+                        R.styleable.WCSettingsToggleOptionView_toggleOptionChecked,
+                        R.styleable.WCSettingsToggleOptionView_tools_toggleOptionIcon
+                )
+            } finally {
+                a.recycle()
+            }
+        }
+    }
+
+    var title: String?
+        get() = toggleSetting_title.text.toString()
+        set(value) { UiHelpers.setTextOrHide(toggleSetting_title, value) }
+
+    var description: String?
+        get() = toggleSetting_desc.text.toString()
+        set(value) { UiHelpers.setTextOrHide(toggleSetting_desc, value) }
+
+    var iconImageResource: Int? = null
+        set(value) { UiHelpers.setImageOrHide(toggleSetting_icon, value) }
+
+    var iconDrawable: Drawable? = null
+        set(value) { UiHelpers.setDrawableOrHide(toggleSetting_icon, value) }
+
+    private val checkable: CompoundButton by lazy { toggleSetting_switch }
+    var listener: OnCheckedChangeListener? = null
+
+    override fun isChecked() = checkable.isChecked
+
+    override fun toggle() {
+        checkable.toggle()
+    }
+
+    override fun setChecked(checked: Boolean) {
+        if (checkable.isChecked != checked) {
+            checkable.isChecked = checked
+            listener?.onCheckedChanged(checkable, isChecked)
+        }
+    }
+
+    private fun onCheckChanged() {
+        listener?.onCheckedChanged(checkable, isChecked)
+    }
+
+    /**
+     * Allows for sending in lambdas in place of a listener object.
+     */
+    fun setOnCheckedChangeListener(onCheckedChangeListener: ((CompoundButton, Boolean) -> Unit)?) {
+        listener = onCheckedChangeListener?.let {
+            OnCheckedChangeListener { buttonView, isChecked -> onCheckedChangeListener(buttonView!!, isChecked) }
+        }
+    }
+
+    // region Accessibility settings
+    override fun getAccessibilityClassName() = this::javaClass.name
+
+    override fun onInitializeAccessibilityEvent(event: AccessibilityEvent?) {
+        event?.isChecked = isChecked
+        super.onInitializeAccessibilityEvent(event)
+    }
+
+    override fun onInitializeAccessibilityNodeInfo(info: AccessibilityNodeInfo?) {
+        info?.isCheckable = true
+        info?.isChecked = isChecked
+        super.onInitializeAccessibilityNodeInfo(info)
+    }
+    // endregion
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StyleAttrUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StyleAttrUtils.kt
@@ -1,10 +1,15 @@
 package com.woocommerce.android.util
 
 import android.content.res.TypedArray
+import android.graphics.Typeface
+import android.graphics.drawable.Drawable
+import androidx.annotation.AnyRes
+import androidx.annotation.ColorInt
+import androidx.annotation.RequiresApi
 import androidx.annotation.StyleableRes
 
 /**
- * Helper functions for working with custom view attributes and styles
+ * Helper functions for working with custom view attributes and styles.
  */
 object StyleAttrUtils {
     fun getString(
@@ -12,20 +17,101 @@ object StyleAttrUtils {
         isInEditMode: Boolean,
         @StyleableRes appAttr: Int,
         @StyleableRes toolsAttr: Int
-    ): String? {
-        return a.getString(if (isInEditMode && a.hasValue(toolsAttr)) toolsAttr else appAttr)
-    }
+    ): String? = a.getString(if (isInEditMode && a.hasValue(toolsAttr)) toolsAttr else appAttr)
 
     fun getBoolean(
         a: TypedArray,
         isInEditMode: Boolean,
         @StyleableRes appAttr: Int,
         @StyleableRes toolsAttr: Int,
-        defVal: Boolean
-    ): Boolean {
-        return a.getBoolean(
-                if (isInEditMode && a.hasValue(toolsAttr)) toolsAttr else appAttr,
-                defVal
-        )
-    }
+        defVal: Boolean = false
+    ) = a.getBoolean(if (isInEditMode && a.hasValue(toolsAttr)) toolsAttr else appAttr, defVal)
+
+    fun getText(
+        a: TypedArray,
+        isInEditMode: Boolean,
+        @StyleableRes appAttr: Int,
+        @StyleableRes toolsAttr: Int
+    ): CharSequence? = a.getText(if (isInEditMode && a.hasValue(toolsAttr)) toolsAttr else appAttr)
+
+    fun getInt(
+        a: TypedArray,
+        isInEditMode: Boolean,
+        @StyleableRes appAttr: Int,
+        @StyleableRes toolsAttr: Int,
+        defVal: Int
+    ) = a.getInt(if (isInEditMode && a.hasValue(toolsAttr)) toolsAttr else appAttr, defVal)
+
+    fun getFloat(
+        a: TypedArray,
+        isInEditMode: Boolean,
+        @StyleableRes appAttr: Int,
+        @StyleableRes toolsAttr: Int,
+        defVal: Float
+    ) = a.getFloat(if (isInEditMode && a.hasValue(toolsAttr)) toolsAttr else appAttr, defVal)
+
+    @ColorInt
+    fun getColor(
+        a: TypedArray,
+        isInEditMode: Boolean,
+        @StyleableRes appAttr: Int,
+        @StyleableRes toolsAttr: Int,
+        @ColorInt defVal: Int
+    ) = a.getColor(if (isInEditMode && a.hasValue(toolsAttr)) toolsAttr else appAttr, defVal)
+
+    fun getInteger(
+        a: TypedArray,
+        isInEditMode: Boolean,
+        @StyleableRes appAttr: Int,
+        @StyleableRes toolsAttr: Int,
+        defVal: Int
+    ) = a.getInteger(if (isInEditMode && a.hasValue(toolsAttr)) toolsAttr else appAttr, defVal)
+
+    fun getDimension(
+        a: TypedArray,
+        isInEditMode: Boolean,
+        @StyleableRes appAttr: Int,
+        @StyleableRes toolsAttr: Int,
+        defVal: Float
+    ) = a.getDimension(if (isInEditMode && a.hasValue(toolsAttr)) toolsAttr else appAttr, defVal)
+
+    fun getDimensionPixelOffset(
+        a: TypedArray,
+        isInEditMode: Boolean,
+        @StyleableRes appAttr: Int,
+        @StyleableRes toolsAttr: Int,
+        defVal: Int
+    ) = a.getDimensionPixelOffset(if (isInEditMode && a.hasValue(toolsAttr)) toolsAttr else appAttr, defVal)
+
+    fun getDimensionPixelSize(
+        a: TypedArray,
+        isInEditMode: Boolean,
+        @StyleableRes appAttr: Int,
+        @StyleableRes toolsAttr: Int,
+        defVal: Int
+    ) = a.getDimensionPixelSize(if (isInEditMode && a.hasValue(toolsAttr)) toolsAttr else appAttr, defVal)
+
+    @AnyRes
+    fun getResourceId(
+        a: TypedArray,
+        isInEditMode: Boolean,
+        @StyleableRes appAttr: Int,
+        @StyleableRes toolsAttr: Int,
+        @AnyRes defVal: Int = 0
+    ) = a.getResourceId(if (isInEditMode && a.hasValue(toolsAttr)) toolsAttr else appAttr, defVal)
+
+    fun getDrawable(
+        a: TypedArray,
+        isInEditMode: Boolean,
+        @StyleableRes appAttr: Int,
+        @StyleableRes toolsAttr: Int
+    ): Drawable? = a.getDrawable(if (isInEditMode && a.hasValue(toolsAttr)) toolsAttr else appAttr)
+
+    @RequiresApi(26)
+    fun getFont(
+        a: TypedArray,
+        isInEditMode: Boolean,
+        @StyleableRes appAttr: Int,
+        @StyleableRes toolsAttr: Int
+    ): Typeface? = a.getFont(if (isInEditMode && a.hasValue(toolsAttr)) toolsAttr else appAttr)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UiHelpers.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UiHelpers.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.util
 import android.app.Dialog
 import android.content.Context
 import android.graphics.Point
+import android.graphics.drawable.Drawable
 import android.view.View
 import android.view.WindowManager.LayoutParams
 import android.widget.ImageView
@@ -31,8 +32,12 @@ object UiHelpers {
                 is UiStringText -> uiString.text
             }
 
-    fun updateVisibility(view: View, visible: Boolean) {
-        view.visibility = if (visible) View.VISIBLE else View.GONE
+    fun updateVisibility(view: View, visible: Boolean, setInvisible: Boolean = false) {
+        view.visibility = if (visible) {
+            View.VISIBLE
+        } else {
+            if (setInvisible) View.INVISIBLE else View.GONE
+        }
     }
 
     fun setTextOrHide(view: TextView, uiString: UiString?) {
@@ -52,11 +57,16 @@ object UiHelpers {
         }
     }
 
-    fun setImageOrHide(imageView: ImageView, @DrawableRes resId: Int?) {
-        updateVisibility(imageView, resId != null)
+    fun setImageOrHide(imageView: ImageView, @DrawableRes resId: Int?, setInvisible: Boolean = false) {
+        updateVisibility(imageView, resId != null, setInvisible)
         resId?.let {
             imageView.setImageResource(resId)
         }
+    }
+
+    fun setDrawableOrHide(imageView: ImageView, image: Drawable?) {
+        updateVisibility(imageView, image != null)
+        image?.let { imageView.setImageDrawable(image) }
     }
 
     fun adjustDialogSize(dialog: Dialog) {

--- a/WooCommerce/src/main/res/drawable/ic_gridicons_bug.xml
+++ b/WooCommerce/src/main/res/drawable/ic_gridicons_bug.xml
@@ -4,6 +4,6 @@
         android:viewportHeight="24"
         android:viewportWidth="24">
     <path
-        android:fillColor="@color/grey_text_min"
+        android:fillColor="@color/color_on_surface_medium"
         android:pathData="M18,14h4v-2h-4v-2h1a2,2 0,0 0,2 -2V6h-2v2H5V6H3v2a2,2 0,0 0,2 2h1v2H2v2h4v1a6,6 0,0 0,0.09 1H5a2,2 0,0 0,-2 2v2h2v-2h1.81A6,6 0,0 0,11 20.91V10h2v10.91A6,6 0,0 0,17.19 18H19v2h2v-2a2,2 0,0 0,-2 -2h-1.09a6,6 0,0 0,0.09 -1zM12,2a4,4 0,0 0,-4 4h8a4,4 0,0 0,-4 -4z"/>
 </vector>

--- a/WooCommerce/src/main/res/drawable/ic_stats_24dp.xml
+++ b/WooCommerce/src/main/res/drawable/ic_stats_24dp.xml
@@ -6,7 +6,7 @@
     android:viewportWidth="24.0" >
 
     <path
-        android:fillColor="@color/grey_text_min"
+        android:fillColor="@color/color_on_surface_medium"
         android:pathData="M19,3H5C3.895,3,3,3.895,3,5v14c0,1.105,0.895,2,2,2h14c1.105,0,2-0.895,2-2V5C21,3.895,20.105,3,19,3z M19,19H5V5h14V19z M9,17H7v-5h2V17z M13,17h-2V7h2V17z M17,17h-2v-7h2V17z" >
     </path>
 

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -35,7 +35,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        tools:visibility="gone">
+        tools:visibility="visible">
 
         <com.google.android.material.textview.MaterialTextView
             style="@style/Woo.Settings.CategoryHeader"
@@ -43,29 +43,29 @@
             android:layout_height="wrap_content"
             android:text="@string/settings_notifs"/>
 
-        <com.woocommerce.android.widgets.WCToggleSingleOptionView
+        <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
             android:id="@+id/option_notifs_orders"
-            style="@style/Woo.Settings.Option"
+            style="@style/Woo.Settings.Option.WithImage"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:switchSummary="@string/settings_notifs_orders_detail"
-            app:switchTitle="@string/settings_notifs_orders"/>
+            app:toggleOptionDesc="@string/settings_notifs_orders_detail"
+            app:toggleOptionTitle="@string/settings_notifs_orders"/>
 
-        <com.woocommerce.android.widgets.WCToggleSingleOptionView
+        <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
             android:id="@+id/option_notifs_tone"
-            style="@style/Woo.Settings.Option"
+            style="@style/Woo.Settings.Option.WithImage"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:switchSummary="@string/settings_notifs_tone_detail"
-            app:switchTitle="@string/settings_notifs_tone"/>
+            app:toggleOptionDesc="@string/settings_notifs_tone_detail"
+            app:toggleOptionTitle="@string/settings_notifs_tone"/>
 
-        <com.woocommerce.android.widgets.WCToggleSingleOptionView
+        <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
             android:id="@+id/option_notifs_reviews"
-            style="@style/Woo.Settings.Option"
+            style="@style/Woo.Settings.Option.WithImage"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:switchSummary="@string/settings_notifs_reviews_detail"
-            app:switchTitle="@string/settings_notifs_reviews"/>
+            app:toggleOptionDesc="@string/settings_notifs_reviews_detail"
+            app:toggleOptionTitle="@string/settings_notifs_reviews"/>
 
         <View style="@style/Woo.Divider"/>
     </LinearLayout>
@@ -96,13 +96,13 @@
     <!--
         Image Optimization
     -->
-    <com.woocommerce.android.widgets.WCToggleSingleOptionView
+    <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
         android:id="@+id/option_image_optimization"
-        style="@style/Woo.Settings.Option"
+        style="@style/Woo.Settings.Option.WithImage"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:switchSummary="@string/settings_image_optimization_message"
-        app:switchTitle="@string/settings_image_optimization_title"/>
+        app:toggleOptionDesc="@string/settings_image_optimization_message"
+        app:toggleOptionTitle="@string/settings_image_optimization_title"/>
 
     <!--
         Privacy

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -45,7 +45,6 @@
 
         <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
             android:id="@+id/option_notifs_orders"
-            style="@style/Woo.Settings.Option.WithImage"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:toggleOptionDesc="@string/settings_notifs_orders_detail"
@@ -53,7 +52,6 @@
 
         <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
             android:id="@+id/option_notifs_tone"
-            style="@style/Woo.Settings.Option.WithImage"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:toggleOptionDesc="@string/settings_notifs_tone_detail"
@@ -61,7 +59,6 @@
 
         <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
             android:id="@+id/option_notifs_reviews"
-            style="@style/Woo.Settings.Option.WithImage"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:toggleOptionDesc="@string/settings_notifs_reviews_detail"
@@ -98,7 +95,6 @@
     -->
     <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
         android:id="@+id/option_image_optimization"
-        style="@style/Woo.Settings.Option.WithImage"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:toggleOptionDesc="@string/settings_image_optimization_message"

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -19,7 +19,6 @@
 
     <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
         android:id="@+id/option_store"
-        style="@style/Woo.Settings.Option"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         tools:optionTitle="testwooshop.mystagingwebsite.com"
@@ -72,7 +71,6 @@
     -->
     <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
         android:id="@+id/option_notifications"
-        style="@style/Woo.Settings.Option"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:optionTitle="@string/settings_notifs_device"
@@ -84,7 +82,6 @@
     -->
     <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
         android:id="@+id/option_theme"
-        style="@style/Woo.Settings.Option"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:optionTitle="@string/settings_app_theme_title"
@@ -105,7 +102,6 @@
     -->
     <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
         android:id="@+id/option_privacy"
-        style="@style/Woo.Settings.Option"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:optionTitle="@string/privacy_settings"/>
@@ -117,7 +113,6 @@
     -->
     <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
         android:id="@+id/option_beta_features"
-        style="@style/Woo.Settings.Option"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:optionTitle="@string/beta_features"/>
@@ -127,7 +122,6 @@
     -->
     <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
         android:id="@+id/option_feature_request"
-        style="@style/Woo.Settings.Option"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:optionTitle="@string/feature_requests"/>
@@ -145,14 +139,12 @@
 
     <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
         android:id="@+id/option_about"
-        style="@style/Woo.Settings.Option"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:optionTitle="@string/app_name"/>
 
     <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
         android:id="@+id/option_licenses"
-        style="@style/Woo.Settings.Option"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:optionTitle="@string/settings_licenses"/>

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -11,8 +11,7 @@
     <!--
         Primary store
     -->
-    <com.google.android.material.textview.MaterialTextView
-        style="@style/Woo.Settings.CategoryHeader"
+    <com.woocommerce.android.ui.prefs.WCSettingsCategoryHeaderView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/settings_selected_store"/>
@@ -36,8 +35,7 @@
         android:orientation="vertical"
         tools:visibility="visible">
 
-        <com.google.android.material.textview.MaterialTextView
-            style="@style/Woo.Settings.CategoryHeader"
+        <com.woocommerce.android.ui.prefs.WCSettingsCategoryHeaderView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/settings_notifs"/>
@@ -131,8 +129,7 @@
     <!--
         About
     -->
-    <com.google.android.material.textview.MaterialTextView
-        style="@style/Woo.Settings.CategoryHeader"
+    <com.woocommerce.android.ui.prefs.WCSettingsCategoryHeaderView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/settings_about"/>

--- a/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
@@ -9,7 +9,6 @@
 
     <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
         android:id="@+id/switchSendStats"
-        style="@style/Woo.Settings.Option.WithImage"
         android:paddingTop="@dimen/minor_00"
         android:paddingBottom="@dimen/minor_00"
         android:layout_width="match_parent"
@@ -133,7 +132,6 @@
 
     <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
         android:id="@+id/switchCrashReporting"
-        style="@style/Woo.Settings.Option.WithImage"
         android:paddingTop="@dimen/minor_00"
         android:paddingBottom="@dimen/minor_00"
         android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
@@ -4,11 +4,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@color/white">
+    android:background="?attr/colorSurface">
 
     <ImageView
         android:id="@+id/imageSendStats"
-        style="@style/Woo.Settings.Icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/major_100"
         android:importantForAccessibility="no"
         app:srcCompat="@drawable/ic_stats_grey_min_24dp"/>
 
@@ -21,14 +23,11 @@
 
         <Switch
             android:id="@+id/switchSendStats"
-            style="@style/Woo.Settings.Label"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/settings_send_stats"/>
 
-        <View
-            style="@style/Woo.Settings.Divider"
-            android:layout_marginStart="@dimen/settings_padding"/>
+        <View style="@style/Woo.Divider"/>
 
         <TextView
             style="@style/Woo.Settings.LabelWithButton"
@@ -38,43 +37,34 @@
 
         <Button
             android:id="@+id/buttonLearnMore"
-            style="@style/Woo.Settings.Button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="end"
             android:text="@string/learn_more"/>
 
-        <View
-            style="@style/Woo.Settings.Divider"
-            android:layout_marginStart="@dimen/settings_padding"/>
+        <View style="@style/Woo.Divider"/>
 
         <TextView
-            style="@style/Woo.Settings.LabelWithButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/settings_privacy_detail"/>
 
         <Button
             android:id="@+id/buttonPrivacyPolicy"
-            style="@style/Woo.Settings.Button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="end"
             android:text="@string/settings_privacy_policy"/>
 
-        <View
-            style="@style/Woo.Settings.Divider"
-            android:layout_marginStart="@dimen/settings_padding"/>
+        <View style="@style/Woo.Divider"/>
 
         <TextView
-            style="@style/Woo.Settings.LabelWithButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/settings_tracking"/>
 
         <Button
             android:id="@+id/buttonTracking"
-            style="@style/Woo.Settings.Button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="end"
@@ -89,22 +79,22 @@
         android:layout_below="@+id/firstGroup"
         android:orientation="vertical">
 
-        <View
-            style="@style/Woo.Settings.Divider"/>
+        <View style="@style/Woo.Divider"/>
 
         <View
             android:layout_width="match_parent"
             android:layout_height="@dimen/margin_extra_large"
             android:background="@color/default_window_background"/>
 
-        <View
-            style="@style/Woo.Settings.Divider"/>
+        <View style="@style/Woo.Divider"/>
 
     </LinearLayout>
 
     <ImageView
         android:id="@+id/imageCrashReporting"
-        style="@style/Woo.Settings.Icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/major_100"
         android:layout_below="@+id/groupSpacer"
         android:importantForAccessibility="no"
         app:srcCompat="@drawable/ic_gridicons_bug"/>
@@ -119,7 +109,6 @@
 
         <Switch
             android:id="@+id/switchCrashReporting"
-            style="@style/Woo.Settings.Label"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/settings_crash_reporting"/>
@@ -131,14 +120,11 @@
 
         <TextView
             android:id="@+id/textCrashReporting"
-            style="@style/Woo.Settings.Label"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/settings_crash_reporting_detail"/>
     </LinearLayout>
 
-    <View
-        style="@style/Woo.Settings.Divider"
-        android:layout_below="@+id/secondGroup"/>
+    <View style="@style/Woo.Divider"/>
 
 </RelativeLayout>

--- a/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
@@ -9,6 +9,9 @@
 
     <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
         android:id="@+id/switchSendStats"
+        style="@style/Woo.Settings.Option.WithImage"
+        android:paddingTop="@dimen/minor_00"
+        android:paddingBottom="@dimen/minor_00"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:toggleOptionTitle="@string/settings_send_stats"
@@ -130,6 +133,9 @@
 
     <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
         android:id="@+id/switchCrashReporting"
+        style="@style/Woo.Settings.Option.WithImage"
+        android:paddingTop="@dimen/minor_00"
+        android:paddingBottom="@dimen/minor_00"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:toggleOptionIcon="@drawable/ic_gridicons_bug"

--- a/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
@@ -14,7 +14,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:toggleOptionTitle="@string/settings_send_stats"
-        app:toggleOptionIcon="@drawable/ic_stats_grey_min_24dp"
+        app:toggleOptionIcon="@drawable/ic_stats_24dp"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>

--- a/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
@@ -1,130 +1,137 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/colorSurface">
 
-    <ImageView
-        android:id="@+id/imageSendStats"
+    <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
+        android:id="@+id/switchSendStats"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:toggleOptionTitle="@string/settings_send_stats"
+        app:toggleOptionIcon="@drawable/ic_stats_grey_min_24dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <View
+        android:id="@+id/divider1"
+        style="@style/Woo.Divider"
+        android:layout_marginStart="@dimen/margin_app_title_aligned"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/switchSendStats"/>
+
+    <TextView
+        android:id="@+id/privacy_share_info"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/settings_send_stats_detail"
+        app:layout_constraintStart_toStartOf="@+id/divider1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/divider1"/>
+
+    <Button
+        android:id="@+id/buttonLearnMore"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_margin="@dimen/major_100"
-        android:importantForAccessibility="no"
-        app:srcCompat="@drawable/ic_stats_grey_min_24dp"/>
+        android:layout_gravity="end"
+        android:text="@string/learn_more"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/privacy_share_info"/>
 
-    <LinearLayout
-        android:id="@+id/firstGroup"
-        android:layout_width="match_parent"
+    <View
+        android:id="@+id/divider2"
+        style="@style/Woo.Divider"
+        android:layout_marginStart="@dimen/margin_app_title_aligned"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/buttonLearnMore"/>
+
+    <TextView
+        android:id="@+id/privacy_policy_info"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_toEndOf="@+id/imageSendStats"
-        android:orientation="vertical">
+        android:text="@string/settings_privacy_detail"
+        app:layout_constraintStart_toStartOf="@+id/divider2"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/divider2"/>
 
-        <Switch
-            android:id="@+id/switchSendStats"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/settings_send_stats"/>
-
-        <View style="@style/Woo.Divider"/>
-
-        <TextView
-            style="@style/Woo.Settings.LabelWithButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/settings_send_stats_detail"/>
-
-        <Button
-            android:id="@+id/buttonLearnMore"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:text="@string/learn_more"/>
-
-        <View style="@style/Woo.Divider"/>
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/settings_privacy_detail"/>
-
-        <Button
-            android:id="@+id/buttonPrivacyPolicy"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:text="@string/settings_privacy_policy"/>
-
-        <View style="@style/Woo.Divider"/>
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/settings_tracking"/>
-
-        <Button
-            android:id="@+id/buttonTracking"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:text="@string/learn_more"/>
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/groupSpacer"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/firstGroup"
-        android:orientation="vertical">
-
-        <View style="@style/Woo.Divider"/>
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/margin_extra_large"
-            android:background="@color/default_window_background"/>
-
-        <View style="@style/Woo.Divider"/>
-
-    </LinearLayout>
-
-    <ImageView
-        android:id="@+id/imageCrashReporting"
+    <Button
+        android:id="@+id/buttonPrivacyPolicy"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_margin="@dimen/major_100"
-        android:layout_below="@+id/groupSpacer"
-        android:importantForAccessibility="no"
-        app:srcCompat="@drawable/ic_gridicons_bug"/>
+        android:layout_gravity="end"
+        android:text="@string/settings_privacy_policy"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/privacy_policy_info"/>
 
-    <LinearLayout
-        android:id="@+id/secondGroup"
+    <View
+        android:id="@+id/divider3"
+        style="@style/Woo.Divider"
+        android:layout_marginStart="@dimen/margin_app_title_aligned"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/buttonPrivacyPolicy"/>
+
+    <TextView
+        android:id="@+id/privacy_tracking_info"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/settings_tracking"
+        app:layout_constraintStart_toStartOf="@+id/divider3"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/divider3"/>
+
+    <Button
+        android:id="@+id/buttonTracking"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end"
+        android:text="@string/learn_more"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/privacy_tracking_info"/>
+
+    <View
+        android:id="@+id/divider4"
+        style="@style/Woo.Divider"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/buttonTracking"/>
+
+    <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
+        android:id="@+id/switchCrashReporting"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignTop="@+id/imageCrashReporting"
-        android:layout_toEndOf="@+id/imageCrashReporting"
-        android:orientation="vertical">
+        app:toggleOptionIcon="@drawable/ic_gridicons_bug"
+        app:toggleOptionTitle="@string/settings_crash_reporting"
+        app:layout_constraintTop_toBottomOf="@id/divider4"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
 
-        <Switch
-            android:id="@+id/switchCrashReporting"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/settings_crash_reporting"/>
+    <View
+        android:id="@+id/divider5"
+        style="@style/Woo.Divider"
+        android:layout_marginStart="@dimen/margin_app_title_aligned"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/switchCrashReporting"/>
 
-        <View
-            android:id="@+id/dividerCrashReporting"
-            style="@style/Woo.Settings.Divider"
-            android:layout_marginStart="@dimen/settings_padding"/>
+    <TextView
+        android:id="@+id/textCrashReporting"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/settings_crash_reporting_detail"
+        app:layout_constraintStart_toStartOf="@+id/divider5"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/divider5"/>
 
-        <TextView
-            android:id="@+id/textCrashReporting"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/settings_crash_reporting_detail"/>
-    </LinearLayout>
-
-    <View style="@style/Woo.Divider"/>
-
-</RelativeLayout>
+    <View
+        style="@style/Woo.Divider"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textCrashReporting"/>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
@@ -25,7 +25,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/switchSendStats"/>
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/privacy_share_info"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -34,7 +34,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/divider1"/>
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonLearnMore"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -51,7 +51,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/buttonLearnMore"/>
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/privacy_policy_info"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -60,7 +60,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/divider2"/>
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonPrivacyPolicy"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -77,7 +77,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/buttonPrivacyPolicy"/>
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/privacy_tracking_info"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -86,7 +86,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/divider3"/>
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonTracking"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -120,7 +120,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/switchCrashReporting"/>
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/textCrashReporting"
         android:layout_width="0dp"
         android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
@@ -27,8 +27,12 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/privacy_share_info"
+        style="@style/Woo.Settings.Option.Value"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/minor_00"
+        android:layout_marginTop="@dimen/major_100"
+        android:layout_marginEnd="@dimen/major_100"
         android:text="@string/settings_send_stats_detail"
         app:layout_constraintStart_toStartOf="@+id/divider1"
         app:layout_constraintEnd_toEndOf="parent"
@@ -36,9 +40,12 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonLearnMore"
+        style="@style/Woo.Button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="end"
+        android:layout_marginEnd="@dimen/major_100"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginTop="@dimen/minor_100"
         android:text="@string/learn_more"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/privacy_share_info"/>
@@ -46,6 +53,7 @@
     <View
         android:id="@+id/divider2"
         style="@style/Woo.Divider"
+        android:layout_marginTop="@dimen/minor_100"
         android:layout_marginStart="@dimen/margin_app_title_aligned"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
@@ -53,18 +61,26 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/privacy_policy_info"
+        style="@style/Woo.Settings.Option.Value"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/minor_00"
+        android:layout_marginTop="@dimen/major_100"
+        android:layout_marginEnd="@dimen/major_100"
         android:text="@string/settings_privacy_detail"
         app:layout_constraintStart_toStartOf="@+id/divider2"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/divider2"/>
+        app:layout_constraintTop_toBottomOf="@+id/divider2"
+        app:layout_constraintBottom_toTopOf="@+id/buttonPrivacyPolicy"/>
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonPrivacyPolicy"
+        style="@style/Woo.Button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="end"
+        android:layout_marginEnd="@dimen/major_100"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginTop="@dimen/minor_100"
         android:text="@string/settings_privacy_policy"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/privacy_policy_info"/>
@@ -72,6 +88,7 @@
     <View
         android:id="@+id/divider3"
         style="@style/Woo.Divider"
+        android:layout_marginTop="@dimen/minor_100"
         android:layout_marginStart="@dimen/margin_app_title_aligned"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
@@ -79,8 +96,12 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/privacy_tracking_info"
+        style="@style/Woo.Settings.Option.Value"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/minor_00"
+        android:layout_marginTop="@dimen/major_100"
+        android:layout_marginEnd="@dimen/major_100"
         android:text="@string/settings_tracking"
         app:layout_constraintStart_toStartOf="@+id/divider3"
         app:layout_constraintEnd_toEndOf="parent"
@@ -88,9 +109,13 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonTracking"
+        style="@style/Woo.Button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="end"
+        android:layout_marginEnd="@dimen/major_100"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginTop="@dimen/minor_100"
+        android:layout_marginBottom="@dimen/minor_100"
         android:text="@string/learn_more"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/privacy_tracking_info"/>
@@ -98,6 +123,7 @@
     <View
         android:id="@+id/divider4"
         style="@style/Woo.Divider"
+        android:layout_marginTop="@dimen/minor_100"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/buttonTracking"/>
@@ -122,16 +148,23 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/textCrashReporting"
+        style="@style/Woo.Settings.Option.Value"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/minor_00"
+        android:layout_marginTop="@dimen/major_100"
+        android:layout_marginBottom="@dimen/major_100"
+        android:layout_marginEnd="@dimen/major_100"
         android:text="@string/settings_crash_reporting_detail"
         app:layout_constraintStart_toStartOf="@+id/divider5"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/divider5"/>
+        app:layout_constraintTop_toBottomOf="@id/divider5"
+        app:layout_constraintBottom_toTopOf="@+id/divider6"/>
 
     <View
+        android:id="@+id/divider6"
         style="@style/Woo.Divider"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textCrashReporting"/>
+        app:layout_constraintBottom_toBottomOf="parent"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/top_earner_list_item.xml
+++ b/WooCommerce/src/main/res/layout/top_earner_list_item.xml
@@ -21,7 +21,7 @@
             android:layout_height="@dimen/image_minor_100"
             android:contentDescription="@string/product_image_content_description"
             android:scaleType="centerCrop"
-            tools:src="@drawable/ic_stats_grey_min_24dp"/>
+            tools:src="@drawable/ic_stats_24dp"/>
     </FrameLayout>
 
     <LinearLayout

--- a/WooCommerce/src/main/res/layout/view_settings_toggle_option.xml
+++ b/WooCommerce/src/main/res/layout/view_settings_toggle_option.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:focusable="true">
+
+    <ImageView
+        android:id="@+id/toggleSetting_icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/major_100"
+        android:importantForAccessibility="no"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/toggleSetting_title"
+        app:layout_constraintHorizontal_chainStyle="spread_inside"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:src="@drawable/ic_stats_grey_min_24dp"
+        tools:visibility="visible" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/toggleSetting_title"
+        style="@style/Woo.Settings.Option.Title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/minor_00"
+        android:layout_marginTop="@dimen/minor_00"
+        android:importantForAccessibility="no"
+        app:layout_constraintBottom_toTopOf="@+id/toggleSetting_desc"
+        app:layout_constraintEnd_toStartOf="@+id/toggleSetting_switch"
+        app:layout_constraintStart_toEndOf="@+id/toggleSetting_icon"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Image optimization" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/toggleSetting_desc"
+        style="@style/Woo.Settings.Option.Value"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/minor_00"
+        android:importantForAccessibility="no"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/toggleSetting_title"
+        app:layout_constraintStart_toStartOf="@+id/toggleSetting_title"
+        app:layout_constraintTop_toBottomOf="@+id/toggleSetting_title"
+        tools:text="Resize and compress because this is a really long message"
+        tools:visibility="go" />
+
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/toggleSetting_switch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginEnd="@dimen/major_100"
+        android:clickable="false"
+        android:importantForAccessibility="no"
+        android:switchPadding="@dimen/major_100"
+        android:textColor="@null"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:showText="false" />
+</merge>

--- a/WooCommerce/src/main/res/layout/view_settings_toggle_option.xml
+++ b/WooCommerce/src/main/res/layout/view_settings_toggle_option.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<merge
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -11,8 +11,8 @@
         android:id="@+id/toggleSetting_icon"
         android:layout_width="@dimen/image_minor_50"
         android:layout_height="@dimen/image_minor_50"
-        android:importantForAccessibility="no"
         android:layout_marginEnd="@dimen/major_100"
+        android:importantForAccessibility="no"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/toggleSetting_title"
         app:layout_constraintHorizontal_chainStyle="spread_inside"
@@ -64,4 +64,4 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:showText="false" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+</merge>

--- a/WooCommerce/src/main/res/layout/view_settings_toggle_option.xml
+++ b/WooCommerce/src/main/res/layout/view_settings_toggle_option.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -9,10 +9,10 @@
 
     <ImageView
         android:id="@+id/toggleSetting_icon"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/major_100"
+        android:layout_width="@dimen/image_minor_50"
+        android:layout_height="@dimen/image_minor_50"
         android:importantForAccessibility="no"
+        android:layout_marginEnd="@dimen/major_100"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/toggleSetting_title"
         app:layout_constraintHorizontal_chainStyle="spread_inside"
@@ -28,6 +28,7 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/minor_00"
         android:layout_marginTop="@dimen/minor_00"
+        android:paddingBottom="@dimen/minor_25"
         android:importantForAccessibility="no"
         app:layout_constraintBottom_toTopOf="@+id/toggleSetting_desc"
         app:layout_constraintEnd_toStartOf="@+id/toggleSetting_switch"
@@ -48,14 +49,13 @@
         app:layout_constraintStart_toStartOf="@+id/toggleSetting_title"
         app:layout_constraintTop_toBottomOf="@+id/toggleSetting_title"
         tools:text="Resize and compress because this is a really long message"
-        tools:visibility="go" />
+        tools:visibility="visible" />
 
     <com.google.android.material.switchmaterial.SwitchMaterial
         android:id="@+id/toggleSetting_switch"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/major_100"
-        android:layout_marginEnd="@dimen/major_100"
         android:clickable="false"
         android:importantForAccessibility="no"
         android:switchPadding="@dimen/major_100"
@@ -64,4 +64,4 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:showText="false" />
-</merge>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/view_settings_toggle_option.xml
+++ b/WooCommerce/src/main/res/layout/view_settings_toggle_option.xml
@@ -18,7 +18,7 @@
         app:layout_constraintHorizontal_chainStyle="spread_inside"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:src="@drawable/ic_stats_grey_min_24dp"
+        tools:src="@drawable/ic_stats_24dp"
         tools:visibility="visible" />
 
     <com.google.android.material.textview.MaterialTextView

--- a/WooCommerce/src/main/res/values/attrs.xml
+++ b/WooCommerce/src/main/res/values/attrs.xml
@@ -22,6 +22,7 @@
         <attr name="flowLayoutStyle" format="reference"/>
         <attr name="settingsToggleOptionStyle" format="reference"/>
         <attr name="settingsOptionValueStyle" format="reference"/>
+        <attr name="settingsCategoryHeaderStyle" format="reference"/>
     </declare-styleable>
 
     <declare-styleable name="WCTextViewCompat">

--- a/WooCommerce/src/main/res/values/attrs.xml
+++ b/WooCommerce/src/main/res/values/attrs.xml
@@ -21,6 +21,7 @@
         <attr name="tagViewStyle" format="reference"/>
         <attr name="flowLayoutStyle" format="reference"/>
         <attr name="settingsToggleOptionStyle" format="reference"/>
+        <attr name="settingsOptionValueStyle" format="reference"/>
     </declare-styleable>
 
     <declare-styleable name="WCTextViewCompat">

--- a/WooCommerce/src/main/res/values/attrs.xml
+++ b/WooCommerce/src/main/res/values/attrs.xml
@@ -42,6 +42,17 @@
         <attr name="tools_optionValue" format="reference|string"/>
     </declare-styleable>
 
+    <declare-styleable name="WCSettingsToggleOptionView">
+        <attr name="toggleOptionTitle" format="reference|string"/>
+        <attr name="toggleOptionDesc" format="reference|string"/>
+        <attr name="toggleOptionIcon" format="reference"/>
+        <attr name="toggleOptionChecked" format="boolean"/>
+        <attr name="tools_toggleOptionTitle" format="reference|string"/>
+        <attr name="tools_toggleOptionDesc" format="reference|string"/>
+        <attr name="tools_toggleOptionIcon" format="reference"/>
+        <attr name="tools_toggleOptionChecked" format="boolean"/>
+    </declare-styleable>
+
     <declare-styleable name="WCProductImageGalleryView">
         <attr name="isGridView" format="boolean" />
         <attr name="showAddImageIcon" format="boolean" />

--- a/WooCommerce/src/main/res/values/attrs.xml
+++ b/WooCommerce/src/main/res/values/attrs.xml
@@ -20,6 +20,7 @@
     <declare-styleable name="WooTheme">
         <attr name="tagViewStyle" format="reference"/>
         <attr name="flowLayoutStyle" format="reference"/>
+        <attr name="settingsToggleOptionStyle" format="reference"/>
     </declare-styleable>
 
     <declare-styleable name="WCTextViewCompat">

--- a/WooCommerce/src/main/res/values/dimens.xml
+++ b/WooCommerce/src/main/res/values/dimens.xml
@@ -53,6 +53,7 @@ so that's the baseline as defined in `major_100`.
     <dimen name="line_height_major_200">112dp</dimen>
 
     <!-- Smaller image sizes (ex. icons) -->
+    <dimen name="image_minor_50">24dp</dimen>
     <dimen name="image_minor_100">40dp</dimen>
     <dimen name="image_major_100">100dp</dimen>
 

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -6,6 +6,8 @@ theme across the entire app. Overridden versions should be added to the styles.x
 -->
 <resources xmlns:tools="http://schemas.android.com/tools">
     <style name="Woo"/>
+    <style name="Widget"/>
+    <style name="Widget.Woo"/>
 
     <!--
         Toolbar Style
@@ -307,8 +309,16 @@ theme across the entire app. Overridden versions should be added to the styles.x
     <!--
         Settings
     -->
-    <style name="Woo.Settings.Option">
+    <style name="Widget.Woo.Settings"/>
+    <style name="Widget.Woo.Settings.OptionValue">
         <item name="android:paddingStart">@dimen/margin_app_title_aligned</item>
+        <item name="android:paddingTop">@dimen/major_100</item>
+        <item name="android:paddingBottom">@dimen/major_100</item>
+        <item name="android:paddingEnd">@dimen/major_100</item>
+    </style>
+
+    <style name="Widget.Woo.Settings.OptionToggle">
+        <item name="android:paddingStart">@dimen/major_100</item>
         <item name="android:paddingTop">@dimen/major_100</item>
         <item name="android:paddingBottom">@dimen/major_100</item>
         <item name="android:paddingEnd">@dimen/major_100</item>
@@ -333,9 +343,5 @@ theme across the entire app. Overridden versions should be added to the styles.x
     <style name="Woo.Settings.Caption" parent="@style/Woo.TextView.Caption">
         <item name="android:layout_margin">@dimen/minor_00</item>
         <item name="android:gravity">center_vertical</item>
-    </style>
-
-    <style name="Woo.Settings.Option.Toggle">
-        <item name="android:paddingStart">@dimen/major_100</item>
     </style>
 </resources>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -314,6 +314,10 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:paddingEnd">@dimen/major_100</item>
     </style>
 
+    <style name="Woo.Settings.Option.WithImage">
+        <item name="android:paddingStart">@dimen/major_100</item>
+    </style>
+
     <style name="Woo.Settings.CategoryHeader" parent="Woo.TextView.Subtitle2">
         <item name="android:textColor">?attr/colorPrimary</item>
         <item name="android:layout_marginBottom">@dimen/minor_00</item>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -314,10 +314,6 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:paddingEnd">@dimen/major_100</item>
     </style>
 
-    <style name="Woo.Settings.Option.WithImage">
-        <item name="android:paddingStart">@dimen/major_100</item>
-    </style>
-
     <style name="Woo.Settings.CategoryHeader" parent="Woo.TextView.Subtitle2">
         <item name="android:textColor">?attr/colorPrimary</item>
         <item name="android:layout_marginBottom">@dimen/minor_00</item>
@@ -337,5 +333,9 @@ theme across the entire app. Overridden versions should be added to the styles.x
     <style name="Woo.Settings.Caption" parent="@style/Woo.TextView.Caption">
         <item name="android:layout_margin">@dimen/minor_00</item>
         <item name="android:gravity">center_vertical</item>
+    </style>
+
+    <style name="Woo.Settings.Option.Toggle">
+        <item name="android:paddingStart">@dimen/major_100</item>
     </style>
 </resources>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -320,13 +320,9 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:layout_marginStart">@dimen/margin_app_title_aligned</item>
     </style>
 
-    <style name="Woo.Settings.Option.Title" parent="@style/Woo.TextView.Subtitle1">
-        <item name="android:layout_margin">@dimen/minor_00</item>
-    </style>
+    <style name="Woo.Settings.Option.Title" parent="@style/Woo.TextView.Subtitle1"/>
 
-    <style name="Woo.Settings.Option.Value" parent="@style/Woo.TextView.Body2">
-        <item name="android:layout_margin">@dimen/minor_00</item>
-    </style>
+    <style name="Woo.Settings.Option.Value" parent="@style/Woo.TextView.Body2"/>
 
     <style name="Woo.Settings.Button" parent="Woo.Button">
         <item name="android:textAlignment">textStart</item>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -305,29 +305,26 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:stepSize">1</item>
     </style>
 
-
     <!--
         Settings
     -->
-    <style name="Widget.Woo.Settings"/>
-    <style name="Widget.Woo.Settings.OptionValue">
+    <style name="Widget.Woo.Settings">
         <item name="android:paddingStart">@dimen/margin_app_title_aligned</item>
         <item name="android:paddingTop">@dimen/major_100</item>
         <item name="android:paddingBottom">@dimen/major_100</item>
         <item name="android:paddingEnd">@dimen/major_100</item>
     </style>
 
+    <style name="Widget.Woo.Settings.OptionValue"/>
+
     <style name="Widget.Woo.Settings.OptionToggle">
         <item name="android:paddingStart">@dimen/major_100</item>
-        <item name="android:paddingTop">@dimen/major_100</item>
-        <item name="android:paddingBottom">@dimen/major_100</item>
-        <item name="android:paddingEnd">@dimen/major_100</item>
     </style>
 
-    <style name="Woo.Settings.CategoryHeader" parent="Woo.TextView.Subtitle2">
+    <style name="Widget.Woo.Settings.CategoryHeader">
+        <item name="android:textAppearance">?attr/textAppearanceSubtitle1</item>
         <item name="android:textColor">?attr/colorPrimary</item>
-        <item name="android:layout_marginBottom">@dimen/minor_00</item>
-        <item name="android:layout_marginStart">@dimen/margin_app_title_aligned</item>
+        <item name="android:paddingBottom">@dimen/minor_00</item>
     </style>
 
     <style name="Woo.Settings.Option.Title" parent="@style/Woo.TextView.Subtitle1"/>

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -83,6 +83,7 @@
         <item name="flowLayoutStyle">@style/Woo.FlowLayout</item>
         <item name="settingsToggleOptionStyle">@style/Widget.Woo.Settings.OptionToggle</item>
         <item name="settingsOptionValueStyle">@style/Widget.Woo.Settings.OptionValue</item>
+        <item name="settingsCategoryHeaderStyle">@style/Widget.Woo.Settings.CategoryHeader</item>
 
         <!-- TODO: convert styles to material -->
         <item name="android:listViewStyle">@style/Woo.List</item>

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -81,7 +81,8 @@
         <!-- Custom Widgets -->
         <item name="tagViewStyle">@style/Woo.Tag</item>
         <item name="flowLayoutStyle">@style/Woo.FlowLayout</item>
-        <item name="settingsToggleOptionStyle">@style/Woo.Settings.Option.Toggle</item>
+        <item name="settingsToggleOptionStyle">@style/Widget.Woo.Settings.OptionToggle</item>
+        <item name="settingsOptionValueStyle">@style/Widget.Woo.Settings.OptionValue</item>
 
         <!-- TODO: convert styles to material -->
         <item name="android:listViewStyle">@style/Woo.List</item>

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -81,6 +81,7 @@
         <!-- Custom Widgets -->
         <item name="tagViewStyle">@style/Woo.Tag</item>
         <item name="flowLayoutStyle">@style/Woo.FlowLayout</item>
+        <item name="settingsToggleOptionStyle">@style/Woo.Settings.Option.Toggle</item>
 
         <!-- TODO: convert styles to material -->
         <item name="android:listViewStyle">@style/Woo.List</item>


### PR DESCRIPTION
Partially fixes #1584 by implementing light/dark designs on the Privacy settings page. Some special notes regarding the changes in this PR:

* I ended up making a custom settings toggle components called `WCSettingsToggleOptionView`.  I needed a custom view that supported the following:
  * Icon (*optional* - if not specified, hide component)
  * Title (*optional* - if not specified, hide component))
  * Description (*optional* - if not specified, hide component))
  * Switch view

  I thought about just modifying the somewhat similar `WCToggleSingleOptionView`, but in the end opted to create a new custom view for a few reasons:
  * `WCToggleSingleOptionView`  was created for use in other areas of the app - most notably, the “Add Order Note” view. The biggest reason was to implement Talkback in a way that made sense for that component.  
  * The options in the settings view follow different rules for margins. The option text should *always* align with the Toolbar title - whether an image is shown or not. For this reason, I set the visibility of the icon’s `ImageView` to `View.INVISIBLE` instead of `View.GONE`.
  * To avoid confusion with styling and usage between a toggle option in settings, and a toggle option elsewhere in the app.

* I went back and replaced the toggle-style settings options in the main settings page with this new component. These will need to be tested as well.
* Created a new `WCSettingsCategoryHeaderView` to simplify creation and maintenance of settings views. 
* I’ve added theme-level styles for `WCSettingsToggleOptionView` , `WCSettingsOptionValueView` , and `WCSettingsCategoryHeaderView` so now  `style=“…”`  no longer needs to be defined when adding these views to a layout. 

## Screenshots
### API 29
![privacy-api29](https://user-images.githubusercontent.com/5810477/72656660-27746200-395a-11ea-848c-c9444d568fac.png)

### API 21
![privacy-api21](https://user-images.githubusercontent.com/5810477/72656673-33f8ba80-395a-11ea-80bb-1ca72f8cdad5.png)

## Recommended Testing
* Test on a device running API 21 and verify the notification settings are properly being drawn, as well as changing the settings are handled and saved.
* Verify the toggle options in privacy settings are being handled properly, saved to SharedPrefs, and the saved value is being properly reflected in settings. 

cc: @kyleaparker  & @Garance91540  for design review
