### PR TITLE
Fixed bug where 0 dimensions were updated when editing a product

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.formatDateToISO8601Format
 import com.woocommerce.android.extensions.formatToString
 import com.woocommerce.android.extensions.formatToYYYYmmDDhhmmss
+import com.woocommerce.android.extensions.isEqualTo
 import com.woocommerce.android.extensions.roundError
 import com.woocommerce.android.ui.products.ProductBackorderStatus
 import com.woocommerce.android.ui.products.ProductStatus
@@ -239,11 +240,11 @@ fun Product.toDataModel(storedProductModel: WCProductModel?): WCProductModel {
         it.soldIndividually = soldIndividually
         it.backorders = ProductBackorderStatus.fromBackorderStatus(backorderStatus)
         it.regularPrice = regularPrice.toString()
-        it.salePrice = salePrice.toString()
-        it.length = length.toString()
-        it.width = width.toString()
-        it.weight = weight.toString()
-        it.height = height.toString()
+        it.salePrice = if (salePrice isEqualTo BigDecimal.ZERO) "" else salePrice.toString()
+        it.length = if (length == 0f) "" else length.formatToString()
+        it.width = if (width == 0f) "" else width.formatToString()
+        it.weight = if (weight == 0f) "" else weight.formatToString()
+        it.height = if (height == 0f) "" else height.formatToString()
         it.shippingClass = shippingClass
         it.taxStatus = ProductTaxStatus.fromTaxStatus(taxStatus)
         it.taxClass = taxClass


### PR DESCRIPTION
Fixes #2164. There are two fixes in this PR.

### Issue 1:
When editing a product that does not have weights assigned, the app places 0.00 in for weights and dimensions and then shows that information on the front end.

#### To test
- Click on a product that does not have any weights/dimensions assigned to it.
- Click on the `Shipping Class` of the product and modify it.
- Click on the `Done` button.
- Click on `UPDATE` menu button.
- Go to the product in `wp-admin` and notice that the weight/length/height/width fields are empty. (Previously the values were set as 0.0)

### Issue 2:
When a product was updated from the Pricing screen, the sale price was set a 0.0 by default, when in fact it should be empty.

#### To test
- Click on a product from the Products tab with sale price set as 0.
- Update the Sale price to any value and click on `Done`.
- Click on the `UPDATE` menu button.
- Open the product on the web and notice the sale price is updated correctly.
- Open the app again and edit the same product.
- Update the Sale price to 0 and click on `Done`.
- Click on the `UPDATE` menu button.
- Open the product on the web and notice that the sale price field is empty (previously it was set as 0.0)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
