### PR TITLE
Fix the new notification crash

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 3.5
 -----
 * Refunds are back! Select individual order items and the refund amount will be automatically calculated for you
+* Fixed a crash when opening the app from a new order notification
  
 3.4
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -14,7 +14,6 @@ import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
-import androidx.navigation.findNavController
 import androidx.navigation.fragment.NavHostFragment
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.findNavController
+import androidx.navigation.fragment.NavHostFragment
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.R
@@ -126,6 +127,10 @@ class MainActivity : AppUpgradeActivity(),
 
         presenter.takeView(this)
 
+        val navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment_main) as NavHostFragment
+        navController = navHostFragment.navController
+        navController.addOnDestinationChangedListener(this)
+
         bottomNavView = bottom_nav.also { it.init(supportFragmentManager, this) }
 
         // Verify authenticated session
@@ -162,13 +167,6 @@ class MainActivity : AppUpgradeActivity(),
         if (!BuildConfig.DEBUG) {
             checkForAppUpdates()
         }
-    }
-
-    override fun onPostCreate(savedInstanceState: Bundle?) {
-        super.onPostCreate(savedInstanceState)
-
-        navController = findNavController(R.id.nav_host_fragment_main)
-        navController.addOnDestinationChangedListener(this)
     }
 
     override fun hideProgressDialog() {


### PR DESCRIPTION
Fixes #1903.

I've reverted the changes from #1809 but I've added a different approach to fix the issue it's trying to fix (#1719), as suggested by https://issuetracker.google.com/issues/142847973.

Given the severity of the error (over 11k crashes), I've targeted the `release/3.5` branch.

**To test:**

1. Kill the app
2. Create a new order and wait for a notification
3. Tap on the notification to open the order detail
4. Notice the app doesn't crash

**Note:** It might be useful to also check whether this change keeps the fix for #1719, but even if it doesn't, I'd still ship this hotfix first and deal with the other problem later.

cc: @jkmassel 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
