### PR TITLE
issue/1798-add-#-to-order-number

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
@@ -118,7 +118,7 @@ class OrderListAdapter(
             // Grab the current context from the underlying view
             val ctx = this.itemView.context
             orderDateView.text = getFormattedOrderDate(ctx, orderItemUI.dateCreated)
-            orderNumView.text = orderItemUI.orderNumber
+            orderNumView.text = "#${orderItemUI.orderNumber}"
             orderNameView.text = orderItemUI.orderName
             orderTotalView.text = currencyFormatter.formatCurrency(orderItemUI.orderTotal, orderItemUI.currencyCode)
             divider.visibility = if (orderItemUI.isLastItemInSection) View.GONE else View.VISIBLE


### PR DESCRIPTION
Closes #1798 - prefixes the order number in the order list with "#"

![Screenshot_1586339483](https://user-images.githubusercontent.com/3903757/78770748-01f56400-795d-11ea-8e86-a066db19cc1b.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
