### PR TITLE
issue/2085-product-list-variants

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListAdapter.kt
@@ -60,7 +60,7 @@ class ProductListAdapter(
                 if (product.type == VARIABLE) {
                     if (product.numVariations > 0) {
                         context.getString(
-                                R.string.product_stock_status_instock_with_variations,
+                                R.string.product_stock_status_instock_with_variants,
                                 product.numVariations
                         )
                     } else {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -458,7 +458,7 @@
     <string name="product_view_in_store">View product on store</string>
     <string name="product_view_affiliate">View affiliate product</string>
     <string name="product_stock_status_instock">In stock</string>
-    <string name="product_stock_status_instock_with_variations">In stock \u2022 %d variations</string>
+    <string name="product_stock_status_instock_with_variants">In stock \u2022 %d variants</string>
     <string name="product_stock_status_out_of_stock">Out of stock</string>
     <string name="product_stock_status_on_backorder">On backorder</string>
     <string name="product_stock_count">%s in stock</string>


### PR DESCRIPTION
Closes #2085 - this simple PR changes the product list to show "Variants" rather than "Variations" for variable products, as per design.

![Screenshot_1584622698](https://user-images.githubusercontent.com/3903757/77070308-5d68ad80-69c0-11ea-9bc7-f146f8d45c63.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
