### PR TITLE
Dark mode: fix bug with splash screen showing after switching themes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.main
 import android.app.Activity
 import android.app.ProgressDialog
 import android.content.Intent
+import android.content.res.Resources.Theme
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
@@ -116,13 +117,18 @@ class MainActivity : AppUpgradeActivity(),
     // TODO: Using deprecated ProgressDialog temporarily - a proper post-login experience will replace this
     private var progressDialog: ProgressDialog? = null
 
+    /**
+     * Manually set the theme here so the splash screen will be visible while this activity
+     * is loading. Also setting it here ensures all fragments used in this activity will also
+     * use this theme at runtime (in the case of switching the theme at runtime).
+     */
+    override fun getTheme(): Theme {
+        return super.getTheme().also { it.applyStyle(R.style.Theme_Woo_DayNight, true) }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         AndroidInjection.inject(this)
         super.onCreate(savedInstanceState)
-
-        // Manually set the theme here so the splash screen will be visible while this
-        // activity is loading.
-        setTheme(R.style.Theme_Woo_DayNight)
 
         setContentView(R.layout.activity_main)
 


### PR DESCRIPTION
This PR fixes a bug outlined in this [PR comment](https://github.com/woocommerce/woocommerce-android/pull/2145#pullrequestreview-383646410) where the splash screen would suddenly be visible after switching the app theme in settings. This had to do with the fragments not getting updated with the correct theme after the switch. 