### PR TITLE
Use ContextCompat to load drawables where context is not reliable

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.2
 -----
 * Bugfix: Removed detached and non-functioning text counter in the support email dialog
+* Fixed issue where dark theme version of placeholder images were not themed properly
 * Minor styling tweaks to various login screens
  
 4.1

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardTopEarnersView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardTopEarnersView.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.StringRes
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.tabs.TabLayout
@@ -181,7 +182,7 @@ class DashboardTopEarnersView @JvmOverloads constructor(
             val imageUrl = PhotonUtils.getPhotonImageUrl(topEarner.image, imageSize, 0)
             GlideApp.with(holder.itemView.context)
                     .load(imageUrl)
-                    .placeholder(R.drawable.ic_product)
+                    .placeholder(ContextCompat.getDrawable(holder.itemView.context, R.drawable.ic_product))
                     .into(holder.productImage)
 
             holder.itemView.setOnClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
@@ -12,6 +12,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
@@ -142,7 +143,7 @@ class LoginNoJetpackFragment : Fragment() {
         userAvatarUrl?.let {
             GlideApp.with(this)
                     .load(it)
-                    .placeholder(R.drawable.img_gravatar_placeholder)
+                    .placeholder(ContextCompat.getDrawable(requireContext(), R.drawable.img_gravatar_placeholder))
                     .circleCrop()
                     .into(image_avatar)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreTopEarnersView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreTopEarnersView.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
@@ -153,7 +154,7 @@ class MyStoreTopEarnersView @JvmOverloads constructor(ctx: Context, attrs: Attri
             val imageUrl = PhotonUtils.getPhotonImageUrl(topEarner.image, imageSize, 0)
             GlideApp.with(holder.itemView.context)
                     .load(imageUrl)
-                    .placeholder(R.drawable.ic_product)
+                    .placeholder(ContextCompat.getDrawable(holder.itemView.context, R.drawable.ic_product))
                     .into(holder.productImage)
 
             holder.itemView.setOnClickListener {

--- a/WooCommerce/src/main/res/layout/top_earner_list_item.xml
+++ b/WooCommerce/src/main/res/layout/top_earner_list_item.xml
@@ -21,7 +21,7 @@
             android:layout_height="@dimen/image_minor_100"
             android:contentDescription="@string/product_image_content_description"
             android:scaleType="centerCrop"
-            tools:src="@drawable/ic_stats_24dp"/>
+            tools:src="@drawable/ic_product"/>
     </FrameLayout>
 
     <LinearLayout


### PR DESCRIPTION
Closes #2313. This fixes an issue where the drawable loaded would not match the current dark mode setting in older versions of Android.

Before | After
-- | --
![Screenshot_1588186673](https://user-images.githubusercontent.com/5810477/80636519-7d08e200-8a12-11ea-8589-736f1b882270.png)|![Screenshot_1588185871](https://user-images.githubusercontent.com/5810477/80636537-82662c80-8a12-11ea-83ca-09e754ed4eb6.png)
![Screenshot_1588186690](https://user-images.githubusercontent.com/5810477/80636582-927e0c00-8a12-11ea-975f-556afe952e73.png)|![Screenshot_1588187320](https://user-images.githubusercontent.com/5810477/80636586-93af3900-8a12-11ea-95e3-17fa53caea8b.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## To Test 

1. Load the app on a device/emulator running android 8.1
2. Set the Woo app to use "Dark" in settings
3. Go back to My Store tab
4. Verify a top performing product missing an image is using the properly themed placeholder image
5. Open settings and enable the new stats
6. Go back to My Store tab
7. Verify a top performing product missing an image is using the properly themed placeholder image
