### PR TITLE
Dark Mode: Product Detail Loading skeleton

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -134,7 +134,6 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
     private fun showSkeleton(show: Boolean) {
         if (show) {
             skeletonView.show(app_bar_layout, R.layout.skeleton_product_detail, delayed = true)
-            skeletonView.findViewById(R.id.productImage_Skeleton)?.layoutParams?.height = imageGallery.height
         } else {
             skeletonView.hide()
         }

--- a/WooCommerce/src/main/res/layout/product_property_read_more_view_layout.xml
+++ b/WooCommerce/src/main/res/layout/product_property_read_more_view_layout.xml
@@ -14,7 +14,9 @@
         android:layout_marginStart="@dimen/major_100"
         android:layout_marginTop="@dimen/major_100"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
         tools:text="textCaption" />
 
     <com.google.android.material.textview.MaterialTextView
@@ -30,6 +32,7 @@
         android:textAlignment="viewStart"
         app:layout_constraintBottom_toTopOf="@id/btnReadMore"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/textCaption"
         tools:text="textContent" />
 

--- a/WooCommerce/src/main/res/layout/product_property_view_vert_layout.xml
+++ b/WooCommerce/src/main/res/layout/product_property_view_vert_layout.xml
@@ -10,13 +10,15 @@
         android:id="@+id/imgPropertyIcon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/major_75"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginEnd="@dimen/major_100"
         android:layout_marginTop="@dimen/major_100"
         android:contentDescription="@string/product_property_edit"
         android:src="@drawable/ic_gridicons_list_checkmark"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/textPropertyName"
         tools:visibility="visible" />
 
     <com.google.android.material.textview.MaterialTextView
@@ -39,7 +41,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_gravity="start"
-        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginStart="@dimen/minor_00"
         android:layout_marginEnd="@dimen/major_100"
         android:layout_marginTop="@dimen/minor_50"
         android:layout_marginBottom="@dimen/major_100"
@@ -48,7 +50,7 @@
         android:textAlignment="viewStart"
         app:layout_constraintBottom_toTopOf="@id/ratingBar"
         app:layout_constraintEnd_toStartOf="@+id/imgProperty"
-        app:layout_constraintStart_toEndOf="@+id/imgPropertyIcon"
+        app:layout_constraintStart_toStartOf="@+id/textPropertyName"
         app:layout_constraintTop_toBottomOf="@+id/textPropertyName"
         app:layout_goneMarginTop="@dimen/major_100"
         tools:text="textPropertyValue tis is really long text that will wrap." />

--- a/WooCommerce/src/main/res/layout/skeleton_notif_list_item.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_notif_list_item.xml
@@ -16,7 +16,7 @@
         app:layout_constraintTop_toTopOf="parent"/>
 
     <View
-        android:id="@+id/view4"
+        android:id="@+id/view_orders_label"
         android:layout_width="0dp"
         android:layout_height="@dimen/skeleton_list_item_title_text_height_100"
         android:layout_marginStart="@dimen/major_100"
@@ -34,8 +34,8 @@
         android:layout_marginTop="@dimen/minor_100"
         android:background="@drawable/skeleton_background"
         app:layout_constraintEnd_toStartOf="@+id/guideline"
-        app:layout_constraintStart_toStartOf="@+id/view4"
-        app:layout_constraintTop_toBottomOf="@+id/view4"/>
+        app:layout_constraintStart_toStartOf="@+id/view_orders_label"
+        app:layout_constraintTop_toBottomOf="@+id/view_orders_label"/>
 
     <View
         android:id="@+id/view3"

--- a/WooCommerce/src/main/res/layout/skeleton_product_detail.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_product_detail.xml
@@ -1,105 +1,215 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@color/white"
     android:orientation="vertical">
 
-    <View
-        android:id="@+id/productImage_Skeleton"
+    <com.google.android.material.card.MaterialCardView
+        style="@style/Woo.Card"
         android:layout_width="match_parent"
-        android:layout_height="224dp"
-        android:background="@drawable/skeleton_background"/>
+        android:layout_height="wrap_content">
 
-    <View
-        android:layout_width="120dp"
-        android:layout_height="@dimen/skeleton_text_height_100"
-        android:layout_marginStart="@dimen/settings_padding"
-        android:layout_marginTop="@dimen/settings_padding"
-        android:background="@drawable/skeleton_background"/>
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
 
-    <View
+            <View
+                android:id="@+id/view_image_1"
+                android:layout_width="@dimen/image_major_120"
+                android:layout_height="@dimen/image_major_120"
+                android:layout_margin="@dimen/major_100"
+                android:background="@color/skeleton_color"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <View
+                android:id="@+id/view_image_2"
+                android:layout_width="@dimen/image_major_120"
+                android:layout_height="@dimen/image_major_120"
+                android:layout_margin="@dimen/major_100"
+                android:background="@color/skeleton_color"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toEndOf="@+id/view_image_1"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <!-- divider -->
+            <View
+                android:id="@+id/divider"
+                style="@style/Woo.Divider"
+                android:layout_marginTop="@dimen/major_100"
+                app:layout_constraintTop_toBottomOf="@+id/view_image_1"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"/>
+
+            <View
+                android:id="@+id/view_title"
+                android:layout_width="120dp"
+                android:layout_height="@dimen/skeleton_text_height_150"
+                android:layout_marginTop="@dimen/major_100"
+                android:layout_marginStart="@dimen/major_100"
+                android:background="@drawable/skeleton_background"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/divider"/>
+
+            <!-- divider -->
+            <View
+                android:id="@+id/divider1"
+                style="@style/Woo.Divider"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_100"
+                app:layout_constraintTop_toBottomOf="@+id/view_title"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"/>
+
+            <View
+                android:id="@+id/view_description_label"
+                android:layout_width="150dp"
+                android:layout_height="@dimen/skeleton_text_height_100"
+                android:layout_marginTop="@dimen/major_100"
+                android:layout_marginStart="@dimen/major_100"
+                android:background="@drawable/skeleton_background"
+                app:layout_constraintTop_toBottomOf="@+id/divider1"
+                app:layout_constraintStart_toStartOf="parent"/>
+
+            <View
+                android:id="@+id/view_description"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/skeleton_text_height_75"
+                android:layout_marginTop="@dimen/major_100"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
+                android:background="@drawable/skeleton_background"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/view_description_label"
+                app:layout_constraintEnd_toEndOf="parent"/>
+
+            <!-- divider -->
+            <View
+                android:id="@+id/divider2"
+                style="@style/Woo.Divider"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_100"
+                app:layout_constraintTop_toBottomOf="@+id/view_description"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"/>
+
+            <View
+                android:id="@+id/view_orders_label"
+                android:layout_width="140dp"
+                android:layout_height="@dimen/skeleton_text_height_100"
+                android:layout_marginTop="@dimen/major_100"
+                android:layout_marginStart="@dimen/major_100"
+                android:background="@drawable/skeleton_background"
+                app:layout_constraintTop_toBottomOf="@+id/divider2"
+                app:layout_constraintStart_toStartOf="parent"/>
+
+            <View
+                android:id="@+id/view_orders_total"
+                android:layout_width="50dp"
+                android:layout_height="@dimen/skeleton_text_height_100"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
+                android:background="@drawable/skeleton_background"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="1.0"
+                app:layout_constraintStart_toEndOf="@+id/view_orders_label"
+                app:layout_constraintTop_toBottomOf="@+id/divider2" />
+
+            <!-- divider -->
+            <View
+                android:id="@+id/divider3"
+                style="@style/Woo.Divider"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_100"
+                app:layout_constraintTop_toBottomOf="@+id/view_orders_label"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent" />
+
+            <View
+                android:id="@+id/view_reviews_label"
+                android:layout_width="120dp"
+                android:layout_height="@dimen/skeleton_text_height_100"
+                android:layout_marginTop="@dimen/major_100"
+                android:layout_marginStart="@dimen/major_100"
+                android:background="@drawable/skeleton_background"
+                app:layout_constraintTop_toBottomOf="@+id/divider3"
+                app:layout_constraintStart_toStartOf="parent"/>
+
+            <View
+                android:id="@+id/view_reviews_count"
+                android:layout_width="100dp"
+                android:layout_height="@dimen/skeleton_text_height_100"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
+                android:background="@drawable/skeleton_background"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="1.0"
+                app:layout_constraintStart_toEndOf="@+id/view_reviews_label"
+                app:layout_constraintTop_toBottomOf="@+id/divider3" />
+
+            <!-- divider -->
+            <View
+                android:id="@+id/divider4"
+                style="@style/Woo.Divider"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_100"
+                app:layout_constraintTop_toBottomOf="@+id/view_reviews_label"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent" />
+
+            <View
+                android:id="@+id/view_product_external"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/skeleton_text_button_height"
+                android:layout_margin="@dimen/major_100"
+                android:background="@drawable/skeleton_background"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/view_product_ext_icon"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/divider4" />
+
+            <View
+                android:id="@+id/view_product_ext_icon"
+                android:layout_width="50dp"
+                android:layout_height="@dimen/skeleton_text_button_height"
+                android:layout_margin="@dimen/major_100"
+                android:background="@drawable/skeleton_background"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="1.0"
+                app:layout_constraintStart_toEndOf="@+id/view_reviews_label"
+                app:layout_constraintTop_toBottomOf="@+id/divider4"
+                app:layout_constraintBottom_toBottomOf="parent"/>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <com.google.android.material.card.MaterialCardView
+        style="@style/Woo.Card"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/skeleton_text_height_100"
-        android:layout_marginEnd="@dimen/settings_padding"
-        android:layout_marginStart="@dimen/settings_padding"
-        android:layout_marginTop="@dimen/settings_padding"
-        android:background="@drawable/skeleton_background"/>
+        android:layout_height="wrap_content">
 
-    <!-- divider -->
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="2dp"
-        android:layout_marginTop="@dimen/settings_padding"
-        android:background="@color/divider_color"/>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/skeleton_text_height_100"
-        android:layout_marginEnd="@dimen/settings_padding"
-        android:layout_marginStart="@dimen/settings_padding"
-        android:layout_marginTop="@dimen/settings_padding"
-        android:background="@drawable/skeleton_background"/>
+            <include layout="@layout/skeleton_product_secondary_card"/>
 
-    <!-- divider -->
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="2dp"
-        android:layout_marginTop="@dimen/settings_padding"
-        android:background="@color/divider_color"/>
+            <!-- divider -->
+            <View
+                style="@style/Woo.Divider"
+                android:layout_marginStart="@dimen/margin_app_title_aligned"
+                android:layout_marginTop="@dimen/minor_00" />
 
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/skeleton_text_height_100"
-        android:layout_marginEnd="@dimen/settings_padding"
-        android:layout_marginStart="@dimen/settings_padding"
-        android:layout_marginTop="@dimen/settings_padding"
-        android:background="@drawable/skeleton_background"/>
+            <include layout="@layout/skeleton_product_secondary_card"/>
+        </LinearLayout>
 
-    <!-- divider -->
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="2dp"
-        android:layout_marginTop="@dimen/settings_padding"
-        android:background="@color/divider_color"/>
+    </com.google.android.material.card.MaterialCardView>
 
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/skeleton_text_height_100"
-        android:layout_marginEnd="@dimen/settings_padding"
-        android:layout_marginStart="@dimen/settings_padding"
-        android:layout_marginTop="@dimen/settings_padding"
-        android:background="@drawable/skeleton_background"/>
-
-    <!-- card divider -->
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/product_detail_card_divider_height"
-        android:layout_marginTop="@dimen/settings_padding"
-        android:background="@color/divider_color"/>
-
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/skeleton_text_height_100"
-        android:layout_marginEnd="@dimen/settings_padding"
-        android:layout_marginStart="@dimen/settings_padding"
-        android:layout_marginTop="@dimen/settings_padding"
-        android:background="@drawable/skeleton_background"/>
-
-    <!-- divider -->
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="2dp"
-        android:layout_marginTop="@dimen/settings_padding"
-        android:background="@color/divider_color"/>
-
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/skeleton_text_height_100"
-        android:layout_marginBottom="@dimen/settings_padding"
-        android:layout_marginEnd="@dimen/settings_padding"
-        android:layout_marginStart="@dimen/settings_padding"
-        android:layout_marginTop="@dimen/settings_padding"
-        android:background="@drawable/skeleton_background"/>
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout/skeleton_product_secondary_card.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_product_secondary_card.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <View
+        android:id="@+id/view_card_icon"
+        android:layout_width="@dimen/skeleton_list_item_icon_100"
+        android:layout_height="@dimen/skeleton_list_item_icon_100"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginTop="@dimen/major_100"
+        android:background="@drawable/skeleton_background"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <View
+        android:id="@+id/view_line_1"
+        android:layout_width="0dp"
+        android:layout_height="@dimen/skeleton_text_height_100"
+        android:layout_marginStart="@dimen/margin_app_title_aligned"
+        android:layout_marginTop="@dimen/major_100"
+        android:layout_marginEnd="@dimen/major_100"
+        android:background="@drawable/skeleton_background"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <View
+        android:id="@+id/view_line_2"
+        android:layout_width="0dp"
+        android:layout_height="@dimen/skeleton_text_height_75"
+        android:layout_marginStart="@dimen/minor_00"
+        android:layout_marginTop="@dimen/minor_100"
+        android:layout_marginEnd="@dimen/major_100"
+        android:background="@drawable/skeleton_background"
+        app:layout_constraintStart_toStartOf="@+id/view_line_1"
+        app:layout_constraintTop_toBottomOf="@+id/view_line_1"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <View
+        android:id="@+id/view_line_3"
+        android:layout_width="0dp"
+        android:layout_height="@dimen/skeleton_text_height_75"
+        android:layout_marginStart="@dimen/minor_00"
+        android:layout_marginEnd="@dimen/major_100"
+        android:layout_marginTop="@dimen/minor_100"
+        android:layout_marginBottom="@dimen/major_100"
+        android:background="@drawable/skeleton_background"
+        app:layout_constraintStart_toStartOf="@+id/view_line_1"
+        app:layout_constraintTop_toBottomOf="@+id/view_line_2"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/values/dimens_base.xml
+++ b/WooCommerce/src/main/res/values/dimens_base.xml
@@ -85,6 +85,7 @@ so that's the baseline as defined in `major_100`.
     <dimen name="skeleton_bar_chart_bar_spacing">@dimen/minor_100</dimen>
     <dimen name="skeleton_text_height_75">@dimen/text_minor_125</dimen>
     <dimen name="skeleton_text_height_100">@dimen/text_major_25</dimen>
+    <dimen name="skeleton_text_height_150">@dimen/text_major_50</dimen>
     <dimen name="skeleton_text_height_200">@dimen/text_major_75</dimen>
     <dimen name="skeleton_tagview_height">24dp</dimen>
     <dimen name="skeleton_text_button_height">24dp</dimen>


### PR DESCRIPTION
This PR closes #2168 by implementing light/dark mode on the product detail loading skeleton. Also included was a little tweak to the margins to follow material guidelines for aligning text with the appbar title if inside a card and proceeded by an icon. 

### Product detail loading screen

|Before (light)| After (light) |
| -- | -- |
|![loading-skeleton-light-old](https://user-images.githubusercontent.com/5810477/78210630-9f353180-745f-11ea-976f-5ab2a20ba225.png)|![loading-skeleton-light-new](https://user-images.githubusercontent.com/5810477/78210639-a65c3f80-745f-11ea-911f-e683c6607f04.png)|

|Before (dark)| After (dark) |
| -- | -- |
|![loading-skeleton-dark-old](https://user-images.githubusercontent.com/5810477/78210720-e15e7300-745f-11ea-8543-dc52fb820566.png)|![loading-skeleton-dark-new](https://user-images.githubusercontent.com/5810477/78210730-eae7db00-745f-11ea-8872-82de89d95f86.png)|

### Product Detail Screen

|Before (light)| After (light) |
| -- | -- |
|![product-detail-light-old](https://user-images.githubusercontent.com/5810477/78210746-fd621480-745f-11ea-8b60-3ccb2a97f012.png)|![product-detail-light-new](https://user-images.githubusercontent.com/5810477/78210751-018e3200-7460-11ea-9fac-f911f6455262.png)|

|Before (dark)| After (dark) |
| -- | -- |
|![product-detail-dark-old](https://user-images.githubusercontent.com/5810477/78210791-18cd1f80-7460-11ea-87d2-c6a714d53427.png)|![product-detail-dark-new](https://user-images.githubusercontent.com/5810477/78210796-1c60a680-7460-11ea-8756-4b594db64c78.png)|

