### PR TITLE
Dark Mode: Loading skeletons on main tabs

### DIFF
--- a/WooCommerce/src/main/res/drawable/skeleton_background.xml
+++ b/WooCommerce/src/main/res/drawable/skeleton_background.xml
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
 
-    <solid
-        android:color="@color/skeleton_color"/>
+    <solid android:color="@color/skeleton_color" />
 
-    <corners
-        android:radius="8dp"/>
-
+    <corners android:radius="8dp" />
 </shape>

--- a/WooCommerce/src/main/res/drawable/skeleton_background_inverse.xml
+++ b/WooCommerce/src/main/res/drawable/skeleton_background_inverse.xml
@@ -4,9 +4,8 @@
     android:shape="rectangle">
 
     <solid
-        android:color="@color/skeleton_color_light"/>
+        android:color="@color/skeleton_color_inverse"/>
 
     <corners
         android:radius="8dp"/>
-
 </shape>

--- a/WooCommerce/src/main/res/drawable/skeleton_background_inverse.xml
+++ b/WooCommerce/src/main/res/drawable/skeleton_background_inverse.xml
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
 
-    <solid
-        android:color="@color/skeleton_color_inverse"/>
+    <solid android:color="@color/skeleton_color_inverse" />
 
-    <corners
-        android:radius="8dp"/>
+    <corners android:radius="8dp" />
 </shape>

--- a/WooCommerce/src/main/res/drawable/skeleton_background_oval.xml
+++ b/WooCommerce/src/main/res/drawable/skeleton_background_oval.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval">
 
-    <solid
-        android:color="@color/skeleton_color"/>
-
+    <solid android:color="@color/skeleton_color" />
 </shape>

--- a/WooCommerce/src/main/res/layout/skeleton_dashboard_stats.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_dashboard_stats.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/chart_skeleton"
     android:layout_width="match_parent"
     android:layout_height="@dimen/chart_height"
     android:orientation="horizontal"
-    android:padding="@dimen/skeleton_bar_chart_padding">
+    android:paddingTop="@dimen/major_200"
+    android:paddingBottom="@dimen/major_300"
+    android:paddingStart="@dimen/major_200"
+    android:paddingEnd="@dimen/major_200">
 
     <View
         android:layout_width="@dimen/skeleton_bar_chart_bar_width_days"

--- a/WooCommerce/src/main/res/layout/skeleton_dashboard_top_earner_list_item.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_dashboard_top_earner_list_item.xml
@@ -4,27 +4,26 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal"
-    android:paddingBottom="@dimen/margin_extra_large"
-    android:paddingTop="@dimen/margin_large">
+    android:padding="@dimen/major_100">
 
     <View
-        android:layout_width="@dimen/product_icon_sz"
-        android:layout_height="@dimen/product_icon_sz"
+        android:layout_width="@dimen/skeleton_list_item_icon_200"
+        android:layout_height="@dimen/skeleton_list_item_icon_200"
         android:layout_gravity="center_vertical"
         android:background="@drawable/skeleton_background"/>
 
     <View
         android:layout_width="0dp"
-        android:layout_height="@dimen/product_icon_sz"
+        android:layout_height="match_parent"
         android:layout_gravity="center_vertical"
-        android:layout_marginEnd="@dimen/margin_large"
-        android:layout_marginStart="@dimen/margin_large"
+        android:layout_marginEnd="@dimen/major_75"
+        android:layout_marginStart="@dimen/major_75"
         android:layout_weight="5"
         android:background="@drawable/skeleton_background"/>
 
     <View
         android:layout_width="0dp"
-        android:layout_height="@dimen/product_icon_sz"
+        android:layout_height="match_parent"
         android:layout_gravity="center_vertical"
         android:layout_weight="1"
         android:background="@drawable/skeleton_background"/>

--- a/WooCommerce/src/main/res/layout/skeleton_dashboard_top_earners.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_dashboard_top_earners.xml
@@ -8,7 +8,11 @@
 
     <include layout="@layout/skeleton_dashboard_top_earner_list_item"/>
 
+    <View style="@style/Woo.Divider.TitleAligned"/>
+
     <include layout="@layout/skeleton_dashboard_top_earner_list_item"/>
+
+    <View style="@style/Woo.Divider.TitleAligned"/>
 
     <include layout="@layout/skeleton_dashboard_top_earner_list_item"/>
 

