### PR TITLE
Merge 3.9 release notes into master

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,6 @@
+4.0
+-----
+ 
 3.9
 -----
 * Fixed a crash when clicking on 2 products at the same time from the Products list section.

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -47,9 +47,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "3.9-rc-1"
+            versionName "3.9-rc-2"
         }
-        versionCode 116
+        versionCode 117
 
         minSdkVersion 21
         targetSdkVersion 29

--- a/WooCommerce/metadata/PlayStoreStrings.pot
+++ b/WooCommerce/metadata/PlayStoreStrings.pot
@@ -11,18 +11,18 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_039"
+msgid ""
+"3.9:\n"
+"Fixed two crashes: one that happened when you selected two products in the Product List at the same time, and another that would happen when editing a negative stock quantity.\n"
+"\n"
+"Stay safe and wash your hands, everyone!\n"
+msgstr ""
+
 msgctxt "release_note_038"
 msgid ""
 "3.8:\n"
 "Raise your hand if you’d like to edit products on the go! To give available editing options a try, enable Product Editing in Settings > Beta Features.\n"
-msgstr ""
-
-msgctxt "release_note_037"
-msgid ""
-"3.7:\n"
-"- Details of refunded orders display both product refunds and shipping refunds.\n"
-"- Product titles no longer show HTML tags.\n"
-"- A few rare crashes fixed.\n"
 msgstr ""
 
 #. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,1 +1,3 @@
-Raise your hand if you’d like to edit products on the go! To give available editing options a try, enable Product Editing in Settings > Beta Features.
+Fixed two crashes: one that happened when you selected two products in the Product List at the same time, and another that would happen when editing a negative stock quantity.
+
+Stay safe and wash your hands, everyone!

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.6.6'
+    fluxCVersion = '1.6.8'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Merges the `3.9` release notes (as well as the new rc-2 beta fixes) into `master` to be picked up by GlotPress for translation.