### PR TITLE
Updated work in progress banner in products screen

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -472,8 +472,8 @@
     <string name="product_list_empty">No products yet</string>
     <string name="product_list_empty_search">No matching products</string>
     <string name="product_search_hint">Search products</string>
-    <string name="product_wip_title">Work in progress!</string>
-    <string name="product_wip_message">We\'re hard at work on the new Products section so you may see some changes as we get ready for launch 🚀</string>
+    <string name="product_wip_title">Limited editing available</string>
+    <string name="product_wip_message">We\'ve added editing functionality to simple products. Keep an eye out for more options soon!</string>
     <string name="product_bullet" translatable="false"> \u2022 </string>
     <string name="product_variant_hidden">Hidden</string>
     <string name="product_variant_list_empty">Add options like size and color from web. These will show up as options on the product page of your site</string>


### PR DESCRIPTION
Fixes #2070 by updating the banner message in product list screen.

<img width="300" src="https://user-images.githubusercontent.com/22608780/76814560-16908180-6821-11ea-9811-b242cf6bde8e.png" />

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
