### PR TITLE
Issue/1839 review notification event

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,8 @@
  
 3.4
 -----
- 
+* Fixed a problem when the order list did not sync with the server
+
 3.3
 -----
 * In rare situations, the labels on the bottom navigation bar could be cut off

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -717,7 +717,7 @@ class MainActivity : AppUpgradeActivity(),
                         }
                     }
                 }
-                PRODUCT_REVIEW -> showReviewDetail(note.getCommentId())
+                PRODUCT_REVIEW -> showReviewDetail(note.getCommentId(), true)
                 else -> { /* do nothing */ }
             }
         }
@@ -729,7 +729,7 @@ class MainActivity : AppUpgradeActivity(),
         navController.navigate(action)
     }
 
-    override fun showReviewDetail(remoteReviewId: Long, tempStatus: String?) {
+    override fun showReviewDetail(remoteReviewId: Long, launchedFromNotification: Boolean, tempStatus: String?) {
         showBottomNav()
         bottomNavView.currentPosition = REVIEWS
 
@@ -738,7 +738,8 @@ class MainActivity : AppUpgradeActivity(),
 
         val action = ReviewDetailFragmentDirections.actionGlobalReviewDetailFragment(
                 remoteReviewId,
-                tempStatus)
+                tempStatus,
+                launchedFromNotification)
         navController.navigate(action)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
@@ -6,5 +6,5 @@ interface MainNavigationRouter {
 
     fun showOrderDetail(localSiteId: Int, remoteOrderId: Long, remoteNoteId: Long = 0, markComplete: Boolean = false)
     fun showProductDetail(remoteProductId: Long)
-    fun showReviewDetail(remoteReviewId: Long, tempStatus: String? = null)
+    fun showReviewDetail(remoteReviewId: Long, launchedFromNotification: Boolean, tempStatus: String? = null)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
@@ -104,7 +104,7 @@ class ReviewDetailFragment : BaseFragment() {
 
     private fun initializeViewModel() {
         setupObservers(viewModel)
-        viewModel.start(navArgs.remoteReviewId)
+        viewModel.start(navArgs.remoteReviewId, navArgs.launchedFromNotification)
     }
 
     private fun setupObservers(viewModel: ReviewDetailViewModel) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModel.kt
@@ -36,9 +36,10 @@ class ReviewDetailViewModel @AssistedInject constructor(
 
     final val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
+    private val navArgs: ReviewDetailFragmentArgs by savedState.navArgs()
 
-    fun start(remoteReviewId: Long) {
-        loadProductReview(remoteReviewId)
+    init {
+        loadProductReview(navArgs.remoteReviewId)
     }
 
     override fun onCleared() {
@@ -123,10 +124,16 @@ class ReviewDetailViewModel @AssistedInject constructor(
             // send request to mark notification as read to the server
             repository.markNotificationAsRead(it)
 
-            // Send the track event that a product review notification was opened
-            AnalyticsTracker.track(Stat.NOTIFICATION_OPEN, mapOf(
-                    AnalyticsTracker.KEY_TYPE to AnalyticsTracker.VALUE_REVIEW,
-                    AnalyticsTracker.KEY_ALREADY_READ to it.read))
+            if (navArgs.launchedFromNotification) {
+                // Send the track event that a product review notification was opened
+                AnalyticsTracker.track(
+                        Stat.NOTIFICATION_OPEN,
+                        mapOf(
+                            AnalyticsTracker.KEY_TYPE to AnalyticsTracker.VALUE_REVIEW,
+                            AnalyticsTracker.KEY_ALREADY_READ to it.read
+                        )
+                    )
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModel.kt
@@ -36,10 +36,9 @@ class ReviewDetailViewModel @AssistedInject constructor(
 
     final val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
-    private val navArgs: ReviewDetailFragmentArgs by savedState.navArgs()
 
-    init {
-        loadProductReview(navArgs.remoteReviewId)
+    fun start(remoteReviewId: Long, launchedFromNotification: Boolean) {
+        loadProductReview(remoteReviewId, launchedFromNotification)
     }
 
     override fun onCleared() {
@@ -66,10 +65,10 @@ class ReviewDetailViewModel @AssistedInject constructor(
         }
     }
 
-    private fun loadProductReview(remoteReviewId: Long) {
+    private fun loadProductReview(remoteReviewId: Long, launchedFromNotification: Boolean) {
         // Mark the notification as read
         launch {
-            markAsRead(remoteReviewId)
+            markAsRead(remoteReviewId, launchedFromNotification)
         }
 
         val shouldFetch = remoteReviewId != this.remoteReviewId
@@ -116,7 +115,7 @@ class ReviewDetailViewModel @AssistedInject constructor(
         }
     }
 
-    private suspend fun markAsRead(remoteReviewId: Long) {
+    private suspend fun markAsRead(remoteReviewId: Long, launchedFromNotification: Boolean) {
         repository.getCachedNotificationForReview(remoteReviewId)?.let {
             // remove notification from the notification panel if it exists
             triggerEvent(MarkNotificationAsRead(it.remoteNoteId))
@@ -124,7 +123,7 @@ class ReviewDetailViewModel @AssistedInject constructor(
             // send request to mark notification as read to the server
             repository.markNotificationAsRead(it)
 
-            if (navArgs.launchedFromNotification) {
+            if (launchedFromNotification) {
                 // Send the track event that a product review notification was opened
                 AnalyticsTracker.track(
                         Stat.NOTIFICATION_OPEN,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -296,7 +296,11 @@ class ReviewListFragment : TopLevelFragment(), ItemDecorationListener, ReviewLis
 
     private fun openReviewDetail(review: ProductReview) {
         showOptionsMenu(false)
-        (activity as? MainNavigationRouter)?.showReviewDetail(review.remoteId, tempStatus = pendingModerationNewStatus)
+        (activity as? MainNavigationRouter)?.showReviewDetail(
+                review.remoteId,
+                launchedFromNotification = false,
+                tempStatus = pendingModerationNewStatus
+        )
     }
 
     /**

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -172,6 +172,9 @@
             android:defaultValue="null"
             app:argType="string"
             app:nullable="true" />
+        <argument
+            android:name="launchedFromNotification"
+            app:argType="boolean" />
     </fragment>
     <action
         android:id="@+id/action_global_reviewDetailFragment"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModelTest.kt
@@ -78,7 +78,7 @@ class ReviewDetailViewModelTest : BaseUnitTest() {
         var markAsRead: Long? = null
         viewModel.event.observeForever { if (it is MarkNotificationAsRead) markAsRead = it.remoteNoteId }
 
-        viewModel.start(REVIEW_ID)
+        viewModel.start(REVIEW_ID, false)
 
         Assertions.assertThat(skeletonShown).containsExactly(true, false)
         Assertions.assertThat(markAsRead).isEqualTo(NOTIF_ID)
@@ -109,7 +109,7 @@ class ReviewDetailViewModelTest : BaseUnitTest() {
             }
         }
 
-        viewModel.start(REVIEW_ID)
+        viewModel.start(REVIEW_ID, false)
 
         Assertions.assertThat(skeletonShown).containsExactly(true, false)
         assertEquals(NOTIF_ID, markAsRead)
@@ -130,7 +130,7 @@ class ReviewDetailViewModelTest : BaseUnitTest() {
 
         // first we must load the product review so the viewmodel will have
         // a reference to it.
-        viewModel.start(REVIEW_ID)
+        viewModel.start(REVIEW_ID, false)
 
         var exitCalled = false
         viewModel.event.observeForever {
@@ -156,7 +156,7 @@ class ReviewDetailViewModelTest : BaseUnitTest() {
 
         // first we must load the product review so the viewmodel will have
         // a reference to it.
-        viewModel.start(REVIEW_ID)
+        viewModel.start(REVIEW_ID, false)
 
         var snackbar: ShowSnackbar? = null
         var exitCalled = false

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.5.9'
+    fluxCVersion = '1.6.1'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Fixes #1839, #1840, #1841.

To test (#1839):
1. Create a product review
2. Tap on the review notification and open the review detail in the app
3. In Tracks, verify that `notification_open` event **was** fired
4. Go back to the review list
5. Open the review detail again
6. Verify the `notification_open` event **was not** fired

To test (#1840):
1. Go to the order list
2. Verify the orders load normally
3. Verify the search works

To test (#1841):
1. Go to the order list
2. Open an order detail
3. Verify there is no `NumberFormatException` being logged in the logcat

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
