### PR TITLE
Merge 4.3 code freeze to develop

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,9 +1,6 @@
 4.4
 -----
  
-4.4
------
-* Fixes text color on support ticket views for dark mode
 
 4.3
 -----
@@ -15,6 +12,7 @@
 * All orders tab now displays future-dated orders
 * Fixed crash in order detail after returning from the refund screen
 * You can now filter and sort Products by clicking on the Products tab!
+* Fixes text color on support ticket views for dark mode
  
 4.2
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,8 @@
 4.4
 -----
+ 
+4.4
+-----
 * Fixes text color on support ticket views for dark mode
 
 4.3

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -47,9 +47,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "4.2"
+            versionName "4.3-rc-1"
         }
-        versionCode 127
+        versionCode 128
 
         minSdkVersion 21
         targetSdkVersion 29


### PR DESCRIPTION
This PR incorrectly shows changes in `BasePresenter.kt` and `OrderDetailPresenter.kt`, this seems to be an issue in Github as these changes don't show up locally. It is incorrect because #2441 was merged to `develop` before it was merged to `release/4.3`, so not sure what the problem is.

@AmandaRiu Do you mind reviewing this PR since you're familiar with it?