### PR TITLE
Invalidate the options menu when returning from review detail

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -317,6 +317,9 @@ class ReviewListFragment : TopLevelFragment(), ItemDecorationListener, ReviewLis
      */
     private fun showOptionsMenu(show: Boolean) {
         setHasOptionsMenu(show)
+        if (show) {
+            activity?.invalidateOptionsMenu()
+        }
     }
 
     private fun handleReviewModerationRequest(request: ProductReviewModerationRequest) {


### PR DESCRIPTION
Fixes #1950 - in both the product list and order list, we were forcing the options menu to be recreated when returning from a child fragment. We neglected to do this for the review list, cause the options menu to disappear in this situation:

* Open the review list
* Tap to view review detail
* Rotate the device
* Return to the review list

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
