### PR TITLE
issue/2052-virtual-product-anr-v3.8

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/ProductDetailNavigationTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/ProductDetailNavigationTest.kt
@@ -10,9 +10,7 @@ import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers
-import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
 import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers
@@ -25,9 +23,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import com.woocommerce.android.R
-import com.woocommerce.android.R.string
 import com.woocommerce.android.helpers.WCMatchers
-import com.woocommerce.android.helpers.WCMatchers.scrollTo
 import com.woocommerce.android.ui.TestBase
 import com.woocommerce.android.ui.main.MainActivityTestRule
 import com.woocommerce.android.ui.orders.WcOrderTestUtils
@@ -53,7 +49,7 @@ class ProductDetailNavigationTest : TestBase() {
     private val mockProductModel = WcProductTestUtils.generateProductDetail()
 
     private fun chooser(matcher: Matcher<Intent>): Matcher<Intent> {
-        return allOf(hasAction(Intent.ACTION_CHOOSER), hasExtra(`is`(Intent.EXTRA_INTENT), matcher))
+        return allOf(IntentMatchers.hasAction(Intent.ACTION_CHOOSER), hasExtra(`is`(Intent.EXTRA_INTENT), matcher))
     }
 
     @Before
@@ -89,7 +85,7 @@ class ProductDetailNavigationTest : TestBase() {
         activityTestRule.setOrderProductListWithMockData(mockWCOrderModel)
 
         // click on the Details button in product list card
-        onView(withId(R.id.productList_btnDetails)).perform(scrollTo(), click())
+        onView(withId(R.id.productList_btnDetails)).perform(WCMatchers.scrollTo(), click())
     }
 
     @After
@@ -111,7 +107,7 @@ class ProductDetailNavigationTest : TestBase() {
                 equalToIgnoringCase(mockProductModel.name))))
 
         // verify that close button is visible
-        onView(withContentDescription(string.abc_action_bar_up_description))
+        onView(withContentDescription(R.string.abc_action_bar_up_description))
                 .check(matches(ViewMatchers.withEffectiveVisibility(VISIBLE)))
 
         // verify that share button is visible
@@ -158,82 +154,6 @@ class ProductDetailNavigationTest : TestBase() {
         // verify that total orders is displayed correctly
         onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 1))
                 .check(matches(withText(mockProductModel.totalSales.toString())))
-    }
-
-    @Test
-    fun verifyProductDetailTitleDisplayedCorrectlyForExternalProducts() {
-        // inject mock data to product detail
-        mockProductModel.type = ProductType.EXTERNAL.name
-        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
-
-        // click on the first item in product list page
-        onView(withId(R.id.productList_products))
-                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
-
-        // verify that product title is displayed correctly
-        val productTitle = appContext.getString(R.string.product_name_external, mockProductModel.name)
-        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 0))
-                .check(matches(withText(productTitle)))
-
-        // verify that toolbar title is displayed correctly
-        onView(withId(R.id.toolbar)).check(matches(WCMatchers.withToolbarTitle(equalToIgnoringCase(productTitle))))
-    }
-
-    @Test
-    fun verifyProductDetailTitleDisplayedCorrectlyForGroupedProducts() {
-        // inject mock data to product detail
-        mockProductModel.type = ProductType.GROUPED.name
-        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
-
-        // click on the first item in product list page
-        onView(withId(R.id.productList_products))
-                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
-
-        // verify that product title is displayed correctly
-        val productTitle = appContext.getString(R.string.product_name_grouped, mockProductModel.name)
-        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 0))
-                .check(matches(withText(productTitle)))
-
-        // verify that toolbar title is displayed correctly
-        onView(withId(R.id.toolbar)).check(matches(WCMatchers.withToolbarTitle(equalToIgnoringCase(productTitle))))
-    }
-
-    @Test
-    fun verifyProductDetailTitleDisplayedCorrectlyForVariableProducts() {
-        // inject mock data to product detail
-        mockProductModel.type = ProductType.VARIABLE.name
-        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
-
-        // click on the first item in product list page
-        onView(withId(R.id.productList_products))
-                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
-
-        // verify that product title is displayed correctly
-        val productTitle = appContext.getString(R.string.product_name_variable, mockProductModel.name)
-        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 0))
-                .check(matches(withText(productTitle)))
-
-        // verify that toolbar title is displayed correctly
-        onView(withId(R.id.toolbar)).check(matches(WCMatchers.withToolbarTitle(equalToIgnoringCase(productTitle))))
-    }
-
-    @Test
-    fun verifyProductDetailTitleDisplayedCorrectlyForVirtualProducts() {
-        // inject mock data to product detail
-        mockProductModel.virtual = true
-        activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
-
-        // click on the first item in product list page
-        onView(withId(R.id.productList_products))
-                .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
-
-        // verify that product title is displayed correctly
-        val productTitle = appContext.getString(R.string.product_name_virtual, mockProductModel.name)
-        onView(WCMatchers.matchesWithIndex(withId(R.id.textPropertyValue), 0))
-                .check(matches(withText(productTitle)))
-
-        // verify that toolbar title is displayed correctly
-        onView(withId(R.id.toolbar)).check(matches(WCMatchers.withToolbarTitle(equalToIgnoringCase(productTitle))))
     }
 
     @Test
