### PR TITLE
Added logic to display shipping section only if product is not virtual

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -409,31 +409,35 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
             }
         }
 
-        val hasShippingInfo = productData.weightWithUnits?.isNotEmpty() == true ||
-                productData.sizeWithUnits?.isNotEmpty() == true ||
-                product.shippingClass.isNotEmpty()
-        val shippingGroup = if (hasShippingInfo) {
-            mapOf(
-                    Pair(getString(R.string.product_weight), requireNotNull(productData.weightWithUnits)),
-                    Pair(getString(R.string.product_dimensions), requireNotNull(productData.sizeWithUnits)),
-                    Pair(getString(R.string.product_shipping_class),
-                            viewModel.getShippingClassByRemoteShippingClassId(product.shippingClassId))
-            )
-        } else mapOf(Pair("", getString(R.string.product_shipping_empty)))
+        if (!product.isVirtual) {
+            val hasShippingInfo = productData.weightWithUnits?.isNotEmpty() == true ||
+                    productData.sizeWithUnits?.isNotEmpty() == true ||
+                    product.shippingClass.isNotEmpty()
+            val shippingGroup = if (hasShippingInfo) {
+                mapOf(
+                        Pair(getString(R.string.product_weight), requireNotNull(productData.weightWithUnits)),
+                        Pair(getString(R.string.product_dimensions), requireNotNull(productData.sizeWithUnits)),
+                        Pair(
+                                getString(R.string.product_shipping_class),
+                                viewModel.getShippingClassByRemoteShippingClassId(product.shippingClassId)
+                        )
+                )
+            } else mapOf(Pair("", getString(R.string.product_shipping_empty)))
 
-        addPropertyGroup(
-                DetailCard.Secondary,
-                R.string.product_shipping,
-                shippingGroup,
-                groupIconId = R.drawable.ic_gridicons_shipping
-        )?.also {
-            // display shipping caption only if shipping info is not available
-            if (!hasShippingInfo) {
-                it.showPropertyName(false)
-            }
-            it.setClickListener {
-                AnalyticsTracker.track(Stat.PRODUCT_DETAIL_VIEW_SHIPPING_SETTINGS_TAPPED)
-                viewModel.onEditProductCardClicked(ViewProductShipping(product.remoteId))
+            addPropertyGroup(
+                    DetailCard.Secondary,
+                    R.string.product_shipping,
+                    shippingGroup,
+                    groupIconId = R.drawable.ic_gridicons_shipping
+            )?.also {
+                // display shipping caption only if shipping info is not available
+                if (!hasShippingInfo) {
+                    it.showPropertyName(false)
+                }
+                it.setClickListener {
+                    AnalyticsTracker.track(Stat.PRODUCT_DETAIL_VIEW_SHIPPING_SETTINGS_TAPPED)
+                    viewModel.onEditProductCardClicked(ViewProductShipping(product.remoteId))
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #2218 by displaying the shipping section of a product only if the product is not a virtual product.

#### To test
- Create a virtual product in your store.
- In the app, open the Products tab.
- Select your virtual product from the product list, scroll down, and notice the "Add shipping" section is NOT displayed.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
