### PR TITLE
Dark Mode: Settings Fine Tuning

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/WCSettingsButton.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/WCSettingsButton.kt
@@ -1,0 +1,12 @@
+package com.woocommerce.android.ui.prefs
+
+import android.content.Context
+import android.util.AttributeSet
+import com.google.android.material.button.MaterialButton
+import com.woocommerce.android.R
+
+class WCSettingsButton @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = R.attr.settingsButtonStyle
+) : MaterialButton(ctx, attrs, defStyleAttr)

--- a/WooCommerce/src/main/res/layout/activity_help.xml
+++ b/WooCommerce/src/main/res/layout/activity_help.xml
@@ -28,7 +28,7 @@
                 android:orientation="vertical">
 
                 <TextView
-                    style="@style/Woo.Settings.Caption"
+                    style="@style/Woo.TextView.Caption"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="@string/support_subtitle"/>

--- a/WooCommerce/src/main/res/layout/activity_help.xml
+++ b/WooCommerce/src/main/res/layout/activity_help.xml
@@ -54,7 +54,7 @@
                 </LinearLayout>
 
                 <View
-                    style="@style/Woo.Settings.Divider"/>
+                    style="@style/Woo.Divider"/>
 
                 <LinearLayout
                     android:id="@+id/contactContainer"
@@ -118,7 +118,7 @@
                 </LinearLayout>
 
                 <View
-                    style="@style/Woo.Settings.Divider"/>
+                    style="@style/Woo.Divider"/>
 
                 <LinearLayout
                     android:id="@+id/appLogContainer"

--- a/WooCommerce/src/main/res/layout/dashboard_stats.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_stats.xml
@@ -23,7 +23,7 @@
         <!-- Date bar -->
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/dashboard_date_range_value"
-            style="@style/Woo.DateBar"
+            style="@style/Woo.TextView.Subtitle1"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             tools:text="June 30-Jul 06"/>

--- a/WooCommerce/src/main/res/layout/fragment_about.xml
+++ b/WooCommerce/src/main/res/layout/fragment_about.xml
@@ -41,34 +41,42 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/about_version"
-        style="@style/Woo.Settings.Caption"
+        style="@style/Woo.TextView.Caption"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_margin="@dimen/minor_00"
+        android:gravity="center_vertical"
         android:text="@string/about_version"
         android:layout_gravity="center"
         tools:text="Version 3.3-rc2" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/about_publisher"
-        style="@style/Woo.Settings.Caption"
+        style="@style/Woo.TextView.Caption"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_margin="@dimen/minor_00"
+        android:gravity="center_vertical"
         android:text="@string/about_publisher"
         android:layout_gravity="center"/>
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/about_copyright"
-        style="@style/Woo.Settings.Caption"
+        style="@style/Woo.TextView.Caption"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_margin="@dimen/minor_00"
+        android:gravity="center_vertical"
         android:layout_gravity="center"
         tools:text="\@Automattic, Inc"/>
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/about_url"
-        style="@style/Woo.Settings.Caption"
+        style="@style/Woo.TextView.Caption"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_margin="@dimen/minor_00"
+        android:gravity="center_vertical"
         android:clickable="true"
         android:focusable="true"
         android:text="@string/about_url_text"

--- a/WooCommerce/src/main/res/layout/fragment_product_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_detail.xml
@@ -90,7 +90,7 @@
                 </FrameLayout>
 
                 <View
-                    style="@style/Woo.Settings.Divider"
+                    style="@style/Woo.Divider"
                     android:layout_gravity="bottom" />
 
             </FrameLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_images.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_images.xml
@@ -19,7 +19,7 @@
 
     <View
         android:id="@+id/divider"
-        style="@style/Woo.Settings.Divider"
+        style="@style/Woo.Divider"
         android:layout_gravity="bottom"
         android:layout_marginTop="@dimen/margin_extra_large"
         android:layout_marginBottom="@dimen/margin_extra_large" />

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -148,9 +148,8 @@
 
     <View style="@style/Woo.Divider"/>
 
-    <com.google.android.material.button.MaterialButton
+    <com.woocommerce.android.ui.prefs.WCSettingsButton
         android:id="@+id/btn_option_logout"
-        style="@style/Woo.Settings.Button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/settings_signout"/>
@@ -175,9 +174,11 @@
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/settingsHiring"
-            style="@style/Woo.Settings.Caption"
+            style="@style/Woo.TextView.Caption"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_margin="@dimen/minor_00"
+            android:gravity="center_vertical"
             android:paddingStart="@dimen/major_200"
             android:paddingEnd="@dimen/major_100"
             android:text="@string/settings_hiring"

