### PR TITLE
Issue/navigate safely

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,8 @@
 4.3
 -----
 * Fixed a crash in the product image viewer
-* Fixed a crash when updating the shipping dimensions of a product.
+* Fixed a crash when updating the shipping dimensions of a product
+* Fixed a crash when rapidly double clicking to navigate to another screen
  
 4.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NavController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NavController.kt
@@ -1,0 +1,19 @@
+package com.woocommerce.android.extensions
+
+import androidx.annotation.IdRes
+import androidx.navigation.NavController
+import androidx.navigation.NavDirections
+
+/**
+ * Prevents crashes caused by rapidly double-clicking views which navigate to the same
+ * destination twice
+ */
+fun NavController.navigateSafely(directions: NavDirections) {
+    currentDestination?.getAction(directions.actionId)?.let { navigate(directions) }
+}
+
+fun NavController.navigateSafely(@IdRes resId: Int) {
+    if (currentDestination?.id == resId == false) {
+        navigate(resId, null)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NavController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NavController.kt
@@ -13,7 +13,7 @@ fun NavController.navigateSafely(directions: NavDirections) {
 }
 
 fun NavController.navigateSafely(@IdRes resId: Int) {
-    if (currentDestination?.id == resId == false) {
+    if (currentDestination?.id != resId) {
         navigate(resId, null)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -30,6 +30,7 @@ import com.woocommerce.android.extensions.active
 import com.woocommerce.android.extensions.getCommentId
 import com.woocommerce.android.extensions.getRemoteOrderId
 import com.woocommerce.android.extensions.getWooType
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.push.NotificationHandler
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
@@ -732,7 +733,7 @@ class MainActivity : AppUpgradeActivity(),
     override fun showProductDetail(remoteProductId: Long) {
         showBottomNav()
         val action = NavGraphMainDirections.actionGlobalProductDetailFragment(remoteProductId)
-        navController.navigate(action)
+        navController.navigateSafely(action)
     }
 
     override fun showReviewDetail(remoteReviewId: Long, launchedFromNotification: Boolean, tempStatus: String?) {
@@ -746,14 +747,14 @@ class MainActivity : AppUpgradeActivity(),
                 remoteReviewId,
                 tempStatus,
                 launchedFromNotification)
-        navController.navigate(action)
+        navController.navigateSafely(action)
     }
 
     override fun showProductFilters(stockStatus: String?, productType: String?, productStatus: String?) {
         val action = NavGraphMainDirections.actionGlobalProductFilterListFragment(
                 stockStatus, productStatus, productType
         )
-        navController.navigate(action)
+        navController.navigateSafely(action)
     }
 
     override fun showOrderDetail(localSiteId: Int, remoteOrderId: Long, remoteNoteId: Long, markComplete: Boolean) {
@@ -776,7 +777,7 @@ class MainActivity : AppUpgradeActivity(),
 
         val orderId = OrderIdentifier(localSiteId, remoteOrderId)
         val action = OrderDetailFragmentDirections.actionGlobalOrderDetailFragment(orderId, remoteNoteId, markComplete)
-        navController.navigate(action)
+        navController.navigateSafely(action)
     }
 
     override fun updateOfflineStatusBar(isConnected: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_DETAIL_TRAC
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_DETAIL_VIEW_REFUND_DETAILS_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SNACK_ORDER_MARKED_COMPLETE_UNDO_BUTTON_TAPPED
 import com.woocommerce.android.extensions.hide
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Refund
@@ -305,14 +306,14 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
                 order.number,
                 presenter.isShipmentTrackingsFetched
         )
-        findNavController().navigate(action)
+        findNavController().navigateSafely(action)
     }
 
     override fun issueOrderRefund(order: Order) {
         AnalyticsTracker.track(ORDER_DETAIL_ISSUE_REFUND_BUTTON_TAPPED)
 
         val action = OrderDetailFragmentDirections.actionOrderDetailFragmentToIssueRefund(order.remoteId)
-        findNavController().navigate(action)
+        findNavController().navigateSafely(action)
     }
 
     override fun showRefundDetail(orderId: Long, refundId: Long) {
@@ -322,7 +323,7 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
         ))
 
         val action = OrderDetailFragmentDirections.actionOrderDetailFragmentToRefundDetailFragment(orderId, refundId)
-        findNavController().navigate(action)
+        findNavController().navigateSafely(action)
     }
 
     override fun openOrderProductList(order: WCOrderModel) {
@@ -330,14 +331,14 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
                 order.getIdentifier(),
                 order.number
         )
-        findNavController().navigate(action)
+        findNavController().navigateSafely(action)
     }
 
     override fun openRefundedProductList(order: WCOrderModel) {
         val action = OrderDetailFragmentDirections.actionOrderDetailFragmentToRefundDetailFragment(
                 order.remoteOrderId
         )
-        findNavController().navigate(action)
+        findNavController().navigateSafely(action)
     }
 
     override fun openOrderProductDetail(remoteProductId: Long) {
@@ -483,7 +484,7 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
                 order.getIdentifier(),
                 order.number
         )
