### PR TITLE
Dark Mode: Fix AppBar TabLayout issues

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams
 import androidx.core.content.ContextCompat
+import androidx.core.view.children
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayout
@@ -161,7 +162,9 @@ class MyStoreFragment : TopLevelFragment(),
 
     override fun onStart() {
         super.onStart()
-        addTabLayoutToAppBar(tabLayout)
+        if (!isHidden) {
+            addTabLayoutToAppBar(tabLayout)
+        }
     }
 
     override fun onResume() {
@@ -362,10 +365,14 @@ class MyStoreFragment : TopLevelFragment(),
     }
 
     private fun addTabLayoutToAppBar(tabLayout: TabLayout) {
-        (activity?.findViewById<View>(R.id.app_bar_layout) as? AppBarLayout)?.addView(
-                tabLayout,
-                LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
-        )
+        (activity?.findViewById<View>(R.id.app_bar_layout) as? AppBarLayout)?.let {appBar ->
+            if (!appBar.children.contains(tabLayout)) {
+                appBar.addView(
+                        tabLayout,
+                        LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
+                )
+            }
+        }
     }
 
     private fun removeTabLayoutFromAppBar(tabLayout: TabLayout) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -365,7 +365,7 @@ class MyStoreFragment : TopLevelFragment(),
     }
 
     private fun addTabLayoutToAppBar(tabLayout: TabLayout) {
-        (activity?.findViewById<View>(R.id.app_bar_layout) as? AppBarLayout)?.let {appBar ->
+        (activity?.findViewById<View>(R.id.app_bar_layout) as? AppBarLayout)?.let { appBar ->
             if (!appBar.children.contains(tabLayout)) {
                 appBar.addView(
                         tabLayout,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -162,9 +162,7 @@ class MyStoreFragment : TopLevelFragment(),
 
     override fun onStart() {
         super.onStart()
-        if (!isHidden) {
-            addTabLayoutToAppBar(tabLayout)
-        }
+        addTabLayoutToAppBar(tabLayout)
     }
 
     override fun onResume() {
@@ -366,7 +364,7 @@ class MyStoreFragment : TopLevelFragment(),
 
     private fun addTabLayoutToAppBar(tabLayout: TabLayout) {
         (activity?.findViewById<View>(R.id.app_bar_layout) as? AppBarLayout)?.let { appBar ->
-            if (!appBar.children.contains(tabLayout)) {
+            if (!isHidden && !appBar.children.contains(tabLayout)) {
                 appBar.addView(
                         tabLayout,
                         LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -770,7 +770,7 @@ class OrderListFragment : TopLevelFragment(),
 
     private fun addTabLayoutToAppBar(tabLayout: TabLayout) {
         (activity?.findViewById<View>(R.id.app_bar_layout) as? AppBarLayout)?.let { appBar ->
-            if (!appBar.children.contains(tabLayout)) {
+            if (!isHidden && !appBar.children.contains(tabLayout)) {
                 appBar.addView(tabLayout)
             }
         }


### PR DESCRIPTION
Fixes #1802. This PR fixes the following issues with the `TabLayout` in the `AppBar`:
* Issue with the MyStore and Orders tab layouts appearing in the appbar if a configuration change happens while on the order tab (see image below). 
- An `IllegalStateException: The specified child already has a parent`  crash that would happen if you minimized the app while on the orders tab, brought it back to the foreground, and then switched to the My Store tab.

The original ticket also reported the tabs disappearing after changing stores, but that issue was fixed in an unrelated PR.

**Steps to reproduce double tab row bug:**
1. Open the app, make sure the v4 stats are enabled
2. Select the Orders tab
3. Send the app to the background
4. Bring the app back into the foreground
5. Notice how there are now 2 tabs in the appbar, the order tabs and the stats tabs.

![Screenshot_1580435775](https://user-images.githubusercontent.com/5810477/73507029-8c41aa80-43a5-11ea-9948-094f1aca5bea.png)

**Steps to reproduce the crash:**
1. Follow the steps above to get the double rows of tabs.
2. Click on the “My Store” tab - crash. 