### PR TITLE
Dark Mode: Basic Zendesk Theming

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -75,6 +75,18 @@
             android:name=".ui.imageviewer.ImageViewerActivity"
             android:theme="@style/ImageViewer.Activity"/>
 
+        <activity android:name="zendesk.support.guide.HelpCenterActivity"
+            android:theme="@style/Theme.Woo.DayNight.Zendesk" />
+
+        <activity android:name="zendesk.support.guide.ViewArticleActivity"
+            android:theme="@style/Theme.Woo.DayNight.Zendesk" />
+
+        <activity android:name="zendesk.support.request.RequestActivity"
+            android:theme="@style/Theme.Woo.DayNight.Zendesk" />
+
+        <activity android:name="zendesk.support.requestlist.RequestListActivity"
+            android:theme="@style/Theme.Woo.DayNight.Zendesk" />
+
         <!-- Services -->
         <service
             android:name=".push.FCMRegistrationIntentService"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -205,6 +205,7 @@ class MyStoreStatsView @JvmOverloads constructor(
                 setDrawAxisLine(false)
                 setDrawGridLines(true)
                 gridColor = ContextCompat.getColor(context, R.color.graph_grid_color)
+                textColor = ContextCompat.getColor(context, R.color.graph_label_color)
 
                 // Couldn't use the dimension resource here due to the way this component is written :/
                 textSize = 10f

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -120,4 +120,10 @@
         <item name="colorControlNormal">@color/transparent</item>
         <item name="android:textAppearance">@style/TextAppearance.Woo.Headline6</item>
     </style>
+
+    <style name="Theme.Woo.DayNight.Zendesk">
+        <item name="colorPrimary">@color/color_primary_surface</item>
+        <item name="colorPrimaryDark">@color/color_primary</item>
+        <item name="colorAccent">@color/color_primary</item>
+    </style>
 </resources>


### PR DESCRIPTION
This PR closes #1854 by creating a specific Zendesk theme and applying it to the activities outlined in this [Zendesk help article](https://developer.zendesk.com/embeddables/docs/android-support-sdk/customize_the_look). This really only takes care of theming the toolbar for the zendesk-provided activities. I dug into their actual views and they _still_ have hard-coded background and text colors. Some colors I can manually override, but it's not full proof since there are entire styles that just have hard-coded hex color values. After tooling around with this for over 2 hours, I decided to rollback and take care of the major parts I can style easily since the rest is going to require hacks that I do not believe we should be doing. 

_Note that light mode was already displaying properly which is why there are no light more "before" screenshots_

| Before - Dark | After - Light | After - Dark |
| -- | -- | -- |
| ![zendesk-list-dark-old](https://user-images.githubusercontent.com/5810477/78095965-41d0b000-738d-11ea-8b32-17837bbd518c.png)|![zendesk-list-light-new](https://user-images.githubusercontent.com/5810477/78095981-4b5a1800-738d-11ea-856b-41e14cc24cb5.png)|![zendesk-list-dark-new](https://user-images.githubusercontent.com/5810477/78095989-514ff900-738d-11ea-9e70-afd03b58723d.png)|
|![zendesk-support-dark-old](https://user-images.githubusercontent.com/5810477/78095970-44330a00-738d-11ea-99ce-4d102a3f80cb.png)|![zendesk-support-light-new](https://user-images.githubusercontent.com/5810477/78096012-60cf4200-738d-11ea-9ddf-a03207aa5ed7.png)|![zendesk-support-dark-new](https://user-images.githubusercontent.com/5810477/78096015-63ca3280-738d-11ea-96ce-c5f07115b3ca.png)|

## To Test
Verify the above styles are properly displayed on API 21, 28 and 29 in light and dark modes


