### PR TITLE
Dark Mode: Login theme status bar color fix

### DIFF
--- a/WooCommerce/src/main/res/values/styles_login.xml
+++ b/WooCommerce/src/main/res/values/styles_login.xml
@@ -4,7 +4,7 @@
         Overloads of Login Themes
      -->
     <style name="LoginTheme" parent="Theme.Woo.DayNight">
-        <item name="android:statusBarColor">@color/color_surface</item>
+        <item name="android:statusBarColor">@color/color_status_bar</item>
     </style>
 
     <style name="LoginTheme.Toolbar">


### PR DESCRIPTION
I noticed while doing a final round of testing on the `feature/darkmode-login` branch that setting the status bar color to `color_surface` looked great on the main welcome page, it messed everything up for all the other views in the login package. This small PR fixes that problem:

| Before | After |
| -- | --|
|![Screenshot_1587410518](https://user-images.githubusercontent.com/5810477/79793721-e5b2d900-8305-11ea-9d84-79a987e4f2b6.png)|![Screenshot_1587410391](https://user-images.githubusercontent.com/5810477/79793728-e8153300-8305-11ea-87b4-1a6841cafec7.png)|
|![Screenshot_1587410537](https://user-images.githubusercontent.com/5810477/79793886-2e6a9200-8306-11ea-9d93-6dc4d4799702.png)|![Screenshot_1587410766](https://user-images.githubusercontent.com/5810477/79793898-3296af80-8306-11ea-9c69-a348a2058bd8.png)|
|![Screenshot_1587410522](https://user-images.githubusercontent.com/5810477/79793920-3c201780-8306-11ea-9546-71d110f85393.png)|![Screenshot_1587412563](https://user-images.githubusercontent.com/5810477/79793961-4e9a5100-8306-11ea-9119-b674b04428d4.png)|
|![Screenshot_1587410560](https://user-images.githubusercontent.com/5810477/79793996-607bf400-8306-11ea-9270-f9e74dbcca62.png)|![Screenshot_1587410770](https://user-images.githubusercontent.com/5810477/79794001-6245b780-8306-11ea-8089-b40500578436.png)|





