### PR TITLE
Use the custom WCMaterialEditTextView for input fields in dialog

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 4.2
 -----
+* Bugfix: Removed detached and non-functioning text counter in the support email dialog
  
 4.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SupportHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SupportHelper.kt
@@ -3,12 +3,12 @@ package com.woocommerce.android.support
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
-import android.widget.EditText
 import androidx.appcompat.app.AlertDialog
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textview.MaterialTextView
 import com.woocommerce.android.R
 import com.woocommerce.android.util.StringUtils
+import com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
 import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.model.SiteModel
 
@@ -43,8 +43,8 @@ class SupportHelper {
         dialog.setOnShowListener {
             val button = dialog.getButton(AlertDialog.BUTTON_POSITIVE)
             button.setOnClickListener {
-                val newEmail = emailEditText.text.toString()
-                val newName = nameEditText.text.toString()
+                val newEmail = emailEditText.getText()
+                val newName = nameEditText.getText()
                 if (StringUtils.isValidEmail(newEmail)) {
                     emailAndNameSelected(newEmail, newName)
                     dialog.dismiss()
@@ -91,7 +91,7 @@ private fun supportIdentityInputDialogLayout(
     isNameInputHidden: Boolean,
     emailSuggestion: String?,
     nameSuggestion: String?
-): Triple<View, EditText, EditText> {
+): Triple<View, WCMaterialOutlinedEditTextView, WCMaterialOutlinedEditTextView> {
     val layout = LayoutInflater.from(context).inflate(R.layout.support_email_and_name_dialog, null)
 
     val messageText = layout.findViewById<MaterialTextView>(R.id.support_identity_input_dialog_message)
@@ -102,12 +102,20 @@ private fun supportIdentityInputDialogLayout(
     }
     messageText.setText(message)
 
-    val emailEditText = layout.findViewById<EditText>(R.id.support_identity_input_dialog_email_edit_text)
-    emailEditText.setText(emailSuggestion)
-    emailEditText.setSelection(0, emailSuggestion?.length ?: 0)
+    val emailEditText = layout.findViewById<WCMaterialOutlinedEditTextView>(
+            R.id.support_identity_input_dialog_email_edit_text
+    )
+    emailSuggestion?.let {
+        emailEditText.setText(it)
+        emailEditText.setSelection(0, it.length)
+    }
 
-    val nameEditText = layout.findViewById<EditText>(R.id.support_identity_input_dialog_name_edit_text)
-    nameEditText.setText(nameSuggestion)
+    val nameEditText = layout.findViewById<WCMaterialOutlinedEditTextView>(
+            R.id.support_identity_input_dialog_name_edit_text
+    )
+    nameSuggestion?.let {
+        nameEditText.setText(it)
+    }
     nameEditText.visibility = if (isNameInputHidden) View.GONE else View.VISIBLE
 
     return Triple(layout, emailEditText, nameEditText)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
@@ -20,9 +20,20 @@ import com.woocommerce.android.R
 import kotlinx.android.synthetic.main.view_material_outlined_edittext.view.*
 
 /**
- * Custom View that mimics a TextInputEditText with a summary TextView below it. This view will display
- * a text box and a summary. The entire view acts as a single component.
+ * Custom View that encapsulates a [TextInputLayout] and [TextInputEditText], and as such has the following
+ * capabilities:
+ * - Show helper text
+ * - Show error text
+ * - Enable/set counter and maxLength
+ * - Set the text on the child [TextInputEditText]
+ * - Set the selected text on the child [TextInputEditText]
  *
+ * The entire view acts as a single component. The following attributes have been exposed to this view as
+ * custom attributes and are used to interact with the nested [TextInputEditText] component:
+ * - [android:inputType]
+ * - [android:maxLength]
+ * - [android:enabled]
+ * - [android:text]
  */
 class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
     ctx: Context,
@@ -69,6 +80,10 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
     }
 
     fun getText() = edit_text.text.toString()
+
+    fun setSelection(start: Int, stop: Int) {
+        edit_text.setSelection(start, stop)
+    }
 
     fun setOnTextChangedListener(cb: (text: Editable?) -> Unit) {
         edit_text.doAfterTextChanged {

--- a/WooCommerce/src/main/res/layout/support_email_and_name_dialog.xml
+++ b/WooCommerce/src/main/res/layout/support_email_and_name_dialog.xml
@@ -17,46 +17,24 @@
         android:paddingBottom="@dimen/minor_100"
         tools:text="@string/support_identity_input_dialog_enter_email_and_name"/>
 
-    <com.google.android.material.textfield.TextInputLayout
-        style="@style/Woo.TextInputLayout"
-        android:layout_height="wrap_content"
+    <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+        android:id="@+id/support_identity_input_dialog_email_edit_text"
         android:layout_width="match_parent"
-        android:hint="@string/support_identity_input_dialog_email_label">
-
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/support_identity_input_dialog_email_edit_text"
-            style="@style/Woo.TextInputEditText"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/minor_00"
-            android:layout_marginEnd="@dimen/minor_00"
-            android:inputType="textEmailAddress"
-            android:layout_marginBottom="@dimen/major_75">
-        </com.google.android.material.textfield.TextInputEditText>
-
-    </com.google.android.material.textfield.TextInputLayout>
-
-    <com.google.android.material.textfield.TextInputLayout
-        style="@style/Woo.TextInputLayout"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginEnd="@dimen/major_100"
+        android:layout_marginBottom="@dimen/major_75"
+        android:hint="@string/support_identity_input_dialog_email_label"
+        android:inputType="textEmailAddress" />
+
+    <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+        android:id="@+id/support_identity_input_dialog_name_edit_text"
         android:layout_width="match_parent"
-        app:counterEnabled="true"
-        app:counterMaxLength="50"
-        tools:visibility="visible">
-
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/support_identity_input_dialog_name_edit_text"
-            style="@style/Woo.TextInputEditText"
-            android:layout_height="wrap_content"
-            android:layout_width="match_parent"
-            android:layout_marginStart="@dimen/minor_00"
-            android:layout_marginEnd="@dimen/minor_00"
-            android:inputType="text"
-            android:hint="@string/support_identity_input_dialog_name_label"
-            android:maxLength="50"
-            tools:visibility="visible">
-        </com.google.android.material.textfield.TextInputEditText>
-
-    </com.google.android.material.textfield.TextInputLayout>
-
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginEnd="@dimen/major_100"
+        android:layout_marginBottom="@dimen/major_75"
+        android:inputType="text"
+        android:hint="@string/support_identity_input_dialog_name_label"
+        android:maxLength="50"/>
 </LinearLayout>


### PR DESCRIPTION
Fixes #2306 by swapping out the `TextInputLayout`'s in the support email dialog and replacing it with the custom `WCMaterialEditTextViews`'s. This is to give a more consistent UI and fixing the issue with the counter showing up when the name field is hidden, as well as fixing the way error messages are displayed.

Before | After 
-- | --
![Screenshot_1587773236](https://user-images.githubusercontent.com/5810477/80265908-14a2b500-864e-11ea-8c22-ede19134f4e7.png)|![Screenshot_1587772660](https://user-images.githubusercontent.com/5810477/80265916-1c625980-864e-11ea-9b9f-8d1a141ff979.png)
![Screenshot_1587772725](https://user-images.githubusercontent.com/5810477/80265873-f341c900-864d-11ea-8168-c7671f60f215.png)|![Screenshot_1587772691](https://user-images.githubusercontent.com/5810477/80265877-f76de680-864d-11ea-8818-24cc4fe2f67e.png)



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
