### PR TITLE
Issue/1973 product title html entity fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringExt.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.extensions
 
+import org.wordpress.android.util.HtmlUtils
+
 /**
  * If the provided [line] is not null and not empty, then add the string to this instance. Will prepend the
  * [separator] if the current contents of this StringBuilder are not empty.
@@ -12,3 +14,5 @@ fun StringBuilder.appendWithIfNotEmpty(line: String?, separator: String = ", "):
         append(it)
     } ?: this
 }
+
+fun String.fastStripHtml(): String = HtmlUtils.fastStripHtml(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringExt.kt
@@ -29,15 +29,15 @@ fun String.fastStripHtml(): String {
     if (str.isEmpty()) return str
 
     if (str.lastIndexOf("<p") > 0) {
-        str = str.replace("<p(.|\n)*?>", "\n<p>")
+        str = str.replace(Regex("<p(.|\n)*?>"), "\n<p>")
     }
 
     // convert BR tags to line breaks
     if (str.contains("<br")) {
-        str = str.replace("<br(.|\n)*?>", "\n")
+        str = str.replace(Regex("<br(.|\n)*?>"), "\n")
     }
 
-    val htmlString = StringEscapeUtils.unescapeHtml4(str.replace("<(.|\n)*?>", ""))
+    val htmlString = StringEscapeUtils.unescapeHtml4(str.replace(Regex("<(.|\n)*?>"), ""))
     if (htmlString.isEmpty()) return str
 
     var start = 0

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringExt.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android.extensions
 
-import org.wordpress.android.util.HtmlUtils
+import org.apache.commons.text.StringEscapeUtils
 
 /**
  * If the provided [line] is not null and not empty, then add the string to this instance. Will prepend the
@@ -15,4 +15,36 @@ fun StringBuilder.appendWithIfNotEmpty(line: String?, separator: String = ", "):
     } ?: this
 }
 
-fun String.fastStripHtml(): String = HtmlUtils.fastStripHtml(this)
+/**
+ * This is much faster than Html.fromHtml but should only be used when we know the html is valid
+ * since the regex will be unpredictable with invalid html
+ * String param containing only valid html
+ * @return String without HTML
+ *
+ * Replicated from HtmlUtils.fastStripHtml and HtmlUtils.trimStart
+ */
+fun String.fastStripHtml(): String {
+    // insert a line break before P tags unless the only one is at the start
+    var str = this
+    if (str.isEmpty()) return str
+
+    if (str.lastIndexOf("<p") > 0) {
+        str = str.replace("<p(.|\n)*?>", "\n<p>")
+    }
+
+    // convert BR tags to line breaks
+    if (str.contains("<br")) {
+        str = str.replace("<br(.|\n)*?>", "\n")
+    }
+
+    val htmlString = StringEscapeUtils.unescapeHtml4(str.replace("<(.|\n)*?>", ""))
+    if (htmlString.isEmpty()) return str
+
+    var start = 0
+    while (start != 0 && (Character.isWhitespace(htmlString[start]) || htmlString[start].toInt() == 160)) {
+        start++
+    }
+
+    // use regex to strip tags, then convert entities in the result
+    return htmlString.substring(start)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus.PENDING
 import org.wordpress.android.util.DateTimeUtils
+import org.wordpress.android.util.HtmlUtils
 import java.math.BigDecimal
 import java.util.Date
 
@@ -150,7 +151,7 @@ fun WCOrderModel.toAppModel(): Order {
                         Item(
                                 it.id!!,
                                 it.productId!!,
-                                it.name ?: "",
+                                HtmlUtils.fastStripHtml(it.name) ?: "",
                                 it.price?.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
                                 it.sku ?: "",
                                 it.quantity?.toInt() ?: 0,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.model
 
 import android.os.Parcelable
+import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.roundError
 import com.woocommerce.android.model.Order.Address
 import com.woocommerce.android.model.Order.Address.Type.BILLING
@@ -14,7 +15,6 @@ import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus.PENDING
 import org.wordpress.android.util.DateTimeUtils
-import org.wordpress.android.util.HtmlUtils
 import java.math.BigDecimal
 import java.util.Date
 
@@ -151,7 +151,7 @@ fun WCOrderModel.toAppModel(): Order {
                         Item(
                                 it.id!!,
                                 it.productId!!,
-                                HtmlUtils.fastStripHtml(it.name) ?: "",
+                                it.name?.fastStripHtml() ?: "",
                                 it.price?.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
                                 it.sku ?: "",
                                 it.quantity?.toInt() ?: 0,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.model
 
 import android.os.Parcelable
+import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.formatDateToISO8601Format
 import com.woocommerce.android.extensions.roundError
 import com.woocommerce.android.ui.products.ProductBackorderStatus
@@ -10,7 +11,6 @@ import com.woocommerce.android.ui.products.ProductType
 import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.util.DateTimeUtils
-import org.wordpress.android.util.HtmlUtils
 import java.math.BigDecimal
 import java.util.Date
 
@@ -83,7 +83,7 @@ data class Product(
                 sku == product.sku &&
                 type == product.type &&
                 numVariations == product.numVariations &&
-                name == product.name &&
+                name.fastStripHtml() == product.name.fastStripHtml() &&
                 description == product.description &&
                 images == product.images
     }
@@ -130,7 +130,7 @@ fun Product.toDataModel(storedProductModel: WCProductModel?): WCProductModel {
 fun WCProductModel.toAppModel(): Product {
     return Product(
         this.remoteProductId,
-        HtmlUtils.fastStripHtml(this.name),
+        this.name,
         this.description,
         ProductType.fromString(this.type),
         ProductStatus.fromString(this.status),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.ui.products.ProductType
 import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.util.DateTimeUtils
+import org.wordpress.android.util.HtmlUtils
 import java.math.BigDecimal
 import java.util.Date
 
@@ -129,7 +130,7 @@ fun Product.toDataModel(storedProductModel: WCProductModel?): WCProductModel {
 fun WCProductModel.toAppModel(): Product {
     return Product(
         this.remoteProductId,
-        this.name,
+        HtmlUtils.fastStripHtml(this.name),
         this.description,
         ProductType.fromString(this.type),
         ProductStatus.fromString(this.status),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -26,6 +26,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_SH
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_UPDATE_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_VIEW_AFFILIATE_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_VIEW_EXTERNAL_TAPPED
+import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.formatToMMMdd
 import com.woocommerce.android.extensions.formatToMMMddYYYY
 import com.woocommerce.android.extensions.takeIfNotEqualTo
@@ -179,7 +180,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         if (!isAdded) return
 
         val product = requireNotNull(productData.product)
-        val productName = product.name
+        val productName = product.name.fastStripHtml()
         productTitle = when (product.type) {
             EXTERNAL -> getString(R.string.product_name_external, productName)
             GROUPED -> getString(R.string.product_name_grouped, productName)
@@ -237,7 +238,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         val product = requireNotNull(productData.product)
 
         if (isAddEditProductRelease1Enabled(product.type)) {
-            addEditableView(DetailCard.Primary, R.string.product_detail_title_hint, product.name)?.also { view ->
+            addEditableView(DetailCard.Primary, R.string.product_detail_title_hint, productTitle)?.also { view ->
                 view.setOnTextChangedListener { viewModel.updateProductDraft(title = it.toString()) }
             }
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -179,7 +179,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         if (!isAdded) return
 
         val product = requireNotNull(productData.product)
-        val productName = HtmlUtils.fastStripHtml(product.name)
+        val productName = product.name
         productTitle = when (product.type) {
             EXTERNAL -> getString(R.string.product_name_external, productName)
             GROUPED -> getString(R.string.product_name_grouped, productName)


### PR DESCRIPTION
Fixes #1973 by striping html entities from product title in Product Detail, Order Detail and Order Fulfilment screen. 

#### Changes
I had previously added logic to strip html entity from product title inside the `Product` model. But this was causing `ProductDetailViewModelTest` to fail. Evidently, if we use `TextUtils` in code and try to unit test that, it results in an error: `Method ... not mocked`.   
More details on that here: https://developer.android.com/training/testing/unit-testing/local-unit-tests.html#error-not-mocked

We can either, as the above link suggests, add the below line to our `build.gradle`. But google doesn't recommend doing that unless it's a last resort.:
```
...
  testOptions {
    unitTests.returnDefaultValues = true
  }
```
Another option would be to use our own `TextUtils` class just so it is unit testable. This change will need to be made in the WordPress Text util lib. 

A third option is to convert the method `HtmlUtils.stripFastHtml` to kotlin and use it as our own extension. I went with this option in this PR but would like to get a second opinion from the reviewer before proceeding forward with the PR :) I'm open to other options as well :) 

#### Testing
- Test updating an existing product.
- Test adding a product title for an unnamed product.
- Test removing product title for an existing product.
- Verify that HTML is stripped from Product Detail, Order Detail and Order Fulfilment

### Screenshots
#### Product Detail
(LEFT: Before. RIGHT: After)
<img width="300" src="https://user-images.githubusercontent.com/22608780/75007767-21fbc180-549c-11ea-96a4-7f546265045c.png">. <img width="300" src="https://user-images.githubusercontent.com/22608780/75007761-1f996780-549c-11ea-9c65-753dd33a2cc0.png">

#### Order Detail
<img width="300" src="https://user-images.githubusercontent.com/22608780/75009526-e4e5fe00-54a0-11ea-8d0f-cbab1da4347e.png">. <img width="300" src="https://user-images.githubusercontent.com/22608780/75009519-e1eb0d80-54a0-11ea-87b0-fe2a3138f5d7.png">

#### Order Fulfilment
<img width="300" src="https://user-images.githubusercontent.com/22608780/75009650-31c9d480-54a1-11ea-9b93-799ce4a23d7f.png">. <img width="300" src="https://user-images.githubusercontent.com/22608780/75009594-152d9c80-54a1-11ea-807b-d203dc238147.png">

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
