### PR TITLE
issue/1881-androidx-browser-1.2.0

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -127,7 +127,9 @@ dependencies {
     implementation "androidx.appcompat:appcompat:1.1.0"
     implementation "com.google.android.material:material:1.0.0"
     implementation "androidx.cardview:cardview:1.0.0"
-    implementation "androidx.browser:browser:1.0.0"
+    implementation ("androidx.browser:browser:1.2.0") {
+        exclude group: 'com.google.guava', module: 'listenablefuture'
+    }
     implementation "androidx.preference:preference:1.1.0"
 
     implementation "androidx.navigation:navigation-fragment-ktx:$navigationVersion"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt
@@ -43,21 +43,23 @@ object ChromeCustomTabUtils {
             return false
         }
 
-        connection = object : CustomTabsServiceConnection() {
+        val thisConnection = object : CustomTabsServiceConnection() {
             override fun onCustomTabsServiceConnected(name: ComponentName, client: CustomTabsClient) {
                 client.warmup(0)
                 session = client.newSession(null)
 
-                val uriToPreload: Uri? = preloadUrl?.let { Uri.parse(it) }
+                val otherLikelyBundles = ArrayList<Bundle>()
                 otherLikelyUrls?.let { urlList ->
-                    val otherLikelyBundles = ArrayList<Bundle>()
                     for (url in urlList) {
                         val bundle = Bundle()
                         bundle.putParcelable(KEY_URL, Uri.parse(url))
                         otherLikelyBundles.add(bundle)
                     }
-                    session?.mayLaunchUrl(uriToPreload, null, otherLikelyBundles)
-                } ?: session?.mayLaunchUrl(uriToPreload, null, null)
+                }
+
+                preloadUrl?.let {
+                    session?.mayLaunchUrl(Uri.parse(it), null, otherLikelyBundles)
+                }
             }
 
             override fun onServiceDisconnected(name: ComponentName) {
@@ -65,7 +67,9 @@ object ChromeCustomTabUtils {
                 connection = null
             }
         }
-        CustomTabsClient.bindCustomTabsService(context, CUSTOM_TAB_PACKAGE_NAME_STABLE, connection)
+        CustomTabsClient.bindCustomTabsService(context, CUSTOM_TAB_PACKAGE_NAME_STABLE, thisConnection)
+        connection = thisConnection
+
         return true
     }
 


### PR DESCRIPTION
Fixes #1881 by updating to the latest version of androidx.browser. This is necessary in order to support dark mode in Chrome Custom Tabs (see #1873).

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
