### PR TITLE
Fix an arithmetics exception

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/BigDecimalExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/BigDecimalExt.kt
@@ -7,4 +7,4 @@ infix fun BigDecimal.isEqualTo(x: BigDecimal) = this.compareTo(x) == 0
 
 infix fun BigDecimal.isNotEqualTo(x: BigDecimal) = this.compareTo(x) != 0
 
-fun BigDecimal.roundError() = this.setScale(2, HALF_UP)
+fun BigDecimal.roundError(): BigDecimal = this.setScale(2, HALF_UP)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/RefundsExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/RefundsExt.kt
@@ -13,6 +13,7 @@ fun List<RefundListItem>.calculateTotals(): Pair<BigDecimal, BigDecimal> {
 
         val singleItemTax = item.orderItem.totalTax.divide(
                 item.orderItem.quantity.toBigDecimal(),
+                2,
                 HALF_UP
         )
         taxes += quantity.times(singleItemTax)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductListView.kt
@@ -23,6 +23,7 @@ import kotlinx.android.synthetic.main.order_detail_product_list.view.*
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import java.math.BigDecimal
+import java.math.RoundingMode.HALF_UP
 
 class OrderDetailProductListView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
     : ConstraintLayout(ctx, attrs) {
@@ -72,7 +73,7 @@ class OrderDetailProductListView @JvmOverloads constructor(ctx: Context, attrs: 
                     it.copy(
                             quantity = newQuantity ?: error("Missing product"),
                             total = it.price.times(newQuantity.toBigDecimal()),
-                            totalTax = it.totalTax.divide(it.quantity.toBigDecimal())
+                            totalTax = it.totalTax.divide(it.quantity.toBigDecimal(), 2, HALF_UP)
                     )
                 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundProductListAdapter.kt
@@ -22,6 +22,7 @@ import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel.WCRefundItem
 import org.wordpress.android.util.PhotonUtils
 import java.math.BigDecimal
+import java.math.RoundingMode.HALF_UP
 
 class RefundProductListAdapter(
     private val formatCurrency: (BigDecimal) -> String,
@@ -151,7 +152,8 @@ class RefundProductListAdapter(
                     orderItem.itemId,
                     quantity,
                     quantity.toBigDecimal().times(orderItem.price),
-                    orderItem.totalTax.divide(orderItem.quantity.toBigDecimal()).times(quantity.toBigDecimal())
+                    orderItem.totalTax.divide(orderItem.quantity.toBigDecimal(), 2, HALF_UP)
+                            .times(quantity.toBigDecimal())
             )
         }
     }


### PR DESCRIPTION
Fixes #1905.

To test this, specific values would need to be used to create a nonterminating decimal expansion (like `1.6 / 9.2`). A solution is to specify the rounding mode for any division operation.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
