### PR TITLE
Replace GlobalScope with scopes specific to the owner class

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BasePresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BasePresenter.kt
@@ -1,6 +1,18 @@
 package com.woocommerce.android.ui.base
 
+import androidx.annotation.CallSuper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+
 interface BasePresenter<in T> {
+    val coroutineScope: CoroutineScope
+        get() = CoroutineScope(Job())
+
     fun takeView(view: T)
-    fun dropView()
+
+    @CallSuper
+    fun dropView() {
+        coroutineScope.cancel()
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BasePresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BasePresenter.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.base
 
-import androidx.annotation.CallSuper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
@@ -11,7 +10,12 @@ interface BasePresenter<in T> {
 
     fun takeView(view: T)
 
-    @CallSuper
+    /**
+     * This method would need to be called by the inherited classes if
+     * [coroutineScope] is being actively used, in order to cancel the coroutine
+     *
+     * See [OrderDetailPresenter] for more details
+     */
     fun dropView() {
         coroutineScope.cancel()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -103,7 +103,7 @@ class OrderDetailPresenter @Inject constructor(
     private var isRefreshingOrderStatusOptions = false
 
     private var deferredRefunds: Deferred<WooResult<List<WCRefundModel>>>? = null
-    private val coroutineScope = CoroutineScope(dispatchers.main)
+    override val coroutineScope = CoroutineScope(dispatchers.main)
 
     override fun takeView(view: OrderDetailContract.View) {
         orderView = view
@@ -112,6 +112,7 @@ class OrderDetailPresenter @Inject constructor(
     }
 
     override fun dropView() {
+        super.dropView()
         orderView = null
         isNotesInit = false
         dispatcher.unregister(this)


### PR DESCRIPTION
Hopefully, fixes #2312 by removing the `GlobalScope` instance from the `OrderDetailPresenter` class. 

I wasn't actually able to reproduce the issue but @AmandaRiu had better luck than me and [added the steps to reproduce the crash](https://github.com/woocommerce/woocommerce-android/issues/2312#issuecomment-620972706). 

@AmandaRiu I have assigned you as a reviewer since you were able to reproduce the crash! 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
