### PR TITLE
issue/2375-product-description-duplication

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -651,7 +651,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         val container = cardView.findViewById<LinearLayout>(R.id.cardContainerView)
 
         // locate the existing property view in the container, add it if not found
-        val propertyTag = "{$propertyName}_tag_{$propertyValue)"
+        val propertyTag = "{$propertyName}_tag"
         var propertyView = container.findViewWithTag<WCProductPropertyView>(propertyTag)
         if (propertyView == null) {
             propertyView = View.inflate(context, R.layout.product_property_view, null) as WCProductPropertyView


### PR DESCRIPTION
Closes #2375 - this PR shortens the tag used when locating views in product detail, which resolves the bug that was causing the description to reappear when the product is updated.

To test:

* Make a change to a product
* Upload the changes
* Note that there's a single description field

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
