### PR TITLE
Add a product editing beta feature to the release notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.3
 -----
 * Fixed a crash in the product image viewer
+* Beta feature: Try out the new product editing functionality
  
 4.2
 -----


### PR DESCRIPTION
This is just an update of the release notes that mentions the product editing feature, which can now be turned on using the beta switch.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
