### PR TITLE
Modified YYYY to yyyy to fix crash when formatting date in API 21 devices

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
@@ -17,7 +17,7 @@ fun Date.formatToDD(): String = SimpleDateFormat("d", Locale.getDefault()).forma
 
 fun Date.formatToMMMdd(): String = SimpleDateFormat("MMM d", Locale.getDefault()).format(this)
 
-fun Date.formatToMMMddYYYY(): String = SimpleDateFormat("MMM d, YYYY", Locale.getDefault()).format(this)
+fun Date.formatToMMMddYYYY(): String = SimpleDateFormat("MMM d, yyyy", Locale.getDefault()).format(this)
 
 fun Date.formatToEEEEMMMddhha(): String {
     val symbols = DateFormatSymbols(Locale.getDefault())


### PR DESCRIPTION
Fixes #1975. This tiny PR fixes a crash issue that happens in API 21 devices when clicking on a product from the Product list or Order Product list screen.

#### To test
- In an emulator with API 21, click on the `Products` tab.
- Click on any product. Notice the app crashes.
- Pull changes from this PR and verify the app is no longer crashing.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
