### PR TITLE
Added logic to display stock status for all products

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListAdapter.kt
@@ -55,10 +55,6 @@ class ProductListAdapter(
             null
         }
 
-        if (!product.manageStock) {
-            return statusHtml
-        }
-
         val stock = when (product.stockStatus) {
             InStock -> {
                 if (product.type == VARIABLE) {
@@ -71,10 +67,14 @@ class ProductListAdapter(
                         context.getString(R.string.product_stock_status_instock)
                     }
                 } else {
-                    context.getString(
-                            R.string.product_stock_count,
-                            FormatUtils.formatInt(product.stockQuantity)
-                    )
+                    if (product.stockQuantity > 0) {
+                        context.getString(
+                                R.string.product_stock_count,
+                                FormatUtils.formatInt(product.stockQuantity)
+                        )
+                    } else {
+                        context.getString(R.string.product_stock_status_instock)
+                    }
                 }
             }
             OutOfStock -> {


### PR DESCRIPTION
Fixes #2078 by adding logic to display:
- Stock quantity for a product only if it is greater than 0.
- Stock Status for all products in the product list screen.

#### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/22608780/77039215-7b8fd700-69db-11ea-95f1-967a295a0a78.png">

#### To test
- Change the stock status in `wp-admin` for a product.
- Refresh the products tab in the app.
- Verify that the correct stock status is displayed for the product.
- Verify that the stock quantity of a product is only displayed if it is greater than 0.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
