### PR TITLE
Dark Mode: Shipment Tracking configuration views

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,8 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <AndroidXmlCodeStyleSettings>
-      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="STATIC_FIELD_NAME_PREFIX" value="s" />

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dialog/CustomDiscardDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dialog/CustomDiscardDialog.kt
@@ -1,8 +1,9 @@
 package com.woocommerce.android.ui.dialog
 
 import android.app.Activity
-import android.app.AlertDialog
 import android.content.DialogInterface.OnClickListener
+import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.woocommerce.android.R.string
 import java.lang.ref.WeakReference
 
@@ -24,7 +25,7 @@ object CustomDiscardDialog {
             return
         }
 
-        val builder = AlertDialog.Builder(activity)
+        val builder = MaterialAlertDialogBuilder(activity)
                 .setMessage(activity.applicationContext.getString(string.discard_message))
                 .setCancelable(true)
                 .setPositiveButton(string.discard, posBtnAction)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderShipmentTrackingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderShipmentTrackingFragment.kt
@@ -74,7 +74,7 @@ class AddOrderShipmentTrackingFragment : BaseFragment(), AddOrderShipmentTrackin
         if (savedInstanceState != null) {
             isSelectedProviderCustom = savedInstanceState.getBoolean(FIELD_IS_CUSTOM_PROVIDER, false)
             addTracking_number.setText(savedInstanceState.getString(FIELD_ORDER_TRACKING_NUMBER, ""))
-            addTracking_date.text = savedInstanceState.getString(FIELD_ORDER_TRACKING_DATE_SHIPPED)
+            addTracking_date.setText(savedInstanceState.getString(FIELD_ORDER_TRACKING_DATE_SHIPPED, ""))
             addTracking_custom_provider_name.setText(
                     savedInstanceState.getString(FIELD_ORDER_TRACKING_CUSTOM_PROVIDER_NAME, "")
             )
@@ -95,10 +95,10 @@ class AddOrderShipmentTrackingFragment : BaseFragment(), AddOrderShipmentTrackin
         } ?: navArgs.orderTrackingProvider
         if (isCustomProvider()) {
             addTracking_custom_provider_name.setText(selectedCarrierName)
-            addTracking_editCarrier.text = getString(R.string.order_shipment_tracking_custom_provider_section_name)
+            addTracking_editCarrier.setText(getString(R.string.order_shipment_tracking_custom_provider_section_name))
             showCustomProviderFields()
         } else {
-            addTracking_editCarrier.text = selectedCarrierName
+            addTracking_editCarrier.setText(selectedCarrierName)
             hideCustomProviderFields()
         }
 
