### PR TITLE
Order list: verify site exists before accessing it to prevent a crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListRepository.kt
@@ -67,10 +67,15 @@ class OrderListRepository @Inject constructor(
 
     suspend fun getCachedOrderStatusOptions(): Map<String, WCOrderStatusModel> {
         return withContext(coroutineDispatchers.io) {
-            val statusOptions = orderStore.getOrderStatusOptionsForSite(selectedSite.get())
-            if (statusOptions.isNotEmpty()) {
-                statusOptions.map { it.statusKey to it }.toMap()
+            if (selectedSite.exists()) {
+                val statusOptions = orderStore.getOrderStatusOptionsForSite(selectedSite.get())
+                if (statusOptions.isNotEmpty()) {
+                    statusOptions.map { it.statusKey to it }.toMap()
+                } else {
+                    emptyMap()
+                }
             } else {
+                WooLog.w(ORDERS, "No site selected - unable to load order status options")
                 emptyMap()
             }
         }


### PR DESCRIPTION
Fixes #2121. I was unable to reproduce this crash issue, but these changes will fix it by first checking if `selectedSite.exists()` before calling `selectedSite.get()` when fetching order status options. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
