### PR TITLE
issue/2393-tracking-date-cut-off

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_add_shipment_tracking.xml
+++ b/WooCommerce/src/main/res/layout/fragment_add_shipment_tracking.xml
@@ -109,7 +109,7 @@
             <com.google.android.material.textfield.TextInputLayout
                 style="@style/Woo.TextInputLayout"
                 android:layout_marginTop="@dimen/minor_00"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="?attr/selectableItemBackground"
                 android:hint="@string/order_shipment_tracking_date_label"


### PR DESCRIPTION
Fixes #2393 - this tiny PR enlarges the date field on the "Add tracking screen" so long dates don't get cut off.


### Before

![before](https://user-images.githubusercontent.com/3903757/82250831-3247ff00-991a-11ea-9c69-82cbe99f2f0e.png)

### After

![after](https://user-images.githubusercontent.com/3903757/82250847-38d67680-991a-11ea-93ce-ddb9a85f9717.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
