### PR TITLE
Issue/1879 1877 update libraries

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,8 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <AndroidXmlCodeStyleSettings>
-      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="STATIC_FIELD_NAME_PREFIX" value="s" />

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -231,9 +231,9 @@ dependencies {
 
     // ViewModel and LiveData
     implementation "androidx.lifecycle:lifecycle-extensions:$archComponentsVersion"
-    implementation "androidx.fragment:fragment-ktx:1.2.0-rc03"
-    implementation "androidx.activity:activity-ktx:1.1.0-rc03"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:1.0.0-rc03"
+    implementation "androidx.fragment:fragment-ktx:1.2.0"
+    implementation "androidx.activity:activity-ktx:1.1.0"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:1.0.0"
 
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -225,7 +225,7 @@ dependencies {
     androidTestImplementation "androidx.annotation:annotation:1.1.0"
     androidTestImplementation "com.google.code.findbugs:jsr305:2.0.1"
 
-    implementation(group: 'com.zendesk', name: 'support', version: '3.0.3') {
+    implementation(group: 'com.zendesk', name: 'support', version: '4.0.0') {
         exclude group: 'com.google.dagger'
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -26,7 +26,7 @@ import org.wordpress.android.util.DeviceUtils
 import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.StringUtils
 import org.wordpress.android.util.UrlUtils
-import zendesk.commonui.UiConfig
+import zendesk.configurations.Configuration
 import zendesk.core.AnonymousIdentity
 import zendesk.core.Identity
 import zendesk.core.PushRegistrationProvider
@@ -345,7 +345,8 @@ class ZendeskHelper(
 // Helpers
 
 /**
- * This is a helper function which builds a `UiConfig` through helpers to be used during ticket creation.
+ * This is a helper function which builds a `zendesk.configurations.Configuration` through helpers
+ * to be used during ticket creation.
  */
 private fun buildZendeskConfig(
     context: Context,
@@ -353,7 +354,7 @@ private fun buildZendeskConfig(
     origin: Origin?,
     selectedSite: SiteModel? = null,
     extraTags: List<String>? = null
-): UiConfig {
+): Configuration {
     val customFields = buildZendeskCustomFields(context, allSites, selectedSite)
     return RequestActivity.builder()
             .withTicketForm(TicketFieldIds.form, customFields)

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.kotlinVersion = '1.3.60'
-    ext.navigationVersion = '2.2.0-rc04'
+    ext.navigationVersion = '2.2.0'
 
     repositories {
         google()
@@ -98,7 +98,7 @@ ext {
     eventBusVersion = '3.1.1'
     googlePlayCoreVersion = '1.6.4'
     coroutinesVersion = '1.2.2'
-    archComponentsVersion = '2.2.0-rc02'
+    archComponentsVersion = '2.2.0'
     assertjVersion = '3.11.1'
     aztecVersion = 'v1.3.35'
 }


### PR DESCRIPTION
Closes #1878 and #1879 by updating the AndroidX components to their release versions and updating Zendesk to v4.0.0.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
