### PR TITLE
issue/2395-order-detail-add-tracking

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 4.3
 -----
+* Added shipment tracking to the order detail screen
  
 4.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailContract.kt
@@ -15,8 +15,8 @@ interface OrderDetailContract {
         var orderModel: WCOrderModel?
         var orderIdentifier: OrderIdentifier?
         var isUsingCachedNotes: Boolean
-        var isUsingCachedShipmentTrackings: Boolean
         var isShipmentTrackingsFetched: Boolean
+        var isShipmentTrackingsFailed: Boolean
         var deletedOrderShipmentTrackingModel: WCOrderShipmentTrackingModel?
         fun refreshOrderDetail(displaySkeleton: Boolean = false)
         fun fetchOrder(remoteOrderId: Long, displaySkeleton: Boolean = false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -273,20 +273,14 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
     }
 
     override fun showOrderShipmentTrackings(trackings: List<WCOrderShipmentTrackingModel>) {
-        if (trackings.isNotEmpty()) {
-            orderDetail_shipmentList.initView(
-                    trackings = trackings,
-                    uiMessageResolver = uiMessageResolver,
-                    isOrderDetail = true,
-                    shipmentTrackingActionListener = this
-            )
-            if (orderDetail_shipmentList.visibility != View.VISIBLE) {
-                WooAnimUtils.scaleIn(orderDetail_shipmentList, WooAnimUtils.Duration.MEDIUM)
-            }
-        } else {
-            if (orderDetail_shipmentList.visibility == View.VISIBLE) {
-                WooAnimUtils.scaleOut(orderDetail_shipmentList, WooAnimUtils.Duration.MEDIUM)
-            }
+        orderDetail_shipmentList.initView(
+            trackings = trackings,
+            uiMessageResolver = uiMessageResolver,
+            isOrderDetail = true,
+            shipmentTrackingActionListener = this
+        )
+        if (orderDetail_shipmentList.visibility != View.VISIBLE) {
+            WooAnimUtils.scaleIn(orderDetail_shipmentList, WooAnimUtils.Duration.MEDIUM)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -365,9 +365,9 @@ class OrderDetailPresenter @Inject constructor(
     fun onOrderChanged(event: OnOrderChanged) {
         if (event.causeOfChange == WCOrderAction.FETCH_SINGLE_ORDER) {
             if (event.isError || (orderIdentifier.isNullOrBlank() && pendingRemoteOrderId == null)) {
+                orderView?.showLoadOrderError()
                 val message = event.error?.message ?: "empty orderIdentifier"
                 WooLog.e(T.ORDERS, "$TAG - Error fetching order : $message")
-                orderView?.showLoadOrderError()
             } else {
                 orderModel = loadOrderDetailFromDb(orderIdentifier!!)
                 GlobalScope.launch(dispatchers.main) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShipmentTrackingListView.kt
@@ -67,9 +67,9 @@ class OrderDetailShipmentTrackingListView @JvmOverloads constructor(
      */
     private fun showOrHideDivider() {
         val show = getShipmentTrackingCount()?.let { it > 0 } ?: false
-        if (show && shipmentTrack_divider.visibility != View.VISIBLE) {
+        if (show) {
             shipmentTrack_divider.visibility = View.VISIBLE
-        } else if (!show && shipmentTrack_divider.visibility != View.GONE) {
+        } else {
             shipmentTrack_divider.visibility = View.GONE
         }
     }

--- a/WooCommerce/src/main/res/layout/fragment_order_fulfillment.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_fulfillment.xml
@@ -35,7 +35,7 @@
             android:layout_height="wrap_content"
             android:contentDescription="@string/order_shipment_tracking_add_label"
             android:visibility="gone"
-            tools:visibility="gone"/>
+            tools:visibility="visible"/>
 
         <!-- Button: Mark Order Complete -->
         <com.google.android.material.button.MaterialButton

--- a/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_list.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_list.xml
@@ -19,8 +19,7 @@
         <View
             android:id="@+id/shipmentTrack_labelDivider"
             style="@style/Woo.Divider"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_75" />
+            android:layout_marginStart="@dimen/major_100" />
 
         <!-- List: Order Shipment Trackings -->
         <androidx.recyclerview.widget.RecyclerView

--- a/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_list.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_list.xml
@@ -1,31 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/shipmentTrack_label"
             style="@style/Woo.Card.Header"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/order_shipment_tracking"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            android:text="@string/order_shipment_tracking" />
 
         <View
-            android:id="@+id/divider"
+            android:id="@+id/shipmentTrack_labelDivider"
             style="@style/Woo.Divider"
             android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_75"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/shipmentTrack_label" />
+            android:layout_marginTop="@dimen/major_75" />
 
         <!-- List: Order Shipment Trackings -->
         <androidx.recyclerview.widget.RecyclerView
@@ -33,12 +28,9 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:nestedScrollingEnabled="false"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/divider"
             tools:itemCount="3"
             tools:listitem="@layout/order_detail_shipment_tracking_list_item"
-            tools:targetApi="lollipop"/>
+            tools:targetApi="lollipop" />
 
         <!-- Divider -->
         <View
@@ -46,10 +38,7 @@
             style="@style/Woo.Divider"
             android:layout_marginStart="@dimen/major_100"
             android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/shipmentTrack_items"
-            tools:visibility="visible"/>
+            tools:visibility="visible" />
 
         <!-- Button: Add Tracking -->
         <com.google.android.material.button.MaterialButton
@@ -57,15 +46,12 @@
             style="@style/Woo.Button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:layout_marginEnd="@dimen/minor_100"
+            android:layout_gravity="center_vertical|end"
             android:layout_marginStart="@dimen/minor_00"
+            android:layout_marginEnd="@dimen/minor_100"
             android:text="@string/order_shipment_tracking_add_button"
             android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/shipmentTrack_divider"
-            app:layout_constraintBottom_toBottomOf="parent"
             tools:visibility="visible" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </LinearLayout>
 </merge>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenterTest.kt
@@ -265,15 +265,16 @@ class OrderDetailPresenterTest {
     }
 
     @Test
-    fun `Request order shipment trackings from api and load cached from db`() = test {
+    fun `Request order shipment trackings from api`() = test {
         doReturn(WooResult(emptyList<WCRefundModel>()))
                 .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
         doReturn(order).whenever(presenter).orderModel
         doReturn(true).whenever(networkStatus).isConnected()
+        doReturn(false).whenever(presenter).isShipmentTrackingsFetched
+        doReturn(false).whenever(presenter).isShipmentTrackingsFailed
         presenter.takeView(orderDetailView)
 
         presenter.loadOrderDetail(orderIdentifier, false)
-        verify(presenter, times(1)).loadShipmentTrackingsFromDb()
         verify(presenter, times(1)).requestShipmentTrackingsFromApi(any())
     }
 
@@ -286,7 +287,6 @@ class OrderDetailPresenterTest {
         presenter.takeView(orderDetailView)
 
         presenter.loadOrderDetail(orderIdentifier, false)
-        verify(presenter, times(1)).loadShipmentTrackingsFromDb()
         verify(presenter, times(0)).requestShipmentTrackingsFromApi(any())
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenterTest.kt
@@ -291,11 +291,11 @@ class OrderDetailPresenterTest {
     }
 
     @Test
-    fun `Request fresh shipment tracking from api on network connected event if using non-updated cached data`() =
+    fun `Request fresh shipment tracking from api on network connected event if not already fetched`() =
             test {
                 doReturn(WooResult(emptyList<WCRefundModel>()))
                         .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
-                doReturn(true).whenever(presenter).isUsingCachedShipmentTrackings
+                doReturn(false).whenever(presenter).isShipmentTrackingsFetched
                 doReturn(order).whenever(presenter).orderModel
                 presenter.takeView(orderDetailView)
 
@@ -304,11 +304,11 @@ class OrderDetailPresenterTest {
             }
 
     @Test
-    fun `Do not refresh shipment trackings on network connected event if cached data already refreshed`() =
+    fun `Do not refresh shipment trackings on network connected event if data already fetched`() =
             test {
                 doReturn(WooResult(emptyList<WCRefundModel>()))
                         .whenever(refundStore).fetchAllRefunds(any(), any(), any(), any())
-                doReturn(false).whenever(presenter).isUsingCachedShipmentTrackings
+                doReturn(true).whenever(presenter).isShipmentTrackingsFetched
                 doReturn(order).whenever(presenter).orderModel
                 presenter.takeView(orderDetailView)
 


### PR DESCRIPTION
Closes #2395 - we now show "Add tracking" on order detail even when trackings don't already exist.

![Screenshot_1588880216](https://user-images.githubusercontent.com/3903757/81337511-1a9a8c00-9079-11ea-83fb-2992e2f387df.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
