### PR TITLE
Dark Mode: Badge Text styling

### DIFF
--- a/WooCommerce/src/main/res/layout/order_badge_view.xml
+++ b/WooCommerce/src/main/res/layout/order_badge_view.xml
@@ -13,14 +13,11 @@
    -->
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/textOrderCount"
+        style="@style/Woo.TextView.Badge"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="top|center_horizontal"
-        android:layout_marginStart="@dimen/margin_large"
-        android:layout_marginTop="@dimen/margin_small"
         android:background="@drawable/badge_orders"
         android:gravity="center"
-        android:textAppearance="?attr/textAppearanceBadge"
         tools:text="99+" />
-
 </FrameLayout>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -210,6 +210,15 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:textAppearance">?attr/textAppearanceOverline</item>
     </style>
 
+    <style name="Woo.TextView.Badge">
+        <item name="android:textAppearance">?attr/textAppearanceBadge</item>
+        <item name="android:textColor">@color/color_surface</item>
+        <item name="android:layout_marginStart">@dimen/major_75</item>
+        <item name="android:layout_marginEnd">@dimen/minor_00</item>
+        <item name="android:layout_marginTop">@dimen/minor_50</item>
+        <item name="android:layout_marginBottom">@dimen/minor_00</item>
+    </style>
+
     <!--
         Button Styles
     -->


### PR DESCRIPTION
Fixes #1895 by implementing a new style `Woo.TextView.Badge` with the appropriate badge text coloring applied. 

## Screenshots

![badge](https://user-images.githubusercontent.com/5810477/73811529-ed4af300-4796-11ea-872b-bc699a0fdb7f.png)
