### PR TITLE
issue/2390-order-detail-status-design-tweaks 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailOrderStatusView.kt
@@ -29,7 +29,7 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
 
     fun initView(orderModel: WCOrderModel, orderStatus: WCOrderStatusModel, listener: OrderStatusListener) {
         val dateStr = if (DateUtils.isToday(orderModel.dateCreated)) {
-            DateUtils.getTimeString(orderModel.dateCreated)
+            DateUtils.getTimeString(context, orderModel.dateCreated)
         } else {
             DateUtils.getMediumDateFromString(context, orderModel.dateCreated)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailOrderStatusView.kt
@@ -28,11 +28,23 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
     }
 
     fun initView(orderModel: WCOrderModel, orderStatus: WCOrderStatusModel, listener: OrderStatusListener) {
-        orderStatus_orderNum.text = context.getString(
-                R.string.orderdetail_orderstatus_heading,
-                orderModel.number, orderModel.billingFirstName, orderModel.billingLastName)
-        val dateStr = DateUtils.getFriendlyShortDateAtTimeString(context, orderModel.dateCreated)
-        orderStatus_created.text = context.getString(R.string.orderdetail_orderstatus_created, dateStr)
+        val dateStr = if (DateUtils.isToday(orderModel.dateCreated)) {
+            DateUtils.getTimeString(orderModel.dateCreated)
+        } else {
+            DateUtils.getMediumDateFromString(context, orderModel.dateCreated)
+        }
+        orderStatus_dateAndOrderNum.text = context.getString(
+            R.string.orderdetail_orderstatus_date_and_ordernum,
+            dateStr,
+            orderModel.number
+        )
+
+        orderStatus_name.text = context.getString(
+            R.string.orderdetail_orderstatus_name,
+            orderModel.billingFirstName,
+            orderModel.billingLastName
+        )
+
         orderStatus_orderTags.removeAllViews()
         orderStatus_orderTags.addView(getTagView(orderStatus))
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -16,6 +16,7 @@ import java.util.Locale
 
 object DateUtils {
     val friendlyMonthDayFormat by lazy { SimpleDateFormat("MMM d", Locale.getDefault()) }
+    val friendlyTimeFormat by lazy { SimpleDateFormat("hh:mm a", Locale.getDefault()) }
     private val weekOfYearStartingMondayFormat by lazy {
         SimpleDateFormat("yyyy-'W'ww", Locale.getDefault()).apply {
             calendar = Calendar.getInstance().apply {
@@ -227,6 +228,44 @@ object DateUtils {
             (dayOfWeek == Calendar.SATURDAY || dayOfWeek == Calendar.SUNDAY)
         } catch (e: Exception) {
             throw IllegalArgumentException("Date string argument is not of format YYYY-MM: $iso8601Date")
+        }
+    }
+
+    /**
+     * Given a date of format MMMM d, YYYY, returns true if it's today
+     *
+     * @throws IllegalArgumentException if the argument is not a valid date string.
+     */
+    @Throws(IllegalArgumentException::class)
+    fun isToday(dateString: String): Boolean {
+        try {
+            val now = GregorianCalendar.getInstance()
+            val date = GregorianCalendar.getInstance().also {
+                it.time = DateTimeUtils.dateUTCFromIso8601(dateString)
+            }
+
+            return now[Calendar.YEAR] == date[Calendar.YEAR] &&
+                now[Calendar.MONTH] == date[Calendar.MONTH] &&
+                now[Calendar.DATE] == date[Calendar.DATE]
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Date string argument is not of format MMMM dd, yyyy: $dateString")
+        }
+    }
+
+    /**
+     * Given a date of format MMMM d, YYYY, returns just the time
+     *
+     * @throws IllegalArgumentException if the argument is not a valid date string.
+     */
+    @Throws(IllegalArgumentException::class)
+    fun getTimeString(dateString: String): String {
+        try {
+            val date = GregorianCalendar.getInstance().also {
+                it.time = DateTimeUtils.dateUTCFromIso8601(dateString)
+            }
+            return friendlyTimeFormat.format(date.time)
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Date string argument is not of format MMMM dd, yyyy: $dateString")
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -16,7 +16,6 @@ import java.util.Locale
 
 object DateUtils {
     val friendlyMonthDayFormat by lazy { SimpleDateFormat("MMM d", Locale.getDefault()) }
-    val friendlyTimeFormat by lazy { SimpleDateFormat("hh:mm a", Locale.getDefault()) }
     private val weekOfYearStartingMondayFormat by lazy {
         SimpleDateFormat("yyyy-'W'ww", Locale.getDefault()).apply {
             calendar = Calendar.getInstance().apply {
@@ -245,12 +244,12 @@ object DateUtils {
      * @throws IllegalArgumentException if the argument is not a valid date string.
      */
     @Throws(IllegalArgumentException::class)
-    fun getTimeString(dateString: String): String {
+    fun getTimeString(context: Context, dateString: String): String {
         try {
             val date = GregorianCalendar.getInstance().also {
                 it.time = DateTimeUtils.dateUTCFromIso8601(dateString)
             }
-            return friendlyTimeFormat.format(date.time)
+            return DateFormat.getTimeFormat(context).format(date.time)
         } catch (e: Exception) {
             throw IllegalArgumentException("Date string argument is not of format MMMM dd, yyyy: $dateString")
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -233,23 +233,10 @@ object DateUtils {
 
     /**
      * Given a date of format MMMM d, YYYY, returns true if it's today
-     *
-     * @throws IllegalArgumentException if the argument is not a valid date string.
      */
-    @Throws(IllegalArgumentException::class)
     fun isToday(dateString: String): Boolean {
-        try {
-            val now = GregorianCalendar.getInstance()
-            val date = GregorianCalendar.getInstance().also {
-                it.time = DateTimeUtils.dateUTCFromIso8601(dateString)
-            }
-
-            return now[Calendar.YEAR] == date[Calendar.YEAR] &&
-                now[Calendar.MONTH] == date[Calendar.MONTH] &&
-                now[Calendar.DATE] == date[Calendar.DATE]
-        } catch (e: Exception) {
-            throw IllegalArgumentException("Date string argument is not of format MMMM dd, yyyy: $dateString")
-        }
+        val then = DateTimeUtils.dateUTCFromIso8601(dateString)
+        return DateUtils.isSameDay(Date(), then)
     }
 
     /**

--- a/WooCommerce/src/main/res/layout/order_detail_order_status.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_order_status.xml
@@ -11,20 +11,20 @@
         android:orientation="vertical">
 
         <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/orderStatus_orderNum"
-            style="@style/Woo.TextView.Headline6"
+            android:id="@+id/orderStatus_dateAndOrderNum"
+            style="@style/Woo.TextView.Caption"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/minor_50"
-            tools:text="#51 Michelle Fredrickson"/>
+            tools:text="Nov 3, 2020 \u2022 #120"/>
 
         <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/orderStatus_created"
-            style="@style/Woo.TextView.Body2"
+            android:id="@+id/orderStatus_name"
+            style="@style/Woo.TextView.Headline6"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/minor_00"
-            tools:text="Created today at 9:51 AM"/>
+            tools:text="George Carlin"/>
 
         <LinearLayout
             android:id="@+id/orderStatus_edit"
@@ -36,7 +36,6 @@
             android:paddingEnd="@dimen/major_100"
             android:paddingStart="@dimen/major_100"
             android:paddingBottom="@dimen/major_75"
-            android:paddingTop="@dimen/major_75"
             android:contentDescription="@string/orderdetail_change_order_status"
             android:background="?attr/selectableItemBackground">
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -211,8 +211,8 @@
     <string name="customer_information">Customer information</string>
     <string name="customer_full_name">%1$s %2$s</string>
     <string name="orderdetail_orderstatus_ordernum">Order #%s</string>
-    <string name="orderdetail_orderstatus_heading">#%1$s %2$s %3$s</string>
-    <string name="orderdetail_orderstatus_created">Created %1$s</string>
+    <string name="orderdetail_orderstatus_date_and_ordernum">%1$s \u2022 #%2$s</string>
+    <string name="orderdetail_orderstatus_name">%1$s %2$s</string>
     <string name="orderdetail_shipping_method">Shipping method</string>
     <string name="orderdetail_shipping_details">Shipping details</string>
     <string name="orderdetail_billing_details">Billing details</string>


### PR DESCRIPTION
Closes #2390 - updates the header in order detail to shpw date & order number. If date is today show the time.

### Before

![before](https://user-images.githubusercontent.com/3903757/81227025-c11f5800-8fb9-11ea-84ae-b89473fc8549.png)

### After

![after](https://user-images.githubusercontent.com/3903757/81227042-c8466600-8fb9-11ea-8978-2bb6141c21ae.png)

### After (today)

![after-today](https://user-images.githubusercontent.com/3903757/81227087-dac09f80-8fb9-11ea-8c6c-76db694f8f54.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
