### PR TITLE
Issue/1908 product list refresh

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,8 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <AndroidXmlCodeStyleSettings>
-      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="STATIC_FIELD_NAME_PREFIX" value="s" />

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -150,14 +150,17 @@ class ProductListViewModel @AssistedInject constructor(
             loadJob = launch {
                 viewState = viewState.copy(isLoadingMore = loadMore)
                 if (!loadMore) {
-                    // if this is the initial load, first get the products from the db and if there are any show
-                    // them immediately, otherwise make sure the skeleton shows
+                    // if this is the initial load, first get the products from the db and show them immediately.
+                    // if there aren't any cached products we show the skeleton, otherwise we only show the
+                    // skeleton if the user pulled to refresh
                     val productsInDb = productRepository.getProductList()
-                    if (productsInDb.isEmpty()) {
-                        viewState = viewState.copy(isSkeletonShown = true, isEmptyViewVisible = false)
+                    val showSkeleton = if (productsInDb.isEmpty()) {
+                        true
                     } else {
                         _productList.value = productsInDb
+                        viewState.isRefreshing
                     }
+                    viewState = viewState.copy(isSkeletonShown = showSkeleton, isEmptyViewVisible = false)
                 }
 
                 fetchProductList(loadMore = loadMore)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -138,7 +138,8 @@ class ProductListViewModel @AssistedInject constructor(
                 delay(SEARCH_TYPING_DELAY_MS)
                 viewState = viewState.copy(
                         isLoadingMore = loadMore,
-                        isSkeletonShown = !loadMore
+                        isSkeletonShown = !loadMore,
+                        isEmptyViewVisible = false
                 )
                 fetchProductList(viewState.query, loadMore)
             }
@@ -153,7 +154,7 @@ class ProductListViewModel @AssistedInject constructor(
                     // them immediately, otherwise make sure the skeleton shows
                     val productsInDb = productRepository.getProductList()
                     if (productsInDb.isEmpty()) {
-                        viewState = viewState.copy(isSkeletonShown = true)
+                        viewState = viewState.copy(isSkeletonShown = true, isEmptyViewVisible = false)
                     } else {
                         _productList.value = productsInDb
                     }
@@ -186,10 +187,6 @@ class ProductListViewModel @AssistedInject constructor(
 
     private suspend fun fetchProductList(searchQuery: String? = null, loadMore: Boolean = false) {
         if (networkStatus.isConnected()) {
-            viewState = viewState.copy(
-                    isEmptyViewVisible = false,
-                    isSkeletonShown = true
-            )
             if (searchQuery.isNullOrEmpty()) {
                 _productList.value = productRepository.fetchProductList(loadMore)
             } else {


### PR DESCRIPTION
Closes #1908 - prior to this PR the product list would always show the loading skeleton when it refreshes, which was annoying because the list always refreshes when returning from product detail. This PR changes this so the skeleton only appears when there are no cached products, or the user performed a pull-to-refresh.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
