### PR TITLE
Issue/2261 radio to the right

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSettingsFragment.kt
@@ -67,8 +67,9 @@ class ProductSettingsFragment : BaseProductFragment(), NavigationResult {
                 updateProductView()
             }
         } else if (requestCode == RequestCodes.PRODUCT_SETTINGS_VISIBLITY) {
-            (result.getSerializable(ARG_VISIBILITY) as? ProductVisibility)?.let {
-                viewModel.updateProductDraft(visibility = it, isFeatured = result.getBoolean(ARG_IS_FEATURED))
+            (result.getString(ARG_VISIBILITY))?.let {
+                val visibility = ProductVisibility.fromString(it)
+                viewModel.updateProductDraft(visibility = visibility, isFeatured = result.getBoolean(ARG_IS_FEATURED))
                 updateProductView()
             }
         } else if (requestCode == RequestCodes.PRODUCT_SETTINGS_SLUG) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSettingsFragment.kt
@@ -61,8 +61,9 @@ class ProductSettingsFragment : BaseProductFragment(), NavigationResult {
 
     override fun onNavigationResult(requestCode: Int, result: Bundle) {
         if (requestCode == RequestCodes.PRODUCT_SETTINGS_STATUS) {
-            (result.getSerializable(ARG_SELECTED_STATUS) as? ProductStatus)?.let {
-                viewModel.updateProductDraft(productStatus = it)
+            (result.getString(ARG_SELECTED_STATUS))?.let {
+                val status = ProductStatus.fromString(it)
+                viewModel.updateProductDraft(productStatus = status)
                 updateProductView()
             }
         } else if (requestCode == RequestCodes.PRODUCT_SETTINGS_VISIBLITY) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductVisibilityFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductVisibilityFragment.kt
@@ -3,8 +3,9 @@ package com.woocommerce.android.ui.products.settings
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
+import android.view.View.OnClickListener
 import android.view.ViewGroup
-import android.widget.RadioButton
+import android.widget.CheckedTextView
 import androidx.annotation.IdRes
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
@@ -20,7 +21,7 @@ import kotlinx.android.synthetic.main.fragment_product_visibility.*
 /**
  * Settings screen which enables choosing a product's catalog visibility
  */
-class ProductVisibilityFragment : BaseProductSettingsFragment() {
+class ProductVisibilityFragment : BaseProductSettingsFragment(), OnClickListener {
     companion object {
         const val ARG_VISIBILITY = "visibility"
         const val ARG_IS_FEATURED = "is_featured"
@@ -29,6 +30,7 @@ class ProductVisibilityFragment : BaseProductSettingsFragment() {
     override val requestCode = RequestCodes.PRODUCT_SETTINGS_VISIBLITY
 
     private val navArgs: ProductVisibilityFragmentArgs by navArgs()
+    private var selectedVisibility: String? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         setHasOptionsMenu(true)
@@ -38,20 +40,45 @@ class ProductVisibilityFragment : BaseProductSettingsFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        getButtonForVisibility(navArgs.visibility)?.isChecked = true
-        btnFeatured.isChecked = navArgs.featured
+        selectedVisibility = savedInstanceState?.getString(ARG_VISIBILITY) ?: navArgs.visibility
+        btnFeatured.isChecked = savedInstanceState?.getBoolean(ARG_IS_FEATURED) ?: navArgs.featured
+
+        selectedVisibility?.let {
+            getButtonForVisibility(it)?.isChecked = true
+        }
+
+        btnVisibilityVisible.setOnClickListener(this)
+        btnVisibilityCatalog.setOnClickListener(this)
+        btnVisibilitySearch.setOnClickListener(this)
+        btnVisibilityHidden.setOnClickListener(this)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putString(ARG_VISIBILITY, selectedVisibility)
+        outState.putBoolean(ARG_IS_FEATURED, btnFeatured.isChecked)
+    }
+
+    override fun onClick(view: View?) {
+        (view as? CheckedTextView)?.let {
+            btnVisibilityVisible.isChecked = it == btnVisibilityVisible
+            btnVisibilityCatalog.isChecked = it == btnVisibilityCatalog
+            btnVisibilitySearch.isChecked = it == btnVisibilitySearch
+            btnVisibilityHidden.isChecked = it == btnVisibilityHidden
+            selectedVisibility = getVisibilityForButtonId(it.id)
+        }
     }
 
     override fun getChangesBundle(): Bundle {
         return Bundle().also {
-            it.putSerializable(ARG_VISIBILITY, getSelectedVisibility())
+            it.putString(ARG_VISIBILITY, selectedVisibility)
             it.putBoolean(ARG_IS_FEATURED, btnFeatured.isChecked)
         }
     }
 
     override fun hasChanges(): Boolean {
         return navArgs.featured != btnFeatured.isChecked ||
-                navArgs.visibility != getSelectedVisibility()?.toString()
+                navArgs.visibility != selectedVisibility
     }
 
     override fun onResume() {
@@ -59,11 +86,9 @@ class ProductVisibilityFragment : BaseProductSettingsFragment() {
         AnalyticsTracker.trackViewShown(this)
     }
 
-    private fun getSelectedVisibility() = getVisibilityForButtonId(radioGroup.checkedRadioButtonId)
-
     override fun getFragmentTitle() = getString(R.string.product_catalog_visibility)
 
-    private fun getButtonForVisibility(visibility: String): RadioButton? {
+    private fun getButtonForVisibility(visibility: String): CheckedTextView? {
         return when (ProductVisibility.fromString(visibility)) {
             VISIBLE -> btnVisibilityVisible
             CATALOG -> btnVisibilityCatalog
@@ -73,12 +98,12 @@ class ProductVisibilityFragment : BaseProductSettingsFragment() {
         }
     }
 
-    private fun getVisibilityForButtonId(@IdRes buttonId: Int): ProductVisibility? {
+    private fun getVisibilityForButtonId(@IdRes buttonId: Int): String? {
         return when (buttonId) {
-            R.id.btnVisibilityVisible -> VISIBLE
-            R.id.btnVisibilityCatalog -> CATALOG
-            R.id.btnVisibilitySearch -> SEARCH
-            R.id.btnVisibilityHidden -> HIDDEN
+            R.id.btnVisibilityVisible -> VISIBLE.toString()
+            R.id.btnVisibilityCatalog -> CATALOG.toString()
+            R.id.btnVisibilitySearch -> SEARCH.toString()
+            R.id.btnVisibilityHidden -> HIDDEN.toString()
             else -> null
         }
     }

--- a/WooCommerce/src/main/res/layout/fragment_product_status.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_status.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RadioGroup xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/radioGroup"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -7,7 +7,7 @@
     android:paddingStart="@dimen/major_100"
     android:paddingEnd="0dp">
 
-    <com.google.android.material.radiobutton.MaterialRadioButton
+    <CheckedTextView
         android:id="@+id/btnPublished"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -15,7 +15,7 @@
 
     <View style="@style/Woo.Divider" />
 
-    <com.google.android.material.radiobutton.MaterialRadioButton
+    <CheckedTextView
         android:id="@+id/btnDraft"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -23,7 +23,7 @@
 
     <View style="@style/Woo.Divider" />
 
-    <com.google.android.material.radiobutton.MaterialRadioButton
+    <CheckedTextView
         android:id="@+id/btnPending"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -31,7 +31,7 @@
 
     <View style="@style/Woo.Divider" />
 
-    <com.google.android.material.radiobutton.MaterialRadioButton
+    <CheckedTextView
         android:id="@+id/btnPrivate"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -39,4 +39,4 @@
 
     <View style="@style/Woo.Divider" />
 
-</RadioGroup>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_visibility.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_visibility.xml
@@ -42,14 +42,14 @@
             android:layout_marginTop="@dimen/major_100"
             android:orientation="vertical">
 
-            <RadioGroup
-                android:id="@+id/radioGroup"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:orientation="vertical"
                 android:paddingStart="@dimen/major_100"
                 android:paddingEnd="0dp">
 
-                <com.google.android.material.radiobutton.MaterialRadioButton
+                <CheckedTextView
                     android:id="@+id/btnVisibilityVisible"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -57,7 +57,7 @@
 
                 <View style="@style/Woo.Divider" />
 
-                <com.google.android.material.radiobutton.MaterialRadioButton
+                <CheckedTextView
                     android:id="@+id/btnVisibilityCatalog"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -65,7 +65,7 @@
 
                 <View style="@style/Woo.Divider" />
 
-                <com.google.android.material.radiobutton.MaterialRadioButton
+                <CheckedTextView
                     android:id="@+id/btnVisibilitySearch"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -73,14 +73,14 @@
 
                 <View style="@style/Woo.Divider" />
 
-                <com.google.android.material.radiobutton.MaterialRadioButton
+                <CheckedTextView
                     android:id="@+id/btnVisibilityHidden"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="@string/product_visibility_hidden" />
 
                 <View style="@style/Woo.Divider" />
-            </RadioGroup>
+            </LinearLayout>
 
         </com.woocommerce.android.widgets.WCElevatedLinearLayout>
     </LinearLayout>


### PR DESCRIPTION
Closes #2261 - updates the status and visibility product settings screens to show the radio on the right. This required converting all the `MaterialRadioButtons` to `CheckedTextViews`. 

![Screenshot_1587139959](https://user-images.githubusercontent.com/3903757/79590298-cd904f00-80a4-11ea-9529-069b6b369d60.png)

![Screenshot_1587139954](https://user-images.githubusercontent.com/3903757/79590299-ce28e580-80a4-11ea-82b4-55bf75c9820c.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
