### PR TITLE
Product settings style tweaks

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_aztec_editor.xml
+++ b/WooCommerce/src/main/res/layout/fragment_aztec_editor.xml
@@ -30,11 +30,13 @@
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/aztecCaption"
+                style="@style/TextAppearance.Woo.Body2"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:gravity="start|center_horizontal"
-                android:padding="@dimen/major_100"
-                android:textColor="@color/color_on_surface_high"
+                android:paddingTop="@dimen/major_100"
+                android:paddingStart="@dimen/major_100"
+                android:paddingEnd="@dimen/major_100"
                 android:visibility="gone"
                 tools:text="@string/product_purchase_note_caption"
                 tools:visibility="visible" />

--- a/WooCommerce/src/main/res/layout/fragment_product_catalog_visibility.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_catalog_visibility.xml
@@ -15,6 +15,7 @@
             android:orientation="vertical">
 
             <com.google.android.material.textview.MaterialTextView
+                style="@style/TextAppearance.Woo.Body2"
                 android:textColor="@color/color_on_surface_high"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -23,7 +24,6 @@
         </com.woocommerce.android.widgets.WCElevatedLinearLayout>
 
         <com.woocommerce.android.widgets.WCElevatedLinearLayout
-            style="Woo.TextView.Caption"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_marginTop="@dimen/minor_100"
@@ -43,51 +43,45 @@
             android:layout_marginTop="@dimen/minor_100"
             android:orientation="vertical">
 
-            <LinearLayout
+            <CheckedTextView
+                android:id="@+id/btnVisibilityVisible"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:text="@string/product_catalog_visibility_visible" />
 
-                <CheckedTextView
-                    android:id="@+id/btnVisibilityVisible"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/product_catalog_visibility_visible" />
+            <View
+                style="@style/Woo.Divider"
+                android:layout_marginStart="@dimen/major_100"/>
 
-                <View
-                    style="@style/Woo.Divider"
-                    android:layout_marginStart="@dimen/major_100"/>
+            <CheckedTextView
+                android:id="@+id/btnVisibilityCatalog"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/product_catalog_visibility_catalog" />
 
-                <CheckedTextView
-                    android:id="@+id/btnVisibilityCatalog"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/product_catalog_visibility_catalog" />
+            <View
+                style="@style/Woo.Divider"
+                android:layout_marginStart="@dimen/major_100"/>
 
-                <View
-                    style="@style/Woo.Divider"
-                    android:layout_marginStart="@dimen/major_100"/>
+            <CheckedTextView
+                android:id="@+id/btnVisibilitySearch"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/product_catalog_visibility_search" />
 
-                <CheckedTextView
-                    android:id="@+id/btnVisibilitySearch"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/product_catalog_visibility_search" />
+            <View
+                style="@style/Woo.Divider"
+                android:layout_marginStart="@dimen/major_100"/>
 
-                <View
-                    style="@style/Woo.Divider"
-                    android:layout_marginStart="@dimen/major_100"/>
+            <CheckedTextView
+                android:id="@+id/btnVisibilityHidden"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/product_catalog_visibility_hidden" />
 
-                <CheckedTextView
-                    android:id="@+id/btnVisibilityHidden"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/product_catalog_visibility_hidden" />
-
-                <View
-                    style="@style/Woo.Divider"
-                    android:layout_marginStart="@dimen/major_100"/>
-            </LinearLayout>
+            <View
+                style="@style/Woo.Divider"
+                android:layout_marginStart="@dimen/major_100"/>
 
         </com.woocommerce.android.widgets.WCElevatedLinearLayout>
     </LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_catalog_visibility.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_catalog_visibility.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -16,11 +15,11 @@
 
             <com.google.android.material.textview.MaterialTextView
                 style="@style/TextAppearance.Woo.Body2"
-                android:textColor="@color/color_on_surface_high"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:padding="@dimen/major_100"
-                android:text="@string/product_visibility_headline" />
+                android:text="@string/product_visibility_headline"
+                android:textColor="@color/color_on_surface_high" />
         </com.woocommerce.android.widgets.WCElevatedLinearLayout>
 
         <com.woocommerce.android.widgets.WCElevatedLinearLayout
