### PR TITLE
issue/1781-order-notes-class-cast-exception

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,8 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <AndroidXmlCodeStyleSettings>
-      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="STATIC_FIELD_NAME_PREFIX" value="s" />

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/OrderNotesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/OrderNotesAdapter.kt
@@ -32,9 +32,9 @@ class OrderNotesAdapter : Adapter<OrderNoteViewHolder>() {
 
     override fun onBindViewHolder(holder: OrderNoteViewHolder, position: Int) {
         val isLast = position == notes.size - 1
-        when (holder) {
-            is NoteItemViewHolder -> holder.bind(notes[position] as Note, isLast)
-            is HeaderItemViewHolder -> holder.bind(notes[position] as Header)
+        when (getItemViewType(position)) {
+            ViewType.NOTE.id -> (holder as NoteItemViewHolder).bind(notes[position] as Note, isLast)
+            ViewType.HEADER.id -> (holder as HeaderItemViewHolder).bind(notes[position] as Header)
             else -> throw IllegalArgumentException("Unexpected view holder in OrderNotesAdapter")
         }
     }


### PR DESCRIPTION
Closes #1781 - this is an attempt at fixing a mystery crash in the the order notes adapter. As you can see from [the discussion on the issue](https://github.com/woocommerce/woocommerce-android/issues/1781#issuecomment-581634863), none of us can reproduce the crash nor could we figure out why it's happening.

The change here is to rely on `getItemViewType()` to determine what type of item (a note or a header) is at the current position.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
