### PR TITLE
Dark Mode: Product Shipping views

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
@@ -262,10 +262,10 @@ class ProductPricingFragment : BaseProductFragment(), ProductInventorySelectorDi
 
     private fun displaySalePriceError(messageId: Int) {
         if (messageId != 0) {
-            product_sale_price.setError(getString(messageId))
+            product_sale_price.error = getString(messageId)
             enablePublishMenuItem(false)
         } else {
-            product_sale_price.clearError()
+            product_sale_price.error = null
             enablePublishMenuItem(true)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingFragment.kt
@@ -111,13 +111,11 @@ class ProductShippingFragment : BaseProductFragment(), NavigationResult {
     private fun showValue(view: WCMaterialOutlinedEditTextView, @StringRes hintRes: Int, value: Float?, unit: String?) {
         val valStr = if (value != 0.0f) (value?.toString() ?: "") else ""
         view.setText(valStr)
-        view.setHint(
-                if (unit != null) {
-                    getString(hintRes) + " ($unit)"
-                } else {
-                    getString(hintRes)
-                }
-        )
+        view.hint = if (unit != null) {
+            getString(hintRes) + " ($unit)"
+        } else {
+            getString(hintRes)
+        }
     }
 
     private fun updateProductView(productData: ProductDetailViewState) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
@@ -1,9 +1,17 @@
 package com.woocommerce.android.widgets
 
 import android.content.Context
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
+import android.os.Bundle
+import android.os.Parcel
+import android.os.Parcelable
 import android.util.AttributeSet
+import android.util.SparseArray
 import android.view.View
-import android.widget.FrameLayout
+import androidx.annotation.AttrRes
+import androidx.annotation.RequiresApi
+import com.google.android.material.textfield.TextInputLayout
 import com.woocommerce.android.R
 import com.woocommerce.android.util.CurrencyFormatter
 import kotlinx.android.synthetic.main.view_material_outlined_currency_edittext.view.*
@@ -24,8 +32,12 @@ import java.math.BigDecimal
  */
 class WCMaterialOutlinedCurrencyEditTextView @JvmOverloads constructor(
     ctx: Context,
-    attrs: AttributeSet? = null
-) : FrameLayout(ctx, attrs) {
+    attrs: AttributeSet? = null,
+    @AttrRes defStyleRes: Int = R.attr.wcMaterialOutlinedCurrencyEditTextViewStyle
+) : TextInputLayout(ctx, attrs, defStyleRes) {
+    companion object {
+        private const val KEY_SUPER_STATE = "WC-OUTLINED-CURRENCY-VIEW-SUPER-STATE"
+    }
     init {
         View.inflate(context, R.layout.view_material_outlined_currency_edittext, this)
         if (attrs != null) {
@@ -34,9 +46,7 @@ class WCMaterialOutlinedCurrencyEditTextView @JvmOverloads constructor(
                     R.styleable.WCMaterialOutlinedCurrencyEditTextView
             )
             try {
-                // Set the edit text hint
-                currency_edit_text_input.hint =
-                        a.getString(R.styleable.WCMaterialOutlinedCurrencyEditTextView_currencyHint).orEmpty()
+                isEnabled = a.getBoolean(R.styleable.WCMaterialOutlinedCurrencyEditTextView_android_enabled, true)
             } finally {
                 a.recycle()
             }
@@ -55,14 +65,95 @@ class WCMaterialOutlinedCurrencyEditTextView @JvmOverloads constructor(
         currency_edit_text.setValue(currentValue)
     }
 
-    fun getCurrencyEditText() = currency_edit_text
+    fun getText() = currency_edit_text.text.toString()
 
-    fun setError(error: String) {
-        currency_edit_text_input.error = error
+    override fun setEnabled(enabled: Boolean) {
+        super.setEnabled(enabled)
+
+        currency_edit_text.isEnabled = enabled
     }
 
-    fun clearError() {
-        currency_edit_text_input.error = null
-        currency_edit_text_input.isErrorEnabled = false
+    fun getCurrencyEditText(): CurrencyEditText = currency_edit_text
+
+    override fun onSaveInstanceState(): Parcelable? {
+        val bundle = Bundle()
+        currency_edit_text.onSaveInstanceState()?.let {
+            bundle.putParcelable(KEY_SUPER_STATE, SavedState(super.onSaveInstanceState(), it))
+        }
+        return bundle
+    }
+
+    override fun onRestoreInstanceState(state: Parcelable?) {
+        val bundle = (state as? Bundle)?.getParcelable<SavedState>(KEY_SUPER_STATE)?.let {
+            restoreViewState(it)
+        } ?: state
+        super.onRestoreInstanceState(bundle)
+    }
+
+    private fun restoreViewState(state: SavedState): Parcelable {
+        currency_edit_text.onRestoreInstanceState(state.editTextState)
+        return state.superState
+    }
+
+    override fun dispatchSaveInstanceState(container: SparseArray<Parcelable>?) {
+        super.dispatchFreezeSelfOnly(container)
+    }
+
+    override fun dispatchRestoreInstanceState(container: SparseArray<Parcelable>?) {
+        super.dispatchThawSelfOnly(container)
+    }
+
+    internal class SavedState : BaseSavedState {
+        internal var editTextState: Parcelable? = null
+
+        constructor(superState: Parcelable?, inEditTextState: Parcelable) : super(superState) {
+            editTextState = inEditTextState
+        }
+
+        /**
+         * Workaround to differentiate between this method and the one that requires API 24+ because
+         * the super(source, loader) method won't work on older APIs - thus the app will crash.
+         */
+        constructor(source: Parcel, loader: ClassLoader?, superState: Parcelable?): super(superState) {
+            editTextState = source.readParcelable<Parcelable>(loader)
+        }
+
+        constructor(source: Parcel) : super(source) {
+            editTextState = source.readParcelable(this::class.java.classLoader)
+        }
+
+        @RequiresApi(VERSION_CODES.N)
+        constructor(source: Parcel, loader: ClassLoader?) : super(source, loader) {
+            editTextState = loader?.let {
+                source.readParcelable<Parcelable>(it)
+            } ?: source.readParcelable<Parcelable>(this::class.java.classLoader)
+        }
+
+        override fun writeToParcel(out: Parcel, flags: Int) {
+            super.writeToParcel(out, flags)
+            out.writeParcelable(editTextState, 0)
+        }
+
+        companion object {
+            @Suppress("UNUSED")
+            @JvmField
+            val CREATOR = object : Parcelable.ClassLoaderCreator<SavedState> {
+                override fun createFromParcel(source: Parcel, loader: ClassLoader?): SavedState {
+                    return if (VERSION.SDK_INT >= VERSION_CODES.N) {
+                        SavedState(source, loader)
+                    } else {
+                        SavedState(source, loader, source.readParcelable<Parcelable>(loader))
+                    }
+                }
+
+                override fun createFromParcel(source: Parcel): SavedState {
+                    return SavedState(source)
+                }
+
+                override fun newArray(size: Int): Array<SavedState?> {
+                    return arrayOfNulls(size)
+                }
+            }
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.widgets
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
-import androidx.constraintlayout.widget.ConstraintLayout
+import android.widget.FrameLayout
 import com.woocommerce.android.R
 import com.woocommerce.android.util.CurrencyFormatter
 import kotlinx.android.synthetic.main.view_material_outlined_currency_edittext.view.*
@@ -22,8 +22,10 @@ import java.math.BigDecimal
  * and deprecate this class.
  *
  */
-class WCMaterialOutlinedCurrencyEditTextView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
-    : ConstraintLayout(ctx, attrs) {
+class WCMaterialOutlinedCurrencyEditTextView @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null
+) : FrameLayout(ctx, attrs) {
     init {
         View.inflate(context, R.layout.view_material_outlined_currency_edittext, this)
         if (attrs != null) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
@@ -1,15 +1,22 @@
 package com.woocommerce.android.widgets
 
 import android.content.Context
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
+import android.os.Bundle
+import android.os.Parcel
+import android.os.Parcelable
 import android.text.Editable
 import android.text.InputFilter
 import android.util.AttributeSet
+import android.util.SparseArray
 import android.view.View
 import android.view.inputmethod.EditorInfo
-import android.widget.FrameLayout
+import androidx.annotation.AttrRes
+import androidx.annotation.RequiresApi
 import androidx.core.widget.doAfterTextChanged
+import com.google.android.material.textfield.TextInputLayout
 import com.woocommerce.android.R
-import com.woocommerce.android.util.StringUtils
 import kotlinx.android.synthetic.main.view_material_outlined_edittext.view.*
 
 /**
@@ -19,8 +26,12 @@ import kotlinx.android.synthetic.main.view_material_outlined_edittext.view.*
  */
 class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
     ctx: Context,
-    attrs: AttributeSet? = null
-) : FrameLayout(ctx, attrs) {
+    attrs: AttributeSet? = null,
+    @AttrRes defStyleAttr: Int = R.attr.wcMaterialOutlinedEditTextViewStyle
+) : TextInputLayout(ctx, attrs, defStyleAttr) {
+    companion object {
+        private const val KEY_SUPER_STATE = "WC-OUTLINED-EDITTEXT-VIEW-SUPER-STATE"
+    }
     init {
         View.inflate(context, R.layout.view_material_outlined_edittext, this)
         if (attrs != null) {
@@ -29,16 +40,6 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
                     R.styleable.WCMaterialOutlinedEditTextView
             )
             try {
-                // Set the edit text hint
-                edit_text_input.hint = a.getString(R.styleable.WCMaterialOutlinedEditTextView_editTextHint)
-                        .orEmpty()
-
-                // Set the edit text summary
-                a.getString(R.styleable.WCMaterialOutlinedEditTextView_editTextSummary)?.let {
-                    edit_text_input.isHelperTextEnabled = true
-                    edit_text_input.helperText = it
-                }
-
                 // Set the edit text input type
                 edit_text.inputType = a.getInt(
                         R.styleable.WCMaterialOutlinedEditTextView_android_inputType,
@@ -50,6 +51,13 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
                     val max = a.getInt(R.styleable.WCMaterialOutlinedEditTextView_android_maxLength, 0)
                     setMaxLength(max)
                 }
+
+                // Set the startup text
+                a.getString(R.styleable.WCMaterialOutlinedSpinnerView_android_text)?.let {
+                    setText(it)
+                }
+
+                isEnabled = a.getBoolean(R.styleable.WCMaterialOutlinedCurrencyEditTextView_android_enabled, true)
             } finally {
                 a.recycle()
             }
@@ -60,9 +68,7 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
         edit_text.setText(selectedText)
     }
 
-    fun setHint(hintStr: String) {
-        edit_text_input.hint = hintStr
-    }
+    fun getText() = edit_text.text.toString()
 
     fun setOnTextChangedListener(cb: (text: Editable?) -> Unit) {
         edit_text.doAfterTextChanged {
@@ -71,17 +77,99 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
         }
     }
 
-    fun setError(error: String) {
-        edit_text_input.isErrorEnabled = true
-        edit_text_input.error = error
-    }
-
     fun clearError() {
-        edit_text_input.isErrorEnabled = false
-        edit_text_input.error = StringUtils.EMPTY
+        error = null
     }
 
     fun setMaxLength(max: Int) {
         edit_text.filters += InputFilter.LengthFilter(max)
+    }
+
+    override fun setEnabled(enabled: Boolean) {
+        super.setEnabled(enabled)
+
+        edit_text.isEnabled = enabled
+    }
+
+    override fun onSaveInstanceState(): Parcelable? {
+        val bundle = Bundle()
+        edit_text.onSaveInstanceState()?.let {
+            bundle.putParcelable(KEY_SUPER_STATE, SavedState(super.onSaveInstanceState(), it))
+        }
+        return bundle
+    }
+
+    override fun onRestoreInstanceState(state: Parcelable?) {
+        val bundle = (state as? Bundle)?.getParcelable<SavedState>(KEY_SUPER_STATE)?.let {
+            restoreViewState(it)
+        } ?: state
+        super.onRestoreInstanceState(bundle)
+    }
+
+    private fun restoreViewState(state: SavedState): Parcelable {
+        edit_text.onRestoreInstanceState(state.editTextState)
+        return state.superState
+    }
+
+    override fun dispatchSaveInstanceState(container: SparseArray<Parcelable>?) {
+        super.dispatchFreezeSelfOnly(container)
+    }
+
+    override fun dispatchRestoreInstanceState(container: SparseArray<Parcelable>?) {
+        super.dispatchThawSelfOnly(container)
+    }
+
+    internal class SavedState : BaseSavedState {
+        internal var editTextState: Parcelable? = null
+
+        constructor(superState: Parcelable?, inEditTextState: Parcelable) : super(superState) {
+            editTextState = inEditTextState
+        }
+
+        /**
+         * Workaround to differentiate between this method and the one that requires API 24+ because
+         * the super(source, loader) method won't work on older APIs - thus the app will crash.
+         */
+        constructor(source: Parcel, loader: ClassLoader?, superState: Parcelable?): super(superState) {
+            editTextState = source.readParcelable<Parcelable>(loader)
+        }
+
+        constructor(source: Parcel) : super(source) {
+            editTextState = source.readParcelable(this::class.java.classLoader)
+        }
+
+        @RequiresApi(VERSION_CODES.N)
+        constructor(source: Parcel, loader: ClassLoader?) : super(source, loader) {
+            editTextState = loader?.let {
+                source.readParcelable<Parcelable>(it)
+            } ?: source.readParcelable<Parcelable>(this::class.java.classLoader)
+        }
+
+        override fun writeToParcel(out: Parcel, flags: Int) {
+            super.writeToParcel(out, flags)
+            out.writeParcelable(editTextState, 0)
+        }
+
+        companion object {
+            @Suppress("UNUSED")
+            @JvmField
+            val CREATOR = object : Parcelable.ClassLoaderCreator<SavedState> {
+                override fun createFromParcel(source: Parcel, loader: ClassLoader?): SavedState {
+                    return if (VERSION.SDK_INT >= VERSION_CODES.N) {
+                        SavedState(source, loader)
+                    } else {
+                        SavedState(source, loader, source.readParcelable<Parcelable>(loader))
+                    }
+                }
+
+                override fun createFromParcel(source: Parcel): SavedState {
+                    return SavedState(source)
+                }
+
+                override fun newArray(size: Int): Array<SavedState?> {
+                    return arrayOfNulls(size)
+                }
+            }
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
@@ -6,9 +6,10 @@ import android.text.InputFilter
 import android.util.AttributeSet
 import android.view.View
 import android.view.inputmethod.EditorInfo
-import androidx.constraintlayout.widget.ConstraintLayout
+import android.widget.FrameLayout
 import androidx.core.widget.doAfterTextChanged
 import com.woocommerce.android.R
+import com.woocommerce.android.util.StringUtils
 import kotlinx.android.synthetic.main.view_material_outlined_edittext.view.*
 
 /**
@@ -16,8 +17,10 @@ import kotlinx.android.synthetic.main.view_material_outlined_edittext.view.*
  * a text box and a summary. The entire view acts as a single component.
  *
  */
-class WCMaterialOutlinedEditTextView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
-    : ConstraintLayout(ctx, attrs) {
+class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null
+) : FrameLayout(ctx, attrs) {
     init {
         View.inflate(context, R.layout.view_material_outlined_edittext, this)
         if (attrs != null) {
@@ -31,9 +34,10 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(ctx: Context, att
                         .orEmpty()
 
                 // Set the edit text summary
-                edit_text_summary.text =
-                        a.getString(R.styleable.WCMaterialOutlinedEditTextView_editTextSummary)
-                                .orEmpty()
+                a.getString(R.styleable.WCMaterialOutlinedEditTextView_editTextSummary)?.let {
+                    edit_text_input.isHelperTextEnabled = true
+                    edit_text_input.helperText = it
+                }
 
                 // Set the edit text input type
                 edit_text.inputType = a.getInt(
@@ -53,7 +57,7 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(ctx: Context, att
     }
 
     fun setText(selectedText: String) {
-        edit_text.post { edit_text.setText(selectedText) }
+        edit_text.setText(selectedText)
     }
 
     fun setHint(hintStr: String) {
@@ -69,13 +73,11 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(ctx: Context, att
 
     fun setError(error: String) {
         edit_text_input.error = error
-        edit_text_summary.visibility = View.GONE
     }
 
     fun clearError() {
-        edit_text_input.error = null
         edit_text_input.isErrorEnabled = false
-        edit_text_summary.visibility = View.VISIBLE
+        edit_text_input.error = StringUtils.EMPTY
     }
 
     fun setMaxLength(max: Int) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
@@ -72,6 +72,7 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
     }
 
     fun setError(error: String) {
+        edit_text_input.isErrorEnabled = true
         edit_text_input.error = error
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedSpinnerView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedSpinnerView.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.widgets
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
-import androidx.constraintlayout.widget.ConstraintLayout
+import android.widget.FrameLayout
 import com.woocommerce.android.R
 import kotlinx.android.synthetic.main.view_material_outlined_spinner.view.*
 
@@ -12,8 +12,10 @@ import kotlinx.android.synthetic.main.view_material_outlined_spinner.view.*
  * This view will display a text box which will open a dialog when clicked.
  * The entire view acts as a single component.
  */
-class WCMaterialOutlinedSpinnerView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null)
-    : ConstraintLayout(ctx, attrs) {
+class WCMaterialOutlinedSpinnerView @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null
+) : FrameLayout(ctx, attrs) {
     init {
         View.inflate(context, R.layout.view_material_outlined_spinner, this)
         if (attrs != null) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedSpinnerView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedSpinnerView.kt
@@ -1,9 +1,17 @@
 package com.woocommerce.android.widgets
 
 import android.content.Context
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
+import android.os.Bundle
+import android.os.Parcel
+import android.os.Parcelable
 import android.util.AttributeSet
+import android.util.SparseArray
 import android.view.View
-import android.widget.FrameLayout
+import androidx.annotation.AttrRes
+import androidx.annotation.RequiresApi
+import com.google.android.material.textfield.TextInputLayout
 import com.woocommerce.android.R
 import kotlinx.android.synthetic.main.view_material_outlined_spinner.view.*
 
@@ -14,16 +22,23 @@ import kotlinx.android.synthetic.main.view_material_outlined_spinner.view.*
  */
 class WCMaterialOutlinedSpinnerView @JvmOverloads constructor(
     ctx: Context,
-    attrs: AttributeSet? = null
-) : FrameLayout(ctx, attrs) {
+    attrs: AttributeSet? = null,
+    @AttrRes defStyleAttr: Int = R.attr.wcMaterialOutlinedSpinnerViewStyle
+) : TextInputLayout(ctx, attrs, defStyleAttr) {
+    companion object {
+        private const val KEY_SUPER_STATE = "WC-OUTLINED-SPINNER-VIEW-SUPER-STATE"
+    }
     init {
         View.inflate(context, R.layout.view_material_outlined_spinner, this)
         if (attrs != null) {
             val a = context.obtainStyledAttributes(attrs, R.styleable.WCMaterialOutlinedSpinnerView)
             try {
-                // Set the edit text spinner hint
-                spinner_edit_text_input.hint =
-                        a.getString(R.styleable.WCMaterialOutlinedSpinnerView_spinnerHint).orEmpty()
+                // Set the startup text
+                a.getString(R.styleable.WCMaterialOutlinedSpinnerView_android_text)?.let {
+                    setText(it)
+                }
+
+                isEnabled = a.getBoolean(R.styleable.WCMaterialOutlinedSpinnerView_android_enabled, true)
             } finally {
                 a.recycle()
             }
@@ -35,8 +50,96 @@ class WCMaterialOutlinedSpinnerView @JvmOverloads constructor(
     }
 
     fun setText(selectedText: String) {
-        spinner_edit_text.post { spinner_edit_text.setText(selectedText) }
+        spinner_edit_text.setText(selectedText)
     }
 
     fun getText() = spinner_edit_text.text.toString()
+
+    override fun setEnabled(enabled: Boolean) {
+        super.setEnabled(enabled)
+
+        spinner_edit_text.isEnabled = enabled
+    }
+
+    override fun onSaveInstanceState(): Parcelable? {
+        val bundle = Bundle()
+        spinner_edit_text.onSaveInstanceState()?.let {
+            bundle.putParcelable(KEY_SUPER_STATE, SavedState(super.onSaveInstanceState(), it))
+        }
+        return bundle
+    }
+
+    override fun onRestoreInstanceState(state: Parcelable?) {
+        val bundle = (state as? Bundle)?.getParcelable<SavedState>(KEY_SUPER_STATE)?.let {
+            restoreViewState(it)
+        } ?: state
+        super.onRestoreInstanceState(bundle)
+    }
+
+    private fun restoreViewState(state: SavedState): Parcelable {
+        spinner_edit_text.onRestoreInstanceState(state.editTextState)
+        return state.superState
+    }
+
+    override fun dispatchSaveInstanceState(container: SparseArray<Parcelable>?) {
+        super.dispatchFreezeSelfOnly(container)
+    }
+
+    override fun dispatchRestoreInstanceState(container: SparseArray<Parcelable>?) {
+        super.dispatchThawSelfOnly(container)
+    }
+
+    internal class SavedState : BaseSavedState {
+        internal var editTextState: Parcelable? = null
+
+        constructor(superState: Parcelable?, inEditTextState: Parcelable) : super(superState) {
+            editTextState = inEditTextState
+        }
+
+        /**
+         * Workaround to differentiate between this method and the one that requires API 24+ because
+         * the super(source, loader) method won't work on older APIs - thus the app will crash.
+         */
+        constructor(source: Parcel, loader: ClassLoader?, superState: Parcelable?): super(superState) {
+            editTextState = source.readParcelable<Parcelable>(loader)
+        }
+
+        constructor(source: Parcel) : super(source) {
+            editTextState = source.readParcelable(this::class.java.classLoader)
+        }
+
+        @RequiresApi(VERSION_CODES.N)
+        constructor(source: Parcel, loader: ClassLoader?) : super(source, loader) {
+            editTextState = loader?.let {
+                source.readParcelable<Parcelable>(it)
+            } ?: source.readParcelable<Parcelable>(this::class.java.classLoader)
+        }
+
+        override fun writeToParcel(out: Parcel, flags: Int) {
+            super.writeToParcel(out, flags)
+            out.writeParcelable(editTextState, 0)
+        }
+
+        companion object {
+            @Suppress("UNUSED")
+            @JvmField
+            val CREATOR = object : Parcelable.ClassLoaderCreator<SavedState> {
+                override fun createFromParcel(source: Parcel, loader: ClassLoader?): SavedState {
+                    return if (VERSION.SDK_INT >= VERSION_CODES.N) {
+                        SavedState(source, loader)
+                    } else {
+                        SavedState(source, loader, source.readParcelable<Parcelable>(loader))
+                    }
+                }
+
+                override fun createFromParcel(source: Parcel): SavedState {
+                    return SavedState(source)
+                }
+
+                override fun newArray(size: Int): Array<SavedState?> {
+                    return arrayOfNulls(size)
+                }
+            }
+        }
+    }
 }

--- a/WooCommerce/src/main/res/drawable/ic_arrow_drop_down.xml
+++ b/WooCommerce/src/main/res/drawable/ic_arrow_drop_down.xml
@@ -1,5 +1,5 @@
 <vector android:autoMirrored="true" android:height="24dp"
     android:viewportHeight="24.0" android:viewportWidth="24.0"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#FF000000" android:pathData="M7,10l5,5 5,-5z"/>
+    <path android:fillColor="@color/color_on_surface_medium_selector" android:pathData="M7,10l5,5 5,-5z"/>
 </vector>

--- a/WooCommerce/src/main/res/drawable/ic_arrow_drop_down.xml
+++ b/WooCommerce/src/main/res/drawable/ic_arrow_drop_down.xml
@@ -1,5 +1,5 @@
 <vector android:autoMirrored="true" android:height="24dp"
     android:viewportHeight="24.0" android:viewportWidth="24.0"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@color/color_on_surface_medium_selector" android:pathData="M7,10l5,5 5,-5z"/>
+    <path android:fillColor="@color/color_on_surface" android:pathData="M7,10l5,5 5,-5z"/>
 </vector>

--- a/WooCommerce/src/main/res/layout/fragment_product_inventory.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_inventory.xml
@@ -1,127 +1,115 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.core.widget.NestedScrollView
+<ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <com.google.android.material.card.MaterialCardView
+        style="@style/Woo.Card"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@color/white"
-        android:orientation="vertical"
-        android:paddingStart="@dimen/card_padding_start"
-        android:paddingTop="@dimen/card_padding_top"
-        android:paddingEnd="@dimen/card_padding_end"
-        android:paddingBottom="@dimen/card_padding_bottom">
-
-        <!-- Product SKU -->
-        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-            android:id="@+id/product_sku"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_medium"
-            android:inputType="text"
-            app:editTextHint="@string/product_sku"
-            app:editTextSummary="@string/product_sku_summary"
-            app:layout_constraintStart_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <!-- Managing Product Stock -->
-        <Switch
-            android:id="@+id/manageStock_switch"
-            style="@style/Woo.Product.Label"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_extra_large"
-            android:layout_marginBottom="@dimen/margin_extra_large"
-            android:paddingStart="@dimen/card_item_padding_intra_v"
-            android:paddingTop="@dimen/card_padding_top"
-            android:paddingEnd="@dimen/card_item_padding_intra_v"
-            android:paddingBottom="@dimen/card_padding_bottom"
-            android:text="@string/product_manage_stock"
-            app:layout_constraintStart_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/product_sku" />
-
-        <!-- Product Stock Status -->
-        <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-            android:id="@+id/edit_product_stock_status"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/margin_extra_large"
-            android:inputType="text"
-            android:paddingTop="@dimen/card_padding_top"
-            android:paddingBottom="@dimen/card_padding_bottom"
-            android:visibility="gone"
-            app:layout_constraintStart_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/manageStock_switch"
-            app:spinnerHint="@string/product_stock_status" />
+        android:layout_height="wrap_content">
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/manageStock_morePanel"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/margin_extra_large"
-            android:paddingTop="@dimen/card_padding_top"
-            android:paddingBottom="@dimen/card_padding_bottom"
-            android:visibility="gone"
-            app:layout_constraintStart_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/manageStock_switch"
-            tools:visibility="visible">
+            android:layout_height="wrap_content">
 
+            <!-- Product SKU -->
             <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                android:id="@+id/product_stock_quantity"
+                android:id="@+id/product_sku"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="numberSigned"
-                app:editTextHint="@string/product_inventory_quantity"
-                app:editTextSummary="@string/product_inventory_quantity_summary"
-                app:layout_constraintStart_toEndOf="parent"
+                android:layout_marginTop="@dimen/major_75"
+                android:inputType="text"
+                app:editTextHint="@string/product_sku"
+                app:editTextSummary="@string/product_sku_summary"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <!-- Product Stock Status -->
-            <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-                android:id="@+id/edit_product_backorders"
+            <!-- Managing Product Stock -->
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/manageStock_switch"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_large"
-                android:inputType="text"
-                android:paddingTop="@dimen/card_padding_top"
-                app:layout_constraintStart_toEndOf="parent"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_75"
+                android:text="@string/product_manage_stock"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/product_stock_quantity"
-                app:spinnerHint="@string/product_backorders" />
+                app:layout_constraintTop_toBottomOf="@+id/product_sku" />
+
+            <!-- Product Stock Status -->
+            <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+                android:id="@+id/edit_product_stock_status"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/major_75"
+                android:inputType="text"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/manageStock_switch"
+                app:spinnerHint="@string/product_stock_status" />
+
+            <LinearLayout
+                android:id="@+id/manageStock_morePanel"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/major_75"
+                android:visibility="gone"
+                android:orientation="vertical"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/manageStock_switch"
+                tools:visibility="visible">
+
+                <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                    android:id="@+id/product_stock_quantity"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="numberSigned"
+                    app:editTextHint="@string/product_inventory_quantity"
+                    app:editTextSummary="@string/product_inventory_quantity_summary" />
+
+                <!-- Product Stock Status -->
+                <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+                    android:id="@+id/edit_product_backorders"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/minor_100"
+                    android:inputType="text"
+                    app:spinnerHint="@string/product_backorders" />
+
+            </LinearLayout>
+
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/manageStock_barrier"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:barrierDirection="bottom"
+                app:constraint_referenced_ids="manageStock_morePanel,edit_product_stock_status" />
+
+            <!-- Product Sold Individually switch -->
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/soldIndividually_switch"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_75"
+                android:layout_marginBottom="@dimen/major_75"
+                android:text="@string/product_sold_individually"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/manageStock_barrier"
+                app:layout_constraintBottom_toBottomOf="parent" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <androidx.constraintlayout.widget.Barrier
-            android:id="@+id/manageStock_barrier"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:barrierDirection="bottom"
-            app:constraint_referenced_ids="manageStock_morePanel,edit_product_stock_status" />
+    </com.google.android.material.card.MaterialCardView>
 
-        <!-- Product Sold Individually switch -->
-        <Switch
-            android:id="@+id/soldIndividually_switch"
-            style="@style/Woo.Product.Label"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingStart="@dimen/card_item_padding_intra_v"
-            android:paddingTop="@dimen/card_padding_top"
-            android:paddingEnd="@dimen/card_item_padding_intra_v"
-            android:paddingBottom="@dimen/card_padding_bottom"
-            android:text="@string/product_sold_individually"
-            app:layout_constraintStart_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/manageStock_barrier" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</androidx.core.widget.NestedScrollView>
+</ScrollView>
 

--- a/WooCommerce/src/main/res/layout/fragment_product_inventory.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_inventory.xml
@@ -21,9 +21,11 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/major_75"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
                 android:inputType="text"
-                app:editTextHint="@string/product_sku"
-                app:editTextSummary="@string/product_sku_summary"
+                android:hint="@string/product_sku"
+                app:helperText="@string/product_sku_summary"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -47,12 +49,14 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/major_75"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
                 android:inputType="text"
                 android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/manageStock_switch"
-                app:spinnerHint="@string/product_stock_status" />
+                android:hint="@string/product_stock_status" />
 
             <LinearLayout
                 android:id="@+id/manageStock_morePanel"
@@ -70,9 +74,11 @@
                     android:id="@+id/product_stock_quantity"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginEnd="@dimen/major_100"
                     android:inputType="numberSigned"
-                    app:editTextHint="@string/product_inventory_quantity"
-                    app:editTextSummary="@string/product_inventory_quantity_summary" />
+                    android:hint="@string/product_inventory_quantity"
+                    app:helperText="@string/product_inventory_quantity_summary" />
 
                 <!-- Product Stock Status -->
                 <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
@@ -80,8 +86,10 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/minor_100"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginEnd="@dimen/major_100"
                     android:inputType="text"
-                    app:spinnerHint="@string/product_backorders" />
+                    android:hint="@string/product_backorders" />
 
             </LinearLayout>
 

--- a/WooCommerce/src/main/res/layout/fragment_product_pricing.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_pricing.xml
@@ -1,187 +1,162 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.core.widget.NestedScrollView
+<ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <com.google.android.material.card.MaterialCardView
+        style="@style/Woo.Card"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@color/white"
-        android:orientation="vertical"
-        android:paddingTop="@dimen/card_padding_top"
-        android:paddingBottom="@dimen/card_padding_bottom">
-
-        <!-- Product Pricing Heading -->
-        <TextView
-            android:id="@+id/product_price_heading"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingStart="@dimen/card_padding_start"
-            android:paddingEnd="@dimen/card_padding_end"
-            android:text="@string/product_price"
-            style="@style/Woo.Product.Label.Large"
-            app:layout_constraintStart_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <!-- Product Regular Price -->
-        <com.woocommerce.android.widgets.WCMaterialOutlinedCurrencyEditTextView
-            android:id="@+id/product_regular_price"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/card_padding_start"
-            android:layout_marginTop="@dimen/margin_large"
-            android:layout_marginEnd="@dimen/card_padding_end"
-            app:currencyHint="@string/product_regular_price"
-            app:layout_constraintStart_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/product_price_heading" />
-
-        <!-- Product Sale Price -->
-        <com.woocommerce.android.widgets.WCMaterialOutlinedCurrencyEditTextView
-            android:id="@+id/product_sale_price"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/card_padding_start"
-            android:layout_marginTop="@dimen/margin_large"
-            android:layout_marginEnd="@dimen/card_padding_end"
-            app:currencyHint="@string/product_sale_price"
-            app:layout_constraintStart_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/product_regular_price" />
-
-        <!-- Managing Product Stock -->
-        <com.woocommerce.android.widgets.WCToggleSingleOptionView
-            android:id="@+id/scheduleSale_switch"
-            style="@style/Woo.Product.Label"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/card_padding_start"
-            android:layout_marginTop="@dimen/margin_extra_large"
-            android:layout_marginEnd="@dimen/card_padding_end"
-            android:layout_marginBottom="@dimen/margin_extra_large"
-            android:importantForAccessibility="yes"
-            android:paddingStart="@dimen/card_item_padding_intra_v"
-            android:paddingEnd="@dimen/card_item_padding_intra_v"
-            app:layout_constraintStart_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/product_sale_price"
-            app:switchSummary="@string/product_schedule_sale_sublabel"
-            app:switchTitle="@string/product_schedule_sale_label" />
+        android:layout_height="wrap_content">
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/scheduleSale_morePanel"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/card_padding_start"
-            android:layout_marginEnd="@dimen/card_padding_end"
-            android:layout_marginBottom="@dimen/margin_extra_large"
-            android:paddingTop="@dimen/card_padding_top"
-            android:visibility="gone"
-            app:layout_constraintStart_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/scheduleSale_switch"
-            tools:visibility="visible">
+            android:layout_height="match_parent">
 
-            <!-- Schedule Sale From -->
-            <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-                android:id="@+id/scheduleSale_startDate"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:inputType="number"
-                app:layout_constraintStart_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:spinnerHint="@string/product_schedule_sale_from_label" />
-
-            <!-- Schedule Sale To -->
-            <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-                android:id="@+id/scheduleSale_endDate"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_large"
-                android:inputType="text"
-                app:layout_constraintStart_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/scheduleSale_startDate"
-                app:spinnerHint="@string/product_schedule_sale_to_label" />
-
-            <!-- Remove End Date button -->
-            <TextView
-                android:id="@+id/scheduleSale_RemoveEndDateButton"
+            <!-- Product Pricing Heading -->
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/product_price_heading"
+                style="@style/Woo.TextView.Headline6"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textSize="@dimen/text_large"
-                android:textColor="@color/wc_purple"
-                android:paddingTop="@dimen/margin_large"
-                android:paddingBottom="@dimen/margin_large"
-                android:background="?attr/selectableItemBackground"
-                android:text="@string/product_schedule_remove_end_date_link_label"
+                android:text="@string/product_price"
                 app:layout_constraintStart_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="@id/scheduleSale_endDate"
-                app:layout_constraintTop_toBottomOf="@id/scheduleSale_endDate" />
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <!-- Product Regular Price -->
+            <com.woocommerce.android.widgets.WCMaterialOutlinedCurrencyEditTextView
+                android:id="@+id/product_regular_price"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/major_75"
+                app:currencyHint="@string/product_regular_price"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/product_price_heading" />
+
+            <!-- Product Sale Price -->
+            <com.woocommerce.android.widgets.WCMaterialOutlinedCurrencyEditTextView
+                android:id="@+id/product_sale_price"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/minor_100"
+                android:layout_marginBottom="@dimen/minor_100"
+                app:currencyHint="@string/product_sale_price"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/product_regular_price" />
+
+            <!-- Managing Product Stock -->
+            <com.woocommerce.android.widgets.WCToggleSingleOptionView
+                android:id="@+id/scheduleSale_switch"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_75"
+                android:layout_marginEnd="@dimen/major_75"
+                android:layout_marginTop="@dimen/minor_100"
+                android:importantForAccessibility="yes"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/product_sale_price"
+                app:switchSummary="@string/product_schedule_sale_sublabel"
+                app:switchTitle="@string/product_schedule_sale_label" />
+
+            <LinearLayout
+                android:id="@+id/scheduleSale_morePanel"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                android:orientation="vertical"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/scheduleSale_switch"
+                tools:visibility="visible">
+
+                <!-- Schedule Sale From -->
+                <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+                    android:id="@+id/scheduleSale_startDate"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/minor_100"
+                    android:inputType="number"
+                    app:spinnerHint="@string/product_schedule_sale_from_label" />
+
+                <!-- Schedule Sale To -->
+                <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+                    android:id="@+id/scheduleSale_endDate"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/minor_100"
+                    android:inputType="text"
+                    app:spinnerHint="@string/product_schedule_sale_to_label" />
+
+                <!-- Remove End Date button -->
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/scheduleSale_RemoveEndDateButton"
+                    style="@style/Woo.Button.Lowercase"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_75"
+                    android:text="@string/product_schedule_remove_end_date_link_label"/>
+
+            </LinearLayout>
+
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/scheduleSale_barrier"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:barrierDirection="bottom"
+                app:constraint_referenced_ids="scheduleSale_morePanel,scheduleSale_switch" />
+
+            <View
+                android:id="@+id/divider"
+                style="@style/Woo.Divider"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/scheduleSale_barrier" />
+
+            <!-- Product Pricing Heading -->
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/product_tax"
+                style="@style/Woo.TextView.Headline6"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/product_tax_settings"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/divider" />
+
+            <!-- Product Tax Status -->
+            <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+                android:id="@+id/product_tax_status"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/major_75"
+                android:inputType="text"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/product_tax"
+                app:spinnerHint="@string/product_tax_status" />
+
+            <!-- Product Tax Class -->
+            <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+                android:id="@+id/product_tax_class"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/minor_100"
+                android:layout_marginBottom="@dimen/major_100"
+                android:inputType="text"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/product_tax_status"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:spinnerHint="@string/product_tax_class" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
 
-        <androidx.constraintlayout.widget.Barrier
-            android:id="@+id/scheduleSale_barrier"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:barrierDirection="bottom"
-            app:constraint_referenced_ids="scheduleSale_morePanel,scheduleSale_switch" />
-
-        <View
-            android:id="@+id/divider"
-            style="@style/Woo.Divider"
-            android:layout_marginTop="@dimen/margin_large"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/scheduleSale_barrier" />
-
-        <!-- Product Pricing Heading -->
-        <TextView
-            android:id="@+id/product_tax"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_extra_large"
-            android:paddingStart="@dimen/card_padding_start"
-            android:paddingEnd="@dimen/card_padding_end"
-            android:text="@string/product_tax_settings"
-            style="@style/Woo.Product.Label.Large"
-            app:layout_constraintStart_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/divider" />
-
-        <!-- Product Tax Status -->
-        <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-            android:id="@+id/product_tax_status"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/card_padding_start"
-            android:layout_marginEnd="@dimen/card_padding_end"
-            android:layout_marginTop="@dimen/margin_large"
-            android:inputType="text"
-            app:layout_constraintStart_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/product_tax"
-            app:spinnerHint="@string/product_tax_status" />
-
-        <!-- Product Tax Class -->
-        <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-            android:id="@+id/product_tax_class"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/card_padding_start"
-            android:layout_marginEnd="@dimen/card_padding_end"
-            android:layout_marginTop="@dimen/margin_large"
-            android:inputType="text"
-            app:layout_constraintStart_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/product_tax_status"
-            app:spinnerHint="@string/product_tax_class" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</androidx.core.widget.NestedScrollView>
+</ScrollView>

--- a/WooCommerce/src/main/res/layout/fragment_product_pricing.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_pricing.xml
@@ -32,7 +32,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/major_75"
-                app:currencyHint="@string/product_regular_price"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
+                android:hint="@string/product_regular_price"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/product_price_heading" />
@@ -44,7 +46,9 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/minor_100"
                 android:layout_marginBottom="@dimen/minor_100"
-                app:currencyHint="@string/product_sale_price"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
+                android:hint="@string/product_sale_price"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/product_regular_price" />
@@ -70,6 +74,8 @@
                 android:layout_height="wrap_content"
                 android:visibility="gone"
                 android:orientation="vertical"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/scheduleSale_switch"
@@ -82,7 +88,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/minor_100"
                     android:inputType="number"
-                    app:spinnerHint="@string/product_schedule_sale_from_label" />
+                    android:hint="@string/product_schedule_sale_from_label" />
 
                 <!-- Schedule Sale To -->
                 <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
@@ -91,7 +97,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/minor_100"
                     android:inputType="text"
-                    app:spinnerHint="@string/product_schedule_sale_to_label" />
+                    android:hint="@string/product_schedule_sale_to_label" />
 
                 <!-- Remove End Date button -->
                 <com.google.android.material.button.MaterialButton
@@ -99,7 +105,6 @@
                     style="@style/Woo.Button.Lowercase"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/major_75"
                     android:text="@string/product_schedule_remove_end_date_link_label"/>
 
             </LinearLayout>
@@ -118,7 +123,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/scheduleSale_barrier" />
 
-            <!-- Product Pricing Heading -->
+            <!-- Product Tax Heading -->
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/product_tax"
                 style="@style/Woo.TextView.Headline6"
@@ -136,11 +141,13 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/major_75"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
                 android:inputType="text"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/product_tax"
-                app:spinnerHint="@string/product_tax_status" />
+                android:hint="@string/product_tax_status" />
 
             <!-- Product Tax Class -->
             <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
@@ -149,12 +156,14 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/minor_100"
                 android:layout_marginBottom="@dimen/major_100"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
                 android:inputType="text"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/product_tax_status"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:spinnerHint="@string/product_tax_class" />
+                android:hint="@string/product_tax_class" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </com.google.android.material.card.MaterialCardView>

--- a/WooCommerce/src/main/res/layout/fragment_product_shipping.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_shipping.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -20,45 +19,55 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/major_100"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
                 android:inputType="numberDecimal"
                 android:maxLength="@integer/maxlength_dimension_edittext"
-                app:editTextHint="@string/product_weight" />
+                android:hint="@string/product_weight" />
 
             <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
                 android:id="@+id/product_length"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/major_75"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
                 android:inputType="numberDecimal"
                 android:maxLength="@integer/maxlength_dimension_edittext"
-                app:editTextHint="@string/product_length" />
+                android:hint="@string/product_length" />
 
             <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
                 android:id="@+id/product_width"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/major_75"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
                 android:inputType="numberDecimal"
                 android:maxLength="@integer/maxlength_dimension_edittext"
-                app:editTextHint="@string/product_width" />
+                android:hint="@string/product_width" />
 
             <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
                 android:id="@+id/product_height"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
                 android:inputType="numberDecimal"
                 android:layout_marginTop="@dimen/major_75"
                 android:maxLength="@integer/maxlength_dimension_edittext"
-                app:editTextHint="@string/product_height" />
+                android:hint="@string/product_height" />
 
             <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
                 android:id="@+id/product_shipping_class_spinner"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/major_75"
                 android:layout_marginBottom="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_100"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
                 android:inputType="text"
-                app:spinnerHint="@string/product_shipping_class" />
+            android:hint="@string/product_shipping_class" />
         </LinearLayout>
 
     </com.google.android.material.card.MaterialCardView>

--- a/WooCommerce/src/main/res/layout/fragment_product_shipping.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_shipping.xml
@@ -67,7 +67,7 @@
                 android:layout_marginStart="@dimen/major_100"
                 android:layout_marginEnd="@dimen/major_100"
                 android:inputType="text"
-            android:hint="@string/product_shipping_class" />
+                android:hint="@string/product_shipping_class" />
         </LinearLayout>
 
     </com.google.android.material.card.MaterialCardView>

--- a/WooCommerce/src/main/res/layout/fragment_product_shipping.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_shipping.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -58,4 +59,4 @@
             android:inputType="text"
             app:spinnerHint="@string/product_shipping_class" />
     </LinearLayout>
-</androidx.core.widget.NestedScrollView>
+</ScrollView>

--- a/WooCommerce/src/main/res/layout/fragment_product_shipping.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_shipping.xml
@@ -5,58 +5,62 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <LinearLayout
+    <com.google.android.material.card.MaterialCardView
+        style="@style/Woo.Card"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@color/white"
-        android:orientation="vertical"
-        android:paddingStart="@dimen/card_padding_start"
-        android:paddingTop="@dimen/card_padding_top"
-        android:paddingEnd="@dimen/card_padding_end"
-        android:paddingBottom="@dimen/card_padding_bottom">
+        android:layout_height="wrap_content">
 
-        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-            android:id="@+id/product_weight"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_large"
-            android:inputType="numberDecimal"
-            android:maxLength="@integer/maxlength_dimension_edittext"
-            app:editTextHint="@string/product_weight" />
+            android:orientation="vertical">
 
-        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-            android:id="@+id/product_length"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_large"
-            android:inputType="numberDecimal"
-            android:maxLength="@integer/maxlength_dimension_edittext"
-            app:editTextHint="@string/product_length" />
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                android:id="@+id/product_weight"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/major_100"
+                android:inputType="numberDecimal"
+                android:maxLength="@integer/maxlength_dimension_edittext"
+                app:editTextHint="@string/product_weight" />
 
-        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-            android:id="@+id/product_width"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_large"
-            android:inputType="numberDecimal"
-            android:maxLength="@integer/maxlength_dimension_edittext"
-            app:editTextHint="@string/product_width" />
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                android:id="@+id/product_length"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/major_75"
+                android:inputType="numberDecimal"
+                android:maxLength="@integer/maxlength_dimension_edittext"
+                app:editTextHint="@string/product_length" />
 
-        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-            android:id="@+id/product_height"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_large"
-            android:inputType="numberDecimal"
-            android:maxLength="@integer/maxlength_dimension_edittext"
-            app:editTextHint="@string/product_height" />
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                android:id="@+id/product_width"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/major_75"
+                android:inputType="numberDecimal"
+                android:maxLength="@integer/maxlength_dimension_edittext"
+                app:editTextHint="@string/product_width" />
 
-        <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-            android:id="@+id/product_shipping_class_spinner"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_large"
-            android:inputType="text"
-            app:spinnerHint="@string/product_shipping_class" />
-    </LinearLayout>
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                android:id="@+id/product_height"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="numberDecimal"
+                android:layout_marginTop="@dimen/major_75"
+                android:maxLength="@integer/maxlength_dimension_edittext"
+                app:editTextHint="@string/product_height" />
+
+            <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+                android:id="@+id/product_shipping_class_spinner"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/major_75"
+                android:layout_marginBottom="@dimen/major_100"
+                android:inputType="text"
+                app:spinnerHint="@string/product_shipping_class" />
+        </LinearLayout>
+
+    </com.google.android.material.card.MaterialCardView>
+
 </ScrollView>

--- a/WooCommerce/src/main/res/layout/product_shipping_class_item.xml
+++ b/WooCommerce/src/main/res/layout/product_shipping_class_item.xml
@@ -1,16 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<CheckedTextView xmlns:android="http://schemas.android.com/apk/res/android"
+<CheckedTextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/text"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?attr/selectableItemBackground"
-    android:checkMark="?android:attr/listChoiceIndicatorSingle"
-    android:gravity="center_vertical"
-    android:paddingStart="@dimen/margin_dialog"
-    android:paddingTop="@dimen/margin_extra_large"
-    android:paddingEnd="@dimen/margin_dialog"
-    android:paddingBottom="@dimen/margin_extra_large"
-    android:textAppearance="@style/Woo.TextView.Caption"
     tools:checked="true"
     tools:text="Shipping class name" />

--- a/WooCommerce/src/main/res/layout/view_material_outlined_currency_edittext.xml
+++ b/WooCommerce/src/main/res/layout/view_material_outlined_currency_edittext.xml
@@ -1,19 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android"
+<merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/Woo.TextInputLayout"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:focusable="true">
+    android:layout_height="wrap_content">
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/currency_edit_text_input"
-        style="@style/Woo.TextInputLayout"
+    <com.woocommerce.android.widgets.CurrencyEditText
+        android:id="@+id/currency_edit_text"
+        android:textAppearance="?attr/textAppearanceSubtitle1"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <com.woocommerce.android.widgets.CurrencyEditText
-            android:id="@+id/currency_edit_text"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:imeOptions="flagNoExtractUi"/>
-    </com.google.android.material.textfield.TextInputLayout>
+        android:layout_height="wrap_content"
+        android:imeOptions="flagNoExtractUi"/>
 </merge>

--- a/WooCommerce/src/main/res/layout/view_material_outlined_currency_edittext.xml
+++ b/WooCommerce/src/main/res/layout/view_material_outlined_currency_edittext.xml
@@ -1,18 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:focusable="true">
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/currency_edit_text_input"
-        style="@style/Woo.MaterialComponents.EditText"
+        style="@style/Woo.TextInputLayout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintStart_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:layout_height="wrap_content">
 
         <com.woocommerce.android.widgets.CurrencyEditText
             android:id="@+id/currency_edit_text"

--- a/WooCommerce/src/main/res/layout/view_material_outlined_edittext.xml
+++ b/WooCommerce/src/main/res/layout/view_material_outlined_edittext.xml
@@ -1,26 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/Woo.TextInputLayout"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:focusable="true">
+    android:layout_height="wrap_content">
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/edit_text_input"
-        style="@style/Woo.TextInputLayout"
+    <com.google.android.material.textfield.TextInputEditText
+        android:id="@+id/edit_text"
+        style="@style/Woo.TextInputEditText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:hintEnabled="true"
-        app:layout_constraintStart_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/edit_text"
-            style="@style/Woo.TextInputEditText"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:imeOptions="actionDone"/>
-    </com.google.android.material.textfield.TextInputLayout>
+        android:imeOptions="actionDone"/>
 </merge>

--- a/WooCommerce/src/main/res/layout/view_material_outlined_edittext.xml
+++ b/WooCommerce/src/main/res/layout/view_material_outlined_edittext.xml
@@ -1,38 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android"
+<merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:focusable="true">
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/edit_text_input"
-        style="@style/Woo.MaterialComponents.EditText"
+        style="@style/Woo.TextInputLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:hintEnabled="true"
+        app:errorEnabled="true"
         app:layout_constraintStart_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/edit_text"
+            style="@style/Woo.TextInputEditText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:imeOptions="actionDone"/>
     </com.google.android.material.textfield.TextInputLayout>
-
-    <TextView
-        android:id="@+id/edit_text_summary"
-        style="@style/Woo.MaterialComponents.EditText.Summary"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:importantForAccessibility="no"
-        android:paddingStart="@dimen/card_padding_start"
-        android:paddingEnd="@dimen/card_padding_end"
-        android:textAlignment="viewStart"
-        app:layout_constraintStart_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/edit_text_input"
-        tools:text="Helps to easily identify this input" />
 </merge>

--- a/WooCommerce/src/main/res/layout/view_material_outlined_edittext.xml
+++ b/WooCommerce/src/main/res/layout/view_material_outlined_edittext.xml
@@ -12,7 +12,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:hintEnabled="true"
-        app:errorEnabled="true"
         app:layout_constraintStart_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">

--- a/WooCommerce/src/main/res/layout/view_material_outlined_spinner.xml
+++ b/WooCommerce/src/main/res/layout/view_material_outlined_spinner.xml
@@ -1,30 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android"
+<merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/Woo.TextInputLayout"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:cursorVisible="false"
+    android:focusable="true"
+    app:endIconMode="custom"
+    app:endIconDrawable="@drawable/ic_arrow_drop_down"
+    app:endIconTintMode="screen"
+    app:endIconTint="@color/color_on_surface_medium_selector"
+    android:background="?attr/selectableItemBackground"
+    android:focusableInTouchMode="true">
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/spinner_edit_text_input"
-        style="@style/Woo.TextInputLayout"
+    <com.google.android.material.textfield.TextInputEditText
+        android:id="@+id/spinner_edit_text"
+        style="@style/Woo.TextInputEditText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:cursorVisible="false"
         android:focusable="false"
-        android:background="?attr/selectableItemBackground"
-        android:focusableInTouchMode="false">
-
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/spinner_edit_text"
-            style="@style/Woo.TextInputEditText"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:drawableEnd="@drawable/ic_arrow_drop_down"
-            android:drawableTint="@color/color_on_surface_medium_selector"
-            android:cursorVisible="false"
-            android:focusable="false"
-            android:focusableInTouchMode="false"
-            android:importantForAutofill="no"
-            tools:ignore="UnusedAttribute" />
-    </com.google.android.material.textfield.TextInputLayout>
+        android:focusableInTouchMode="false"
+        android:importantForAutofill="no"
+        tools:ignore="UnusedAttribute" />
 </merge>

--- a/WooCommerce/src/main/res/layout/view_material_outlined_spinner.xml
+++ b/WooCommerce/src/main/res/layout/view_material_outlined_spinner.xml
@@ -1,23 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/spinner_edit_text_input"
-        style="@style/Woo.MaterialComponents.EditText"
+        style="@style/Woo.TextInputLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintStart_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
         android:cursorVisible="false"
         android:focusable="false"
+        android:background="?attr/selectableItemBackground"
         android:focusableInTouchMode="false">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/spinner_edit_text"
+            style="@style/Woo.TextInputEditText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:drawableEnd="@drawable/ic_arrow_drop_down_black"

--- a/WooCommerce/src/main/res/layout/view_material_outlined_spinner.xml
+++ b/WooCommerce/src/main/res/layout/view_material_outlined_spinner.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -18,10 +19,12 @@
             style="@style/Woo.TextInputEditText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:drawableEnd="@drawable/ic_arrow_drop_down_black"
+            android:drawableEnd="@drawable/ic_arrow_drop_down"
+            android:drawableTint="@color/color_on_surface_medium_selector"
             android:cursorVisible="false"
             android:focusable="false"
             android:focusableInTouchMode="false"
-            android:importantForAutofill="no" />
+            android:importantForAutofill="no"
+            tools:ignore="UnusedAttribute" />
     </com.google.android.material.textfield.TextInputLayout>
 </merge>

--- a/WooCommerce/src/main/res/values/attrs.xml
+++ b/WooCommerce/src/main/res/values/attrs.xml
@@ -69,18 +69,19 @@
     </declare-styleable>
 
     <declare-styleable name="WCMaterialOutlinedEditTextView">
-        <attr name="editTextHint" format="string"/>
-        <attr name="editTextSummary" format="string"/>
         <attr name="android:inputType"/>
         <attr name="android:maxLength"/>
+        <attr name="android:enabled"/>
+        <attr name="android:text"/>
     </declare-styleable>
 
     <declare-styleable name="WCMaterialOutlinedSpinnerView">
-        <attr name="spinnerHint" format="string"/>
+        <attr name="android:text"/>
+        <attr name="android:enabled"/>
     </declare-styleable>
 
     <declare-styleable name="WCMaterialOutlinedCurrencyEditTextView">
-        <attr name="currencyHint" format="string"/>
+        <attr name="android:enabled"/>
     </declare-styleable>
 
     <declare-styleable name="ActionableEmptyView">
@@ -124,6 +125,13 @@
     -->
     <!-- Sets the thickness of indicators like the tab indicator or new review indicator -->
     <attr name="lineIndicatorThickness" format="dimension" />
+
+    <!--
+        Theme-level Text Input styles
+    -->
+    <attr name="wcMaterialOutlinedSpinnerViewStyle" format="reference"/>
+    <attr name="wcMaterialOutlinedCurrencyEditTextViewStyle" format="reference"/>
+    <attr name="wcMaterialOutlinedEditTextViewStyle" format="reference"/>
 
     <declare-styleable name="DashboardStatsBarChart">
         <!-- Optional: Specifies the radius of the rounded corners of the bar chart -->

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -302,6 +302,30 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:layout_margin">@dimen/minor_00</item>
     </style>
 
+    <!--  Style set at the theme level, no need to set in layout files  -->
+    <style name="Widget.Woo.WCMaterialOutlinedSpinnerView" parent="Woo.TextInputLayout">
+        <item name="endIconMode">custom</item>
+        <item name="endIconDrawable">@drawable/ic_arrow_drop_down</item>
+        <item name="endIconTint">@color/color_on_surface_medium_selector</item>
+        <item name="endIconTintMode">src_atop</item>
+        <item name="android:cursorVisible">false</item>
+        <item name="android:background">?attr/selectableItemBackground</item>
+        <item name="android:focusable">true</item>
+        <item name="android:focusableInTouchMode">true</item>
+    </style>
+
+    <!--  Style set at the theme level, no need to set in layout files  -->
+    <style name="Widget.Woo.WCMaterialOutlinedCurrencyEditTextView" parent="Woo.TextInputLayout">
+        <item name="android:focusable">true</item>
+        <item name="android:focusableInTouchMode">true</item>
+    </style>
+
+    <!--  Style set at the theme level, no need to set in layout files  -->
+    <style name="Widget.Woo.WCMaterialOutlinedEditTextView" parent="Woo.TextInputLayout">
+        <item name="android:focusable">true</item>
+        <item name="android:focusableInTouchMode">true</item>
+    </style>
+
     <!--
         Button Styles
     -->

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -5,7 +5,8 @@ properties necessary. The goal is to make as few modifications as possible to ke
 theme across the entire app. Overridden versions should be added to the styles.xml file.
 -->
 <resources
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
     <style name="Woo"/>
     <style name="Widget"/>
     <style name="Widget.Woo"/>
@@ -235,6 +236,24 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:layout_marginEnd">@dimen/minor_00</item>
         <item name="android:layout_marginTop">@dimen/minor_50</item>
         <item name="android:layout_marginBottom">@dimen/minor_00</item>
+    </style>
+
+    <!--
+        CheckedTextView style
+    -->
+    <!-- Set at the theme level so no need to set it in the layout -->
+    <style name="Woo.CheckedTextView">
+        <item name="textAppearance">@style/TextAppearance.Woo.Subtitle1</item>
+        <item name="android:textAppearance">@style/TextAppearance.Woo.Subtitle1</item>
+        <item name="android:checkMark">?android:attr/listChoiceIndicatorSingle</item>
+        <item name="android:background">?attr/selectableItemBackground</item>
+        <item name="android:paddingStart">@dimen/major_100</item>
+        <item name="android:paddingEnd">@dimen/major_100</item>
+        <item name="android:paddingTop">@dimen/minor_100</item>
+        <item name="android:paddingBottom">@dimen/minor_100</item>
+        <item name="android:minHeight">@dimen/min_tap_target</item>
+        <item name="android:textColor">@color/color_on_surface_high</item>
+        <item name="android:gravity">center_vertical</item>
     </style>
 
     <!--

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -271,6 +271,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:layout_marginEnd">@dimen/major_100</item>
         <item name="android:layout_marginTop">@dimen/minor_00</item>
         <item name="android:layout_marginBottom">@dimen/minor_75</item>
+        <item name="helperTextTextAppearance">@style/TextAppearance.AppCompat.Caption</item>
     </style>
 
     <style name="Woo.TextInputEditText"

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -329,6 +329,13 @@ theme across the entire app. Overridden versions should be added to the styles.x
     </style>
 
     <!--
+        Switch Styles
+    -->
+    <style name="Woo.Switch" parent="Widget.MaterialComponents.CompoundButton.Switch">
+        <item name="android:textAppearance">@style/TextAppearance.Woo.Subtitle1</item>
+    </style>
+
+    <!--
         Divider Style
     -->
     <style name="Woo.Divider">

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -85,6 +85,7 @@
         <item name="android:textViewStyle">@style/Woo.TextView</item>
         <item name="editTextStyle">@style/Woo.TextInputEditText</item>
         <item name="switchStyle">@style/Woo.Switch</item>
+        <item name="android:checkedTextViewStyle">@style/Woo.CheckedTextView</item>
 
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -84,6 +84,7 @@
         <item name="textInputStyle">@style/Woo.TextInputLayout</item>
         <item name="android:textViewStyle">@style/Woo.TextView</item>
         <item name="editTextStyle">@style/Woo.TextInputEditText</item>
+        <item name="switchStyle">@style/Woo.Switch</item>
 
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
 
     <!-- Final top-level theme -->
     <style name="Theme.Woo.DayNight" parent="Theme.Woo"/>
@@ -99,6 +99,9 @@
         <item name="settingsOptionValueStyle">@style/Widget.Woo.Settings.OptionValue</item>
         <item name="settingsCategoryHeaderStyle">@style/Widget.Woo.Settings.CategoryHeader</item>
         <item name="settingsButtonStyle">@style/Widget.Woo.Settings.Button</item>
+        <item name="wcMaterialOutlinedSpinnerViewStyle">@style/Widget.Woo.WCMaterialOutlinedSpinnerView</item>
+        <item name="wcMaterialOutlinedCurrencyEditTextViewStyle">@style/Widget.Woo.WCMaterialOutlinedCurrencyEditTextView</item>
+        <item name="wcMaterialOutlinedEditTextViewStyle">@style/Widget.Woo.WCMaterialOutlinedEditTextView</item>
 
         <!-- TODO: convert styles to material -->
 <!--        <item name="android:listViewStyle"></item>-->


### PR DESCRIPTION
This PR closes #2088 and requires PR #2245 to be merged before this one can be taken out of draft status. This PR implements light and dark theming on the product shipping views. It also creates a new default theme-level style for `CheckedTextView`. This means that if you use this component in a layout, you will not have to assign a style to it, it will be done automatically. 

This PR also fixes #2242 . 

### Main Shipping View

| Before | After |
| -- | -- |
|![shipping-1-light-before](https://user-images.githubusercontent.com/5810477/79290213-5d08e880-7e80-11ea-9452-15d8c37a5032.png)|![shipping-1-light-after](https://user-images.githubusercontent.com/5810477/79290215-5e3a1580-7e80-11ea-8b38-8bebad0e295d.png)|
|![shipping-2-light-before](https://user-images.githubusercontent.com/5810477/79290228-65612380-7e80-11ea-8231-713c9463bfb9.png)|![shipping-2-light-after](https://user-images.githubusercontent.com/5810477/79290233-68f4aa80-7e80-11ea-8fbf-1b06b27e9948.png)|
|![shipping-1-dark-before](https://user-images.githubusercontent.com/5810477/79290240-6f832200-7e80-11ea-9e04-44362012fd55.png)|![shipping-1-dark-after](https://user-images.githubusercontent.com/5810477/79290247-73af3f80-7e80-11ea-9e9d-fd1cf73b16b4.png)|
|![shipping-2-dark-before](https://user-images.githubusercontent.com/5810477/79290251-79a52080-7e80-11ea-8f04-2a851fb5686a.png)|![shipping-2-dark-after](https://user-images.githubusercontent.com/5810477/79290253-7b6ee400-7e80-11ea-8b08-89430eb4ac2f.png)|

### Shipping Classes List
| Before | After |
| -- | -- |
|![shipping-class-light-before](https://user-images.githubusercontent.com/5810477/79290290-98a3b280-7e80-11ea-96eb-81a42935faac.png)|![shipping-class-light-after](https://user-images.githubusercontent.com/5810477/79290292-9a6d7600-7e80-11ea-9469-5aab163f29c9.png)|
|![shipping-class-dark-before](https://user-images.githubusercontent.com/5810477/79290303-a22d1a80-7e80-11ea-8b65-45a8fdbaaa70.png)|![shipping-class-dark-after](https://user-images.githubusercontent.com/5810477/79290308-a3f6de00-7e80-11ea-9dcb-4c24c3d866af.png)|

## To Test
Verify views in light and dark modes on API 21, 28 and 29




