### PR TITLE
Set colorForeground to always use black for zendesk theme

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+4.4
+-----
+* Fixes text color on support ticket views for dark mode
+
 4.3
 -----
 * Added shipment tracking to the order detail screen

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -142,5 +142,6 @@
         <item name="colorPrimary">@color/color_primary_surface</item>
         <item name="colorPrimaryDark">@color/color_primary</item>
         <item name="colorAccent">@color/color_primary</item>
+        <item name="android:colorForeground">@color/woo_black_90</item>
     </style>
 </resources>


### PR DESCRIPTION
Fixes #2384 by setting the text color to always be black. This is needed at this time because the background of the Zendesk-provided activities do not follow light/dark theming and are always white.

Before | After
-- | --
![Screenshot_1589603025](https://user-images.githubusercontent.com/5810477/82110379-33e7ac00-96fb-11ea-9382-80f299cb876c.png)|![Screenshot_1589602903](https://user-images.githubusercontent.com/5810477/82110380-3518d900-96fb-11ea-8b4e-8c2ca382e18e.png)

## To Test
Test these changes on devices running API 21, 28 and 29 in dark mode.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
