### PR TITLE
issue/1729-viewpager-pointer-index-oob

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 4.3
 -----
+* Fixed a crash in the product image viewer
  
 4.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.orders
 
 import android.content.Context
-import android.os.Handler
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_NOTE_ADD_FAILED
@@ -27,6 +26,7 @@ import com.woocommerce.android.util.WooLog.T.NOTIFICATIONS
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -160,9 +160,10 @@ class OrderDetailPresenter @Inject constructor(
     }
 
     override fun refreshOrderAfterDelay(refreshDelay: Long) {
-        Handler().postDelayed ({
+        GlobalScope.launch(dispatchers.computation) {
+            delay(refreshDelay)
             refreshOrderDetail(false)
-        }, refreshDelay)
+        }
     }
 
     override fun loadOrderNotes() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders
 
 import android.content.Context
+import android.os.Handler
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_NOTE_ADD_FAILED
@@ -26,7 +27,6 @@ import com.woocommerce.android.util.WooLog.T.NOTIFICATIONS
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -160,10 +160,9 @@ class OrderDetailPresenter @Inject constructor(
     }
 
     override fun refreshOrderAfterDelay(refreshDelay: Long) {
-        GlobalScope.launch(dispatchers.computation) {
-            delay(refreshDelay)
+        Handler().postDelayed ({
             refreshOrderDetail(false)
-        }
+        }, refreshDelay)
     }
 
     override fun loadOrderNotes() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCViewPager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCViewPager.kt
@@ -1,0 +1,37 @@
+package com.woocommerce.android.widgets
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.MotionEvent
+import androidx.viewpager.widget.ViewPager
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T
+
+/**
+ * Simple ViewPager wrapped design to address the common "pointer index out of bounds" exception in
+ * the native ViewPager.
+ *
+ * https://github.com/woocommerce/woocommerce-android/issues/1729
+ */
+class WCViewPager @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : ViewPager(context, attrs) {
+    override fun onTouchEvent(ev: MotionEvent?): Boolean {
+        return try {
+            super.onTouchEvent(ev)
+        } catch (e: IllegalArgumentException) {
+            WooLog.e(T.PRODUCTS, e)
+            false
+        }
+    }
+
+    override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean {
+        return try {
+            super.onInterceptTouchEvent(ev)
+        } catch (e: IllegalArgumentException) {
+            WooLog.e(T.PRODUCTS, e)
+            false
+        }
+    }
+}

--- a/WooCommerce/src/main/res/layout/fragment_product_image_viewer.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_image_viewer.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     android:background="@color/black">
 
-    <androidx.viewpager.widget.ViewPager
+    <com.woocommerce.android.widgets.WCViewPager
         android:id="@+id/viewPager"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />


### PR DESCRIPTION
Closes #1729 - this PR should address one of our most common crashes (according to Sentry). The crash is in the `OnInterceptTouchEvent()` method of the native `ViewPager`. The fix here is to create a `ViewPager` wrapper which swallows the exception.

[This is a well-known crash](https://stackoverflow.com/questions/6919292/pointerindex-out-of-range-android-multitouch) in the `ViewPager` and [others have fixed it](https://github.com/chrisbanes/PhotoView/issues/31) the same way.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
