### PR TITLE
Issue/2057 empty sku fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
@@ -99,9 +99,7 @@ class ProductInventoryFragment : BaseProductFragment(), ProductInventorySelector
 
         val product = requireNotNull(productData.product)
         with(product_sku) {
-            if (product.sku.isNotEmpty()) {
-                setText(product.sku)
-            }
+            setText(product.sku)
             setOnTextChangedListener {
                 viewModel.updateProductDraft(sku = it.toString())
                 viewModel.onSkuChanged(it.toString())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
@@ -119,9 +119,10 @@ class ProductInventoryFragment : BaseProductFragment(), ProductInventorySelector
         with(product_stock_quantity) {
             setText(product.stockQuantity.toString())
             setOnTextChangedListener {
-                if (it.toString().isNotEmpty()) {
-                    viewModel.updateProductDraft(stockQuantity = it.toString())
-                }
+                val stockQuantity = if (it.toString().isNotEmpty()) {
+                    it.toString()
+                } else "0"
+                viewModel.updateProductDraft(stockQuantity = stockQuantity)
             }
         }
 


### PR DESCRIPTION
Fixes #2057. This PR fixes 2 bugs in the product inventory screen.

#### Issue 1: empty SKU field is filled with Quantity value when device is rotated 
Fixed in c059b41
- Go to the Products tab.
- Select a product.
- Select Inventory.
- Delete all text from the SKU field.
- Rotate your device. Notice that the SKU field is still empty.

#### Issue 2: empty stock quantity is not updated to the backend API
Fixed in da5ede1
- Go to the Products tab.
- Select a product.
- Select Inventory.
- Delete all text from the Stock Quantity field.
- Rotate your device. Notice that the Stock Quantity field defaults to 0 (which is the current behaviour in Core).

Note that this PR is against the release/3.8 branch and would require a new beta once merged.

cc @jkmassel. Thank you once again 🙏🙏

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
