### PR TITLE
Issue/2113 switch on products

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 4.0
 -----
+* Products is now available with limited editing for simple products!
  
 3.9
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -24,7 +24,6 @@ import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.main.BottomNavigationPosition.DASHBOARD
 import com.woocommerce.android.ui.main.BottomNavigationPosition.ORDERS
 import com.woocommerce.android.ui.main.BottomNavigationPosition.REVIEWS
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
 import org.wordpress.android.util.DisplayUtils
@@ -62,8 +61,6 @@ class MainBottomNavigationView @JvmOverloads constructor(
         this.fragmentManager = fm
         this.listener = listener
 
-        refreshProductsTab()
-
         navAdapter = NavAdapter()
         addTopDivider()
 
@@ -84,11 +81,6 @@ class MainBottomNavigationView @JvmOverloads constructor(
 
         // Default to the dashboard position
         active(DASHBOARD.position)
-    }
-
-    private fun refreshProductsTab() {
-        menu.findItem(R.id.products)?.isVisible = FeatureFlag.PRODUCT_RELEASE_M1.isEnabled()
-        detectLabelVisibilityMode()
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -159,15 +159,19 @@ class MainSettingsFragment : androidx.fragment.app.Fragment(), MainSettingsContr
             findNavController().navigate(R.id.action_mainSettingsFragment_to_betaFeaturesFragment)
         }
 
-        // if v4 stats is available, show both products & stats under the beta setting label, otherwise
-        // only show products
-        textBetaFeaturesDetail.text = if (AppPrefs.isUsingV4Api()) {
-            getString(R.string.settings_enable_product_teaser_title) +
-                    ", " +
-                    getString(R.string.settings_enable_v4_stats_title)
-        } else {
-            getString(R.string.settings_enable_product_teaser_title)
-        }
+        // TODO: commenting out this code since we are enabling products for all users in the next release.
+        // Once product M2 editing features are live, we can enable product editing switch from this screen again.
+        textBetaFeaturesDetail.text = getString(R.string.settings_enable_v4_stats_title)
+
+//         // if v4 stats is available, show both products & stats under the beta setting label, otherwise
+//         // only show products
+//        textBetaFeaturesDetail.text = if (AppPrefs.isUsingV4Api()) {
+//            getString(R.string.settings_enable_product_teaser_title) +
+//                    ", " +
+//                    getString(R.string.settings_enable_v4_stats_title)
+//        } else {
+//            getString(R.string.settings_enable_product_teaser_title)
+//        }
 
         textPrivacySettings.setOnClickListener {
             AnalyticsTracker.track(SETTINGS_PRIVACY_SETTINGS_BUTTON_TAPPED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -107,7 +107,7 @@ class MainSettingsFragment : androidx.fragment.app.Fragment(), MainSettingsContr
             setLinkTextColor(ContextCompat.getColor(context, R.color.wc_purple))
         }
 
-        if (FeatureFlag.PRODUCT_IMAGE_CHOOSER.isEnabled(requireActivity())) {
+        if (FeatureFlag.PRODUCT_RELEASE_M2.isEnabled(requireActivity())) {
             switchImageOptimizaton.visibility = View.VISIBLE
             switchImageOptimizaton.isChecked = AppPrefs.getImageOptimizationEnabled()
             switchImageOptimizaton.setOnCheckedChangeListener { _, isChecked ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -261,9 +261,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         }
 
         // show product variants only if product type is variable and if there are variations for the product
-        if (product.type == VARIABLE &&
-                FeatureFlag.PRODUCT_RELEASE_M1.isEnabled(context) &&
-                product.numVariations > 0) {
+        if (product.type == VARIABLE && product.numVariations > 0) {
             val properties = mutableMapOf<String, String>()
             for (attribute in product.attributes) {
                 properties[attribute.name] = attribute.options.size.toString()
@@ -773,8 +771,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
     }
 
     /**
-     * Add/Edit Product Release 1 is enabled only if beta setting is enabled and only for SIMPLE products
+     * Add/Edit Product Release 1 is enabled by default for SIMPLE products
      */
-    private fun isAddEditProductRelease1Enabled(productType: ProductType) =
-            FeatureFlag.PRODUCT_RELEASE_M1.isEnabled() && productType == ProductType.SIMPLE
+    private fun isAddEditProductRelease1Enabled(productType: ProductType) = productType == ProductType.SIMPLE
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -170,7 +170,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
 
         if (product.images.isEmpty() && !viewModel.isUploading()) {
             imageGallery.visibility = View.GONE
-            if (FeatureFlag.PRODUCT_IMAGE_CHOOSER.isEnabled(requireActivity())) {
+            if (FeatureFlag.PRODUCT_RELEASE_M2.isEnabled(requireActivity())) {
                 addImageContainer.visibility = View.VISIBLE
                 addImageContainer.setOnClickListener {
                     viewModel.onAddImageClicked()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -73,7 +73,7 @@ class ProductNavigator @Inject constructor() {
             is ViewProductImageChooser -> viewProductImageChooser(fragment, target.remoteId)
 
             is ViewProductImages -> {
-                if (FeatureFlag.PRODUCT_IMAGE_CHOOSER.isEnabled(fragment.requireActivity())) {
+                if (FeatureFlag.PRODUCT_RELEASE_M2.isEnabled(fragment.requireActivity())) {
                     viewProductImageChooser(fragment, target.product.remoteId)
                 } else if (target.imageModel != null) {
                     ImageViewerActivity.showProductImages(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -8,14 +8,12 @@ import com.woocommerce.android.BuildConfig
  */
 enum class FeatureFlag {
     PRODUCT_RELEASE_M2,
-    DB_DOWNGRADE,
-    PRODUCT_IMAGE_CHOOSER;
+    DB_DOWNGRADE;
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
             // currently only enabled for debug users but once live, this feature will live switched on from the
             // setting screen. i.e. check AppPrefs.isProductsFeatureEnabled() method
             PRODUCT_RELEASE_M2 -> BuildConfig.DEBUG
-            PRODUCT_IMAGE_CHOOSER -> BuildConfig.DEBUG && PRODUCT_RELEASE_M2.isEnabled(context)
             DB_DOWNGRADE -> {
                 BuildConfig.DEBUG || context != null && PackageUtils.isBetaBuild(context)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -1,20 +1,21 @@
 package com.woocommerce.android.util
 
 import android.content.Context
-import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig
 
 /**
  * "Feature flags" are used to hide in-progress features from release versions
  */
 enum class FeatureFlag {
-    PRODUCT_RELEASE_M1,
+    PRODUCT_RELEASE_M2,
     DB_DOWNGRADE,
     PRODUCT_IMAGE_CHOOSER;
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
-            PRODUCT_RELEASE_M1 -> AppPrefs.isProductsFeatureEnabled()
-            PRODUCT_IMAGE_CHOOSER -> BuildConfig.DEBUG && PRODUCT_RELEASE_M1.isEnabled(context)
+            // currently only enabled for debug users but once live, this feature will live switched on from the
+            // setting screen. i.e. check AppPrefs.isProductsFeatureEnabled() method
+            PRODUCT_RELEASE_M2 -> BuildConfig.DEBUG
+            PRODUCT_IMAGE_CHOOSER -> BuildConfig.DEBUG && PRODUCT_RELEASE_M2.isEnabled(context)
             DB_DOWNGRADE -> {
                 BuildConfig.DEBUG || context != null && PackageUtils.isBetaBuild(context)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -64,7 +64,7 @@ class WCProductImageGalleryView @JvmOverloads constructor(
             val attrArray = context.obtainStyledAttributes(it, R.styleable.WCProductImageGalleryView)
             try {
                 isGridView = attrArray.getBoolean(R.styleable.WCProductImageGalleryView_isGridView, false)
-                if (FeatureFlag.PRODUCT_IMAGE_CHOOSER.isEnabled(context)) {
+                if (FeatureFlag.PRODUCT_RELEASE_M2.isEnabled(context)) {
                     showAddImageIcon = attrArray.getBoolean(
                             R.styleable.WCProductImageGalleryView_showAddImageIcon,
                             false

--- a/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
@@ -26,6 +26,7 @@
         android:id="@+id/switchProductsUI"
         style="@style/Woo.Settings.Label"
         android:layout_width="0dp"
+        android:visibility="gone"
         android:layout_height="wrap_content"
         app:switchSummary="@string/settings_enable_product_teaser_message"
         app:switchSummaryTextColor="@color/wc_grey_medium"


### PR DESCRIPTION
Fixes #2113 by removing the feature flag for products M1 release and enabling the products tab by default.

#### Changes
- Hide the products switch in the beta features settings screen.
- Removed `PRODUCT_RELEASE_M1` from the `FeatureFlag` since we are switching on products tab and editing for simple products, by default.

#### To test
- Verify that there is no mention of products in the Beta Features section in the Settings page.
- Verify that the products tab is displayed by default.
- Verify that product editing features is enabled for simple products only.
- Read only product variants are available by default for variable products.
- M2 features are not displayed in the release version of the app.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
