### PR TITLE
Added logic to display stock status when there is no sku

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -287,7 +287,9 @@ class ProductDetailCardBuilder(
                 Pair(resources.getString(R.string.product_stock_status),
                     ProductStockStatus.stockStatusToDisplayString(resources, product.stockStatus))
             )
-            else -> mapOf(Pair("", resources.getString(R.string.product_inventory_empty)))
+            else -> mapOf(
+                Pair("", ProductStockStatus.stockStatusToDisplayString(resources, product.stockStatus))
+            )
         }
 
         items.addPropertyIfNotEmpty(
@@ -295,7 +297,7 @@ class ProductDetailCardBuilder(
                 R.string.product_inventory,
                 inventoryGroup,
                 R.drawable.ic_gridicons_list_checkmark,
-                product.manageStock || product.sku.isNotEmpty()
+                true
             ) {
                 viewModel.onEditProductCardClicked(
                     ViewProductInventory(product.remoteId),


### PR DESCRIPTION
Fixes #2429. This tiny PR adds logic to display the stock status by default (when there are no other inventory details available for the product).

#### To test 
- Click on a Product that does not contain any inventory info.
- Notice that under the Inventory section, the stock status is displayed.

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/82046534-bc038c80-96ce-11ea-938e-bd0593eb4d17.png" width="300"/>
 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
