### PR TITLE
Dark Mode: Fix AppBar TabLayout issues - Take 2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -325,12 +325,10 @@ class MainActivity : AppUpgradeActivity(),
         val showUpIcon: Boolean
         val showCrossIcon: Boolean
         val showBottomNav: Boolean
-        val showToolbarShadow: Boolean
         if (isAtRoot) {
             showUpIcon = false
             showCrossIcon = false
             showBottomNav = true
-            showToolbarShadow = true
         } else {
             showUpIcon = true
             showCrossIcon = when (destination.id) {
@@ -357,10 +355,6 @@ class MainActivity : AppUpgradeActivity(),
                     true
                 }
             }
-            showToolbarShadow = when (destination.id) {
-                R.id.issueRefundFragment -> false
-                else -> true
-            }
         }
         supportActionBar?.let { actionBar ->
             actionBar.setDisplayHomeAsUpEnabled(showUpIcon)
@@ -370,12 +364,6 @@ class MainActivity : AppUpgradeActivity(),
                 R.drawable.ic_back_white_24dp
             }
             actionBar.setHomeAsUpIndicator(icon)
-
-            if (showToolbarShadow) {
-                actionBar.elevation = resources.getDimension(R.dimen.appbar_elevation)
-            } else {
-                actionBar.elevation = 0f
-            }
         }
 
         if (showBottomNav) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -169,9 +169,11 @@ class MyStoreFragment : TopLevelFragment(),
     override fun onHiddenChanged(hidden: Boolean) {
         super.onHiddenChanged(hidden)
 
-        // silently refresh if this fragment is no longer hidden
-        if (!isHidden && !isStatsRefreshed) {
-            refreshMyStoreStats(forced = false)
+        if (!isHidden) {
+            if (!isStatsRefreshed) {
+                // silently refresh if this fragment is no longer hidden
+                refreshMyStoreStats(forced = false)
+            }
             addTabLayoutToAppBar(tabLayout)
         } else {
             isStatsRefreshed = false
@@ -185,6 +187,7 @@ class MyStoreFragment : TopLevelFragment(),
         if (!deferInit) {
             refreshMyStoreStats(forced = this.isRefreshPending)
         }
+        addTabLayoutToAppBar(tabLayout)
     }
 
     override fun onStop() {
@@ -326,6 +329,7 @@ class MyStoreFragment : TopLevelFragment(),
     }
 
     override fun onTopEarnerClicked(topEarner: WCTopEarnerModel) {
+        removeTabLayoutFromAppBar(tabLayout)
         (activity as? MainNavigationRouter)?.showProductDetail(topEarner.id)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -160,13 +160,9 @@ class MyStoreFragment : TopLevelFragment(),
         }
     }
 
-    override fun onStart() {
-        super.onStart()
-        addTabLayoutToAppBar(tabLayout)
-    }
-
     override fun onResume() {
         super.onResume()
+        addTabLayoutToAppBar(tabLayout)
         AnalyticsTracker.trackViewShown(this)
     }
 
@@ -364,7 +360,7 @@ class MyStoreFragment : TopLevelFragment(),
 
     private fun addTabLayoutToAppBar(tabLayout: TabLayout) {
         (activity?.findViewById<View>(R.id.app_bar_layout) as? AppBarLayout)?.let { appBar ->
-            if (!isHidden && !appBar.children.contains(tabLayout)) {
+            if (isActive && !appBar.children.contains(tabLayout)) {
                 appBar.addView(
                         tabLayout,
                         LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -192,6 +192,7 @@ class OrderListFragment : TopLevelFragment(),
 
     override fun onResume() {
         super.onResume()
+        addTabLayoutToAppBar(tabLayout)
         AnalyticsTracker.trackViewShown(this)
     }
 
@@ -217,7 +218,6 @@ class OrderListFragment : TopLevelFragment(),
                         tab.select()
                     }
                 }
-        addTabLayoutToAppBar(tabLayout)
 
         listState?.let {
             order_list_view.onFragmentRestoreInstanceState(it)
@@ -770,7 +770,7 @@ class OrderListFragment : TopLevelFragment(),
 
     private fun addTabLayoutToAppBar(tabLayout: TabLayout) {
         (activity?.findViewById<View>(R.id.app_bar_layout) as? AppBarLayout)?.let { appBar ->
-            if (!isHidden && !appBar.children.contains(tabLayout)) {
+            if (isActive && !appBar.children.contains(tabLayout)) {
                 appBar.addView(tabLayout)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -285,16 +285,12 @@ class OrderListFragment : TopLevelFragment(),
     override fun onHiddenChanged(hidden: Boolean) {
         super.onHiddenChanged(hidden)
 
-        if (!hidden) {
-            // silently refresh if this fragment is no longer hidden
-            val isChildFragmentShowing = isChildFragmentShowing()
-            if (!isChildFragmentShowing) {
-                showOptionsMenu(true)
-                addTabLayoutToAppBar(tabLayout)
+        if (isActive) {
+            showOptionsMenu(true)
+            addTabLayoutToAppBar(tabLayout)
 
-                if (isSearching) {
-                    clearSearchResults()
-                }
+            if (isSearching) {
+                clearSearchResults()
             }
         } else {
             removeTabLayoutFromAppBar(tabLayout)


### PR DESCRIPTION
While testing changes for an unrelated feature, I found there were still issues with the tabLayout being added to the Appbar when it shouldn't be. 

## To Reproduce
1. Open an order from the order list screen
2. Minimize the app
3. Bring the app back into the foreground
4. The order list tabs will be erroneously added to the appbar (see below)

<img src="https://user-images.githubusercontent.com/5810477/74074219-654d2f00-49ca-11ea-9cbe-42ca72b22fa0.png" width="350"/>

## The Fix
The fix required the following changes:
- Use `isActive` instead of `!isHidden` to determine if at navigation root since this property takes not only the hidden status of the fragment, but also whether or not a child fragment is active. 
- Move the logic for adding the tablayout to the appbar to the `onResume()` method so the logic for `isActive` works properly. 
- Also removed the logic to show a shadow below the AppBar in `MainActivity`. This causes some visual issues by showing a line between the appbar and the tablayout contained within. The line is visible in the screenshot above. 

## To Test
Follow the same steps in the "To Reproduce" section to ensure the issue is no longer happening. 
