### PR TITLE
Dark Mode: Minor Order Detail Products card tweak

### DIFF
--- a/WooCommerce/src/main/res/layout/order_detail_product_list.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_product_list.xml
@@ -12,7 +12,7 @@
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/productList_lblProduct"
-            style="@style/Woo.ListHeader"
+            style="@style/Woo.Card.Header"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/orderdetail_product"
@@ -21,7 +21,7 @@
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/productList_lblQty"
-            style="@style/Woo.ListHeader"
+            style="@style/Woo.Card.Header"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/orderdetail_product_qty"


### PR DESCRIPTION
Updated the style of the card header to match the current design being used for the rest of the cards in the order detail view.

## Before & Afters

![light](https://user-images.githubusercontent.com/5810477/74872045-bb4e9a80-5319-11ea-910f-99481a31c02c.png)

![after](https://user-images.githubusercontent.com/5810477/74872051-bc7fc780-5319-11ea-82b1-11970f2454fc.png)
