### PR TITLE
Issue/1906 nav component 2.2.1

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,8 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <AndroidXmlCodeStyleSettings>
-      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="STATIC_FIELD_NAME_PREFIX" value="s" />

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -235,7 +235,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-extensions:$archComponentsVersion"
     implementation "androidx.fragment:fragment-ktx:1.2.0"
     implementation "androidx.activity:activity-ktx:1.1.0"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:1.0.0"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.2.0"
 
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.kotlinVersion = '1.3.60'
-    ext.navigationVersion = '2.2.0'
+    ext.navigationVersion = '2.2.1'
 
     repositories {
         google()


### PR DESCRIPTION
Closes #1906 - this PR simply updates the navigation and saved state libraries to their latest release versions.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
