### PR TITLE
Issue/1848 options menu base fragments

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -181,8 +181,13 @@ class MainActivity : AppUpgradeActivity(),
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
-        menuInflater.inflate(R.menu.menu_action_bar, menu)
-        return true
+        // don't show the options menu unless we're at the root
+        if (isAtNavigationRoot()) {
+            menuInflater.inflate(R.menu.menu_action_bar, menu)
+            return true
+        } else {
+            return false
+        }
     }
 
     override fun onResume() {

--- a/WooCommerce/src/main/res/menu/menu_product_detail_fragment.xml
+++ b/WooCommerce/src/main/res/menu/menu_product_detail_fragment.xml
@@ -12,5 +12,5 @@
         android:id="@+id/menu_share"
         android:icon="@drawable/ic_share_white_24dp"
         android:title="@string/share"
-        app:showAsAction="ifRoom"/>
+        app:showAsAction="withText"/>
 </menu>

--- a/WooCommerce/src/main/res/menu/menu_product_detail_fragment.xml
+++ b/WooCommerce/src/main/res/menu/menu_product_detail_fragment.xml
@@ -12,5 +12,5 @@
         android:id="@+id/menu_share"
         android:icon="@drawable/ic_share_white_24dp"
         android:title="@string/share"
-        app:showAsAction="withText"/>
+        app:showAsAction="ifRoom"/>
 </menu>


### PR DESCRIPTION
Closes #1848 by not inflating the main options menu when a child fragment (ie: a fragment other than the four base fragments) is showing.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
