### PR TITLE
Issue/2339 add tracking events

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -256,6 +256,8 @@ class AnalyticsTracker private constructor(private val context: Context) {
         PRODUCT_LIST_PULLED_TO_REFRESH,
         PRODUCT_LIST_SEARCHED,
         PRODUCT_LIST_MENU_SEARCH_TAPPED,
+        PRODUCT_LIST_VIEW_FILTER_OPTIONS_TAPPED,
+        PRODUCT_LIST_VIEW_SORTING_OPTIONS_TAPPED,
 
         // -- Product detail
         PRODUCT_DETAIL_LOADED,
@@ -269,11 +271,18 @@ class AnalyticsTracker private constructor(private val context: Context) {
         PRODUCT_DETAIL_VIEW_PRICE_SETTINGS_TAPPED,
         PRODUCT_DETAIL_VIEW_INVENTORY_SETTINGS_TAPPED,
         PRODUCT_DETAIL_VIEW_SHIPPING_SETTINGS_TAPPED,
+        PRODUCT_DETAIL_VIEW_SHORT_DESCRIPTION_TAPPED,
         PRODUCT_PRICE_SETTINGS_DONE_BUTTON_TAPPED,
         PRODUCT_INVENTORY_SETTINGS_DONE_BUTTON_TAPPED,
         PRODUCT_SHIPPING_SETTINGS_DONE_BUTTON_TAPPED,
+        PRODUCT_IMAGE_SETTINGS_DONE_BUTTON_TAPPED,
+        PRODUCT_SETTINGS_DONE_BUTTON_TAPPED,
         PRODUCT_DETAIL_UPDATE_SUCCESS,
         PRODUCT_DETAIL_UPDATE_ERROR,
+
+        // -- Product filters
+        PRODUCT_FILTER_LIST_SHOW_PRODUCTS_BUTTON_TAPPED,
+        PRODUCT_FILTER_LIST_CLEAR_MENU_BUTTON_TAPPED,
 
         // -- Aztec editor
         AZTEC_EDITOR_DONE_BUTTON_TAPPED,
@@ -502,6 +511,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_REVIEW_ID = "review_id"
         const val KEY_NOTE_ID = "note_id"
         const val KEY_IMAGE_SOURCE = "source"
+        const val KEY_FILTERS = "filters"
 
         const val VALUE_ORDER = "order"
         const val VALUE_REVIEW = "review"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -457,7 +457,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
             )?.also {
                 it.setMaxLines(1)
                 it.setClickListener {
-                    // TODO: track event
+                    AnalyticsTracker.track(Stat.PRODUCT_DETAIL_VIEW_SHORT_DESCRIPTION_TAPPED)
                     viewModel.onEditProductCardClicked(
                             ViewProductShortDescriptionEditor(
                                     product.shortDescription, getString(R.string.product_short_description)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -194,7 +194,7 @@ class ProductDetailViewModel @AssistedInject constructor(
                 hasChanges = viewState.storedProduct?.hasShippingChanges(viewState.productDraft) ?: false
             }
             is ExitImages -> {
-                // TODO: eventName = ??
+                eventName = Stat.PRODUCT_IMAGE_SETTINGS_DONE_BUTTON_TAPPED
                 hasChanges = viewState.storedProduct?.hasImageChanges(viewState.productDraft) ?: false
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListAdapter.kt
@@ -40,7 +40,6 @@ class ProductFilterListAdapter(
         holder.txtFilterSelection.text = filter.filterOptionListItems.first { it.isSelected }.filterOptionItemName
 
         holder.itemView.setOnClickListener {
-            // TODO: Add tracking event here
             clickListener.onProductFilterClick(position)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
@@ -15,6 +15,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
@@ -76,7 +77,8 @@ class ProductFilterListFragment : BaseFragment(), OnProductFilterClickListener {
         }
 
         filterList_btnShowProducts.setOnClickListener {
-            // TODO: add tracking event
+            AnalyticsTracker.track(Stat.PRODUCT_FILTER_LIST_SHOW_PRODUCTS_BUTTON_TAPPED,
+                    mapOf(AnalyticsTracker.KEY_FILTERS to viewModel.getFilterString()))
             val bundle = Bundle()
             bundle.putString(ARG_PRODUCT_FILTER_STOCK_STATUS, viewModel.getFilterByStockStatus())
             bundle.putString(ARG_PRODUCT_FILTER_STATUS, viewModel.getFilterByProductStatus())
@@ -100,7 +102,7 @@ class ProductFilterListFragment : BaseFragment(), OnProductFilterClickListener {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_clear -> {
-                // TODO: add tracking event
+                AnalyticsTracker.track(Stat.PRODUCT_FILTER_LIST_CLEAR_MENU_BUTTON_TAPPED)
                 viewModel.onClearFilterSelected()
                 true
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -64,6 +64,8 @@ class ProductFilterListViewModel @AssistedInject constructor(
         params
     }
 
+    fun getFilterString() = productFilterOptions.values.joinToString(", ")
+
     fun getFilterByStockStatus() = productFilterOptions[STOCK_STATUS]
 
     fun getFilterByProductStatus() = productFilterOptions[STATUS]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
@@ -11,6 +11,8 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.RequestCodes
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
@@ -67,7 +69,10 @@ class ProductFilterOptionListFragment : BaseFragment(), OnProductFilterOptionCli
         }
 
         filterOptionList_btnShowProducts.setOnClickListener {
-            // TODO: add tracking event
+            AnalyticsTracker.track(
+                    Stat.PRODUCT_FILTER_LIST_SHOW_PRODUCTS_BUTTON_TAPPED,
+                    mapOf(AnalyticsTracker.KEY_FILTERS to viewModel.getFilterString())
+            )
             val bundle = Bundle()
             bundle.putString(ARG_PRODUCT_FILTER_STOCK_STATUS, viewModel.getFilterByStockStatus())
             bundle.putString(ARG_PRODUCT_FILTER_STATUS, viewModel.getFilterByProductStatus())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -370,6 +370,7 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener, ProductS
     }
 
     override fun onFilterOptionSelected() {
+        AnalyticsTracker.track(Stat.PRODUCT_LIST_VIEW_FILTER_OPTIONS_TAPPED)
         disableSearchListeners()
         showOptionsMenu(false)
         (activity as? MainNavigationRouter)?.showProductFilters(
@@ -380,6 +381,7 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener, ProductS
     }
 
     override fun onSortOptionSelected() {
+        AnalyticsTracker.track(Stat.PRODUCT_LIST_VIEW_SORTING_OPTIONS_TAPPED)
         val bottomSheet = ProductSortingFragment()
         bottomSheet.show(childFragmentManager, bottomSheet.tag)
     }


### PR DESCRIPTION
Fixes #2339 by adding tracking events for filtering and sorting products, editing product short description and product settings.

- All the below events have been added to the Events spreadsheet.
- Note that the `*_product_settings_done_button_tapped` is added to the `AnalyticsTracker` class but not used anywhere in code yet since it is part of the `feature_product_settings` branch and probably should be added once the feature is ready for merge. cc @nbradbury 
- ~**This PR is in draft till #2338 can be merged.**~

#### Events
| Event Name  | Description | Event Properties |
| ------------- | ------------- | ------------- |
| `*_product_detail_view_short_description_tapped`  | User tapped on the product short description field in the Product Detail screen.  | -  |
| `*_product_image_settings_done_button_tapped`  | User tapped on the Done menu button in the product images screen.    | `has_changed_data=true|false` |
| `*_product_detail_view_settings_button_tapped`  | User tapped the Product Settings menu button in product detail   | - |
| `*_product_settings_done_button_tapped`  | User tapped on the Done menu button in the product settings screen   | `has_changed_data=true|false` |
| `*_product_list_view_filter_options_tapped`  | User tapped on the filter button in the Product List screen.   | - |
| `*_product_list_view_sorting_options_tapped`  | User tapped on the sorting button in the Product List screen.   | - |
| `*_product_filter_list_show_products_button_tapped`  | User tapped on the Show Products button in the product filter list screen .   | `filters=comma-separated-filter-options` i.e `"filters":"instock, publish, simple"` |
| `*_product_filter_list_clear_menu_button_tapped`  | User tapped on the Clear menu button in the product filter list screen   | - |


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