--- a/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
@@ -28,7 +28,7 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/privacy_share_info"
-        style="@style/Woo.Settings.Option.Value"
+        style="@style/Woo.TextView.Body2"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/minor_00"
@@ -61,7 +61,7 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/privacy_policy_info"
-        style="@style/Woo.Settings.Option.Value"
+        style="@style/Woo.TextView.Body2"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/minor_00"
@@ -95,7 +95,7 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/privacy_tracking_info"
-        style="@style/Woo.Settings.Option.Value"
+        style="@style/Woo.TextView.Body2"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/minor_00"
@@ -148,7 +148,7 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/textCrashReporting"
-        style="@style/Woo.Settings.Option.Value"
+        style="@style/Woo.TextView.Body2"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/minor_00"

--- a/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
@@ -21,8 +21,7 @@
 
     <View
         android:id="@+id/divider1"
-        style="@style/Woo.Divider"
-        android:layout_marginStart="@dimen/margin_app_title_aligned"
+        style="@style/Woo.Divider.TitleAligned"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/switchSendStats"/>
@@ -54,9 +53,8 @@
 
     <View
         android:id="@+id/divider2"
-        style="@style/Woo.Divider"
+        style="@style/Woo.Divider.TitleAligned"
         android:layout_marginTop="@dimen/minor_100"
-        android:layout_marginStart="@dimen/margin_app_title_aligned"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/buttonLearnMore"/>
@@ -89,9 +87,8 @@
 
     <View
         android:id="@+id/divider3"
-        style="@style/Woo.Divider"
+        style="@style/Woo.Divider.TitleAligned"
         android:layout_marginTop="@dimen/minor_100"
-        android:layout_marginStart="@dimen/margin_app_title_aligned"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/buttonPrivacyPolicy"/>
@@ -144,8 +141,7 @@
 
     <View
         android:id="@+id/divider5"
-        style="@style/Woo.Divider"
-        android:layout_marginStart="@dimen/margin_app_title_aligned"
+        style="@style/Woo.Divider.TitleAligned"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/switchCrashReporting"/>

--- a/WooCommerce/src/main/res/layout/my_store_date_bar.xml
+++ b/WooCommerce/src/main/res/layout/my_store_date_bar.xml
@@ -8,7 +8,7 @@
     <!-- Date bar -->
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/dashboard_date_range_value"
-        style="@style/Woo.DateBar"
+        style="@style/Woo.TextView.Subtitle1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         tools:text="June 30-Jul 06"/>

--- a/WooCommerce/src/main/res/layout/product_property_cardview.xml
+++ b/WooCommerce/src/main/res/layout/product_property_cardview.xml
@@ -17,7 +17,7 @@
             android:id="@+id/cardCaptionText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            style="@style/Woo.Settings.Caption"
+            style="@style/Woo.TextView.Caption"
             android:visibility="gone"
             tools:text="cardCaptionText"
             tools:visibility="visible"/>

--- a/WooCommerce/src/main/res/layout/product_property_editable_view.xml
+++ b/WooCommerce/src/main/res/layout/product_property_editable_view.xml
@@ -20,7 +20,7 @@
 
     <View
         android:id="@+id/divider"
-        style="@style/Woo.Settings.Divider"
+        style="@style/Woo.Divider"
         android:layout_marginTop="@dimen/product_detail_property_margin"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/WooCommerce/src/main/res/layout/product_property_link_view.xml
+++ b/WooCommerce/src/main/res/layout/product_property_link_view.xml
@@ -35,7 +35,7 @@
 
     <View
         android:id="@+id/divider"
-        style="@style/Woo.Settings.Divider"
+        style="@style/Woo.Divider"
         android:layout_marginTop="@dimen/product_detail_property_margin"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/WooCommerce/src/main/res/layout/product_property_read_more_view.xml
+++ b/WooCommerce/src/main/res/layout/product_property_read_more_view.xml
@@ -58,7 +58,7 @@
 
     <View
         android:id="@+id/divider"
-        style="@style/Woo.Settings.Divider"
+        style="@style/Woo.Divider"
         android:layout_marginTop="@dimen/product_detail_property_margin"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/WooCommerce/src/main/res/layout/product_property_view_horz.xml
+++ b/WooCommerce/src/main/res/layout/product_property_view_horz.xml
@@ -59,7 +59,7 @@
 
     <View
         android:id="@+id/divider"
-        style="@style/Woo.Settings.Divider"
+        style="@style/Woo.Divider"
         android:layout_marginTop="@dimen/product_detail_property_margin"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/WooCommerce/src/main/res/layout/product_property_view_vert.xml
