### PR TITLE
issue/2074-multi-click-event-crash-fix

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 3.9
 -----
+* Fixed a crash when clicking on 2 products at the same time from the Products list section.
  
 3.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreTopEarnersView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreTopEarnersView.kt
@@ -50,6 +50,11 @@ class MyStoreTopEarnersView @JvmOverloads constructor(ctx: Context, attrs: Attri
         topEarners_recycler.layoutManager = androidx.recyclerview.widget.LinearLayoutManager(context)
         topEarners_recycler.adapter = TopEarnersAdapter(context, formatCurrencyForDisplay, listener)
         topEarners_recycler.itemAnimator = androidx.recyclerview.widget.DefaultItemAnimator()
+
+        // Setting this field to false ensures that the RecyclerView children do NOT receive the multiple clicks,
+        // and only processes the first click event. More details on this issue can be found here:
+        // https://github.com/woocommerce/woocommerce-android/issues/2074
+        topEarners_recycler.isMotionEventSplittingEnabled = false
     }
 
     fun removeListener() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductListView.kt
@@ -110,6 +110,11 @@ class OrderDetailProductListView @JvmOverloads constructor(ctx: Context, attrs: 
             layoutManager = viewManager
             itemAnimator = androidx.recyclerview.widget.DefaultItemAnimator()
             adapter = viewAdapter
+
+            // Setting this field to false ensures that the RecyclerView children do NOT receive the multiple clicks,
+            // and only processes the first click event. More details on this issue can be found here:
+            // https://github.com/woocommerce/woocommerce-android/issues/2074
+            isMotionEventSplittingEnabled = false
         }
 
         if (isExpanded) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListView.kt
@@ -42,6 +42,11 @@ class OrderListView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet?
             setHasFixedSize(true)
             addItemDecoration(ordersDividerDecoration)
             adapter = ordersAdapter
+
+            // Setting this field to false ensures that the RecyclerView children do NOT receive the multiple clicks,
+            // and only processes the first click event. More details on this issue can be found here:
+            // https://github.com/woocommerce/woocommerce-android/issues/2074
+            isMotionEventSplittingEnabled = false
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -88,6 +88,11 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener,
                 )
         )
 
+        // Setting this field to false ensures that the RecyclerView children do NOT receive the multiple clicks,
+        // and only processes the first click event. More details on this issue can be found here:
+        // https://github.com/woocommerce/woocommerce-android/issues/2074
+        productsRecycler.isMotionEventSplittingEnabled = false
+
         productsRefreshLayout?.apply {
             setColorSchemeColors(
                     ContextCompat.getColor(activity, R.color.colorPrimary),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -123,6 +123,11 @@ class ReviewListFragment : TopLevelFragment(), ItemDecorationListener, ReviewLis
                     }
                 }
             })
+
+            // Setting this field to false ensures that the RecyclerView children do NOT receive the multiple clicks,
+            // and only processes the first click event. More details on this issue can be found here:
+            // https://github.com/woocommerce/woocommerce-android/issues/2074
+            isMotionEventSplittingEnabled = false
         }
 
         notifsRefreshLayout?.apply {


### PR DESCRIPTION
Fixes #2074. The app was crashing when multiple items are clicked simultaneously in the product list screen. This was because when 2 items were clicked, multiple fragments were opened and the `productDetailViewStateData` was being observed twice and there is logic in place to ensure that the `LiveDataDelegate` would only have single observer. More details on that can be found [here](https://github.com/woocommerce/woocommerce-android/blob/d6bad983c3f2844d2a7ee4df072d62e03e13be5c/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/LiveDataDelegate.kt#L22). 

Searching online, I found that this [SO answer](https://stackoverflow.com/a/36184567/9862062), that suggested that setting `setMotionEventSplittingEnabled` in the `RecyclerView` to false ensures that the RecyclerView children do NOT receive the multiple clicks and only processes the first click event.

#### To Test
- Click on the `Products` tab.
- Click on 2 product items from the list at the same time.
- Notice the app crashes.
- Pull changes from this PR and notice that the app no longer crashes. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
