### PR TITLE
Issue/2035 review shimmer empty view

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -275,9 +275,7 @@ class ReviewListFragment : TopLevelFragment(), ItemDecorationListener, ReviewLis
     }
 
     private fun showLoadMoreProgress(show: Boolean) {
-        if (isActive) {
-            notifsLoadMoreProgress.visibility = if (show) View.VISIBLE else View.GONE
-        }
+        notifsLoadMoreProgress.visibility = if (show) View.VISIBLE else View.GONE
     }
 
     private fun showSkeleton(show: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -281,14 +281,12 @@ class ReviewListFragment : TopLevelFragment(), ItemDecorationListener, ReviewLis
     }
 
     private fun showSkeleton(show: Boolean) {
-        if (isActive) {
-            when (show) {
-                true -> {
-                    skeletonView.show(notifsView, R.layout.skeleton_notif_list, delayed = true)
-                    showEmptyView(false)
-                }
-                false -> skeletonView.hide()
+        when (show) {
+            true -> {
+                skeletonView.show(notifsView, R.layout.skeleton_notif_list, delayed = true)
+                showEmptyView(false)
             }
+            false -> skeletonView.hide()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModel.kt
@@ -82,13 +82,13 @@ class ReviewListViewModel @AssistedInject constructor(
      */
     fun start() {
         launch {
-            viewState = viewState.copy(isSkeletonShown = true)
-
             // Initial load. Get and show reviewList from the db if any
             val reviewsInDb = reviewRepository.getCachedProductReviews()
             if (reviewsInDb.isNotEmpty()) {
                 _reviewList.value = reviewsInDb
                 viewState = viewState.copy(isSkeletonShown = false)
+            } else {
+                viewState = viewState.copy(isSkeletonShown = true)
             }
             fetchReviewList(loadMore = false)
         }


### PR DESCRIPTION
Fixes #2035 - prior to this change, if the skeleton was showing in the review list and the user switches tabs, the skeleton may continue to appear when the user switches back. This was because the call to `showSkeleton()` only toggled the skeleton if the review list fragment was active.

I made a similar change to the "load more progress," since it suffered from a similar problem.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
