### PR TITLE
Products/add sort filter ui

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -254,6 +254,9 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener,
                     empty_view.hide()
                 }
             }
+            new.displaySortAndFilterCard.takeIfNotEqualTo(old?.displaySortAndFilterCard) {
+                showProductSortAndFiltersCard(it)
+            }
         }
 
         viewModel.productList.observe(viewLifecycleOwner, Observer {
@@ -307,6 +310,15 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener,
             products_wip_card.initView()
         } else {
             products_wip_card.visibility = View.GONE
+        }
+    }
+
+    private fun showProductSortAndFiltersCard(show: Boolean) {
+        if (show) {
+            products_sort_filter_card.visibility = View.VISIBLE
+            products_sort_filter_card.initView()
+        } else {
+            products_sort_filter_card.visibility = View.GONE
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -24,6 +24,7 @@ import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.ui.products.ProductListAdapter.OnProductClickListener
+import com.woocommerce.android.ui.products.ProductSortAndFiltersCard.ProductSortAndFilterListener
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.SkeletonView
@@ -32,7 +33,7 @@ import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_product_list.*
 import javax.inject.Inject
 
-class ProductListFragment : TopLevelFragment(), OnProductClickListener,
+class ProductListFragment : TopLevelFragment(), OnProductClickListener, ProductSortAndFilterListener,
         OnLoadMoreListener,
         OnQueryTextListener,
         OnActionExpandListener {
@@ -316,7 +317,7 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener,
     private fun showProductSortAndFiltersCard(show: Boolean) {
         if (show) {
             products_sort_filter_card.visibility = View.VISIBLE
-            products_sort_filter_card.initView()
+            products_sort_filter_card.initView(this)
         } else {
             products_sort_filter_card.visibility = View.GONE
         }
@@ -330,5 +331,13 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener,
 
     override fun onRequestLoadMore() {
         viewModel.onLoadMoreRequested()
+    }
+
+    override fun onFilterOptionSelected() {
+        // TODO: handle filtering in another PR
+    }
+
+    override fun onSortOptionSelected() {
+        // TODO: handle sorting in another PR
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.media.ProductImagesService.Companion.OnProductIma
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -243,7 +244,8 @@ class ProductListViewModel @AssistedInject constructor(
         val isRefreshing: Boolean? = null,
         val query: String? = null,
         val isSearchActive: Boolean? = null,
-        val isEmptyViewVisible: Boolean? = null
+        val isEmptyViewVisible: Boolean? = null,
+        val displaySortAndFilterCard: Boolean = FeatureFlag.PRODUCT_RELEASE_M2.isEnabled()
     ) : Parcelable
 
     @AssistedInject.Factory

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSortAndFiltersCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSortAndFiltersCard.kt
@@ -14,4 +14,8 @@ class ProductSortAndFiltersCard @JvmOverloads constructor(
     init {
         View.inflate(context, R.layout.products_sort_and_filters_card, this)
     }
+
+    fun initView() {
+        // TODO: implement filter & sort actions in a separate PR
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSortAndFiltersCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSortAndFiltersCard.kt
@@ -1,0 +1,17 @@
+package com.woocommerce.android.ui.products
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import com.google.android.material.card.MaterialCardView
+import com.woocommerce.android.R
+
+class ProductSortAndFiltersCard @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : MaterialCardView(ctx, attrs, defStyleAttr) {
+    init {
+        View.inflate(context, R.layout.products_sort_and_filters_card, this)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSortAndFiltersCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSortAndFiltersCard.kt
@@ -5,6 +5,7 @@ import android.util.AttributeSet
 import android.view.View
 import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
+import kotlinx.android.synthetic.main.products_sort_and_filters_card.view.*
 
 class ProductSortAndFiltersCard @JvmOverloads constructor(
     ctx: Context,
@@ -15,7 +16,13 @@ class ProductSortAndFiltersCard @JvmOverloads constructor(
         View.inflate(context, R.layout.products_sort_and_filters_card, this)
     }
 
-    fun initView() {
-        // TODO: implement filter & sort actions in a separate PR
+    interface ProductSortAndFilterListener {
+        fun onFilterOptionSelected()
+        fun onSortOptionSelected()
+    }
+
+    fun initView(listener: ProductSortAndFilterListener) {
+        btn_product_filter.setOnClickListener { listener.onFilterOptionSelected() }
+        btn_product_sorting.setOnClickListener { listener.onSortOptionSelected() }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCToggleOutlinedButton.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCToggleOutlinedButton.kt
@@ -1,0 +1,12 @@
+package com.woocommerce.android.widgets
+
+import android.content.Context
+import android.util.AttributeSet
+import com.google.android.material.button.MaterialButton
+import com.woocommerce.android.R
+
+class WCToggleOutlinedButton @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = R.attr.wcToggleOutlinedButtonStyle
+) : MaterialButton(ctx, attrs, defStyleAttr)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCToggleOutlinedSelectorButton.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCToggleOutlinedSelectorButton.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.widgets
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.annotation.AttrRes
+import com.google.android.material.button.MaterialButton
+import com.woocommerce.android.R
+
+class WCToggleOutlinedSelectorButton @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null,
+    @AttrRes defStyleAttr: Int = R.attr.wcToggleOutlinedSelectorButtonStyle
+) : MaterialButton(ctx, attrs, defStyleAttr)

--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -24,16 +24,27 @@
             app:layout_constraintTop_toTopOf="parent"
             tools:visibility="visible" />
 
+        <!-- Products filter and sort view -->
+        <com.woocommerce.android.ui.products.ProductSortAndFiltersCard
+            android:id="@+id/products_sort_filter_card"
+            style="@style/Woo.Card.Expandable"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/minor_100"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/products_wip_card"
+            tools:visibility="visible" />
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/productsRecycler"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_marginTop="@dimen/minor_100"
             android:background="?attr/colorSurface"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/products_wip_card"
+            app:layout_constraintTop_toBottomOf="@+id/products_sort_filter_card"
             tools:itemCount="5"
             tools:listitem="@layout/product_list_item"
             tools:visibility="visible"/>

--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -31,6 +31,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/minor_100"
+            android:visibility="gone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/products_wip_card"

--- a/WooCommerce/src/main/res/layout/products_sort_and_filters_card.xml
+++ b/WooCommerce/src/main/res/layout/products_sort_and_filters_card.xml
@@ -1,0 +1,36 @@
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="@dimen/minor_50"
+        android:paddingBottom="@dimen/minor_50">
+
+        <com.woocommerce.android.widgets.WCToggleOutlinedSelectorButton
+            android:id="@+id/btn_product_sorting"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/minor_100"
+            android:drawableEnd="@drawable/ic_arrow_drop_down_black"
+            android:text="@string/product_list_sorting"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.woocommerce.android.widgets.WCToggleOutlinedButton
+            android:id="@+id/btn_product_filter"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/minor_100"
+            android:text="@string/product_list_filters"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toEndOf="@+id/btn_product_sorting"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</merge>

--- a/WooCommerce/src/main/res/values/attrs.xml
+++ b/WooCommerce/src/main/res/values/attrs.xml
@@ -129,4 +129,16 @@
         <!-- Optional: Specifies the radius of the rounded corners of the bar chart -->
         <attr name="radius" format="dimension" />
     </declare-styleable>
+
+    <!--
+        Theme-level default style attribute for WCToggleOutlinedSelectorButton since MaterialButton
+        doesn't allow for overriding defStyleRes for some stupid reason.
+    -->
+    <attr name="wcToggleOutlinedSelectorButtonStyle" format="reference"/>
+
+    <!--
+        Theme-level default style attribute for WCToggleOutlinedButton since MaterialButton doesn't
+        allow for overriding defStyleRes for some stupid reason.
+    -->
+    <attr name="wcToggleOutlinedButtonStyle" format="reference"/>
 </resources>

--- a/WooCommerce/src/main/res/values/dimens_base.xml
+++ b/WooCommerce/src/main/res/values/dimens_base.xml
@@ -92,6 +92,7 @@ so that's the baseline as defined in `major_100`.
 
     <!-- Corner Radius -->
     <dimen name="corner_radius_small">2dp</dimen>
+    <dimen name="corner_radius_round_button">20dp</dimen>
 
     <!-- Other literal dimensions -->
     <dimen name="margin_app_title_aligned">72dp</dimen>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -471,6 +471,9 @@
     <string name="product_backorders_notify">Allow, but notify customer</string>
     <string name="product_list_empty">No products yet</string>
     <string name="product_list_empty_search">No matching products</string>
+    <string name="product_list_sorting">Newest</string>
+    <string name="product_list_filters">Filters</string>
+    <string name="product_list_filters_selected">Filters \u2022 %d</string>
     <string name="product_search_hint">Search products</string>
     <string name="product_wip_title">Limited editing available</string>
     <string name="product_wip_message">We\'ve added editing functionality to simple products. Keep an eye out for more options soon!</string>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -327,6 +327,26 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:src">@drawable/ic_menu_more_vert_compat</item>
     </style>
 
+    <!-- Set at the theme level so no need to set directly on the component -->
+    <style name="Widget.Woo.WCToggleOutlinedButton" parent="Widget.MaterialComponents.Button.OutlinedButton">
+        <item name="android:paddingStart">@dimen/major_100</item>
+        <item name="android:paddingEnd">@dimen/major_100</item>
+        <item name="strokeColor">@color/color_on_surface_medium</item>
+        <item name="cornerRadius">@dimen/corner_radius_round_button</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="fontFamily">@font/roboto</item>
+        <item name="android:fontFamily">@font/roboto</item>
+        <item name="android:textSize">@dimen/text_minor_125</item>
+        <item name="android:textColor">@color/color_on_surface_medium_selector</item>
+    </style>
+
+    <!-- Set at the theme level so no need to set directly on the component -->
+    <style name="Widget.Woo.WCToggleOutlinedSelectorButton" parent="Widget.Woo.WCToggleOutlinedButton">
+        <item name="android:drawableEnd">@drawable/ic_arrow_drop_down_black</item>
+        <item name="android:paddingEnd">@dimen/minor_100</item>
+        <item name="drawableTint">@color/color_on_surface_medium</item>
+    </style>
+
     <!--
         Divider Style
     -->

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -97,6 +97,8 @@
         <item name="settingsOptionValueStyle">@style/Widget.Woo.Settings.OptionValue</item>
         <item name="settingsCategoryHeaderStyle">@style/Widget.Woo.Settings.CategoryHeader</item>
         <item name="settingsButtonStyle">@style/Widget.Woo.Settings.Button</item>
+        <item name="wcToggleOutlinedButtonStyle">@style/Widget.Woo.WCToggleOutlinedButton</item>
+        <item name="wcToggleOutlinedSelectorButtonStyle">@style/Widget.Woo.WCToggleOutlinedSelectorButton</item>
 
         <!-- TODO: convert styles to material -->
 <!--        <item name="android:listViewStyle"></item>-->


### PR DESCRIPTION
Partially addresses #2117 by adding the UI for sort and filtering of products. This PR gets the following components updated as well:

```
WCToggleOutlinedButton
WCToggleOutlinedSelectorButton
```

It also creates a new default theme-level style for both the above components. This means that if you use this component in a layout, you will not have to assign a style to it, it will be done automatically. Thanks @AmandaRiu for all your help on this 🙇‍♀️ 

**Note that this PR is to be merged into a feature branch and the filter and sort options is enabled only for debug users at this point.**

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/79325490-e1b24000-7f2e-11ea-8e9a-093d2c475a28.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/79325479-deb74f80-7f2e-11ea-847b-87f7e0024392.png" width="300"/>

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
