### PR TITLE
Fix a crash in Product details

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.Observer
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.LayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -44,6 +45,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
     private val LIST_STATE_KEY = "list_state"
 
     private var progressDialog: CustomProgressDialog? = null
+    private var layoutManager: LayoutManager? = null
 
     private val navArgs: ProductDetailFragmentArgs by navArgs()
 
@@ -71,6 +73,8 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
 
     private fun initializeViews(savedInstanceState: Bundle?) {
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
+        this.layoutManager = layoutManager
+
         savedInstanceState?.getParcelable<Parcelable>(LIST_STATE_KEY)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
@@ -220,7 +224,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
-        cardsRecyclerView.layoutManager?.let {
+        layoutManager?.let {
             outState.putParcelable(LIST_STATE_KEY, it.onSaveInstanceState())
         }
     }


### PR DESCRIPTION
Fixes #2425.

**To test:**
1. Open a product to view the product detail
2. Click to add a product image
3. Take a photo with camera and accept it
4. Notice the app doesn't crash