### PR TITLE
Dark Mode: Order Status Dialog and Dialog Theme

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,8 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <AndroidXmlCodeStyleSettings>
+      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
+    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="STATIC_FIELD_NAME_PREFIX" value="s" />

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusSelectorDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusSelectorDialog.kt
@@ -1,8 +1,8 @@
 package com.woocommerce.android.ui.orders
 
-import android.app.AlertDialog
 import android.app.Dialog
 import android.os.Bundle
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
@@ -68,7 +68,7 @@ class OrderStatusSelectorDialog : androidx.fragment.app.DialogFragment() {
         } else {
             resources.getString(R.string.orderstatus_select_status)
         }
-        return AlertDialog.Builder(context)
+        return MaterialAlertDialogBuilder(context)
                 .setTitle(title)
                 .setCancelable(true)
                 .setSingleChoiceItems(orderStatusMap.values.toTypedArray(), selectedIndex) { _, which ->

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -14,6 +14,7 @@
     <color name="color_on_primary_high">@color/woo_black</color>
     <color name="color_on_primary_medium">@color/woo_black_90_alpha_060</color>
     <color name="color_on_primary_disabled">@color/woo_black_90_alpha_038</color>
+    <color name="color_on_primary_surface_high">@color/color_on_surface_high</color>
     <color name="color_on_background">@color/woo_white</color>
     <color name="color_on_error">@color/woo_black</color>
     <!--

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -6,6 +6,7 @@
     <color name="color_primary">@color/woo_purple_30</color>
     <color name="color_primary_surface">@color/woo_black_90</color>
     <color name="color_secondary">@color/woo_pink_30</color>
+    <color name="color_error">@color/woo_red_30</color>
     <color name="color_surface">@color/woo_black_90</color>
     <color name="color_on_surface_high">@color/woo_white_alpha_087</color>
     <color name="color_on_surface_medium">@color/woo_white_alpha_060</color>
@@ -14,6 +15,8 @@
     <color name="color_on_primary_medium">@color/woo_black_90_alpha_060</color>
     <color name="color_on_primary_disabled">@color/woo_black_90_alpha_038</color>
     <color name="color_on_primary_surface_high">@color/color_on_surface_high</color>
+    <color name="color_on_background">@color/woo_white</color>
+    <color name="color_on_error">@color/woo_black</color>
     <!--
         App colors
     -->

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -7,6 +7,7 @@
     <color name="color_primary_surface">@color/woo_purple_60</color>
     <color name="color_secondary">@color/woo_pink_50</color>
     <color name="color_surface">@color/woo_white</color>
+    <color name="color_error">@color/woo_red_50</color>
     <color name="color_on_surface_high">@color/woo_black_90_alpha_087</color>
     <color name="color_on_surface_medium">@color/woo_black_90_alpha_060</color>
     <color name="color_on_surface_disabled">@color/woo_black_90_alpha_038</color>
@@ -14,6 +15,9 @@
     <color name="color_on_primary_medium">@color/woo_white_alpha_060</color>
     <color name="color_on_primary_disabled">@color/woo_white_alpha_038</color>
     <color name="color_on_primary_surface_high">@color/color_on_primary_high</color>
+    <color name="color_on_secondary">@color/woo_black</color>
+    <color name="color_on_background">@color/woo_black</color>
+    <color name="color_on_error">@color/woo_white</color>
     <!--
         Custom widget tint
     -->

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -14,6 +14,7 @@
     <color name="color_on_primary_high">@color/woo_white</color>
     <color name="color_on_primary_medium">@color/woo_white_alpha_060</color>
     <color name="color_on_primary_disabled">@color/woo_white_alpha_038</color>
+    <color name="color_on_primary_surface_high">@color/color_on_primary_high</color>
     <color name="color_on_secondary">@color/woo_black</color>
     <color name="color_on_background">@color/woo_black</color>
     <color name="color_on_error">@color/woo_white</color>

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -64,7 +64,7 @@
         <item name="navigationViewStyle">@style/Widget.MaterialComponents.NavigationView</item>
         <item name="toolbarStyle">@style/Widget.Woo.Toolbar</item>
         <item name="chipStyle">@style/Widget.MaterialComponents.Chip.Entry</item>
-        <item name="materialAlertDialogTheme">@style/ThemeOverlay.MaterialComponents.MaterialAlertDialog</item>
+        <item name="materialAlertDialogTheme">@style/Theme.Woo.Dialog</item>
         <item name="tabStyle">@style/Woo.TabLayout</item>
         <item name="scrollableTabStyle">@style/Woo.TabLayout.Scrollable</item>
         <item name="appBarLayoutStyle">@style/Woo.AppBarLayout</item>
@@ -89,5 +89,22 @@
         <!-- TODO: convert styles to material -->
 <!--        <item name="android:listViewStyle"></item>-->
         <item name="autoCompleteTextViewStyle">@style/SearchViewCursor</item>
+    </style>
+
+    <style name="Theme.Woo.Dialog" parent="@style/ThemeOverlay.MaterialComponents.MaterialAlertDialog">
+        <!-- Colors -->
+        <item name="colorPrimary">@color/color_secondary</item>
+        <item name="colorSecondary">@color/color_primary</item>
+
+        <item name="android:colorBackground">@color/default_window_background</item>
+        <item name="colorSurface">@color/color_surface</item>
+        <item name="colorError">@color/color_error</item>
+
+        <item name="colorOnPrimary">@color/color_on_primary_high</item>
+        <item name="colorOnPrimarySurface">@color/color_on_primary_surface_high</item>
+        <item name="colorOnSecondary">@color/color_on_secondary</item>
+        <item name="colorOnBackground">@color/color_on_background</item>
+        <item name="colorOnSurface">@color/color_on_surface_high</item>
+        <item name="colorOnError">@color/color_on_error</item>
     </style>
 </resources>


### PR DESCRIPTION
Fixes #1713 by implementing a new light/dark material theme for dialogs. This is set at the theme level so it will apply to all dialogs that have been converted over to using `MaterialAlertDialogBuilder`. This PR also partially fixes #1587 by converting the order status selector dialog over to using the `MaterialAlertDialogBuilder`.

![order-status-dialog](https://user-images.githubusercontent.com/5810477/74898388-fde29800-5356-11ea-9556-01112fbb7df6.png)


## To Test
- Verify in light and dark themes on API 21, 28 and 29
