### PR TITLE
Crash fix: Init bottomNavView before setting navController listener

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -126,11 +126,11 @@ class MainActivity : AppUpgradeActivity(),
 
         presenter.takeView(this)
 
+        bottomNavView = bottom_nav.also { it.init(supportFragmentManager, this) }
+
         val navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment_main) as NavHostFragment
         navController = navHostFragment.navController
         navController.addOnDestinationChangedListener(this)
-
-        bottomNavView = bottom_nav.also { it.init(supportFragmentManager, this) }
 
         // Verify authenticated session
         if (!presenter.userIsLoggedIn()) {


### PR DESCRIPTION
Fixes #2120 . I was able to reproduce the crash by enabling `Do not keep activities` and resuming the app from the product detail screen. The problem was that `bottomNavView` was being initialized too late in onCreate, after logic which sets the `navController` listener. Calls to `onDestinationChanged` in this state would cause the `UninitializedPropertyAccessException`.

#### To test
- Enable `Do not keep activities`.
- Open the app and click on a product from the `Top earners` list.
- Click on the `Home` button.
- Open the app again and notice app crashes.
- Pull changes from this PR and notice the app no longer crashes.

**This is a hotfix and would likely require a new beta release. cc @jkmassel 🙏** 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
