### PR TITLE
issue/1877-zendesk-4.0

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,8 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <AndroidXmlCodeStyleSettings>
-      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="STATIC_FIELD_NAME_PREFIX" value="s" />

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -225,7 +225,7 @@ dependencies {
     androidTestImplementation "androidx.annotation:annotation:1.1.0"
     androidTestImplementation "com.google.code.findbugs:jsr305:2.0.1"
 
-    implementation(group: 'com.zendesk', name: 'support', version: '3.0.3') {
+    implementation(group: 'com.zendesk', name: 'support', version: '4.0.0') {
         exclude group: 'com.google.dagger'
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -26,7 +26,7 @@ import org.wordpress.android.util.DeviceUtils
 import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.StringUtils
 import org.wordpress.android.util.UrlUtils
-import zendesk.commonui.UiConfig
+import zendesk.configurations.Configuration
 import zendesk.core.AnonymousIdentity
 import zendesk.core.Identity
 import zendesk.core.PushRegistrationProvider
@@ -353,7 +353,7 @@ private fun buildZendeskConfig(
     origin: Origin?,
     selectedSite: SiteModel? = null,
     extraTags: List<String>? = null
-): UiConfig {
+): Configuration {
     val customFields = buildZendeskCustomFields(context, allSites, selectedSite)
     return RequestActivity.builder()
             .withTicketForm(TicketFieldIds.form, customFields)


### PR DESCRIPTION
Closes #1877 by updating Zendesk to v4.0.0. I decided to target the `feature/dark-mode` branch rather than `develop` since the main reason for the upgrade is dark mode support, but we can change this to be merged into `develop` if that seems like a better idea.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
