### PR TITLE
 Migrated View product link to options menu

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -40,6 +40,7 @@ import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductPr
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductShipping
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductVariations
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.StringUtils
@@ -111,6 +112,8 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         menu.clear()
         inflater.inflate(R.menu.menu_product_detail_fragment, menu)
+
+        menu.findItem(R.id.menu_view_product).isVisible = FeatureFlag.PRODUCT_RELEASE_M2.isEnabled()
         super.onCreateOptionsMenu(menu, inflater)
     }
 
@@ -126,6 +129,14 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
                 AnalyticsTracker.track(PRODUCT_DETAIL_UPDATE_BUTTON_TAPPED)
                 ActivityUtils.hideKeyboard(activity)
                 viewModel.onUpdateButtonClicked()
+                true
+            }
+
+            R.id.menu_view_product -> {
+                viewModel.getProduct().productDraft?.permalink?.let {
+                    AnalyticsTracker.track(PRODUCT_DETAIL_VIEW_EXTERNAL_TAPPED)
+                    ChromeCustomTabUtils.launchUrl(requireContext(), it)
+                }
                 true
             }
             else -> super.onOptionsItemSelected(item)
@@ -281,12 +292,15 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
             removePropertyView(DetailCard.Primary, getString(R.string.product_variations))
         }
 
-        addLinkView(
-                DetailCard.Primary,
-                R.string.product_view_in_store,
-                product.permalink,
-                PRODUCT_DETAIL_VIEW_EXTERNAL_TAPPED
-        )
+        // display `View product on Store` in options menu from M2 products release
+        if (!FeatureFlag.PRODUCT_RELEASE_M2.isEnabled()) {
+            addLinkView(
+                    DetailCard.Primary,
+                    R.string.product_view_in_store,
+                    product.permalink,
+                    PRODUCT_DETAIL_VIEW_EXTERNAL_TAPPED
+            )
+        }
         addLinkView(
                 DetailCard.Primary,
                 R.string.product_view_affiliate,

--- a/WooCommerce/src/main/res/menu/menu_product_detail_fragment.xml
+++ b/WooCommerce/src/main/res/menu/menu_product_detail_fragment.xml
@@ -13,4 +13,10 @@
         android:icon="@drawable/ic_share_white_24dp"
         android:title="@string/share"
         app:showAsAction="withText"/>
+
+    <item
+        android:id="@+id/menu_view_product"
+        android:title="@string/product_view_in_store"
+        app:showAsAction="withText"
+        android:visible="false"/>
 </menu>


### PR DESCRIPTION
Fixes #2080 by moving the `View product in Store` section to the options menu as part of the M2 product release. **Note that this will only be displayed to debug users for now**.

#### Screenshot
<img src="https://user-images.githubusercontent.com/22608780/77875134-cd065480-726c-11ea-80ee-1701386fc907.png" width="300" />


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
