### PR TITLE
Fix order detail payment paddings

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
  
 3.5
 -----
+* Refunds are back! Select individual order items and the refund amount will be automatically calculated for you
  
 3.4
 -----
@@ -13,7 +14,6 @@
 * In rare situations, the labels on the bottom navigation bar could be cut off
 * Fixed a rare crash when updating a product variant in wp-admin and refreshing the same in the app.
 * Fixed bug that could cause stats chart to prevent scrolling vertically
-* Refunds are back! Select individual order items and the refund amount will be automatically calculated for you.
 * Fixed bug that caused reviews to show an incorrect timestamp
 * Fixed rare crash when backing out of an order immediately after changing order status
 * Fixed the sorting in product variations to match the sorting displayed on the web.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPaymentView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPaymentView.kt
@@ -49,11 +49,9 @@ class OrderDetailPaymentView @JvmOverloads constructor(ctx: Context, attrs: Attr
 
         if (order.paymentMethodTitle.isEmpty()) {
             paymentInfo_paymentMsg.hide()
-            paymentInfo_total_paid_divider.hide()
             paymentInfo_paidSection.hide()
         } else {
             paymentInfo_paymentMsg.show()
-            paymentInfo_total_paid_divider.show()
 
             if (order.status == CoreOrderStatus.PENDING ||
                     order.status == CoreOrderStatus.ON_HOLD ||

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPaymentView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPaymentView.kt
@@ -119,7 +119,8 @@ class OrderDetailPaymentView @JvmOverloads constructor(ctx: Context, attrs: Attr
             availableRefundQuantity -= refundedCount
         }
 
-        if (availableRefundQuantity > 0) {
+        // TODO: Once the refund by amount is supported again, this condition will need to be updated
+        if (availableRefundQuantity > 0 && order.refundTotal < order.total) {
             paymentInfo_issueRefundButtonSection.show()
         } else {
             paymentInfo_issueRefundButtonSection.hide()

--- a/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
@@ -134,6 +134,7 @@
                 android:layout_height="wrap_content"
                 android:textAppearance="@style/Woo.OrderDetail.TextAppearance"
                 tools:text="$1.00"/>
+
         </LinearLayout>
 
         <!-- Total -->
@@ -142,6 +143,7 @@
             android:layout_height="wrap_content"
             android:focusable="true"
             android:layout_marginTop="@dimen/card_item_padding_intra_double"
+            android:layout_marginBottom="@dimen/card_item_padding_intra_double"
             android:orientation="horizontal">
 
             <TextView
@@ -161,53 +163,60 @@
                 tools:text="$49.00"/>
         </LinearLayout>
 
-        <!-- Divider -->
-        <View
-            android:id="@+id/paymentInfo_total-paid_divider"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginTop="@dimen/card_item_padding_intra_double"
-            android:background="@color/list_divider"
-            app:srcCompat="@drawable/list_divider"/>
 
-        <!-- Paid by customer -->
-        <LinearLayout
-            android:id="@+id/paymentInfo_paidSection"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/card_item_padding_intra_double"
-            android:focusable="true"
-            android:orientation="horizontal">
+    <LinearLayout
+        android:id="@+id/paymentInfo_paidSection"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+            <!-- Divider -->
+            <View
+                android:id="@+id/paymentInfo_total-paid_divider"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="@color/list_divider"
+                app:srcCompat="@drawable/list_divider"/>
+
+            <!-- Paid by customer -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/card_item_padding_intra_double"
+                android:focusable="true"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/paymentInfo_lblPaid"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/orderdetail_payment_paid_by_customer"
+                    android:textAlignment="viewStart"
+                    android:textAppearance="@style/Woo.OrderDetail.TextAppearance.Bold" />
+
+                <TextView
+                    android:id="@+id/paymentInfo_paid"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textAppearance="@style/Woo.OrderDetail.TextAppearance.Bold"
+                    tools:text="$45.00"/>
+
+            </LinearLayout>
 
             <TextView
-                android:id="@+id/paymentInfo_lblPaid"
-                android:layout_width="0dp"
+                android:id="@+id/paymentInfo_paymentMsg"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="@string/orderdetail_payment_paid_by_customer"
+                android:layout_marginTop="@dimen/card_item_padding_intra_h"
                 android:textAlignment="viewStart"
-                android:textAppearance="@style/Woo.OrderDetail.TextAppearance.Bold" />
-
-            <TextView
-                android:id="@+id/paymentInfo_paid"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textAppearance="@style/Woo.OrderDetail.TextAppearance.Bold"
-                tools:text="$45.00"/>
+                android:textSize="@dimen/text_caption"
+                android:textAppearance="@style/Woo.OrderDetail.TextAppearance"
+                android:layout_marginBottom="@dimen/card_item_padding_intra_double"
+                android:textColor="@color/wc_grey_medium"
+                tools:text="Payment of $49.00 received via credit card (PayPal)"/>
 
         </LinearLayout>
-
-        <TextView
-            android:id="@+id/paymentInfo_paymentMsg"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/card_item_padding_intra_h"
-            android:textAlignment="viewStart"
-            android:textSize="@dimen/text_caption"
-            android:textAppearance="@style/Woo.OrderDetail.TextAppearance"
-            android:layout_marginBottom="@dimen/card_item_padding_intra_double"
-            android:textColor="@color/wc_grey_medium"
-            tools:text="Payment of $49.00 received via credit card (PayPal)"/>
 
         <!-- Refund and New Total Section -->
         <LinearLayout


### PR DESCRIPTION
This PR adds the missing padding between order total and a divider. I also added an extra condition to hide the refund button if the order status is manually changed to `Refunded`. This action refunds all of the remaining amount and so it doesn't make sense to allow refunds.

![image](https://user-images.githubusercontent.com/1522856/73435009-1b1fda00-4348-11ea-8fca-7db32f90cc99.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
