### PR TITLE
Issue/2132 product settings toggle

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/MockedProductDetailViewModel.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/MockedProductDetailViewModel.kt
@@ -52,7 +52,7 @@ final class MockedProductDetailViewModel @AssistedInject constructor(
         }.trim()
 
         return ProductDetailViewState(
-                product = product,
+                productDraft = product,
                 storedProduct = product,
                 cachedProduct = product,
                 weightWithUnits = weight,

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/MockedProductDetailViewModel.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/MockedProductDetailViewModel.kt
@@ -54,7 +54,6 @@ final class MockedProductDetailViewModel @AssistedInject constructor(
         return ProductDetailViewState(
                 productDraft = product,
                 storedProduct = product,
-                cachedProduct = product,
                 weightWithUnits = weight,
                 sizeWithUnits = size,
                 priceWithCurrency = formatCurrency(product.price, parameters.currencyCode),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
@@ -31,9 +31,16 @@ abstract class BaseProductFragment : BaseFragment(), BackPressListener {
 
     private var publishMenuItem: MenuItem? = null
 
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupObservers(viewModel)
+        // if this is the initial creation of this fragment, tell the viewModel to make a copy of the product
+        // as it exists now so we can easily discard changes are determine if any changes were made inside
+        // this fragment
+        if (savedInstanceState == null) {
+            viewModel.updateProductBeforeEnteringFragment()
+        }
     }
 
     private fun setupObservers(viewModel: ProductDetailViewModel) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
@@ -31,7 +31,6 @@ abstract class BaseProductFragment : BaseFragment(), BackPressListener {
 
     private var publishMenuItem: MenuItem? = null
 
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupObservers(viewModel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -98,7 +98,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
 
     private fun setupObservers(viewModel: ProductDetailViewModel) {
         viewModel.productDetailViewStateData.observe(viewLifecycleOwner) { old, new ->
-            new.product?.takeIfNotEqualTo(old?.product) { showProduct(new) }
+            new.productDraft?.takeIfNotEqualTo(old?.productDraft) { showProduct(new) }
             new.isProductUpdated?.takeIfNotEqualTo(old?.isProductUpdated) { showUpdateProductAction(it) }
             new.isSkeletonShown?.takeIfNotEqualTo(old?.isSkeletonShown) { showSkeleton(it) }
             new.isProgressDialogShown?.takeIfNotEqualTo(old?.isProgressDialogShown) { showProgressDialog(it) }
@@ -164,7 +164,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
     private fun showProduct(productData: ProductDetailViewState) {
         if (!isAdded) return
 
-        val product = requireNotNull(productData.product)
+        val product = requireNotNull(productData.productDraft)
         productName = product.name.fastStripHtml()
         updateActivityTitle()
 
@@ -207,7 +207,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
     }
 
     private fun addPrimaryCard(productData: ProductDetailViewState) {
-        val product = requireNotNull(productData.product)
+        val product = requireNotNull(productData.productDraft)
 
         if (isAddEditProductRelease1Enabled(product.type)) {
             addEditableView(DetailCard.Primary, R.string.product_detail_title_hint, productName)?.also { view ->
@@ -299,7 +299,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
      * New product detail card UI slated for new products release 1
      */
     private fun addSecondaryCard(productData: ProductDetailViewState) {
-        val product = requireNotNull(productData.product)
+        val product = requireNotNull(productData.productDraft)
 
         // If we have pricing info, show price & sales price as a group,
         // otherwise provide option to add pricing info for the product
@@ -416,7 +416,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
      * Product Release 1 changes are completed.
      */
     private fun addPricingAndInventoryCard(productData: ProductDetailViewState) {
-        val product = requireNotNull(productData.product)
+        val product = requireNotNull(productData.productDraft)
 
         // if we have pricing info this card is "Pricing and inventory" otherwise it's just "Inventory"
         val hasPricingInfo = product.price != null || product.salePrice != null || product.taxClass.isNotEmpty()
@@ -459,7 +459,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
     }
 
     private fun addPurchaseDetailsCard(productData: ProductDetailViewState) {
-        val product = requireNotNull(productData.product)
+        val product = requireNotNull(productData.productDraft)
 
         // shipping group is part of the secondary card if edit product is enabled
         if (!isAddEditProductRelease1Enabled(product.type)) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -313,7 +313,7 @@ class ProductDetailViewModel @AssistedInject constructor(
      * changes in that specific screen
      */
     fun updateProductBeforeEnteringFragment() {
-        viewState.productBeforeEnteringFragment = viewState.cachedProduct ?: viewState.product
+        viewState.productBeforeEnteringFragment = viewState.product
     }
 
     /**
@@ -372,7 +372,7 @@ class ProductDetailViewModel @AssistedInject constructor(
                         dateOnSaleFromGmt ?: product.dateOnSaleFromGmt
                     } else viewState.storedProduct?.dateOnSaleFromGmt
             )
-            viewState = viewState.copy(cachedProduct = currentProduct, product = updatedProduct)
+            viewState = viewState.copy(product = updatedProduct)
 
             updateProductEditAction()
         }
@@ -389,10 +389,7 @@ class ProductDetailViewModel @AssistedInject constructor(
      * the state it was in when the screen was first entered
      */
     private fun discardEditChanges(event: ProductExitEvent) {
-        viewState = viewState.copy(
-                product = viewState.productBeforeEnteringFragment,
-                cachedProduct = viewState.productBeforeEnteringFragment
-        )
+        viewState = viewState.copy(product = viewState.productBeforeEnteringFragment)
 
         // updates the UPDATE menu button in the product detail screen i.e. the UPDATE menu button
         // will only be displayed if there are changes made to the Product model.
@@ -575,7 +572,6 @@ class ProductDetailViewModel @AssistedInject constructor(
 
         viewState = viewState.copy(
                 product = updatedProduct,
-                cachedProduct = viewState.cachedProduct ?: updatedProduct,
                 storedProduct = storedProduct,
                 weightWithUnits = weightWithUnits,
                 sizeWithUnits = sizeWithUnits,
@@ -631,7 +627,6 @@ class ProductDetailViewModel @AssistedInject constructor(
 
     /**
      * [product] is used for the UI. Any updates to the fields in the UI would update this model.
-     * [cachedProduct] is a copy of the [product] model before a change has been made to the [product] model.
      * [storedProduct] is the [Product] model that is fetched from the API and available in the local db.
      * This is read only and is not updated in any way. It is used in the product detail screen, to check
      * if we need to display the UPDATE menu button (which is only displayed if there are changes made to
@@ -641,13 +636,9 @@ class ProductDetailViewModel @AssistedInject constructor(
      * [product] and [storedProduct]. Currently used in the product detail screen to display or hide the UPDATE
      * menu button.
      *
-     * When the user first enters the product detail screen, the [product] , [storedProduct]  and [cachedProduct] 
-     * are the same. When a change is made to the product in the UI,
-     * 1. the [cachedProduct] is updated with the [product] model first, then
-     * 2. the [product] model is updated with whatever change has been made in the UI.
-     *
-     * The [cachedProduct] keeps track of the changes made to the [product] in order to discard the changes
-     * when necessary.
+     * When the user first enters the product detail screen, the [product] and [storedProduct] are the same.
+     * When a change is made to the product in the UI, the [product] model is updated with whatever change
+     * has been made in the UI.
      *
      * The [productBeforeEnteringFragment] is a copy of the product before a specific detail fragment is entered
      *
@@ -656,7 +647,6 @@ class ProductDetailViewModel @AssistedInject constructor(
     data class ProductDetailViewState(
         val product: Product? = null,
         var productBeforeEnteringFragment: Product? = null,
-        var cachedProduct: Product? = null,
         var storedProduct: Product? = null,
         val isSkeletonShown: Boolean? = null,
         val uploadingImageUris: List<Uri>? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -244,7 +244,7 @@ class ProductDetailViewModel @AssistedInject constructor(
             triggerEvent(ShowDiscardDialog(
                     positiveBtnAction = DialogInterface.OnClickListener { _, _ ->
                         // discard changes made to the current screen
-                        discardEditChanges(event)
+                        discardEditChanges()
 
                         // If user in Product detail screen, exit product detail,
                         // otherwise, redirect to Product Detail screen
@@ -388,7 +388,7 @@ class ProductDetailViewModel @AssistedInject constructor(
      * Called when discard is clicked on any of the product screens to restore the product to
      * the state it was in when the screen was first entered
      */
-    private fun discardEditChanges(event: ProductExitEvent) {
+    private fun discardEditChanges() {
         viewState = viewState.copy(productDraft = viewState.productBeforeEnteringFragment)
 
         // updates the UPDATE menu button in the product detail screen i.e. the UPDATE menu button

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
@@ -99,7 +99,7 @@ class ProductInventoryFragment : BaseProductFragment(), ProductInventorySelector
     private fun updateProductView(productData: ProductDetailViewState) {
         if (!isAdded) return
 
-        val product = requireNotNull(productData.product)
+        val product = requireNotNull(productData.productDraft)
         with(product_sku) {
             setText(product.sku)
             setOnTextChangedListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
@@ -111,7 +111,7 @@ class ProductPricingFragment : BaseProductFragment(), ProductInventorySelectorDi
             }
             new.minDate?.takeIfNotEqualTo(old?.minDate) {
                 // update end date to min date if current end date < start date
-                val dateOnSaleToGmt = viewModel.getProduct().product?.dateOnSaleToGmt
+                val dateOnSaleToGmt = viewModel.getProduct().productDraft?.dateOnSaleToGmt
                 if (dateOnSaleToGmt?.before(it) == true) {
                     scheduleSale_endDate.setText(it.formatToMMMddYYYY())
                 }
@@ -120,7 +120,7 @@ class ProductPricingFragment : BaseProductFragment(), ProductInventorySelectorDi
             // update start date to max date if current start date > end date
             if (new.maxDate == null) {
                 scheduleSale_endDate.setText("")
-            } else if (new.maxDate.before(viewModel.getProduct().product?.dateOnSaleFromGmt)) {
+            } else if (new.maxDate.before(viewModel.getProduct().productDraft?.dateOnSaleFromGmt)) {
                 scheduleSale_startDate.setText(new.maxDate.formatToMMMddYYYY())
             }
 
@@ -146,7 +146,7 @@ class ProductPricingFragment : BaseProductFragment(), ProductInventorySelectorDi
     ) {
         if (!isAdded) return
 
-        val product = requireNotNull(productData.product)
+        val product = requireNotNull(productData.productDraft)
         with(product_regular_price) {
             initialiseCurrencyEditText(currency, decimals, currencyFormatter)
             product.regularPrice?.let { setText(it) }
@@ -249,7 +249,7 @@ class ProductPricingFragment : BaseProductFragment(), ProductInventorySelectorDi
     ) {
         if (!isAdded) return
 
-        val product = requireNotNull(productData.product)
+        val product = requireNotNull(productData.productDraft)
 
         val productTaxClass = if (product.taxClass.isEmpty()) {
             getString(R.string.product_tax_class_standard)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassFragment.kt
@@ -36,7 +36,7 @@ class ProductShippingClassFragment : BaseProductFragment(), ShippingClassAdapter
         shippingClassAdapter = ProductShippingClassAdapter(
                 requireActivity(),
                 this,
-                viewModel.getProduct().product?.shippingClass
+                viewModel.getProduct().productDraft?.shippingClass
         )
 
         with(recycler) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingFragment.kt
@@ -119,7 +119,7 @@ class ProductShippingFragment : BaseProductFragment() {
     private fun updateProductView(productData: ProductDetailViewState) {
         if (!isAdded) return
 
-        val product = productData.product
+        val product = productData.productDraft
         if (product == null) {
             WooLog.w(T.PRODUCTS, "product shipping > productData.product is null")
             return

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -46,7 +46,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: ProductDetailViewModel
 
     private val productWithParameters = ProductDetailViewState(
-            product = product,
+            productDraft = product,
             cachedProduct = product,
             storedProduct = product,
             isSkeletonShown = false,
@@ -167,7 +167,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         viewModel.updateProductDraft(updatedDescription)
 
         viewModel.start(productRemoteId)
-        assertThat(productData?.product?.description).isEqualTo(updatedDescription)
+        assertThat(productData?.productDraft?.description).isEqualTo(updatedDescription)
     }
 
     @Test
@@ -269,6 +269,6 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         assertThat(snackbar).isEqualTo(ShowSnackbar(R.string.product_detail_update_product_success))
         assertThat(productData?.isProgressDialogShown).isFalse()
         assertThat(productData?.isProductUpdated).isFalse()
-        assertThat(productData?.product).isEqualTo(product)
+        assertThat(productData?.productDraft).isEqualTo(product)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -47,7 +47,6 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
     private val productWithParameters = ProductDetailViewState(
             productDraft = product,
-            cachedProduct = product,
             storedProduct = product,
             isSkeletonShown = false,
             uploadingImageUris = emptyList(),


### PR DESCRIPTION
Fixes #2132 - this PR changes the logic for the product editing experience so we store a copy of the product when a product fragment is entered. This copy is used to detect whether changes to the product have been made in that fragment. and the copy is restored if the user chooses to discard changes.

I also renamed `product` to `productDraft` to clarify its purpose.

@anitaa1990 and @0nko I'd love to have both of you look at this PR, since you're more familiar with this code than I am.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
