### PR TITLE
Merge 3.6 code freeze into develop

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,6 @@
+3.7
+-----
+ 
 3.6
 -----
 * Fixed a few problems with the new "empty states," such as being cut off on smaller screens in landscape

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -47,9 +47,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "3.5"
+            versionName "3.6-rc-1"
         }
-        versionCode 107
+        versionCode 108
 
         minSdkVersion 21
         targetSdkVersion 29


### PR DESCRIPTION
Merges the 3.6 code freeze into `develop`. 

Includes updated version numbers.