### PR TITLE
Dark Mode: Outlined button style

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_product_images.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_images.xml
@@ -7,9 +7,9 @@
     android:orientation="vertical"
     tools:context="com.woocommerce.android.ui.products.ProductImagesFragment">
 
-    <androidx.appcompat.widget.AppCompatButton
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/addImageButton"
-        style="@style/Woo.Button.Bordered"
+        style="@style/Woo.Button.Outlined"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/margin_extra_large"

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -292,8 +292,10 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:paddingEnd">@dimen/major_100</item>
     </style>
 
-    <style name="Woo.Button.Bordered">
-        <item name="android:background">@drawable/button_bordered_bg</item>
+    <style name="Woo.Button.Outlined" parent="@style/Widget.MaterialComponents.Button.OutlinedButton">
+        <item name="android:textColor">@color/button_text_color_selector</item>
+        <item name="android:paddingStart">@dimen/major_100</item>
+        <item name="android:paddingEnd">@dimen/major_100</item>
     </style>
 
     <style name="Woo.Button.Toggle">


### PR DESCRIPTION
Created a new `Woo.Button.Outlined` style that extends the material outlined button style and removed the existing border button style. Updated the only view using that style at the moment which required also converting it to a material button.

Before | After (light) | After (dark)
--- | --- | ---
![outline-button-before](https://user-images.githubusercontent.com/5810477/75307484-0deff100-5809-11ea-8217-253a29c18c75.png)|![outline-button-light](https://user-images.githubusercontent.com/5810477/75307488-0f211e00-5809-11ea-81f9-cf30d02a286b.png)|![outline-button-dark](https://user-images.githubusercontent.com/5810477/75307491-10eae180-5809-11ea-80b2-377bfe8aac94.png)
