### PR TITLE
Issue/2040 chart negative revenue design fixes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsBarChart.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsBarChart.kt
@@ -7,16 +7,26 @@ import android.util.AttributeSet
 import android.view.MotionEvent
 import com.github.mikephil.charting.charts.BarChart
 import com.github.mikephil.charting.data.BarEntry
+import com.woocommerce.android.R
 import kotlin.math.abs
 
 /**
  * Creating a custom BarChart to fix this issue:
  * https://github.com/woocommerce/woocommerce-android/issues/1048
  */
-class DashboardStatsBarChart(context: Context?, attrs: AttributeSet?) : BarChart(
+class DashboardStatsBarChart(context: Context, attrs: AttributeSet) : BarChart(
         context,
         attrs
 ) {
+    init {
+        val typedArray = context.theme.obtainStyledAttributes(attrs, R.styleable.DashboardStatsBarChart, 0, 0)
+        try {
+            setRadius(typedArray.getDimensionPixelSize(R.styleable.DashboardStatsBarChart_radius, 0).toFloat())
+        } finally {
+            typedArray.recycle()
+        }
+    }
+
     private val startTouchPoint = Point(0, 0)
 
     // Overriding this method from the Chart.java: line 719
@@ -87,5 +97,9 @@ class DashboardStatsBarChart(context: Context?, attrs: AttributeSet?) : BarChart
         }
 
         return super.onTouchEvent(event)
+    }
+
+    private fun setRadius(radius: Float) {
+        renderer = RoundedBarChartRenderer(this, animator, viewPortHandler, radius)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -37,7 +37,6 @@ import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.FormatCurrencyRounded
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
-import com.woocommerce.android.util.max
 import com.woocommerce.android.widgets.SkeletonView
 import kotlinx.android.synthetic.main.dashboard_main_stats_row.view.*
 import kotlinx.android.synthetic.main.dashboard_stats.view.*
@@ -47,7 +46,6 @@ import org.wordpress.android.util.DateTimeUtils
 import java.io.Serializable
 import java.util.ArrayList
 import java.util.Date
-import kotlin.math.absoluteValue
 
 class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
     : LinearLayout(ctx, attrs), OnChartValueSelectedListener, BarChartGestureListener {
@@ -342,14 +340,6 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
             }
 
             with(axisLeft) {
-                if (data.yMin < 0) {
-                    val difference = max(data.yMin.absoluteValue.toBigDecimal(), data.yMax.toBigDecimal())
-                    axisMinimum = - difference.toFloat()
-                    axisMaximum = difference.toFloat()
-                } else {
-                    axisMinimum = 0f
-                    axisMaximum = data.yMax
-                }
                 setLabelCount(3, true)
                 valueFormatter = RevenueAxisFormatter()
             }
@@ -624,12 +614,7 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
      */
     private inner class RevenueAxisFormatter : IAxisValueFormatter {
         override fun getFormattedValue(value: Float, axis: AxisBase): String {
-            return when (value) {
-                0f -> value.toInt().toString()
-                axis.mEntries.first() -> getFormattedRevenueValue(value.toDouble())
-                axis.mEntries.max() -> getFormattedRevenueValue(value.toDouble())
-                else -> ""
-            }
+            return getFormattedRevenueValue(value.toDouble())
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -37,6 +37,7 @@ import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.FormatCurrencyRounded
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
+import com.woocommerce.android.util.max
 import com.woocommerce.android.widgets.SkeletonView
 import kotlinx.android.synthetic.main.dashboard_main_stats_row.view.*
 import kotlinx.android.synthetic.main.dashboard_stats.view.*
@@ -46,6 +47,7 @@ import org.wordpress.android.util.DateTimeUtils
 import java.io.Serializable
 import java.util.ArrayList
 import java.util.Date
+import kotlin.math.absoluteValue
 
 class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
     : LinearLayout(ctx, attrs), OnChartValueSelectedListener, BarChartGestureListener {
@@ -196,6 +198,7 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
                 setLabelCount(2, true) // Only show first and last date
 
                 valueFormatter = StartEndDateAxisFormatter()
+                yOffset = resources.getDimension(R.dimen.chart_axis_bottom_padding)
             }
 
             axisRight.isEnabled = false
@@ -339,9 +342,16 @@ class DashboardStatsView @JvmOverloads constructor(ctx: Context, attrs: Attribut
             }
 
             with(axisLeft) {
-                labelCount = 3
+                if (data.yMin < 0) {
+                    val difference = max(data.yMin.absoluteValue.toBigDecimal(), data.yMax.toBigDecimal())
+                    axisMinimum = - difference.toFloat()
+                    axisMaximum = difference.toFloat()
+                } else {
+                    axisMinimum = 0f
+                    axisMaximum = data.yMax
+                }
+                setLabelCount(3, true)
                 valueFormatter = RevenueAxisFormatter()
-                spaceBottom = resources.getDimension(R.dimen.chart_axis_bottom_padding)
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/RoundedBarChartRenderer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/RoundedBarChartRenderer.kt
@@ -1,0 +1,164 @@
+package com.woocommerce.android.ui.dashboard
+
+import android.graphics.Canvas
+import android.graphics.Path
+import android.graphics.RectF
+import com.github.mikephil.charting.animation.ChartAnimator
+import com.github.mikephil.charting.highlight.Highlight
+import com.github.mikephil.charting.interfaces.dataprovider.BarDataProvider
+import com.github.mikephil.charting.interfaces.datasets.IBarDataSet
+import com.github.mikephil.charting.renderer.BarChartRenderer
+import com.github.mikephil.charting.utils.Utils
+import com.github.mikephil.charting.utils.ViewPortHandler
+import kotlin.math.ceil
+
+/**
+ * Custom [BarChartRenderer] to handle rounded corner bars for our stats screen. This custom class takes in
+ * an additional param [mRadius] which is used to determine the radius of the rounded corners.
+ *
+ * Round corner bars are not supported in MPAndroidChart lib and based on some suggestions from
+ * StackOverFlow, the logic is to override the [drawDataSet] method of the [BarChartRenderer] class
+ * and draw the bars with rounded corners:
+ *
+ * https://stackoverflow.com/questions/30761082/mpandroidchart-round-edged-bar-chart
+ */
+class RoundedBarChartRenderer internal constructor(
+    chart: BarDataProvider?,
+    animator: ChartAnimator?,
+    viewPortHandler: ViewPortHandler?,
+    private val mRadius: Float
+) : BarChartRenderer(chart, animator, viewPortHandler) {
+    private val mBarShadowRectBuffer: RectF = RectF()
+
+    override fun drawHighlighted(c: Canvas, indices: Array<Highlight>) {
+        val barData = mChart.barData
+        for (high in indices) {
+            val set = barData.getDataSetByIndex(high.dataSetIndex)
+            if (set == null || !set.isHighlightEnabled) continue
+
+            val e = set.getEntryForXValue(high.x, high.y)
+            if (!isInBoundsX(e, set)) continue
+
+            val trans = mChart.getTransformer(set.axisDependency)
+            mHighlightPaint.color = set.highLightColor
+            mHighlightPaint.alpha = set.highLightAlpha
+
+            val isStack = high.stackIndex >= 0 && e.isStacked
+            val y1: Float
+            val y2: Float
+            if (isStack) {
+                if (mChart.isHighlightFullBarEnabled) {
+                    y1 = e.positiveSum
+                    y2 = -e.negativeSum
+                } else {
+                    val range = e.ranges[high.stackIndex]
+                    y1 = range.from
+                    y2 = range.to
+                }
+            } else {
+                y1 = e.y
+                y2 = 0f
+            }
+            prepareBarHighlight(e.x, y1, y2, barData.barWidth / 2f, trans)
+            setHighlightDrawPos(high, mBarRect)
+            c.drawRoundRect(mBarRect, mRadius, mRadius, mHighlightPaint)
+        }
+    }
+
+    override fun drawDataSet(c: Canvas, dataSet: IBarDataSet, index: Int) {
+        val trans = mChart.getTransformer(dataSet.axisDependency)
+        mBarBorderPaint.color = dataSet.barBorderColor
+        mBarBorderPaint.strokeWidth = Utils.convertDpToPixel(dataSet.barBorderWidth)
+        val drawBorder = dataSet.barBorderWidth > 0f
+        val phaseX = mAnimator.phaseX
+        val phaseY = mAnimator.phaseY
+
+        // draw the bar shadow before the values
+        if (mChart.isDrawBarShadowEnabled) {
+            mShadowPaint.color = dataSet.barShadowColor
+            val barData = mChart.barData
+            val barWidth = barData.barWidth
+            val barWidthHalf = barWidth / 2.0f
+            var x: Float
+            var i = 0
+            val count = ceil(dataSet.entryCount.toFloat() * phaseX.toDouble()).toInt()
+                    .coerceAtMost(dataSet.entryCount)
+
+            while (i < count) {
+                val e = dataSet.getEntryForIndex(i)
+                x = e.x
+                mBarShadowRectBuffer.left = x - barWidthHalf
+                mBarShadowRectBuffer.right = x + barWidthHalf
+                trans.rectValueToPixel(mBarShadowRectBuffer)
+                if (!mViewPortHandler.isInBoundsLeft(mBarShadowRectBuffer.right)) {
+                    i++
+                    continue
+                }
+                if (!mViewPortHandler.isInBoundsRight(mBarShadowRectBuffer.left)) {
+                    break
+                }
+
+                mBarShadowRectBuffer.top = mViewPortHandler.contentTop()
+                mBarShadowRectBuffer.bottom = mViewPortHandler.contentBottom()
+                c.drawRoundRect(mBarShadowRectBuffer, mRadius, mRadius, mShadowPaint)
+                i++
+            }
+        }
+
+        // initialize the buffer
+        val buffer = mBarBuffers[index]
+        buffer.setPhases(phaseX, phaseY)
+        buffer.setDataSet(index)
+        buffer.setInverted(mChart.isInverted(dataSet.axisDependency))
+        buffer.setBarWidth(mChart.barData.barWidth)
+        buffer.feed(dataSet)
+        trans.pointValuesToPixel(buffer.buffer)
+        val isSingleColor = dataSet.colors.size == 1
+        if (isSingleColor) {
+            mRenderPaint.color = dataSet.color
+        }
+        var j = 0
+        while (j < buffer.size()) {
+            if (!mViewPortHandler.isInBoundsLeft(buffer.buffer[j + 2])) {
+                j += 4
+                continue
+            }
+            if (!mViewPortHandler.isInBoundsRight(buffer.buffer[j])) break
+            if (!isSingleColor) {
+                mRenderPaint.color = dataSet.getColor(j / 4)
+            }
+
+            // Since the bar chart can contain negative and positive values, we first get the current y axis value
+            // that is being rendered here.If the value is negative, only the bottom right and bottom left corners
+            // of the bar is rounded. Similarly, if the value is positive, the top right and top left corners of
+            // the bar is rounded.
+            val barEntry = dataSet.getEntryForIndex(j / 4)
+            val corners = if (barEntry != null && barEntry.y < 0) {
+                floatArrayOf(
+                        0f, 0f, // Top left corner
+                        0f, 0f, // Top right corner
+                        mRadius, mRadius, // Bottom right corner
+                        mRadius, mRadius // Bottom left corner
+                )
+            } else {
+                floatArrayOf(
+                        mRadius, mRadius, // Top left corner
+                        mRadius, mRadius, // Top right corner
+                        0f, 0f, // Bottom right corner
+                        0f, 0f // Bottom left corner
+                )
+            }
+
+            val path = Path()
+            path.addRoundRect(
+                    RectF(buffer.buffer[j], buffer.buffer[j + 1], buffer.buffer[j + 2],
+                            buffer.buffer[j + 3]), corners, Path.Direction.CW)
+            c.drawPath(path, mRenderPaint)
+
+            if (drawBorder) {
+                c.drawPath(path, mBarBorderPaint)
+            }
+            j += 4
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -279,97 +279,9 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
 
         // There are times when the stats v4 api returns no grossRevenue or ordersCount for a site
         // https://github.com/woocommerce/woocommerce-android/issues/1455#issuecomment-540401646
-//        this.chartRevenueStats = revenueStatsModel?.getIntervalList()?.map {
-//            it.interval!! to (it.subtotals?.totalSales ?: 0.0)
-//        }?.toMap() ?: mapOf()
-        chartRevenueStats = when (activeGranularity) {
-            StatsGranularity.MONTHS -> {
-                mapOf(
-                        "2020-02-01" to 101.1,
-                        "2020-02-02" to 111.1,
-                        "2020-02-03" to 121.1,
-                        "2020-02-04" to 201.1,
-                        "2020-02-05" to 221.1,
-                        "2020-02-06" to 321.1,
-                        "2020-02-07" to -101.1,
-                        "2020-02-08" to 450.1,
-                        "2020-02-09" to 111.1,
-                        "2020-02-10" to 455.1,
-                        "2020-02-11" to 555.1,
-                        "2020-02-12" to 655.1,
-                        "2020-02-13" to -34.1,
-                        "2020-02-14" to 386.1,
-                        "2020-02-15" to 111.1,
-                        "2020-02-16" to 121.1,
-                        "2020-02-17" to 131.1,
-                        "2020-02-18" to 141.1,
-                        "2020-02-19" to 151.1,
-                        "2020-02-20" to 161.1,
-                        "2020-02-21" to 171.1,
-                        "2020-02-22" to -101.1,
-                        "2020-02-23" to 84.1,
-                        "2020-02-24" to 23.1,
-                        "2020-02-25" to 90.1,
-                        "2020-02-26" to 23.1,
-                        "2020-02-27" to 289.1,
-                        "2020-02-28" to 222.1,
-                        "2020-02-29" to 121.1
-                )
-            }
-            StatsGranularity.WEEKS -> {
-                mapOf(
-                        "2020-02-01" to 101.1,
-                        "2020-02-02" to -111.1,
-                        "2020-02-03" to 121.1,
-                        "2020-02-04" to 201.1,
-                        "2020-02-05" to 221.1,
-                        "2020-02-06" to 251.1,
-                        "2020-02-07" to -41.1
-                )
-            }
-            StatsGranularity.YEARS -> {
-                mapOf(
-                        "2020-01" to 101.1,
-                        "2020-02" to 111.1,
-                        "2020-03" to -121.1,
-                        "2020-04" to 201.1,
-                        "2020-05" to 221.1,
-                        "2020-06" to 321.1,
-                        "2020-07" to 555.1,
-                        "2020-08" to 341.1,
-                        "2020-09" to -31.1,
-                        "2020-10" to 141.1,
-                        "2020-11" to 121.1,
-                        "2020-12" to 41.1
-                )
-            }
-            else -> mapOf(
-                    "2020-02-23 00" to 101.1,
-                    "2020-02-23 01" to 101.1,
-                    "2020-02-23 02" to 201.1,
-                    "2020-02-23 03" to 201.1,
-                    "2020-02-23 04" to 311.1,
-                    "2020-02-23 05" to 312.1,
-                    "2020-02-23 06" to 333.1,
-                    "2020-02-23 07" to 343.1,
-                    "2020-02-23 08" to 353.1,
-                    "2020-02-23 09" to -44.1,
-                    "2020-02-23 10" to 363.1,
-                    "2020-02-23 11" to 464.1,
-                    "2020-02-23 12" to 454.1,
-                    "2020-02-23 13" to 20.1,
-                    "2020-02-23 14" to -123.1,
-                    "2020-02-23 15" to 222.1,
-                    "2020-02-23 16" to 17.1,
-                    "2020-02-23 17" to -98.1,
-                    "2020-02-23 18" to 9.1,
-                    "2020-02-23 19" to 12.1,
-                    "2020-02-23 20" to 67.1,
-                    "2020-02-23 21" to 34.1,
-                    "2020-02-23 22" to 232.1,
-                    "2020-02-23 23" to 121.1
-            )
-        }
+        this.chartRevenueStats = revenueStatsModel?.getIntervalList()?.map {
+            it.interval!! to (it.subtotals?.totalSales ?: 0.0)
+        }?.toMap() ?: mapOf()
 
         this.chartOrderStats = revenueStatsModel?.getIntervalList()?.map {
             it.interval!! to (it.subtotals?.ordersCount ?: 0)
@@ -425,11 +337,11 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
         fadeInLabelValue(revenue_value, revenue)
         fadeInLabelValue(orders_value, orders)
 
-//        if (chartRevenueStats.isEmpty() || revenueStatsModel?.getTotal()?.totalSales?.toInt() == 0) {
-//            clearLastUpdated()
-//            isRequestingStats = false
-//            return
-//        }
+        if (chartRevenueStats.isEmpty() || revenueStatsModel?.getTotal()?.totalSales?.toInt() == 0) {
+            clearLastUpdated()
+            isRequestingStats = false
+            return
+        }
 
         val barColors = ArrayList<Int>()
         val normalColor = ContextCompat.getColor(context, R.color.graph_data_color)
@@ -524,95 +436,7 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
     }
 
     private fun generateBarDataSet(revenueStats: Map<String, Double>): BarDataSet {
-        chartRevenueStats = when (activeGranularity) {
-            StatsGranularity.MONTHS -> {
-                mapOf(
-                        "2020-02-01" to 101.1,
-                        "2020-02-02" to 111.1,
-                        "2020-02-03" to 121.1,
-                        "2020-02-04" to 201.1,
-                        "2020-02-05" to 221.1,
-                        "2020-02-06" to 321.1,
-                        "2020-02-07" to -101.1,
-                        "2020-02-08" to 450.1,
-                        "2020-02-09" to 111.1,
-                        "2020-02-10" to 455.1,
-                        "2020-02-11" to 555.1,
-                        "2020-02-12" to 655.1,
-                        "2020-02-13" to -34.1,
-                        "2020-02-14" to 386.1,
-                        "2020-02-15" to 111.1,
-                        "2020-02-16" to 121.1,
-                        "2020-02-17" to 131.1,
-                        "2020-02-18" to 141.1,
-                        "2020-02-19" to 151.1,
-                        "2020-02-20" to 161.1,
-                        "2020-02-21" to 171.1,
-                        "2020-02-22" to -101.1,
-                        "2020-02-23" to 84.1,
-                        "2020-02-24" to 23.1,
-                        "2020-02-25" to 90.1,
-                        "2020-02-26" to 23.1,
-                        "2020-02-27" to 289.1,
-                        "2020-02-28" to 222.1,
-                        "2020-02-29" to 121.1
-                )
-            }
-            StatsGranularity.WEEKS -> {
-                mapOf(
-                        "2020-02-01" to 101.1,
-                        "2020-02-02" to -111.1,
-                        "2020-02-03" to 121.1,
-                        "2020-02-04" to 201.1,
-                        "2020-02-05" to 221.1,
-                        "2020-02-06" to 251.1,
-                        "2020-02-07" to -41.1
-                )
-            }
-            StatsGranularity.YEARS -> {
-                mapOf(
-                        "2020-01" to 101.1,
-                        "2020-02" to 111.1,
-                        "2020-03" to -121.1,
-                        "2020-04" to 201.1,
-                        "2020-05" to 221.1,
-                        "2020-06" to 321.1,
-                        "2020-07" to 555.1,
-                        "2020-08" to 341.1,
-                        "2020-09" to -31.1,
-                        "2020-10" to 141.1,
-                        "2020-11" to 121.1,
-                        "2020-12" to 41.1
-                )
-            }
-            else -> mapOf(
-                    "2020-02-23 00" to 101.1,
-                    "2020-02-23 01" to 101.1,
-                    "2020-02-23 02" to 201.1,
-                    "2020-02-23 03" to 201.1,
-                    "2020-02-23 04" to 311.1,
-                    "2020-02-23 05" to 312.1,
-                    "2020-02-23 06" to 333.1,
-                    "2020-02-23 07" to 343.1,
-                    "2020-02-23 08" to 353.1,
-                    "2020-02-23 09" to -44.1,
-                    "2020-02-23 10" to 363.1,
-                    "2020-02-23 11" to 464.1,
-                    "2020-02-23 12" to 454.1,
-                    "2020-02-23 13" to 20.1,
-                    "2020-02-23 14" to -123.1,
-                    "2020-02-23 15" to 222.1,
-                    "2020-02-23 16" to 17.1,
-                    "2020-02-23 17" to -98.1,
-                    "2020-02-23 18" to 9.1,
-                    "2020-02-23 19" to 12.1,
-                    "2020-02-23 20" to 67.1,
-                    "2020-02-23 21" to 34.1,
-                    "2020-02-23 22" to 232.1,
-                    "2020-02-23 23" to 121.1
-            )
-        }
-//        chartRevenueStats = revenueStats
+        chartRevenueStats = revenueStats
         val barEntries = chartRevenueStats.values.mapIndexed { index, value ->
             BarEntry((index + 1).toFloat(), value.toFloat())
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -36,6 +36,7 @@ import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.FormatCurrencyRounded
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
+import com.woocommerce.android.util.max
 import com.woocommerce.android.widgets.SkeletonView
 import kotlinx.android.synthetic.main.dashboard_main_stats_row.view.*
 import kotlinx.android.synthetic.main.dashboard_stats.view.*
@@ -44,6 +45,7 @@ import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.util.DateTimeUtils
 import java.util.ArrayList
 import java.util.Date
+import kotlin.math.absoluteValue
 import kotlin.math.round
 
 class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
@@ -192,11 +194,9 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
 
             axisRight.isEnabled = false
             with(axisLeft) {
-                setDrawZeroLine(true)
                 setDrawTopYLabelEntry(true)
                 setDrawAxisLine(false)
                 setDrawGridLines(true)
-                zeroLineColor = ContextCompat.getColor(context, R.color.wc_border_color)
                 gridColor = ContextCompat.getColor(context, R.color.wc_border_color)
             }
 
@@ -380,10 +380,18 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
                 labelCount = getBarLabelCount()
                 setCenterAxisLabels(false)
                 valueFormatter = StartEndDateAxisFormatter()
+                yOffset = resources.getDimension(R.dimen.chart_axis_bottom_padding)
             }
             with(axisLeft) {
-                labelCount = 3
-                setCenterAxisLabels(false)
+                if (data.yMin < 0) {
+                    val difference = max(data.yMin.absoluteValue.toBigDecimal(), data.yMax.toBigDecimal())
+                    axisMinimum = - difference.toFloat()
+                    axisMaximum = difference.toFloat()
+                } else {
+                    axisMinimum = 0f
+                    axisMaximum = data.yMax
+                }
+                setLabelCount(3, true)
                 valueFormatter = RevenueAxisFormatter()
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -36,7 +36,6 @@ import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.FormatCurrencyRounded
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
-import com.woocommerce.android.util.max
 import com.woocommerce.android.widgets.SkeletonView
 import kotlinx.android.synthetic.main.dashboard_main_stats_row.view.*
 import kotlinx.android.synthetic.main.dashboard_stats.view.*
@@ -45,7 +44,6 @@ import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.util.DateTimeUtils
 import java.util.ArrayList
 import java.util.Date
-import kotlin.math.absoluteValue
 import kotlin.math.round
 
 class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
@@ -281,9 +279,97 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
 
         // There are times when the stats v4 api returns no grossRevenue or ordersCount for a site
         // https://github.com/woocommerce/woocommerce-android/issues/1455#issuecomment-540401646
-        this.chartRevenueStats = revenueStatsModel?.getIntervalList()?.map {
-            it.interval!! to (it.subtotals?.totalSales ?: 0.0)
-        }?.toMap() ?: mapOf()
+//        this.chartRevenueStats = revenueStatsModel?.getIntervalList()?.map {
+//            it.interval!! to (it.subtotals?.totalSales ?: 0.0)
+//        }?.toMap() ?: mapOf()
+        chartRevenueStats = when (activeGranularity) {
+            StatsGranularity.MONTHS -> {
+                mapOf(
+                        "2020-02-01" to 101.1,
+                        "2020-02-02" to 111.1,
+                        "2020-02-03" to 121.1,
+                        "2020-02-04" to 201.1,
+                        "2020-02-05" to 221.1,
+                        "2020-02-06" to 321.1,
+                        "2020-02-07" to -101.1,
+                        "2020-02-08" to 450.1,
+                        "2020-02-09" to 111.1,
+                        "2020-02-10" to 455.1,
+                        "2020-02-11" to 555.1,
+                        "2020-02-12" to 655.1,
+                        "2020-02-13" to -34.1,
+                        "2020-02-14" to 386.1,
+                        "2020-02-15" to 111.1,
+                        "2020-02-16" to 121.1,
+                        "2020-02-17" to 131.1,
+                        "2020-02-18" to 141.1,
+                        "2020-02-19" to 151.1,
+                        "2020-02-20" to 161.1,
+                        "2020-02-21" to 171.1,
+                        "2020-02-22" to -101.1,
+                        "2020-02-23" to 84.1,
+                        "2020-02-24" to 23.1,
+                        "2020-02-25" to 90.1,
+                        "2020-02-26" to 23.1,
+                        "2020-02-27" to 289.1,
+                        "2020-02-28" to 222.1,
+                        "2020-02-29" to 121.1
+                )
+            }
+            StatsGranularity.WEEKS -> {
+                mapOf(
+                        "2020-02-01" to 101.1,
+                        "2020-02-02" to -111.1,
+                        "2020-02-03" to 121.1,
+                        "2020-02-04" to 201.1,
+                        "2020-02-05" to 221.1,
+                        "2020-02-06" to 251.1,
+                        "2020-02-07" to -41.1
+                )
+            }
+            StatsGranularity.YEARS -> {
+                mapOf(
+                        "2020-01" to 101.1,
+                        "2020-02" to 111.1,
+                        "2020-03" to -121.1,
+                        "2020-04" to 201.1,
+                        "2020-05" to 221.1,
+                        "2020-06" to 321.1,
+                        "2020-07" to 555.1,
+                        "2020-08" to 341.1,
+                        "2020-09" to -31.1,
+                        "2020-10" to 141.1,
+                        "2020-11" to 121.1,
+                        "2020-12" to 41.1
+                )
+            }
+            else -> mapOf(
+                    "2020-02-23 00" to 101.1,
+                    "2020-02-23 01" to 101.1,
+                    "2020-02-23 02" to 201.1,
+                    "2020-02-23 03" to 201.1,
+                    "2020-02-23 04" to 311.1,
+                    "2020-02-23 05" to 312.1,
+                    "2020-02-23 06" to 333.1,
+                    "2020-02-23 07" to 343.1,
+                    "2020-02-23 08" to 353.1,
+                    "2020-02-23 09" to -44.1,
+                    "2020-02-23 10" to 363.1,
+                    "2020-02-23 11" to 464.1,
+                    "2020-02-23 12" to 454.1,
+                    "2020-02-23 13" to 20.1,
+                    "2020-02-23 14" to -123.1,
+                    "2020-02-23 15" to 222.1,
+                    "2020-02-23 16" to 17.1,
+                    "2020-02-23 17" to -98.1,
+                    "2020-02-23 18" to 9.1,
+                    "2020-02-23 19" to 12.1,
+                    "2020-02-23 20" to 67.1,
+                    "2020-02-23 21" to 34.1,
+                    "2020-02-23 22" to 232.1,
+                    "2020-02-23 23" to 121.1
+            )
+        }
 
         this.chartOrderStats = revenueStatsModel?.getIntervalList()?.map {
             it.interval!! to (it.subtotals?.ordersCount ?: 0)
@@ -339,11 +425,11 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
         fadeInLabelValue(revenue_value, revenue)
         fadeInLabelValue(orders_value, orders)
 
-        if (chartRevenueStats.isEmpty() || revenueStatsModel?.getTotal()?.totalSales?.toInt() == 0) {
-            clearLastUpdated()
-            isRequestingStats = false
-            return
-        }
+//        if (chartRevenueStats.isEmpty() || revenueStatsModel?.getTotal()?.totalSales?.toInt() == 0) {
+//            clearLastUpdated()
+//            isRequestingStats = false
+//            return
+//        }
 
         val barColors = ArrayList<Int>()
         val normalColor = ContextCompat.getColor(context, R.color.graph_data_color)
@@ -383,14 +469,6 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
                 yOffset = resources.getDimension(R.dimen.chart_axis_bottom_padding)
             }
             with(axisLeft) {
-                if (data.yMin < 0) {
-                    val difference = max(data.yMin.absoluteValue.toBigDecimal(), data.yMax.toBigDecimal())
-                    axisMinimum = - difference.toFloat()
-                    axisMaximum = difference.toFloat()
-                } else {
-                    axisMinimum = 0f
-                    axisMaximum = data.yMax
-                }
                 setLabelCount(3, true)
                 valueFormatter = RevenueAxisFormatter()
             }
@@ -446,7 +524,95 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
     }
 
     private fun generateBarDataSet(revenueStats: Map<String, Double>): BarDataSet {
-        chartRevenueStats = revenueStats
+        chartRevenueStats = when (activeGranularity) {
+            StatsGranularity.MONTHS -> {
+                mapOf(
+                        "2020-02-01" to 101.1,
+                        "2020-02-02" to 111.1,
+                        "2020-02-03" to 121.1,
+                        "2020-02-04" to 201.1,
+                        "2020-02-05" to 221.1,
+                        "2020-02-06" to 321.1,
+                        "2020-02-07" to -101.1,
+                        "2020-02-08" to 450.1,
+                        "2020-02-09" to 111.1,
+                        "2020-02-10" to 455.1,
+                        "2020-02-11" to 555.1,
+                        "2020-02-12" to 655.1,
+                        "2020-02-13" to -34.1,
+                        "2020-02-14" to 386.1,
+                        "2020-02-15" to 111.1,
+                        "2020-02-16" to 121.1,
+                        "2020-02-17" to 131.1,
+                        "2020-02-18" to 141.1,
+                        "2020-02-19" to 151.1,
+                        "2020-02-20" to 161.1,
+                        "2020-02-21" to 171.1,
+                        "2020-02-22" to -101.1,
+                        "2020-02-23" to 84.1,
+                        "2020-02-24" to 23.1,
+                        "2020-02-25" to 90.1,
+                        "2020-02-26" to 23.1,
+                        "2020-02-27" to 289.1,
+                        "2020-02-28" to 222.1,
+                        "2020-02-29" to 121.1
+                )
+            }
+            StatsGranularity.WEEKS -> {
+                mapOf(
+                        "2020-02-01" to 101.1,
+                        "2020-02-02" to -111.1,
+                        "2020-02-03" to 121.1,
+                        "2020-02-04" to 201.1,
+                        "2020-02-05" to 221.1,
+                        "2020-02-06" to 251.1,
+                        "2020-02-07" to -41.1
+                )
+            }
+            StatsGranularity.YEARS -> {
+                mapOf(
+                        "2020-01" to 101.1,
+                        "2020-02" to 111.1,
+                        "2020-03" to -121.1,
+                        "2020-04" to 201.1,
+                        "2020-05" to 221.1,
+                        "2020-06" to 321.1,
+                        "2020-07" to 555.1,
+                        "2020-08" to 341.1,
+                        "2020-09" to -31.1,
+                        "2020-10" to 141.1,
+                        "2020-11" to 121.1,
+                        "2020-12" to 41.1
+                )
+            }
+            else -> mapOf(
+                    "2020-02-23 00" to 101.1,
+                    "2020-02-23 01" to 101.1,
+                    "2020-02-23 02" to 201.1,
+                    "2020-02-23 03" to 201.1,
+                    "2020-02-23 04" to 311.1,
+                    "2020-02-23 05" to 312.1,
+                    "2020-02-23 06" to 333.1,
+                    "2020-02-23 07" to 343.1,
+                    "2020-02-23 08" to 353.1,
+                    "2020-02-23 09" to -44.1,
+                    "2020-02-23 10" to 363.1,
+                    "2020-02-23 11" to 464.1,
+                    "2020-02-23 12" to 454.1,
+                    "2020-02-23 13" to 20.1,
+                    "2020-02-23 14" to -123.1,
+                    "2020-02-23 15" to 222.1,
+                    "2020-02-23 16" to 17.1,
+                    "2020-02-23 17" to -98.1,
+                    "2020-02-23 18" to 9.1,
+                    "2020-02-23 19" to 12.1,
+                    "2020-02-23 20" to 67.1,
+                    "2020-02-23 21" to 34.1,
+                    "2020-02-23 22" to 232.1,
+                    "2020-02-23 23" to 121.1
+            )
+        }
+//        chartRevenueStats = revenueStats
         val barEntries = chartRevenueStats.values.mapIndexed { index, value ->
             BarEntry((index + 1).toFloat(), value.toFloat())
         }
@@ -590,12 +756,7 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
      */
     private inner class RevenueAxisFormatter : IAxisValueFormatter {
         override fun getFormattedValue(value: Float, axis: AxisBase): String {
-            return when (value) {
-                0f -> value.toInt().toString()
-                axis.mEntries.first() -> getFormattedRevenueValue(value.toDouble())
-                axis.mEntries.max() -> getFormattedRevenueValue(value.toDouble())
-                else -> ""
-            }
+            return getFormattedRevenueValue(value.toDouble())
         }
     }
 }

--- a/WooCommerce/src/main/res/layout/dashboard_stats.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_stats.xml
@@ -47,7 +47,8 @@
         <com.woocommerce.android.ui.dashboard.DashboardStatsBarChart
             android:id="@+id/chart"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"/>
+            android:layout_height="match_parent"
+            app:radius="@dimen/chart_bar_radius"/>
 
         <ImageView
             android:id="@+id/dashboard_stats_error"

--- a/WooCommerce/src/main/res/layout/my_store_stats.xml
+++ b/WooCommerce/src/main/res/layout/my_store_stats.xml
@@ -16,7 +16,8 @@
         <com.woocommerce.android.ui.dashboard.DashboardStatsBarChart
             android:id="@+id/chart"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"/>
+            android:layout_height="match_parent"
+            app:radius="@dimen/chart_bar_radius"/>
 
         <ImageView
             android:id="@+id/dashboard_stats_error"

--- a/WooCommerce/src/main/res/values/attrs.xml
+++ b/WooCommerce/src/main/res/values/attrs.xml
@@ -73,4 +73,9 @@
         <!-- Optional: resource id of title style -->
         <attr name="aevTitleAppearance" format="reference"/>
     </declare-styleable>
+
+    <declare-styleable name="DashboardStatsBarChart">
+        <!-- Optional: Specifies the radius of the rounded corners of the bar chart -->
+        <attr name="radius" format="dimension" />
+    </declare-styleable>
 </resources>

--- a/WooCommerce/src/main/res/values/dimens.xml
+++ b/WooCommerce/src/main/res/values/dimens.xml
@@ -114,6 +114,7 @@
     -->
     <dimen name="chart_height">200dp</dimen>
     <dimen name="chart_axis_bottom_padding">10dp</dimen>
+    <dimen name="chart_bar_radius">2dp</dimen>
 
     <!--
         Login

--- a/WooCommerce/src/main/res/values/dimens.xml
+++ b/WooCommerce/src/main/res/values/dimens.xml
@@ -113,7 +113,7 @@
         Default Chart
     -->
     <dimen name="chart_height">200dp</dimen>
-    <dimen name="chart_axis_bottom_padding">4dp</dimen>
+    <dimen name="chart_axis_bottom_padding">10dp</dimen>
 
     <!--
         Login


### PR DESCRIPTION
Fixes #2027 by adding some design fixes fo supporting negative revenue stats.

#### Changes
- The y-axis labels should display only the min revenue, 0 and max revenue values.
- The bar chart corners should be rounded

#### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/22608780/76715843-0b235480-6754-11ea-8da3-e5870cc854d0.png">. <img width="300" src="https://user-images.githubusercontent.com/22608780/76715845-0d85ae80-6754-11ea-84f3-71bfc93a09ce.png">. <img width="300" src="https://user-images.githubusercontent.com/22608780/76715846-0e1e4500-6754-11ea-9538-6380ff3ce47c.png">. <img width="300" src="https://user-images.githubusercontent.com/22608780/76715847-0eb6db80-6754-11ea-9dda-7d5290835e9e.png">
 
##### Old Stats UI
<img width="300" src="https://user-images.githubusercontent.com/22608780/76716290-b5e84280-6755-11ea-968d-aa6e9e4c0e28.png">. <img width="300" src="https://user-images.githubusercontent.com/22608780/76716293-b7b20600-6755-11ea-9f98-948335b533d4.png">. <img width="300" src="https://user-images.githubusercontent.com/22608780/76716294-b8e33300-6755-11ea-9dbb-b30678fa79d1.png">. <img width="300" src="https://user-images.githubusercontent.com/22608780/76716295-b97bc980-6755-11ea-806f-6647a6acd8d9.png">

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
