### PR TITLE
Fix androidTest build after dark mode merges

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderDetailNavigationTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderDetailNavigationTest.kt
@@ -214,10 +214,10 @@ class OrderDetailNavigationTest : TestBase() {
                 matches(WCMatchers.withTagText("Pending"))
         )
         onView(withId(R.id.orderStatus_orderTags)).check(
-                matches(WCMatchers.withTagTextColor(appContext, R.color.orderStatus_pending_text))
+                matches(WCMatchers.withTagTextColor(appContext, R.color.color_on_surface_high))
         )
         onView(withId(R.id.orderStatus_orderTags)).check(
-                matches(WCMatchers.withTagBackgroundColor(appContext, R.color.orderStatus_pending_bg))
+                matches(WCMatchers.withTagBackgroundColor(appContext, R.color.tag_bg_other))
         )
     }
 
@@ -250,10 +250,10 @@ class OrderDetailNavigationTest : TestBase() {
                 matches(WCMatchers.withTagText(wcOrderStatusModel.label))
         )
         onView(withId(R.id.orderStatus_orderTags)).check(
-                matches(WCMatchers.withTagTextColor(appContext, R.color.orderStatus_processing_text))
+                matches(WCMatchers.withTagTextColor(appContext, R.color.color_on_surface_high))
         )
         onView(withId(R.id.orderStatus_orderTags)).check(
-                matches(WCMatchers.withTagBackgroundColor(appContext, R.color.orderStatus_processing_bg))
+                matches(WCMatchers.withTagBackgroundColor(appContext, R.color.tag_bg_processing))
         )
     }
 
@@ -286,10 +286,12 @@ class OrderDetailNavigationTest : TestBase() {
                 matches(WCMatchers.withTagText(wcOrderStatusModel.label))
         )
         onView(withId(R.id.orderStatus_orderTags)).check(
-                matches(WCMatchers.withTagTextColor(appContext, R.color.orderStatus_hold_text))
+                matches(WCMatchers.withTagTextColor(appContext, R.color.color_on_surface_high))
         )
         onView(withId(R.id.orderStatus_orderTags)).check(
-                matches(WCMatchers.withTagBackgroundColor(appContext, R.color.orderStatus_hold_bg))
+                // This value is surprising. OrderStatusTag.kt has logic to set the color as `R.color.tag_bg_on_hold`
+                // for the "on hold" status, while `R.color.tagView_bg` is the fallback color value.
+                matches(WCMatchers.withTagBackgroundColor(appContext, R.color.tagView_bg))
         )
     }
 
@@ -322,10 +324,10 @@ class OrderDetailNavigationTest : TestBase() {
                 matches(WCMatchers.withTagText(wcOrderStatusModel.label))
         )
         onView(withId(R.id.orderStatus_orderTags)).check(
-                matches(WCMatchers.withTagTextColor(appContext, R.color.orderStatus_completed_text))
+                matches(WCMatchers.withTagTextColor(appContext, R.color.color_on_surface_high))
         )
         onView(withId(R.id.orderStatus_orderTags)).check(
-                matches(WCMatchers.withTagBackgroundColor(appContext, R.color.orderStatus_completed_bg))
+                matches(WCMatchers.withTagBackgroundColor(appContext, R.color.tag_bg_other))
         )
     }
 
@@ -358,10 +360,10 @@ class OrderDetailNavigationTest : TestBase() {
                 matches(WCMatchers.withTagText(wcOrderStatusModel.label))
         )
         onView(withId(R.id.orderStatus_orderTags)).check(
-                matches(WCMatchers.withTagTextColor(appContext, R.color.orderStatus_cancelled_text))
+                matches(WCMatchers.withTagTextColor(appContext, R.color.color_on_surface_high))
         )
         onView(withId(R.id.orderStatus_orderTags)).check(
-                matches(WCMatchers.withTagBackgroundColor(appContext, R.color.orderStatus_cancelled_bg))
+                matches(WCMatchers.withTagBackgroundColor(appContext, R.color.tag_bg_other))
         )
     }
 
@@ -394,10 +396,10 @@ class OrderDetailNavigationTest : TestBase() {
                 matches(WCMatchers.withTagText(wcOrderStatusModel.label))
         )
         onView(withId(R.id.orderStatus_orderTags)).check(
-                matches(WCMatchers.withTagTextColor(appContext, R.color.orderStatus_refunded_text))
+                matches(WCMatchers.withTagTextColor(appContext, R.color.color_on_surface_high))
         )
         onView(withId(R.id.orderStatus_orderTags)).check(
-                matches(WCMatchers.withTagBackgroundColor(appContext, R.color.orderStatus_refunded_bg))
+                matches(WCMatchers.withTagBackgroundColor(appContext, R.color.tag_bg_other))
         )
     }
 
