### PR TITLE
Added logic to show/hide stock status if manage stock is disabled/ena…

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -379,16 +379,18 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         // show stock properties as a group if stock management is enabled, otherwise show sku separately
         val inventoryGroup = when {
             product.manageStock -> mapOf(
-                    Pair(getString(R.string.product_stock_status), ProductStockStatus.stockStatusToDisplayString(
-                            requireContext(), product.stockStatus
-                    )),
                     Pair(getString(R.string.product_backorders), ProductBackorderStatus.backordersToDisplayString(
                             requireContext(), product.backorderStatus
                     )),
                     Pair(getString(R.string.product_stock_quantity), StringUtils.formatCount(product.stockQuantity)),
                     Pair(getString(R.string.product_sku), product.sku)
             )
-            product.sku.isNotEmpty() -> mapOf(Pair(getString(R.string.product_sku), product.sku))
+            product.sku.isNotEmpty() -> mapOf(
+                    Pair(getString(R.string.product_sku), product.sku),
+                    Pair(getString(R.string.product_stock_status), ProductStockStatus.stockStatusToDisplayString(
+                            requireContext(), product.stockStatus
+                    ))
+            )
             else -> mapOf(Pair("", getString(R.string.product_inventory_empty)))
         }
 


### PR DESCRIPTION
Fixes #2058 by adding logic to display stock status of a product only if `manageStock` option is disabled in the product detail screen.

#### Screenshots
LEFT: manage stock is disabled.  RIGHT: manage stock is enabled
<img width="300" src="https://user-images.githubusercontent.com/22608780/76706969-844d8800-6711-11ea-982a-459ec0dbb5e6.png">. <img width="300" src="https://user-images.githubusercontent.com/22608780/76706971-87487880-6711-11ea-9c95-7fb2a838f7d3.png">

#### To Test
- Go to the Products tab.
- Select a product.
- Select Inventory.
- With Manage stock disabled, set the Stock status to "Out of stock." and click `DONE`.
- Verify that the `stock status` is displayed in the Product detail screen.
- Enable Manage stock and enter a quantity (e.g. "10").
- Tap "Done". Notice that the stock status is no longer displayed but quantity is displayed.

**Note that this PR is against the release/3.8 branch and would require a new beta once merged.**

cc @jkmassel. Thank you once again 🙏🙏

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
