### PR TITLE
Dark Mode: Aztec Editor Fragment - product description editor

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_aztec_editor.xml
+++ b/WooCommerce/src/main/res/layout/fragment_aztec_editor.xml
@@ -3,7 +3,8 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/color_surface">
 
     <org.wordpress.aztec.toolbar.AztecToolbar
         android:id="@+id/aztecToolbar"

--- a/WooCommerce/src/main/res/layout/fragment_aztec_editor.xml
+++ b/WooCommerce/src/main/res/layout/fragment_aztec_editor.xml
@@ -1,19 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
     <org.wordpress.aztec.toolbar.AztecToolbar
         android:id="@+id/aztecToolbar"
+        style="@style/Woo.AztecToolbar"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/aztec_format_bar_height"
-        app:advanced="false"
+        android:layout_height="@dimen/min_tap_target"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:mediaToolbarAvailable="false" />
+        app:layout_constraintStart_toStartOf="parent" />
 
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
@@ -30,15 +29,15 @@
 
             <org.wordpress.aztec.AztecText
                 android:id="@+id/visualEditor"
-                style="@style/Woo.Aztec.VisualEditor"
+                style="@style/Woo.AztecText.VisualEditor"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:hint="@string/product_description_hint"
-                android:scrollbars="vertical" />
+                android:scrollbars="vertical"/>
 
             <org.wordpress.aztec.source.SourceViewEditText
                 android:id="@+id/sourceEditor"
-                style="@style/Woo.Aztec.SourceEditor"
+                style="@style/Woo.AztecText.SourceEditor"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:hint="@string/product_description_hint"

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -63,6 +63,22 @@
     <color name="product_status_fg_pending">@color/woo_orange_30</color>
 
     <!--
+        Aztec Editor
+    -->
+    <color name="editor_attribute_color">@color/color_secondary</color>
+    <color name="editor_bullet_color">@color/color_on_surface</color>
+    <color name="editor_code_bg_color">@android:color/transparent</color>
+    <color name="editor_code_fg_color">@color/color_on_surface</color>
+    <color name="editor_link_color">@color/color_primary</color>
+    <color name="editor_preformat_bg_color">@color/woo_white</color>
+    <color name="editor_preformat_fg_color">@color/color_on_surface_high</color>
+    <color name="editor_quote_bg_color">@color/woo_blue_30</color>
+    <color name="editor_quote_fg_color">@color/color_on_surface_high</color>
+    <color name="editor_tag_color">@color/color_primary</color>
+    <color name="editor_text_color">@color/color_on_surface_high</color>
+    <color name="editor_text_hint_color">@color/color_on_surface_disabled</color>
+
+    <!--
         Loading Skeletons
     -->
     <color name="skeleton_color">@color/woo_white_alpha_012</color>

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -87,6 +87,22 @@
     <color name="product_status_fg_pending">@color/woo_orange_50</color>
 
     <!--
+        Aztec Editor
+    -->
+    <color name="editor_attribute_color">@color/color_secondary</color>
+    <color name="editor_bullet_color">@color/color_on_surface</color>
+    <color name="editor_code_bg_color">@android:color/transparent</color>
+    <color name="editor_code_fg_color">@color/color_on_surface</color>
+    <color name="editor_link_color">@color/color_primary</color>
+    <color name="editor_preformat_bg_color">@color/woo_black</color>
+    <color name="editor_preformat_fg_color">@color/color_on_surface_high</color>
+    <color name="editor_quote_bg_color">@color/woo_blue_50</color>
+    <color name="editor_quote_fg_color">@color/color_on_surface_high</color>
+    <color name="editor_tag_color">@color/color_primary</color>
+    <color name="editor_text_color">@color/color_on_surface_high</color>
+    <color name="editor_text_hint_color">@color/color_on_surface_disabled</color>
+
+    <!--
         Loading Skeletons
     -->
     <color name="skeleton_color">@color/woo_black_90_alpha_012</color>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -457,4 +457,53 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:layout_marginTop">@dimen/minor_75</item>
         <item name="android:layout_marginBottom">@dimen/minor_75</item>
     </style>
