### PR TITLE
issue/1470-product-detail-crash-fix-take3

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
@@ -78,7 +78,7 @@ class ProductDetailRepository @Inject constructor(
             WooLog.e(PRODUCTS, "CancellationException while fetching single product")
         }
 
-        continuationFetchProduct
+        continuationFetchProduct = null
         return getProduct(remoteProductId)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
@@ -56,6 +56,7 @@ class ProductDetailRepository @Inject constructor(
     private var continuationVerifySku: CancellableContinuation<Boolean>? = null
 
     private var isFetchingTaxClassList = false
+    private var remoteProductId: Long = 0L
 
     init {
         dispatcher.register(this)
@@ -67,6 +68,7 @@ class ProductDetailRepository @Inject constructor(
 
     suspend fun fetchProduct(remoteProductId: Long): Product? {
         try {
+            this.remoteProductId = remoteProductId
             continuationFetchProduct?.cancel()
             suspendCancellableCoroutineWithTimeout<Boolean>(ACTION_TIMEOUT) {
                 continuationFetchProduct = it
@@ -187,7 +189,7 @@ class ProductDetailRepository @Inject constructor(
     @SuppressWarnings("unused")
     @Subscribe(threadMode = MAIN)
     fun onProductChanged(event: OnProductChanged) {
-        if (event.causeOfChange == FETCH_SINGLE_PRODUCT) {
+        if (event.causeOfChange == FETCH_SINGLE_PRODUCT && event.remoteProductId == remoteProductId) {
             if (continuationFetchProduct?.isActive == true) {
                 if (event.isError) {
                     continuationFetchProduct?.resume(false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.model.toDataModel
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.WooLog
-import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.util.WooLog.T.PRODUCTS
 import com.woocommerce.android.util.suspendCancellableCoroutineWithTimeout
 import com.woocommerce.android.util.suspendCoroutineWithTimeout

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailRepository.kt
@@ -180,7 +180,7 @@ class ReviewDetailRepository @Inject constructor(
     @SuppressWarnings("unused")
     @Subscribe(threadMode = MAIN)
     fun onProductChanged(event: OnProductChanged) {
-        if (event.causeOfChange == FETCH_SINGLE_PRODUCT) {
+        if (event.causeOfChange == FETCH_SINGLE_PRODUCT && event.remoteProductId == remoteProductId) {
             continuationProduct?.let {
                 if (event.isError) {
                     AnalyticsTracker.track(Stat.REVIEW_PRODUCT_LOAD_FAILED, mapOf(

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '0fd3de12565d0bf0c3110797ca7d835a24802b38'
+    fluxCVersion = '08418f1540c2b5bed445edf226178c71a8518f6c'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Potential fix for #1470 - this is our third attempt to fix this issue, which is the top crash according to Sentry.

I was unable to reproduce the crash, but it seemed clear it was due to a product being fetched multiple times. So to trigger the crash, I added another request to fetch the product by adding this line [below this one](https://github.com/woocommerce/woocommerce-android/blob/70e6990f824dac2dae63dbbc0f8644254c4056dc/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt#L75):

```
dispatcher.dispatch(WCProductActionBuilder.newFetchSingleProductAction(payload))
```

Once I was able to reproduce the crash, it was simpler to fix it. The solution (we hope) was to check whether the continuation is still active before resuming it. If it's not active, it means it has already been resumed and completed.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
