### PR TITLE
Issue/2392 order detail product card design tweaks

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductCardTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductCardTest.kt
@@ -72,12 +72,6 @@ class OrderDetailProductCardTest : TestBase() {
                 withText(appContext.getString(R.string.orderdetail_product))
         ))
 
-        // check if order product card quantity label matches this title:
-        // R.string.orderdetail_product_qty
-        onView(withId(R.id.productList_lblQty)).check(matches(
-                withText(appContext.getString(R.string.orderdetail_product_qty))
-        ))
-
         // check if product list is 1
         val recyclerView = activityTestRule.activity.findViewById(R.id.productList_products) as RecyclerView
         assertSame(1, recyclerView.adapter?.itemCount)
@@ -153,7 +147,7 @@ class OrderDetailProductCardTest : TestBase() {
                 .check(matches(withText(mockWCOrderModel.getLineItemList()[0].name)))
 
         // verify if the second product quantity matches: 2
-        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_qty))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_totalPaid))
                 .check(matches(withText(mockWCOrderModel.getLineItemList()[1].quantity?.toInt().toString())))
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentProductListCardTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentProductListCardTest.kt
@@ -104,14 +104,8 @@ class OrderFulfillmentProductListCardTest : TestBase() {
                 withText(appContext.getString(R.string.orderdetail_product))
         ))
 
-        // check if order product card quantity label matches this title:
-        // R.string.orderdetail_product_qty
-        onView(withId(R.id.productList_lblQty)).check(matches(
-                withText(appContext.getString(R.string.orderdetail_product_qty))
-        ))
-
         // verify that the product total label is visible
-        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productTotal))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withEffectiveVisibility(VISIBLE)))
 
         // verify that the product total tax label is visible
@@ -127,7 +121,7 @@ class OrderFulfillmentProductListCardTest : TestBase() {
                 .check(matches(withText(mockWCOrderModel.getLineItemList()[0].name)))
 
         // verify if the second product quantity matches: 2
-        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_qty))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_totalPaid))
                 .check(matches(withText(mockWCOrderModel.getLineItemList()[1].quantity?.toInt().toString())))
 
         // verify that the product total tax is visible
@@ -151,14 +145,14 @@ class OrderFulfillmentProductListCardTest : TestBase() {
 
         // verify that the product total is displayed correctly for multiple quantities
         // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
-        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productTotal))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
                         R.string.orderdetail_product_lineitem_total_single,
                         "$${mockWCOrderModel.getLineItemList()[0].total}.00"
                 ))))
 
         // for multiple quantities: $13.00 ($11.00x2)
-        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productTotal))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
                         R.string.orderdetail_product_lineitem_total_multiple,
                         "$${mockWCOrderModel.getLineItemList()[1].total}.00",
@@ -189,14 +183,14 @@ class OrderFulfillmentProductListCardTest : TestBase() {
 
         // verify that the product total is displayed correctly for multiple quantities
         // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
-        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productTotal))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
                         R.string.orderdetail_product_lineitem_total_single,
                         "€${mockWCOrderModel.getLineItemList()[0].total}.00"
                 ))))
 
         // for multiple quantities: €13.00 (€11.00x2)
-        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productTotal))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
                         R.string.orderdetail_product_lineitem_total_multiple,
                         "€${mockWCOrderModel.getLineItemList()[1].total}.00",
@@ -227,14 +221,14 @@ class OrderFulfillmentProductListCardTest : TestBase() {
 
         // verify that the product total is displayed correctly for multiple quantities
         // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
-        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productTotal))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
                         R.string.orderdetail_product_lineitem_total_single,
                         "₹${mockWCOrderModel.getLineItemList()[0].total}.00"
                 ))))
 
         // for multiple quantities: ₹13.00 (₹11.00x2)
-        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productTotal))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
                         R.string.orderdetail_product_lineitem_total_multiple,
                         "₹${mockWCOrderModel.getLineItemList()[1].total}.00",
@@ -265,14 +259,14 @@ class OrderFulfillmentProductListCardTest : TestBase() {
 
         // verify that the product total is displayed correctly for multiple quantities
         // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
-        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productTotal))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
                         R.string.orderdetail_product_lineitem_total_single,
                         "A$${mockWCOrderModel.getLineItemList()[0].total}.00"
                 ))))
 
         // for multiple quantities: A$13.00 (A$11.00x2)
