### PR TITLE
issue/1864-empty-reviews-list

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 3.6
 -----
+* Fixed a bug that could cause the reviews list to be empty when returning to it after rotating the device
  
 3.5
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -194,6 +194,8 @@ class ReviewListFragment : TopLevelFragment(), ItemDecorationListener, ReviewLis
         // s it can be processed immediately, otherwise silently refresh
         if (hidden) {
             changeReviewStatusSnackbar?.dismiss()
+        } else {
+            checkForNewDataAvailable()
         }
     }
 
@@ -413,13 +415,16 @@ class ReviewListFragment : TopLevelFragment(), ItemDecorationListener, ReviewLis
     }
 
     override fun onReturnedFromChildFragment() {
-        if (newDataAvailable) {
+        checkForNewDataAvailable()
+        showOptionsMenu(true)
+    }
+
+    private fun checkForNewDataAvailable() {
+        if (newDataAvailable && isActive) {
             viewModel.reloadReviewsFromCache()
             viewModel.checkForUnreadReviews()
             newDataAvailable = false
         }
-
-        showOptionsMenu(true)
     }
 
     override fun getItemTypeAtPosition(position: Int) = reviewsAdapter.getItemTypeAtRecyclerPosition(position)


### PR DESCRIPTION
Closes #1864 - to test, perform the following and verify that the reviews list populates:

* Switch to the reviews tab and wait for it to load
* Switch to the store tab
* Rotate the device
* Switch to the reviews tab again

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
