### PR TITLE
Dark Mode: Beta Features Settings Page

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
@@ -4,32 +4,32 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:background="@color/color_surface">
 
-    <com.woocommerce.android.widgets.WCToggleSingleOptionView
+    <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
         android:id="@+id/switchStatsV4UI"
         style="@style/Woo.Settings.Label"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:switchSummary="@string/settings_enable_v4_stats_message"
-        app:switchTitle="@string/settings_enable_v4_stats_title"
-        android:background="@color/white"
+        app:toggleOptionDesc="@string/settings_enable_v4_stats_message"
+        app:toggleOptionTitle="@string/settings_enable_v4_stats_title"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         android:visibility="gone"
         tools:visibility="visible"/>
 
-    <com.woocommerce.android.widgets.WCToggleSingleOptionView
+    <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
         android:id="@+id/switchProductsUI"
         style="@style/Woo.Settings.Label"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:switchSummary="@string/settings_enable_product_teaser_message"
-        app:switchTitle="@string/settings_enable_product_teaser_title"
-        android:background="@color/white"
+        app:toggleOptionDesc="@string/settings_enable_product_teaser_message"
+        app:toggleOptionTitle="@string/settings_enable_product_teaser_title"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/switchStatsV4UI"/>
+        app:layout_constraintTop_toBottomOf="@+id/switchStatsV4UI"
+        app:layout_constraintBottom_toBottomOf="parent"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
The final step in closing #1584. This PR applies light/dark mode styling by swapping out widgets with the new custom settings widgets and tweaking styles. 

![beta-features](https://user-images.githubusercontent.com/5810477/72851178-2bf58f00-3c68-11ea-94dc-4cc8f3d97216.png)

## Recommended Testing
Since the changes in this component use custom widgets already previously tested, a simple review of the code and design should suffice. The changes in this PR are minimal.

cc: @Garance91540 and @kyleaparker design review