### PR TITLE
issue/2354-saved-state

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
@@ -2,11 +2,8 @@ package com.woocommerce.android.ui.wpmediapicker
 
 import android.content.Context
 import android.graphics.drawable.Drawable
-import android.os.Build.VERSION
-import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.os.Handler
-import android.os.Parcel
 import android.os.Parcelable
 import android.util.AttributeSet
 import android.util.SparseArray
@@ -14,7 +11,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import androidx.annotation.RequiresApi
 import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -28,6 +24,7 @@ import com.woocommerce.android.model.Product
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
 import com.woocommerce.android.widgets.BorderedImageView
+import com.woocommerce.android.widgets.WCSavedState
 import kotlinx.android.synthetic.main.wpmedia_gallery_item.view.*
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.PhotonUtils
@@ -276,7 +273,7 @@ class WPMediaGalleryView @JvmOverloads constructor(
 
         // save the recycler's stat
         super.onSaveInstanceState()?.let { recyclerState ->
-            bundle.putParcelable(KEY_RECYCLER_STATE, SavedState(super.onSaveInstanceState(), recyclerState))
+            bundle.putParcelable(KEY_RECYCLER_STATE, WCSavedState(super.onSaveInstanceState(), recyclerState))
         }
 
         // save the selected images
@@ -287,7 +284,7 @@ class WPMediaGalleryView @JvmOverloads constructor(
 
     override fun onRestoreInstanceState(state: Parcelable?) {
         // restore the recycler's state
-        (state as? Bundle)?.getParcelable<SavedState>(KEY_RECYCLER_STATE)?.let { recyclerState ->
+        (state as? Bundle)?.getParcelable<WCSavedState>(KEY_RECYCLER_STATE)?.let { recyclerState ->
             super.onRestoreInstanceState(recyclerState)
         }
 
@@ -324,60 +321,6 @@ class WPMediaGalleryView @JvmOverloads constructor(
                     onImageLongClicked(adapterPosition)
                 }
                 true
-            }
-        }
-    }
-
-    internal class SavedState : BaseSavedState {
-        private var recyclerState: Parcelable? = null
-
-        constructor(superState: Parcelable?, inRecyclerState: Parcelable) : super(superState) {
-            recyclerState = inRecyclerState
-        }
-
-        /**
-         * Workaround to differentiate between this method and the one that requires API 24+ because
-         * the super(source, loader) method won't work on older APIs - thus the app will crash.
-         */
-        constructor(source: Parcel, loader: ClassLoader?, superState: Parcelable?): super(superState) {
-            recyclerState = source.readParcelable(loader)
-        }
-
-        constructor(source: Parcel) : super(source) {
-            recyclerState = source.readParcelable(this::class.java.classLoader)
-        }
-
-        @RequiresApi(VERSION_CODES.N)
-        constructor(source: Parcel, loader: ClassLoader?) : super(source, loader) {
-            recyclerState = loader?.let {
-                source.readParcelable<Parcelable>(it)
-            } ?: source.readParcelable<Parcelable>(this::class.java.classLoader)
-        }
-
-        override fun writeToParcel(out: Parcel, flags: Int) {
-            super.writeToParcel(out, flags)
-            out.writeParcelable(recyclerState, 0)
-        }
-
-        companion object {
-            @Suppress("UNUSED")
-            @JvmField
-            val CREATOR = object : Parcelable.ClassLoaderCreator<SavedState> {
-                override fun createFromParcel(source: Parcel, loader: ClassLoader?): SavedState {
-                    return if (VERSION.SDK_INT >= VERSION_CODES.N) {
-                        SavedState(source, loader)
-                    } else {
-                        SavedState(source, loader, source.readParcelable<Parcelable>(loader))
-                    }
-                }
-
-                override fun createFromParcel(source: Parcel): SavedState {
-                    return SavedState(source)
-                }
-
-                override fun newArray(size: Int): Array<SavedState?> {
-                    return arrayOfNulls(size)
-                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
@@ -1,16 +1,12 @@
 package com.woocommerce.android.widgets
 
 import android.content.Context
-import android.os.Build.VERSION
-import android.os.Build.VERSION_CODES
 import android.os.Bundle
-import android.os.Parcel
 import android.os.Parcelable
 import android.util.AttributeSet
 import android.util.SparseArray
 import android.view.View
 import androidx.annotation.AttrRes
-import androidx.annotation.RequiresApi
 import androidx.lifecycle.LiveData
 import com.google.android.material.textfield.TextInputLayout
 import com.woocommerce.android.R
@@ -82,20 +78,20 @@ class WCMaterialOutlinedCurrencyEditTextView @JvmOverloads constructor(
     override fun onSaveInstanceState(): Parcelable? {
         val bundle = Bundle()
         currency_edit_text.onSaveInstanceState()?.let {
-            bundle.putParcelable(KEY_SUPER_STATE, SavedState(super.onSaveInstanceState(), it))
+            bundle.putParcelable(KEY_SUPER_STATE, WCSavedState(super.onSaveInstanceState(), it))
         }
         return bundle
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
-        val bundle = (state as? Bundle)?.getParcelable<SavedState>(KEY_SUPER_STATE)?.let {
+        val bundle = (state as? Bundle)?.getParcelable<WCSavedState>(KEY_SUPER_STATE)?.let {
             restoreViewState(it)
         } ?: state
         super.onRestoreInstanceState(bundle)
     }
 
-    private fun restoreViewState(state: SavedState): Parcelable {
-        currency_edit_text.onRestoreInstanceState(state.editTextState)
+    private fun restoreViewState(state: WCSavedState): Parcelable {
+        currency_edit_text.onRestoreInstanceState(state.savedState)
         return state.superState
     }
 
@@ -105,59 +101,5 @@ class WCMaterialOutlinedCurrencyEditTextView @JvmOverloads constructor(
 
     override fun dispatchRestoreInstanceState(container: SparseArray<Parcelable>?) {
         super.dispatchThawSelfOnly(container)
-    }
-
-    internal class SavedState : BaseSavedState {
-        internal var editTextState: Parcelable? = null
-
-        constructor(superState: Parcelable?, inEditTextState: Parcelable) : super(superState) {
-            editTextState = inEditTextState
-        }
-
-        /**
-         * Workaround to differentiate between this method and the one that requires API 24+ because
-         * the super(source, loader) method won't work on older APIs - thus the app will crash.
-         */
-        constructor(source: Parcel, loader: ClassLoader?, superState: Parcelable?): super(superState) {
-            editTextState = source.readParcelable<Parcelable>(loader)
-        }
-
-        constructor(source: Parcel) : super(source) {
-            editTextState = source.readParcelable(this::class.java.classLoader)
-        }
-
-        @RequiresApi(VERSION_CODES.N)
-        constructor(source: Parcel, loader: ClassLoader?) : super(source, loader) {
-            editTextState = loader?.let {
-                source.readParcelable<Parcelable>(it)
-            } ?: source.readParcelable<Parcelable>(this::class.java.classLoader)
-        }
-
-        override fun writeToParcel(out: Parcel, flags: Int) {
-            super.writeToParcel(out, flags)
-            out.writeParcelable(editTextState, 0)
-        }
-
-        companion object {
-            @Suppress("UNUSED")
-            @JvmField
-            val CREATOR = object : Parcelable.ClassLoaderCreator<SavedState> {
-                override fun createFromParcel(source: Parcel, loader: ClassLoader?): SavedState {
-                    return if (VERSION.SDK_INT >= VERSION_CODES.N) {
-                        SavedState(source, loader)
-                    } else {
-                        SavedState(source, loader, source.readParcelable<Parcelable>(loader))
-                    }
-                }
-
-                override fun createFromParcel(source: Parcel): SavedState {
-                    return SavedState(source)
-                }
-
-                override fun newArray(size: Int): Array<SavedState?> {
-                    return arrayOfNulls(size)
-                }
-            }
-        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
@@ -1,10 +1,7 @@
 package com.woocommerce.android.widgets
 
 import android.content.Context
-import android.os.Build.VERSION
-import android.os.Build.VERSION_CODES
 import android.os.Bundle
-import android.os.Parcel
 import android.os.Parcelable
 import android.text.Editable
 import android.text.InputFilter
@@ -13,7 +10,6 @@ import android.util.SparseArray
 import android.view.View
 import android.view.inputmethod.EditorInfo
 import androidx.annotation.AttrRes
-import androidx.annotation.RequiresApi
 import androidx.core.widget.doAfterTextChanged
 import com.google.android.material.textfield.TextInputLayout
 import com.woocommerce.android.R
@@ -109,20 +105,20 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
     override fun onSaveInstanceState(): Parcelable? {
         val bundle = Bundle()
         edit_text.onSaveInstanceState()?.let {
-            bundle.putParcelable(KEY_SUPER_STATE, SavedState(super.onSaveInstanceState(), it))
+            bundle.putParcelable(KEY_SUPER_STATE, WCSavedState(super.onSaveInstanceState(), it))
         }
         return bundle
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
-        val bundle = (state as? Bundle)?.getParcelable<SavedState>(KEY_SUPER_STATE)?.let {
+        val bundle = (state as? Bundle)?.getParcelable<WCSavedState>(KEY_SUPER_STATE)?.let {
             restoreViewState(it)
         } ?: state
         super.onRestoreInstanceState(bundle)
     }
 
-    private fun restoreViewState(state: SavedState): Parcelable {
-        edit_text.onRestoreInstanceState(state.editTextState)
+    private fun restoreViewState(state: WCSavedState): Parcelable {
+        edit_text.onRestoreInstanceState(state.savedState)
         return state.superState
     }
 
@@ -132,59 +128,5 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
 
     override fun dispatchRestoreInstanceState(container: SparseArray<Parcelable>?) {
         super.dispatchThawSelfOnly(container)
-    }
-
-    internal class SavedState : BaseSavedState {
-        internal var editTextState: Parcelable? = null
-
-        constructor(superState: Parcelable?, inEditTextState: Parcelable) : super(superState) {
-            editTextState = inEditTextState
-        }
-
-        /**
-         * Workaround to differentiate between this method and the one that requires API 24+ because
-         * the super(source, loader) method won't work on older APIs - thus the app will crash.
-         */
-        constructor(source: Parcel, loader: ClassLoader?, superState: Parcelable?): super(superState) {
-            editTextState = source.readParcelable<Parcelable>(loader)
-        }
-
-        constructor(source: Parcel) : super(source) {
-            editTextState = source.readParcelable(this::class.java.classLoader)
-        }
-
-        @RequiresApi(VERSION_CODES.N)
-        constructor(source: Parcel, loader: ClassLoader?) : super(source, loader) {
-            editTextState = loader?.let {
-                source.readParcelable<Parcelable>(it)
-            } ?: source.readParcelable<Parcelable>(this::class.java.classLoader)
-        }
-
-        override fun writeToParcel(out: Parcel, flags: Int) {
-            super.writeToParcel(out, flags)
-            out.writeParcelable(editTextState, 0)
-        }
-
-        companion object {
-            @Suppress("UNUSED")
-            @JvmField
-            val CREATOR = object : Parcelable.ClassLoaderCreator<SavedState> {
-                override fun createFromParcel(source: Parcel, loader: ClassLoader?): SavedState {
-                    return if (VERSION.SDK_INT >= VERSION_CODES.N) {
-                        SavedState(source, loader)
-                    } else {
-                        SavedState(source, loader, source.readParcelable<Parcelable>(loader))
-                    }
-                }
-
-                override fun createFromParcel(source: Parcel): SavedState {
-                    return SavedState(source)
-                }
-
-                override fun newArray(size: Int): Array<SavedState?> {
-                    return arrayOfNulls(size)
-                }
-            }
-        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedSpinnerView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedSpinnerView.kt
@@ -1,16 +1,12 @@
 package com.woocommerce.android.widgets
 
 import android.content.Context
-import android.os.Build.VERSION
-import android.os.Build.VERSION_CODES
 import android.os.Bundle
-import android.os.Parcel
 import android.os.Parcelable
 import android.util.AttributeSet
 import android.util.SparseArray
 import android.view.View
 import androidx.annotation.AttrRes
-import androidx.annotation.RequiresApi
 import com.google.android.material.textfield.TextInputLayout
 import com.woocommerce.android.R
 import kotlinx.android.synthetic.main.view_material_outlined_spinner.view.*
@@ -64,20 +60,20 @@ class WCMaterialOutlinedSpinnerView @JvmOverloads constructor(
     override fun onSaveInstanceState(): Parcelable? {
         val bundle = Bundle()
         spinner_edit_text.onSaveInstanceState()?.let {
-            bundle.putParcelable(KEY_SUPER_STATE, SavedState(super.onSaveInstanceState(), it))
+            bundle.putParcelable(KEY_SUPER_STATE, WCSavedState(super.onSaveInstanceState(), it))
         }
         return bundle
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
-        val bundle = (state as? Bundle)?.getParcelable<SavedState>(KEY_SUPER_STATE)?.let {
+        val bundle = (state as? Bundle)?.getParcelable<WCSavedState>(KEY_SUPER_STATE)?.let {
             restoreViewState(it)
         } ?: state
         super.onRestoreInstanceState(bundle)
     }
 
-    private fun restoreViewState(state: SavedState): Parcelable {
-        spinner_edit_text.onRestoreInstanceState(state.editTextState)
+    private fun restoreViewState(state: WCSavedState): Parcelable {
+        spinner_edit_text.onRestoreInstanceState(state.savedState)
         return state.superState
     }
 
@@ -87,59 +83,5 @@ class WCMaterialOutlinedSpinnerView @JvmOverloads constructor(
 
     override fun dispatchRestoreInstanceState(container: SparseArray<Parcelable>?) {
         super.dispatchThawSelfOnly(container)
-    }
-
-    internal class SavedState : BaseSavedState {
-        internal var editTextState: Parcelable? = null
-
-        constructor(superState: Parcelable?, inEditTextState: Parcelable) : super(superState) {
-            editTextState = inEditTextState
-        }
-
-        /**
-         * Workaround to differentiate between this method and the one that requires API 24+ because
-         * the super(source, loader) method won't work on older APIs - thus the app will crash.
-         */
-        constructor(source: Parcel, loader: ClassLoader?, superState: Parcelable?): super(superState) {
-            editTextState = source.readParcelable<Parcelable>(loader)
-        }
-
-        constructor(source: Parcel) : super(source) {
-            editTextState = source.readParcelable(this::class.java.classLoader)
-        }
-
-        @RequiresApi(VERSION_CODES.N)
-        constructor(source: Parcel, loader: ClassLoader?) : super(source, loader) {
-            editTextState = loader?.let {
-                source.readParcelable<Parcelable>(it)
-            } ?: source.readParcelable<Parcelable>(this::class.java.classLoader)
-        }
-
-        override fun writeToParcel(out: Parcel, flags: Int) {
-            super.writeToParcel(out, flags)
-            out.writeParcelable(editTextState, 0)
-        }
-
-        companion object {
-            @Suppress("UNUSED")
-            @JvmField
-            val CREATOR = object : Parcelable.ClassLoaderCreator<SavedState> {
-                override fun createFromParcel(source: Parcel, loader: ClassLoader?): SavedState {
-                    return if (VERSION.SDK_INT >= VERSION_CODES.N) {
-                        SavedState(source, loader)
-                    } else {
-                        SavedState(source, loader, source.readParcelable<Parcelable>(loader))
-                    }
-                }
-
-                override fun createFromParcel(source: Parcel): SavedState {
-                    return SavedState(source)
-                }
-
-                override fun newArray(size: Int): Array<SavedState?> {
-                    return arrayOfNulls(size)
-                }
-            }
-        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCSavedState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCSavedState.kt
@@ -1,0 +1,67 @@
+package com.woocommerce.android.widgets
+
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
+import android.os.Parcel
+import android.os.Parcelable
+import android.view.View.BaseSavedState
+import androidx.annotation.RequiresApi
+
+/**
+ * Wrapper for custom view state which can be used to save the parent's (super.onSaveInstanceState) state
+ * or any child view's state
+ */
+class WCSavedState : BaseSavedState {
+    var savedState: Parcelable? = null
+        private set
+
+    constructor(superState: Parcelable?, inState: Parcelable) : super(superState) {
+        savedState = inState
+    }
+
+    /**
+     * Workaround to differentiate between this method and the one that requires API 24+ because
+     * the super(source, loader) method won't work on older APIs - thus the app will crash.
+     */
+    constructor(source: Parcel, loader: ClassLoader?, superState: Parcelable?): super(superState) {
+        savedState = source.readParcelable(loader)
+    }
+
+    constructor(source: Parcel) : super(source) {
+        savedState = source.readParcelable(this::class.java.classLoader)
+    }
+
+    @RequiresApi(VERSION_CODES.N)
+    constructor(source: Parcel, loader: ClassLoader?) : super(source, loader) {
+        savedState = loader?.let {
+            source.readParcelable<Parcelable>(it)
+        } ?: source.readParcelable<Parcelable>(this::class.java.classLoader)
+    }
+
+    override fun writeToParcel(out: Parcel, flags: Int) {
+        super.writeToParcel(out, flags)
+        out.writeParcelable(savedState, 0)
+    }
+
+    companion object {
+        @Suppress("UNUSED")
+        @JvmField
+        val CREATOR = object : Parcelable.ClassLoaderCreator<WCSavedState> {
+            override fun createFromParcel(source: Parcel, loader: ClassLoader?): WCSavedState {
+                return if (VERSION.SDK_INT >= VERSION_CODES.N) {
+                    WCSavedState(source, loader)
+                } else {
+                    WCSavedState(source, loader, source.readParcelable<Parcelable>(loader))
+                }
+            }
+
+            override fun createFromParcel(source: Parcel): WCSavedState {
+                return WCSavedState(source)
+            }
+
+            override fun newArray(size: Int): Array<WCSavedState?> {
+                return arrayOfNulls(size)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #2354 - prior to this PR, we had four different custom views with the exact same `SavedState` code. This PR addresses this by creating a `WCSavedState` class that's reused by all four views.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