--- a/WooCommerce/src/main/res/layout/skeleton_notif_detail.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_notif_detail.xml
@@ -65,14 +65,14 @@
             <View
                 android:id="@+id/review_user_name"
                 android:layout_width="200dp"
-                android:layout_height="@dimen/skeleton_default_text_height"
+                android:layout_height="@dimen/skeleton_text_height_100"
                 android:layout_marginTop="@dimen/margin_small"
                 android:layout_toEndOf="@+id/review_gravatar"
                 android:background="@drawable/skeleton_background"/>
 
             <View
                 android:layout_width="128dp"
-                android:layout_height="@dimen/skeleton_default_text_height"
+                android:layout_height="@dimen/skeleton_text_height_100"
                 android:layout_alignBottom="@id/review_gravatar"
                 android:layout_marginBottom="@dimen/margin_small"
                 android:layout_toEndOf="@+id/review_gravatar"
@@ -82,21 +82,21 @@
 
         <View
             android:layout_width="match_parent"
-            android:layout_height="@dimen/skeleton_default_text_height"
+            android:layout_height="@dimen/skeleton_text_height_100"
             android:layout_marginEnd="@dimen/margin_large"
             android:layout_marginTop="32dp"
             android:background="@drawable/skeleton_background"/>
 
         <View
             android:layout_width="match_parent"
-            android:layout_height="@dimen/skeleton_default_text_height"
+            android:layout_height="@dimen/skeleton_text_height_100"
             android:layout_marginEnd="@dimen/margin_extra_extra_large"
             android:layout_marginTop="@dimen/margin_medium"
             android:background="@drawable/skeleton_background"/>
 
         <View
             android:layout_width="match_parent"
-            android:layout_height="@dimen/skeleton_default_text_height"
+            android:layout_height="@dimen/skeleton_text_height_100"
             android:layout_marginEnd="@dimen/margin_large"
             android:layout_marginTop="@dimen/margin_medium"
             android:background="@drawable/skeleton_background"/>
@@ -115,13 +115,13 @@
 
             <View
                 android:layout_width="0dp"
-                android:layout_height="@dimen/skeleton_default_text_height"
+                android:layout_height="@dimen/skeleton_text_height_100"
                 android:layout_weight="3"
                 android:background="@drawable/skeleton_background"/>
 
             <View
                 android:layout_width="0dp"
-                android:layout_height="@dimen/skeleton_default_text_height"
+                android:layout_height="@dimen/skeleton_text_height_100"
                 android:layout_marginEnd="@dimen/margin_large"
                 android:layout_marginStart="@dimen/margin_large"
                 android:layout_weight="3"
@@ -129,7 +129,7 @@
 
             <View
                 android:layout_width="0dp"
-                android:layout_height="@dimen/skeleton_default_text_height"
+                android:layout_height="@dimen/skeleton_text_height_100"
                 android:layout_weight="3"
                 android:background="@drawable/skeleton_background"/>
 

--- a/WooCommerce/src/main/res/layout/skeleton_notif_header.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_notif_header.xml
@@ -9,21 +9,21 @@
     <View
         android:id="@+id/view5"
         android:layout_width="0dp"
-        android:layout_height="16dp"
-        android:layout_marginBottom="20dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="20dp"
+        android:layout_height="@dimen/skeleton_list_header_text_height_100"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginTop="@dimen/major_125"
+        android:layout_marginBottom="@dimen/major_125"
         android:background="@drawable/skeleton_background_inverse"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/guideline4"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideline4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.33"/>
+        app:layout_constraintGuide_percent="0.33" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/skeleton_notif_header.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_notif_header.xml
@@ -13,7 +13,7 @@
         android:layout_marginBottom="20dp"
         android:layout_marginStart="16dp"
         android:layout_marginTop="20dp"
-        android:background="@drawable/skeleton_background_light"
+        android:background="@drawable/skeleton_background_inverse"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/guideline4"
         app:layout_constraintStart_toStartOf="parent"

--- a/WooCommerce/src/main/res/layout/skeleton_notif_list.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_notif_list.xml
@@ -3,8 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="@color/white">
+    android:layout_height="wrap_content">
 
     <include
         android:id="@+id/include4"
@@ -25,18 +24,15 @@
 
     <View
         android:id="@+id/divider2"
+        style="@style/Woo.Divider"
         android:layout_width="0dp"
