### PR TITLE
Display floating bars only when there is negative revenue

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -378,10 +378,16 @@ class MyStoreStatsView @JvmOverloads constructor(ctx: Context, attrs: AttributeS
                 labelCount = getBarLabelCount()
                 setCenterAxisLabels(false)
                 valueFormatter = StartEndDateAxisFormatter()
-                yOffset = resources.getDimension(R.dimen.chart_axis_bottom_padding)
+                yOffset = if (minRevenue < 0f) {
+                    resources.getDimension(R.dimen.chart_axis_bottom_padding)
+                } else 0f
             }
             with(axisLeft) {
-                setLabelCount(3, true)
+                if (minRevenue < 0f) {
+                    setDrawZeroLine(true)
+                    zeroLineColor = ContextCompat.getColor(context, R.color.wc_border_color)
+                    setLabelCount(3, true)
+                } else labelCount = 3
                 valueFormatter = RevenueAxisFormatter()
             }
         }


### PR DESCRIPTION
This tiny PR fixes #2198 by adding logic to display the floating bars only if there is negative revenue in the stats data.

##### Stats with negative revenue
<img src ="https://user-images.githubusercontent.com/22608780/78530798-f2153d00-7801-11ea-96e4-7973956cfca3.png" width="300" />. <img src="https://user-images.githubusercontent.com/22608780/78530805-f3df0080-7801-11ea-977a-c91e12a93c7f.png" width="300"/>. <img src ="https://user-images.githubusercontent.com/22608780/78530912-1e30be00-7802-11ea-970f-5172782eca2b.png" width="300" />. <img src="https://user-images.githubusercontent.com/22608780/78530810-f5102d80-7801-11ea-8049-64c5fcfb1034.png" width="300"/>


##### Stats with only positive revenue
<img src ="https://user-images.githubusercontent.com/22608780/78530645-aebace80-7801-11ea-87b0-aefd5b12c0b3.png" width="300" />. <img src="https://user-images.githubusercontent.com/22608780/78530649-b11d2880-7801-11ea-9ec6-12c2e976ecfa.png" width="300"/>. <img src ="https://user-images.githubusercontent.com/22608780/78530651-b1b5bf00-7801-11ea-9249-5f037f4434a8.png" width="300" />. <img src="https://user-images.githubusercontent.com/22608780/78530652-b1b5bf00-7801-11ea-9d00-2b7028f7d4f9.png" width="300"/>

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
