### PR TITLE
issue/2372-order-detail-animation-crash

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,7 @@
 4.3
 -----
+* Fixed crash is order detail after returning from the refund screen
+
  
 4.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -160,7 +160,7 @@ class OrderDetailPresenter @Inject constructor(
     }
 
     override fun refreshOrderAfterDelay(refreshDelay: Long) {
-        Handler().postDelayed ({
+        Handler().postDelayed({
             refreshOrderDetail(false)
         }, refreshDelay)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders
 
 import android.content.Context
+import android.os.Handler
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_NOTE_ADD_FAILED
@@ -26,7 +27,6 @@ import com.woocommerce.android.util.WooLog.T.NOTIFICATIONS
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -160,10 +160,9 @@ class OrderDetailPresenter @Inject constructor(
     }
 
     override fun refreshOrderAfterDelay(refreshDelay: Long) {
-        GlobalScope.launch(dispatchers.computation) {
-            delay(refreshDelay)
+        Handler().postDelayed ({
             refreshOrderDetail(false)
-        }
+        }, refreshDelay)
     }
 
     override fun loadOrderNotes() {


### PR DESCRIPTION
Fixes #2372 - The "Animators may only be run on Looper thread" exception was occuring because we were trying to animate on a non-UI thread. Here's what was happening:

* User completes an order refund and returns to order detail
* We tell the app to [re-fetch the order after a brief delay](https://github.com/woocommerce/woocommerce-android/blob/f65a1cbb1da4bfb402ec3ab5dee2ba631f37190e/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt#L656)
* After the delay the order is re-fetched, but [we're not on the main thread](https://github.com/woocommerce/woocommerce-android/blob/8f33552a5a60d5ca92cff583d49e72638153b96f/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt#L165)
* Fetching the order tells [the skeleton to hide](https://github.com/woocommerce/woocommerce-android/blob/8f33552a5a60d5ca92cff583d49e72638153b96f/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt#L253)
* If the skeleton was showing, it gets animated out
* Boom! App crashes because we're trying to run a view animation outside the main thread

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