@@ -51,7 +50,7 @@
 
             <View
                 style="@style/Woo.Divider"
-                android:layout_marginStart="@dimen/major_100"/>
+                android:layout_marginStart="@dimen/major_100" />
 
             <CheckedTextView
                 android:id="@+id/btnVisibilityCatalog"
@@ -61,7 +60,7 @@
 
             <View
                 style="@style/Woo.Divider"
-                android:layout_marginStart="@dimen/major_100"/>
+                android:layout_marginStart="@dimen/major_100" />
 
             <CheckedTextView
                 android:id="@+id/btnVisibilitySearch"
@@ -71,7 +70,7 @@
 
             <View
                 style="@style/Woo.Divider"
-                android:layout_marginStart="@dimen/major_100"/>
+                android:layout_marginStart="@dimen/major_100" />
 
             <CheckedTextView
                 android:id="@+id/btnVisibilityHidden"
@@ -79,9 +78,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/product_catalog_visibility_hidden" />
 
-            <View
-                style="@style/Woo.Divider"
-                android:layout_marginStart="@dimen/major_100"/>
+            <View style="@style/Woo.Divider" />
 
         </com.woocommerce.android.widgets.WCElevatedLinearLayout>
     </LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_menu_order.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_menu_order.xml
@@ -2,27 +2,17 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="?attr/colorSurface">
 
-    <com.woocommerce.android.widgets.WCElevatedLinearLayout
-        style="@style/Woo.Card"
+    <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+        android:id="@+id/product_menu_order"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:paddingBottom="@dimen/major_100">
-
-        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-            android:id="@+id/product_menu_order"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_75"
-            android:layout_marginEnd="@dimen/major_100"
-            android:hint="@string/product_menu_order"
-            android:inputType="numberSigned"
-            app:helperText="@string/product_menu_order_caption" />
-
-    </com.woocommerce.android.widgets.WCElevatedLinearLayout>
+        android:layout_margin="@dimen/major_100"
+        android:hint="@string/product_menu_order"
+        android:inputType="numberSigned"
+        app:helperText="@string/product_menu_order_caption" />
 
 </ScrollView>
 

--- a/WooCommerce/src/main/res/layout/fragment_product_settings.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_settings.xml
@@ -46,7 +46,7 @@
         <com.woocommerce.android.widgets.WCElevatedLinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/major_100"
+            android:layout_marginTop="@dimen/minor_100"
             android:orientation="vertical">
 
             <com.google.android.material.textview.MaterialTextView
@@ -54,8 +54,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:padding="@dimen/major_100"
-                android:text="@string/more_options"
-                android:textColor="@color/color_on_surface_high" />
+                android:textColor="@color/color_on_surface_disabled"
+                android:text="@string/more_options" />
 
             <View style="@style/Woo.Divider.TitleAligned" />
 

--- a/WooCommerce/src/main/res/layout/fragment_product_settings.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_settings.xml
@@ -40,7 +40,7 @@
                 app:optionTitle="@string/product_catalog_visibility"
                 tools:optionValue="Shop only" />
 
-            <View style="@style/Woo.Divider.TitleAligned" />
+            <View style="@style/Woo.Divider" />
         </com.woocommerce.android.widgets.WCElevatedLinearLayout>
 
         <com.woocommerce.android.widgets.WCElevatedLinearLayout

--- a/WooCommerce/src/main/res/layout/fragment_product_slug.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_slug.xml
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/editSlug"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_margin="@dimen/major_100"
-    android:hint="@string/product_slug"
-    android:inputType="text"
-    app:helperText="@string/product_slug_label" />
+    android:layout_height="match_parent"
+    android:background="?attr/colorSurface">
+
+    <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+        android:id="@+id/editSlug"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/major_100"
+        android:hint="@string/product_slug"
+        android:inputType="text"
+        app:helperText="@string/product_slug_label" />
+
+</FrameLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_status.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_status.xml
@@ -4,6 +4,8 @@
     android:id="@+id/radioGroup"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:paddingTop="@dimen/minor_100"
