### PR TITLE
issue/2371-image-viewer-crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImageViewerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImageViewerFragment.kt
@@ -111,7 +111,7 @@ class ProductImageViewerFragment : BaseProductFragment(), ImageViewerListener {
             images.addAll(draft.images)
         }
 
-        pagerAdapter = ImageViewerAdapter(requireActivity().supportFragmentManager, images)
+        pagerAdapter = ImageViewerAdapter(childFragmentManager, images)
         viewPager.adapter = pagerAdapter
 
         val position = pagerAdapter.indexOfImageId(remoteMediaId)


### PR DESCRIPTION
Fixes #2371 - I was never able to reproduce the crash, but [this SO comment](https://stackoverflow.com/a/28360506/1673548) suggested it can happen when using `fragmentManager` instead of `childFragmentManager`.

I made that change and tested on multiple versions of Android and it all worked fine. To test:

* View product detail for a product with several images
* Open the product fullscreen image viewer
* Swipe between images and verify it all works well

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
