### PR TITLE
Merge 3.6 release notes into master

### DIFF
--- a/WooCommerce/metadata/PlayStoreStrings.pot
+++ b/WooCommerce/metadata/PlayStoreStrings.pot
@@ -11,19 +11,18 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_036"
+msgid ""
+"3.6:\n"
+"- You can now create new refunds and view past refunds within the app.\n"
+"- When you’re looking at an empty list, the fancy new images won’t be cut off on smaller screens in landscape mode.\n"
+"- Fixed a bug that emptied the reviews list after rotating the device.\n"
+msgstr ""
+
 msgctxt "release_note_035"
 msgid ""
 "3.5:\n"
 "When you’re just getting started and there’s nothing for the app to display in a list (e.g., for orders and reviews, before you get your first one), you’ll see a friendly message to help you get started.\n"
-msgstr ""
-
-msgctxt "release_note_034"
-msgid ""
-"3.4:\n"
-"- Minor design tweaks to the My Store tab.\n"
-"- Fixed a navigation bug that causing crashes when bringing the app back from background.\n"
-"- Other miscellaneous bug fixes.\n"
-"\n"
 msgstr ""
 
 #. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,1 +1,3 @@
-When you’re just getting started and there’s nothing for the app to display in a list (e.g., for orders and reviews, before you get your first one), you’ll see a friendly message to help you get started.
+- You can now create new refunds and view past refunds within the app.
+- When you’re looking at an empty list, the fancy new images won’t be cut off on smaller screens in landscape mode.
+- Fixed a bug that emptied the reviews list after rotating the device.


### PR DESCRIPTION
Adds the `3.6` release notes to `master` for translation.