### PR TITLE
Fixed crash when entering dot values when updating product dimensions

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.3
 -----
 * Fixed a crash in the product image viewer
+* Fixed a crash when updating the shipping dimensions of a product.
  
 4.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringExt.kt
@@ -8,6 +8,11 @@ import org.apache.commons.text.StringEscapeUtils
 fun String?.isNumeric() = this?.toIntOrNull()?.let { true } ?: false
 
 /**
+ * Checks if a given string is a Float
+ */
+fun String?.isFloat() = this?.toFloatOrNull()?.let { true } ?: false
+
+/**
  * If the provided [line] is not null and not empty, then add the string to this instance. Will prepend the
  * [separator] if the current contents of this StringBuilder are not empty.
  */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingFragment.kt
@@ -14,6 +14,7 @@ import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.extensions.isFloat
 import com.woocommerce.android.ui.main.MainActivity.NavigationResult
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductDetailViewState
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitShipping
@@ -82,9 +83,11 @@ class ProductShippingFragment : BaseProductFragment(), NavigationResult {
     }
 
     private fun initListeners() {
-        fun editableToFloat(editable: Editable?): Float {
+        fun editableToFloat(editable: Editable?): Float? {
             val str = editable?.toString() ?: ""
-            return if (str.isEmpty()) 0.0f else str.toFloat()
+            return if (str.isFloat()) {
+                str.toFloat()
+            } else 0.0f
         }
 
         product_weight.setOnTextChangedListener {


### PR DESCRIPTION
Fixes #2370 by adding logic to ensure that the app does not crash when updating product dimension float values.

#### To Reproduce
- Click on a Product with Shipping dimensions.
- Click on the Shipping section.
- Click on any one of the dimension fields. Remove the existing values from the field and add a `.`. 
- Notice the app crashes.
- Pull changes from this PR and verify that the app no longer crashes. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
