### PR TITLE
Issue/2131 hide bottom nav product detail 3.9

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -346,14 +346,6 @@ class MainActivity : AppUpgradeActivity(),
                 }
             }
             showBottomNav = when (destination.id) {
-                R.id.aztecEditorFragment,
-                R.id.productDetailFragment,
-                R.id.productShippingClassFragment,
-                R.id.productImagesFragment,
-                R.id.productInventoryFragment,
-                R.id.productPricingFragment,
-                R.id.productShippingFragment,
-                R.id.productVariantsFragment,
                 R.id.addOrderShipmentTrackingFragment,
                 R.id.addOrderNoteFragment,
                 R.id.issueRefundFragment,
@@ -364,7 +356,7 @@ class MainActivity : AppUpgradeActivity(),
                     false
                 }
                 else -> {
-                    true
+                    destination.parent?.id != R.id.nav_graph_products
                 }
             }
             showToolbarShadow = when (destination.id) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -346,6 +346,14 @@ class MainActivity : AppUpgradeActivity(),
                 }
             }
             showBottomNav = when (destination.id) {
+                R.id.aztecEditorFragment,
+                R.id.productDetailFragment,
+                R.id.productShippingClassFragment,
+                R.id.productImagesFragment,
+                R.id.productInventoryFragment,
+                R.id.productPricingFragment,
+                R.id.productShippingFragment,
+                R.id.productVariantsFragment,
                 R.id.addOrderShipmentTrackingFragment,
                 R.id.addOrderNoteFragment,
                 R.id.issueRefundFragment,


### PR DESCRIPTION
Closes #2131 - this PR hides the bottom navigation bar while in any product detail fragment. This way users can't accidentally tap bottom nav while editing a product and lose their changes.

**Note:** This targets `release/3.9`.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
