### PR TITLE
Products release 1/handle discard changes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -99,17 +99,20 @@ data class Product(
     fun mergeProduct(newProduct: Product?): Product {
         return newProduct?.let { updatedProduct ->
             this.copy(
-                    description = updatedProduct.description.takeIf { this.description != updatedProduct.description } ?: this.description,
+                    description = updatedProduct.description
+                            .takeIf { this.description != updatedProduct.description } ?: this.description,
                     name = updatedProduct.name.takeIf { name != updatedProduct.name } ?: name,
                     sku = updatedProduct.sku.takeIf { sku != updatedProduct.sku } ?: sku,
-                    manageStock = updatedProduct.manageStock.takeIf { manageStock != updatedProduct.manageStock } ?: manageStock,
-                    stockStatus = updatedProduct.stockStatus.takeIf { stockStatus != updatedProduct.stockStatus } ?: stockStatus,
-                    stockQuantity = updatedProduct.stockQuantity.takeIf { stockQuantity != updatedProduct.stockQuantity }
-                            ?: stockQuantity,
-                    backorderStatus = updatedProduct.backorderStatus.takeIf { backorderStatus != updatedProduct.backorderStatus }
-                            ?: backorderStatus,
-                    soldIndividually = updatedProduct.soldIndividually.takeIf { soldIndividually != updatedProduct.soldIndividually }
-                            ?: soldIndividually
+                    manageStock = updatedProduct.manageStock
+                            .takeIf { manageStock != updatedProduct.manageStock } ?: manageStock,
+                    stockStatus = updatedProduct.stockStatus
+                            .takeIf { stockStatus != updatedProduct.stockStatus } ?: stockStatus,
+                    stockQuantity = updatedProduct.stockQuantity
+                            .takeIf { stockQuantity != updatedProduct.stockQuantity } ?: stockQuantity,
+                    backorderStatus = updatedProduct.backorderStatus
+                            .takeIf { backorderStatus != updatedProduct.backorderStatus } ?: backorderStatus,
+                    soldIndividually = updatedProduct.soldIndividually
+                            .takeIf { soldIndividually != updatedProduct.soldIndividually } ?: soldIndividually
             )
         } ?: this.copy()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -99,16 +99,16 @@ data class Product(
     fun mergeProduct(newProduct: Product?): Product {
         return newProduct?.let { updatedProduct ->
             this.copy(
-                    description = updatedProduct.description.takeIf { it != updatedProduct.description } ?: description,
-                    name = updatedProduct.name.takeIf { it != updatedProduct.name } ?: name,
-                    sku = updatedProduct.sku.takeIf { it != updatedProduct.sku } ?: sku,
-                    manageStock = updatedProduct.manageStock.takeIf { it != updatedProduct.manageStock } ?: manageStock,
-                    stockStatus = updatedProduct.stockStatus.takeIf { it != updatedProduct.stockStatus } ?: stockStatus,
-                    stockQuantity = updatedProduct.stockQuantity.takeIf { it != updatedProduct.stockQuantity }
+                    description = updatedProduct.description.takeIf { this.description != updatedProduct.description } ?: this.description,
+                    name = updatedProduct.name.takeIf { name != updatedProduct.name } ?: name,
+                    sku = updatedProduct.sku.takeIf { sku != updatedProduct.sku } ?: sku,
+                    manageStock = updatedProduct.manageStock.takeIf { manageStock != updatedProduct.manageStock } ?: manageStock,
+                    stockStatus = updatedProduct.stockStatus.takeIf { stockStatus != updatedProduct.stockStatus } ?: stockStatus,
+                    stockQuantity = updatedProduct.stockQuantity.takeIf { stockQuantity != updatedProduct.stockQuantity }
                             ?: stockQuantity,
-                    backorderStatus = updatedProduct.backorderStatus.takeIf { it != updatedProduct.backorderStatus }
+                    backorderStatus = updatedProduct.backorderStatus.takeIf { backorderStatus != updatedProduct.backorderStatus }
                             ?: backorderStatus,
-                    soldIndividually = updatedProduct.soldIndividually.takeIf { it != updatedProduct.soldIndividually }
+                    soldIndividually = updatedProduct.soldIndividually.takeIf { soldIndividually != updatedProduct.soldIndividually }
                             ?: soldIndividually
             )
         } ?: this.copy()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -99,20 +99,14 @@ data class Product(
     fun mergeProduct(newProduct: Product?): Product {
         return newProduct?.let { updatedProduct ->
             this.copy(
-                    description = updatedProduct.description
-                            .takeIf { this.description != updatedProduct.description } ?: this.description,
-                    name = updatedProduct.name.takeIf { name != updatedProduct.name } ?: name,
-                    sku = updatedProduct.sku.takeIf { sku != updatedProduct.sku } ?: sku,
-                    manageStock = updatedProduct.manageStock
-                            .takeIf { manageStock != updatedProduct.manageStock } ?: manageStock,
-                    stockStatus = updatedProduct.stockStatus
-                            .takeIf { stockStatus != updatedProduct.stockStatus } ?: stockStatus,
-                    stockQuantity = updatedProduct.stockQuantity
-                            .takeIf { stockQuantity != updatedProduct.stockQuantity } ?: stockQuantity,
-                    backorderStatus = updatedProduct.backorderStatus
-                            .takeIf { backorderStatus != updatedProduct.backorderStatus } ?: backorderStatus,
+                    description = updatedProduct.description,
+                    name = updatedProduct.name,
+                    sku = updatedProduct.sku,
+                    manageStock = updatedProduct.manageStock,
+                    stockStatus = updatedProduct.stockStatus,
+                    stockQuantity = updatedProduct.stockQuantity,
+                    backorderStatus = updatedProduct.backorderStatus,
                     soldIndividually = updatedProduct.soldIndividually
-                            .takeIf { soldIndividually != updatedProduct.soldIndividually } ?: soldIndividually
             )
         } ?: this.copy()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -16,12 +16,12 @@ import java.util.Date
 @Parcelize
 data class Product(
     val remoteId: Long,
-    var name: String,
-    var description: String,
+    val name: String,
+    val description: String,
     val type: ProductType,
     val status: ProductStatus?,
-    var stockStatus: ProductStockStatus,
-    var backorderStatus: ProductBackorderStatus,
+    val stockStatus: ProductStockStatus,
+    val backorderStatus: ProductBackorderStatus,
     val dateCreated: Date,
     val firstImageUrl: String?,
     val totalSales: Int,
@@ -35,9 +35,9 @@ data class Product(
     val salePrice: BigDecimal?,
     val regularPrice: BigDecimal?,
     val taxClass: String,
-    var manageStock: Boolean,
-    var stockQuantity: Int,
-    var sku: String,
+    val manageStock: Boolean,
+    val stockQuantity: Int,
+    val sku: String,
     val length: Float,
     val width: Float,
     val height: Float,
@@ -53,7 +53,7 @@ data class Product(
     val attributes: List<Attribute>,
     val dateOnSaleTo: Date?,
     val dateOnSaleFrom: Date?,
-    var soldIndividually: Boolean
+    val soldIndividually: Boolean
 ) : Parcelable {
     @Parcelize
     data class Image(
@@ -98,32 +98,19 @@ data class Product(
      */
     fun mergeProduct(newProduct: Product?): Product {
         return newProduct?.let { updatedProduct ->
-            this.copy().apply {
-                if (updatedProduct.description != this.description) {
-                    description = updatedProduct.description
-                }
-                if (updatedProduct.name != this.name) {
-                    name = updatedProduct.name
-                }
-                if (sku != updatedProduct.sku) {
-                    sku = updatedProduct.sku
-                }
-                if (manageStock != updatedProduct.manageStock) {
-                    manageStock = updatedProduct.manageStock
-                }
-                if (stockStatus != updatedProduct.stockStatus) {
-                    stockStatus = updatedProduct.stockStatus
-                }
-                if (stockQuantity != updatedProduct.stockQuantity) {
-                    stockQuantity = updatedProduct.stockQuantity
-                }
-                if (backorderStatus != updatedProduct.backorderStatus) {
-                    backorderStatus = updatedProduct.backorderStatus
-                }
-                if (soldIndividually != updatedProduct.soldIndividually) {
-                    soldIndividually = updatedProduct.soldIndividually
-                }
-            }
+            this.copy(
+                    description = updatedProduct.description.takeIf { it != updatedProduct.description } ?: description,
+                    name = updatedProduct.name.takeIf { it != updatedProduct.name } ?: name,
+                    sku = updatedProduct.sku.takeIf { it != updatedProduct.sku } ?: sku,
+                    manageStock = updatedProduct.manageStock.takeIf { it != updatedProduct.manageStock } ?: manageStock,
+                    stockStatus = updatedProduct.stockStatus.takeIf { it != updatedProduct.stockStatus } ?: stockStatus,
+                    stockQuantity = updatedProduct.stockQuantity.takeIf { it != updatedProduct.stockQuantity }
+                            ?: stockQuantity,
+                    backorderStatus = updatedProduct.backorderStatus.takeIf { it != updatedProduct.backorderStatus }
+                            ?: backorderStatus,
+                    soldIndividually = updatedProduct.soldIndividually.takeIf { it != updatedProduct.soldIndividually }
+                            ?: soldIndividually
+            )
         } ?: this.copy()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -236,7 +236,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         val product = requireNotNull(productData.product)
 
         if (isAddEditProductRelease1Enabled(product.type)) {
-            addEditableView(DetailCard.Primary, R.string.product_detail_title_hint, productTitle)?.also { view ->
+            addEditableView(DetailCard.Primary, R.string.product_detail_title_hint, product.name)?.also { view ->
                 view.setOnTextChangedListener { viewModel.updateProductDraft(title = it.toString()) }
             }
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -181,9 +181,12 @@ class ProductDetailViewModel @AssistedInject constructor(
                     backorderStatus = backorderStatus.takeIf { it != null && it != product.backorderStatus }
                             ?: product.backorderStatus,
                     stockQuantity = stockQuantity?.toInt().takeIf { it != null && it != product.stockQuantity }
-                            ?: product.stockQuantity
+                            ?: product.stockQuantity,
+                    images = viewState.storedProduct?.images ?: product.images
             )
             viewState = viewState.copy(cachedProduct = currentProduct, product = updatedProduct)
+
+            updateProductEditAction()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -200,7 +200,7 @@ class ProductDetailViewModel @AssistedInject constructor(
         when (event) {
             // discard inventory screen changes
             is ExitInventory -> {
-                viewState.storedProduct?.let {
+                viewState.cachedProduct?.let {
                     val product = viewState.product?.copy(
                             sku = it.sku,
                             manageStock = it.manageStock,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -171,17 +171,14 @@ class ProductDetailViewModel @AssistedInject constructor(
         viewState.product?.let { product ->
             val currentProduct = product.copy()
             val updatedProduct = product.copy(
-                    description = description.takeIf { it != null && it != product.description } ?: product.description,
-                    name = title.takeIf { it != null && it != product.name } ?: product.name,
-                    sku = sku.takeIf { it != null && it != product.sku } ?: product.sku,
-                    manageStock = manageStock.takeIf { it != null && it != product.manageStock } ?: product.manageStock,
-                    stockStatus = stockStatus.takeIf { it != null && it != product.stockStatus } ?: product.stockStatus,
-                    soldIndividually = soldIndividually.takeIf { it != null && it != product.soldIndividually }
-                            ?: product.soldIndividually,
-                    backorderStatus = backorderStatus.takeIf { it != null && it != product.backorderStatus }
-                            ?: product.backorderStatus,
-                    stockQuantity = stockQuantity?.toInt().takeIf { it != null && it != product.stockQuantity }
-                            ?: product.stockQuantity,
+                    description = description ?: product.description,
+                    name = title ?: product.name,
+                    sku = sku ?: product.sku,
+                    manageStock = manageStock ?: product.manageStock,
+                    stockStatus = stockStatus ?: product.stockStatus,
+                    soldIndividually = soldIndividually ?: product.soldIndividually,
+                    backorderStatus = backorderStatus ?: product.backorderStatus,
+                    stockQuantity = stockQuantity?.toInt() ?: product.stockQuantity,
                     images = viewState.storedProduct?.images ?: product.images
             )
             viewState = viewState.copy(cachedProduct = currentProduct, product = updatedProduct)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -323,9 +323,11 @@ class ProductDetailViewModel @AssistedInject constructor(
             ""
         }.trim()
 
-        val updatedProduct = storedProduct.mergeProduct(viewState.product)
+        val updatedProduct = viewState.product?.let {
+            if (storedProduct.isSameProduct(it)) storedProduct else storedProduct.mergeProduct(viewState.product)
+        } ?: storedProduct
         viewState = viewState.copy(
-                product = viewState.product ?: updatedProduct,
+                product = updatedProduct,
                 cachedProduct = viewState.cachedProduct ?: updatedProduct,
                 storedProduct = storedProduct,
                 weightWithUnits = weight,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -164,49 +164,25 @@ class ProductDetailViewModel @AssistedInject constructor(
         stockQuantity: String? = null,
         backorderStatus: ProductBackorderStatus? = null
     ) {
-        description?.let {
-            if (it != viewState.product?.description) {
-                viewState.product?.description = it
-            }
-        }
-        title?.let {
-            if (it != viewState.product?.name) {
-                viewState.product?.name = it
-            }
-        }
-        sku?.let {
-            if (it != viewState.product?.sku) {
-                viewState.product?.sku = it
-            }
-        }
-        manageStock?.let {
-            if (it != viewState.product?.manageStock) {
-                viewState.product?.manageStock = it
-            }
-        }
-        stockStatus?.let {
-            if (it != viewState.product?.stockStatus) {
-                viewState.product?.stockStatus = it
-            }
-        }
-        soldIndividually?.let {
-            if (it != viewState.product?.soldIndividually) {
-                viewState.product?.soldIndividually = it
-            }
-        }
-        stockQuantity?.let {
-            val quantity = it.toInt()
-            if (quantity != viewState.product?.stockQuantity) {
-                viewState.product?.stockQuantity = quantity
-            }
-        }
-        backorderStatus?.let {
-            if (it != viewState.product?.backorderStatus) {
-                viewState.product?.backorderStatus = it
-            }
-        }
+        viewState.product?.let { product ->
+            val currentProduct = product.copy()
+            val updatedProduct = product.copy(
+                    description = description.takeIf { it != null && it != product.description } ?: product.description,
+                    name = title.takeIf { it != null && it != product.name } ?: product.name,
+                    sku = sku.takeIf { it != null && it != product.sku } ?: product.sku,
+                    manageStock = manageStock.takeIf { it != null && it != product.manageStock } ?: product.manageStock,
+                    stockStatus = stockStatus.takeIf { it != null && it != product.stockStatus } ?: product.stockStatus,
+                    soldIndividually = soldIndividually.takeIf { it != null && it != product.soldIndividually }
+                            ?: product.soldIndividually,
+                    backorderStatus = backorderStatus.takeIf { it != null && it != product.backorderStatus }
+                            ?: product.backorderStatus,
+                    stockQuantity = stockQuantity?.toInt().takeIf { it != null && it != product.stockQuantity }
+                            ?: product.stockQuantity
+            )
+            viewState = viewState.copy(storedProduct = currentProduct, product = updatedProduct)
 
-        updateProductEditAction()
+            updateProductEditAction()
+        }
     }
 
     override fun onCleared() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -47,6 +47,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
     private val productWithParameters = ProductDetailViewState(
             product = product,
+            cachedProduct = product,
             storedProduct = product,
             isSkeletonShown = false,
             uploadingImageUris = emptyList(),


### PR DESCRIPTION
Fixes #1901. This PR adds the following changes:
- Adds logic to ensure that the discard dialog is only displayed when there are changes made to the sub product detail screen. 
- Adds logic keep the Product model as read only and update fields using `copy()` function.  

#### Testing
- Go to the inventory screen and fill out some data (for example stock quantity)
- Tap the Done button to save it
- Notice the change is reflected in the product detail screen
- Go back to the inventory screen
- Tap the back
- A discard dialog should NOT be displayed (when there are no changes made)

Logic changes included in the `ProductDetailViewModel` is for updating product title, description and inventory screens. So it would be a good idea to smoke test the editing products functionality.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
