### PR TITLE
issue/reset-database

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
@@ -40,4 +40,23 @@ class WooWellSqlConfig(context: Context) : WellSqlConfig(context, ADDON_WOOCOMME
             super.onDowngrade(db, helper, oldVersion, newVersion)
         }
     }
+
+    /**
+     * Useful during development when we want to test features with a "fresh" database. This can be
+     * called from WooCommerce.onCreate() after we initialize the database. For safety, this has no
+     * effect when called from a release build.
+     */
+    fun resetDatabase() {
+        if (BuildConfig.DEBUG) {
+            val toast = Toast.makeText(
+                    context,
+                    "Resetting database",
+                    Toast.LENGTH_LONG
+            )
+            toast.setGravity(Gravity.CENTER_HORIZONTAL or Gravity.BOTTOM, 0, 0)
+            toast.show()
+            AppPrefs.setDatabaseDowngraded(true)
+            reset()
+        }
+    }
 }


### PR DESCRIPTION
Adds the ability to reset the database at startup to help test the app with an empty database. Prior to this, we would have to clear storage or uninstall to reset the database, which can be time consuming.

To test, add `wellSqlConfig.resetDatabase()` after [this line](https://github.com/woocommerce/woocommerce-android/blob/develop/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt#L117) in `WooCommerce.kt` where we initialize the database.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