-        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productTotal))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
                         R.string.orderdetail_product_lineitem_total_multiple,
                         "A\$${mockWCOrderModel.getLineItemList()[1].total}.00",

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/ProductListCardTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/ProductListCardTest.kt
@@ -81,12 +81,6 @@ class ProductListCardTest : TestBase() {
                 withText(appContext.getString(R.string.orderdetail_product))
         ))
 
-        // check if order product card quantity label matches this title:
-        // R.string.orderdetail_product_qty
-        onView(withId(R.id.productList_lblQty)).check(matches(
-                withText(appContext.getString(R.string.orderdetail_product_qty))
-        ))
-
         // check if product list is 2
         val recyclerView = activityTestRule.activity.findViewById(R.id.productList_products) as RecyclerView
         assertSame(2, recyclerView.adapter?.itemCount)
@@ -109,11 +103,11 @@ class ProductListCardTest : TestBase() {
                 .check(matches(withText(mockWCOrderModel.getLineItemList()[0].name)))
 
         // verify if the second product quantity matches: 2
-        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_qty))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_totalPaid))
                 .check(matches(withText(mockWCOrderModel.getLineItemList()[1].quantity?.toInt().toString())))
 
         // verify that the product total label is visible
-        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productTotal))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withEffectiveVisibility(VISIBLE)))
 
         // verify that the product total tax is visible
@@ -149,14 +143,14 @@ class ProductListCardTest : TestBase() {
 
         // verify that the product total is displayed correctly for multiple quantities
         // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
-        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productTotal))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
                         R.string.orderdetail_product_lineitem_total_single,
                         "$${mockWCOrderModel.getLineItemList()[0].total}.00"
                 ))))
 
         // for multiple quantities: $13.00 ($11.00x2)
-        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productTotal))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
                         R.string.orderdetail_product_lineitem_total_multiple,
                         "$${mockWCOrderModel.getLineItemList()[1].total}.00",
@@ -190,14 +184,14 @@ class ProductListCardTest : TestBase() {
 
         // verify that the product total is displayed correctly for multiple quantities
         // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
-        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productTotal))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
                         R.string.orderdetail_product_lineitem_total_single,
                         "€${mockWCOrderModel.getLineItemList()[0].total}.00"
                 ))))
 
         // for multiple quantities: €13.00 (€11.00x2)
-        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productTotal))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
                         R.string.orderdetail_product_lineitem_total_multiple,
                         "€${mockWCOrderModel.getLineItemList()[1].total}.00",
@@ -231,14 +225,14 @@ class ProductListCardTest : TestBase() {
 
         // verify that the product total is displayed correctly for multiple quantities
         // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
-        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productTotal))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
                         R.string.orderdetail_product_lineitem_total_single,
                         "₹${mockWCOrderModel.getLineItemList()[0].total}.00"
                 ))))
 
         // for multiple quantities: ₹13.00 (₹11.00x2)
-        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productTotal))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
                         R.string.orderdetail_product_lineitem_total_multiple,
                         "₹${mockWCOrderModel.getLineItemList()[1].total}.00",
@@ -272,14 +266,14 @@ class ProductListCardTest : TestBase() {
 
         // verify that the product total is displayed correctly for multiple quantities
         // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
-        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productTotal))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
                         R.string.orderdetail_product_lineitem_total_single,
                         "A$${mockWCOrderModel.getLineItemList()[0].total}.00"
                 ))))
 
         // for multiple quantities: A$13.00 (A$11.00x2)
-        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productTotal))
+        onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
                         R.string.orderdetail_product_lineitem_total_multiple,
                         "A\$${mockWCOrderModel.getLineItemList()[1].total}.00",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.View
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.constraintlayout.widget.ConstraintSet
 import com.woocommerce.android.R
 import com.woocommerce.android.di.GlideApp
 import com.woocommerce.android.model.Order
