### PR TITLE
Dark Mode: Fix y-axis label color

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -205,6 +205,7 @@ class MyStoreStatsView @JvmOverloads constructor(
                 setDrawAxisLine(false)
                 setDrawGridLines(true)
                 gridColor = ContextCompat.getColor(context, R.color.graph_grid_color)
+                textColor = ContextCompat.getColor(context, R.color.graph_label_color)
 
                 // Couldn't use the dimension resource here due to the way this component is written :/
                 textSize = 10f


### PR DESCRIPTION
Tiny PR to fix the label color for the y-axis label coloring for stats. This must've gotten messed up during the last refresh with the develop branch. 

| Before | After |
| -- | -- |
|![Screenshot_1585700547](https://user-images.githubusercontent.com/5810477/78087004-797f2e00-7374-11ea-9f2e-d2434144ca14.png)|![Screenshot_1585700506](https://user-images.githubusercontent.com/5810477/78087009-7be18800-7374-11ea-8a5b-9323161cb7f1.png)|

