### PR TITLE
Add support for uploading release builds

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -210,8 +210,8 @@ end
   # bundle exec fastlane build_release 
   # bundle exec fastlane build_release skip_confirm:true 
   #####################################################################################
-  desc "Builds and updates for distribution"
-  lane :build_release do | options |
+  desc "Builds and uploads release for distribution"
+  lane :build_and_upload_release do | options |
     android_build_prechecks(skip_confirm: options[:skip_confirm], 
       alpha: false,
       beta: false,
@@ -221,6 +221,25 @@ end
     # Create the file names
     version=android_get_release_version()
     build_bundle(version: version, flavor:"Vanilla")
+
+    version=android_get_release_version()
+
+    project_root = File.dirname(File.expand_path(File.dirname(__FILE__)))
+    aab_file_path = File.join(project_root, "artifacts", "wcandroid-#{ version["name"] }.aab")
+
+    UI.error("Unable to find a build artifact at #{aab_file_path}") unless File.exist? aab_file_path
+
+    upload_to_play_store(
+      package_name: 'com.woocommerce.android',
+      aab: aab_file_path,
+      track: 'production',
+      release_status: 'draft',
+      skip_upload_metadata: true,
+      skip_upload_changelogs: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+      json_key: './google-upload-credentials.json',
+    )
   end
 
   #####################################################################################


### PR DESCRIPTION
Adds support for uploading release builds – this follows https://github.com/woocommerce/woocommerce-android/pull/1857 which added support for beta build uploads.

**To Test:**

_Strategy 1_
1. See that the code is copy/pasted from https://github.com/woocommerce/woocommerce-android/pull/1857. 
2. See that version 3.5 has been published to the Google Play Store using this code
3. Trust the author and approve. [note: this is not recommended]

_Strategy 2_
1. Checkout this branch
2. Change the `WooCommerce/build.gradle` file to use `3.6` and `999` as the `versionName` and `versionCode`, respectively.
3. Run `bundle exec fastlane build_and_upload_release`, and confirm that you want to upload.
4. Wait a while for it to run.
5. Verify that there's a new production release draft created in Google Play.
6. Cleanup: delete the release draft as well as the draft artifact from Google Play. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
