### PR TITLE
Dark Mode v2: Jetpack Required screen tweaks

### DIFF
--- a/WooCommerce/src/main/res/layout-land/fragment_login_jetpack_required.xml
+++ b/WooCommerce/src/main/res/layout-land/fragment_login_jetpack_required.xml
@@ -27,6 +27,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/major_200"
+                android:textColor="@color/color_on_surface_high"
                 android:text="@string/login_jetpack_required_msg"
                 app:layout_constraintBottom_toTopOf="@+id/btn_jetpack_instructions"
                 app:layout_constraintEnd_toEndOf="@+id/btn_jetpack_instructions"
@@ -66,26 +67,22 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 
-    <com.google.android.material.card.MaterialCardView
+    <com.woocommerce.android.widgets.WCElevatedLinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
 
-        <FrameLayout
-            android:id="@+id/btn_jetpack_sign_in"
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/txt_signin_jetpack"
+            style="@style/TextAppearance.Woo.Body2"
+            android:textColor="@color/color_on_surface_high"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/txt_signin_jetpack"
-                style="@style/TextAppearance.Woo.Body1"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:minHeight="@dimen/min_tap_target"
-                android:layout_gravity="center"
-                android:gravity="center"
-                android:text="@string/login_jetpack_installed_sign_in"
-                tools:text="Already have Jetpack? Sign in" />
-        </FrameLayout>
-    </com.google.android.material.card.MaterialCardView>
+            android:layout_height="wrap_content"
+            android:minHeight="@dimen/min_tap_target"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:text="@string/login_jetpack_installed_sign_in"
+            tools:text="Already have Jetpack? Sign in" />
+    </com.woocommerce.android.widgets.WCElevatedLinearLayout>
 
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_login_jetpack_required.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_jetpack_required.xml
@@ -40,6 +40,7 @@
                 android:textAlignment="center"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:textColor="@color/color_on_surface_high"
                 android:text="@string/login_jetpack_required_msg"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="@+id/btn_jetpack_instructions"
@@ -78,26 +79,22 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 
-    <com.google.android.material.card.MaterialCardView
+    <com.woocommerce.android.widgets.WCElevatedLinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
 
-        <FrameLayout
-            android:id="@+id/btn_jetpack_sign_in"
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/txt_signin_jetpack"
+            style="@style/TextAppearance.Woo.Body2"
+            android:textColor="@color/color_on_surface_high"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/txt_signin_jetpack"
-                style="@style/TextAppearance.Woo.Body1"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:minHeight="@dimen/min_tap_target"
-                android:layout_gravity="center"
-                android:gravity="center"
-                android:text="@string/login_jetpack_installed_sign_in"
-                tools:text="Already have Jetpack? Sign in" />
-        </FrameLayout>
-    </com.google.android.material.card.MaterialCardView>
+            android:layout_height="wrap_content"
+            android:minHeight="@dimen/min_tap_target"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:text="@string/login_jetpack_installed_sign_in"
+            tools:text="Already have Jetpack? Sign in" />
+    </com.woocommerce.android.widgets.WCElevatedLinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
Fixes #2327 by implementing some minor tweaks to the Jetpack required view:

- Optimize layout by converting card to elevated layout (also ensures proper background color)
- Update description body text color to `color_on_surface_high`
- Update sign in bar text to `body2` and `color_on_surface_high`

Before | After
-- | --
![Screenshot_1588040753](https://user-images.githubusercontent.com/5810477/80440461-afed9180-88bd-11ea-8bca-c8abd1c1353c.png)|![Screenshot_1588040852](https://user-images.githubusercontent.com/5810477/80440467-b1b75500-88bd-11ea-8c03-8d822319e140.png)
![Screenshot_1588040761](https://user-images.githubusercontent.com/5810477/80440482-b7149f80-88bd-11ea-8709-fc265d8b7375.png)|![Screenshot_1588040844](https://user-images.githubusercontent.com/5810477/80440490-b976f980-88bd-11ea-9ced-f9ba36edac54.png)

Requires design review

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
