### PR TITLE
issue/2054-selected-product-price-field

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
@@ -31,7 +31,6 @@ class CurrencyEditText : AppCompatEditText {
 
     init {
         this.inputType = InputType.TYPE_CLASS_NUMBER
-        this.isCursorVisible = false
     }
 
     fun initView(currency: String, decimals: Int, currencyFormatter: CurrencyFormatter) {


### PR DESCRIPTION
Fixes #2054 - our custom currency editText used `isCursorVisible = false`, which prevented all currency fields from indicating when they're focused. This tiny PR simply removes that line.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