-        android:layout_height="1dp"
-        android:background="@color/list_divider"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@+id/guideline5"
         app:layout_constraintTop_toBottomOf="@+id/include"/>
 
     <View
         android:id="@+id/divider3"
-        android:layout_width="0dp"
-        android:layout_height="1dp"
-        android:background="@color/list_divider"
+        style="@style/Woo.Divider"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/include4"/>
@@ -62,18 +58,15 @@
 
     <View
         android:id="@+id/divider4"
+        style="@style/Woo.Divider"
         android:layout_width="0dp"
-        android:layout_height="1dp"
-        android:background="@color/list_divider"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@+id/guideline5"
         app:layout_constraintTop_toBottomOf="@+id/include2"/>
 
     <View
         android:id="@+id/divider5"
-        android:layout_width="0dp"
-        android:layout_height="1dp"
-        android:background="@color/list_divider"
+        style="@style/Woo.Divider"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/include3"/>

--- a/WooCommerce/src/main/res/layout/skeleton_notif_list_item.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_notif_list_item.xml
@@ -3,60 +3,59 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/white">
+    android:layout_height="match_parent">
 
     <View
         android:id="@+id/view"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="20dp"
-        android:background="@drawable/skeleton_background_oval"
+        android:layout_width="@dimen/skeleton_list_item_icon_100"
+        android:layout_height="@dimen/skeleton_list_item_icon_100"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginTop="@dimen/major_100"
+        android:background="@drawable/skeleton_background"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"/>
 
     <View
         android:id="@+id/view4"
         android:layout_width="0dp"
-        android:layout_height="16dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="20dp"
+        android:layout_height="@dimen/skeleton_list_item_title_text_height_100"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginTop="@dimen/major_100"
         android:background="@drawable/skeleton_background"
-        app:layout_constraintEnd_toStartOf="@+id/guideline"
+        app:layout_constraintEnd_toStartOf="@+id/guideline2"
         app:layout_constraintStart_toEndOf="@+id/view"
         app:layout_constraintTop_toTopOf="parent"/>
 
     <View
         android:id="@+id/view2"
         android:layout_width="0dp"
-        android:layout_height="16dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginTop="12dp"
+        android:layout_height="@dimen/skeleton_list_item_body_text_height_100"
+        android:layout_marginEnd="@dimen/minor_100"
+        android:layout_marginTop="@dimen/minor_100"
         android:background="@drawable/skeleton_background"
-        app:layout_constraintEnd_toStartOf="@+id/guideline2"
+        app:layout_constraintEnd_toStartOf="@+id/guideline"
         app:layout_constraintStart_toStartOf="@+id/view4"
         app:layout_constraintTop_toBottomOf="@+id/view4"/>
 
     <View
         android:id="@+id/view3"
         android:layout_width="0dp"
-        android:layout_height="16dp"
-        android:layout_marginBottom="16dp"
-        android:layout_marginTop="12dp"
+        android:layout_height="@dimen/skeleton_list_item_body_text_height_100"
+        android:layout_marginTop="@dimen/minor_100"
+        android:layout_marginBottom="@dimen/major_100"
         android:background="@drawable/skeleton_background"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/guideline3"
         app:layout_constraintStart_toStartOf="@+id/view2"
         app:layout_constraintTop_toBottomOf="@+id/view2"
-        app:layout_constraintVertical_bias="0.0"/>
+        app:layout_constraintVertical_bias="0.0" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideline"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.54744524"/>
+        app:layout_constraintGuide_percent="0.67" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideline2"
@@ -70,5 +69,5 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_begin="299dp"/>
+        app:layout_constraintGuide_percent="0.33" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/skeleton_order_list_item.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_order_list_item.xml
@@ -3,31 +3,33 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:layout_marginStart="@dimen/major_100"
+    android:layout_marginEnd="@dimen/major_100"
+    android:layout_marginTop="@dimen/major_75"
+    android:layout_marginBottom="@dimen/major_75">
 
     <View
         android:layout_width="80dp"
-        android:layout_height="@dimen/skeleton_text_height_100"
-        android:layout_marginEnd="@dimen/list_item_padding_intra_h"
-        android:layout_marginTop="8dp"
+        android:layout_height="@dimen/skeleton_text_height_75"
         android:background="@drawable/skeleton_background" />
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="@dimen/minor_100"
         android:orientation="horizontal">
 
         <View
             android:layout_width="0dp"
