### PR TITLE
Issue/1967 product release 1 crash fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductBackorderStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductBackorderStatus.kt
@@ -6,13 +6,14 @@ import android.os.Parcelable
 import android.os.Parcelable.Creator
 import androidx.annotation.StringRes
 import com.woocommerce.android.R
+import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductBackOrders
 
 sealed class ProductBackorderStatus(@StringRes val stringResource: Int = 0, val value: String = "") : Parcelable {
-    object No : ProductBackorderStatus(R.string.product_backorders_no)
-    object Yes : ProductBackorderStatus(R.string.product_backorders_yes)
-    object Notify : ProductBackorderStatus(R.string.product_backorders_notify)
-    object NotAvailable : ProductBackorderStatus()
+    @Parcelize object No : ProductBackorderStatus(R.string.product_backorders_no)
+    @Parcelize object Yes : ProductBackorderStatus(R.string.product_backorders_yes)
+    @Parcelize object Notify : ProductBackorderStatus(R.string.product_backorders_notify)
+    @Parcelize object NotAvailable : ProductBackorderStatus()
     class Custom(value: String) : ProductBackorderStatus(value = value)
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -383,7 +383,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
             }
             it.setClickListener {
                 // TODO: add event listener for click
-                showProductPricing()
+                showProductPricing(product.remoteId)
             }
         }
 
@@ -411,7 +411,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
             }
             it.setClickListener {
                 // TODO: add event listener for click
-                showProductInventory()
+                showProductInventory(product.remoteId)
             }
         }
 
@@ -778,17 +778,17 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
                 )))
     }
 
