### PR TITLE
Issue/1955 negative revenue stats

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 3.7
 -----
+* Added support to display negative revenue in our new stats screen!
  
 3.6
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -341,6 +341,7 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
             with(axisLeft) {
                 labelCount = 3
                 valueFormatter = RevenueAxisFormatter()
+                spaceBottom = resources.getDimension(R.dimen.chart_axis_bottom_padding)
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -164,13 +164,6 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
         return context.resources.getDimensionPixelSize(resId)
     }
 
-    private fun getAxisOffset(): Float {
-        return if (activeGranularity == StatsGranularity.DAYS ||
-                activeGranularity == StatsGranularity.MONTHS) {
-            1f
-        } else 0.5f
-    }
-
     private fun getBarLabelCount(): Int {
         val resId = when (activeGranularity) {
             StatsGranularity.DAYS -> R.integer.stats_label_count_days
@@ -204,13 +197,6 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
                 setDrawGridLines(true)
                 gridColor = ContextCompat.getColor(context, R.color.wc_border_color)
                 setLabelCount(3, true)
-
-                valueFormatter = IAxisValueFormatter { value, _ ->
-                    // Only use non-zero values for the axis
-                    value.toDouble().takeIf { it > 0 }?.let {
-                        getFormattedRevenueValue(it)
-                    }.orEmpty()
-                }
             }
 
             description.isEnabled = false
@@ -389,11 +375,11 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
             with(xAxis) {
                 // Added axis minimum offset & axis max offset in order to align the bar chart with the x-axis labels
                 // Related fix: https://github.com/PhilJay/MPAndroidChart/issues/2566
-                val axisValue = getAxisOffset()
+                val axisValue = 0.5f
                 axisMinimum = data.xMin - axisValue
                 axisMaximum = data.xMax + axisValue
                 labelCount = getBarLabelCount()
-                setCenterAxisLabels(activeGranularity == StatsGranularity.YEARS)
+                setCenterAxisLabels(false)
                 valueFormatter = StartEndDateAxisFormatter()
             }
         }
@@ -541,7 +527,7 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
     private inner class StartEndDateAxisFormatter : IAxisValueFormatter {
         override fun getFormattedValue(value: Float, axis: AxisBase): String {
             var index = round(value).toInt() - 1
-            index = if (index == -1 || activeGranularity == StatsGranularity.YEARS) index + 1 else index
+            index = if (index == -1) index + 1 else index
             return if (index > -1 && index < chartRevenueStats.keys.size) {
                 // if this is the first entry in the chart, then display the month as well as the date
                 // for weekly and monthly stats

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -192,11 +192,12 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
 
             axisRight.isEnabled = false
             with(axisLeft) {
-                setDrawZeroLine(false)
+                setDrawZeroLine(true)
+                setDrawTopYLabelEntry(true)
                 setDrawAxisLine(false)
                 setDrawGridLines(true)
+                zeroLineColor = ContextCompat.getColor(context, R.color.wc_border_color)
                 gridColor = ContextCompat.getColor(context, R.color.wc_border_color)
-                setLabelCount(3, true)
             }
 
             description.isEnabled = false
@@ -366,8 +367,6 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
 
         val duration = context.resources.getInteger(android.R.integer.config_shortAnimTime)
         with(chart) {
-            axisLeft.axisMinimum = minRevenue
-            axisRight.axisMinimum = 0f
             data = BarData(dataSet)
             if (wasEmpty) {
                 animateY(duration)
@@ -381,6 +380,11 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
                 labelCount = getBarLabelCount()
                 setCenterAxisLabels(false)
                 valueFormatter = StartEndDateAxisFormatter()
+            }
+            with(axisLeft) {
+                labelCount = 3
+                setCenterAxisLabels(false)
+                valueFormatter = RevenueAxisFormatter()
             }
         }
 
@@ -568,6 +572,21 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
                 dateString.formatToMonthDateOnly()
             } else {
                 dateString.formatToDateOnly()
+            }
+        }
+    }
+
+    /**
+     * Custom AxisFormatter for the Y-axis which only displays 3 labels:
+     * the maximum, minimum and 0 value labels
+     */
+    private inner class RevenueAxisFormatter : IAxisValueFormatter {
+        override fun getFormattedValue(value: Float, axis: AxisBase): String {
+            return when (value) {
+                0f -> value.toInt().toString()
+                axis.mEntries.first() -> getFormattedRevenueValue(value.toDouble())
+                axis.mEntries.max() -> getFormattedRevenueValue(value.toDouble())
+                else -> ""
             }
         }
     }

--- a/WooCommerce/src/main/res/values/dimens.xml
+++ b/WooCommerce/src/main/res/values/dimens.xml
@@ -113,6 +113,7 @@
         Default Chart
     -->
     <dimen name="chart_height">200dp</dimen>
+    <dimen name="chart_axis_bottom_padding">4dp</dimen>
 
     <!--
         Login


### PR DESCRIPTION
Fixes #1955. This PR adds the following changes to the new stats UI. 

- Modifies the label count of y-axis to 3 and removes logic to NOT display labels with revenue <= 0.
- Right align the x-axis labels so there's enough space in between the x-axis and y-axis labels.

#### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/22608780/75131807-992e9100-56fa-11ea-819a-44299a875c4b.png">. <img width="300" src="https://user-images.githubusercontent.com/22608780/75131845-b4010580-56fa-11ea-9d43-ea0b749fca9a.png">. <img width="300" src="https://user-images.githubusercontent.com/22608780/75131867-c67b3f00-56fa-11ea-97f3-a4434513a9c4.png">. <img width="300" src="https://user-images.githubusercontent.com/22608780/75131868-c9762f80-56fa-11ea-988d-ea0f705c784a.png"> 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