-            android:layout_height="@dimen/text_extra_large"
-            android:layout_marginEnd="@dimen/list_item_padding_intra_h"
+            android:layout_height="@dimen/skeleton_text_height_100"
+            android:layout_marginEnd="@dimen/minor_100"
             android:layout_weight="4"
             android:background="@drawable/skeleton_background"/>
 
         <View
             android:layout_width="0dp"
-            android:layout_height="@dimen/text_extra_large"
+            android:layout_height="@dimen/skeleton_text_height_100"
             android:layout_weight="1"
             android:background="@drawable/skeleton_background"/>
 
@@ -35,8 +37,7 @@
 
     <View
         android:layout_width="100dp"
-        android:layout_height="@dimen/text_extra_large"
-        android:layout_marginBottom="@dimen/margin_medium"
-        android:layout_marginTop="8dp"
+        android:layout_height="@dimen/skeleton_tagview_height"
+        android:layout_marginTop="@dimen/minor_100"
         android:background="@drawable/skeleton_background"/>
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout/skeleton_order_list_item.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_order_list_item.xml
@@ -6,8 +6,8 @@
     android:orientation="vertical">
 
     <View
-        android:layout_width="58dp"
-        android:layout_height="@dimen/text_large"
+        android:layout_width="80dp"
+        android:layout_height="@dimen/skeleton_text_height_100"
         android:layout_marginEnd="@dimen/list_item_padding_intra_h"
         android:layout_marginTop="8dp"
         android:background="@drawable/skeleton_background" />

--- a/WooCommerce/src/main/res/layout/skeleton_order_list_item_auto.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_order_list_item_auto.xml
@@ -1,14 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.facebook.shimmer.ShimmerFrameLayout
+<com.google.android.material.card.MaterialCardView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/orderListLoading"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    app:shimmer_auto_start="true"
-    app:shimmer_clip_to_children="true"
-    app:shimmer_duration="2000"
-    app:shimmer_repeat_delay="400">
+    style="@style/Woo.Card.WithoutPadding"
+    android:layout_margin="@dimen/minor_00">
 
-    <include layout="@layout/skeleton_order_list_item"/>
-</com.facebook.shimmer.ShimmerFrameLayout>
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <com.facebook.shimmer.ShimmerFrameLayout
+            android:id="@+id/orderListLoading"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:shimmer_auto_start="true"
+            app:shimmer_clip_to_children="true"
+            app:shimmer_duration="2000"
+            app:shimmer_repeat_delay="400">
+
+            <include layout="@layout/skeleton_order_list_item"/>
+        </com.facebook.shimmer.ShimmerFrameLayout>
+
+        <View
+            style="@style/Woo.Divider"
+            android:id="@+id/divider"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_width="match_parent"/>
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/WooCommerce/src/main/res/layout/skeleton_product_detail.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_product_detail.xml
@@ -14,14 +14,14 @@
 
     <View
         android:layout_width="120dp"
-        android:layout_height="@dimen/skeleton_default_text_height"
+        android:layout_height="@dimen/skeleton_text_height_100"
         android:layout_marginStart="@dimen/settings_padding"
         android:layout_marginTop="@dimen/settings_padding"
         android:background="@drawable/skeleton_background"/>
 
     <View
         android:layout_width="match_parent"
-        android:layout_height="@dimen/skeleton_default_text_height"
+        android:layout_height="@dimen/skeleton_text_height_100"
         android:layout_marginEnd="@dimen/settings_padding"
         android:layout_marginStart="@dimen/settings_padding"
         android:layout_marginTop="@dimen/settings_padding"
@@ -36,7 +36,7 @@
 
     <View
         android:layout_width="match_parent"
-        android:layout_height="@dimen/skeleton_default_text_height"
+        android:layout_height="@dimen/skeleton_text_height_100"
         android:layout_marginEnd="@dimen/settings_padding"
         android:layout_marginStart="@dimen/settings_padding"
         android:layout_marginTop="@dimen/settings_padding"
@@ -51,7 +51,7 @@
 
     <View
         android:layout_width="match_parent"
-        android:layout_height="@dimen/skeleton_default_text_height"
+        android:layout_height="@dimen/skeleton_text_height_100"
         android:layout_marginEnd="@dimen/settings_padding"
         android:layout_marginStart="@dimen/settings_padding"
         android:layout_marginTop="@dimen/settings_padding"