-    private fun showProductInventory() {
+    private fun showProductInventory(remoteId: Long) {
         findNavController().navigate(
                 ProductDetailFragmentDirections
-                        .actionProductDetailFragmentToProductInventoryFragment()
+                        .actionProductDetailFragmentToProductInventoryFragment(remoteId)
         )
     }
 
-    private fun showProductPricing() {
+    private fun showProductPricing(remoteId: Long) {
         findNavController().navigate(
                 ProductDetailFragmentDirections
-                        .actionProductDetailFragmentToProductPricingFragment()
+                        .actionProductDetailFragmentToProductPricingFragment(remoteId)
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailModule.kt
@@ -2,7 +2,9 @@ package com.woocommerce.android.ui.products
 
 import android.os.Bundle
 import androidx.lifecycle.ViewModel
+import androidx.navigation.fragment.findNavController
 import androidx.savedstate.SavedStateRegistryOwner
+import com.woocommerce.android.R
 import com.woocommerce.android.di.ViewModelAssistedFactory
 import com.woocommerce.android.viewmodel.ViewModelKey
 import dagger.Binds
@@ -19,13 +21,16 @@ abstract class ProductDetailModule {
         fun provideDefaultArgs(fragment: ProductDetailFragment): Bundle? {
             return fragment.arguments
         }
+
+        @JvmStatic
+        @Provides
+        fun provideSavedStateRegistryOwner(fragment: ProductDetailFragment): SavedStateRegistryOwner {
+            return fragment.findNavController().getBackStackEntry(R.id.nav_graph_products)
+        }
     }
 
     @Binds
     @IntoMap
     @ViewModelKey(ProductDetailViewModel::class)
     abstract fun bindFactory(factory: ProductDetailViewModel.Factory): ViewModelAssistedFactory<out ViewModel>
-
-    @Binds
-    abstract fun bindSavedStateRegistryOwner(fragment: ProductDetailFragment): SavedStateRegistryOwner
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -100,6 +100,7 @@ class ProductDetailViewModel @AssistedInject constructor(
     }
 
     fun initialisePricing() {
+        if (parameters == null) loadParameters()
         val decimals = wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyDecimalNumber
                 ?: DEFAULT_DECIMAL_PRECISION
         productPricingViewState = productPricingViewState.copy(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -255,10 +255,10 @@ class ProductDetailViewModel @AssistedInject constructor(
                     isSaleScheduled = isSaleScheduled ?: product.isSaleScheduled,
                     dateOnSaleToGmt = if (isSaleScheduled == true) {
                         dateOnSaleToGmt ?: product.dateOnSaleToGmt
-                    } else product.dateOnSaleToGmt,
+                    } else viewState.storedProduct?.dateOnSaleToGmt,
                     dateOnSaleFromGmt = if (isSaleScheduled == true) {
                         dateOnSaleFromGmt ?: product.dateOnSaleFromGmt
-                    } else product.dateOnSaleFromGmt
+                    } else viewState.storedProduct?.dateOnSaleFromGmt
             )
             viewState = viewState.copy(cachedProduct = currentProduct, product = updatedProduct)
 
@@ -573,6 +573,18 @@ class ProductDetailViewModel @AssistedInject constructor(
         val gmtOffset: Float
     ) : Parcelable
 
+    /**
+     * [product] - used for the UI. Any updates to the fields in the UI would update this model.
+     *
+     * [cachedProduct] is the [Product] model that is used to verify if there are any changes made to the
+     * [product] model locally, which are not yet updated to the API.
+     *
+     * [storedProduct] is the [Product] model that is fetched from the API and available in the local db
+     *
+     * [isProductUpdated] - flag to determine if there are any changes made to the product by comparing
+     * [product] and [storedProduct] OR [product] and [cachedProduct].
+     *
+     */
     @Parcelize
     data class ProductDetailViewState(
         val product: Product? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -154,8 +154,8 @@ class ProductDetailViewModel @AssistedInject constructor(
      * viewState.product != viewState.storedProduct
      */
     fun onBackButtonClicked(event: ProductExitEvent): Boolean {
-        val isProductDetailUpdated = viewState.product?.let { viewState.storedProduct?.isSameProduct(it) == false }
-        val isProductSubDetailUpdated = viewState.product?.let { viewState.cachedProduct?.isSameProduct(it) == false }
+        val isProductDetailUpdated = isProductUpdated()
+        val isProductSubDetailUpdated = isProductLocalCacheUpdated()
         val isProductUpdated = when (event) {
             is ExitProductDetail -> isProductDetailUpdated
             else -> isProductDetailUpdated == true && isProductSubDetailUpdated == true
@@ -273,10 +273,14 @@ class ProductDetailViewModel @AssistedInject constructor(
     }
 
     private fun discardEditChanges(event: ProductExitEvent) {
+        val currentProduct = if (isProductLocalCacheUpdated() == true) {
+            viewState.cachedProduct
+        } else viewState.storedProduct
+
         when (event) {
             // discard inventory screen changes
             is ExitInventory -> {
-                viewState.cachedProduct?.let {
+                currentProduct?.let {
                     val product = viewState.product?.copy(
                             sku = it.sku,
                             manageStock = it.manageStock,
@@ -293,7 +297,7 @@ class ProductDetailViewModel @AssistedInject constructor(
             }
             // discard pricing screen changes
             is ExitPricing -> {
-                viewState.cachedProduct?.let {
+                currentProduct?.let {
                     val product = viewState.product?.copy(
                             dateOnSaleFromGmt = it.dateOnSaleFromGmt,
                             dateOnSaleToGmt = it.dateOnSaleToGmt,
@@ -311,7 +315,7 @@ class ProductDetailViewModel @AssistedInject constructor(
             }
             // discard shipping screen changes
             is ExitShipping -> {
-                viewState.cachedProduct?.let {
+                currentProduct?.let {
                     val product = viewState.product?.copy(
                             weight = it.weight,
                             height = it.height,
@@ -357,6 +361,11 @@ class ProductDetailViewModel @AssistedInject constructor(
             viewState = viewState.copy(isSkeletonShown = false)
         }
     }
+
+    private fun isProductUpdated() = viewState.product?.let { viewState.storedProduct?.isSameProduct(it) == false }
+
+    private fun isProductLocalCacheUpdated() =
+            viewState.product?.let { viewState.cachedProduct?.isSameProduct(it) == false }
 
     private fun loadParameters() {
         val currencyCode = wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyCode

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryModule.kt
@@ -2,7 +2,9 @@ package com.woocommerce.android.ui.products
 
 import android.os.Bundle
 import androidx.lifecycle.ViewModel
+import androidx.navigation.fragment.findNavController
 import androidx.savedstate.SavedStateRegistryOwner
+import com.woocommerce.android.R
 import com.woocommerce.android.di.ViewModelAssistedFactory
 import com.woocommerce.android.viewmodel.ViewModelKey
 import dagger.Binds
@@ -19,13 +21,16 @@ abstract class ProductInventoryModule {
         fun provideDefaultArgs(fragment: ProductInventoryFragment): Bundle? {
             return fragment.arguments
         }
+
+        @JvmStatic
+        @Provides
+        fun provideSavedStateRegistryOwner(fragment: ProductInventoryFragment): SavedStateRegistryOwner {
+            return fragment.findNavController().getBackStackEntry(R.id.nav_graph_products)
+        }
     }
 
     @Binds
     @IntoMap
     @ViewModelKey(ProductDetailViewModel::class)
     abstract fun bindFactory(factory: ProductDetailViewModel.Factory): ViewModelAssistedFactory<out ViewModel>
-
-    @Binds
-    abstract fun bindSavedStateRegistryOwner(fragment: ProductInventoryFragment): SavedStateRegistryOwner
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingModule.kt
@@ -2,7 +2,9 @@ package com.woocommerce.android.ui.products
 
 import android.os.Bundle
 import androidx.lifecycle.ViewModel
+import androidx.navigation.fragment.findNavController
 import androidx.savedstate.SavedStateRegistryOwner
+import com.woocommerce.android.R
 import com.woocommerce.android.di.ViewModelAssistedFactory
 import com.woocommerce.android.viewmodel.ViewModelKey
 import dagger.Binds
@@ -19,13 +21,16 @@ abstract class ProductPricingModule {
         fun provideDefaultArgs(fragment: ProductPricingFragment): Bundle? {
             return fragment.arguments
         }
+
+        @JvmStatic
+        @Provides
+        fun provideSavedStateRegistryOwner(fragment: ProductPricingFragment): SavedStateRegistryOwner {
+            return fragment.findNavController().getBackStackEntry(R.id.nav_graph_products)
+        }
     }
 
     @Binds
     @IntoMap
     @ViewModelKey(ProductDetailViewModel::class)
     abstract fun bindFactory(factory: ProductDetailViewModel.Factory): ViewModelAssistedFactory<out ViewModel>
-
-    @Binds
-    abstract fun bindSavedStateRegistryOwner(fragment: ProductPricingFragment): SavedStateRegistryOwner
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingModule.kt
@@ -2,7 +2,9 @@ package com.woocommerce.android.ui.products
 
 import android.os.Bundle
 import androidx.lifecycle.ViewModel
+import androidx.navigation.fragment.findNavController
 import androidx.savedstate.SavedStateRegistryOwner
+import com.woocommerce.android.R
 import com.woocommerce.android.di.ViewModelAssistedFactory
 import com.woocommerce.android.viewmodel.ViewModelKey
 import dagger.Binds
@@ -19,13 +21,16 @@ abstract class ProductShippingModule {
         fun provideDefaultArgs(fragment: ProductShippingFragment): Bundle? {
             return fragment.arguments
         }
+
+        @JvmStatic
+        @Provides
+        fun provideSavedStateRegistryOwner(fragment: ProductShippingFragment): SavedStateRegistryOwner {
+            return fragment.findNavController().getBackStackEntry(R.id.nav_graph_products)
+        }
     }
 
     @Binds
     @IntoMap
     @ViewModelKey(ProductDetailViewModel::class)
     abstract fun bindFactory(factory: ProductDetailViewModel.Factory): ViewModelAssistedFactory<out ViewModel>
-
-    @Binds
-    abstract fun bindSavedStateRegistryOwner(fragment: ProductShippingFragment): SavedStateRegistryOwner
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductStockStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductStockStatus.kt
@@ -6,13 +6,14 @@ import android.os.Parcelable
 import android.os.Parcelable.Creator
 import androidx.annotation.StringRes
 import com.woocommerce.android.R
+import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
 
 sealed class ProductStockStatus(@StringRes val stringResource: Int = 0, val value: String = "") : Parcelable {
-    object InStock : ProductStockStatus(R.string.product_stock_status_instock)
-    object OutOfStock : ProductStockStatus(R.string.product_stock_status_out_of_stock)
-    object OnBackorder : ProductStockStatus(R.string.product_stock_status_on_backorder)
-    object NotAvailable : ProductStockStatus()
+    @Parcelize object InStock : ProductStockStatus(R.string.product_stock_status_instock)
+    @Parcelize object OutOfStock : ProductStockStatus(R.string.product_stock_status_out_of_stock)
+    @Parcelize object OnBackorder : ProductStockStatus(R.string.product_stock_status_on_backorder)
+    @Parcelize object NotAvailable : ProductStockStatus()
     class Custom(value: String) : ProductStockStatus(value = value)
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTaxStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTaxStatus.kt
@@ -6,13 +6,14 @@ import android.os.Parcelable
 import android.os.Parcelable.Creator
 import androidx.annotation.StringRes
 import com.woocommerce.android.R
+import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductTaxStatus
 
 sealed class ProductTaxStatus(@StringRes val stringResource: Int = 0, val value: String = "") : Parcelable {
-    object Taxable : ProductTaxStatus(R.string.product_tax_status_taxable)
-    object Shipping : ProductTaxStatus(R.string.product_tax_status_shipping)
-    object None : ProductTaxStatus(R.string.product_tax_status_none)
-    object NotAvailable : ProductTaxStatus()
+    @Parcelize object Taxable : ProductTaxStatus(R.string.product_tax_status_taxable)
+    @Parcelize object Shipping : ProductTaxStatus(R.string.product_tax_status_shipping)
+    @Parcelize object None : ProductTaxStatus(R.string.product_tax_status_none)
+    @Parcelize object NotAvailable : ProductTaxStatus()
     class Custom(value: String) : ProductTaxStatus(value = value)
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {

--- a/WooCommerce/src/main/res/navigation/nav_graph_products.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_products.xml
@@ -78,7 +78,12 @@
     <fragment
         android:id="@+id/productInventoryFragment"
         android:name="com.woocommerce.android.ui.products.ProductInventoryFragment"
-        tools:layout="@layout/fragment_product_inventory"/>
+        tools:layout="@layout/fragment_product_inventory">
+        <argument
+            android:name="remoteProductId"
+            android:defaultValue="0L"
+            app:argType="long" />
+    </fragment>
     <fragment
         android:id="@+id/productShippingFragment"
         android:name="com.woocommerce.android.ui.products.ProductShippingFragment"
@@ -98,5 +103,10 @@
     <fragment
         android:id="@+id/productPricingFragment"
         android:name="com.woocommerce.android.ui.products.ProductPricingFragment"
-        tools:layout="@layout/fragment_product_pricing"/>
+        tools:layout="@layout/fragment_product_pricing">
+        <argument
+            android:name="remoteProductId"
+            android:defaultValue="0L"
+            app:argType="long" />
+    </fragment>
 </navigation>


### PR DESCRIPTION
Fixes #1967.  This PR fixes a number of small bugs when editing products.

### Issue 1 
 Product sub detail crashing when app is resumed from background. Fixed in 5a8ad0c

##### To Test
- Enable `Do not keep activities`. 
- Click on a Product from the product list (that has inventory or pricing info).
- Click on `Inventory` or `Pricing` section.
- Click on the `Home` button and resume the app from the background.
- Notice the app crashes.
- Pull changes from this PR and verify that the app is no longer crashing.

### Issue 2
`ProductBackOrderStatus`, `ProductTaxStatus`, `ProductStockStatus` fields are not retained when app is resumed from background. Fixed in 1a18997. This was because `sealed` classes were not stored in `SavedState` when activity was destroyed by system process.

##### To Test
- Click on a Product from the product list (that has inventory or pricing info).
- Click on `Inventory` or `Pricing` section.
- Click on the `Home` button and resume the app from the background.
- Notice the app does not crash anymore.

### Issue 3
As mentioned in this [PR](https://github.com/woocommerce/woocommerce-android/pull/1954), the discard dialog is displayed when I have schedule sale toggled off and then toggle it on and off again. Fixed in 77c909e.

##### To Test
- Click on a Product from the product list (that has inventory or pricing info).
- Click on `Pricing` section for a product that does not have a sale scheduled.
- Toggle the `Schedule Sale` option and click on the back button. Notice that the discard dialog is displayed.
- Click on `Keep editing`.
- Toggle the `Schedule sale` option and click on the back button. Notice that the discard dialog is displayed, even though there are no changes. 
- Pull changes from this PR and verify that the discard dialog is NOT displayed when there are no changes.

#### Issue 4
Discarded changes were not reflected in Product Detail screen. Fixed in 497f8f3.

##### To Test
- Click on a Product from the product list (that has inventory info).
- Click on `Inventory` section for a product.
- Modify any field in the screen (such as `Regular price`).
- Click on the back button and notice the discard dialog is displayed.
- Click on `Discard`.
- Notice that the value is updated, even though discard is clicked.
- Pull changes from this PR and verify that once discard is clicked, the changes are NOT updated in the product detail screen.

#### Known issues
- When `Do not keep activities` is enabled, the discard dialog not displayed when app is resumed from background, even when there are changes made to the screen.  Separate issue filed [here](https://github.com/woocommerce/woocommerce-android/issues/1998).
- When modifying shipping fields and discarding those changes, the correct value is not updated in the product detail screen. Separate issue filed [here](https://github.com/woocommerce/woocommerce-android/issues/1996).

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
