### PR TITLE
Add ktlint as part of the pre-commit hook

### DIFF
--- a/tools/team-props/git-hooks/pre-commit
+++ b/tools/team-props/git-hooks/pre-commit
@@ -19,7 +19,7 @@ if [[ "$BRANCH" == "master" || "$BRANCH" == "develop" ]]; then
 fi
 
 # Runs ktlint to make sure everything matches the desired style
-./gradlew ktlint
+./gradlew ktlint checkstyle
 
 # This block allows for chaining pre-commit hooks if this hook is a global hook
 # (via core.hooksPath) and there also exists a repo-specific pre-commit hook

--- a/tools/team-props/git-hooks/pre-commit
+++ b/tools/team-props/git-hooks/pre-commit
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# With this, if a command returns an exit code that's not 0, the script will
+# fail
+set -e
+
 # Stops accidental commits to master and develop. Pulled from: https://gist.github.com/stefansundin/9059706
 # Install:
 # cd path/to/git/repo
@@ -12,6 +17,9 @@ if [[ "$BRANCH" == "master" || "$BRANCH" == "develop" ]]; then
   echo "If so, commit with -n to bypass this pre-commit hook."
   exit 1
 fi
+
+# Runs ktlint to make sure everything matches the desired style
+./gradlew ktlint
 
 # This block allows for chaining pre-commit hooks if this hook is a global hook
 # (via core.hooksPath) and there also exists a repo-specific pre-commit hook


### PR DESCRIPTION
<p>I've opened a few PRs on the Android repo recently. <a href="https://app.circleci.com/pipelines/github/woocommerce/woocommerce-android/5888/workflows/a7c58aee-5edc-4664-b49d-44661bff8175/jobs/15397" target="_blank" rel="noreferrer noopener">A couple</a> <a href="https://app.circleci.com/pipelines/github/woocommerce/woocommerce-android/5859/workflows/c39ada26-8adc-4295-867d-7c113d748b0d/jobs/15310/steps" target="_blank" rel="noreferrer noopener">of times</a>, I've been bitten by <code>ktlint</code> failures reported on CI which I didn't notice locally.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Even though that's why we have CI, I don't like when that happens. The feedback loop between when I write the code and when I discover the failure is long, and if the PR is in a state when an interactive rebase is not appropriate, then I'll have to leave a "fix linter issue" in the history. Yuck.</p>
<!-- /wp:paragraph -->

This PR automatically runs `ktlint` as part of the pre-commit hook.

![2020-05-14 14-32-11 2020-05-14 14_42_40](https://user-images.githubusercontent.com/1218433/81894445-20e9b480-95f3-11ea-8007-ff83dbea6acb.gif)


#### Pros

Less likely that code failing the lint checks will make it into the remote, which means less likely you'll have to followup on your PR with a commit just to fix the lint issues.

#### Cons

It does make the committing process longer.

**I think this should be okayed by all Android devs before merging, as it might impact the workflow.** Have I missed someone? I asked review from the active contributors in the past month.

---

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.