### PR TITLE
Dark Mode: Rename list divider color resource

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -83,7 +83,7 @@ class MainBottomNavigationView @JvmOverloads constructor(
      */
     private fun addTopDivider() {
         val divider = View(context)
-        val dividerColor = ContextCompat.getColor(context, R.color.list_divider)
+        val dividerColor = ContextCompat.getColor(context, R.color.divider_color)
         divider.setBackgroundColor(dividerColor)
 
         val dividerHeight = resources.getDimensionPixelSize(R.dimen.bottomm_nav_top_border)

--- a/WooCommerce/src/main/res/drawable/card_expander_bg.xml
+++ b/WooCommerce/src/main/res/drawable/card_expander_bg.xml
@@ -3,7 +3,7 @@
     <item>
         <shape
             android:shape="rectangle">
-            <stroke android:width="1dp" android:color="@color/list_divider" />
+            <stroke android:width="1dp" android:color="@color/divider_color" />
         </shape>
     </item>
     <item android:top="1dp">

--- a/WooCommerce/src/main/res/drawable/list_divider.xml
+++ b/WooCommerce/src/main/res/drawable/list_divider.xml
@@ -2,7 +2,7 @@
 <inset
     xmlns:android="http://schemas.android.com/apk/res/android">
     <shape android:shape="rectangle">
-        <solid android:color="@color/list_divider"/>
+        <solid android:color="@color/divider_color"/>
         <size android:height="1dp" android:width="1dp"/>
     </shape>
 </inset>

--- a/WooCommerce/src/main/res/drawable/picture_frame.xml
+++ b/WooCommerce/src/main/res/drawable/picture_frame.xml
@@ -4,5 +4,5 @@
     <corners android:radius="2dp" />
     <stroke
         android:width="1dp"
-        android:color="@color/list_divider" />
+        android:color="@color/divider_color" />
 </shape>

--- a/WooCommerce/src/main/res/layout/skeleton_notif_detail.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_notif_detail.xml
@@ -42,7 +42,7 @@
         style="@style/Woo.Divider"
         android:layout_marginBottom="@dimen/major_75"
         android:layout_marginTop="@dimen/major_75"
-        android:background="@color/list_divider"/>
+        android:background="@color/divider_color"/>
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -139,7 +139,7 @@
             android:layout_width="match_parent"
             android:layout_height="2dp"
             android:layout_marginTop="@dimen/margin_extra_large"
-            android:background="@color/list_divider"/>
+            android:background="@color/divider_color"/>
 
     </LinearLayout>
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout/skeleton_product_detail.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_product_detail.xml
@@ -32,7 +32,7 @@
         android:layout_width="match_parent"
         android:layout_height="2dp"
         android:layout_marginTop="@dimen/settings_padding"
-        android:background="@color/list_divider"/>
+        android:background="@color/divider_color"/>
 
     <View
         android:layout_width="match_parent"
@@ -47,7 +47,7 @@
         android:layout_width="match_parent"
         android:layout_height="2dp"
         android:layout_marginTop="@dimen/settings_padding"
-        android:background="@color/list_divider"/>
+        android:background="@color/divider_color"/>
 
     <View
         android:layout_width="match_parent"
@@ -62,7 +62,7 @@
         android:layout_width="match_parent"
         android:layout_height="2dp"
         android:layout_marginTop="@dimen/settings_padding"
-        android:background="@color/list_divider"/>
+        android:background="@color/divider_color"/>
 
     <View
         android:layout_width="match_parent"
@@ -77,7 +77,7 @@
         android:layout_width="match_parent"
         android:layout_height="@dimen/product_detail_card_divider_height"
         android:layout_marginTop="@dimen/settings_padding"
-        android:background="@color/list_divider"/>
+        android:background="@color/divider_color"/>
 
     <View
         android:layout_width="match_parent"
@@ -92,7 +92,7 @@
         android:layout_width="match_parent"
         android:layout_height="2dp"
         android:layout_marginTop="@dimen/settings_padding"
-        android:background="@color/list_divider"/>
+        android:background="@color/divider_color"/>
 
     <View
         android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -29,7 +29,7 @@
         App colors
     -->
     <color name="default_window_background">#1D1E1F</color>
-    <color name="list_divider">@color/woo_white_alpha_012</color>
+    <color name="divider_color">@color/woo_white_alpha_012</color>
     <color name="color_ripple_overlay">@color/woo_white_alpha_012</color>
     <color name="image_border_color">@color/woo_white_alpha_012</color>
 

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -36,7 +36,7 @@
         App colors
     -->
     <color name="default_window_background">#F2F2F2</color>
-    <color name="list_divider">@color/woo_black_90_alpha_012</color>
+    <color name="divider_color">@color/woo_black_90_alpha_012</color>
     <color name="color_ripple_overlay">@color/woo_black_90_alpha_012</color>
     <color name="image_border_color">@color/woo_black_90_alpha_012</color>
 

--- a/WooCommerce/src/main/res/values/styles.xml
+++ b/WooCommerce/src/main/res/values/styles.xml
@@ -197,9 +197,9 @@ Use this file to override styles in the styles_base.xml file.
     <style name="Woo.Refunds.EditText" parent="@style/EditText">
         <item name="android:textColorHint">@color/edit_text_color_control_normal</item>
         <item name="android:textSize">@dimen/text_large</item>
-        <item name="colorControlNormal">@color/list_divider</item>
-        <item name="colorControlActivated">@color/list_divider</item>
-        <item name="colorControlHighlight">@color/list_divider</item>
+        <item name="colorControlNormal">@color/divider_color</item>
+        <item name="colorControlActivated">@color/divider_color</item>
+        <item name="colorControlHighlight">@color/divider_color</item>
         <item name="android:textAlignment">viewStart</item>
         <item name="android:gravity">start</item>
     </style>
@@ -287,9 +287,9 @@ Use this file to override styles in the styles_base.xml file.
     <style name="Woo.OrderTracking.Add.EditText" parent="@style/EditText">
         <item name="android:textColorHint">@color/edit_text_color_control_normal</item>
         <item name="android:textSize">@dimen/text_large</item>
-        <item name="colorControlNormal">@color/list_divider</item>
-        <item name="colorControlActivated">@color/list_divider</item>
-        <item name="colorControlHighlight">@color/list_divider</item>
+        <item name="colorControlNormal">@color/divider_color</item>
+        <item name="colorControlActivated">@color/divider_color</item>
+        <item name="colorControlHighlight">@color/divider_color</item>
         <item name="android:textAlignment">viewStart</item>
         <item name="android:gravity">start</item>
     </style>
@@ -430,12 +430,12 @@ Use this file to override styles in the styles_base.xml file.
         <item name="android:textColor">@color/wc_black_darker</item>
         <item name="android:textColorHint">@color/wc_black_lighter</item>
         <item name="android:textSize">@dimen/text_large</item>
-        <item name="colorControlNormal">@color/list_divider</item>
-        <item name="android:colorAccent">@color/list_divider</item>
-        <item name="boxStrokeColor">@color/list_divider</item>
+        <item name="colorControlNormal">@color/divider_color</item>
+        <item name="android:colorAccent">@color/divider_color</item>
+        <item name="boxStrokeColor">@color/divider_color</item>
         <item name="hintTextAppearance">@style/Woo.MaterialComponents.EditText.HintTextAppearance</item>
-        <item name="colorControlActivated">@color/list_divider</item>
-        <item name="colorControlHighlight">@color/list_divider</item>
+        <item name="colorControlActivated">@color/divider_color</item>
+        <item name="colorControlHighlight">@color/divider_color</item>
         <item name="android:textAlignment">viewStart</item>
         <item name="android:gravity">start</item>
     </style>


### PR DESCRIPTION
This is a really simple PR to rename the list divider color resource from `list_divider` to `divider_color` to make it clear it's for use in all dividers - regardless if inside a list, card or form. :) Very simple change. Closes #2031 

 