### PR TITLE
Updated material components to 1.1.0 release version

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -125,7 +125,7 @@ dependencies {
     implementation "androidx.recyclerview:recyclerview:1.1.0"
     implementation "androidx.multidex:multidex:2.0.1"
     implementation "androidx.appcompat:appcompat:1.1.0"
-    implementation "com.google.android.material:material:1.1.0-rc01"
+    implementation "com.google.android.material:material:1.1.0"
     implementation "androidx.cardview:cardview:1.0.0"
     implementation "androidx.browser:browser:1.0.0"
     implementation "androidx.preference:preference:1.1.0"


### PR DESCRIPTION
Closes #1910 by updating the material components to the v1.1.0 release version. 

Note that this will be merged into the `darkmode` feature branch rather than `develop` since the v1.1.0 library requires using a material theme, and we didn't do that until the dark mode work. Attempting to update the components in `develop` results in this crash when viewing product inventory info:

```
IllegalArgumentException: The style on this component requires your app theme to be Theme.MaterialComponents (or a descendant).
```

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
