### PR TITLE
Products release m1 design fixes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
@@ -81,6 +81,8 @@ class ProductPricingFragment : BaseProductFragment(), ProductInventorySelectorDi
         setupObservers(viewModel)
     }
 
+    override fun getFragmentTitle() = getString(R.string.product_price)
+
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         menu.clear()
         inflater.inflate(R.menu.menu_done, menu)

--- a/WooCommerce/src/main/res/layout/product_property_cardview.xml
+++ b/WooCommerce/src/main/res/layout/product_property_cardview.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.cardview.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    app:elevation="@dimen/card_elevation">
+    android:layout_height="wrap_content">
 
     <LinearLayout
         android:id="@+id/cardContainerView"

--- a/WooCommerce/src/main/res/layout/product_property_link_view.xml
+++ b/WooCommerce/src/main/res/layout/product_property_link_view.xml
@@ -33,12 +33,4 @@
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/ic_external"/>
 
-    <View
-        android:id="@+id/divider"
-        style="@style/Woo.Settings.Divider"
-        android:layout_marginTop="@dimen/product_detail_property_margin"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"/>
-
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Fixes #2092 and #2091. This PR adds some design fixes to the product editing screens. 

#### Issue 1
Display price title in toolbar in product pricing screen. Fixed in 185c7ec. 

##### To test
- Open Product Details
- Select "add price"
- Verify that the screen title displays the "Price".

#### Issue 2
Removed divider from product detail primary card below the `View Product in store` section. 
Fixed in 540fc04.

LEFT: Before. RIGHT: After
<img width="300" src="https://user-images.githubusercontent.com/22608780/77303496-13adf900-6d19-11ea-9011-2b06822b660b.png">. <img width="300" src="https://user-images.githubusercontent.com/22608780/77303363-dcd7e300-6d18-11ea-983a-4dc1d71543ae.png">

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
