### PR TITLE
Dark Mode: Review detail loading skeleton

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,8 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <AndroidXmlCodeStyleSettings>
-      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="STATIC_FIELD_NAME_PREFIX" value="s" />

--- a/WooCommerce/src/main/res/layout/skeleton_notif_detail.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_notif_detail.xml
@@ -3,26 +3,26 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@color/white"
     android:orientation="vertical">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/margin_large"
-        android:layout_marginStart="@dimen/margin_large"
-        android:layout_marginTop="@dimen/margin_large"
+        android:layout_marginEnd="@dimen/major_100"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginTop="@dimen/major_100"
         android:orientation="horizontal">
 
         <View
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:background="@drawable/skeleton_background_oval"/>
+            android:layout_width="@dimen/skeleton_list_item_icon_200"
+            android:layout_height="@dimen/skeleton_list_item_icon_200"
+            android:background="@drawable/skeleton_background"/>
 
         <View
             android:layout_width="200dp"
-            android:layout_height="match_parent"
-            android:layout_marginStart="@dimen/margin_large"
+            android:layout_height="@dimen/skeleton_text_height_100"
+            android:layout_gravity="center"
+            android:layout_marginStart="@dimen/major_100"
             android:background="@drawable/skeleton_background"/>
 
         <Space
@@ -31,24 +31,24 @@
             android:layout_weight="1"/>
 
         <View
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:background="@drawable/skeleton_background_oval"/>
+            android:layout_width="@dimen/skeleton_text_button_height"
+            android:layout_height="@dimen/skeleton_text_button_height"
+            android:layout_gravity="center"
+            android:background="@drawable/skeleton_background"/>
 
     </LinearLayout>
 
     <View
-        android:layout_width="match_parent"
-        android:layout_height="2dp"
-        android:layout_marginBottom="@dimen/margin_large"
-        android:layout_marginTop="@dimen/margin_large"
+        style="@style/Woo.Divider"
+        android:layout_marginBottom="@dimen/major_75"
+        android:layout_marginTop="@dimen/major_75"
         android:background="@color/list_divider"/>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/margin_large"
-        android:layout_marginStart="@dimen/margin_large"
+        android:layout_marginEnd="@dimen/major_75"
+        android:layout_marginStart="@dimen/major_75"
         android:orientation="vertical">
 
         <RelativeLayout
@@ -57,16 +57,16 @@
 
             <View
                 android:id="@+id/review_gravatar"
-                android:layout_width="60dp"
-                android:layout_height="60dp"
+                android:layout_width="@dimen/skeleton_avatar_100"
+                android:layout_height="@dimen/skeleton_avatar_100"
                 android:layout_marginEnd="@dimen/margin_large"
-                android:background="@drawable/skeleton_background"/>
+                android:background="@drawable/skeleton_background_oval"/>
 
             <View
                 android:id="@+id/review_user_name"
                 android:layout_width="200dp"
                 android:layout_height="@dimen/skeleton_text_height_100"
-                android:layout_marginTop="@dimen/margin_small"
+                android:layout_marginTop="@dimen/minor_100"
                 android:layout_toEndOf="@+id/review_gravatar"
                 android:background="@drawable/skeleton_background"/>
 
@@ -74,7 +74,7 @@
                 android:layout_width="128dp"
                 android:layout_height="@dimen/skeleton_text_height_100"
                 android:layout_alignBottom="@id/review_gravatar"
-                android:layout_marginBottom="@dimen/margin_small"
+                android:layout_marginBottom="@dimen/minor_50"
                 android:layout_toEndOf="@+id/review_gravatar"
                 android:background="@drawable/skeleton_background"/>
 
@@ -83,29 +83,29 @@
         <View
             android:layout_width="match_parent"
             android:layout_height="@dimen/skeleton_text_height_100"
-            android:layout_marginEnd="@dimen/margin_large"
-            android:layout_marginTop="32dp"
+            android:layout_marginEnd="@dimen/major_75"
+            android:layout_marginTop="@dimen/major_110"
             android:background="@drawable/skeleton_background"/>
 
         <View
             android:layout_width="match_parent"
             android:layout_height="@dimen/skeleton_text_height_100"
-            android:layout_marginEnd="@dimen/margin_extra_extra_large"
-            android:layout_marginTop="@dimen/margin_medium"
+            android:layout_marginEnd="@dimen/major_100"
+            android:layout_marginTop="@dimen/minor_100"
             android:background="@drawable/skeleton_background"/>
 
         <View
             android:layout_width="match_parent"
             android:layout_height="@dimen/skeleton_text_height_100"
-            android:layout_marginEnd="@dimen/margin_large"
-            android:layout_marginTop="@dimen/margin_medium"
+            android:layout_marginEnd="@dimen/major_75"
+            android:layout_marginTop="@dimen/minor_100"
             android:background="@drawable/skeleton_background"/>
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/margin_large"
-            android:layout_marginTop="@dimen/margin_extra_large"
+            android:layout_marginEnd="@dimen/major_75"
+            android:layout_marginTop="@dimen/major_150"
             android:orientation="horizontal">
 
             <Space
@@ -115,13 +115,13 @@
 
             <View
                 android:layout_width="0dp"
-                android:layout_height="@dimen/skeleton_text_height_100"
+                android:layout_height="@dimen/skeleton_text_button_height"
                 android:layout_weight="3"
                 android:background="@drawable/skeleton_background"/>
 
             <View
                 android:layout_width="0dp"
-                android:layout_height="@dimen/skeleton_text_height_100"
+                android:layout_height="@dimen/skeleton_text_button_height"
                 android:layout_marginEnd="@dimen/margin_large"
                 android:layout_marginStart="@dimen/margin_large"
                 android:layout_weight="3"
@@ -129,7 +129,7 @@
 
             <View
                 android:layout_width="0dp"
-                android:layout_height="@dimen/skeleton_text_height_100"
+                android:layout_height="@dimen/skeleton_text_button_height"
                 android:layout_weight="3"
                 android:background="@drawable/skeleton_background"/>
 

--- a/WooCommerce/src/main/res/values/dimens.xml
+++ b/WooCommerce/src/main/res/values/dimens.xml
@@ -79,6 +79,8 @@ so that's the baseline as defined in `major_100`.
     <dimen name="skeleton_text_height_75">@dimen/text_minor_125</dimen>
     <dimen name="skeleton_text_height_100">@dimen/text_major_25</dimen>
     <dimen name="skeleton_tagview_height">24dp</dimen>
+    <dimen name="skeleton_text_button_height">24dp</dimen>
+
 
     <!-- Other literal dimensions -->
     <dimen name="margin_app_title_aligned">72dp</dimen>


### PR DESCRIPTION
Closes #1773 by implementing light/dark styling on the order detail loading skeleton

Before | After (light) | After (dark)
--- | --- | ---
![review-detail-loading-before](https://user-images.githubusercontent.com/5810477/75198245-6053e380-571d-11ea-8a4d-33695228d7c0.png)|![review-detail-loading-light](https://user-images.githubusercontent.com/5810477/75198247-621da700-571d-11ea-8860-f0a56742a110.png)|![review-detail-loading-dark](https://user-images.githubusercontent.com/5810477/75198249-634ed400-571d-11ea-906e-e89d2bfef38c.png)
