### PR TITLE
Fix crash caused by invalid casting of AppBarLayout to Toolbar

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_login_discovery_error.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_discovery_error.xml
@@ -7,7 +7,6 @@
     android:orientation="vertical">
 
     <include
-        android:id="@+id/toolbar"
         layout="@layout/toolbar_login" />
 
     <ScrollView


### PR DESCRIPTION
This PR fixes a crash currently happening in 4.1-rc-1 caused by the dark mode product. The Login Discovery Error view was missed during the first round of changes and since it's difficult to get it to be shown, it wasn't failing during testing. The bug is the duplicated `+id/toolbar` ID assigned in `fragment_login_discovery_error.xml` layout. When the login library was updated, the toolbar was placed inside an `AppBarLayout` so using that ID in the `<include/>` element was erroneously attempting to assign that id to an AppBarLayout instead of a Toolbar and that was causing the crash. 

## To Test

If the screen appears without crashing, then the bug is fixed. This view is only shown during a very specific error scenario that is a pain to reproduce so I recommend doing the following to get it to show:

- View the updated fragment by replacing the `onResume()` function in `MainActivity` with this:

```
override fun onResume() {
    super.onResume()
    AnalyticsTracker.trackViewShown(this)

    val discoveryErrorFragment = LoginDiscoveryErrorFragment.newInstance(
            "testwooshop.mystagingwebsite.com", null, "amandariu", "", null, R.string.login_discovery_error_xmlrpc)
    val fragmentTransaction = supportFragmentManager.beginTransaction()
    fragmentTransaction.replace(R.id.container, discoveryErrorFragment, LoginDiscoveryErrorFragment.TAG)
    fragmentTransaction.commitAllowingStateLoss()
}
```

cc: @oguzkocer This will require a new release candidate