+++ b/WooCommerce/src/main/res/layout/product_property_view_vert.xml
@@ -74,7 +74,7 @@
 
     <View
         android:id="@+id/divider"
-        style="@style/Woo.Settings.Divider"
+        style="@style/Woo.Divider"
         android:layout_marginTop="@dimen/product_detail_property_margin"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/WooCommerce/src/main/res/layout/view_settings_toggle_option.xml
+++ b/WooCommerce/src/main/res/layout/view_settings_toggle_option.xml
@@ -23,7 +23,7 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/toggleSetting_title"
-        style="@style/Woo.Settings.Option.Title"
+        style="@style/Woo.TextView.Subtitle1"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/minor_00"
@@ -38,7 +38,7 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/toggleSetting_desc"
-        style="@style/Woo.Settings.Option.Value"
+        style="@style/Woo.TextView.Body2"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/minor_00"

--- a/WooCommerce/src/main/res/layout/view_toggle_single_option.xml
+++ b/WooCommerce/src/main/res/layout/view_toggle_single_option.xml
@@ -8,7 +8,7 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/switchSetting_title"
-        style="@style/Woo.Settings.Option.Title"
+        style="@style/Woo.TextView.Subtitle1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:importantForAccessibility="no"

--- a/WooCommerce/src/main/res/values/attrs.xml
+++ b/WooCommerce/src/main/res/values/attrs.xml
@@ -23,6 +23,7 @@
         <attr name="settingsToggleOptionStyle" format="reference"/>
         <attr name="settingsOptionValueStyle" format="reference"/>
         <attr name="settingsCategoryHeaderStyle" format="reference"/>
+        <attr name="settingsButtonStyle" format="reference"/>
     </declare-styleable>
 
     <declare-styleable name="WCTextViewCompat">

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -493,7 +493,7 @@
     <string name="settings_send_stats">Collect information</string>
     <string name="settings_enable_v4_stats_title">Improved stats</string>
     <string name="settings_enable_product_teaser_title">Products</string>
-    <string name="settings_enable_v4_stats_message">Try the new stats available with the\nWooCommerce admin plugin</string>
+    <string name="settings_enable_v4_stats_message">Try the new stats available with the WooCommerce admin plugin</string>
     <string name="settings_enable_product_teaser_message">Test out the new products section as we get ready to launch</string>
     <string name="settings_send_stats_detail">Share information with our analytics tool about your use of services while logged in to your WordPress account</string>
     <string name="settings_privacy_detail">This information helps us improve our products, make marketing to you more relevant, personalize your WooCommerce experience, and more as detailed in our privacy policy</string>

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -3,14 +3,6 @@
 Use this file to override styles in the styles_base.xml file.
 -->
 <resources>
-    <!--
-        DateBar Style
-    -->
-    <style name="Woo.DateBar" parent="@style/Woo.TextView.Subtitle1">
-        <item name="android:gravity">start</item>
-    </style>
-
-
     <!---
         -
         -
@@ -21,7 +13,6 @@ Use this file to override styles in the styles_base.xml file.
         -
         -
     -->
-
 
     <!--
         Set a custom cursor for search views so they don't inherit colorAccent
@@ -192,45 +183,6 @@ Use this file to override styles in the styles_base.xml file.
         <item name="android:textColor">@color/list_item_text_title</item>
     </style>
 
-    <style name="Woo.TextAppearance.ListItem.Title.Bold">
-        <item name="android:textStyle">bold</item>
-    </style>
-    <!--
-        Default List Item Header Styles
-    -->
-
-    <style name="Woo.TextAppearance.ListHeader">
-        <item name="android:textStyle">bold</item>
-        <item name="android:textColor">@color/List_header_text</item>
-        <item name="android:textSize">@dimen/list_header_text_size</item>
-    </style>
-    <!--
-        Order: List Style
-    -->
-    <style name="Woo.OrderList.TextAppearance.Header" parent="Woo.TextAppearance.ListHeader"/>
-    <style name="Woo.OrderList.TextAppearance.ListItem" parent="Woo.TextAppearance.ListItem"/>
-    <style name="Woo.OrderList.TextAppearance.ListItem.Date" parent="Woo.TextAppearance.ListItem">
-        <item name="tabTextColor">@color/wc_grey</item>
-        <item name="android:textSize">@dimen/text_small</item>
-    </style>
-    <style name="Woo.OrderList.TextAppearance.ListItem.Title" parent="Woo.TextAppearance.ListItem.Title"/>
-    <style name="Woo.OrderList.TextAppearance.ListItem.Title.Bold">
-        <item name="android:textStyle">bold</item>
-    </style>
-    <style name="Woo.OrderList.TabLayout" parent="Woo.TabLayout">
-        <item name="android:background">@color/colorPrimary</item>
-        <item name="android:elevation">@dimen/tablayout_elevation</item>
-        <item name="tabGravity">fill</item>
-        <item name="tabMaxWidth">0dp</item>
-        <item name="tabMode">fixed</item>
-        <item name="tabPaddingStart">25dp</item>
-        <item name="tabPaddingEnd">25dp</item>
-        <item name="tabIndicatorHeight">2.5dp</item>
-        <item name="tabTextColor">@color/white_translucent_65</item>
-        <item name="tabSelectedTextColor">@color/white</item>
-        <item name="tabIndicatorColor">@color/white</item>
-    </style>
-
     <!--
         OrderDetail Styles
     -->
