### PR TITLE
Add workaround for a failing test in OrderListItemTest

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderListItemTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderListItemTest.kt
@@ -163,8 +163,11 @@ class OrderListItemTest : TestBase() {
 
         // PROCESSING: Check if order status label name, label text color, label background color
         val processingStatusPosition = 1
+        // Notice that this expectation uses a string literal, while the rest of the method computes them.
+        // This was done as part of a fix after UI changes in order to make these tests build and pass.
+        // Computing the value for `processingStatusPosition` would result in "processing", and the test would fail.
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(processingStatusPosition, R.id.orderTags))
-                .check(matches(WCMatchers.withTagText(getAsOrderItem(processingStatusPosition).status)))
+                .check(matches(WCMatchers.withTagText("Processing")))
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(processingStatusPosition, R.id.orderTags))
                 .check(matches(WCMatchers.withTagTextColor(appContext, R.color.color_on_surface_high)))
         onView(WCMatchers.withRecyclerView(R.id.ordersList).atPositionOnView(processingStatusPosition, R.id.orderTags))


### PR DESCRIPTION
I had this patch laying around from some work I did last week and it seemed a shame do drop it.

I know we may not use these tests anymore, but just in case someone will get to run them and need to address some of the failures, here's one that's already addressed.

Happy to close this if you think it's not worth it.

---

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.