### PR TITLE
Issue/2146 shipping class bug fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
@@ -23,16 +23,13 @@ import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_SHIPPING_CLASS_LIST
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_SKU_AVAILABILITY
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT
 import org.wordpress.android.fluxc.action.WCProductAction.UPDATED_PRODUCT
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.store.WCProductStore
-import org.wordpress.android.fluxc.store.WCProductStore.FetchProductShippingClassListPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductSkuAvailabilityPayload
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
-import org.wordpress.android.fluxc.store.WCProductStore.OnProductShippingClassesChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductSkuAvailabilityChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductUpdated
 import org.wordpress.android.fluxc.store.WCTaxStore
@@ -49,19 +46,13 @@ class ProductDetailRepository @Inject constructor(
 ) {
     companion object {
         private const val ACTION_TIMEOUT = 10L * 1000
-        private const val SHIPPING_CLASS_PAGE_SIZE = WCProductStore.DEFAULT_PRODUCT_SHIPPING_CLASS_PAGE_SIZE
     }
 
     private var continuationUpdateProduct: Continuation<Boolean>? = null
     private var continuationFetchProduct: CancellableContinuation<Boolean>? = null
     private var continuationVerifySku: CancellableContinuation<Boolean>? = null
-    private var continuationShippingClasses: CancellableContinuation<Boolean>? = null
 
     private var isFetchingTaxClassList = false
-
-    private var shippingClassOffset = 0
-    final var canLoadMoreShippingClasses = true
-        private set
 
     init {
         dispatcher.register(this)
@@ -148,34 +139,6 @@ class ProductDetailRepository @Inject constructor(
         }
     }
 
-    /**
-     * Fetches the list of shipping classes for the [selectedSite], optionally loading the next page of classes
-     */
-    suspend fun fetchShippingClassesForSite(loadMore: Boolean = false): List<ShippingClass> {
-        try {
-            continuationShippingClasses?.cancel()
-            suspendCancellableCoroutineWithTimeout<Boolean>(ACTION_TIMEOUT) {
-                continuationShippingClasses = it
-                shippingClassOffset = if (loadMore) {
-                    shippingClassOffset + SHIPPING_CLASS_PAGE_SIZE
-                } else {
-                    0
-                }
-                val payload = FetchProductShippingClassListPayload(
-                        selectedSite.get(),
-                        pageSize = SHIPPING_CLASS_PAGE_SIZE,
-                        offset = shippingClassOffset
-                )
-                dispatcher.dispatch(WCProductActionBuilder.newFetchProductShippingClassListAction(payload))
-            }
-        } catch (e: CancellationException) {
-            WooLog.d(PRODUCTS, "CancellationException while fetching product shipping classes")
-        }
-
-        continuationShippingClasses = null
-        return getProductShippingClassesForSite()
-    }
-
     private fun getCachedWCProductModel(remoteProductId: Long) =
             productStore.getProductByRemoteId(selectedSite.get(), remoteProductId)
 
@@ -233,22 +196,6 @@ class ProductDetailRepository @Inject constructor(
             // TODO: add event to track sku availability success
             continuationVerifySku?.resume(event.available)
             continuationVerifySku = null
-        }
-    }
-
-    /**
-     * The list of shipping classes has been fetched for the current site
-     */
-    @SuppressWarnings("unused")
-    @Subscribe(threadMode = MAIN)
-    fun onProductShippingClassesChanged(event: OnProductShippingClassesChanged) {
-        if (event.causeOfChange == FETCH_PRODUCT_SHIPPING_CLASS_LIST) {
-            canLoadMoreShippingClasses = event.canLoadMore
-            if (event.isError) {
-                continuationShippingClasses?.resume(false)
-            } else {
-                continuationShippingClasses?.resume(true)
-            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassFragment.kt
@@ -4,25 +4,37 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.navigation.fragment.findNavController
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
+import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.extensions.hide
+import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.ShippingClass
+import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.products.ProductShippingClassAdapter.ShippingClassAdapterListener
+import com.woocommerce.android.viewmodel.ViewModelFactory
 import kotlinx.android.synthetic.main.fragment_product_shipping_class_list.*
+import javax.inject.Inject
 
 /**
  * Dialog which displays a list of product shipping classes
  */
-class ProductShippingClassFragment : BaseProductFragment(), ShippingClassAdapterListener {
+class ProductShippingClassFragment : BaseFragment(), ShippingClassAdapterListener {
     companion object {
         const val TAG = "ProductShippingClassFragment"
+        const val ARG_SELECTED_SHIPPING_CLASS_SLUG = "selected-shipping-class-slug"
     }
+
+    @Inject lateinit var viewModelFactory: ViewModelFactory
+    private val viewModel: ProductShippingClassViewModel by viewModels { viewModelFactory }
+
+    private val navArgs: ProductShippingClassFragmentArgs by navArgs()
 
     private var shippingClassAdapter: ProductShippingClassAdapter? = null
 
@@ -36,7 +48,7 @@ class ProductShippingClassFragment : BaseProductFragment(), ShippingClassAdapter
         shippingClassAdapter = ProductShippingClassAdapter(
                 requireActivity(),
                 this,
-                viewModel.getProduct().productDraft?.shippingClass
+                navArgs.productShippingClassSlug
         )
 
         with(recycler) {
@@ -80,17 +92,18 @@ class ProductShippingClassFragment : BaseProductFragment(), ShippingClassAdapter
     override fun getFragmentTitle() = getString(R.string.product_shipping_class)
 
     override fun onShippingClassClicked(shippingClass: ShippingClass?) {
-        viewModel.updateProductDraft(shippingClass = shippingClass?.slug ?: "")
-        findNavController().navigateUp()
+        val bundle = Bundle()
+        bundle.putString(ARG_SELECTED_SHIPPING_CLASS_SLUG, shippingClass?.slug ?: "")
+        requireActivity().navigateBackWithResult(
+                RequestCodes.PRODUCT_SHIPPING_CLASS,
+                bundle,
+                R.id.nav_host_fragment_main,
+                R.id.productShippingFragment
+        )
     }
 
     override fun onRequestLoadMore() {
         viewModel.loadShippingClasses(loadMore = true)
-    }
-
-    override fun onRequestAllowBackPress(): Boolean {
-        // we always return true here because the fragment is left as soon as the user chooses a shipping class
-        return true
     }
 
     private fun showLoadingProgress(show: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassModule.kt
@@ -23,8 +23,8 @@ abstract class ProductShippingClassModule {
 
     @Binds
     @IntoMap
-    @ViewModelKey(ProductDetailViewModel::class)
-    abstract fun bindFactory(factory: ProductDetailViewModel.Factory): ViewModelAssistedFactory<out ViewModel>
+    @ViewModelKey(ProductShippingClassViewModel::class)
+    abstract fun bindFactory(factory: ProductShippingClassViewModel.Factory): ViewModelAssistedFactory<out ViewModel>
 
     @Binds
     abstract fun bindSavedStateRegistryOwner(fragment: ProductShippingClassFragment): SavedStateRegistryOwner

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassRepository.kt
@@ -1,0 +1,98 @@
+package com.woocommerce.android.ui.products
+
+import com.woocommerce.android.model.ShippingClass
+import com.woocommerce.android.model.toAppModel
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T.PRODUCTS
+import com.woocommerce.android.util.suspendCancellableCoroutineWithTimeout
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.CancellationException
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode.MAIN
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_SHIPPING_CLASS_LIST
+import org.wordpress.android.fluxc.generated.WCProductActionBuilder
+import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCProductStore.FetchProductShippingClassListPayload
+import org.wordpress.android.fluxc.store.WCProductStore.OnProductShippingClassesChanged
+import javax.inject.Inject
+import kotlin.coroutines.resume
+
+class ProductShippingClassRepository@Inject constructor(
+    private val dispatcher: Dispatcher,
+    private val productStore: WCProductStore,
+    private val selectedSite: SelectedSite
+) {
+    companion object {
+        private const val ACTION_TIMEOUT = 10L * 1000
+        private const val SHIPPING_CLASS_PAGE_SIZE = WCProductStore.DEFAULT_PRODUCT_SHIPPING_CLASS_PAGE_SIZE
+    }
+
+
+    private var continuationShippingClasses: CancellableContinuation<Boolean>? = null
+
+    private var shippingClassOffset = 0
+    final var canLoadMoreShippingClasses = true
+        private set
+
+    init {
+        dispatcher.register(this)
+    }
+
+    fun onCleanup() {
+        dispatcher.unregister(this)
+    }
+
+
+    /**
+     * Fetches the list of shipping classes for the [selectedSite], optionally loading the next page of classes
+     */
+    suspend fun fetchShippingClassesForSite(loadMore: Boolean = false): List<ShippingClass> {
+        try {
+            continuationShippingClasses?.cancel()
+            suspendCancellableCoroutineWithTimeout<Boolean>(ACTION_TIMEOUT) {
+                continuationShippingClasses = it
+                shippingClassOffset = if (loadMore) {
+                    shippingClassOffset + SHIPPING_CLASS_PAGE_SIZE
+                } else {
+                    0
+                }
+                val payload = FetchProductShippingClassListPayload(
+                        selectedSite.get(),
+                        pageSize = SHIPPING_CLASS_PAGE_SIZE,
+                        offset = shippingClassOffset
+                )
+                dispatcher.dispatch(WCProductActionBuilder.newFetchProductShippingClassListAction(payload))
+            }
+        } catch (e: CancellationException) {
+            WooLog.d(PRODUCTS, "CancellationException while fetching product shipping classes")
+        }
+
+        continuationShippingClasses = null
+        return getProductShippingClassesForSite()
+    }
+
+    /**
+     * Returns a list of cached (SQLite) shipping classes for the current site
+     */
+    fun getProductShippingClassesForSite(): List<ShippingClass> =
+            productStore.getShippingClassListForSite(selectedSite.get()).map { it.toAppModel() }
+
+
+    /**
+     * The list of shipping classes has been fetched for the current site
+     */
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = MAIN)
+    fun onProductShippingClassesChanged(event: OnProductShippingClassesChanged) {
+        if (event.causeOfChange == FETCH_PRODUCT_SHIPPING_CLASS_LIST) {
+            canLoadMoreShippingClasses = event.canLoadMore
+            if (event.isError) {
+                continuationShippingClasses?.resume(false)
+            } else {
+                continuationShippingClasses?.resume(true)
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassRepository.kt
@@ -29,7 +29,6 @@ class ProductShippingClassRepository@Inject constructor(
         private const val SHIPPING_CLASS_PAGE_SIZE = WCProductStore.DEFAULT_PRODUCT_SHIPPING_CLASS_PAGE_SIZE
     }
 
-
     private var continuationShippingClasses: CancellableContinuation<Boolean>? = null
 
     private var shippingClassOffset = 0
@@ -43,7 +42,6 @@ class ProductShippingClassRepository@Inject constructor(
     fun onCleanup() {
         dispatcher.unregister(this)
     }
-
 
     /**
      * Fetches the list of shipping classes for the [selectedSite], optionally loading the next page of classes
@@ -78,7 +76,6 @@ class ProductShippingClassRepository@Inject constructor(
      */
     fun getProductShippingClassesForSite(): List<ShippingClass> =
             productStore.getShippingClassListForSite(selectedSite.get()).map { it.toAppModel() }
-
 
     /**
      * The list of shipping classes has been fetched for the current site

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassViewModel.kt
@@ -1,0 +1,96 @@
+package com.woocommerce.android.ui.products
+
+import android.os.Parcelable
+import com.squareup.inject.assisted.Assisted
+import com.squareup.inject.assisted.AssistedInject
+import com.woocommerce.android.annotations.OpenClassOnDebug
+import com.woocommerce.android.di.ViewModelAssistedFactory
+import com.woocommerce.android.model.ShippingClass
+import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T
+import com.woocommerce.android.viewmodel.LiveDataDelegate
+import com.woocommerce.android.viewmodel.SavedStateWithArgs
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import kotlinx.android.parcel.Parcelize
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+@OpenClassOnDebug
+class ProductShippingClassViewModel @AssistedInject constructor(
+    @Assisted savedState: SavedStateWithArgs,
+    dispatchers: CoroutineDispatchers,
+    private val productRepository: ProductShippingClassRepository
+) : ScopedViewModel(savedState, dispatchers) {
+    private var shippingClassLoadJob: Job? = null
+
+    // view state for the shipping class screen
+    final val productShippingClassViewStateData = LiveDataDelegate(savedState, ProductShippingClassViewState())
+    private var productShippingClassViewState by productShippingClassViewStateData
+
+    /**
+     * Load & fetch the shipping classes for the current site, optionally performing a "load more" to
+     * load the next page of shipping classes
+     */
+    fun loadShippingClasses(loadMore: Boolean = false) {
+        if (loadMore && !productRepository.canLoadMoreShippingClasses) {
+            WooLog.d(T.PRODUCTS, "Can't load more product shipping classes")
+            return
+        }
+
+        waitForExistingShippingClassFetch()
+
+        shippingClassLoadJob = launch {
+            productShippingClassViewState = if (loadMore) {
+                productShippingClassViewState.copy(isLoadingMoreProgressShown = true)
+            } else {
+                // get cached shipping classes and only show loading progress the list is empty, otherwise show
+                // them right away
+                val cachedShippingClasses = productRepository.getProductShippingClassesForSite()
+                if (cachedShippingClasses.isEmpty()) {
+                    productShippingClassViewState.copy(isLoadingProgressShown = true)
+                } else {
+                    productShippingClassViewState.copy(shippingClassList = cachedShippingClasses)
+                }
+            }
+
+            // fetch shipping classes from the backend
+            val shippingClasses = productRepository.fetchShippingClassesForSite(loadMore)
+            productShippingClassViewState = productShippingClassViewState.copy(
+                    isLoadingProgressShown = false,
+                    isLoadingMoreProgressShown = false,
+                    shippingClassList = shippingClasses
+            )
+        }
+    }
+
+    /**
+     * If shipping classes are already being fetch, wait for the current fetch to complete - this is
+     * used above to avoid fetching multiple pages of shipping classes in unison
+     */
+    private fun waitForExistingShippingClassFetch() {
+        if (shippingClassLoadJob?.isActive == true) {
+            launch {
+                try {
+                    shippingClassLoadJob?.join()
+                } catch (e: CancellationException) {
+                    WooLog.d(
+                            T.PRODUCTS,
+                            "CancellationException while waiting for existing shipping class list fetch"
+                    )
+                }
+            }
+        }
+    }
+
+    @Parcelize
+    data class ProductShippingClassViewState(
+        val isLoadingProgressShown: Boolean = false,
+        val isLoadingMoreProgressShown: Boolean = false,
+        val shippingClassList: List<ShippingClass>? = null
+    ) : Parcelable
+
+    @AssistedInject.Factory
+    interface Factory : ViewModelAssistedFactory<ProductShippingClassViewModel>
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingFragment.kt
@@ -12,7 +12,9 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
+import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.ui.main.MainActivity.NavigationResult
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductDetailViewState
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitShipping
 import com.woocommerce.android.util.WooLog
@@ -24,7 +26,7 @@ import org.wordpress.android.util.ActivityUtils
 /**
  * Fragment which enables updating product shipping data.
  */
-class ProductShippingFragment : BaseProductFragment() {
+class ProductShippingFragment : BaseProductFragment(), NavigationResult {
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -136,7 +138,22 @@ class ProductShippingFragment : BaseProductFragment() {
     }
 
     private fun showShippingClassFragment() {
-        val action = ProductShippingFragmentDirections.actionProductShippingFragmentToProductShippingClassFragment()
+        val action = ProductShippingFragmentDirections
+                .actionProductShippingFragmentToProductShippingClassFragment(
+                        productShippingClassSlug = viewModel.getProduct().productDraft?.shippingClass ?: ""
+                )
         findNavController().navigate(action)
+    }
+
+    override fun onNavigationResult(requestCode: Int, result: Bundle) {
+        when (requestCode) {
+            RequestCodes.PRODUCT_SHIPPING_CLASS -> {
+                val selectedShippingClassSlug = result.getString(
+                        ProductShippingClassFragment.ARG_SELECTED_SHIPPING_CLASS_SLUG, ""
+                )
+                viewModel.updateProductDraft(shippingClass = selectedShippingClassSlug)
+                product_shipping_class_spinner.setText(viewModel.getShippingClassBySlug(selectedShippingClassSlug))
+            }
+        }
     }
 }

--- a/WooCommerce/src/main/res/navigation/nav_graph_products.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_products.xml
@@ -99,7 +99,12 @@
     <fragment
         android:id="@+id/productShippingClassFragment"
         android:name="com.woocommerce.android.ui.products.ProductShippingClassFragment"
-        android:label="ProductShippingClassFragment" />
+        android:label="ProductShippingClassFragment">
+        <argument
+            android:name="productShippingClassSlug"
+            android:defaultValue='""'
+            app:argType="string" />
+    </fragment>
     <fragment
         android:id="@+id/productPricingFragment"
         android:name="com.woocommerce.android.ui.products.ProductPricingFragment"


### PR DESCRIPTION
Fixes #2146. I thought about this approach and felt it was best to decouple the shipping class logic from the product detail view model since the shipping class fragment fetches only shipping classes and updates the product once a new shipping class is selected. This PR moves the shipping class fragment to it's own viewModel + repository since the shipping class does not need to use the shared viewmodel. 

#### Changes
- The logic is to pass the product's shipping class slug to the `ProductShippingClassFragment` as an `argument` so that it is retained during config change.
- When a new shipping class is selected, the result is passed onto the previous screen (`ProductShippingFragment`) and the product is updated accordingly.

I felt this was cleaner than including the shipping class logic in the product detail viewmodel but if this feels like the wrong approach, do let me know 😅 

#### Screenshots
(LEFT: Before. RIGHT: After)
<img width="300" src="https://user-images.githubusercontent.com/22608780/77869666-f7e8ac80-725c-11ea-89a8-4b9b1ff1e5a0.gif" />. <img width="300" src="https://user-images.githubusercontent.com/22608780/77869668-f9b27000-725c-11ea-8dd6-85a273bcc2cf.gif" />

#### To test
- Click on a product from the products tab.
- Click on the `Shipping` section.
- Click on the `Shipping Class` field.
- Select a shipping class from the list.
- Notice the selected shipping class is updated in the shipping class field.
- Click on the back button.
- Notice the discard dialog is not displayed.
- Pull changes from this PR and verify that the discard dialog is displayed.
- Smoke testing with config changes and `Do not keep activities` enabled just to ensure everything is working correctly, would also be great. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
