### PR TITLE
Added logic to display shipping section with caption

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -408,8 +408,9 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
             }
         }
 
-        val hasShippingInfo = productData.weightWithUnits?.isNotEmpty() == true
-                || productData.sizeWithUnits?.isNotEmpty() == true || product.shippingClass.isNotEmpty()
+        val hasShippingInfo = productData.weightWithUnits?.isNotEmpty() == true ||
+                productData.sizeWithUnits?.isNotEmpty() == true ||
+                product.shippingClass.isNotEmpty()
         val shippingGroup = if (hasShippingInfo) {
             mapOf(
                     Pair(getString(R.string.product_weight), requireNotNull(productData.weightWithUnits)),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -408,17 +408,26 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
             }
         }
 
-        val shippingGroup = mapOf(
-                Pair(getString(R.string.product_weight), requireNotNull(productData.weightWithUnits)),
-                Pair(getString(R.string.product_dimensions), requireNotNull(productData.sizeWithUnits)),
-                Pair(getString(R.string.product_shipping_class), product.shippingClass)
-        )
+        val hasShippingInfo = productData.weightWithUnits?.isNotEmpty() == true
+                || productData.sizeWithUnits?.isNotEmpty() == true || product.shippingClass.isNotEmpty()
+        val shippingGroup = if (hasShippingInfo) {
+            mapOf(
+                    Pair(getString(R.string.product_weight), requireNotNull(productData.weightWithUnits)),
+                    Pair(getString(R.string.product_dimensions), requireNotNull(productData.sizeWithUnits)),
+                    Pair(getString(R.string.product_shipping_class), product.shippingClass)
+            )
+        } else mapOf(Pair("", getString(R.string.product_shipping_empty)))
+
         addPropertyGroup(
                 DetailCard.Secondary,
                 R.string.product_shipping,
                 shippingGroup,
                 groupIconId = R.drawable.ic_gridicons_shipping
         )?.also {
+            // display shipping caption only if shipping info is not available
+            if (!hasShippingInfo) {
+                it.showPropertyName(false)
+            }
             it.setClickListener {
                 AnalyticsTracker.track(Stat.PRODUCT_DETAIL_VIEW_SHIPPING_SETTINGS_TAPPED)
                 viewModel.onEditProductCardClicked(ViewProductShipping(product.remoteId))

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -412,6 +412,7 @@
     <string name="product_variants">Variants</string>
     <string name="product_price">Price</string>
     <string name="product_price_empty">Add price</string>
+    <string name="product_shipping_empty">Add shipping</string>
     <string name="product_regular_price">Regular price</string>
     <string name="product_sale_price">Sale price</string>
     <string name="product_schedule_sale_label">Schedule sale</string>


### PR DESCRIPTION
Fixes #2172 by providing the option to add shipping details to a product, if none is available.

#### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/22608780/78130884-bc560a00-7437-11ea-9031-cff7bd96c24f.png" />. <img width="300" src="https://user-images.githubusercontent.com/22608780/78130877-ba8c4680-7437-11ea-8ab5-b764a09a0bbf.png" />

#### To test
- Click on a products from the Products that does not have any shipping info available and verify that the shipping section is displayed.
- Remove the shipping section info for a product and click on the `Done` button. Verify that the shipping section is still displayed.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
