### PR TITLE
Added logic to strip HTML tags from product name in Reviews

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.di.GlideApp
+import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.ProductReview
 import com.woocommerce.android.push.NotificationHandler
@@ -144,7 +145,7 @@ class ReviewDetailFragment : BaseFragment() {
 
         // Populate reviewed product info
         review.product?.let { product ->
-            review_product_name.text = product.name
+            review_product_name.text = product.name.fastStripHtml()
             review_open_product.setOnClickListener {
                 AnalyticsTracker.track(Stat.REVIEW_DETAIL_OPEN_EXTERNAL_BUTTON_TAPPED)
                 ChromeCustomTabUtils.launchUrl(activity as Context, product.externalUrl)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListAdapter.kt
@@ -12,6 +12,7 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.model.ProductReview
 import com.woocommerce.android.model.TimeGroup
 import com.woocommerce.android.util.StringUtils
@@ -358,7 +359,7 @@ class ReviewListAdapter(
             }
 
             itemHolder.title.text = context.getString(
-                    R.string.review_list_item_title, review.reviewerName, review.product?.name)
+                    R.string.review_list_item_title, review.reviewerName, review.product?.name?.fastStripHtml())
             itemHolder.desc.text = StringUtils.getRawTextFromHtml(review.review)
 
             itemHolder.itemView.setOnClickListener {


### PR DESCRIPTION
Fixes #2003 by adding logic to strip HTML tags from product name in Review list and Review detail.

#### Screenshots
<img src="https://user-images.githubusercontent.com/8658164/75247707-723f9000-57ca-11ea-8618-507a7082ac3d.png" width="300">. <img src="https://user-images.githubusercontent.com/22608780/75322507-e21c4c00-5898-11ea-9ccd-e589871f390f.png" width="300">

<img src="https://user-images.githubusercontent.com/8658164/75247705-7075cc80-57ca-11ea-8323-19d81d0427a3.png" width="300">. <img src="https://user-images.githubusercontent.com/22608780/75322511-e47ea600-5898-11ea-8a40-655fb44444f5.png" width="50%">



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
