### PR TITLE
Issue/1928 woo log concurrent exception

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,8 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <AndroidXmlCodeStyleSettings>
-      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="STATIC_FIELD_NAME_PREFIX" value="s" />

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -233,7 +233,9 @@ object WooLog {
          */
         fun toHtmlList(): ArrayList<String> {
             val list = ArrayList<String>()
-            for (entry in this) {
+            // work with a copy of the log entries in case they're modified while traversing them
+            val entries = ArrayList<LogEntry>().also { it.addAll(this) }
+            for (entry in entries) {
                 // same colors as WPAndroid
                 val color = when (entry.level) {
                     LogLevel.v -> "grey"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -75,7 +75,7 @@ object WooLog {
      * @param message The message you would like logged.
      */
     fun v(tag: T, message: String) {
-        Log.v(TAG + "-" + tag.toString(), message)
+        Log.v("$TAG-$tag", message)
         addEntry(tag, LogLevel.v, message)
     }
 
@@ -86,7 +86,7 @@ object WooLog {
      * @param message The message you would like logged.
      */
     fun d(tag: T, message: String) {
-        Log.d(TAG + "-" + tag.toString(), message)
+        Log.d("$TAG-$tag", message)
         addEntry(tag, LogLevel.d, message)
     }
 
@@ -97,7 +97,7 @@ object WooLog {
      * @param message The message you would like logged.
      */
     fun i(tag: T, message: String) {
-        Log.i(TAG + "-" + tag.toString(), message)
+        Log.i("$TAG-$tag", message)
         addEntry(tag, LogLevel.i, message)
     }
 
@@ -108,7 +108,7 @@ object WooLog {
      * @param message The message you would like logged.
      */
     fun w(tag: T, message: String) {
-        Log.w(TAG + "-" + tag.toString(), message)
+        Log.w("$TAG-$tag", message)
         addEntry(tag, LogLevel.w, message)
     }
 
@@ -119,7 +119,7 @@ object WooLog {
      * @param message The message you would like logged.
      */
     fun e(tag: T, message: String) {
-        Log.e(TAG + "-" + tag.toString(), message)
+        Log.e("$TAG-$tag", message)
         addEntry(tag, LogLevel.e, message)
     }
 
@@ -131,7 +131,7 @@ object WooLog {
      * @param tr An exception to log
      */
     fun e(tag: T, message: String, tr: Throwable) {
-        Log.e(TAG + "-" + tag.toString(), message, tr)
+        Log.e("$TAG-$tag", message, tr)
         addEntry(tag, LogLevel.e, message + " - exception: " + tr.message)
         addEntry(tag, LogLevel.e, "StackTrace: " + getStringStackTrace(tr))
     }
@@ -143,7 +143,7 @@ object WooLog {
      * @param tr An exception to log to get StackTrace
      */
     fun e(tag: T, tr: Throwable) {
-        Log.e(TAG + "-" + tag.toString(), tr.message, tr)
+        Log.e("$TAG-$tag", tr.message, tr)
         addEntry(tag, LogLevel.e, tr.message ?: "")
         addEntry(tag, LogLevel.e, "StackTrace: " + getStringStackTrace(tr))
     }
@@ -163,7 +163,7 @@ object WooLog {
         } else {
             "$volleyErrorMsg, status $statusCode"
         }
-        Log.e(TAG + "-" + tag.toString(), logText)
+        Log.e("$TAG-$tag", logText)
         addEntry(tag, LogLevel.w, logText)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -234,7 +234,7 @@ object WooLog {
         fun toHtmlList(): ArrayList<String> {
             val list = ArrayList<String>()
             // work with a copy of the log entries in case they're modified while traversing them
-            val entries = ArrayList<LogEntry>().also { it.addAll(this) }
+            val entries = mutableListOf<LogEntry>().also { it.addAll(this) }
             for (entry in entries) {
                 // same colors as WPAndroid
                 val color = when (entry.level) {
@@ -254,7 +254,7 @@ object WooLog {
          */
         override fun toString(): String {
             val sb = StringBuilder()
-            val entries = ArrayList<LogEntry>().also { it.addAll(this) }
+            val entries = mutableListOf<LogEntry>().also { it.addAll(this) }
             for (entry in entries) {
                 sb.append("${entry}\n")
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -254,7 +254,8 @@ object WooLog {
          */
         override fun toString(): String {
             val sb = StringBuilder()
-            for (entry in this) {
+            val entries = ArrayList<LogEntry>().also { it.addAll(this) }
+            for (entry in entries) {
                 sb.append("${entry}\n")
             }
             return sb.toString()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -40,7 +40,7 @@ object WooLog {
      * @param message The message you would like logged.
      */
     fun v(tag: T, message: String) {
-        System.out.println("v - " + TAG + "-" + tag.toString() + " - " + message)
+        System.out.println("v - $TAG-$tag - $message")
         addEntry(tag, LogLevel.v, message)
     }
 
@@ -51,7 +51,7 @@ object WooLog {
      * @param message The message you would like logged.
      */
     fun d(tag: T, message: String) {
-        System.out.println("d - " + TAG + "-" + tag.toString() + " - " + message)
+        System.out.println("d - $TAG-$tag - $message")
         addEntry(tag, LogLevel.d, message)
     }
 
@@ -62,7 +62,7 @@ object WooLog {
      * @param message The message you would like logged.
      */
     fun i(tag: T, message: String) {
-        System.out.println("i - " + TAG + "-" + tag.toString() + " - " + message)
+        System.out.println("i - $TAG-$tag - $message")
         addEntry(tag, LogLevel.i, message)
     }
 
@@ -73,7 +73,7 @@ object WooLog {
      * @param message The message you would like logged.
      */
     fun w(tag: T, message: String) {
-        System.out.println("w - " + TAG + "-" + tag.toString() + " - " + message)
+        System.out.println("w - $TAG-$tag - $message")
         addEntry(tag, LogLevel.w, message)
     }
 
@@ -84,7 +84,7 @@ object WooLog {
      * @param message The message you would like logged.
      */
     fun e(tag: T, message: String) {
-        System.out.println("e - " + TAG + "-" + tag.toString() + " - " + message)
+        System.out.println("e - $TAG-$tag - $message")
         addEntry(tag, LogLevel.e, message)
     }
 
@@ -96,7 +96,7 @@ object WooLog {
      * @param tr An exception to log
      */
     fun e(tag: T, message: String, tr: Throwable) {
-        System.out.println("e - " + TAG + "-" + tag.toString() + " - " + message)
+        System.out.println("e - $TAG-$tag - $message")
         System.out.println(tr)
         addEntry(tag, LogLevel.e, message + " - exception: " + tr.message)
         addEntry(tag, LogLevel.e, "StackTrace: " + getStringStackTrace(tr))
@@ -130,7 +130,7 @@ object WooLog {
         } else {
             "$volleyErrorMsg, status $statusCode"
         }
-        System.out.println("e - " + TAG + "-" + tag.toString() + " - " + logText)
+        System.out.println("e - $TAG-$tag - $logText")
         addEntry(tag, LogLevel.w, logText)
     }
 


### PR DESCRIPTION
Resolves #1928 - our application log has apparently had a long-standing bug that could crash the app if a log entry was added while iterating the list of entries. You can easily reproduce this crash by adding the following line [here](https://github.com/woocommerce/woocommerce-android/blob/develop/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt#L245) and then viewing the log:

```
this.add(entry)
```

This PR resolves the concurrency exception by making a copy of the entry list and iterating that instead of the actual list.

As part of this PR, I also converted the log's string formatting to use Kotlin string templates.

Update release notes

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
