### PR TITLE
Fixed crash when order note list adapter is null

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/OrderDetailOrderNoteListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/OrderDetailOrderNoteListView.kt
@@ -60,7 +60,7 @@ class OrderDetailOrderNoteListView @JvmOverloads constructor(ctx: Context, attrs
     }
 
     fun updateView(notes: List<OrderNote>) {
-        val adapter = notesList_notes.adapter as OrderNotesAdapter
+        val adapter = notesList_notes.adapter as? OrderNotesAdapter ?: OrderNotesAdapter()
         enableItemAnimator(adapter.itemCount == 0)
 
         val notesWithHeaders = addHeaders(notes)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/OrderDetailOrderNoteListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/OrderDetailOrderNoteListView.kt
@@ -32,12 +32,6 @@ class OrderDetailOrderNoteListView @JvmOverloads constructor(ctx: Context, attrs
     fun initView(notes: List<OrderNote>, orderDetailListener: OrderDetailNoteListener) {
         listener = orderDetailListener
 
-        val viewAdapter = OrderNotesAdapter()
-        val notesWithHeaders = addHeaders(notes)
-        viewAdapter.setNotes(notesWithHeaders)
-
-        val viewManager = LinearLayoutManager(context)
-
         noteList_addNoteContainer.setOnClickListener {
             AnalyticsTracker.track(Stat.ORDER_DETAIL_ADD_NOTE_BUTTON_TAPPED)
 
@@ -46,9 +40,11 @@ class OrderDetailOrderNoteListView @JvmOverloads constructor(ctx: Context, attrs
 
         notesList_notes.apply {
             setHasFixedSize(false)
-            layoutManager = viewManager
-            adapter = viewAdapter
+            layoutManager = LinearLayoutManager(context)
+            adapter = OrderNotesAdapter()
         }
+
+        updateView(notes)
     }
 
     private fun addHeaders(notes: List<OrderNote>): List<OrderNoteListItem> {


### PR DESCRIPTION
Fixes #2153. I wasn't able to reproduce the crash 🤦‍♀but thought that initialising the adapter again if it is null would fix the crash.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