@@ -300,11 +300,11 @@ class AddOrderShipmentTrackingFragment : BaseFragment(), AddOrderShipmentTrackin
     }
 
     override fun onTrackingProviderSelected(selectedCarrierName: String) {
-        addTracking_editCarrier.text = selectedCarrierName
+        addTracking_editCarrier.setText(selectedCarrierName)
         addTracking_editCarrier.error = null
         addTracking_editCarrier.isFocusableInTouchMode = false
         addTracking_editCarrier.isFocusable = false
-        isSelectedProviderCustom = addTracking_editCarrier.text ==
+        isSelectedProviderCustom = addTracking_editCarrier.text.toString() ==
                 getString(R.string.order_shipment_tracking_custom_provider_section_name)
         // Display custom provider fields only if selectedCarrierName = custom provider
         if (isCustomProvider()) {
@@ -330,10 +330,10 @@ class AddOrderShipmentTrackingFragment : BaseFragment(), AddOrderShipmentTrackin
 
     private fun displayFormatDateShippedText(dateString: String) {
         context?.let {
-            addTracking_date.text = DateUtils.getLocalizedLongDateString(
+            addTracking_date.setText(DateUtils.getLocalizedLongDateString(
                     it,
                     dateString
-            )
+            ))
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderShipmentTrackingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderShipmentTrackingFragment.kt
@@ -170,29 +170,27 @@ class AddOrderShipmentTrackingFragment : BaseFragment(), AddOrderShipmentTrackin
         return when (item.itemId) {
             R.id.menu_add -> {
                 if (addTracking_editCarrier.text.toString().isEmpty()) {
-                    addTracking_editCarrier.isFocusableInTouchMode = true
-                    addTracking_editCarrier.requestFocus()
-                    addTracking_editCarrier.error = getString(R.string.order_shipment_tracking_empty_provider)
-                    addTracking_number.error = null
-                    addTracking_custom_provider_name.error = null
+                    addTracking_carrierLayout.error = getString(R.string.order_shipment_tracking_empty_provider)
+                    addTracking_numberLayout.error = null
+                    addTracking_customNameLayout.error = null
                     return true
                 }
 
                 if (isCustomProvider() && addTracking_custom_provider_name.text.toString().isEmpty()) {
                     addTracking_number.error = null
-                    addTracking_editCarrier.error = null
+                    addTracking_carrierLayout.error = null
                     addTracking_custom_provider_name.requestFocus()
-                    addTracking_custom_provider_name.error = getString(
+                    addTracking_customNameLayout.error = getString(
                             R.string.order_shipment_tracking_empty_custom_provider_name
                     )
                     return true
                 }
 
                 if (addTracking_number.text.isNullOrEmpty()) {
-                    addTracking_editCarrier.error = null
-                    addTracking_custom_provider_name.error = null
+                    addTracking_carrierLayout.error = null
+                    addTracking_customNameLayout.error = null
                     addTracking_number.requestFocus()
-                    addTracking_number.error = getString(R.string.order_shipment_tracking_empty_tracking_num)
+                    addTracking_numberLayout.error = getString(R.string.order_shipment_tracking_empty_tracking_num)
                     return true
                 }
 
@@ -338,12 +336,12 @@ class AddOrderShipmentTrackingFragment : BaseFragment(), AddOrderShipmentTrackin
     }
 
     private fun showCustomProviderFields() {
-        addTracking_custom_provider_name_view.visibility = View.VISIBLE
-        addTracking_custom_provider_url_view.visibility = View.VISIBLE
+        addTracking_customNameLayout.visibility = View.VISIBLE
+        addTracking_customUrlLayout.visibility = View.VISIBLE
     }
 
     private fun hideCustomProviderFields() {
-        addTracking_custom_provider_name_view.visibility = View.GONE
-        addTracking_custom_provider_url_view.visibility = View.GONE
+        addTracking_customNameLayout.visibility = View.GONE
+        addTracking_customUrlLayout.visibility = View.GONE
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderTrackingProviderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderTrackingProviderListFragment.kt
@@ -167,7 +167,7 @@ class AddOrderTrackingProviderListFragment : DialogFragment(), AddOrderTrackingP
 
     override fun showSkeleton(show: Boolean) {
         if (show) {
-            skeletonView.show(providersView, R.layout.skeleton_order_list, delayed = true)
+            skeletonView.show(providersView, R.layout.skeleton_tracking_provider_list, delayed = true)
         } else {
             skeletonView.hide()
         }

--- a/WooCommerce/src/main/res/drawable/ic_done_secondary.xml
+++ b/WooCommerce/src/main/res/drawable/ic_done_secondary.xml
@@ -1,5 +1,5 @@
 <vector android:height="24dp"
-    android:tint="#96588A" android:viewportHeight="24.0"
+    android:tint="@color/color_secondary" android:viewportHeight="24.0"
     android:viewportWidth="24.0" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="#FF000000" android:pathData="M9,16.2L4.8,12l-1.4,1.4L9,19 21,7l-1.4,-1.4L9,16.2z"/>
 </vector>

--- a/WooCommerce/src/main/res/layout/dialog_order_tracking_provider_list.xml
+++ b/WooCommerce/src/main/res/layout/dialog_order_tracking_provider_list.xml
@@ -1,30 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                                                   xmlns:app="http://schemas.android.com/apk/res-auto"
-                                                   xmlns:tools="http://schemas.android.com/tools"
-                                                   android:id="@+id/snack_root"
-                                                   android:layout_width="match_parent"
-                                                   android:layout_height="match_parent"
-                                                   tools:context="com.woocommerce.android.ui.orders.AddOrderTrackingProviderListFragment">
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/snack_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context="com.woocommerce.android.ui.orders.AddOrderTrackingProviderListFragment">
 
-    <include
-        android:id="@+id/toolbar"
-        layout="@layout/view_toolbar"/>
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar">
 
+        <include
+            layout="@layout/view_toolbar"
+            android:id="@+id/toolbar"/>
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <!--
+        This container is necessary for displaying the loading skeleton
+    -->
     <LinearLayout
         android:id="@+id/providersView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:orientation="vertical"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/toolbar">
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/addTrackingProviderList"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"/>
+            android:layout_height="wrap_content"
+            tools:listitem="@layout/dialog_order_tracking_provider_list_item"
+            tools:itemCount="3"/>
     </LinearLayout>
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/dialog_order_tracking_provider_list_header.xml
+++ b/WooCommerce/src/main/res/layout/dialog_order_tracking_provider_list_header.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TextView
+<com.google.android.material.textview.MaterialTextView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/providerListHeader"
-    style="@style/Woo.Dialog.ProviderList.Header"
+    style="@style/Woo.ListHeader"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"/>
+    android:layout_height="wrap_content"
+    tools:text="United Stats" />

--- a/WooCommerce/src/main/res/layout/dialog_order_tracking_provider_list_item.xml
+++ b/WooCommerce/src/main/res/layout/dialog_order_tracking_provider_list_item.xml
@@ -1,40 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.cardview.widget.CardView
+<com.google.android.material.card.MaterialCardView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    style="@style/Woo.ListItem"
+    style="@style/Woo.Card.WithoutPadding"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    app:cardElevation="0dp">
+    android:layout_height="wrap_content">
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        style="@style/Woo.ListItem"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="?attr/selectableItemBackground"
-        android:paddingBottom="@dimen/card_padding_bottom"
-        android:paddingTop="@dimen/card_padding_top">
+        android:layout_height="wrap_content">
 
-        <TextView
+        <com.google.android.material.textview.MaterialTextView
             android:id="@+id/addShipmentTrackingProviderListItem_name"
-            style="@style/Woo.TextAppearance.Title.Large"
+            style="@style/Woo.ListItem.Title"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_margin="@dimen/default_padding"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintRight_toLeftOf="@+id/addShipmentTrackingProviderListItem_tick"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            tools:text="Canada Post"/>
+            tools:text="Canada Post" />
 
-        <RadioButton
+        <com.google.android.material.radiobutton.MaterialRadioButton
             android:id="@+id/addShipmentTrackingProviderListItem_tick"
-            android:layout_width="wrap_content"
+            style="@style/Woo.Button.Toggle"
+            android:layout_width="@dimen/min_tap_target"
             android:layout_height="wrap_content"
-            android:background="@drawable/ic_done_purple_24dp"
-            android:button="@null"
             android:contentDescription="@string/order_shipment_tracking_provider_list_item"
+            android:button="@null"
+            android:drawableEnd="@drawable/ic_done_secondary"
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
@@ -42,4 +37,4 @@
             tools:visibility="visible"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-</androidx.cardview.widget.CardView>
+</com.google.android.material.card.MaterialCardView>

--- a/WooCommerce/src/main/res/layout/fragment_add_order_note.xml
+++ b/WooCommerce/src/main/res/layout/fragment_add_order_note.xml
@@ -33,16 +33,14 @@
 
             <EditText
                 android:id="@+id/addNote_editor"
-                style="@style/Woo.EditText.Subtitle1"
+                style="@style/Woo.EditText"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:textAlignment="viewStart"
                 android:gravity="top|start"
-                android:background="@null"
                 android:hint="@string/orderdetail_note_hint"
                 android:importantForAutofill="no"
                 android:inputType="textAutoComplete|textMultiLine|textCapSentences"
-                tools:text="This is at test order note. This is only a test. IF this were a real order note it'd contain something worth reading."/>
+                tools:text="This is at test order note. This is only a test. IF this were a real order note it'd contain something worth reading." />
         </LinearLayout>
     </com.google.android.material.card.MaterialCardView>
 

--- a/WooCommerce/src/main/res/layout/fragment_add_shipment_tracking.xml
+++ b/WooCommerce/src/main/res/layout/fragment_add_shipment_tracking.xml
@@ -5,183 +5,106 @@
     android:id="@+id/scroll_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fillViewport="true"
     tools:context="com.woocommerce.android.ui.orders.AddOrderShipmentTrackingFragment">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <com.google.android.material.card.MaterialCardView
         android:id="@+id/snack_root"
+        style="@style/Woo.Card"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@color/default_window_background">
+        android:layout_height="wrap_content">
 
         <LinearLayout
             android:id="@+id/addTracking_editContainer"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_alignWithParentIfMissing="true"
-            android:background="@color/white"
-            android:focusable="true"
-            android:focusableInTouchMode="true"
             android:orientation="vertical"
-            android:padding="@dimen/margin_large"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            android:layout_marginTop="@dimen/minor_100"
+            android:layout_marginBottom="@dimen/minor_100">
 
             <!-- Select provider view -->
-            <TextView
-                android:id="@+id/addTracking_carrier_label"
-                style="@style/Woo.TextAppearance"
+            <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/order_shipment_tracking_carrier_label"/>
+                android:hint="@string/order_shipment_tracking_carrier_label">
 
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/addTracking_editCarrier"
-                style="@style/Woo.OrderTracking.Add.EditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="?android:attr/selectableItemBackground"
-                android:backgroundTint="@color/list_divider"
-                android:gravity="top"
-                android:hint="@string/order_shipment_tracking_provider_hint"
-                android:minHeight="0dp"
-                android:paddingBottom="@dimen/default_padding"
-                android:paddingEnd="0dp"
-                android:paddingLeft="0dp"
-                android:paddingRight="0dp"
-                android:paddingStart="0dp"
-                android:paddingTop="@dimen/default_padding"/>
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/addTracking_editCarrier"
+                    style="@style/Woo.EditText.Subtitle1"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:editable="false"
+                    android:focusable="false"/>
 
-            <View
-                android:id="@+id/addTracking_editCarrierDivider"
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_marginBottom="@dimen/margin_large"
-                android:background="@color/list_divider"/>
+            </com.google.android.material.textfield.TextInputLayout>
 
             <!-- Add custom provider name view -only visible if custom provider is selected -->
-            <androidx.constraintlayout.widget.ConstraintLayout
+            <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/addTracking_custom_provider_name_view"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:visibility="gone"
+                android:hint="@string/order_shipment_tracking_custom_provider_name_label"
                 tools:visibility="visible">
-
-                <TextView
-                    android:id="@+id/addTracking_custom_provider_name_label"
-                    style="@style/Woo.TextAppearance"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_medium"
-                    android:text="@string/order_shipment_tracking_custom_provider_name_label"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"/>
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/addTracking_custom_provider_name"
+                    style="@style/Woo.EditText.Subtitle1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/margin_medium"
-                    android:gravity="top"
-                    android:hint="@string/order_shipment_tracking_custom_provider_name_hint"
                     android:inputType="text"
-                    android:maxLength="@integer/max_length_tracking_number"
                     android:nextFocusForward="@+id/addTracking_number"
-                    android:paddingBottom="@dimen/margin_extra_large"
-                    android:theme="@style/Woo.OrderTracking.Add.EditText"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/addTracking_custom_provider_name_label"/>
+                    android:maxLength="@integer/max_length_tracking_number" />
 
-            </androidx.constraintlayout.widget.ConstraintLayout>
+            </com.google.android.material.textfield.TextInputLayout>
 
             <!-- Add tracking number view -->
-            <TextView
-                android:id="@+id/addTracking_number_label"
-                style="@style/Woo.TextAppearance"
+            <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_medium"
-                android:text="@string/order_shipment_tracking_number_label"/>
+                android:hint="@string/order_shipment_tracking_number_label">
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/addTracking_number"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/margin_medium"
-                android:gravity="top"
-                android:hint="@string/order_shipment_tracking_number_hint"
-                android:inputType="text"
-                android:maxLength="@integer/max_length_tracking_number"
-                android:paddingBottom="@dimen/margin_extra_large"
-                android:theme="@style/Woo.OrderTracking.Add.EditText"/>
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/addTracking_number"
+                    style="@style/Woo.EditText.Subtitle1"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="text"
+                    android:maxLength="@integer/max_length_tracking_number" />
+
+            </com.google.android.material.textfield.TextInputLayout>
 
             <!-- Add custom provider tracking url view -only visible if custom provider is selected -->
-            <androidx.constraintlayout.widget.ConstraintLayout
+            <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/addTracking_custom_provider_url_view"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:visibility="gone"
-                tools:visibility="visible">
-
-                <TextView
-                    android:id="@+id/addTracking_custom_provider_url_label"
-                    style="@style/Woo.TextAppearance"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_medium"
-                    android:text="@string/order_shipment_tracking_custom_provider_url_label"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"/>
+                android:hint="@string/order_shipment_tracking_custom_provider_url_label">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/addTracking_custom_provider_url"
+                    style="@style/Woo.EditText.Subtitle1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/margin_medium"
-                    android:gravity="top"
-                    android:hint="@string/order_shipment_tracking_custom_provider_url_hint"
                     android:inputType="textUri"
-                    android:maxLength="@integer/max_length_tracking_number"
-                    android:paddingBottom="@dimen/margin_extra_large"
-                    android:theme="@style/Woo.OrderTracking.Add.EditText"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/addTracking_custom_provider_url_label"/>
+                    android:maxLength="@integer/max_length_tracking_number"/>
 
-            </androidx.constraintlayout.widget.ConstraintLayout>
+            </com.google.android.material.textfield.TextInputLayout>
 
             <!-- Select date shipped view -->
-            <TextView
-                android:id="@+id/addTracking_date_label"
-                style="@style/Woo.TextAppearance"
-                android:layout_width="match_parent"
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_medium"
-                android:text="@string/order_shipment_tracking_date_label"/>
+                android:hint="@string/order_shipment_tracking_date_label">
 
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/addTracking_date"
-                style="@style/Woo.OrderTracking.Add.EditText"
-                android:background="?android:attr/selectableItemBackground"
-                android:backgroundTint="@color/list_divider"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="top"
-                android:inputType="date"
-                android:minHeight="0dp"
-                android:paddingEnd="0dp"
-                android:paddingLeft="0dp"
-                android:paddingRight="0dp"
-                android:paddingStart="0dp"
-                android:textColor="@color/edit_text_text_color"
-                tools:text="May 8, 2019"
-                android:paddingTop="@dimen/default_padding"
-                android:paddingBottom="@dimen/default_padding"/>
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/addTracking_date"
+                    style="@style/Woo.EditText.Subtitle1"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="date"
+                    android:editable="false"
+                    android:focusable="false"/>
+
+            </com.google.android.material.textfield.TextInputLayout>
         </LinearLayout>
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
 </androidx.core.widget.NestedScrollView>

--- a/WooCommerce/src/main/res/layout/fragment_add_shipment_tracking.xml
+++ b/WooCommerce/src/main/res/layout/fragment_add_shipment_tracking.xml
@@ -23,6 +23,7 @@
 
             <!-- Select provider view -->
             <com.google.android.material.textfield.TextInputLayout
+                style="@style/Woo.TextInputLayout.Outlined"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="?attr/selectableItemBackground"
@@ -30,7 +31,7 @@
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/addTracking_editCarrier"
-                    style="@style/Woo.EditText.Subtitle1"
+                    style="@style/Woo.TextInputEditText.Subtitle1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:editable="false"
@@ -41,6 +42,7 @@
             <!-- Add custom provider name view -only visible if custom provider is selected -->
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/addTracking_custom_provider_name_view"
+                style="@style/Woo.TextInputLayout.Outlined"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/order_shipment_tracking_custom_provider_name_label"
@@ -48,7 +50,7 @@
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/addTracking_custom_provider_name"
-                    style="@style/Woo.EditText.Subtitle1"
+                    style="@style/Woo.TextInputEditText.Subtitle1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:inputType="text"
@@ -59,13 +61,14 @@
 
             <!-- Add tracking number view -->
             <com.google.android.material.textfield.TextInputLayout
+                style="@style/Woo.TextInputLayout.Outlined"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/order_shipment_tracking_number_label">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/addTracking_number"
-                    style="@style/Woo.EditText.Subtitle1"
+                    style="@style/Woo.TextInputEditText.Subtitle1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:inputType="text"
@@ -76,13 +79,14 @@
             <!-- Add custom provider tracking url view -only visible if custom provider is selected -->
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/addTracking_custom_provider_url_view"
+                style="@style/Woo.TextInputLayout.Outlined"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/order_shipment_tracking_custom_provider_url_label">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/addTracking_custom_provider_url"
-                    style="@style/Woo.EditText.Subtitle1"
+                    style="@style/Woo.TextInputEditText.Subtitle1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:inputType="textUri"
@@ -92,6 +96,8 @@
 
             <!-- Select date shipped view -->
             <com.google.android.material.textfield.TextInputLayout
+                style="@style/Woo.TextInputLayout.Outlined"
+                android:layout_marginTop="@dimen/minor_00"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:background="?attr/selectableItemBackground"
@@ -99,7 +105,7 @@
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/addTracking_date"
-                    style="@style/Woo.EditText.Subtitle1"
+                    style="@style/Woo.TextInputEditText.Subtitle1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:inputType="date"

--- a/WooCommerce/src/main/res/layout/fragment_add_shipment_tracking.xml
+++ b/WooCommerce/src/main/res/layout/fragment_add_shipment_tracking.xml
@@ -23,29 +23,34 @@
 
             <!-- Select provider view -->
             <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/addTracking_carrierLayout"
                 style="@style/Woo.TextInputLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="?attr/selectableItemBackground"
-                android:hint="@string/order_shipment_tracking_carrier_label">
+                android:hint="@string/order_shipment_tracking_carrier_label"
+                app:errorEnabled="true">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/addTracking_editCarrier"
                     style="@style/Woo.TextInputEditText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:focusable="false"/>
+                    android:focusable="false" />
 
             </com.google.android.material.textfield.TextInputLayout>
 
             <!-- Add custom provider name view -only visible if custom provider is selected -->
             <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/addTracking_custom_provider_name_view"
+                android:id="@+id/addTracking_customNameLayout"
                 style="@style/Woo.TextInputLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/order_shipment_tracking_custom_provider_name_label"
-                tools:visibility="visible">
+                tools:visibility="visible"
+                app:errorEnabled="true"
+                app:counterEnabled="true"
+                app:counterMaxLength="@integer/max_length_tracking_number">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/addTracking_custom_provider_name"
@@ -60,10 +65,14 @@
 
             <!-- Add tracking number view -->
             <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/addTracking_numberLayout"
                 style="@style/Woo.TextInputLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/order_shipment_tracking_number_label">
+                android:hint="@string/order_shipment_tracking_number_label"
+                app:errorEnabled="true"
+                app:counterEnabled="true"
+                app:counterMaxLength="@integer/max_length_tracking_number">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/addTracking_number"
@@ -77,11 +86,14 @@
 
             <!-- Add custom provider tracking url view -only visible if custom provider is selected -->
             <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/addTracking_custom_provider_url_view"
+                android:id="@+id/addTracking_customUrlLayout"
                 style="@style/Woo.TextInputLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/order_shipment_tracking_custom_provider_url_label">
+                android:hint="@string/order_shipment_tracking_custom_provider_url_label"
+                app:errorEnabled="true"
+                app:counterEnabled="true"
+                app:counterMaxLength="@integer/max_length_tracking_number">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/addTracking_custom_provider_url"
@@ -100,7 +112,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:background="?attr/selectableItemBackground"
-                android:hint="@string/order_shipment_tracking_date_label">
+                android:hint="@string/order_shipment_tracking_date_label"
+                app:errorEnabled="true">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/addTracking_date"

--- a/WooCommerce/src/main/res/layout/fragment_add_shipment_tracking.xml
+++ b/WooCommerce/src/main/res/layout/fragment_add_shipment_tracking.xml
@@ -25,6 +25,7 @@
             <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackground"
                 android:hint="@string/order_shipment_tracking_carrier_label">
 
                 <com.google.android.material.textfield.TextInputEditText
@@ -93,6 +94,7 @@
             <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackground"
                 android:hint="@string/order_shipment_tracking_date_label">
 
                 <com.google.android.material.textfield.TextInputEditText

--- a/WooCommerce/src/main/res/layout/fragment_add_shipment_tracking.xml
+++ b/WooCommerce/src/main/res/layout/fragment_add_shipment_tracking.xml
@@ -23,7 +23,7 @@
 
             <!-- Select provider view -->
             <com.google.android.material.textfield.TextInputLayout
-                style="@style/Woo.TextInputLayout.Outlined"
+                style="@style/Woo.TextInputLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="?attr/selectableItemBackground"
@@ -31,7 +31,7 @@
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/addTracking_editCarrier"
-                    style="@style/Woo.TextInputEditText.Subtitle1"
+                    style="@style/Woo.TextInputEditText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:editable="false"
@@ -42,7 +42,7 @@
             <!-- Add custom provider name view -only visible if custom provider is selected -->
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/addTracking_custom_provider_name_view"
-                style="@style/Woo.TextInputLayout.Outlined"
+                style="@style/Woo.TextInputLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/order_shipment_tracking_custom_provider_name_label"
@@ -50,7 +50,7 @@
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/addTracking_custom_provider_name"
-                    style="@style/Woo.TextInputEditText.Subtitle1"
+                    style="@style/Woo.TextInputEditText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:inputType="text"
@@ -61,14 +61,14 @@
 
             <!-- Add tracking number view -->
             <com.google.android.material.textfield.TextInputLayout
-                style="@style/Woo.TextInputLayout.Outlined"
+                style="@style/Woo.TextInputLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/order_shipment_tracking_number_label">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/addTracking_number"
-                    style="@style/Woo.TextInputEditText.Subtitle1"
+                    style="@style/Woo.TextInputEditText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:inputType="text"
@@ -79,14 +79,14 @@
             <!-- Add custom provider tracking url view -only visible if custom provider is selected -->
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/addTracking_custom_provider_url_view"
-                style="@style/Woo.TextInputLayout.Outlined"
+                style="@style/Woo.TextInputLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/order_shipment_tracking_custom_provider_url_label">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/addTracking_custom_provider_url"
-                    style="@style/Woo.TextInputEditText.Subtitle1"
+                    style="@style/Woo.TextInputEditText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:inputType="textUri"
@@ -96,7 +96,7 @@
 
             <!-- Select date shipped view -->
             <com.google.android.material.textfield.TextInputLayout
-                style="@style/Woo.TextInputLayout.Outlined"
+                style="@style/Woo.TextInputLayout"
                 android:layout_marginTop="@dimen/minor_00"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -105,7 +105,7 @@
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/addTracking_date"
-                    style="@style/Woo.TextInputEditText.Subtitle1"
+                    style="@style/Woo.TextInputEditText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:inputType="date"

--- a/WooCommerce/src/main/res/layout/fragment_add_shipment_tracking.xml
+++ b/WooCommerce/src/main/res/layout/fragment_add_shipment_tracking.xml
@@ -34,7 +34,6 @@
                     style="@style/Woo.TextInputEditText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:editable="false"
                     android:focusable="false"/>
 
             </com.google.android.material.textfield.TextInputLayout>
@@ -109,7 +108,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:inputType="date"
-                    android:editable="false"
                     android:focusable="false"/>
 
             </com.google.android.material.textfield.TextInputLayout>

--- a/WooCommerce/src/main/res/layout/skeleton_list_header.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_list_header.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/skeleton_header"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@color/skeleton_color">

--- a/WooCommerce/src/main/res/layout/skeleton_notif_list.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_notif_list.xml
@@ -7,7 +7,7 @@
 
     <include
         android:id="@+id/include4"
-        layout="@layout/skeleton_notif_header"
+        layout="@layout/skeleton_list_header"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"/>

--- a/WooCommerce/src/main/res/layout/skeleton_tracking_provider_list.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_tracking_provider_list.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <include
+        layout="@layout/skeleton_list_header"/>
+
+    <View
+        style="@style/Woo.Skeleton.ListItem.Single"
+        android:layout_width="200dp"
+        android:layout_marginTop="@dimen/major_75"/>
+
+    <View
+        style="@style/Woo.Skeleton.ListItem.Single"
+        android:layout_width="150dp"/>
+
+    <View
+        style="@style/Woo.Skeleton.ListItem.Single"
+        android:layout_width="100dp"/>
+
+    <View
+        style="@style/Woo.Skeleton.ListItem.Single"
+        android:layout_width="200dp"
+        android:layout_marginBottom="@dimen/major_75"/>
+
+
+</LinearLayout>

--- a/WooCommerce/src/main/res/values/dimens.xml
+++ b/WooCommerce/src/main/res/values/dimens.xml
@@ -82,6 +82,7 @@ so that's the baseline as defined in `major_100`.
     <dimen name="skeleton_bar_chart_bar_spacing">@dimen/minor_100</dimen>
     <dimen name="skeleton_text_height_75">@dimen/text_minor_125</dimen>
     <dimen name="skeleton_text_height_100">@dimen/text_major_25</dimen>
+    <dimen name="skeleton_text_height_200">@dimen/text_major_75</dimen>
     <dimen name="skeleton_tagview_height">24dp</dimen>
 
     <!-- Other literal dimensions -->

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -436,4 +436,23 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:paddingStart">@dimen/margin_app_title_aligned</item>
         <item name="android:paddingEnd">@dimen/major_100</item>
     </style>
+
+    <!--
+        Skeleton Styles
+    -->
+    <style name="Woo.Skeleton">
+        <item name="android:background">@drawable/skeleton_background</item>
+        <item name="android:layout_marginStart">@dimen/major_100</item>
+        <item name="android:layout_marginEnd">@dimen/major_100</item>
+        <item name="android:layout_marginTop">@dimen/major_75</item>
+        <item name="android:layout_marginBottom">@dimen/major_75</item>
+    </style>
+
+    <style name="Woo.Skeleton.ListItem"/>
+    <style name="Woo.Skeleton.ListItem.Single">
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_height">@dimen/skeleton_text_height_200</item>
+        <item name="android:layout_marginTop">@dimen/minor_75</item>
+        <item name="android:layout_marginBottom">@dimen/minor_75</item>
+    </style>
 </resources>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -255,7 +255,21 @@ theme across the entire app. Overridden versions should be added to the styles.x
     -->
     <style name="Woo.TextInputLayout"/>
     <style name="Woo.TextInputLayout.Outlined"
-        parent="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"/>
+        parent="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+        <item name="android:layout_marginStart">@dimen/major_100</item>
+        <item name="android:layout_marginEnd">@dimen/major_100</item>
+        <item name="android:layout_marginTop">@dimen/minor_00</item>
+        <item name="android:layout_marginBottom">@dimen/minor_75</item>
+    </style>
+
+    <style name="Woo.TextInputEditText"/>
+    <style name="Woo.TextInputEditText.Subtitle1">
+        <item name="android:textAppearance">?attr/textAppearanceSubtitle1</item>
+        <item name="android:textColor">@color/color_on_surface_high</item>
+        <item name="android:gravity">center_vertical|start</item>
+        <item name="android:lineSpacingExtra">@dimen/line_spacing_extra_100</item>
+        <item name="android:layout_margin">@dimen/minor_00</item>
+    </style>
 
     <!--
         Button Styles

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -4,7 +4,8 @@ Base Woo Styles. Use these styles as a base for custom component styles and over
 properties necessary. The goal is to make as few modifications as possible to keep a consistent
 theme across the entire app. Overridden versions should be added to the styles.xml file.
 -->
-<resources>
+<resources
+    xmlns:tools="http://schemas.android.com/tools">
     <style name="Woo"/>
     <style name="Widget"/>
     <style name="Widget.Woo"/>
@@ -239,22 +240,32 @@ theme across the entire app. Overridden versions should be added to the styles.x
     <!--
         EditText styles
     -->
-    <style name="Woo.EditText" parent="Woo.TextView"/>
-
-    <style name="Woo.EditText.Subtitle1">
+    <!--
+        Most edit text widgets in the app should use TextInputLayout + TextInputEditText which
+        will use the outlined box style. This specific style is to be used with EditText and
+        will not show an outlined box.
+    -->
+    <style name="Woo.EditText" parent="Woo.TextView">
         <item name="android:textAppearance">?attr/textAppearanceSubtitle1</item>
         <item name="android:textColor">@color/color_on_surface_high</item>
         <item name="android:gravity">center_vertical|start</item>
         <item name="android:lineSpacingExtra">@dimen/line_spacing_extra_100</item>
-        <item name="android:layout_marginTop">@dimen/minor_75</item>
+        <item name="android:layout_marginTop">@dimen/major_75</item>
         <item name="android:layout_marginBottom">@dimen/minor_75</item>
+        <item name="android:textAlignment">viewStart</item>
+        <item name="android:background">@null</item>
+        <item name="android:paddingStart" tools:ignore="NewApi">0dp</item>
+        <item name="android:paddingEnd" tools:ignore="NewApi">0dp</item>
+        <item name="android:paddingLeft">0dp</item>
+        <item name="android:paddingRight">0dp</item>
+        <item name="android:paddingTop">0dp</item>
+        <item name="android:paddingBottom">0dp</item>
     </style>
 
     <!--
         TextInputLayout styles
     -->
-    <style name="Woo.TextInputLayout"/>
-    <style name="Woo.TextInputLayout.Outlined"
+    <style name="Woo.TextInputLayout"
         parent="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
         <item name="android:layout_marginStart">@dimen/major_100</item>
         <item name="android:layout_marginEnd">@dimen/major_100</item>
@@ -262,8 +273,8 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:layout_marginBottom">@dimen/minor_75</item>
     </style>
 
-    <style name="Woo.TextInputEditText"/>
-    <style name="Woo.TextInputEditText.Subtitle1">
+    <style name="Woo.TextInputEditText"
+        parent="@style/Widget.MaterialComponents.TextInputEditText.OutlinedBox">
         <item name="android:textAppearance">?attr/textAppearanceSubtitle1</item>
         <item name="android:textColor">@color/color_on_surface_high</item>
         <item name="android:gravity">center_vertical|start</item>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -246,7 +246,16 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:textColor">@color/color_on_surface_high</item>
         <item name="android:gravity">center_vertical|start</item>
         <item name="android:lineSpacingExtra">@dimen/line_spacing_extra_100</item>
+        <item name="android:layout_marginTop">@dimen/minor_75</item>
+        <item name="android:layout_marginBottom">@dimen/minor_75</item>
     </style>
+
+    <!--
+        TextInputLayout styles
+    -->
+    <style name="Woo.TextInputLayout"/>
+    <style name="Woo.TextInputLayout.Outlined"
+        parent="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"/>
 
     <!--
         Button Styles

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -72,6 +72,8 @@
         <item name="materialCardViewStyle">@style/Woo.Card</item>
         <item name="android:listDivider">@drawable/list_divider</item>
         <item name="ratingBarStyleSmall">@style/Woo.RatingsBar.Small</item>
+        <item name="textInputStyle">@style/Woo.TextInputLayout.Outlined</item>
+        <item name="editTextStyle">@style/Woo.EditText.Subtitle1</item>
 
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -72,8 +72,9 @@
         <item name="materialCardViewStyle">@style/Woo.Card</item>
         <item name="android:listDivider">@drawable/list_divider</item>
         <item name="ratingBarStyleSmall">@style/Woo.RatingsBar.Small</item>
-        <item name="textInputStyle">@style/Woo.TextInputLayout.Outlined</item>
-        <item name="editTextStyle">@style/Woo.EditText.Subtitle1</item>
+        <item name="textInputStyle">@style/Woo.TextInputLayout</item>
+        <item name="android:textViewStyle">@style/Woo.TextView</item>
+        <item name="editTextStyle">@style/Woo.TextInputEditText</item>
 
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>


### PR DESCRIPTION
Closes #1897 by implementing light/dark material components for the various screens used to add new order tracking records to an order. This includes:

- Add new order tracking screen including custom tracking, error message display tweaks, etc.
- The "confirm discard" dialog
- Shipment tracking providers list screen
- Shipment tracking providers loading screen

**NOTE:** PR #1977 must be merged and this branch updated with the changes before this PR will be ready for merge. 

# Screenshots

### Add Tracking form changes

Before | After (light) | After (dark)
--- | --- | ---
![provider-before](https://user-images.githubusercontent.com/5810477/75192056-c1c18580-5710-11ea-941a-95f0c27b3bdd.png)|![provider-light](https://user-images.githubusercontent.com/5810477/75192063-c5550c80-5710-11ea-802e-7873a96bb3b6.png)|![provider-dark](https://user-images.githubusercontent.com/5810477/75192066-c6863980-5710-11ea-8c23-ed93495e50e5.png)
![custom-provider-before](https://user-images.githubusercontent.com/5810477/75192132-e61d6200-5710-11ea-83bc-e4c3291f1649.png)|![custom-provider-light](https://user-images.githubusercontent.com/5810477/75192140-e87fbc00-5710-11ea-9d21-c45321a391b6.png)|![custom-provider-dark](https://user-images.githubusercontent.com/5810477/75192143-e9b0e900-5710-11ea-9fc0-565020044347.png)
![error-before](https://user-images.githubusercontent.com/5810477/75192178-fa615f00-5710-11ea-8442-03f694285f11.png)|![error-light](https://user-images.githubusercontent.com/5810477/75192186-fb928c00-5710-11ea-919a-82ed903497a8.png)|![error-dark](https://user-images.githubusercontent.com/5810477/75192188-fd5c4f80-5710-11ea-8fff-92fa4128b62d.png)
![confirm-discard-before](https://user-images.githubusercontent.com/5810477/75192264-1f55d200-5711-11ea-929f-9bdc52156669.png)|![confirm-discard-light](https://user-images.githubusercontent.com/5810477/75192267-211f9580-5711-11ea-9c68-d639af6cfd56.png)|![confirm-discard-dark](https://user-images.githubusercontent.com/5810477/75192270-21b82c00-5711-11ea-813e-964a0ba669ec.png)

### Tracking provider list changes

Before | After (light) | After (dark)
--- | --- | ---
![provider-list-before](https://user-images.githubusercontent.com/5810477/75192495-8e332b00-5711-11ea-8106-12eb3a0fcc8f.png)|![provider-list-light](https://user-images.githubusercontent.com/5810477/75192499-8f645800-5711-11ea-9ead-5661239c520a.png)|![provider-list-dark](https://user-images.githubusercontent.com/5810477/75192505-91c6b200-5711-11ea-9c97-fd3ef316459a.png)
![provider-loading-before](https://user-images.githubusercontent.com/5810477/75192284-2a106700-5711-11ea-9c16-5764a78bb84e.png)|![provider-loading-light](https://user-images.githubusercontent.com/5810477/75192287-2bda2a80-5711-11ea-83f1-9752b4013f50.png)|![provider-loading-dark](https://user-images.githubusercontent.com/5810477/75192288-2d0b5780-5711-11ea-8df4-5ca3b60b8852.png)