### PR TITLE
Product release 1/1993 m1 beta editing

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 3.8
 -----
+* Limited editing is now available for simple products (requires enabling Settings > Beta features > Products)
  
 3.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -87,7 +87,7 @@ class MainBottomNavigationView @JvmOverloads constructor(
     }
 
     private fun refreshProductsTab() {
-        menu.findItem(R.id.products)?.isVisible = FeatureFlag.PRODUCT_RELEASE_TEASER.isEnabled()
+        menu.findItem(R.id.products)?.isVisible = FeatureFlag.PRODUCT_RELEASE_M1.isEnabled()
         detectLabelVisibilityMode()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -154,9 +154,17 @@ class MainSettingsFragment : androidx.fragment.app.Fragment(), MainSettingsContr
             }
         }
 
-        textBetaFeatures.setOnClickListener {
+        betaFeaturesContainer.setOnClickListener {
             AnalyticsTracker.track(SETTINGS_BETA_FEATURES_BUTTON_TAPPED)
             findNavController().navigate(R.id.action_mainSettingsFragment_to_betaFeaturesFragment)
+        }
+
+        // if v4 stats is available, show both products & stats under the beta setting label, otherwise
+        // only show products
+        textBetaFeaturesDetail.text = if (AppPrefs.isUsingV4Api()) {
+            getString(R.string.settings_enable_product_teaser_title) + ", " + getString(R.string.settings_enable_v4_stats_title)
+        } else {
+            getString(R.string.settings_enable_product_teaser_title)
         }
 
         textPrivacySettings.setOnClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -162,7 +162,9 @@ class MainSettingsFragment : androidx.fragment.app.Fragment(), MainSettingsContr
         // if v4 stats is available, show both products & stats under the beta setting label, otherwise
         // only show products
         textBetaFeaturesDetail.text = if (AppPrefs.isUsingV4Api()) {
-            getString(R.string.settings_enable_product_teaser_title) + ", " + getString(R.string.settings_enable_v4_stats_title)
+            getString(R.string.settings_enable_product_teaser_title) +
+                    ", " +
+                    getString(R.string.settings_enable_v4_stats_title)
         } else {
             getString(R.string.settings_enable_product_teaser_title)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -288,7 +288,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
 
         // show product variants only if product type is variable and if there are variations for the product
         if (product.type == VARIABLE &&
-                FeatureFlag.PRODUCT_RELEASE_TEASER.isEnabled(context) &&
+                FeatureFlag.PRODUCT_RELEASE_M1.isEnabled(context) &&
                 product.numVariations > 0) {
             val properties = mutableMapOf<String, String>()
             for (attribute in product.attributes) {
@@ -870,8 +870,8 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
     }
 
     /**
-     * Add/Edit Product Release 1 is enabled only for debug users for SIMPLE products only
+     * Add/Edit Product Release 1 is enabled only if beta setting is enabled and only for SIMPLE products
      */
     private fun isAddEditProductRelease1Enabled(productType: ProductType) =
-            FeatureFlag.ADD_EDIT_PRODUCT_RELEASE_1.isEnabled() && productType == ProductType.SIMPLE
+            FeatureFlag.PRODUCT_RELEASE_M1.isEnabled() && productType == ProductType.SIMPLE
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -14,7 +14,7 @@ enum class FeatureFlag {
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
             PRODUCT_RELEASE_M1 -> AppPrefs.isProductsFeatureEnabled()
-            PRODUCT_IMAGE_CHOOSER -> BuildConfig.DEBUG && AppPrefs.isProductsFeatureEnabled()
+            PRODUCT_IMAGE_CHOOSER -> BuildConfig.DEBUG && PRODUCT_RELEASE_M1.isEnabled(context)
             DB_DOWNGRADE -> {
                 BuildConfig.DEBUG || context != null && PackageUtils.isBetaBuild(context)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -8,14 +8,12 @@ import com.woocommerce.android.BuildConfig
  * "Feature flags" are used to hide in-progress features from release versions
  */
 enum class FeatureFlag {
-    PRODUCT_RELEASE_TEASER,
-    ADD_EDIT_PRODUCT_RELEASE_1,
+    PRODUCT_RELEASE_M1,
     DB_DOWNGRADE,
     PRODUCT_IMAGE_CHOOSER;
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
-            ADD_EDIT_PRODUCT_RELEASE_1 -> BuildConfig.DEBUG
-            PRODUCT_RELEASE_TEASER -> AppPrefs.isProductsFeatureEnabled()
+            PRODUCT_RELEASE_M1 -> AppPrefs.isProductsFeatureEnabled()
             PRODUCT_IMAGE_CHOOSER -> BuildConfig.DEBUG && AppPrefs.isProductsFeatureEnabled()
             DB_DOWNGRADE -> {
                 BuildConfig.DEBUG || context != null && PackageUtils.isBetaBuild(context)

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -152,10 +152,17 @@
 
             <TextView
                 android:id="@+id/textBetaFeatures"
-                style="@style/Woo.Settings.Label"
+                style="@style/Woo.Settings.LabelWithDetail"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/beta_features"/>
+
+            <TextView
+                android:id="@+id/textBetaFeaturesDetail"
+                style="@style/Woo.Settings.Label.Detail"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                tools:text="@string/settings_enable_v4_stats_title"/>
 
             <View
                 style="@style/Woo.Settings.Divider"/>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -540,7 +540,7 @@
     <string name="settings_enable_v4_stats_title">Improved stats</string>
     <string name="settings_enable_product_teaser_title">Products</string>
     <string name="settings_enable_v4_stats_message">Try the new stats available with the\nWooCommerce admin plugin</string>
-    <string name="settings_enable_product_teaser_message">Test out the new products section as we get ready to launch</string>
+    <string name="settings_enable_product_teaser_message">Test out the new product editing functionality as we get ready to launch</string>
     <string name="settings_send_stats_detail">Share information with our analytics tool about your use of services while logged in to your WordPress account</string>
     <string name="settings_privacy_detail">This information helps us improve our products, make marketing to you more relevant, personalize your WooCommerce experience, and more as detailed in our privacy policy</string>
     <string name="settings_privacy_policy">Read privacy policy</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -538,7 +538,7 @@
     <string name="settings_confirm_logout">Are you sure you want to logout from the account %s?</string>
     <string name="settings_send_stats">Collect information</string>
     <string name="settings_enable_v4_stats_title">Improved stats</string>
-    <string name="settings_enable_product_teaser_title">Products</string>
+    <string name="settings_enable_product_teaser_title">Product editing</string>
     <string name="settings_enable_v4_stats_message">Try the new stats available with the\nWooCommerce admin plugin</string>
     <string name="settings_enable_product_teaser_message">Test out the new product editing functionality as we get ready to launch</string>
     <string name="settings_send_stats_detail">Share information with our analytics tool about your use of services while logged in to your WordPress account</string>


### PR DESCRIPTION
Closes #1993 - enables editing for simple products when Settings > Beta features > Products is enabled, and updates the text displayed under that setting, in preparation for products M1 release.

![Screenshot_1582664246](https://user-images.githubusercontent.com/3903757/75287025-a4131f80-57e7-11ea-9848-b74e8fc148e5.png)

![Screenshot_1582664250](https://user-images.githubusercontent.com/3903757/75287027-a4abb600-57e7-11ea-89ca-4a7ad1b2683f.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
