### PR TITLE
Removed feature flag check for filter and sort in product list

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 * Fixed a crash when rapidly double clicking to navigate to another screen
 * All orders tab now displays future-dated orders
 * Fixed crash in order detail after returning from the refund screen
+* You can now filter and sort Products by clicking on the Products tab!
  
 4.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -354,7 +354,7 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener, ProductS
     }
 
     private fun showProductSortAndFiltersCard(show: Boolean) {
-        if (show && FeatureFlag.PRODUCT_RELEASE_M2.isEnabled()) {
+        if (show) {
             products_sort_filter_card.visibility = View.VISIBLE
             products_sort_filter_card.initView(this)
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -13,9 +13,9 @@ enum class FeatureFlag {
     DB_DOWNGRADE;
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
-            // currently only enabled for debug users but once live, this feature will live switched on from the
+            // This feature will live switched on from the
             // setting screen. i.e. check AppPrefs.isProductsFeatureEnabled() method
-            PRODUCT_RELEASE_M2 -> BuildConfig.DEBUG || AppPrefs.isProductsFeatureEnabled()
+            PRODUCT_RELEASE_M2 -> AppPrefs.isProductsFeatureEnabled()
             PRODUCT_RELEASE_M3 -> BuildConfig.DEBUG
             DB_DOWNGRADE -> {
                 BuildConfig.DEBUG || context != null && PackageUtils.isBetaBuild(context)

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -497,7 +497,7 @@
     <string name="product_limited_editing_title">Limited editing available</string>
     <string name="product_limited_editing_message">We\'ve added editing functionality to simple products. Keep an eye out for more options soon!</string>
     <string name="product_wip_title">New editing options available</string>
-    <string name="product_wip_message">We\'ve added more editing functionalities to products. You can now update images, see previews and sort, filter &amp; share products!</string>
+    <string name="product_wip_message">We\'ve added more editing functionalities to products. You can now update images, edit product settings &amp; share products!</string>
     <string name="product_bullet" translatable="false"> \u2022 </string>
     <string name="product_variant_hidden">Hidden</string>
     <string name="product_variant_list_empty">Add options like size and color from web. These will show up as options on the product page of your site</string>


### PR DESCRIPTION
Fixes #2433. This tiny PR enables the product filter and sort feature for all users starting from the next release.

#### To test
- Switch off the products feature from the Beta Features option in the Settings page.
- Click on the `Products` tab and verify that the sort and filter option is visible.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
