### PR TITLE
Removed variation from the product type enum class

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -64,7 +64,6 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
     }
 
     private var productName = ""
-    private var isVariation = false
     private val skeletonView = SkeletonView()
 
     private var progressDialog: CustomProgressDialog? = null
@@ -192,8 +191,6 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
             imageGallery.showProductImages(product, this)
         }
 
-        isVariation = product.type == ProductType.VARIATION
-
         // show status badge for unpublished products
         product.status?.let { status ->
             if (status != ProductStatus.PUBLISH) {
@@ -254,7 +251,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
 
         // we don't show total sales for variations because they're always zero
         // we are removing the total orders sections from products M2 release
-        if (!isVariation && !FeatureFlag.PRODUCT_RELEASE_M2.isEnabled()) {
+        if (product.type != VARIABLE && !FeatureFlag.PRODUCT_RELEASE_M2.isEnabled()) {
             addPropertyView(
                     DetailCard.Primary,
                     R.string.product_total_orders,
@@ -263,7 +260,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         }
 
         // we don't show reviews for variations because they're always empty
-        if (!isVariation && product.reviewsAllowed) {
+        if (product.type != VARIABLE && product.reviewsAllowed) {
             addPropertyView(
                     DetailCard.Primary,
                     R.string.product_reviews,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductType.kt
@@ -3,21 +3,20 @@ package com.woocommerce.android.ui.products
 import androidx.annotation.StringRes
 import com.woocommerce.android.R
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductType
+import java.util.Locale
 
 enum class ProductType(@StringRes val stringResource: Int = 0, val value: String = "") {
     SIMPLE(R.string.product_type_simple, CoreProductType.SIMPLE.value),
     GROUPED(R.string.product_type_grouped, CoreProductType.GROUPED.value),
     EXTERNAL(R.string.product_type_external, CoreProductType.EXTERNAL.value),
-    VARIABLE(R.string.product_type_variable, CoreProductType.VARIABLE.value),
-    VARIATION(R.string.product_type_variation, CoreProductType.VARIATION.value);
+    VARIABLE(R.string.product_type_variable, CoreProductType.VARIABLE.value);
 
     companion object {
         fun fromString(type: String): ProductType {
-            return when (type.toLowerCase()) {
+            return when (type.toLowerCase(Locale.US)) {
                 "grouped" -> GROUPED
                 "external" -> EXTERNAL
                 "variable" -> VARIABLE
-                "variation" -> VARIATION
                 else -> SIMPLE
             }
         }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -792,7 +792,6 @@
     <string name="product_type_grouped">Grouped</string>
     <string name="product_type_external">External</string>
     <string name="product_type_variable">Variable</string>
-    <string name="product_type_variation">Variation</string>
 
     <!-- permissions -->
     <string name="permissions_denied_title">Permissions</string>


### PR DESCRIPTION
Fixes #2336 by removing `VARIATION` from the `ProductType` enum class since this is not supported by the API.

#### To test
- Click on the Filters button in Product TAB.
- Click on `Product Type` and notice that `Variation` is not displayed.

@nbradbury, I have added you as a reviewer since you had worked on the Product Detail screen where `VARIATION` was used. I tested the app and removing this did not cause any issues but wanted to get your 👌 for that in case I missed any scenarios where this might be used.  

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
