### PR TITLE
Add indentation settings to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,4 @@
 [*.{kt,kts}]
 max_line_length=120
+indent_style=space
+indent_size=4


### PR DESCRIPTION
When I open Kotlin files in Vim, it use 2 spaces for indentation, which is not how this project is configured.

Now, maybe my Vim has something messed up in its own configuration, but I don't think it hurts to make the indentation settings explicit in the `.editorconfig`.

---

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.