### PR TITLE
[2185] Display Product Categories on Product Page

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -93,7 +93,7 @@ data class Product(
         val id: Long,
         val name: String,
         val slug: String
-    ): Parcelable
+    ) : Parcelable
 
     fun isSameProduct(product: Product): Boolean {
         return remoteId == product.remoteId &&

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -59,6 +59,7 @@ data class Product(
     val purchaseNote: String,
     val numVariations: Int,
     val images: List<Image>,
+    val categories: List<Category>,
     val attributes: List<Attribute>,
     val saleEndDateGmt: Date?,
     val saleStartDateGmt: Date?,
@@ -87,6 +88,13 @@ data class Product(
         val isVisible: Boolean
     ) : Parcelable
 
+    @Parcelize
+    data class Category(
+        val id: Long,
+        val name: String,
+        val slug: String
+    ): Parcelable
+
     fun isSameProduct(product: Product): Boolean {
         return remoteId == product.remoteId &&
                 stockQuantity == product.stockQuantity &&
@@ -114,7 +122,8 @@ data class Product(
                 width == product.width &&
                 shippingClass == product.shippingClass &&
                 shippingClassId == product.shippingClassId &&
-                isSameImages(product.images)
+                isSameImages(product.images) &&
+                isSameCategories(product.categories)
     }
 
     private fun isSamePrice(first: BigDecimal?, second: BigDecimal?): Boolean {
@@ -169,6 +178,33 @@ data class Product(
                     height != it.height ||
                     shippingClass != it.shippingClass
         } ?: false
+    }
+
+    /**
+     * Verifies if there are any changes made to the product categories
+     * by comparing the updated product model ([updatedProduct]) with the product model stored
+     * in the local db and returns a [Boolean] flag
+     */
+    fun hasCategoryChanges(updatedProduct: Product?): Boolean {
+        return updatedProduct?.let {
+            !isSameCategories(it.categories)
+        } ?: false
+    }
+
+    /**
+     * Compares this product's categories with the passed list, returns true only if both lists contain
+     * the same categories in the same order
+     */
+    private fun isSameCategories(updatedCategories: List<Category>): Boolean {
+        if (this.categories.size != updatedCategories.size) {
+            return false
+        }
+        for (i in categories.indices) {
+            if (categories[i].id != updatedCategories[i].id) {
+                return false
+            }
+        }
+        return true
     }
 
     /**
@@ -233,6 +269,7 @@ data class Product(
                     weight = updatedProduct.weight,
                     shippingClass = updatedProduct.shippingClass,
                     images = updatedProduct.images,
+                    categories = updatedProduct.categories,
                     shippingClassId = updatedProduct.shippingClassId
             )
         } ?: this.copy()
@@ -284,6 +321,18 @@ fun Product.toDataModel(storedProductModel: WCProductModel?): WCProductModel {
         return jsonArray.toString()
     }
 
+    fun categoriesToJson(): String {
+        val jsonArray = JsonArray()
+        for (category in categories) {
+            jsonArray.add(JsonObject().also { json ->
+                json.addProperty("id", category.id)
+                json.addProperty("name", category.name)
+                json.addProperty("slug", category.slug)
+            })
+        }
+        return jsonArray.toString()
+    }
+
     return (storedProductModel ?: WCProductModel()).also {
         it.remoteProductId = remoteId
         it.description = description
@@ -306,6 +355,7 @@ fun Product.toDataModel(storedProductModel: WCProductModel?): WCProductModel {
         it.taxStatus = ProductTaxStatus.fromTaxStatus(taxStatus)
         it.taxClass = taxClass
         it.images = imagesToJson()
+        it.categories = categoriesToJson()
         if (isSaleScheduled) {
             saleStartDateGmt?.let { dateOnSaleFrom ->
                 it.dateOnSaleFromGmt = dateOnSaleFrom.formatToYYYYmmDDhhmmss()
@@ -363,6 +413,13 @@ fun WCProductModel.toAppModel(): Product {
                     it.name,
                     it.src,
                     DateTimeUtils.dateFromIso8601(this.dateCreated) ?: Date()
+            )
+        },
+        categories = this.getCategories().map {
+            Product.Category(
+                    it.id,
+                    it.name,
+                    it.slug
             )
         },
         attributes = this.getAttributes().map {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -409,17 +409,20 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         }
 
         if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled()) {
-            addPropertyView(
+            addPropertyGroup(
                     Secondary,
-                    getString(R.string.product_categories),
+                    R.string.product_categories,
                     if (product.categories.isEmpty()) {
-                        getString(R.string.product_category_empty)
+                        mapOf(Pair("", getString(R.string.product_category_empty)))
                     } else {
-                        product.categories.joinToString(transform = { it.name })
+                        mapOf(Pair("", product.categories.joinToString(transform = { it.name })))
                     },
-                    LinearLayout.VERTICAL,
-                    R.drawable.ic_gridicons_folder
+                    groupIconId = R.drawable.ic_gridicons_folder
             )?.also {
+                // display the group title only when categories are available
+                if (product.categories.isEmpty()) {
+                    it.showPropertyName(false)
+                }
                 it.setMaxLines(5)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -31,6 +31,7 @@ import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.aztec.AztecEditorFragment
 import com.woocommerce.android.ui.aztec.AztecEditorFragment.Companion.ARG_AZTEC_EDITOR_TEXT
 import com.woocommerce.android.ui.main.MainActivity.NavigationResult
+import com.woocommerce.android.ui.products.ProductDetailFragment.DetailCard.Secondary
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductDetailViewState
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitProductDetail
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductDescriptionEditor
@@ -404,6 +405,22 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
             it.setClickListener {
                 AnalyticsTracker.track(Stat.PRODUCT_DETAIL_VIEW_INVENTORY_SETTINGS_TAPPED)
                 viewModel.onEditProductCardClicked(ViewProductInventory(product.remoteId))
+            }
+        }
+
+        if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled()) {
+            addPropertyView(
+                    Secondary,
+                    getString(R.string.product_categories),
+                    if (product.categories.isEmpty()) {
+                        getString(R.string.product_category_empty)
+                    } else {
+                        product.categories.joinToString(transform = { it.name })
+                    },
+                    LinearLayout.VERTICAL,
+                    R.drawable.ic_gridicons_folder
+            )?.also {
+                it.setMaxLines(5)
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -8,12 +8,13 @@ import com.woocommerce.android.BuildConfig
  */
 enum class FeatureFlag {
     PRODUCT_RELEASE_M2,
+    PRODUCT_RELEASE_M3,
     DB_DOWNGRADE;
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
             // currently only enabled for debug users but once live, this feature will live switched on from the
             // setting screen. i.e. check AppPrefs.isProductsFeatureEnabled() method
-            PRODUCT_RELEASE_M2 -> BuildConfig.DEBUG
+            PRODUCT_RELEASE_M2, PRODUCT_RELEASE_M3 -> BuildConfig.DEBUG
             DB_DOWNGRADE -> {
                 BuildConfig.DEBUG || context != null && PackageUtils.isBetaBuild(context)
             }

--- a/WooCommerce/src/main/res/drawable/ic_gridicons_folder.xml
+++ b/WooCommerce/src/main/res/drawable/ic_gridicons_folder.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <group>
+        <clip-path android:pathData="M18,19H6C4.9,19 4,18.1 4,17V7C4,5.9 4.9,5 6,5H9C10.1,5 11,5.9 11,7H18C19.1,7 20,7.9 20,9V17C20,18.1 19.1,19 18,19Z" />
+        <path
+            android:fillColor="#A2AAB2"
+            android:pathData="M0,0h24v24h-24z" />
+    </group>
+</vector>

--- a/WooCommerce/src/main/res/drawable/ic_gridicons_folder.xml
+++ b/WooCommerce/src/main/res/drawable/ic_gridicons_folder.xml
@@ -6,7 +6,7 @@
     <group>
         <clip-path android:pathData="M18,19H6C4.9,19 4,18.1 4,17V7C4,5.9 4.9,5 6,5H9C10.1,5 11,5.9 11,7H18C19.1,7 20,7.9 20,9V17C20,18.1 19.1,19 18,19Z" />
         <path
-            android:fillColor="#A2AAB2"
+            android:fillColor="@color/color_icon"
             android:pathData="M0,0h24v24h-24z" />
     </group>
 </vector>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -411,7 +411,9 @@
     <string name="product_property_variant_formatter" translatable="false">%1$s (%2$s options)</string>
     <string name="product_property_edit">Edit product</string>
     <string name="product_inventory">Inventory</string>
+    <string name="product_categories">Categories</string>
     <string name="product_inventory_empty">Add inventory</string>
+    <string name="product_category_empty">Add category</string>
     <string name="product_variants">Variants</string>
     <string name="product_price">Price</string>
     <string name="product_price_empty">Add price</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -20,6 +20,7 @@ object ProductTestUtils {
             name = "product 1"
             description = "product 1 description"
             images = "[]"
+            categories = "[]"
             downloads = "[]"
             weight = "10"
             length = "1"


### PR DESCRIPTION
## Description
Fixes #2185 ; the display of categories on the Product page. The categories are taken from the existing `ProductModel` and shown as a comma delimited list on the page.

The list is currently non interactive and will be interactive in the next step that is slated for #2186.

<p float="left">
<img src="https://user-images.githubusercontent.com/1773060/80667293-24a11580-8ae2-11ea-9a2b-2a1cd888279f.png" alt="Dark Mode" height="300"/>

<img src="https://user-images.githubusercontent.com/1773060/80667362-51edc380-8ae2-11ea-91dc-563379f43bca.png" alt="Light Mode" height="300" />

<img src="https://user-images.githubusercontent.com/1773060/80667390-63cf6680-8ae2-11ea-8001-82660ea3c6a9.png" alt="No Category" height="300" />
</p>

## Related Changes
The following units are also part of this PR:

- Introduced a `FeatureFlag` for `M3` that will be used in subsequent PRs.
- Shows `Add Category` when no categories are found for the product.
- Shows a maximum of 5 lines of categories, comma delimited.
- If the 5 line limit is reached, it will be truncated with `...`.

## Notes
Release notes will be updated when this feature branch will be merged into develop. Some tests will be updated when the view models and associated classes are modified.

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