-        findNavController().navigate(action)
+        findNavController().navigateSafely(action)
     }
 
     override fun showAddOrderNoteErrorSnack() {
@@ -585,7 +586,7 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
                     orderTrackingProvider = AppPrefs.getSelectedShipmentTrackingProviderName(),
                     isCustomProvider = AppPrefs.getIsSelectedShipmentTrackingProviderCustom()
             )
-            findNavController().navigate(action)
+            findNavController().navigateSafely(action)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragment.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_FULFILLMENT_MARK_ORDER_COMPLETE_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_FULFILLMENT_TRACKING_ADD_TRACKING_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_FULFILLMENT_TRACKING_DELETE_BUTTON_TAPPED
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.Refund
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.ProductImageMap
@@ -207,7 +208,7 @@ class OrderFulfillmentFragment : BaseFragment(), OrderFulfillmentContract.View, 
                             orderTrackingProvider = AppPrefs.getSelectedShipmentTrackingProviderName(),
                             isCustomProvider = AppPrefs.getIsSelectedShipmentTrackingProviderCustom()
                     )
-            findNavController().navigate(action)
+            findNavController().navigateSafely(action)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -30,6 +30,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SETTINGS_PRIVACY_
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SETTINGS_SELECTED_SITE_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SETTINGS_WE_ARE_HIRING_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SETTING_CHANGE
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.sitepicker.SitePickerActivity
 import com.woocommerce.android.util.AnalyticsUtils
 import com.woocommerce.android.util.AppThemeUtils
@@ -157,7 +158,7 @@ class MainSettingsFragment : androidx.fragment.app.Fragment(), MainSettingsContr
 
         option_beta_features.setOnClickListener {
             AnalyticsTracker.track(SETTINGS_BETA_FEATURES_BUTTON_TAPPED)
-            findNavController().navigate(R.id.action_mainSettingsFragment_to_betaFeaturesFragment)
+            findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_betaFeaturesFragment)
         }
 
         val productsTeaser = getString(R.string.settings_enable_product_teaser_title)