@@ -66,7 +66,7 @@
 
     <View
         android:layout_width="match_parent"
-        android:layout_height="@dimen/skeleton_default_text_height"
+        android:layout_height="@dimen/skeleton_text_height_100"
         android:layout_marginEnd="@dimen/settings_padding"
         android:layout_marginStart="@dimen/settings_padding"
         android:layout_marginTop="@dimen/settings_padding"
@@ -81,7 +81,7 @@
 
     <View
         android:layout_width="match_parent"
-        android:layout_height="@dimen/skeleton_default_text_height"
+        android:layout_height="@dimen/skeleton_text_height_100"
         android:layout_marginEnd="@dimen/settings_padding"
         android:layout_marginStart="@dimen/settings_padding"
         android:layout_marginTop="@dimen/settings_padding"
@@ -96,7 +96,7 @@
 
     <View
         android:layout_width="match_parent"
-        android:layout_height="@dimen/skeleton_default_text_height"
+        android:layout_height="@dimen/skeleton_text_height_100"
         android:layout_marginBottom="@dimen/settings_padding"
         android:layout_marginEnd="@dimen/settings_padding"
         android:layout_marginStart="@dimen/settings_padding"

--- a/WooCommerce/src/main/res/layout/skeleton_product_list.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_product_list.xml
@@ -3,67 +3,87 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@color/white"
+    android:background="@color/color_surface"
     android:orientation="vertical">
 
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_marginBottom="@dimen/margin_small"
-        android:paddingEnd="@dimen/margin_large"
-        android:paddingStart="@dimen/margin_large"
-        android:layout_marginTop="@dimen/margin_large"
+        android:layout_marginBottom="@dimen/minor_50"
+        android:paddingEnd="@dimen/major_75"
+        android:paddingStart="@dimen/major_75"
+        android:layout_marginTop="@dimen/major_75"
         android:layout_weight="1"
         android:orientation="horizontal">
 
         <View
             android:layout_width="100dp"
-            android:layout_height="@dimen/text_large"
+            android:layout_height="@dimen/skeleton_text_height_75"
             android:background="@drawable/skeleton_background"/>
 
         <View
             android:layout_width="80dp"
-            android:layout_height="@dimen/text_large"
+            android:layout_height="@dimen/skeleton_text_height_75"
             android:layout_alignParentEnd="true"
             android:background="@drawable/skeleton_background"/>
     </RelativeLayout>
 
     <include layout="@layout/skeleton_product_list_item"/>
 
-    <include layout="@layout/skeleton_product_list_item"/>
+    <View style="@style/Woo.Divider.TitleAligned"/>
 
     <include layout="@layout/skeleton_product_list_item"/>
 
-    <include layout="@layout/skeleton_product_list_item"/>
+    <View style="@style/Woo.Divider.TitleAligned"/>
 
     <include layout="@layout/skeleton_product_list_item"/>
 
-    <include layout="@layout/skeleton_product_list_item"/>
+    <View style="@style/Woo.Divider.TitleAligned"/>
 
     <include layout="@layout/skeleton_product_list_item"/>
 
-    <include layout="@layout/skeleton_product_list_item"/>
+    <View style="@style/Woo.Divider.TitleAligned"/>
 
     <include layout="@layout/skeleton_product_list_item"/>
 
+    <View style="@style/Woo.Divider.TitleAligned"/>
+
     <include layout="@layout/skeleton_product_list_item"/>
+
+    <View style="@style/Woo.Divider.TitleAligned"/>
+
+    <include layout="@layout/skeleton_product_list_item"/>
+
+    <View style="@style/Woo.Divider.TitleAligned"/>
+
+    <include layout="@layout/skeleton_product_list_item"/>
+
+    <View style="@style/Woo.Divider.TitleAligned"/>
+
+    <include layout="@layout/skeleton_product_list_item"/>
+
+    <View style="@style/Woo.Divider.TitleAligned"/>
+
+    <include layout="@layout/skeleton_product_list_item"/>
+
+    <View style="@style/Woo.Divider.TitleAligned"/>
 
     <include layout="@layout/skeleton_product_list_item"/>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/settings_padding"
