### PR TITLE
Added logic to display product shipping class name instead of slug

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -481,7 +481,10 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
             val shippingGroup = mapOf(
                     Pair(getString(R.string.product_weight), requireNotNull(productData.weightWithUnits)),
                     Pair(getString(R.string.product_size), requireNotNull(productData.sizeWithUnits)),
-                    Pair(getString(R.string.product_shipping_class), product.shippingClass)
+                    Pair(
+                            getString(R.string.product_shipping_class),
+                            viewModel.getShippingClassBySlug(product.shippingClass)
+                    )
             )
             addPropertyGroup(DetailCard.PurchaseDetails, R.string.product_shipping, shippingGroup)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -488,6 +488,15 @@ class ProductDetailViewModel @AssistedInject constructor(
     }
 
     /**
+     * Fetch the shipping class name of a product based on the slug
+     */
+    fun getShippingClassBySlug(slug: String): String {
+        val shippingClassList = productShippingClassViewState.shippingClassList
+                ?: productRepository.getProductShippingClassesForSite()
+        return shippingClassList.filter { it.slug == slug }.getOrNull(0)?.name ?: ""
+    }
+
+    /**
      * Load & fetch the shipping classes for the current site, optionally performing a "load more" to
      * load the next page of shipping classes
      */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingFragment.kt
@@ -132,7 +132,7 @@ class ProductShippingFragment : BaseProductFragment() {
         showValue(product_length, R.string.product_length, product.length, dimensionUnit)
         showValue(product_height, R.string.product_height, product.height, dimensionUnit)
         showValue(product_width, R.string.product_width, product.width, dimensionUnit)
-        product_shipping_class_spinner.setText(product.shippingClass)
+        product_shipping_class_spinner.setText(viewModel.getShippingClassBySlug(product.shippingClass))
     }
 
     private fun showShippingClassFragment() {


### PR DESCRIPTION
Fixes #2056 by adding logic to display product shipping class name when updating product.

#### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/22608780/76706103-1ef69880-670b-11ea-85c1-82c89331dc71.gif">

##### Test 1
- Go to the Products tab.
- Select a physical product.
- Select Shipping.
- Select Shipping Class and then select a shipping class.
- On the Shipping settings screen, verify that the **shipping class name** is showing instead of the slug.
- Click `Done` menu button.
- Verify that the shipping class name is displayed in the product detail screen instead of the slug.

##### Test 2
- Go to the Products tab.
- Select a physical product.
- Select Shipping.
- Select Shipping Class and then `No shipping class`. 
- On the Shipping settings screen, verify that the `Shipping class` is displayed.
- Click `Done` menu button.
- Verify that the shipping class is NOT displayed in the product detail screen.

Note that this PR is against the `release/3.8` branch and would require a new beta once merged. 

cc @jkmassel. Thank you 🙏🙏  

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