@@ -166,7 +167,7 @@ class MainSettingsFragment : androidx.fragment.app.Fragment(), MainSettingsContr
 
         option_privacy.setOnClickListener {
             AnalyticsTracker.track(SETTINGS_PRIVACY_SETTINGS_BUTTON_TAPPED)
-            findNavController().navigate(R.id.action_mainSettingsFragment_to_privacySettingsFragment)
+            findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_privacySettingsFragment)
         }
 
         option_feature_request.setOnClickListener {
@@ -176,12 +177,12 @@ class MainSettingsFragment : androidx.fragment.app.Fragment(), MainSettingsContr
 
         option_about.setOnClickListener {
             AnalyticsTracker.track(SETTINGS_ABOUT_WOOCOMMERCE_LINK_TAPPED)
-            findNavController().navigate(R.id.action_mainSettingsFragment_to_aboutFragment)
+            findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_aboutFragment)
         }
 
         option_licenses.setOnClickListener {
             AnalyticsTracker.track(SETTINGS_ABOUT_OPEN_SOURCE_LICENSES_LINK_TAPPED)
-            findNavController().navigate(R.id.action_mainSettingsFragment_to_licensesFragment)
+            findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_licensesFragment)
         }
 
         if (presenter.hasMultipleStores()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.main.MainActivity
@@ -132,7 +133,7 @@ class ProductFilterListFragment : BaseFragment(), OnProductFilterClickListener {
     override fun onProductFilterClick(selectedFilterPosition: Int) {
         val action = ProductFilterListFragmentDirections
                 .actionProductFilterListFragmentToProductFilterOptionListFragment(selectedFilterPosition)
-        findNavController().navigate(action)
+        findNavController().navigateSafely(action)
     }
 
     override fun onResume() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_IMAGE_TAPPED
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.media.ProductImagesUtils
 import com.woocommerce.android.model.Product
@@ -124,7 +125,7 @@ class ProductImagesFragment : BaseProductFragment(), OnGalleryImageClickListener
         val action = ProductImageViewerFragmentDirections.actionGlobalProductImageViewerFragment(
                 image.id
         )
-        findNavController().navigate(action)
+        findNavController().navigateSafely(action)
     }
 
     private fun showImageSourceDialog() {
@@ -161,7 +162,7 @@ class ProductImagesFragment : BaseProductFragment(), OnGalleryImageClickListener
 
     private fun showWPMediaPicker() {
         val action = ProductDetailFragmentDirections.actionGlobalWpMediaFragment()
-        findNavController().navigate(action)
+        findNavController().navigateSafely(action)
     }
 
     private fun chooseProductImage() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -5,6 +5,7 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.RequestCodes
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ExitProduct
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ShareProduct
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductCatalogVisibility
@@ -53,7 +54,7 @@ class ProductNavigator @Inject constructor() {
             is ViewProductVariations -> {
                 val action = ProductDetailFragmentDirections
                         .actionProductDetailFragmentToProductVariantsFragment(target.remoteId)
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ViewProductDescriptionEditor -> {
@@ -64,7 +65,7 @@ class ProductNavigator @Inject constructor() {
                                 null,
                                 RequestCodes.AZTEC_EDITOR_PRODUCT_DESCRIPTION
                         )
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ViewProductShortDescriptionEditor -> {
@@ -75,7 +76,7 @@ class ProductNavigator @Inject constructor() {
                                 null,
                                 RequestCodes.AZTEC_EDITOR_PRODUCT_SHORT_DESCRIPTION
                         )
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ViewProductPurchaseNoteEditor -> {
@@ -86,31 +87,31 @@ class ProductNavigator @Inject constructor() {
                                 target.caption,
                                 RequestCodes.PRODUCT_SETTINGS_PURCHASE_NOTE
                         )
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ViewProductInventory -> {
                 val action = ProductDetailFragmentDirections
                         .actionProductDetailFragmentToProductInventoryFragment(target.remoteId)
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ViewProductPricing -> {
                 val action = ProductDetailFragmentDirections
                         .actionProductDetailFragmentToProductPricingFragment(target.remoteId)
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ViewProductExternalLink -> {
                 val action = ProductDetailFragmentDirections
                         .actionProductDetailFragmentToProductExternalLinkFragment(target.remoteId)
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ViewProductShipping -> {
                 val action = ProductDetailFragmentDirections
                         .actionProductDetailFragmentToProductShippingFragment(target.remoteId)
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ViewProductImageChooser -> viewProductImageChooser(fragment, target.remoteId)
@@ -118,14 +119,14 @@ class ProductNavigator @Inject constructor() {
             is ViewProductSettings -> {
                 val action = ProductDetailFragmentDirections
                         .actionProductDetailFragmentToProductSettingsFragment()
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ViewProductStatus -> {
                 val status = target.status?.toString() ?: ""
                 val action = ProductSettingsFragmentDirections
                         .actionProductSettingsFragmentToProductStatusFragment(status)
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ViewProductCatalogVisibility -> {
@@ -135,20 +136,20 @@ class ProductNavigator @Inject constructor() {
                                 catalogVisibility,
                                 target.isFeatured
                         )
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ViewProductVisibility -> {
                 val visibility = target.visibility.toString()
                 val action = ProductSettingsFragmentDirections
                         .actionProductSettingsFragmentToProductVisibilityFragment(visibility, target.password)
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ViewProductSlug -> {
                 val action = ProductSettingsFragmentDirections
                         .actionProductSettingsFragmentToProductSlugFragment(target.slug)
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ViewProductImages -> {
@@ -162,7 +163,7 @@ class ProductNavigator @Inject constructor() {
             is ViewProductMenuOrder -> {
                 val action = ProductSettingsFragmentDirections
                         .actionProductSettingsFragmentToProductMenuOrderFragment(target.menuOrder)
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ExitProduct -> fragment.findNavController().navigateUp()
@@ -172,12 +173,12 @@ class ProductNavigator @Inject constructor() {
     private fun viewProductImageChooser(fragment: Fragment, remoteId: Long) {
         val action = ProductDetailFragmentDirections
                 .actionProductDetailFragmentToProductImagesFragment(remoteId)
-        fragment.findNavController().navigate(action)
+        fragment.findNavController().navigateSafely(action)
     }
 
     private fun viewProductImageViewer(fragment: Fragment, remoteId: Long) {
         val action = ProductImageViewerFragmentDirections
                 .actionGlobalProductImageViewerFragment(remoteId)
-        fragment.findNavController().navigate(action)
+        fragment.findNavController().navigateSafely(action)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingFragment.kt
@@ -14,6 +14,7 @@ import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.main.MainActivity.NavigationResult
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductDetailViewState
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitShipping
@@ -144,7 +145,7 @@ class ProductShippingFragment : BaseProductFragment(), NavigationResult {
                 .actionProductShippingFragmentToProductShippingClassFragment(
                         productShippingClassSlug = viewModel.getProduct().productDraft?.shippingClass ?: ""
                 )
-        findNavController().navigate(action)
+        findNavController().navigateSafely(action)
     }
 
     override fun onNavigationResult(requestCode: Int, result: Bundle) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundFragment.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.UIMessageResolver
 import javax.inject.Inject
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.refunds.IssueRefundViewModel.IssueRefundEvent.ShowRefundSummary
@@ -84,7 +85,7 @@ class IssueRefundFragment : BaseFragment() {
             when (event) {
                 is ShowRefundSummary -> {
                     val action = IssueRefundFragmentDirections.actionIssueRefundFragmentToRefundSummaryFragment()
-                    findNavController().navigate(action)
+                    findNavController().navigateSafely(action)
                 }
                 else -> event.isHandled = false
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByItemsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByItemsFragment.kt
@@ -58,6 +58,7 @@ class RefundByItemsFragment : BaseFragment() {
     private fun initializeViews() {
         issueRefund_products.layoutManager = LinearLayoutManager(context)
         issueRefund_products.setHasFixedSize(true)
+        issueRefund_products.isMotionEventSplittingEnabled = false
 
         issueRefund_selectButton.setOnClickListener {
             viewModel.onSelectButtonTapped()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByItemsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByItemsFragment.kt
@@ -15,6 +15,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.extensions.hide
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.tools.ProductImageMap
@@ -161,7 +162,7 @@ class RefundByItemsFragment : BaseFragment() {
                             event.refundItem.maxQuantity,
                             event.refundItem.quantity
                     )
-                    findNavController().navigate(action)
+                    findNavController().navigateSafely(action)
                 }
                 is ShowRefundAmountDialog -> {
                     val action = IssueRefundFragmentDirections.actionIssueRefundFragmentToRefundAmountDialog(
@@ -171,7 +172,7 @@ class RefundByItemsFragment : BaseFragment() {
                             BigDecimal.ZERO,
                             event.message
                     )
-                    findNavController().navigate(action)
+                    findNavController().navigateSafely(action)
                 }
                 is OpenUrl -> {
                     ChromeCustomTabUtils.launchUrl(requireContext(), event.url)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundSummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundSummaryFragment.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
@@ -65,7 +66,7 @@ class RefundSummaryFragment : BaseFragment(), BackPressListener {
                     val action = RefundSummaryFragmentDirections.actionRefundSummaryFragmentToRefundConfirmationDialog(
                             event.title, event.message, event.confirmButtonTitle
                     )
-                    findNavController().navigate(action)
+                    findNavController().navigateSafely(action)
                 }
                 else -> event.isHandled = false
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaPickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaPickerFragment.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.Product
@@ -165,7 +166,7 @@ class WPMediaPickerFragment : BaseFragment(), WPMediaGalleryListener, BackPressL
      */
     override fun onImageLongClicked(image: Product.Image) {
         val action = ProductDetailFragmentDirections.actionGlobalWpMediaViewerFragment(image.source)
-        findNavController().navigate(action)
+        findNavController().navigateSafely(action)
     }
 
     override fun onRequestAllowBackPress(): Boolean {


### PR DESCRIPTION
Fixes #2400, #2074, #2400, and #1719 - we have a ton of Sentry reports of crashes caused by navigating to the same destination twice after users rapidly click the same view.

We've tried various ways to fix these, but the crashes are still happening. I've opened this PR which adds a `NavController` extension that enables safely navigating and avoiding these crashes.

One way to initially test this is to run `develop` then rapidly double-click here in order refund:

![Screenshot_1588963074](https://user-images.githubusercontent.com/3903757/81443745-fc4d9280-9143-11ea-97ff-4edaa479a048.png)

That will crash the app. Now run this branch and see the crash is gone.

@anitaa1990, @AmandaRiu, @0nko - I've asked all three of you to give this a spin since it changes navigation throughout the app. It would be good to get this merged soon since it touches so many files.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
