### PR TITLE
Changed default sorting to name asc

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListRepository.kt
@@ -22,7 +22,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductsSearched
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
-import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_DESC
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_ASC
 import javax.inject.Inject
 import kotlin.coroutines.resume
 
@@ -54,7 +54,7 @@ final class ProductListRepository @Inject constructor(
     var productSortingChoice: ProductSorting
         get() {
             return ProductSorting.valueOf(
-                    sharedPreferences.getString(PRODUCT_SORTING_PREF_KEY, DATE_DESC.name) ?: DATE_DESC.name
+                    sharedPreferences.getString(PRODUCT_SORTING_PREF_KEY, TITLE_ASC.name) ?: TITLE_ASC.name
             )
         }
         set(value) {


### PR DESCRIPTION
This tiny PR fixes #2387 by setting the default sorting to name asc. Currently, the sorting is set to date desc.

### To Reproduce
- Open the Products tab.
- Scroll through the products tab and notice the products are in alphabetical order.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
