### PR TITLE
issue/1986-image-viewer-toolbar-after-delete

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/imageviewer/ImageViewerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/imageviewer/ImageViewerActivity.kt
@@ -262,10 +262,11 @@ class ImageViewerActivity : AppCompatActivity(), ImageViewerListener {
                 override fun onAnimationEnd(animation: Animator) {
                     remoteMediaId = newMediaId
                     viewModel.removeProductImage(currentMediaId)
-                    // activity will finish if we removed the last image, so only scale back in
+                    // activity will finish if we removed the last image, so only scale back in and show toolbar
                     // if there are more images
                     if (newImageCount > 0) {
                         WooAnimUtils.scaleIn(viewPager)
+                        showToolbar(true)
                     }
                 }
             })


### PR DESCRIPTION
Fixes #1986 - after deleting a product image from the full-screen image viewer, the toolbar may quickly fade out. This is annoying when you want to delete the next image because you're forced to tap the image to make the toolbar re-appear.

This PR resolves this by making sure the toolbar re-appears after deleting an image.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