+    android:background="?attr/colorSurface"
     android:orientation="vertical">
 
     <CheckedTextView

--- a/WooCommerce/src/main/res/layout/fragment_product_status.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_status.xml
@@ -4,9 +4,9 @@
     android:id="@+id/radioGroup"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingTop="@dimen/minor_100"
     android:background="?attr/colorSurface"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:paddingTop="@dimen/minor_100">
 
     <CheckedTextView
         android:id="@+id/btnPublishedPrivately"
@@ -42,8 +42,6 @@
         android:layout_height="wrap_content"
         android:text="@string/product_status_pending" />
 
-    <View
-        style="@style/Woo.Divider"
-        android:layout_marginStart="@dimen/major_100" />
+    <View style="@style/Woo.Divider" />
 
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_visibility.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_visibility.xml
@@ -50,9 +50,7 @@
             android:layout_height="wrap_content"
             android:text="@string/product_visibility_private" />
 
-        <View
-            style="@style/Woo.Divider"
-            android:layout_marginStart="@dimen/major_100" />
+        <View style="@style/Woo.Divider" />
 
     </LinearLayout>
 </ScrollView>

--- a/WooCommerce/src/main/res/layout/fragment_product_visibility.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_visibility.xml
@@ -3,62 +3,56 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="?attr/colorSurface">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/minor_100"
         android:orientation="vertical">
 
-        <com.woocommerce.android.widgets.WCElevatedLinearLayout
+        <CheckedTextView
+            android:id="@+id/btnPublic"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginTop="@dimen/minor_100"
-            android:orientation="vertical">
+            android:layout_height="wrap_content"
+            android:text="@string/product_visibility_public" />
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:animateLayoutChanges="true"
-                android:orientation="vertical">
+        <View
+            style="@style/Woo.Divider"
+            android:layout_marginStart="@dimen/major_100" />
 
-                <CheckedTextView
-                    android:id="@+id/btnPublic"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/product_visibility_public" />
+        <CheckedTextView
+            android:id="@+id/btnPasswordProtected"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/product_visibility_password_protected" />
 
-                <View style="@style/Woo.Divider" />
+        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+            android:id="@+id/editPassword"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginEnd="@dimen/major_100"
+            android:layout_marginBottom="@dimen/major_100"
+            android:inputType="textPassword"
+            android:visibility="gone"
+            app:hintEnabled="false"
+            tools:visibility="visible" />
 
-                <CheckedTextView
-                    android:id="@+id/btnPasswordProtected"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/product_visibility_password_protected" />
+        <View
+            style="@style/Woo.Divider"
+            android:layout_marginStart="@dimen/major_100" />
 
-                <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                    android:id="@+id/editPassword"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/major_100"
-                    android:layout_marginEnd="@dimen/major_100"
-                    android:layout_marginBottom="@dimen/minor_100"
-                    android:inputType="textPassword"
-                    android:visibility="gone"
-                    app:hintEnabled="false"
-                    tools:visibility="visible" />
+        <CheckedTextView
+            android:id="@+id/btnPrivate"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/product_visibility_private" />
 
-                <View style="@style/Woo.Divider" />
+        <View
+            style="@style/Woo.Divider"
+            android:layout_marginStart="@dimen/major_100" />
 
-                <CheckedTextView
-                    android:id="@+id/btnPrivate"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/product_visibility_private" />
-
-                <View style="@style/Woo.Divider" />
-            </LinearLayout>
-
-        </com.woocommerce.android.widgets.WCElevatedLinearLayout>
     </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
This PR fixes the code review comments left in  PR #2355. That product settings feature was under development at the same time as the dark mode project so this PR cleans up the various screens to match the new style patterns and adds consistency to the all the screens. 

### Product Settings
Updated the group heading text color and style to match designs and fixed the padding between the two cards. 

