### PR TITLE
Dark Mode v2: Site address help

### DIFF
--- a/WooCommerce/src/main/res/layout/login_alert_site_address_help.xml
+++ b/WooCommerce/src/main/res/layout/login_alert_site_address_help.xml
@@ -8,10 +8,9 @@
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="180dp"
         android:layout_marginBottom="@dimen/major_125"
-        android:layout_marginTop="@dimen/minor_100"
-        android:paddingTop="@dimen/major_100"
+        android:paddingTop="@dimen/major_150"
         android:paddingStart="@dimen/major_250"
         android:paddingEnd="@dimen/major_250"
         android:background="@color/color_default_image_background">
@@ -28,12 +27,21 @@
     </FrameLayout>
 
     <com.google.android.material.textview.MaterialTextView
+        style="@style/TextAppearance.Woo.Subtitle1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginEnd="@dimen/major_100"
+        android:layout_marginBottom="@dimen/major_100"
+        android:textColor="@color/color_on_surface_high"
+        android:text="@string/login_site_address_help_title"/>
+
+    <com.google.android.material.textview.MaterialTextView
         style="@style/TextAppearance.Woo.Body2"
         android:textColor="@color/color_on_surface_high"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="?attr/dialogPreferredPadding"
-        android:layout_marginEnd="?attr/dialogPreferredPadding"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginEnd="@dimen/major_100"
         android:text="@string/login_site_address_help_content" />
-
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout/login_alert_site_address_help.xml
+++ b/WooCommerce/src/main/res/layout/login_alert_site_address_help.xml
@@ -30,8 +30,8 @@
         style="@style/TextAppearance.Woo.Subtitle1"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/major_100"
-        android:layout_marginEnd="@dimen/major_100"
+        android:layout_marginStart="@dimen/major_150"
+        android:layout_marginEnd="@dimen/major_150"
         android:layout_marginBottom="@dimen/major_100"
         android:textColor="@color/color_on_surface_high"
         android:text="@string/login_site_address_help_title"/>
@@ -41,7 +41,7 @@
         android:textColor="@color/color_on_surface_high"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/major_100"
-        android:layout_marginEnd="@dimen/major_100"
+        android:layout_marginStart="@dimen/major_150"
+        android:layout_marginEnd="@dimen/major_150"
         android:text="@string/login_site_address_help_content" />
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout/login_alert_site_address_help.xml
+++ b/WooCommerce/src/main/res/layout/login_alert_site_address_help.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/major_125"
+        android:layout_marginTop="@dimen/minor_100"
+        android:paddingTop="@dimen/major_100"
+        android:paddingStart="@dimen/major_250"
+        android:paddingEnd="@dimen/major_250"
+        android:background="@color/color_default_image_background">
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:adjustViewBounds="true"
+            android:contentDescription="@null"
+            android:importantForAccessibility="no"
+            android:scaleType="fitXY"
+            android:layout_gravity="center|bottom"
+            app:srcCompat="@drawable/login_site_address_help" />
+    </FrameLayout>
+
+    <com.google.android.material.textview.MaterialTextView
+        style="@style/TextAppearance.Woo.Body2"
+        android:textColor="@color/color_on_surface_high"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="?attr/dialogPreferredPadding"
+        android:layout_marginEnd="?attr/dialogPreferredPadding"
+        android:text="@string/login_site_address_help_content" />
+
+</LinearLayout>

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -45,6 +45,7 @@
     <color name="image_border_color">@color/woo_white_alpha_012</color>
     <color name="color_ripple_overlay">@color/woo_white_alpha_012</color>
     <color name="color_scrim_background">@color/woo_black_90_alpha_038</color>
+    <color name="color_default_image_background">@color/woo_gray_80</color>
 
     <!--
         Elevation colors

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -38,6 +38,7 @@
 
     <color name="inverted_surface_overlay">@color/woo_black_90_alpha_012</color>
     <color name="color_scrim_background">@color/woo_white_alpha_038</color>
+    <color name="color_default_image_background">@color/woo_gray_900</color>
 
     <!--
         Icon-related resources that use the surface color should be assigned

--- a/WooCommerce/src/main/res/values/dimens_base.xml
+++ b/WooCommerce/src/main/res/values/dimens_base.xml
@@ -28,6 +28,7 @@ so that's the baseline as defined in `major_100`.
     <dimen name="major_150">24dp</dimen>
     <dimen name="major_175">28dp</dimen>
     <dimen name="major_200">32dp</dimen>
+    <dimen name="major_250">40dp</dimen>
     <dimen name="major_300">48dp</dimen>
     <dimen name="major_325">56dp</dimen>
 

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -69,6 +69,7 @@
         <item name="toolbarStyle">@style/Widget.Woo.Toolbar</item>
         <item name="chipStyle">@style/Widget.MaterialComponents.Chip.Entry</item>
         <item name="materialAlertDialogTheme">@style/Theme.Woo.Dialog</item>
