### PR TITLE
Fixed bug where the end date of sale was not displayed and incorrect sale dates were displayed in product detail

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
@@ -110,22 +110,18 @@ class ProductPricingFragment : BaseProductFragment(), ProductInventorySelectorDi
                 updateProductTaxClassList(it, viewModel.getProduct())
             }
             new.minDate?.takeIfNotEqualTo(old?.minDate) {
-                // update end date to min date if current end date < start date
-                val dateOnSaleToGmt = viewModel.getProduct().productDraft?.dateOnSaleToGmt
-                if (dateOnSaleToGmt?.before(it) == true) {
-                    scheduleSale_endDate.setText(it.formatToMMMddYYYY())
-                }
+                // update end date to min date since current end date < start date
+                scheduleSale_endDate.setText(it.formatToMMMddYYYY())
             }
-
-            // update start date to max date if current start date > end date
-            if (new.maxDate == null) {
-                scheduleSale_endDate.setText("")
-            } else if (new.maxDate.before(viewModel.getProduct().productDraft?.dateOnSaleFromGmt)) {
+            new.maxDate?.takeIfNotEqualTo(old?.maxDate) {
+                // update start date to max date since current start date > end date
                 scheduleSale_startDate.setText(new.maxDate.formatToMMMddYYYY())
             }
-
             new.isRemoveMaxDateButtonVisible.takeIfNotEqualTo(old?.isRemoveMaxDateButtonVisible) { isVisible ->
-                scheduleSale_RemoveEndDateButton.visibility = if (isVisible) View.VISIBLE else View.GONE
+                scheduleSale_RemoveEndDateButton.visibility = if (isVisible == true) View.VISIBLE else {
+                    scheduleSale_endDate.setText("")
+                    View.GONE
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #2126. This PR fixes two bugs when scheduling sale of a product.

#### Issue 1:
I noticed that the end date of a sale was not displayed, even if available. This was because we were setting the end date text to be empty, [if `maxDate` was null](https://github.com/woocommerce/woocommerce-android/blob/eaa9849ceb84b8bec8016052cfe63e2a321aa45c/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt#L122).

######To reproduce
- Open `wp-admin` for your test site and schedule a sale with an end date.
- Open the app and login to your test site.
- Click on the `Products` tab and click on the product edited in Step 1.
- Click on the `Pricing` section.
- Notice the end date of the sale is not displayed.
- Pull changes from this PR and verify that the end date is displayed.
- Click on `Remove end date` and `Done` and notice that the end date is no longer displayed.
- If the end date is empty, the `Remove end date` button should not be displayed.

#### Issue 2:
The dates of a sale was not displayed correctly in the product detail screen if the end date selected was before the start date.

##### To reproduce
- Click on the `Products` tab and click on the product edited in Step 1.
- Click on the `Pricing` section.
- Toggle on the schedule sale button.
- Select an end date of a sale before the start date.
- Click on `Done`.
- Notice the dates of the sale in product detail is not displayed correctly.
- Pull changes from this PR and verify that the dates are displayed correctly.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
