### PR TITLE
Bugfix: order list tabs show up after marking order complete

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragmentView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragmentView.kt
@@ -20,4 +20,12 @@ interface TopLevelFragmentView : BaseFragmentView {
      * User returned to this top level fragment from a nav component fragment
      */
     fun onReturnedFromChildFragment()
+
+    /**
+     * A child fragment for the active tab has been opened.
+     */
+    fun onChildFragmentOpened() {
+        // Override this method if the top level fragment needs to perform some
+        // sort of cleanup once a child fragment has been opened.
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -382,10 +382,12 @@ class MainActivity : AppUpgradeActivity(),
             hideBottomNav()
         }
 
-        if (isAtRoot) {
-            getActiveTopLevelFragment()?.let {
+        getActiveTopLevelFragment()?.let {
+            if (isAtRoot) {
                 it.updateActivityTitle()
                 it.onReturnedFromChildFragment()
+            } else {
+                it.onChildFragmentOpened()
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -299,6 +299,10 @@ class OrderListFragment : TopLevelFragment(),
         }
     }
 
+    override fun onChildFragmentOpened() {
+        removeTabLayoutFromAppBar(tabLayout)
+    }
+
     /**
      * This is a replacement for activity?.invalidateOptionsMenu() since that causes the
      * search menu item to collapse
@@ -456,7 +460,6 @@ class OrderListFragment : TopLevelFragment(),
 
     override fun openOrderDetail(remoteOrderId: Long) {
         showOptionsMenu(false)
-        removeTabLayoutFromAppBar(tabLayout)
         (activity as? MainNavigationRouter)?.showOrderDetail(selectedSite.get().id, remoteOrderId)
     }
 


### PR DESCRIPTION
This was happening because the request to re-open the order detail view after marking an order complete from the order fulfillment screen was being routed through the `MainActivity`, so the `onReturnedFromChildFragment()` method was getting called, but there was no logic to then hide the tabs once the order detail was displayed since it wasn't opened through the order list fragment. Added a complimentary `onChildFragmentOpened()` to `TopLevelFragmentView` to allow top level fragments to do any cleanup needed. I created it as an implemented empty function so only fragments that have use of this method would need to implement it. This give us better control over managing the lifecycle of child to root navigation. 

| Before | After |
| -- | -- |
|![before](https://user-images.githubusercontent.com/5810477/79827241-ab235d80-8352-11ea-9c46-4be21d11f5f7.gif)|![after](https://user-images.githubusercontent.com/5810477/79827244-aeb6e480-8352-11ea-9979-8cc67bdf2a51.gif)|

## To Test

1. open an order in a the "Processing" state. 
2. Click "Begin Fulfillment" - the order fulfillment screen will open
3. Click "Mark order complete" - the order detail view should open
4. Verify the order list tabs are not added to the AppBar. 
5. Go back to the orders list. Verify the tabs are properly added. 


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
