### PR TITLE
Added logic to set a min and max date when scheduling a sale

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -179,6 +179,18 @@ class ProductDetailViewModel @AssistedInject constructor(
     }
 
     /**
+     * Called when the date is selected from the date picker in the pricing screen.
+     * Keeps track of the min and max date value when scheduling a sale.
+     */
+    fun onDatePickerValueSelected(selectedDate: Date, isMinValue: Boolean) {
+        productPricingViewState = if (isMinValue) {
+            productPricingViewState.copy(minDate = selectedDate)
+        } else {
+            productPricingViewState.copy(maxDate = selectedDate)
+        }
+    }
+
+    /**
      * Method called when back button is clicked.
      *
      * Each product screen has it's own [ProductExitEvent]
@@ -653,7 +665,9 @@ class ProductDetailViewModel @AssistedInject constructor(
     data class ProductPricingViewState(
         val currency: String? = null,
         val decimals: Int = DEFAULT_DECIMAL_PRECISION,
-        val taxClassList: List<TaxClass>? = null
+        val taxClassList: List<TaxClass>? = null,
+        val minDate: Date? = null,
+        val maxDate: Date? = null
     ) : Parcelable
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
@@ -107,6 +107,18 @@ class ProductPricingFragment : BaseProductFragment(), ProductInventorySelectorDi
             new.taxClassList?.takeIfNotEqualTo(old?.taxClassList) {
                 updateProductTaxClassList(it, viewModel.getProduct())
             }
+            new.minDate?.takeIfNotEqualTo(old?.minDate) {
+                // update end date to min date if current end date < start date
+                if (it.after(viewModel.getProduct().product?.dateOnSaleToGmt)) {
+                    scheduleSale_endDate.setText(it.formatToMMMddYYYY())
+                }
+            }
+            new.maxDate?.takeIfNotEqualTo(old?.maxDate) {
+                // update start date to max date if current start date > end date
+                if (it.before(viewModel.getProduct().product?.dateOnSaleFromGmt)) {
+                    scheduleSale_startDate.setText(it.formatToMMMddYYYY())
+                }
+            }
         }
 
         viewModel.event.observe(viewLifecycleOwner, Observer { event ->
@@ -169,6 +181,7 @@ class ProductPricingFragment : BaseProductFragment(), ProductInventorySelectorDi
                     )
                     setText(selectedDate.formatToMMMddYYYY())
                     viewModel.updateProductDraft(isSaleScheduled = true, dateOnSaleFromGmt = selectedDate)
+                    viewModel.onDatePickerValueSelected(selectedDate, true)
                 })
             }
         }
@@ -183,6 +196,7 @@ class ProductPricingFragment : BaseProductFragment(), ProductInventorySelectorDi
                     )
                     setText(selectedDate.formatToMMMddYYYY())
                     viewModel.updateProductDraft(isSaleScheduled = true, dateOnSaleToGmt = selectedDate)
+                    viewModel.onDatePickerValueSelected(selectedDate, false)
                 })
             }
         }


### PR DESCRIPTION
Fixes #2059. This PR adds logic to update the start date of a sale when the selected end date is less than the start date and updates the end date of a sale when the selected start date is greater than the end date.

#### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/22608780/76736248-7e48bd00-678c-11ea-8515-2031ea230c85.gif">. <img width="300" src="https://user-images.githubusercontent.com/22608780/76736254-80128080-678c-11ea-9e04-d05e9280ff68.gif">

#### Test 1
- Go to the Products tab.
- Select a product.
- Select Price.
- Enable "Schedule sale."
- Notice that the start and end dates are set to the current date.
- In the "From" field, select a date in the future (e.g. 1 April 2020).
- In the "To" field, notice that the date is set to the date you selected in the `From` field.
- Tap Done. Notice that on the product details screen, it shows the correct start and end date.

##### Test 2
- Go to the Products tab.
- Select a product.
- Select Price.
- Enable "Schedule sale."
- Notice that the start and end dates are set to the current date.
- In the `To` field, select a date in the past (e.g. 1 Feb 2020).
- In the `From` field, notice that the date is set to the date you selected in the `To` field.
- Tap Done. Notice that on the product details screen, it shows the correct start and end date.

**Note that this PR is against the release/3.8 branch and would require a new beta once merged.**

cc @jkmassel. Thank you once again 🙏🙏

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