-        android:layout_marginEnd="@dimen/margin_large"
-        android:layout_marginStart="@dimen/margin_large"
+        android:layout_marginBottom="@dimen/major_100"
+        android:layout_marginEnd="@dimen/major_75"
+        android:layout_marginStart="@dimen/major_75"
         android:orientation="vertical">
 
         <View
             android:layout_width="120dp"
-            android:layout_height="@dimen/text_large"
+            android:layout_height="@dimen/skeleton_text_height_75"
             android:layout_gravity="end"
-            android:layout_marginStart="@dimen/settings_padding"
-            android:layout_marginTop="@dimen/settings_padding"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_100"
             android:background="@drawable/skeleton_background"/>
 
     </LinearLayout>

--- a/WooCommerce/src/main/res/layout/skeleton_product_list_item.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_product_list_item.xml
@@ -18,7 +18,7 @@
     <View
         android:id="@+id/productName"
         android:layout_width="wrap_content"
-        android:layout_height="@dimen/skeleton_default_text_height"
+        android:layout_height="@dimen/skeleton_text_height_100"
         android:layout_marginEnd="@dimen/margin_extra_large"
         android:layout_marginStart="@dimen/margin_extra_large"
         android:background="@color/skeleton_color"
@@ -36,7 +36,7 @@
     <View
         android:id="@+id/productStockAndStatus"
         android:layout_width="wrap_content"
-        android:layout_height="@dimen/skeleton_default_text_height"
+        android:layout_height="@dimen/skeleton_text_height_100"
         android:background="@color/skeleton_color"
         app:layout_constraintEnd_toEndOf="@+id/productName"
         app:layout_constraintHorizontal_bias="0.0"

--- a/WooCommerce/src/main/res/layout/skeleton_product_list_item.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_product_list_item.xml
@@ -4,13 +4,13 @@
     android:id="@+id/linearLayout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@color/list_item_bg"
-    android:padding="@dimen/margin_extra_large">
+    android:background="@color/color_surface"
+    android:padding="@dimen/major_100">
 
     <View
         android:id="@+id/productImage"
-        android:layout_width="@dimen/product_icon_sz"
-        android:layout_height="@dimen/product_icon_sz"
+        android:layout_width="@dimen/skeleton_list_item_icon_200"
+        android:layout_height="@dimen/skeleton_list_item_icon_200"
         android:background="@color/skeleton_color"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
@@ -19,8 +19,8 @@
         android:id="@+id/productName"
         android:layout_width="wrap_content"
         android:layout_height="@dimen/skeleton_text_height_100"
-        android:layout_marginEnd="@dimen/margin_extra_large"
-        android:layout_marginStart="@dimen/margin_extra_large"
+        android:layout_marginEnd="@dimen/major_100"
+        android:layout_marginStart="@dimen/major_100"
         android:background="@color/skeleton_color"
         app:layout_constrainedWidth="true"
         app:layout_constraintHorizontal_bias="0.0"
@@ -30,7 +30,7 @@
     <Space
         android:id="@+id/spacer"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/margin_small"
+        android:layout_height="@dimen/minor_50"
         app:layout_constraintTop_toBottomOf="@+id/productName" />
 
     <View

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -42,4 +42,9 @@
     <color name="product_stock_fg">@color/color_on_surface_medium</color>
     <color name="product_status_fg_other">@color/woo_blue_30</color>
     <color name="product_status_fg_pending">@color/woo_orange_30</color>
+
+    <!--
+        Loading Skeletons
+    -->
+    <color name="skeleton_color">@color/woo_black_90_alpha_038</color>
 </resources>

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -46,5 +46,5 @@
     <!--
         Loading Skeletons
     -->
-    <color name="skeleton_color">@color/woo_black_90_alpha_038</color>
+    <color name="skeleton_color">@color/woo_white_alpha_012</color>
 </resources>

--- a/WooCommerce/src/main/res/values/colors.xml
+++ b/WooCommerce/src/main/res/values/colors.xml
@@ -123,9 +123,6 @@
     <color name="login_input_icon_color">@color/wc_grey_30</color>
     <color name="login_input_password_icon_color">@color/wc_grey_30</color>
     <color name="login_notification_accent_color">@color/colorPrimary</color>
