### PR TITLE
Hotfix: Order date comparison bug

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 4.0
 -----
 * Products is now available with limited editing for simple products!
+* Fixed a date conversion bug in orders that was causing some orders to be hidden or grouped incorrectly.
  
 3.9
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/TimeGroup.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/TimeGroup.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.model
 import androidx.annotation.StringRes
 import com.woocommerce.android.R
 import org.apache.commons.lang3.time.DateUtils
-import org.wordpress.android.util.DateTimeUtils
 import java.util.Date
 
 enum class TimeGroup(@StringRes val labelRes: Int) {
@@ -16,16 +15,15 @@ enum class TimeGroup(@StringRes val labelRes: Int) {
 
     companion object {
         fun getTimeGroupForDate(localDate: Date): TimeGroup {
-            val utcDate = DateTimeUtils.localDateToUTC(localDate)
-            val dateToday = DateTimeUtils.nowUTC()
+            val dateToday = Date()
 
             return when {
-                utcDate < DateUtils.addMonths(dateToday, -1) -> GROUP_OLDER_MONTH
-                utcDate < DateUtils.addWeeks(dateToday, -1) -> GROUP_OLDER_WEEK
-                utcDate < DateUtils.addDays(dateToday, -2) -> GROUP_OLDER_TWO_DAYS
-                DateUtils.isSameDay(DateUtils.addDays(dateToday, -2), utcDate) -> GROUP_OLDER_TWO_DAYS
-                DateUtils.isSameDay(DateUtils.addDays(dateToday, -1), utcDate) -> GROUP_YESTERDAY
-                DateUtils.isSameDay(dateToday, utcDate) -> GROUP_TODAY
+                localDate < DateUtils.addMonths(dateToday, -1) -> GROUP_OLDER_MONTH
+                localDate < DateUtils.addWeeks(dateToday, -1) -> GROUP_OLDER_WEEK
+                localDate < DateUtils.addDays(dateToday, -2) -> GROUP_OLDER_TWO_DAYS
+                DateUtils.isSameDay(DateUtils.addDays(dateToday, -2), localDate) -> GROUP_OLDER_TWO_DAYS
+                DateUtils.isSameDay(DateUtils.addDays(dateToday, -1), localDate) -> GROUP_YESTERDAY
+                DateUtils.isSameDay(dateToday, localDate) -> GROUP_TODAY
                 else -> GROUP_FUTURE
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
@@ -22,6 +22,7 @@ import com.woocommerce.android.widgets.tags.TagView
 import kotlinx.android.synthetic.main.order_list_item.view.*
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.util.DateTimeUtils
+import java.util.Date
 
 class OrderListAdapter(
     val listener: OrderListListener,
@@ -94,7 +95,7 @@ class OrderListAdapter(
      */
     private fun getFormattedOrderDate(context: Context, orderDate: String): String? {
         DateTimeUtils.dateUTCFromIso8601(orderDate)?.let { date ->
-            val flags = if (DateTimeUtils.isSameYear(date, DateTimeUtils.nowUTC())) {
+            val flags = if (DateTimeUtils.isSameYear(date, Date())) {
                 DateUtils.FORMAT_SHOW_DATE or DateUtils.FORMAT_ABBREV_MONTH or DateUtils.FORMAT_NO_YEAR
             } else {
                 DateUtils.FORMAT_SHOW_DATE or DateUtils.FORMAT_ABBREV_MONTH

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemDataSource.kt
@@ -106,12 +106,12 @@ class OrderListItemDataSource(
         }
         orderSummaries.forEach {
             // Default to today if the date cannot be parsed. This date is in UTC.
-            val date: Date = DateTimeUtils.dateUTCFromIso8601(it.dateCreated) ?: DateTimeUtils.nowUTC()
+            val date: Date = DateTimeUtils.dateUTCFromIso8601(it.dateCreated) ?: Date()
 
             // Check if future-dated orders should be excluded from the results list.
             if (listDescriptor.excludeFutureOrders) {
-                val currentUtcDate = DateTimeUtils.nowUTC()
-                if (DateUtils.isAfterDate(currentUtcDate, date)) {
+                val currentDate = Date()
+                if (DateUtils.isAfterDate(currentDate, date)) {
                     // This order is dated for the future so skip adding it to the list
                     return@forEach
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -37,6 +37,9 @@ object DateUtils {
      * Takes a date string in ISO8601 standard and returns a string, such as Jan 3, 2000
      */
     fun getMediumDateFromString(context: Context, rawDate: String): String {
+        // Note: dateUTCFromIso8601 has an unfortunate method name. It returns a date object appropriately created
+        // from a UTC date string. This means that the date object will properly reflect the local date conversion from
+        // UTC.
         val date = DateTimeUtils.dateUTCFromIso8601(rawDate) ?: Date()
         return DateFormat.getMediumDateFormat(context).format(date)
     }
@@ -61,11 +64,17 @@ object DateUtils {
     }
 
     fun getFriendlyShortDateAtTimeString(context: Context, rawDate: String): String {
+        // Note: dateUTCFromIso8601 has an unfortunate method name. It returns a date object appropriately created
+        // from a UTC date string. This means that the date object will properly reflect the local date conversion from
+        // UTC.
         val date = DateTimeUtils.dateUTCFromIso8601(rawDate) ?: Date()
         return getFriendlyShortDateAtTimeString(context, date)
     }
 
     fun getFriendlyLongDateAtTimeString(context: Context, rawDate: String): String {
+        // Note: dateUTCFromIso8601 has an unfortunate method name. It returns a date object appropriately created
+        // from a UTC date string. This means that the date object will properly reflect the local date conversion from
+        // UTC.
         val date = DateTimeUtils.dateUTCFromIso8601(rawDate) ?: Date()
         return getFriendlyShortDateAtTimeString(context, date)
     }
@@ -181,7 +190,7 @@ object DateUtils {
     fun getShortMonthDayStringForWeek(iso8601Week: String): String {
         return try {
             val date = weekOfYearStartingMondayFormat.parse(iso8601Week)
-            friendlyMonthDayFormat.format(date)
+            friendlyMonthDayFormat.format(date!!)
         } catch (e: Exception) {
             throw IllegalArgumentException("Date string argument is not of format YYYY-'W'WW: $iso8601Week")
         }
@@ -232,7 +241,7 @@ object DateUtils {
             val originalFormat = SimpleDateFormat("MMMM dd, yyyy", Locale.ROOT)
             val targetFormat = SimpleDateFormat("yyyy-MM-dd", Locale.ROOT)
             val date = originalFormat.parse(dateString)
-            targetFormat.format(date)
+            targetFormat.format(date!!)
         } catch (e: Exception) {
             throw IllegalArgumentException("Date string argument is not of format MMMM dd, yyyy: $dateString")
         }
@@ -256,7 +265,7 @@ object DateUtils {
             val originalFormat = SimpleDateFormat("yyyy-MM-dd HH", Locale.getDefault())
             val targetFormat = SimpleDateFormat("hha", Locale.getDefault())
             val date = originalFormat.parse(iso8601Date)
-            targetFormat.format(date).toLowerCase().trimStart('0')
+            targetFormat.format(date!!).toLowerCase(Locale.getDefault()).trimStart('0')
         } catch (e: Exception) {
             throw IllegalArgumentException("Date string argument is not of format yyyy-MM-dd H: $iso8601Date")
         }
@@ -306,7 +315,7 @@ object DateUtils {
     @Throws(IllegalArgumentException::class)
     fun getYearString(iso8601Month: String): String {
         return try {
-            val (year, month) = iso8601Month.split("-")
+            val (year, _) = iso8601Month.split("-")
             year
         } catch (e: Exception) {
             throw IllegalArgumentException("Date string argument is not of format yyyy-MM: $iso8601Month")
@@ -319,7 +328,7 @@ object DateUtils {
     }
 
     /**
-     * Compares two dates to determine if [date2] is after [Date1]. Note that
+     * Compares two dates to determine if [date2] is after [date1]. Note that
      * this method strips the time information from the comparison and is only comparing
      * the dates.
      *

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -315,7 +315,7 @@ object DateUtils {
     @Throws(IllegalArgumentException::class)
     fun getYearString(iso8601Month: String): String {
         return try {
-            val (year, _) = iso8601Month.split("-")
+            val (year, month) = iso8601Month.split("-")
             year
         } catch (e: Exception) {
             throw IllegalArgumentException("Date string argument is not of format yyyy-MM: $iso8601Month")


### PR DESCRIPTION
Closes #2219 by fixing an issue with local order date conversion and grouping. This issue was due to the local date created from the orders's UTC datestring being treated as if it were a UTC date and so in various areas of the code we were comparing it against the **_device local date in UTC_**, therefore skewing the results. Since the conversion would often land the comparison date in the correct "day", the bug wasn't always obvious. Especially since it seems this conversion was mostly happening to figure out relative date buckets and friendly labels like "today", "yesterday", "last week"...etc.

The confusion comes from the naming of the method `DateTimeUtils.dateUTCFromIso8601()` which could be misconstrued as returning a `Date` object _**in UTC**_, but really it's taking an ISO8601 UTC datestring and parsing it into a **_local_** `Date` object. The formatter used sets the timeZone as "UTC" **_prior_** to parsing out the date object so the conversion is done appropriately. You can see that happening in the method:

```
public static Date dateUTCFromIso8601(String iso8601date) {
    try {
        iso8601date = iso8601date.replace("Z", "+0000").replace("+00:00", "+0000");
        DateFormat formatter = ISO8601_FORMAT.get();
        formatter.setTimeZone(TimeZone.getTimeZone("UTC")); // <-- set timezone before parsing
        return formatter.parse(iso8601date);
    } catch (ParseException e) {
        return null;
    }
}
```

**You can see this play out in the following two test orders.** My test device is using the Pacific timezone (-07:00):
- 9053 - created 4/8 @ 4:06pm (`2020-04-08T23:06:17Z` UTC)
- 9055 - created 4/8 @ 6:36pm (`2020-04-09T01:36:59Z` UTC)

In the device database, observe `DATE_CREATED` is in UTC:

<img width="751" alt="Screen Shot 2020-04-08 at 8 48 46 PM" src="https://user-images.githubusercontent.com/5810477/78857034-22fd9980-79dd-11ea-9a3d-b8a2e94d03d2.png">

**Here is how it looked before the fix:** 

| Order List | Order 9053 | Order 9055 |
| -- | -- | -- |
|![Screenshot_1586404030](https://user-images.githubusercontent.com/5810477/78856871-c1d5c600-79dc-11ea-806d-30866854579a.png)|![Screenshot_1586404044](https://user-images.githubusercontent.com/5810477/78856888-d023e200-79dc-11ea-9fd6-01c94c42a901.png)|![Screenshot_1586404039](https://user-images.githubusercontent.com/5810477/78856912-da45e080-79dc-11ea-9831-1491aa72feba.png)|

**Here is how it looks after the fix:**

| Order List | Order 9053 | Order 9055 |
| -- | -- | -- |
|![Screenshot_1586405550](https://user-images.githubusercontent.com/5810477/78857229-acad6700-79dd-11ea-9f1b-43d5315b7f5a.png)|![Screenshot_1586404301](https://user-images.githubusercontent.com/5810477/78857244-b33bde80-79dd-11ea-8992-bcdf7db3ac22.png)|![Screenshot_1586404297](https://user-images.githubusercontent.com/5810477/78857252-b8992900-79dd-11ea-8e4b-4514cad5fd1b.png)|

You can see why this would be difficult to catch since half of the orders in my examples appeared fine despite the conversion since the time portion in the order detail was being converted properly to begin with, but the "friendly" day was all wrong depending on the the time of day being viewed.

During the fix I found other instances where this conversion wasn't being properly understood and fixed those as well. Since the `dateUTCFromIso8601()` method is in the WordPress-Utils library, I only added some comments to the `DateUtils` class in this repo to make it clear how this method works. I also cleaned up some lint errors.

This fix would also fix any issues where an order is showing up in the **PROCESSING** but not in the **ALL** tab since future-dated orders are hidden in the **ALL** tab.

Updated the `RELEASE-NOTES` as well since this would be a user-facing fix. 

