### PR TITLE
Dark Mode: Update status bar color for dark version

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,8 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <AndroidXmlCodeStyleSettings>
+      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
+    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="STATIC_FIELD_NAME_PREFIX" value="s" />

--- a/WooCommerce/src/main/res/values-night/themes.xml
+++ b/WooCommerce/src/main/res/values-night/themes.xml
@@ -23,7 +23,7 @@
         <item name="colorOnError">@color/woo_black</item>
 
         <item name="scrimBackground">@color/woo_black_90_alpha_087</item>
-        <item name="android:statusBarColor">@color/woo_black_90_alpha_038</item>
+        <item name="android:statusBarColor">@color/woo_black_900</item>
 
         <item name="elevationOverlayEnabled">true</item>
 

--- a/WooCommerce/src/main/res/values/wc_colors_base.xml
+++ b/WooCommerce/src/main/res/values/wc_colors_base.xml
@@ -36,6 +36,7 @@
     <color name="woo_black_90_alpha_038">#61121212</color>
     <color name="woo_black_90_alpha_060">#99121212</color>
     <color name="woo_black_90_alpha_087">#DE121212</color>
+    <color name="woo_black_900">#272727</color>
 
     <color name="woo_red_5">#FACFD2</color>
     <color name="woo_orange_5">#F7DCC6</color>


### PR DESCRIPTION
Fixes #1945 by setting the status bar color to `#272727` when dark mode is active. 


|Before|After|
|-|-|
|![Screenshot_1582249232](https://user-images.githubusercontent.com/5810477/74996336-86713f00-5410-11ea-849f-b201a5d98780.png)|![Screenshot_1582248932](https://user-images.githubusercontent.com/5810477/74996130-f9c68100-540f-11ea-8231-dea549eedc31.png)|

