### PR TITLE
Dark Mode: Fix shadows in elevated custom component

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCElevatedLinearLayout.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCElevatedLinearLayout.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.widgets
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.ViewGroup
 import android.widget.LinearLayout
 import com.google.android.material.shape.MaterialShapeDrawable
 import com.woocommerce.android.R
@@ -12,7 +13,7 @@ open class WCElevatedLinearLayout @JvmOverloads constructor(
     defStyleAttr: Int = 0,
     defStyleRes: Int = 0
 ) : LinearLayout(context, attrs, defStyleAttr, defStyleRes) {
-    private var shapeElevation = context.resources.getDimensionPixelSize(R.dimen.plane_02).toFloat()
+    private var shapeElevation = context.resources.getDimension(R.dimen.plane_02)
     private var elevatedBackground: MaterialShapeDrawable
 
     init {
@@ -26,12 +27,23 @@ open class WCElevatedLinearLayout @JvmOverloads constructor(
         }
 
         elevatedBackground = MaterialShapeDrawable.createWithElevationOverlay(context, shapeElevation)
+        elevatedBackground.setShadowCompatibilityMode(MaterialShapeDrawable.SHADOW_COMPAT_MODE_ALWAYS)
     }
 
     override fun onFinishInflate() {
         super.onFinishInflate()
 
         background = elevatedBackground
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+
+        // Automatically don't clip children for the parent view. This allows the shadow
+        // to be drawn outside the bounds.
+        if (parent is ViewGroup) {
+            (parent as ViewGroup).clipChildren = false
+        }
     }
 
     override fun setElevation(elevation: Float) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCElevatedLinearLayout.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCElevatedLinearLayout.kt
@@ -13,7 +13,7 @@ open class WCElevatedLinearLayout @JvmOverloads constructor(
     defStyleAttr: Int = 0,
     defStyleRes: Int = 0
 ) : LinearLayout(context, attrs, defStyleAttr, defStyleRes) {
-    private var shapeElevation = context.resources.getDimension(R.dimen.plane_02)
+    private var shapeElevation = context.resources.getDimension(R.dimen.plane_01)
     private var elevatedBackground: MaterialShapeDrawable
 
     init {


### PR DESCRIPTION
Small PR that allows shadows to properly be drawn when using `WCElevatedLinearLayout` by setting the parent `ViewGroups` `clipChildren` setting to `false`. I didn't have a great example to show in this branch, but I did test these changes in the product settings branch. Here are the screenshots:

|Before| After |
| -- | -- |
|![shadow](https://user-images.githubusercontent.com/5810477/79634815-c9564700-8121-11ea-9b92-b84dc84b2ebe.png)|![Screenshot_1587204781](https://user-images.githubusercontent.com/5810477/79634940-8648a380-8122-11ea-8ed9-19c5c31d353c.png)|