Before | After
-- | --
![settings-light](https://user-images.githubusercontent.com/5810477/80764420-8a4acd00-8af5-11ea-862a-74774e202862.png)|![product-settings-light](https://user-images.githubusercontent.com/5810477/80764432-90d94480-8af5-11ea-9784-7b2ec7e139dd.png)
![settings](https://user-images.githubusercontent.com/5810477/80764443-959df880-8af5-11ea-9078-6c89532396d9.png)|![product-settings](https://user-images.githubusercontent.com/5810477/80764454-99ca1600-8af5-11ea-81cc-99e36ba2ed6c.png)

### Product Status
Set the background color of this view to `colorSurface` so it wouldn't be gray in light mode

Before | After
-- | --
![status-light](https://user-images.githubusercontent.com/5810477/80764524-b6fee480-8af5-11ea-93ae-00eea895cfed.png)|![status-light](https://user-images.githubusercontent.com/5810477/80764528-ba926b80-8af5-11ea-850d-3111452e5361.png)

### Product Visibility
Removed card layout to match designs and stay consistent with the rest of the option screens. 

Before | After
-- | --
![visibility-light](https://user-images.githubusercontent.com/5810477/80764640-03e2bb00-8af6-11ea-88f7-d1064e70a63b.png)|![visibility-light](https://user-images.githubusercontent.com/5810477/80764645-06451500-8af6-11ea-8e5d-4decfb120d43.png)
![visibility](https://user-images.githubusercontent.com/5810477/80764695-178e2180-8af6-11ea-93cc-4aa86fbc48e2.png)|![visibility](https://user-images.githubusercontent.com/5810477/80764706-1ceb6c00-8af6-11ea-980d-fbd1ec0e8816.png)

### Catalog Visibility
Updated the font styling used in the top description panel.

Before | After
-- | --
![catalog-vis-light](https://user-images.githubusercontent.com/5810477/80764815-57ed9f80-8af6-11ea-9e0f-98a6e0b7a5ef.png)|![catalog-vis-light](https://user-images.githubusercontent.com/5810477/80764819-5a4ff980-8af6-11ea-997a-c403330b9c5a.png)
![catalog-vis](https://user-images.githubusercontent.com/5810477/80764832-60de7100-8af6-11ea-8ce4-c5efea606ace.png)|![catalog-vis-dark](https://user-images.githubusercontent.com/5810477/80764835-63d96180-8af6-11ea-9ac7-4f1aea06324b.png)

### Slug
Set the background color of this view to `colorSurface` so it wouldn't be gray in light mode

Before | After
-- | --
![slug-light](https://user-images.githubusercontent.com/5810477/80764944-a8fd9380-8af6-11ea-8a2b-f36bd12fd718.png)|![Screenshot_1588285619](https://user-images.githubusercontent.com/5810477/80765113-13163880-8af7-11ea-8130-8bbf3687a8be.png)

### Purchase Note
Updated caption text to Body2 to match designs. Removed padding on the bottom of the caption to reduce the gap between the caption and the text editor. 

Before | After
-- | --
![purchase-note-light](https://user-images.githubusercontent.com/5810477/80765201-4bb61200-8af7-11ea-866b-0f8a7ac7c020.png)|![purchase-note-light](https://user-images.githubusercontent.com/5810477/80765205-4d7fd580-8af7-11ea-9a5b-cec60a264659.png)
![purchase-note-dark](https://user-images.githubusercontent.com/5810477/80765210-52448980-8af7-11ea-803e-e391d1f6c026.png)|![purchase-note-dark](https://user-images.githubusercontent.com/5810477/80765217-54a6e380-8af7-11ea-901a-ca8b1f8171bc.png)

### Menu Order
Removed card layout to match designs and stay consistent with the rest of the option screens. 

Before | After
-- | --
![menu-order-light](https://user-images.githubusercontent.com/5810477/80765243-69837700-8af7-11ea-93b6-d89fb1dbc2a9.png)|![menu-light](https://user-images.githubusercontent.com/5810477/80765246-6ab4a400-8af7-11ea-97f3-a5e43d7ec86f.png)
![menu-order](https://user-images.githubusercontent.com/5810477/80765248-6c7e6780-8af7-11ea-9b08-ffb4f4ab3240.png)|![menu](https://user-images.githubusercontent.com/5810477/80765250-6e482b00-8af7-11ea-93bc-9234030a243e.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
