### PR TITLE
Add pseudolocales support for debug builds

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -92,6 +92,7 @@ android {
 
         debug {
             minifyEnabled false
+            pseudoLocalesEnabled true
         }
     }
 


### PR DESCRIPTION
This PR is a tiny change that [enables pseudolocale support in debug builds](https://developer.android.com/guide/topics/resources/pseudolocales). This PR has already been helpful in finding several LTR issues just in the two screens I visited.  

> A pseudolocale is a locale that is designed to simulate characteristics of languages that cause UI, layout, and other translation-related problems when an app is translated

Pseudolocales are Android jibberish languages for testing locale/text handling in the app by populating all the _localized_ text fields with jibberish. There are two options available:
- English (XA): Left-to-right (LTR)
- AR (XB): right-to-left (RTL)

To use with our app:
1. Enable developer options
2. Open device language settings and select either of the following:

![Screen Shot on 2020-05-13 at 13:27:18](https://user-images.githubusercontent.com/5810477/81856073-7ce20980-951d-11ea-8931-98ea69150c10.png)

XA | XB
-- | --
![Screenshot_1589398129](https://user-images.githubusercontent.com/5810477/81856237-c3376880-951d-11ea-8040-cec3d6730bca.png)|![Screenshot_1589398109](https://user-images.githubusercontent.com/5810477/81856242-c4689580-951d-11ea-8987-442ff4d593c3.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
