### PR TITLE
issue/2131-hide-bottom-nav-product-detail

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -356,7 +356,7 @@ class MainActivity : AppUpgradeActivity(),
                     false
                 }
                 else -> {
-                    true
+                    destination.parent?.id != R.id.nav_graph_products
                 }
             }
             showToolbarShadow = when (destination.id) {


### PR DESCRIPTION
Closes #2131 - this PR hides the bottom navigation bar while in any product detail fragment. This way users can't accidentally tap bottom nav while editing a product and lose their changes.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
