### PR TITLE
Remove Refunded status from the picker

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusSelectorDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusSelectorDialog.kt
@@ -21,6 +21,7 @@ class OrderStatusSelectorDialog : androidx.fragment.app.DialogFragment() {
         const val TAG: String = "OrderStatusSelectorDialog"
 
         private const val ALL_FILTER_ID: String = "all"
+        private const val REFUNDED_ID: String = "refunded"
 
         fun newInstance(
             orderStatusOptions: Map<String, WCOrderStatusModel>,
@@ -42,12 +43,15 @@ class OrderStatusSelectorDialog : androidx.fragment.app.DialogFragment() {
     }
 
     private val orderStatusMap: Map<String, String> by lazy {
+        // remove the Refunded status from the dialog to avoid reporting problems
+        val statusesWithoutRefunded = orderStatusOptions
+                .filter { it.key != REFUNDED_ID }
+                .values.associate { it.statusKey to it.label }
+
         if (isFilter) {
-            mapOf(ALL_FILTER_ID to getString(R.string.all)).plus(
-                    orderStatusOptions.values.associate { it.statusKey to it.label }
-            )
+            mapOf(ALL_FILTER_ID to getString(R.string.all)).plus(statusesWithoutRefunded)
         } else {
-            orderStatusOptions.values.associate { it.statusKey to it.label }
+            statusesWithoutRefunded
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusSelectorDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusSelectorDialog.kt
@@ -43,9 +43,9 @@ class OrderStatusSelectorDialog : androidx.fragment.app.DialogFragment() {
     }
 
     private val orderStatusMap: Map<String, String> by lazy {
-        // remove the Refunded status from the dialog to avoid reporting problems
+        // remove the Refunded status from the dialog to avoid reporting problems (unless it's already Refunded)
         val statusesWithoutRefunded = orderStatusOptions
-                .filter { it.key != REFUNDED_ID }
+                .filter { selectedOrderStatus == REFUNDED_ID || it.key != REFUNDED_ID }
                 .values.associate { it.statusKey to it.label }
 
         if (isFilter) {


### PR DESCRIPTION
Fixes #1837 

To test:

1. Go to Orders
2. Open any order detail
3. Tap on an order status 
4. Notice the Refunded status isn't available anymore

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
