### PR TITLE
Fix the product screen container ID reference

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/products/SingleProductScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/products/SingleProductScreen.kt
@@ -5,7 +5,7 @@ import com.woocommerce.android.screenshots.util.Screen
 
 class SingleProductScreen : Screen {
     companion object {
-        const val PRODUCT_DETAIL_CONTAINER = R.id.productDetail_container
+        const val PRODUCT_DETAIL_CONTAINER = R.id.cardsRecyclerView
     }
 
     constructor(): super(PRODUCT_DETAIL_CONTAINER)


### PR DESCRIPTION
I've updated the old container reference to the RecyclerView but I couldn't test it because there were some errors in `SingleOrderScreen`.