-
-    <color name="skeleton_color">#16000000</color>
-    <color name="skeleton_color_light">@color/white</color>
-
+    
     <color name="mtrl_textinput_default_box_stroke_color" tools:override="true">#1F000000</color>
 </resources>

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -68,4 +68,10 @@
     <color name="product_stock_fg">@color/color_on_surface_medium</color>
     <color name="product_status_fg_other">@color/woo_blue_50</color>
     <color name="product_status_fg_pending">@color/woo_orange_50</color>
+
+    <!--
+        Loading Skeletons
+    -->
+    <color name="skeleton_color">@color/woo_black_90_alpha_012</color>
+    <color name="skeleton_color_inverse">@color/color_surface</color>
 </resources>

--- a/WooCommerce/src/main/res/values/dimens.xml
+++ b/WooCommerce/src/main/res/values/dimens.xml
@@ -56,6 +56,7 @@ so that's the baseline as defined in `major_100`.
 
     <!-- Smaller image sizes (ex. icons) -->
     <dimen name="image_minor_50">24dp</dimen>
+    <dimen name="image_minor_60">26dp</dimen>
     <dimen name="image_minor_100">40dp</dimen>
     <dimen name="image_major_50">50dp</dimen>
     <dimen name="image_major_64">64dp</dimen>
@@ -68,6 +69,16 @@ so that's the baseline as defined in `major_100`.
     <dimen name="skeleton_list_header_text_height_100">@dimen/major_100</dimen>
     <dimen name="skeleton_list_item_title_text_height_100">@dimen/major_110</dimen>
     <dimen name="skeleton_list_item_body_text_height_100">@dimen/major_100</dimen>
+
+    <!--
+        Skeletons
+    -->
+    <dimen name="skeleton_bar_chart_bar_width_days">14dp</dimen>
+    <dimen name="skeleton_bar_chart_bar_width_weeks">18dp</dimen>
+    <dimen name="skeleton_bar_chart_bar_width_months">24dp</dimen>
+    <dimen name="skeleton_bar_chart_bar_width_years">38dp</dimen>
+    <dimen name="skeleton_bar_chart_bar_spacing">@dimen/minor_100</dimen>
+    <dimen name="skeleton_default_text_height">@dimen/text_major_25</dimen>
 
     <!-- Other literal dimensions -->
     <dimen name="margin_app_title_aligned">72dp</dimen>

--- a/WooCommerce/src/main/res/values/dimens.xml
+++ b/WooCommerce/src/main/res/values/dimens.xml
@@ -69,16 +69,14 @@ so that's the baseline as defined in `major_100`.
     <dimen name="skeleton_list_header_text_height_100">@dimen/major_100</dimen>
     <dimen name="skeleton_list_item_title_text_height_100">@dimen/major_110</dimen>
     <dimen name="skeleton_list_item_body_text_height_100">@dimen/major_100</dimen>
-
-    <!--
-        Skeletons
-    -->
     <dimen name="skeleton_bar_chart_bar_width_days">14dp</dimen>
     <dimen name="skeleton_bar_chart_bar_width_weeks">18dp</dimen>
     <dimen name="skeleton_bar_chart_bar_width_months">24dp</dimen>
     <dimen name="skeleton_bar_chart_bar_width_years">38dp</dimen>
     <dimen name="skeleton_bar_chart_bar_spacing">@dimen/minor_100</dimen>
+    <dimen name="skeleton_text_height_75">@dimen/text_minor_125</dimen>
     <dimen name="skeleton_text_height_100">@dimen/text_major_25</dimen>
+    <dimen name="skeleton_tagview_height">24dp</dimen>
 
     <!-- Other literal dimensions -->
     <dimen name="margin_app_title_aligned">72dp</dimen>

--- a/WooCommerce/src/main/res/values/dimens.xml
+++ b/WooCommerce/src/main/res/values/dimens.xml
@@ -78,7 +78,7 @@ so that's the baseline as defined in `major_100`.
     <dimen name="skeleton_bar_chart_bar_width_months">24dp</dimen>
     <dimen name="skeleton_bar_chart_bar_width_years">38dp</dimen>
     <dimen name="skeleton_bar_chart_bar_spacing">@dimen/minor_100</dimen>
-    <dimen name="skeleton_default_text_height">@dimen/text_major_25</dimen>
+    <dimen name="skeleton_text_height_100">@dimen/text_major_25</dimen>
 
     <!-- Other literal dimensions -->
     <dimen name="margin_app_title_aligned">72dp</dimen>