@@ -408,8 +328,8 @@ class ProductDetailNavigationTest : TestBase() {
         onView(withId(R.id.menu_share)).perform(click())
 
         // check if share intent is opened with the given product details
-        intended(chooser(allOf(
-                hasAction(Intent.ACTION_SEND),
+        Intents.intended(chooser(allOf(
+                IntentMatchers.hasAction(Intent.ACTION_SEND),
                 hasExtra(Intent.EXTRA_TEXT, mockProductModel.permalink)
         )))
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -65,6 +65,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
     }
 
     private var productTitle = ""
+    private var productName = ""
     private var isVariation = false
     private val skeletonView = SkeletonView()
 
@@ -167,7 +168,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         if (!isAdded) return
 
         val product = requireNotNull(productData.product)
-        val productName = product.name.fastStripHtml()
+        productName = product.name.fastStripHtml()
         productTitle = when (product.type) {
             EXTERNAL -> getString(R.string.product_name_external, productName)
             GROUPED -> getString(R.string.product_name_grouped, productName)
@@ -225,7 +226,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         val product = requireNotNull(productData.product)
 
         if (isAddEditProductRelease1Enabled(product.type)) {
-            addEditableView(DetailCard.Primary, R.string.product_detail_title_hint, productTitle)?.also { view ->
+            addEditableView(DetailCard.Primary, R.string.product_detail_title_hint, productName)?.also { view ->
                 view.setOnTextChangedListener { viewModel.updateProductDraft(title = it.toString()) }
             }
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -39,8 +39,6 @@ import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductIn
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductPricing
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductShipping
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductVariations
-import com.woocommerce.android.ui.products.ProductType.EXTERNAL
-import com.woocommerce.android.ui.products.ProductType.GROUPED
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.FeatureFlag
@@ -64,7 +62,6 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         PurchaseDetails
     }
 
-    private var productTitle = ""
     private var productName = ""
     private var isVariation = false
     private val skeletonView = SkeletonView()
@@ -162,26 +159,13 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         progressDialog = null
     }
 
-    override fun getFragmentTitle() = productTitle
+    override fun getFragmentTitle() = productName
 
     private fun showProduct(productData: ProductDetailViewState) {
         if (!isAdded) return
 
         val product = requireNotNull(productData.product)
         productName = product.name.fastStripHtml()
-        productTitle = when (product.type) {
-            EXTERNAL -> getString(R.string.product_name_external, productName)
-            GROUPED -> getString(R.string.product_name_grouped, productName)
-            VARIABLE -> getString(R.string.product_name_variable, productName)
-            else -> {
-                if (product.isVirtual) {
-                    getString(R.string.product_name_virtual, productName)
-                } else {
-                    productName
-                }
-            }
-        }
-
         updateActivityTitle()
 
         if (product.images.isEmpty() && !viewModel.isUploading()) {
@@ -230,7 +214,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
                 view.setOnTextChangedListener { viewModel.updateProductDraft(title = it.toString()) }
             }
         } else {
-            addPropertyView(DetailCard.Primary, R.string.product_name, productTitle, LinearLayout.VERTICAL)
+            addPropertyView(DetailCard.Primary, R.string.product_name, productName, LinearLayout.VERTICAL)
         }
 
         if (isAddEditProductRelease1Enabled(product.type)) {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -465,10 +465,6 @@
     <string name="product_backorders_no">Do not allow</string>
     <string name="product_backorders_yes">Allow</string>
     <string name="product_backorders_notify">Allow, but notify customer</string>
-    <string name="product_name_variable">Variable %s</string>
-    <string name="product_name_external">Affiliate %s</string>
-    <string name="product_name_grouped">Grouped %s</string>
-    <string name="product_name_virtual">Virtual %s</string>
     <string name="product_list_empty">No products yet</string>
     <string name="product_list_empty_search">No matching products</string>
     <string name="product_search_hint">Search products</string>


### PR DESCRIPTION
Fixes #2052 by showing the actual product name in the editable product name field. The ANR was caused by us adding "Virtual" to the product name, causing the view's change listener to fire continuously.

I could've fixed this by disabling the listener when adding "Virtual" to the product name, but a side effect of adding "Virtual" to the product name was that it would be added to the actual product name if the user taps to edit it. So instead I opted to use the actual product name.

Note that this PR still adds "Virtual" to the product name in the screen title. Note also that this targets `release/3.8`.

@Garance91540 Let me know if you'd like this to be addressed differently.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
