### PR TITLE
Check for null products

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/imageviewer/ImageViewerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/imageviewer/ImageViewerActivity.kt
@@ -148,7 +148,7 @@ class ImageViewerActivity : AppCompatActivity(), ImageViewerListener {
 
     private fun setupObservers(viewModel: ImageViewerViewModel) {
         viewModel.product.observe(this, Observer { product ->
-            if (product.images.isEmpty()) {
+            if (product == null || product.images.isEmpty()) {
                 finishAfterTransition()
             } else {
                 setupViewPager(product.images)


### PR DESCRIPTION
Fixes #2122. 

I've tried different Android versions but I couldn't reproduce the issue. I'm suspecting the `remoteProductId` is somehow lost while the app is killed & restored for some users. Then the `0` default value is used, which produces a `null` product and causes the crash. So I simply added a null check to prevent it.