+        <item name="alertDialogTheme">@style/Theme.Woo.Dialog</item>
         <item name="tabStyle">@style/Woo.TabLayout</item>
         <item name="scrollableTabStyle">@style/Woo.TabLayout.Scrollable</item>
         <item name="appBarLayoutStyle">@style/Woo.AppBarLayout</item>
@@ -116,6 +117,17 @@
         <item name="colorOnBackground">@color/color_on_background</item>
         <item name="colorOnSurface">@color/color_on_surface_high</item>
         <item name="colorOnError">@color/color_on_error</item>
+
+        <item name="buttonBarStyle">@style/Woo.Dialog.ButtonBar</item>
+        <item name="android:buttonBarStyle">@style/Woo.Dialog.ButtonBar</item>
+    </style>
+
+    <style name="Woo.Dialog"/>
+    <style name="Woo.Dialog.ButtonBar">
+        <item name="android:paddingStart">@dimen/minor_100</item>
+        <item name="android:paddingEnd">@dimen/minor_100</item>
+        <item name="android:paddingTop">@dimen/minor_50</item>
+        <item name="android:paddingBottom">@dimen/minor_50</item>
     </style>
 
     <style name="Theme.Woo.NumberPicker" parent="Theme.Woo.DayNight">

--- a/WooCommerce/src/main/res/values/wc_colors_base.xml
+++ b/WooCommerce/src/main/res/values/wc_colors_base.xml
@@ -38,6 +38,7 @@
 
     <color name="woo_gray_5">#DCDCDE</color>
     <color name="woo_gray_40">#787C82</color>
+    <color name="woo_gray_80">#2C3338</color>
     <color name="woo_gray_900">#F7F7F7</color>
 
     <color name="woo_black">@android:color/black</color>

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressHelpDialogFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressHelpDialogFragment.java
@@ -48,7 +48,11 @@ public class LoginSiteAddressHelpDialogFragment extends DialogFragment {
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         AlertDialog.Builder alert = new MaterialAlertDialogBuilder(getActivity());
-        alert.setTitle(R.string.login_site_address_help_title);
+        if (mLoginListener.getLoginMode() != LoginMode.WOO_LOGIN_MODE) {
+            // Only set the title if not the woo app, since the woo app specifies an override
+            // layout that includes the title.
+            alert.setTitle(R.string.login_site_address_help_title);
+        }
 
         //noinspection InflateParams
         alert.setView(getActivity().getLayoutInflater().inflate(R.layout.login_alert_site_address_help, null));


### PR DESCRIPTION
This PR fixes #2325 by overriding the site address help dialog to better match designs. The most recent designs call for the image to be on top, then the title, then the body. Since the login library is shared, the closest I could get was to override the dialog content layout which places the image above the body - but cannot move the title since that's set in the login library when setting the alert dialog title. 

@Garance91540 ~This is the closest I could get by overriding the login library layout. The dialog text is set programmatically in the login library and that's where android places the title - so overriding the layout only changes the body and image arrangement. Ideally we'd not be overriding layout files just because it then makes it difficult to track where to make changes, but if you think the changes are worth it, we can push it. Here are the comparisons:~

Never mind! I figured out a clean way to do this :) I just check if the login mode is "Woo" and only add the title if it's not. This way we could add the title to the layout as well. Updated the screenshots. I also updated the dialog theme to fix the padding on the button bars so they are 24dp. 

Design | v1 | v2
-- | -- | --
![Screen Shot 2020-04-27 at 5 41 49 PM](https://user-images.githubusercontent.com/5810477/80434512-ca6c3e80-88ae-11ea-82d2-086b5e4d6831.png)|![Screen Shot 2020-04-27 at 5 39 55 PM](https://user-images.githubusercontent.com/5810477/80434558-ec65c100-88ae-11ea-9d0e-caa94892d2a7.png)|![Screen Shot 2020-04-28 at 11 49 44 AM](https://user-images.githubusercontent.com/5810477/80525653-6c8b3580-8946-11ea-9ecb-7627f1a0e7d2.png)
![Screen Shot 2020-04-27 at 5 41 58 PM](https://user-images.githubusercontent.com/5810477/80434515-cc360200-88ae-11ea-8ffa-f075e184891d.png)|![Screen Shot 2020-04-27 at 5 42 26 PM](https://user-images.githubusercontent.com/5810477/80434559-ed96ee00-88ae-11ea-90db-b61e228cdb6c.png)|![Screen Shot 2020-04-28 at 11 49 58 AM](https://user-images.githubusercontent.com/5810477/80525675-744ada00-8946-11ea-8ef1-43063a8d6ed7.png)



Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
