### PR TITLE
Create build folder when required

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -333,7 +333,7 @@ end
     end
 
     Dir.chdir("..") do
-      sh("cp -v #{output_dir}#{options[:flavor]}Release/#{aab_file} #{build_dir}#{name}")
+      sh("mkdir -p #{build_dir} && cp -v #{output_dir}#{options[:flavor]}Release/#{aab_file} #{build_dir}#{name}")
       UI.message("Bundle ready: #{name}")
       extract_universal_apk(bundle_path:"#{build_dir}#{name}", apk_path:"#{build_dir}#{apk_name}")
     end


### PR DESCRIPTION
While reviewing https://github.com/woocommerce/woocommerce-android/pull/1857 on a fresh checkout I noticed that using Fastlane for the first build fails because of a missing folder. 
This PR fixes it. 

## To Test:
1. Run `bundle exec fastlane build_pre_releases` and verify it has no errors.
2. Delete the `artifcacts` folder to bring the repository to the same state of a fresh checkout.
3. Run `bundle exec fastlane build_pre_releases` again and verify that it has no errors.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
