### PR TITLE
issue/2035-review-shimmer-empty-view-dark-mode

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -257,20 +257,16 @@ class ReviewListFragment : TopLevelFragment(), ItemDecorationListener, ReviewLis
     }
 
     private fun showLoadMoreProgress(show: Boolean) {
-        if (isActive) {
-            notifsLoadMoreProgress.visibility = if (show) View.VISIBLE else View.GONE
-        }
+        notifsLoadMoreProgress.visibility = if (show) View.VISIBLE else View.GONE
     }
 
     private fun showSkeleton(show: Boolean) {
-        if (isActive) {
-            when (show) {
-                true -> {
-                    skeletonView.show(notifsView, R.layout.skeleton_notif_list, delayed = true)
-                    showEmptyView(false)
-                }
-                false -> skeletonView.hide()
+        when (show) {
+            true -> {
+                skeletonView.show(notifsView, R.layout.skeleton_notif_list, delayed = true)
+                showEmptyView(false)
             }
+            false -> skeletonView.hide()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModel.kt
@@ -82,13 +82,13 @@ class ReviewListViewModel @AssistedInject constructor(
      */
     fun start() {
         launch {
-            viewState = viewState.copy(isSkeletonShown = true)
-
             // Initial load. Get and show reviewList from the db if any
             val reviewsInDb = reviewRepository.getCachedProductReviews()
             if (reviewsInDb.isNotEmpty()) {
                 _reviewList.value = reviewsInDb
                 viewState = viewState.copy(isSkeletonShown = false)
+            } else {
+                viewState = viewState.copy(isSkeletonShown = true)
             }
             fetchReviewList(loadMore = false)
         }


### PR DESCRIPTION
Closes #2035 - this is the same as the now-closed #2087, except this one targets `feature/dark-mode` as per @anitaa1990's suggestion.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
