### PR TITLE
Fixed crash when selecting a start date for sale without the end date

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
@@ -108,13 +108,15 @@ class ProductPricingFragment : BaseProductFragment(), ProductInventorySelectorDi
             }
             new.minDate?.takeIfNotEqualTo(old?.minDate) {
                 // update end date to min date if current end date < start date
-                if (it.after(viewModel.getProduct().product?.dateOnSaleToGmt)) {
+                val dateOnSaleToGmt = viewModel.getProduct().product?.dateOnSaleToGmt
+                if (dateOnSaleToGmt?.before(it) == true) {
                     scheduleSale_endDate.setText(it.formatToMMMddYYYY())
                 }
             }
             new.maxDate?.takeIfNotEqualTo(old?.maxDate) {
                 // update start date to max date if current start date > end date
-                if (it.before(viewModel.getProduct().product?.dateOnSaleFromGmt)) {
+                val dateOnSaleFromGmt = viewModel.getProduct().product?.dateOnSaleFromGmt
+                if (dateOnSaleFromGmt?.after(it) == true) {
                     scheduleSale_startDate.setText(it.formatToMMMddYYYY())
                 }
             }


### PR DESCRIPTION
Fixes #2133. The app was crashing when an previously scheduled sale was switched off and the product pricing section was clicked. 

This crash is already fixed in this [PR](https://github.com/woocommerce/woocommerce-android/issues/PR) and has been merged into `develop` but given that this might be happening to users using the latest beta version, it would be a good idea to release a hotfix for this crash.

#### To Test
- Click on a product from the Products tab without a sale scheduled.
- Click on the pricing section.
- Toggle on the `Schedule sale` option.
- Click on the end date and choose a date.
- Click `Done`.
- Click on the pricing section again.
- Switch off the `Schedule sale` toggle.
- Click on the back button. Notice the discard dialog is clicked.
- Click on `Discard`.
- Notice the changes are discarded in the product detail screen.
- Click on the Pricing section again.
- Note that the app crashes.
- Pull changes from this PR and verify that the app is no longer crashing.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
