### PR TITLE
Product Property: Fix margins for when the label is no longer visible in vertical mode

### DIFF
--- a/WooCommerce/src/main/res/layout/product_property_view_vert_layout.xml
+++ b/WooCommerce/src/main/res/layout/product_property_view_vert_layout.xml
@@ -33,7 +33,8 @@
         app:layout_constraintEnd_toStartOf="@+id/imgProperty"
         app:layout_constraintStart_toEndOf="@+id/imgPropertyIcon"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="textPropertyName tis is really long text that will wrap." />
+        tools:text="textPropertyName tis is really long text that will wrap."
+        tools:visibility="visible"/>
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/textPropertyValue"
@@ -48,6 +49,7 @@
         android:ellipsize="end"
         android:lineSpacingExtra="@dimen/minor_25"
         android:textAlignment="viewStart"
+        app:layout_goneMarginStart="@dimen/major_100"
         app:layout_constraintBottom_toTopOf="@id/ratingBar"
         app:layout_constraintEnd_toStartOf="@+id/imgProperty"
         app:layout_constraintStart_toStartOf="@+id/textPropertyName"
@@ -66,6 +68,7 @@
         android:stepSize="1"
         android:visibility="gone"
         android:layout_marginBottom="@dimen/major_100"
+        app:layout_goneMarginStart="@dimen/major_100"
         app:layout_constraintBottom_toTopOf="@id/divider"
         app:layout_constraintStart_toStartOf="@+id/textPropertyName"
         app:layout_constraintTop_toBottomOf="@+id/textPropertyValue"
@@ -90,6 +93,7 @@
         style="@style/Woo.Divider"
         android:layout_marginTop="@dimen/major_100"
         android:layout_width="@dimen/minor_00"
+        app:layout_goneMarginStart="@dimen/major_100"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@id/textPropertyValue" />

--- a/WooCommerce/src/main/res/layout/product_property_view_vert_layout.xml
+++ b/WooCommerce/src/main/res/layout/product_property_view_vert_layout.xml
@@ -11,14 +11,13 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/major_100"
-        android:layout_marginEnd="@dimen/major_100"
         android:layout_marginTop="@dimen/major_100"
+        android:layout_marginEnd="@dimen/major_100"
         android:contentDescription="@string/product_property_edit"
         android:src="@drawable/ic_gridicons_list_checkmark"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/textPropertyName"
         tools:visibility="visible" />
 
     <com.google.android.material.textview.MaterialTextView
@@ -26,14 +25,15 @@
         style="@style/Woo.TextView.Subtitle1"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginStart="@dimen/major_200"
         android:layout_marginTop="@dimen/major_100"
         android:ellipsize="end"
         android:maxLines="1"
         app:layout_constraintEnd_toStartOf="@+id/imgProperty"
         app:layout_constraintStart_toEndOf="@+id/imgPropertyIcon"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="textPropertyName tis is really long text that will wrap."
+        app:layout_goneMarginStart="@dimen/major_100"
+        tools:text="textPropertyName this is really long text that will wrap."
         tools:visibility="visible"/>
 
     <com.google.android.material.textview.MaterialTextView
@@ -42,36 +42,37 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_gravity="start"
-        android:layout_marginStart="@dimen/minor_00"
-        android:layout_marginEnd="@dimen/major_100"
+        android:layout_marginStart="@dimen/major_200"
         android:layout_marginTop="@dimen/minor_50"
+        android:layout_marginEnd="@dimen/major_100"
         android:layout_marginBottom="@dimen/major_100"
         android:ellipsize="end"
         android:lineSpacingExtra="@dimen/minor_25"
         android:textAlignment="viewStart"
-        app:layout_goneMarginStart="@dimen/major_100"
         app:layout_constraintBottom_toTopOf="@id/ratingBar"
         app:layout_constraintEnd_toStartOf="@+id/imgProperty"
-        app:layout_constraintStart_toStartOf="@+id/textPropertyName"
+        app:layout_constraintStart_toEndOf="@+id/imgPropertyIcon"
         app:layout_constraintTop_toBottomOf="@+id/textPropertyName"
+        app:layout_goneMarginStart="@dimen/major_100"
         app:layout_goneMarginTop="@dimen/major_100"
-        tools:text="textPropertyValue tis is really long text that will wrap." />
+        tools:text="textPropertyValue this is really long text that will wrap." />
 
     <RatingBar
         android:id="@+id/ratingBar"
         style="@style/Woo.RatingsBar.Small.Colored"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/major_200"
+        android:layout_marginBottom="@dimen/major_100"
         android:isIndicator="true"
         android:numStars="5"
         android:rating="0"
         android:stepSize="1"
         android:visibility="gone"
-        android:layout_marginBottom="@dimen/major_100"
-        app:layout_goneMarginStart="@dimen/major_100"
         app:layout_constraintBottom_toTopOf="@id/divider"
-        app:layout_constraintStart_toStartOf="@+id/textPropertyName"
+        app:layout_constraintStart_toEndOf="@+id/imgPropertyIcon"
         app:layout_constraintTop_toBottomOf="@+id/textPropertyValue"
+        app:layout_goneMarginStart="@dimen/major_100"
         tools:rating="3"
         tools:visibility="visible" />
 
@@ -91,11 +92,12 @@
     <View
         android:id="@+id/divider"
         style="@style/Woo.Divider"
-        android:layout_marginTop="@dimen/major_100"
         android:layout_width="@dimen/minor_00"
-        app:layout_goneMarginStart="@dimen/major_100"
+        android:layout_marginStart="@dimen/major_200"
+        android:layout_marginTop="@dimen/major_100"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@id/textPropertyValue" />
+        app:layout_constraintStart_toEndOf="@+id/imgPropertyIcon"
+        app:layout_goneMarginStart="@dimen/major_100" />
 
 </merge>


### PR DESCRIPTION
This PR closes #2211 by fixing the margins of the description, ratings, and the divider when the property view label is no longer visible.

|Before|After|
| -- | -- |
|![Screenshot_1586295690](https://user-images.githubusercontent.com/5810477/78730663-56afc500-78f2-11ea-869e-f55044b4df3c.png)|![Screenshot_1586304477](https://user-images.githubusercontent.com/5810477/78730675-6202f080-78f2-11ea-84e5-fb2013921c20.png)|

## To Test
1. Open a product and add text to the description field - verify margins
2. Clear the text in the product description field - verify margins