@@ -33,11 +32,10 @@ class OrderDetailProductItemView @JvmOverloads constructor(
         val numberFormatter = NumberFormat.getNumberInstance().apply {
             maximumFractionDigits = 2
         }
-        productInfo_qty.text = numberFormatter.format(item.quantity)
+        productInfo_totalPaid.text = numberFormatter.format(item.quantity)
 
         // Modify views for expanded or collapsed mode
         val viewMode = if (expanded) View.VISIBLE else View.GONE
-        productInfo_productTotal.visibility = viewMode
         productInfo_totalTax.visibility = viewMode
         productInfo_lblTax.visibility = viewMode
 
@@ -53,31 +51,16 @@ class OrderDetailProductItemView @JvmOverloads constructor(
             productInfo_sku.text = item.sku
         }
 
+        val orderTotal = formatCurrencyForDisplay(item.total)
+        val productPrice = formatCurrencyForDisplay(item.price)
+
+        productInfo_totalPaid.text = orderTotal
+        productInfo_productQtyAndPrice.text = context.getString(
+            R.string.orderdetail_product_lineitem_qty_and_price, item.quantity.toString(), productPrice
+        )
+
         if (expanded) {
-            // Populate formatted total and tax values
-            val res = context.resources
-            val orderTotal = formatCurrencyForDisplay(item.total)
-            val productPrice = formatCurrencyForDisplay(item.price)
-
-            item.quantity.takeIf { it > 1 }?.let {
-                val itemQty = numberFormatter.format(it)
-                productInfo_productTotal.text = res.getString(
-                        R.string.orderdetail_product_lineitem_total_multiple, orderTotal, productPrice, itemQty
-                )
-            } ?: run {
-                productInfo_productTotal.text = res.getString(
-                        R.string.orderdetail_product_lineitem_total_single, orderTotal
-                )
-            }
-
             productInfo_totalTax.text = formatCurrencyForDisplay(item.totalTax)
-        } else {
-            // vertically center the product name and quantity since they're the only text showing
-            val set = ConstraintSet()
-            set.clone(this)
-            set.centerVertically(productInfo_name.id, ConstraintSet.PARENT_ID)
-            set.centerVertically(productInfo_qty.id, ConstraintSet.PARENT_ID)
-            set.applyTo(this)
         }
 
         productImage?.let {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductListView.kt
@@ -5,7 +5,6 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.card.MaterialCardView
@@ -33,7 +32,6 @@ class OrderDetailProductListView @JvmOverloads constructor(
     init {
         View.inflate(context, R.layout.order_detail_product_list, this)
     }
-    private lateinit var divider: AlignedDividerDecoration
     private lateinit var viewAdapter: ProductListAdapter
     private var isExpanded = false
 
@@ -58,13 +56,6 @@ class OrderDetailProductListView @JvmOverloads constructor(
         refunds: List<Refund>
     ) {
         isExpanded = expanded
-
-        divider = AlignedDividerDecoration(context,
-                DividerItemDecoration.VERTICAL, R.id.productInfo_name, clipToMargin = false)
-
-        ContextCompat.getDrawable(context, R.drawable.list_divider)?.let { drawable ->
-            divider.setDrawable(drawable)
-        }
 
         val viewManager = androidx.recyclerview.widget.LinearLayoutManager(context)
 
@@ -93,6 +84,17 @@ class OrderDetailProductListView @JvmOverloads constructor(
             layoutManager = viewManager
             itemAnimator = androidx.recyclerview.widget.DefaultItemAnimator()
             adapter = viewAdapter
+
+            if (itemDecorationCount == 0) {
+                addItemDecoration(
+                    AlignedDividerDecoration(
+                        context,
+                        DividerItemDecoration.VERTICAL,
+                        R.id.productInfo_name,
+                        clipToMargin = false
+                    )
+                )
+            }
 
             // Setting this field to false ensures that the RecyclerView children do NOT receive the multiple clicks,
             // and only processes the first click event. More details on this issue can be found here:
@@ -123,10 +125,6 @@ class OrderDetailProductListView @JvmOverloads constructor(
                 productList_btnFulfill.setOnClickListener(null)
             }
         } ?: hideButtons()
-
-        if (isExpanded) {
-            productList_products.addItemDecoration(divider)
-        }
     }
 
     // called when a product is fetched to ensure we show the correct product image

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductListView.kt
@@ -79,6 +79,14 @@ class OrderDetailProductListView @JvmOverloads constructor(
                 productListener
         )
 
+        productList_lblProduct.setText(
+            if (filteredItems.size > 1) {
+                R.string.orderdetail_product_multiple
+            } else {
+                R.string.orderdetail_product
+            }
+        )
+
         productList_products.apply {
             setHasFixedSize(false)
             layoutManager = viewManager
@@ -90,8 +98,7 @@ class OrderDetailProductListView @JvmOverloads constructor(
                     AlignedDividerDecoration(
                         context,
                         DividerItemDecoration.VERTICAL,
-                        R.id.productInfo_name,
-                        clipToMargin = false
+                        R.id.productInfo_name
                     )
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductListView.kt
@@ -98,7 +98,8 @@ class OrderDetailProductListView @JvmOverloads constructor(
                     AlignedDividerDecoration(
                         context,
                         DividerItemDecoration.VERTICAL,
-                        R.id.productInfo_name
+                        R.id.productInfo_name,
+                        padding = context.resources.getDimensionPixelSize(R.dimen.major_100)
                     )
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/AlignedDividerDecoration.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/AlignedDividerDecoration.kt
@@ -62,7 +62,7 @@ class AlignedDividerDecoration @JvmOverloads constructor(
     private val alignStartToStartOf: Int = 0,
     private val alignEndToEndOf: Int = 0,
     private val clipToMargin: Boolean = false,
-    private val padding: Int? = null
+    private val padding: Int = 0
 )
     : RecyclerView.ItemDecoration() {
     companion object {
@@ -152,7 +152,7 @@ class AlignedDividerDecoration @JvmOverloads constructor(
     }
 
     override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
-        if (padding != null) {
+        if (padding > 0) {
             if (orientation == VERTICAL) {
                 outRect.set(0, 0, 0, padding)
             } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/AlignedDividerDecoration.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/AlignedDividerDecoration.kt
@@ -61,7 +61,8 @@ class AlignedDividerDecoration @JvmOverloads constructor(
     private val orientation: Int,
     private val alignStartToStartOf: Int = 0,
     private val alignEndToEndOf: Int = 0,
-    private val clipToMargin: Boolean = false
+    private val clipToMargin: Boolean = false,
+    private val padding: Int? = null
 )
     : RecyclerView.ItemDecoration() {
     companion object {
@@ -151,10 +152,18 @@ class AlignedDividerDecoration @JvmOverloads constructor(
     }
 
     override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
-        if (orientation == VERTICAL) {
-            outRect.set(0, 0, 0, divider.intrinsicHeight)
-        } else {
-            outRect.set(0, 0, divider.intrinsicWidth, 0)
+        if (padding != null) {
+            if (orientation == VERTICAL) {
+                outRect.set(0, 0, 0, padding)
+            } else {
+                outRect.set(0, 0, padding, 0)
+            }
+        }  else {
+            if (orientation == VERTICAL) {
+                outRect.set(0, 0, 0, divider.intrinsicHeight)
+            } else {
+                outRect.set(0, 0, divider.intrinsicWidth, 0)
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/AlignedDividerDecoration.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/AlignedDividerDecoration.kt
@@ -158,7 +158,7 @@ class AlignedDividerDecoration @JvmOverloads constructor(
             } else {
                 outRect.set(0, 0, padding, 0)
             }
-        }  else {
+        } else {
             if (orientation == VERTICAL) {
                 outRect.set(0, 0, 0, divider.intrinsicHeight)
             } else {

--- a/WooCommerce/src/main/res/layout/order_detail_product_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_product_item.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -11,8 +10,8 @@
         android:layout_width="@dimen/image_minor_100"
         android:layout_height="@dimen/image_minor_100"
         android:layout_gravity="center_vertical"
-        android:background="@drawable/picture_frame"
         android:layout_margin="@dimen/major_100"
+        android:background="@drawable/picture_frame"
         android:padding="1dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
@@ -21,11 +20,11 @@
             android:id="@+id/productInfo_icon"
             android:layout_width="@dimen/image_minor_100"
             android:layout_height="@dimen/image_minor_100"
-            android:contentDescription="@string/orderdetail_product_image_contentdesc"
             android:layout_gravity="center"
+            android:contentDescription="@string/orderdetail_product_image_contentdesc"
             android:scaleType="centerCrop"
             app:srcCompat="@drawable/ic_product"
-            tools:visibility="visible"/>
+            tools:visibility="visible" />
     </FrameLayout>
 
     <com.google.android.material.textview.MaterialTextView
@@ -35,30 +34,29 @@
         android:layout_height="wrap_content"
         android:ellipsize="end"
         app:layout_constrainedWidth="true"
-        app:layout_constraintBaseline_toBaselineOf="@+id/productInfo_qty"
-        app:layout_constraintEnd_toStartOf="@+id/productInfo_qty"
+        app:layout_constraintBaseline_toBaselineOf="@+id/productInfo_totalPaid"
+        app:layout_constraintEnd_toStartOf="@+id/productInfo_totalPaid"
         app:layout_constraintStart_toEndOf="@+id/productInfo_iconFrame"
-        tools:text="Candle"/>
+        tools:text="Candle" />
 
     <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/productInfo_qty"
+        android:id="@+id/productInfo_totalPaid"
         style="@style/Woo.ListItem.Title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="2"/>
+        tools:text="$30.00" />
 
     <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/productInfo_productTotal"
+        android:id="@+id/productInfo_productQtyAndPrice"
         style="@style/Woo.ListItem.Body"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintEnd_toStartOf="@+id/productInfo_qty"
+        app:layout_constraintEnd_toStartOf="@+id/productInfo_totalPaid"
         app:layout_constraintStart_toEndOf="@+id/productInfo_iconFrame"
         app:layout_constraintTop_toBottomOf="@+id/productInfo_name"
-        tools:text="$30.00 ($15.00 x 2)"
-        tools:visibility="visible"/>
+        tools:text="$30.00 ($15.00 x 2)" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/productInfo_lblTax"
@@ -67,9 +65,9 @@
         android:layout_height="wrap_content"
         android:text="@string/orderdetail_product_lineitem_tax"
         app:layout_constraintStart_toEndOf="@+id/productInfo_iconFrame"
-        app:layout_constraintTop_toBottomOf="@+id/productInfo_productTotal"
+        app:layout_constraintTop_toBottomOf="@+id/productInfo_productQtyAndPrice"
         tools:text="Tax:"
-        tools:visibility="visible"/>
+        tools:visibility="visible" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/productInfo_totalTax"
@@ -79,12 +77,12 @@
         android:layout_marginStart="@dimen/minor_50"
         android:layout_marginEnd="@dimen/minor_50"
         app:layout_constrainedWidth="true"
+        app:layout_constraintEnd_toStartOf="@+id/productInfo_totalPaid"
         app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintEnd_toStartOf="@+id/productInfo_qty"
         app:layout_constraintStart_toEndOf="@+id/productInfo_lblTax"
-        app:layout_constraintTop_toBottomOf="@+id/productInfo_productTotal"
+        app:layout_constraintTop_toBottomOf="@+id/productInfo_productQtyAndPrice"
         tools:text="$0.75"
-        tools:visibility="visible"/>
+        tools:visibility="visible" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/productInfo_lblSku"
@@ -93,10 +91,10 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/major_75"
         android:text="@string/orderdetail_product_lineitem_sku"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toEndOf="@+id/productInfo_iconFrame"
         app:layout_constraintTop_toBottomOf="@+id/productInfo_lblTax"
-        app:layout_constraintBottom_toBottomOf="parent"
-        tools:visibility="visible"/>
+        tools:visibility="visible" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/productInfo_sku"
@@ -107,11 +105,11 @@
         android:layout_marginEnd="@dimen/minor_50"
         android:layout_marginBottom="@dimen/major_75"
         app:layout_constrainedWidth="true"
-        app:layout_constraintEnd_toStartOf="@+id/productInfo_qty"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/productInfo_totalPaid"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toEndOf="@+id/productInfo_lblSku"
         app:layout_constraintTop_toBottomOf="@+id/productInfo_lblTax"
-        app:layout_constraintBottom_toBottomOf="parent"
         tools:text="T3124"
-        tools:visibility="visible"/>
+        tools:visibility="visible" />
 </merge>

--- a/WooCommerce/src/main/res/layout/order_detail_product_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_product_item.xml
@@ -105,7 +105,6 @@
         android:layout_marginEnd="@dimen/minor_50"
         android:layout_marginBottom="@dimen/major_75"
         app:layout_constrainedWidth="true"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/productInfo_totalPaid"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toEndOf="@+id/productInfo_lblSku"

--- a/WooCommerce/src/main/res/layout/order_detail_product_list.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_product_list.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -17,7 +16,7 @@
             android:layout_height="wrap_content"
             android:text="@string/orderdetail_product"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"/>
+            app:layout_constraintTop_toTopOf="parent" />
 
         <!-- List: Products -->
         <androidx.recyclerview.widget.RecyclerView
@@ -30,7 +29,7 @@
             app:layout_constraintTop_toBottomOf="@+id/productList_lblProduct"
             tools:itemCount="3"
             tools:listitem="@layout/order_detail_product_list_item"
-            tools:targetApi="lollipop"/>
+            tools:targetApi="lollipop" />
 
         <!-- Button: Details -->
         <com.google.android.material.button.MaterialButton
@@ -41,10 +40,10 @@
             android:layout_marginStart="@dimen/major_100"
             android:layout_marginEnd="@dimen/minor_50"
             android:text="@string/details"
-            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/productList_products"
-            tools:visibility="visible"/>
+            tools:visibility="visible" />
 
         <!-- Button: Fulfill Order-->
         <com.google.android.material.button.MaterialButton
@@ -52,12 +51,14 @@
             style="@style/Woo.Button.Colored"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_margin="@dimen/major_100"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginEnd="@dimen/major_100"
+            android:layout_marginBottom="@dimen/major_100"
             android:text="@string/order_begin_fulfillment"
-            tools:visibility="visible"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/productList_btnDetails"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/productList_products"/>
+            app:layout_constraintTop_toBottomOf="@+id/productList_products"
+            tools:visibility="visible" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </merge>

--- a/WooCommerce/src/main/res/layout/order_detail_product_list.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_product_list.xml
@@ -19,15 +19,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"/>
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/productList_lblQty"
-            style="@style/Woo.Card.Header"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/orderdetail_product_qty"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"/>
-
         <!-- List: Products -->
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/productList_products"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -225,6 +225,7 @@
     <string name="orderdetail_product_lineitem_sku">SKU:</string>
     <string name="orderdetail_product_image_contentdesc">Product Image</string>
     <string name="orderdetail_product">Product</string>
+    <string name="orderdetail_product_multiple">Products</string>
     <string name="orderdetail_product_qty">QTY</string>
     <string name="orderdetail_payment_summary_completed">%1$s via %2$s</string>
     <string name="orderdetail_payment_summary_onhold">Awaiting payment via %s</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -220,8 +220,7 @@
     <string name="orderdetail_call_or_message_contentdesc">Call or message customer</string>
     <string name="orderdetail_call_customer">Call</string>
     <string name="orderdetail_message_customer">Message</string>
-    <string name="orderdetail_product_lineitem_total_multiple">%1$s (%2$s x %3$s)</string>
-    <string name="orderdetail_product_lineitem_total_single">%1$s</string>
+    <string name="orderdetail_product_lineitem_qty_and_price">%1$s x %2$s</string>
     <string name="orderdetail_product_lineitem_tax">Tax:</string>
     <string name="orderdetail_product_lineitem_sku">SKU:</string>
     <string name="orderdetail_product_image_contentdesc">Product Image</string>


### PR DESCRIPTION
Closes #2392 - Updates the order detail product card with the following:

- Moved the quantity from the right to below product name, appended with the product price
- Order total is now shown on the right.

Note that the original design included moving the variations to below the product name, but the backend doesn't enable us to do that.

### Before

![before](https://user-images.githubusercontent.com/3903757/81331461-a4455c00-906f-11ea-90ab-1697f6182e6a.png)

### After

![single](https://user-images.githubusercontent.com/3903757/81331128-1d907f00-906f-11ea-9959-4c8c9b3a0487.png)

![multiple](https://user-images.githubusercontent.com/3903757/81331146-22553300-906f-11ea-90db-4bc6d9b06d7a.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