--- a/WooCommerce/src/main/res/values/dimens.xml
+++ b/WooCommerce/src/main/res/values/dimens.xml
@@ -21,10 +21,12 @@ so that's the baseline as defined in `major_100`.
 
     <dimen name="major_75">12dp</dimen>
     <dimen name="major_100">16dp</dimen>
+    <dimen name="major_110">18sp</dimen>
     <dimen name="major_125">20dp</dimen>
     <dimen name="major_150">24dp</dimen>
     <dimen name="major_175">28dp</dimen>
     <dimen name="major_200">32dp</dimen>
+    <dimen name="major_300">48dp</dimen>
 
     <!-- Regular text dimensions (body, subtitles, caption, etc -->
     <dimen name="text_minor_60">10sp</dimen>
@@ -56,7 +58,15 @@ so that's the baseline as defined in `major_100`.
     <dimen name="image_minor_50">24dp</dimen>
     <dimen name="image_minor_100">40dp</dimen>
     <dimen name="image_major_50">50dp</dimen>
+    <dimen name="image_major_64">64dp</dimen>
     <dimen name="image_major_100">100dp</dimen>
+
+    <!-- Skeleton sizes -->
+    <dimen name="skeleton_list_item_icon_100">@dimen/image_minor_50</dimen>
+    <dimen name="skeleton_avatar_100">@dimen/image_major_64</dimen>
+    <dimen name="skeleton_list_header_text_height_100">@dimen/major_100</dimen>
+    <dimen name="skeleton_list_item_title_text_height_100">@dimen/major_110</dimen>
+    <dimen name="skeleton_list_item_body_text_height_100">@dimen/major_100</dimen>
 
     <!-- Other literal dimensions -->
     <dimen name="margin_app_title_aligned">72dp</dimen>

--- a/WooCommerce/src/main/res/values/dimens.xml
+++ b/WooCommerce/src/main/res/values/dimens.xml
@@ -63,6 +63,7 @@ so that's the baseline as defined in `major_100`.
 
     <!-- Skeleton sizes -->
     <dimen name="skeleton_list_item_icon_100">@dimen/image_minor_50</dimen>
+    <dimen name="skeleton_list_item_icon_200">@dimen/image_minor_100</dimen>
     <dimen name="skeleton_avatar_100">@dimen/image_major_64</dimen>
     <dimen name="skeleton_list_header_text_height_100">@dimen/major_100</dimen>
     <dimen name="skeleton_list_item_title_text_height_100">@dimen/major_110</dimen>

--- a/WooCommerce/src/main/res/values/dimens_old.xml
+++ b/WooCommerce/src/main/res/values/dimens_old.xml
@@ -133,14 +133,7 @@
     <!--
         Skeletons
     -->
-    <dimen name="skeleton_bar_chart_padding">30dp</dimen>
-    <dimen name="skeleton_bar_chart_bar_width_days">14dp</dimen>
-    <dimen name="skeleton_bar_chart_bar_width_weeks">18dp</dimen>
-    <dimen name="skeleton_bar_chart_bar_width_months">24dp</dimen>
-    <dimen name="skeleton_bar_chart_bar_width_years">38dp</dimen>
-    <dimen name="skeleton_bar_chart_bar_spacing">@dimen/margin_medium</dimen>
     <dimen name="skeleton_order_note_item_height">96dp</dimen>
-    <dimen name="skeleton_default_text_height">20sp</dimen>
     <dimen name="skeleton_default_text_height_two_lines">40sp</dimen>
 
     <!--


### PR DESCRIPTION
Fixes #1771 #1770 #1768 #1769 by applying light/dark styling to the loading skeletons for the following views:
- Top Performers + Stats chart in My Store tab (old and new stats)
- Orders List
- Products List
- Reviews List

## Screenshots
![skeleton_stats](https://user-images.githubusercontent.com/5810477/73807176-cf769180-4788-11ea-922a-714c87671422.png)

![skeleton_orders](https://user-images.githubusercontent.com/5810477/73807179-d1405500-4788-11ea-9249-47e3c629357a.png)

![skeleton_products](https://user-images.githubusercontent.com/5810477/73807183-d30a1880-4788-11ea-92eb-552085d55b7e.png)

![skeleton_reviews](https://user-images.githubusercontent.com/5810477/73807187-d4d3dc00-4788-11ea-9be6-332e35fed531.png)