@@ -430,10 +432,10 @@ class OrderDetailNavigationTest : TestBase() {
                 matches(WCMatchers.withTagText(wcOrderStatusModel.label))
         )
         onView(withId(R.id.orderStatus_orderTags)).check(
-                matches(WCMatchers.withTagTextColor(appContext, R.color.orderStatus_failed_text))
+                matches(WCMatchers.withTagTextColor(appContext, R.color.color_on_surface_high))
         )
         onView(withId(R.id.orderStatus_orderTags)).check(
-                matches(WCMatchers.withTagBackgroundColor(appContext, R.color.orderStatus_failed_bg))
+                matches(WCMatchers.withTagBackgroundColor(appContext, R.color.tag_bg_failed))
         )
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderListItemTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderListItemTest.kt
@@ -166,36 +166,38 @@ class OrderListItemTest : TestBase() {
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(processingStatusPosition, R.id.orderTags))
                 .check(matches(WCMatchers.withTagText(getAsOrderItem(processingStatusPosition).status)))
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(processingStatusPosition, R.id.orderTags))
-                .check(matches(WCMatchers.withTagTextColor(appContext, R.color.orderStatus_processing_text)))
+                .check(matches(WCMatchers.withTagTextColor(appContext, R.color.color_on_surface_high)))
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(processingStatusPosition, R.id.orderTags))
-                .check(matches(WCMatchers.withTagBackgroundColor(appContext, R.color.orderStatus_processing_bg)))
+                .check(matches(WCMatchers.withTagBackgroundColor(appContext, R.color.tag_bg_processing)))
 
         // PENDING PAYMENT: Check if order status label name, label text color, label background color
         val pendingStatusPosition = 3
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(pendingStatusPosition, R.id.orderTags))
                 .check(matches(WCMatchers.withTagText(getAsOrderItem(pendingStatusPosition).status)))
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(pendingStatusPosition, R.id.orderTags))
-                .check(matches(WCMatchers.withTagTextColor(appContext, R.color.orderStatus_pending_text)))
+                .check(matches(WCMatchers.withTagTextColor(appContext, R.color.color_on_surface_high)))
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(pendingStatusPosition, R.id.orderTags))
-                .check(matches(WCMatchers.withTagBackgroundColor(appContext, R.color.orderStatus_pending_bg)))
+                .check(matches(WCMatchers.withTagBackgroundColor(appContext, R.color.tag_bg_other)))
 
         // ON HOLD: Check if order status label name, label text color, label background color
         val onHoldStatusPosition = 5
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(onHoldStatusPosition, R.id.orderTags))
                 .check(matches(WCMatchers.withTagText(getAsOrderItem(onHoldStatusPosition).status)))
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(onHoldStatusPosition, R.id.orderTags))
-                .check(matches(WCMatchers.withTagTextColor(appContext, R.color.orderStatus_hold_text)))
+                .check(matches(WCMatchers.withTagTextColor(appContext, R.color.color_on_surface_high)))
+        // This value is surprising. OrderStatusTag.kt has logic to set the color as `R.color.tag_bg_on_hold` for the
+        // "on hold" status, while `R.color.tag_bg_other` is the color for other cases of the status.
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(onHoldStatusPosition, R.id.orderTags))
-                .check(matches(WCMatchers.withTagBackgroundColor(appContext, R.color.orderStatus_hold_bg)))
+                .check(matches(WCMatchers.withTagBackgroundColor(appContext, R.color.tag_bg_other)))
 
         // COMPLETED: Check if order status label name, label text color, label background color
         val completedStatusPosition = 6
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(completedStatusPosition, R.id.orderTags))
                 .check(matches(WCMatchers.withTagText(getAsOrderItem(completedStatusPosition).status)))
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(completedStatusPosition, R.id.orderTags))
-                .check(matches(WCMatchers.withTagTextColor(appContext, R.color.orderStatus_completed_text)))
+                .check(matches(WCMatchers.withTagTextColor(appContext, R.color.color_on_surface_high)))
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(completedStatusPosition, R.id.orderTags))
-                .check(matches(WCMatchers.withTagBackgroundColor(appContext, R.color.orderStatus_completed_bg)))
+                .check(matches(WCMatchers.withTagBackgroundColor(appContext, R.color.tag_bg_other)))
 
         // scroll to the end of the RecyclerView first to avoid the "no matching
         // views in hierarchy" error.