@@ -262,8 +214,6 @@ Use this file to override styles in the styles_base.xml file.
     </style>
 
     <style name="Woo.Refunds.TextAppearance.SectionTitle" parent="Woo.TextAppearance.Title"/>
-
-    <style name="Woo.Refunds.TabLayout" parent="Woo.OrderList.TabLayout" />
 
     <style name="Woo.Refunds.Button" parent="Woo.Button">
         <item name="android:textAlignment">viewEnd</item>
@@ -299,20 +249,6 @@ Use this file to override styles in the styles_base.xml file.
         <item name="android:background">?attr/selectableItemBackground</item>
     </style>
 
-    <style name="Woo.Settings.Icon">
-        <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:padding">@dimen/settings_padding</item>
-        <item name="android:tint">@color/wc_grey_dark</item>
-    </style>
-
-
-    <style name="Woo.Settings.Divider">
-        <item name="android:background">@color/wc_border_color</item>
-        <item name="android:layout_width">match_parent</item>
-        <item name="android:layout_height">1dp</item>
-    </style>
-
     <!--
         Offline Status Bar
     -->
@@ -326,38 +262,6 @@ Use this file to override styles in the styles_base.xml file.
         <item name="android:textSize">@dimen/text_caption</item>
         <item name="android:gravity">center_vertical</item>
         <item name="android:layout_gravity">center</item>
-    </style>
-
-    <!--
-        About screen
-    -->
-    <style name="Woo.About"/>
-    <style name="Woo.About.Title">
-        <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:gravity">center_horizontal</item>
-        <item name="android:textColor">@color/white</item>
-        <item name="android:textSize">28sp</item>
-        <item name="android:lineSpacingExtra">-4sp</item>
-        <item name="android:fontFamily">sans-serif-light</item>
-    </style>
-    <style name="Woo.About.Label">
-        <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:textSize">@dimen/text_medium</item>
-        <item name="android:gravity">center_horizontal</item>
-        <item name="android:textColor">@color/white</item>
-    </style>
-    <style name="Woo.About.Button" parent="android:TextAppearance.DeviceDefault">
-        <item name="android:textColor">@color/color_primary_surface</item>
-        <item name="android:textSize">@dimen/text_medium</item>
-        <item name="android:layout_width">match_parent</item>
-        <item name="android:layout_height">@dimen/min_tap_target</item>
-        <item name="android:gravity">center</item>
-        <item name="android:layout_marginStart">4dp</item>
-        <item name="android:layout_marginEnd">4dp</item>
-        <item name="android:background">@drawable/about_button_selector</item>
-
     </style>
 
     <!--
@@ -507,42 +411,6 @@ Use this file to override styles in the styles_base.xml file.
         <item name="codeTextColor">@color/wc_black_darker</item>
         <item name="codeBackgroundColor">@android:color/transparent</item>
         <item name="android:inputType">textNoSuggestions|textMultiLine</item>
