### PR TITLE
Dark Mode bugfixes: About screen + settings beta text

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_about.xml
+++ b/WooCommerce/src/main/res/layout/fragment_about.xml
@@ -19,24 +19,29 @@
         android:layout_gravity="center"
         app:srcCompat="@drawable/img_woo_bubble_colored"/>
 
-    <View style="@style/Woo.Divider"/>
-
     <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
         android:id="@+id/about_privacy"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:paddingStart="@dimen/major_100"
+        android:paddingEnd="@dimen/minor_00"
         app:optionTitle="@string/settings_privacy_policy_header"/>
 
-    <View style="@style/Woo.Divider"/>
+    <View
+        style="@style/Woo.Divider"
+        android:layout_marginStart="@dimen/major_100"/>
 
     <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
         android:id="@+id/about_tos"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:paddingStart="@dimen/major_100"
+        android:paddingEnd="@dimen/minor_00"
         app:optionTitle="@string/about_tos"/>
 
     <View
         style="@style/Woo.Divider"
+        android:layout_marginStart="@dimen/major_100"
         android:layout_marginBottom="@dimen/major_200"/>
 
     <com.google.android.material.textview.MaterialTextView

--- a/WooCommerce/src/main/res/layout/fragment_about.xml
+++ b/WooCommerce/src/main/res/layout/fragment_about.xml
@@ -5,8 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:background="@color/color_surface">
+    android:orientation="vertical">
 
     <ImageView
         android:id="@+id/about_image"
@@ -19,30 +18,37 @@
         android:layout_gravity="center"
         app:srcCompat="@drawable/img_woo_bubble_colored"/>
 
-    <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-        android:id="@+id/about_privacy"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingStart="@dimen/major_100"
-        android:paddingEnd="@dimen/minor_00"
-        app:optionTitle="@string/settings_privacy_policy_header"/>
+        android:orientation="vertical"
+        android:layout_marginBottom="@dimen/major_200"
+        android:background="?attr/colorSurface">
 
-    <View
-        style="@style/Woo.Divider"
-        android:layout_marginStart="@dimen/major_100"/>
+        <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+            android:id="@+id/about_privacy"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingStart="@dimen/major_100"
+            android:paddingEnd="@dimen/minor_00"
+            app:optionTitle="@string/settings_privacy_policy_header"/>
 
-    <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-        android:id="@+id/about_tos"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingStart="@dimen/major_100"
-        android:paddingEnd="@dimen/minor_00"
-        app:optionTitle="@string/about_tos"/>
+        <View
+            style="@style/Woo.Divider"
+            android:layout_marginStart="@dimen/major_100"/>
 
-    <View
-        style="@style/Woo.Divider"
-        android:layout_marginStart="@dimen/major_100"
-        android:layout_marginBottom="@dimen/major_200"/>
+        <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+            android:id="@+id/about_tos"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingStart="@dimen/major_100"
+            android:paddingEnd="@dimen/minor_00"
+            app:optionTitle="@string/about_tos"/>
+
+        <View
+            style="@style/Woo.Divider"
+            android:layout_marginStart="@dimen/major_100" />
+    </LinearLayout>
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/about_version"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -543,7 +543,7 @@
     <string name="settings_send_stats">Collect information</string>
     <string name="settings_enable_v4_stats_title">Improved stats</string>
     <string name="settings_enable_product_teaser_title">Product editing</string>
-    <string name="settings_enable_v4_stats_message">Try the new stats available with the\nWooCommerce admin plugin</string>
+    <string name="settings_enable_v4_stats_message">Try the new stats available with the WooCommerce admin plugin</string>
     <string name="settings_enable_product_teaser_message">Test out the new product editing functionality as we get ready to launch</string>
     <string name="settings_send_stats_detail">Share information with our analytics tool about your use of services while logged in to your WordPress account</string>
     <string name="settings_privacy_detail">This information helps us improve our products, make marketing to you more relevant, personalize your WooCommerce experience, and more as detailed in our privacy policy</string>


### PR DESCRIPTION
This PR fixes #2303 and fixes #2214. This include:

- Fixed the alignment of the buttons on the About screen
- Removed the forced line break (`\n`) in the middle of the text for the stats beta features setting option.

Design | Before | After 
-- | -- | --
![image](https://user-images.githubusercontent.com/5810477/80267444-cbeefa00-8655-11ea-9090-e0c55234d72e.png)|<img src="https://user-images.githubusercontent.com/5810477/80267602-b75f3180-8656-11ea-9137-f076d53c9f3c.png" width="491"/>|<img src="https://user-images.githubusercontent.com/5810477/80267605-b9c18b80-8656-11ea-8de5-81fda18e4de1.png" width="491"/>
![image](https://user-images.githubusercontent.com/5810477/80267453-e1fcba80-8655-11ea-9e83-e5f565c61de5.png)|<img src="https://user-images.githubusercontent.com/5810477/80267620-d1990f80-8656-11ea-8010-016669a9c148.png" width="491"/>|<img src="https://user-images.githubusercontent.com/5810477/80267623-d65dc380-8656-11ea-86ea-6552f27331a2.png" width="491"/>






Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
