### PR TITLE
Removed the total orders section from product detail

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -243,7 +243,8 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         }
 
         // we don't show total sales for variations because they're always zero
-        if (!isVariation) {
+        // we are removing the total orders sections from products M2 release
+        if (!isVariation && !FeatureFlag.PRODUCT_RELEASE_M2.isEnabled()) {
             addPropertyView(
                     DetailCard.Primary,
                     R.string.product_total_orders,


### PR DESCRIPTION
Fixes #2071 by removing the total orders section from the product detail screen. **Note that this tiny change only happens for the products m2 release (which is only enabled for debug users now)**.

<img width="300" src="https://user-images.githubusercontent.com/22608780/77875526-fa073700-726d-11ea-9aca-b82f9a7c2e05.png"/>

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
