### PR TITLE
issue/2139-show-bottom-nav-only-for-primary-fragments

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -318,15 +318,12 @@ class MainActivity : AppUpgradeActivity(),
             container.visibility = View.INVISIBLE
         }
 
-        // make sure the correct up icon appears
         val showUpIcon: Boolean
         val showCrossIcon: Boolean
-        val showBottomNav: Boolean
         val showToolbarShadow: Boolean
         if (isAtRoot) {
             showUpIcon = false
             showCrossIcon = false
-            showBottomNav = true
             showToolbarShadow = true
         } else {
             showUpIcon = true
@@ -343,20 +340,6 @@ class MainActivity : AppUpgradeActivity(),
                 }
                 else -> {
                     false
-                }
-            }
-            showBottomNav = when (destination.id) {
-                R.id.addOrderShipmentTrackingFragment,
-                R.id.addOrderNoteFragment,
-                R.id.issueRefundFragment,
-                R.id.refundAmountDialog,
-                R.id.refundConfirmationDialog,
-                R.id.refundItemsPickerDialog,
-                R.id.refundSummaryFragment -> {
-                    false
-                }
-                else -> {
-                    true
                 }
             }
             showToolbarShadow = when (destination.id) {
@@ -380,7 +363,8 @@ class MainActivity : AppUpgradeActivity(),
             }
         }
 
-        if (showBottomNav) {
+        // only show bottom nav if we're at a root fragment
+        if (isAtRoot) {
             showBottomNav()
         } else {
             hideBottomNav()


### PR DESCRIPTION
Closes #2139 - as per [this design comment](https://github.com/woocommerce/woocommerce-android/issues/2131#issuecomment-604941027), this PR changes bottom navigation so it only appears for the four main fragments.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
