### PR TITLE
Added logic to display UP icon if product opened from products TAB

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -331,7 +331,6 @@ class MainActivity : AppUpgradeActivity(),
         } else {
             showUpIcon = true
             showCrossIcon = when (destination.id) {
-                R.id.productDetailFragment,
                 R.id.productShippingClassFragment,
                 R.id.issueRefundFragment,
                 R.id.addOrderShipmentTrackingFragment,
@@ -339,7 +338,9 @@ class MainActivity : AppUpgradeActivity(),
                     true
                 }
                 else -> {
-                    false
+                    // display CROSS icon in product detail screen only if product opened from order or top earners
+                    // UP icons should be displayed if product opened from products TAB
+                    destination.id == R.id.productDetailFragment && bottomNavView.currentPosition != PRODUCTS
                 }
             }
             showBottomNav = when (destination.id) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -337,10 +337,12 @@ class MainActivity : AppUpgradeActivity(),
                 R.id.addOrderNoteFragment -> {
                     true
                 }
+                R.id.productDetailFragment -> {
+                    // show Cross icon only when product detail isn't opened from the product list
+                    bottomNavView.currentPosition != PRODUCTS
+                }
                 else -> {
-                    // display CROSS icon in product detail screen only if product opened from order or top earners
-                    // UP icons should be displayed if product opened from products TAB
-                    destination.id == R.id.productDetailFragment && bottomNavView.currentPosition != PRODUCTS
+                    false
                 }
             }
             showBottomNav = when (destination.id) {


### PR DESCRIPTION
Fixes #1912 by adding logic to display `X` icon in the product detail screen only if product is opened from an order or from the top earners list. When product is opened from the products TAB, the UP icon should be displayed.

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/77038910-d8d75880-69da-11ea-862c-f5e5b4020c33.png" width="300"/>

#### Testing
- Click on a product from the product list and notice that the UP icon is displayed.
- Click on a product from the Top earners list and notice that the `X` icon is displayed.
- Click on a product from the order. detail screen and notice that the `X` icon is displayed.
- It would be great to perform a quick smoke test for other screens such as reviews/orders to verify that the UP icon and `X` icon are working as expected in each screen.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
