### PR TITLE
Added logic to hide keyboard when exiting product detail and sub detail screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ViewModelFactory
+import org.wordpress.android.util.ActivityUtils
 import javax.inject.Inject
 
 /**
@@ -75,5 +76,8 @@ abstract class BaseProductFragment : BaseFragment(), BackPressListener {
     override fun onStop() {
         super.onStop()
         CustomDiscardDialog.onCleared()
+        activity?.let {
+            ActivityUtils.hideKeyboard(it)
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
@@ -48,13 +48,6 @@ class ProductInventoryFragment : BaseProductFragment(), ProductInventorySelector
         AnalyticsTracker.trackViewShown(this)
     }
 
-    override fun onStop() {
-        super.onStop()
-        activity?.let {
-            ActivityUtils.hideKeyboard(it)
-        }
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupObservers(viewModel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
@@ -70,13 +70,6 @@ class ProductPricingFragment : BaseProductFragment(), ProductInventorySelectorDi
         AnalyticsTracker.trackViewShown(this)
     }
 
-    override fun onStop() {
-        super.onStop()
-        activity?.let {
-            ActivityUtils.hideKeyboard(it)
-        }
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupObservers(viewModel)


### PR DESCRIPTION
Fixes #2259. This tiny PR adds the logic to hide the keypad when the user exits the product detail or any of the product sub detail screens.

#### To test
- Click on a product from the Products tab.
- Click on the product title and notice the keypad is up.
- Click the back button and notice the keypad is no longer displayed.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
