### PR TITLE
Fixed bug where discard dialog was displayed when default tax class was selected

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -274,7 +274,7 @@ fun WCProductModel.toAppModel(): Product {
         price = this.price.toBigDecimalOrNull()?.roundError(),
         salePrice = this.salePrice.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
         regularPrice = this.regularPrice.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
-        taxClass = this.taxClass,
+        taxClass = if (this.taxClass.isEmpty()) "standard" else this.taxClass,
         manageStock = this.manageStock,
         stockQuantity = this.stockQuantity,
         sku = this.sku,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -61,6 +61,10 @@ data class Product(
     val taxStatus: ProductTaxStatus,
     val isSaleScheduled: Boolean
 ) : Parcelable {
+    companion object {
+        const val TAX_CLASS_DEFAULT = "standard"
+    }
+
     @Parcelize
     data class Image(
         val id: Long,
@@ -274,7 +278,9 @@ fun WCProductModel.toAppModel(): Product {
         price = this.price.toBigDecimalOrNull()?.roundError(),
         salePrice = this.salePrice.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
         regularPrice = this.regularPrice.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
-        taxClass = if (this.taxClass.isEmpty()) "standard" else this.taxClass,
+            // In Core, if a tax class is empty it is considered as standard and we are following the same
+            // procedure here
+        taxClass = if (this.taxClass.isEmpty()) Product.TAX_CLASS_DEFAULT else this.taxClass,
         manageStock = this.manageStock,
         stockQuantity = this.stockQuantity,
         sku = this.sku,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
@@ -251,11 +251,7 @@ class ProductPricingFragment : BaseProductFragment(), ProductInventorySelectorDi
 
         val product = requireNotNull(productData.productDraft)
 
-        val productTaxClass = if (product.taxClass.isEmpty()) {
-            getString(R.string.product_tax_class_standard)
-        } else viewModel.getTaxClassBySlug(product.taxClass)?.name ?: product.taxClass
-        product_tax_class.setText(productTaxClass)
-
+        product_tax_class.setText(viewModel.getTaxClassBySlug(product.taxClass)?.name ?: product.taxClass)
         taxClassList?.let { taxClasses ->
             product_tax_class.setClickListener {
                 productTaxClassSelectorDialog = ProductInventorySelectorDialog.newInstance(


### PR DESCRIPTION
Fixes #2147. The `tax_class` by default is set an empty string but the default option displayed in the UI is Standard Rate. When Standard Rate is selected again, the discard dialog is displayed (even though it shouldn't) because the `tax_class` is saved as standard instead of an empty string. This PR adds logic so that the default `tax_class` set is `standard` (which is what Core is doing).

#### Screenshots
(LEFT: Before the fix. RIGHT: after the fix)
<img width="300" src="https://user-images.githubusercontent.com/22608780/77869211-54e36300-725b-11ea-86a6-1e6a1e85a747.gif"/>. <img width="300" src="https://user-images.githubusercontent.com/22608780/77869215-57de5380-725b-11ea-97aa-f30153fc78d0.gif"/>

#### To test
- Click on a product from the products tab.
- Click on the `Inventory` section.
- Notice that the Tax class is set to `Standard Rate`.
- Click on the `Tax Class` field and select `Standard Rate` again.
- Click on the back/Home button.
- Notice the discard dialog is displayed, even when there are no changes to the product.
- Pull changes from this PR and verify that the discard dialog is not displayed in this scenario.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