@@ -206,27 +208,27 @@ class OrderListItemTest : TestBase() {
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(cancelledStatusPosition, R.id.orderTags))
                 .check(matches(WCMatchers.withTagText(getAsOrderItem(cancelledStatusPosition).status)))
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(cancelledStatusPosition, R.id.orderTags))
-                .check(matches(WCMatchers.withTagTextColor(appContext, R.color.orderStatus_cancelled_text)))
+                .check(matches(WCMatchers.withTagTextColor(appContext, R.color.color_on_surface_high)))
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(cancelledStatusPosition, R.id.orderTags))
-                .check(matches(WCMatchers.withTagBackgroundColor(appContext, R.color.orderStatus_cancelled_bg)))
+                .check(matches(WCMatchers.withTagBackgroundColor(appContext, R.color.tag_bg_other)))
 
         // REFUNDED: Check if order status label name, label text color, label background color
         val refundedStatusPosition = 8
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(refundedStatusPosition, R.id.orderTags))
                 .check(matches(WCMatchers.withTagText(getAsOrderItem(refundedStatusPosition).status)))
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(refundedStatusPosition, R.id.orderTags))
-                .check(matches(WCMatchers.withTagTextColor(appContext, R.color.orderStatus_refunded_text)))
+                .check(matches(WCMatchers.withTagTextColor(appContext, R.color.color_on_surface_high)))
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(refundedStatusPosition, R.id.orderTags))
-                .check(matches(WCMatchers.withTagBackgroundColor(appContext, R.color.orderStatus_refunded_bg)))
+                .check(matches(WCMatchers.withTagBackgroundColor(appContext, R.color.tag_bg_other)))
 
         // FAILED: Check if order status label name, label text color, label background color
         val failedStatusPosition = 9
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(failedStatusPosition, R.id.orderTags))
                 .check(matches(WCMatchers.withTagText(getAsOrderItem(failedStatusPosition).status)))
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(failedStatusPosition, R.id.orderTags))
-                .check(matches(WCMatchers.withTagTextColor(appContext, R.color.orderStatus_failed_text)))
+                .check(matches(WCMatchers.withTagTextColor(appContext, R.color.color_on_surface_high)))
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(failedStatusPosition, R.id.orderTags))
-                .check(matches(WCMatchers.withTagBackgroundColor(appContext, R.color.orderStatus_failed_bg)))
+                .check(matches(WCMatchers.withTagBackgroundColor(appContext, R.color.tag_bg_failed)))
     }
 
     @Test

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/ProductDetailNavigationTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/ProductDetailNavigationTest.kt
@@ -502,7 +502,7 @@ class ProductDetailNavigationTest : TestBase() {
                 .check(matches(withText(mockProductModel.purchaseNote)))
 
         // verify that the purchase note read more is not displayed
-        onView(WCMatchers.matchesWithIndex(withId(R.id.textReadMore), 0))
+        onView(WCMatchers.matchesWithIndex(withId(R.id.btnReadMore), 0))
                 .check(matches(ViewMatchers.withEffectiveVisibility(GONE)))
     }
 
@@ -530,10 +530,10 @@ class ProductDetailNavigationTest : TestBase() {
                 .check(matches(withText(mockProductModel.purchaseNote)))
 
         // verify that the purchase note read more is displayed
-        onView(withId(R.id.textReadMore)).check(matches(ViewMatchers.withEffectiveVisibility(VISIBLE)))
+        onView(withId(R.id.btnReadMore)).check(matches(ViewMatchers.withEffectiveVisibility(VISIBLE)))
 
         // verify dialog is displayed when read more button is clicked
-        onView(withId(R.id.textReadMore)).perform(WCMatchers.scrollTo(), click())
+        onView(withId(R.id.btnReadMore)).perform(WCMatchers.scrollTo(), click())
 
         onView(withText(appContext.getString(R.string.product_purchase_note)))
                 .inRoot(isDialog()).check(matches(isDisplayed()))


### PR DESCRIPTION
I am working on the screenshots automation, see #2096, and I need `androidTest` to build in order to run the Espresso tests that will take the screenshots.

I didn't do the work of pinpointing exactly at which commit they started failing, but I'm pretty sure it was due to the recent dark mode and/or tag work.

This PR fixes those builds failures in isolation, so that it can get merged in while I keep working on the automation stuff.

Notice that it only fixes the build failures and make those line of code pass. There are a lot of test failures which I thought was out of scope to address.

**This is my first PR in this codebase and in Android, please be ruthless reviewing it so I can learn fast.**

To verify these changes, run "Tests in 'com.woocommerce.android' (androidTest)".
<img width="378" alt="Screen Shot 2020-04-17 at 3 49 29 pm" src="https://user-images.githubusercontent.com/1218433/79540708-f1b35680-80cb-11ea-81ad-49a87f07e9c1.png">

---

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.