### PR TITLE
Fix broken build on ProductDetailNavigationTest.kt

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/ProductDetailNavigationTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/ProductDetailNavigationTest.kt
@@ -154,7 +154,7 @@ class ProductDetailNavigationTest : TestBase() {
     @Test
     fun verifyProductDetailForVariationProductsDisplayedCorrectly() {
         // inject mock data to product detail
-        mockProductModel.type = ProductType.VARIATION.name
+        mockProductModel.type = ProductType.VARIABLE.name
         mockProductModel.reviewsAllowed = true
         activityTestRule.setOrderProductDetailWithMockData(mockProductModel)
 


### PR DESCRIPTION
A recent change on `develop` broke the build for the Instrumentation tests.

<img width="1169" alt="Screen Shot 2020-04-29 at 12 41 19 pm" src="https://user-images.githubusercontent.com/1218433/80556726-de7f7f80-8a17-11ea-90c3-24b6cef9f11b.png">


This PR fixes it. To verify, try to run the `verifyProductDetailForVariationProductsDisplayedCorrectly` test. On `develop`, it'll fail, here, it'll succeed.

---

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.