### PR TITLE
Update the PR template for contributors to follow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,24 +1,10 @@
 ## Description
 
-> Add an explanation of what the PR is trying to achieve. Don't be shy and add as much detail about it as you can.
->
-> This is your space. If the change is rather simple, you can keep this short; otherwise, make good use of why a change was made. Why you selected a pattern over another etc.
+> Please review the pull request guidelines here: https://git.io/Jf3t6
 
 ## Issue
 
-> If this PR implements changes related to one or more Github issues, please:
->
-> - Add the issue ids in the title, e.g: [#123 - Refactor the View Models]
-> - Add a link to each of the related issues
-> - Here's a nifty guide on [Github's Issue linking](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-
-> Fixes #<insert_issue_number_here> (**if you do not have access to issue linking, do not forget to fill this**)
-
-## Feature Flags
-
-> If the change is not directly executable, and works behind a compile time or runtime flag, mention the flag here.
->
-> It's a good idea to mention the creation of the flag in the related issue or where required.
+> Fixes #<insert_issue_number_here>
 
 ## UI Changes
 
@@ -30,43 +16,10 @@
 >   <img src="/scr2.png" width="300" />
 > </p>
 
-## Events Changes
-
-> If this PR introduces any changes to analytics, mention them here. It's possible that you have multiple events that are tracked or changed; in that case list them all and describe what they do.
-
-## Reviewers
-
-> Assign the PR to someone that’s either familiar with the code being modified, working on the same project or who could benefit from being exposed to this particular area of the app.
->
-> If you do not have access to change/assign reviewers; someone from the maintainer team will update those fields.
-
-## Milestones
-> Please select on which milestone you expect this PR to be merged.
->
-> If you do not have access to change milestones; someone from the maintainer team will update those fields.
-
-## Labels
-> There are multiple types of labels available to select from. For example, if your PR is related to [Product], [Stats] or [Enhancement], use the labels to categorise.
->
-> There's also [Status] labels to depict the status of the PR. One example of that would be, if your PR is Blocked or needs update for any reason.
->
-> If you do not have access to change/assign reviewers; someone from the maintainer team will update those fields.
+## Event Changes
 
 ## Testing
 
-> Have you tested the change? How did you test it?
-> List the steps for others to test the change
->
-> Are there any unit tests or integration tests that cover the functionality, mention them here.
-
-## Blocked
-
-> If this PR is blocked for some reason:
->
-> - Add the required label
-> - Add a comment explaining what the blockers are or any issues that are blocking it.
-> You can use [GitHub flavoured markdown](https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown) to [add checkboxes](https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments) for each blocker.
-
-## Update Release Notes:
+## Author Checklist:
 
 - [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,72 @@
+## Description
 
-Update release notes:
+> Add an explanation of what the PR is trying to achieve. Don't be shy and add as much detail about it as you can.
+>
+> This is your space. If the change is rather simple, you can keep this short; otherwise, make good use of why a change was made. Why you selected a pattern over another etc.
+
+## Issue
+
+> If this PR implements changes related to one or more Github issues, please:
+>
+> - Add the issue ids in the title, e.g: [#123 - Refactor the View Models]
+> - Add a link to each of the related issues
+> - Here's a nifty guide on [Github's Issue linking](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
+
+> Fixes #<insert_issue_number_here> (**if you do not have access to issue linking, do not forget to fill this**)
+
+## Feature Flags
+
+> If the change is not directly executable, and works behind a compile time or runtime flag, mention the flag here.
+>
+> It's a good idea to mention the creation of the flag in the related issue or where required.
+
+## UI Changes
+
+> If this PR introduces UI changes please add before & after screenshots
+>
+> You can resize the screenshots using the <img> html tags, and you can also create a clickable list like:
+> <p float="left">
+>   <img src="/scr1.png" width="300" />
+>   <img src="/scr2.png" width="300" />
+> </p>
+
+## Events Changes
+
+> If this PR introduces any changes to analytics, mention them here. It's possible that you have multiple events that are tracked or changed; in that case list them all and describe what they do.
+
+## Reviewers
+
+> Assign the PR to someone that’s either familiar with the code being modified, working on the same project or who could benefit from being exposed to this particular area of the app.
+>
+> If you do not have access to change/assign reviewers; someone from the maintainer team will update those fields.
+
+## Milestones
+> Please select on which milestone you expect this PR to be merged.
+>
+> If you do not have access to change milestones; someone from the maintainer team will update those fields.
+
+## Labels
+> There are multiple types of labels available to select from. For example, if your PR is related to [Product], [Stats] or [Enhancement], use the labels to categorise.
+>
+> There's also [Status] labels to depict the status of the PR. One example of that would be, if your PR is Blocked or needs update for any reason.
+>
+> If you do not have access to change/assign reviewers; someone from the maintainer team will update those fields.
+
+## Testing
+
+> Have you tested the change? How did you test it?
+> List the steps for others to test the change
+>
+> Are there any unit tests or integration tests that cover the functionality, mention them here.
+
+## Blocked
+
+> If this PR is blocked for some reason:
+>
+> - Add the required label
+> - Add a comment explaining what the blockers are or any issues that are blocking it.
+> You can use [GitHub flavoured markdown](https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown) to [add checkboxes](https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments) for each blocker.
+
+## Update Release Notes:
 
 - [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


### PR DESCRIPTION
The PR introduces a template for contributors to follow when creating Pull Request against issues.

The template is a guide and you're not limited to follow it to the word. But it's a good idea to go through it whenever you're about to open a new Pull Request.

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
