### PR TITLE
Add instructions on how to get require realpath tool in Git pre-commit hook

### DIFF
--- a/tools/team-props/git-hooks/pre-commit
+++ b/tools/team-props/git-hooks/pre-commit
@@ -13,11 +13,25 @@ if [[ "$BRANCH" == "master" || "$BRANCH" == "develop" ]]; then
   exit 1
 fi
 
-# This block allows for chaining pre-commit hooks if this hook is a global hook (via core.hooksPath) and there also exists a repo-specific pre-commit hook
+# This block allows for chaining pre-commit hooks if this hook is a global hook
+# (via core.hooksPath) and there also exists a repo-specific pre-commit hook
 if [[ -f ".git/hooks/pre-commit" ]]; then
-  red='\033[0;31m'
-  reset='\033[0m'
-  type realpath >/dev/null 2>&1 || { echo -e "$(echo -e $red)NOTE: the realpath binary is required to chain to the repo-specific pre-commit hook.\n\nOn macOS, you can install it via \"brew install coreutils\".\n\nIgnoring.$reset" >&2; exit 0; }
+  type realpath >/dev/null 2>&1 # Check if realpath is available
+  # If the command above failed, then we don't have realpath and we should exit
+  if [ $? -ne 0 ]; then
+    red='\033[0;31m'
+    reset='\033[0m'
+
+    message=$red
+    message+="NOTE: the realpath binary is required to chain to the repo-specific pre-commit hook.\n\n"
+    message+="On macOS, you can install it via \"brew install coreutils\".\n\n"
+    message+="Ignoring."
+    message+="$reset"
+
+    echo $message >&2
+    exit 0 # exit 0 won't fail the commit, just show the message
+  fi
+
   if [[ "$(realpath "${BASH_SOURCE[0]}")" != "$(realpath ".git/hooks/pre-commit")" ]]; then
     .git/hooks/pre-commit
     exit $?

--- a/tools/team-props/git-hooks/pre-commit
+++ b/tools/team-props/git-hooks/pre-commit
@@ -15,7 +15,7 @@ fi
 
 # This block allows for chaining pre-commit hooks if this hook is a global hook (via core.hooksPath) and there also exists a repo-specific pre-commit hook
 if [[ -f ".git/hooks/pre-commit" ]]; then
-  type realpath >/dev/null 2>&1 || { echo >&2 "NOTE: the realpath binary is required to chain to the repo-specific pre-commit hook. Ignoring."; exit 0; }
+  type realpath >/dev/null 2>&1 || { echo >&2 "NOTE: the realpath binary is required to chain to the repo-specific pre-commit hook.\nOn macOS, you can install it via \"brew install coreutils\".\nIgnoring."; exit 0; }
   if [[ "$(realpath "${BASH_SOURCE[0]}")" != "$(realpath ".git/hooks/pre-commit")" ]]; then
     .git/hooks/pre-commit
     exit $?

--- a/tools/team-props/git-hooks/pre-commit
+++ b/tools/team-props/git-hooks/pre-commit
@@ -15,7 +15,9 @@ fi
 
 # This block allows for chaining pre-commit hooks if this hook is a global hook (via core.hooksPath) and there also exists a repo-specific pre-commit hook
 if [[ -f ".git/hooks/pre-commit" ]]; then
-  type realpath >/dev/null 2>&1 || { echo "NOTE: the realpath binary is required to chain to the repo-specific pre-commit hook.\n\nOn macOS, you can install it via \"brew install coreutils\".\n\nIgnoring." >&2; exit 0; }
+  red='\033[0;31m'
+  reset='\033[0m'
+  type realpath >/dev/null 2>&1 || { echo -e "$(echo -e $red)NOTE: the realpath binary is required to chain to the repo-specific pre-commit hook.\n\nOn macOS, you can install it via \"brew install coreutils\".\n\nIgnoring.$reset" >&2; exit 0; }
   if [[ "$(realpath "${BASH_SOURCE[0]}")" != "$(realpath ".git/hooks/pre-commit")" ]]; then
     .git/hooks/pre-commit
     exit $?

--- a/tools/team-props/git-hooks/pre-commit
+++ b/tools/team-props/git-hooks/pre-commit
@@ -15,7 +15,7 @@ fi
 
 # This block allows for chaining pre-commit hooks if this hook is a global hook (via core.hooksPath) and there also exists a repo-specific pre-commit hook
 if [[ -f ".git/hooks/pre-commit" ]]; then
-  type realpath >/dev/null 2>&1 || { echo >&2 "NOTE: the realpath binary is required to chain to the repo-specific pre-commit hook.\nOn macOS, you can install it via \"brew install coreutils\".\nIgnoring."; exit 0; }
+  type realpath >/dev/null 2>&1 || { echo "NOTE: the realpath binary is required to chain to the repo-specific pre-commit hook.\n\nOn macOS, you can install it via \"brew install coreutils\".\n\nIgnoring." >&2; exit 0; }
   if [[ "$(realpath "${BASH_SOURCE[0]}")" != "$(realpath ".git/hooks/pre-commit")" ]]; then
     .git/hooks/pre-commit
     exit $?

--- a/tools/team-props/git-hooks/pre-commit
+++ b/tools/team-props/git-hooks/pre-commit
@@ -28,7 +28,7 @@ if [[ -f ".git/hooks/pre-commit" ]]; then
     message+="Ignoring."
     message+="$reset"
 
-    echo $message >&2
+    echo -e $message >&2
     exit 0 # exit 0 won't fail the commit, just show the message
   fi
 


### PR DESCRIPTION
While working on the screenshot automation, I noticed this repo has a nice pre-commit hook (which `gradle` sets up).

The hook uses the `realpath` program in order to source other hooks that the user might have added. 

I noticed all this because I didn't have `realpath` installed, and the hook gave me a warning message about the fact that it couldn't find the binary.

Even if it didn't take long to find out how to get `realpath`, I thought I'd make it easier on the next dev bumping into this.

### To test

To test these changes, you'll have to edit `tools/team-props/git-hooks/pre-commit` and replace the check for `realpath` to something that fails, e.g.:

```diff
--- a/tools/team-props/git-hooks/pre-commit
+++ b/tools/team-props/git-hooks/pre-commit
@@ -17,7 +17,7 @@ fi
 if [[ -f ".git/hooks/pre-commit" ]]; then
   red='\033[0;31m'
   reset='\033[0m'
-  type realpath >/dev/null 2>&1 || { echo -e "$(echo -e $red)NOTE: the realpath binary is required to chain to the repo-specific pre-commit hook.\n\nOn macOS, you can install it via \"brew install coreutils\".\n\nIgnoring.$reset" >&2; exit 0; }
+  type rrealpath >/dev/null 2>&1 || { echo -e "$(echo -e $red)NOTE: the realpath binary is required to chain to the repo-specific pre-commit hook.\n\nOn macOS, you can install it via \"brew install coreutils\".\n\nIgnoring.$reset" >&2; exit 0; }
   if [[ "$(realpath "${BASH_SOURCE[0]}")" != "$(realpath ".git/hooks/pre-commit")" ]]; then
     .git/hooks/pre-commit
     exit $?
```

Then run `gradle installGitHooks` and try to commit something

<img width="1060" alt="Screen Shot 2020-04-22 at 11 27 31 am" src="https://user-images.githubusercontent.com/1218433/79930971-30ab2880-848d-11ea-85b3-8fd7a5463959.png">


---

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.