### PR TITLE
Updates the WordPress Util lib hash to include a crash fix for product description

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -140,7 +140,7 @@ dependencies {
     implementation "androidx.navigation:navigation-fragment-ktx:$navigationVersion"
     implementation "androidx.navigation:navigation-ui-ktx:$navigationVersion"
 
-    implementation('org.wordpress:utils:1.22') {
+    implementation('org.wordpress:utils:1.24-beta-1') {
         exclude group: "com.mcxiaoke.volley"
         exclude group: "com.android.support"
     }

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -140,7 +140,7 @@ dependencies {
     implementation "androidx.navigation:navigation-fragment-ktx:$navigationVersion"
     implementation "androidx.navigation:navigation-ui-ktx:$navigationVersion"
 
-    implementation('org.wordpress:utils:1.24-beta-1') {
+    implementation('org.wordpress:utils:1.24') {
         exclude group: "com.mcxiaoke.volley"
         exclude group: "com.android.support"
     }


### PR DESCRIPTION
Fixes #2431. This tiny PR updates the WordPress-Utils lib hash to fix the crash issue when displaying product description with a null img tag.

#### To test 
- Set the description of a product to `<div><img /></div>` in `wp-admin`.
- Click on the product from the app.
- Notice the app crashes.
- Pull changes from this PR and notice the app no longer crashes.

This PR is in draft since this [WordPress-Utils-Android PR ](https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/29) needs to be merged and the version should be updated. 

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