+
+
+    <!--
+        Aztec Editor Styles
+    -->
+    <style name="Woo.AztecText">
+        <item name="android:gravity">top|start</item>
+        <item name="android:paddingStart">@dimen/major_100</item>
+        <item name="android:paddingEnd">@dimen/major_100</item>
+        <item name="android:paddingTop">@dimen/major_100</item>
+        <item name="android:paddingBottom">@dimen/major_100</item>
+        <item name="android:textAlignment">viewStart</item>
+        <item name="android:textAppearance">?attr/textAppearanceSubtitle1</item>
+        <item name="backgroundColor">@android:color/transparent</item>
+    </style>
+
+    <style name="Woo.AztecText.VisualEditor">
+        <item name="android:imeOptions">flagNoExtractUi</item>
+        <item name="bulletColor">@color/editor_bullet_color</item>
+        <item name="codeBackground">@color/editor_code_bg_color</item>
+        <item name="codeColor">@color/editor_code_fg_color</item>
+        <item name="lineSpacingExtra">@dimen/line_spacing_extra_50</item>
+        <item name="linkColor">@color/editor_link_color</item>
+        <item name="linkUnderline">true</item>
+        <item name="historyEnable">true</item>
+        <item name="historySize">10</item>
+        <item name="preformatBackground">@color/editor_preformat_bg_color</item>
+        <item name="preformatBackgroundAlpha">15%</item>
+        <item name="preformatColor">@color/editor_preformat_fg_color</item>
+        <item name="quoteBackground">@color/editor_quote_bg_color</item>
+        <item name="quoteBackgroundAlpha">25%</item>
+        <item name="quoteColor">@color/editor_quote_fg_color</item>
+        <item name="quoteMargin">0dp</item>
+        <item name="textColor">@color/editor_text_color</item>
+        <item name="textColorHint">@color/editor_text_hint_color</item>
+    </style>
+
+    <style name="Woo.AztecText.SourceEditor">
+        <item name="android:inputType">textNoSuggestions|textMultiLine</item>
+        <item name="attributeColor">@color/editor_attribute_color</item>
+        <item name="codeBackgroundColor">@color/editor_code_bg_color</item>
+        <item name="codeTextColor">@color/editor_code_fg_color</item>
+        <item name="tagColor">@color/editor_tag_color</item>
+    </style>
+
+    <style name="Woo.AztecToolbar">
+        <item name="advanced">false</item>
+        <item name="mediaToolbarAvailable">false</item>
+    </style>
 </resources>


### PR DESCRIPTION
This PR closes #2184 by implementing light/dark styling on the aztec editor fragment used for editing the product description. 

The following new styles have been added to `styles_base.xml`:
- `Woo.AztecText`: Base common styles shared between the visual and source editors
- `Woo.AztecText.VisualEditor`: Aztec visual editor
- `Woo.AztecText.SourceEditor`: Aztec HTML editor
- `Woo.AztecToolbar`

The following styles in `styles.xml` have been **deprecated**:
- `Woo.Aztec.Text`
- `Woo.Aztec.VisualEditor`
- `Woo.Aztec.SourceEditor`

### Screenshots

| Before | After (light) | After (dark) |
| -- | -- | -- |
|![editor-old](https://user-images.githubusercontent.com/5810477/78418470-3a114580-75f1-11ea-9935-573138a39969.png)|![Screenshot_1585974043](https://user-images.githubusercontent.com/5810477/78418474-42698080-75f1-11ea-83da-47444bed6152.png)|![Screenshot_1585974088](https://user-images.githubusercontent.com/5810477/78418477-4ac1bb80-75f1-11ea-975f-b0245ae5aef1.png)|
|![source-old](https://user-images.githubusercontent.com/5810477/78418485-544b2380-75f1-11ea-964d-ab431dcd36d9.png)|![Screenshot_1585974048](https://user-images.githubusercontent.com/5810477/78418488-5a410480-75f1-11ea-950a-cf0d9040fcd3.png)|![Screenshot_1585974094](https://user-images.githubusercontent.com/5810477/78418494-60cf7c00-75f1-11ea-9da1-14851d713e32.png)|

### To Test
Verify theming on devices running API 21, 28 and 29 in light and dark mode. 