### PR TITLE
Moved URL constant from order list to AppUrls.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -14,6 +14,7 @@ object AppUrls {
     const val WOOCOMMERCE_ADMIN_PLUGIN = "https://wordpress.org/plugins/woocommerce-admin"
 
     const val URL_LEARN_MORE_REVIEWS = "https://woocommerce.com/posts/reviews-woocommerce-best-practices/"
+    const val URL_LEARN_MORE_ORDERS = "https://woocommerce.com/blog/"
 
     const val JETPACK_INSTRUCTIONS =
             "https://docs.woocommerce.com/document/jetpack-setup-instructions-for-the-woocommerce-mobile-app/"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.Observer
 import androidx.paging.PagedList
 import com.google.android.material.tabs.TabLayout
 import com.woocommerce.android.AppPrefs
+import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
@@ -64,8 +65,6 @@ class OrderListFragment : TopLevelFragment(),
         private const val SEARCH_TYPING_DELAY_MS = 500L
         private const val TAB_INDEX_PROCESSING = 0
         private const val TAB_INDEX_ALL = 1
-
-        private const val URL_LEARN_MORE = "https://woocommerce.com/blog/"
 
         fun newInstance(orderStatus: String? = null): OrderListFragment {
             val fragment = OrderListFragment()
@@ -421,7 +420,7 @@ class OrderListFragment : TopLevelFragment(),
                     }
                     EmptyViewType.ORDER_LIST -> {
                         empty_view.show(emptyViewType) {
-                            ChromeCustomTabUtils.launchUrl(requireActivity(), URL_LEARN_MORE)
+                            ChromeCustomTabUtils.launchUrl(requireActivity(), AppUrls.URL_LEARN_MORE_ORDERS)
                         }
                     }
                     EmptyViewType.ORDER_LIST_FILTERED -> {


### PR DESCRIPTION
This tiny PR moves a URL constant from the order list fragment to our new `AppUrls` object. I added this constant during the empty states work and meant to make this change before it was merged.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