-    </style>
-
-    <!--
-         Stats
-        -->
-    <style name="Woo.Stats.Card" parent="Woo.Card">
-        <item name="android:layout_marginBottom">@dimen/card_item_padding_intra_h</item>
-    </style>
-
-    <style name="Woo.Stats.Notice.Card" parent="Woo.Card">
-        <item name="android:paddingEnd">@dimen/margin_small</item>
-        <item name="android:paddingBottom">@dimen/default_padding</item>
-        <item name="android:layout_marginBottom">@dimen/margin_medium</item>
-    </style>
-
-    <style name="Woo.Stats.Card.Expandable" parent="Woo.Card.Expandable">
-        <item name="android:paddingTop">0dp</item>
-        <item name="android:layout_marginBottom">@dimen/margin_medium</item>
-    </style>
-
-    <style name="Woo.Stats.Availability.CardExtenderButton" parent="Woo.CardExtenderButton">
-        <item name="android:background">@drawable/button_white_bg</item>
-        <item name="android:textColor">@color/wc_grey_dark</item>
-        <item name="android:drawableStart">@drawable/ic_gridicons_gift</item>
-        <item name="android:drawableEnd">@drawable/card_expander_selector</item>
-        <item name="android:paddingStart">@dimen/card_padding_start</item>
-        <item name="android:paddingTop">@dimen/card_padding_top</item>
-        <item name="android:paddingBottom">@dimen/card_padding_bottom</item>
-        <item name="android:drawablePadding">@dimen/card_padding_start</item>
-        <item name="android:textAllCaps">false</item>
-    </style>
-
-    <style name="Woo.Products.WIP.CardExtenderButton" parent="Woo.Stats.Availability.CardExtenderButton">
-        <item name="android:drawableStart">@drawable/ic_gridicons_tools</item>
-        <item name="android:textSize">@dimen/text_large</item>
-        <item name="android:textColor">@color/black_85</item>
     </style>
 
     <style name="Woo.Product"/>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -345,8 +345,4 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:layout_margin">@dimen/minor_00</item>
         <item name="android:gravity">center_vertical</item>
     </style>
-
-    <style name="Woo.Settings.About.Title" parent="@style/Woo.TextView.Headline5">
-        <item name="android:textColor">@color/color_on_primary_surface_high</item>
-    </style>
 </resources>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -331,18 +331,9 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:paddingBottom">@dimen/minor_00</item>
     </style>
 
-    <style name="Woo.Settings.Option.Title" parent="@style/Woo.TextView.Subtitle1"/>
-
-    <style name="Woo.Settings.Option.Value" parent="@style/Woo.TextView.Body2"/>
-
-    <style name="Woo.Settings.Button" parent="Woo.Button">
+    <style name="Widget.Woo.Settings.Button" parent="Woo.Button">
         <item name="android:textAlignment">textStart</item>
         <item name="android:paddingStart">@dimen/margin_app_title_aligned</item>
         <item name="android:paddingEnd">@dimen/major_100</item>
-    </style>
-
-    <style name="Woo.Settings.Caption" parent="@style/Woo.TextView.Caption">
-        <item name="android:layout_margin">@dimen/minor_00</item>
-        <item name="android:gravity">center_vertical</item>
     </style>
 </resources>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -238,6 +238,10 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:background">?android:attr/listDivider</item>
     </style>
 
+    <style name="Woo.Divider.TitleAligned">
+        <item name="android:layout_marginStart">@dimen/margin_app_title_aligned</item>
+    </style>
+
     <!--
         List Styles
     -->

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -86,7 +86,7 @@
         <item name="settingsCategoryHeaderStyle">@style/Widget.Woo.Settings.CategoryHeader</item>
 
         <!-- TODO: convert styles to material -->
-        <item name="android:listViewStyle">@style/Woo.List</item>
+<!--        <item name="android:listViewStyle"></item>-->
         <item name="autoCompleteTextViewStyle">@style/SearchViewCursor</item>
     </style>
 </resources>

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -84,6 +84,7 @@
         <item name="settingsToggleOptionStyle">@style/Widget.Woo.Settings.OptionToggle</item>
         <item name="settingsOptionValueStyle">@style/Widget.Woo.Settings.OptionValue</item>
         <item name="settingsCategoryHeaderStyle">@style/Widget.Woo.Settings.CategoryHeader</item>
+        <item name="settingsButtonStyle">@style/Widget.Woo.Settings.Button</item>
 
         <!-- TODO: convert styles to material -->
 <!--        <item name="android:listViewStyle"></item>-->


### PR DESCRIPTION
This PR covers the miscellaneous fine tuning for the settings views in the app and includes:
- A custom `WCSettingsButton` with style attributes and default style applied for light/dark mode automatically.
- Removal of unused styles
- Addition of a "title aligned" Divider style for dividers that should be aligned with the Appbar title
- Cleanup of base styles (see notes below)

After getting a better handle on styling, it's become clear that having custom styles for different areas of the app (ex: Orders, Settings, etc) quickly create a spaghetti mess that is too difficult to follow. All views should use the base styles. The only time there should be a custom non-base style is when required for a custom widget. This will keep the styles simple to follow and easy tweak if needed in the future. With this in mind I've removed the `Woo.Settings.*` styles and updated the views that were using them to use the base styles instead. 