### PR TITLE
Hotfix: Update FluxC hash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.6.4'
+    fluxCVersion = '1.6.6'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
This tiny PR updates the FluxC hash to include the change in FluxC to limit the maximum number of batched orders fetched from 25 to 15 for reasons outlined in the [original PR.](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1502)