### PR TITLE
Dark Mode v2: Login no woo stores

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -243,7 +243,7 @@ class DashboardStatsView @JvmOverloads constructor(
             isDragEnabled = true
 
             setNoDataTextColor(ContextCompat.getColor(context, R.color.graph_no_data_text_color))
-            getPaint(Chart.PAINT_INFO).textSize = context.resources.getDimension(R.dimen.text_large)
+            getPaint(Chart.PAINT_INFO).textSize = context.resources.getDimension(R.dimen.text_minor_125)
         }
 
         chart.setOnChartValueSelectedListener(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
@@ -29,6 +29,7 @@ import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_login_no_jetpack.*
 import kotlinx.android.synthetic.main.view_login_epilogue_button_bar.*
 import kotlinx.android.synthetic.main.view_login_no_stores.*
+import kotlinx.android.synthetic.main.view_login_user_info.*
 import org.wordpress.android.login.LoginListener
 import org.wordpress.android.login.LoginMode
 import javax.inject.Inject
@@ -141,7 +142,7 @@ class LoginNoJetpackFragment : Fragment() {
         userAvatarUrl?.let {
             GlideApp.with(this)
                     .load(it)
-                    .placeholder(R.drawable.ic_placeholder_gravatar_grey_lighten_20_100dp)
+                    .placeholder(R.drawable.img_gravatar_placeholder)
                     .circleCrop()
                     .into(image_avatar)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -34,7 +34,6 @@ import com.woocommerce.android.ui.login.LoginEmailHelpDialogFragment
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.mystore.RevenueStatsAvailabilityFetcher
 import com.woocommerce.android.ui.sitepicker.SitePickerAdapter.OnSiteClickListener
-import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.CrashUtils
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WooClickableSpan
@@ -108,7 +107,6 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
 
         if (calledFromLogin) {
             toolbar.visibility = View.GONE
-            ActivityUtils.setStatusBarColor(this, R.color.wc_grey_mid)
             button_help.setOnClickListener {
                 startActivity(HelpActivity.createIntent(this, Origin.LOGIN_EPILOGUE, null))
                 AnalyticsTracker.track(Stat.SITE_PICKER_HELP_BUTTON_TAPPED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -41,6 +41,7 @@ import dagger.android.AndroidInjection
 import kotlinx.android.synthetic.main.activity_site_picker.*
 import kotlinx.android.synthetic.main.view_login_epilogue_button_bar.*
 import kotlinx.android.synthetic.main.view_login_no_stores.*
+import kotlinx.android.synthetic.main.view_login_user_info.*
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.login.LoginMode
 import javax.inject.Inject
@@ -221,7 +222,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
 
             GlideApp.with(this)
                     .load(presenter.getUserAvatarUrl())
-                    .placeholder(R.drawable.ic_placeholder_gravatar_grey_lighten_20_100dp)
+                    .placeholder(R.drawable.img_gravatar_placeholder)
                     .circleCrop()
                     .into(image_avatar)
         } else {

--- a/WooCommerce/src/main/res/drawable/img_gravatar_placeholder.xml
+++ b/WooCommerce/src/main/res/drawable/img_gravatar_placeholder.xml
@@ -6,12 +6,12 @@
     android:viewportWidth="100.0">
 
     <path
-        android:fillColor="@color/grey_lighten_20"
+        android:fillColor="@color/image_border_color"
         android:pathData="M100,100H0V0h100V100z">
     </path>
 
     <path
-        android:fillColor="@color/white"
+        android:fillColor="@color/color_surface_elevated_04"
         android:pathData="M85,96c0,1.4 -0.1,2.7 -0.2,4H15.2c-0.1,-1.3 -0.2,-2.6 -0.2,-4c0,-16.3 11.1,-29.9 26.1,-33.9C33.4,58.7 28,51 28,42c0,-12.2 9.8,-22 22,-22s22,9.8 22,22c0,9 -5.4,16.7 -13.1,20.1C73.9,66.1 85,79.7 85,96z">
     </path>
 

--- a/WooCommerce/src/main/res/layout-land/view_login_no_stores.xml
+++ b/WooCommerce/src/main/res/layout-land/view_login_no_stores.xml
@@ -11,9 +11,10 @@
     android:gravity="center_horizontal"
     android:lineSpacingExtra="@dimen/line_spacing_extra_50"
     android:text="@string/login_no_stores"
+    android:textStyle="bold"
     android:visibility="gone"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@+id/text_username"
+    app:layout_constraintTop_toBottomOf="@+id/user_info_group"
     app:layout_constraintVertical_bias="0.0"
     tools:visibility="visible"/>

--- a/WooCommerce/src/main/res/layout/activity_site_picker.xml
+++ b/WooCommerce/src/main/res/layout/activity_site_picker.xml
@@ -39,57 +39,6 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"/>
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/button_email_help"
-                style="@style/Woo.Button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/major_150"
-                android:layout_marginTop="@dimen/minor_00"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:textAllCaps="false"
-                android:text="@string/login_need_help_finding_email"
-                android:visibility="gone"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/no_stores_view"
-                app:layout_constraintVertical_bias="1.0"
-                tools:visibility="visible"/>
-
-            <ImageView
-                android:id="@+id/image_avatar"
-                android:layout_width="@dimen/image_major_64"
-                android:layout_height="@dimen/image_major_64"
-                android:layout_marginTop="@dimen/major_300"
-                android:contentDescription="@string/login_avatar_content_description"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:srcCompat="@drawable/ic_placeholder_gravatar_grey_lighten_20_100dp"/>
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/text_username"
-                style="@style/Woo.TextView.Caption"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/minor_10"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/text_displayname"
-                tools:text="\@droidtester2018"/>
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/text_displayname"
-                style="@style/Woo.TextView.Subtitle1"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/minor_100"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/image_avatar"
-                tools:text="droidtester2018"/>
-
             <com.woocommerce.android.widgets.WCElevatedLinearLayout
                 android:id="@+id/site_list_container"
                 android:layout_width="match_parent"
@@ -101,7 +50,7 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/text_username"
+                app:layout_constraintTop_toBottomOf="@+id/user_info_group"
                 app:layout_constraintVertical_bias="0.0"
                 tools:visibility="gone">
 
@@ -122,16 +71,29 @@
                     tools:itemCount="3"/>
             </com.woocommerce.android.widgets.WCElevatedLinearLayout>
 
-            <androidx.constraintlayout.widget.Group
-                android:id="@+id/user_info_group"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:visibility="gone"
-                app:constraint_referenced_ids="image_avatar,text_displayname,text_username"
-                tools:visibility="visible"/>
+            <include
+                layout="@layout/view_login_user_info"/>
 
             <include
                 layout="@layout/view_login_no_stores"/>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/button_email_help"
+                style="@style/Woo.Button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/major_150"
+                android:layout_marginTop="@dimen/minor_00"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
+                android:textAllCaps="false"
+                android:text="@string/login_need_help_finding_email"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/no_stores_view"
+                app:layout_constraintVertical_bias="1.0"
+                tools:visibility="visible"/>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.core.widget.NestedScrollView>

--- a/WooCommerce/src/main/res/layout/fragment_login_no_jetpack.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_no_jetpack.xml
@@ -14,8 +14,7 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@color/wc_grey_light">
+            android:layout_height="wrap_content">
 
             <Button
                 android:id="@+id/button_help"
@@ -26,42 +25,11 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <ImageView
-                android:id="@+id/image_avatar"
-                android:layout_width="@dimen/login_avatar_size"
-                android:layout_height="@dimen/login_avatar_size"
-                android:layout_marginTop="40dp"
-                android:contentDescription="@string/login_avatar_content_description"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:srcCompat="@drawable/ic_placeholder_gravatar_grey_lighten_20_100dp" />
+            <include
+                layout="@layout/view_login_user_info"/>
 
-            <TextView
-                android:id="@+id/text_username"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textColor="@color/grey_dark"
-                android:textSize="@dimen/text_large"
-                android:gravity="center"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/text_displayname"
-                tools:text="\@droidtester2018" />
-
-            <TextView
-                android:id="@+id/text_displayname"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_large"
-                android:textColor="@color/grey_dark"
-                android:textSize="@dimen/text_extra_large"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/image_avatar"
-                tools:text="droidtester2018" />
-
-            <include layout="@layout/view_login_no_stores" />
+            <include
+                layout="@layout/view_login_no_stores"/>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>

--- a/WooCommerce/src/main/res/layout/view_login_no_stores.xml
+++ b/WooCommerce/src/main/res/layout/view_login_no_stores.xml
@@ -12,9 +12,10 @@
     android:gravity="center_horizontal"
     android:lineSpacingExtra="@dimen/line_spacing_extra_50"
     android:text="@string/login_no_stores"
+    android:textStyle="bold"
     android:visibility="gone"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@+id/text_username"
+    app:layout_constraintTop_toBottomOf="@+id/user_info_group"
     app:layout_constraintVertical_bias="0.0"
     tools:visibility="visible"/>

--- a/WooCommerce/src/main/res/layout/view_login_user_info.xml
+++ b/WooCommerce/src/main/res/layout/view_login_user_info.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/user_info_group"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:layout_marginTop="@dimen/major_300"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent">
+
+    <ImageView
+        android:id="@+id/image_avatar"
+        android:layout_width="@dimen/image_major_64"
+        android:layout_height="@dimen/image_major_64"
+        android:layout_marginBottom="@dimen/major_75"
+        android:contentDescription="@string/login_avatar_content_description"
+        tools:srcCompat="@drawable/img_gravatar_placeholder"/>
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/text_displayname"
+        android:textAppearance="@style/TextAppearance.Woo.Headline6"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="0dp"
+        tools:text="droidtester2018"/>
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/text_username"
+        style="@style/Woo.TextView.Body1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="0dp"
+        tools:text="\@droidtester2018"/>
+</LinearLayout>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -200,8 +200,6 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:textAppearance">?attr/textAppearanceSubtitle1</item>
         <item name="android:textColor">@color/color_on_surface_high</item>
         <item name="android:gravity">center_vertical|start</item>
-        <item name="drawableTint">@color/color_on_surface_high_selector</item>
-        <item name="drawableTintMode">src_atop</item>
     </style>
 
     <style name="Woo.TextView.Subtitle2">


### PR DESCRIPTION
Partially fixes #2169 by finding and replacing more old resources with values from the new style resources. This led to some nice fixes to the "No woo stores" error view during login:

**NOTE** PR #2300 must be merged before this one can come out of draft status. 

Before | After Light | After Dark
-- | -- | --
![no-woo-before](https://user-images.githubusercontent.com/5810477/80053269-5bb76b80-84d1-11ea-94db-96f4df0d3398.png)|![no-woo-light-after](https://user-images.githubusercontent.com/5810477/80053270-5ce89880-84d1-11ea-967a-7e90d163e20e.png)|![no-woo-dark-after](https://user-images.githubusercontent.com/5810477/80053272-5e19c580-84d1-11ea-994c-b702b0dae651.png)

Also implemented light/dark coloring on the gravatar placeholder image:

Light | Dark
-- | --
![Screenshot_1587607664](https://user-images.githubusercontent.com/5810477/80053323-7f7ab180-84d1-11ea-8937-9872db46ae61.png)|![Screenshot_1587607655](https://user-images.githubusercontent.com/5810477/80053330-84d7fc00-84d1-11ea-9c1a-0af6b45909ef.png)


## To Test
Log in with a site that has Jetpack installed but no woo stores 
