### PR TITLE
issue/2233-fix-cursor-position-product-title

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.4
 -----
 * Fixes text color on support ticket views for dark mode
+* Adds a fix to retain the cursor position when updating product title
 
 4.3
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyEditableView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyEditableView.kt
@@ -23,7 +23,7 @@ class WCProductPropertyEditableView @JvmOverloads constructor(
     fun show(hint: String, detail: String?, isFocused: Boolean) {
         editableText.hint = hint
 
-        if (!detail.isNullOrEmpty()) {
+        if (!detail.isNullOrEmpty() && detail != editableText.text.toString()) {
             editableText.setText(detail)
             editableText.setSelection(detail.length)
         }


### PR DESCRIPTION
Fixes #2233. 

I noticed that when the product title `EditText` is updated, the `productDraft` model in `ProductDetailViewModel` is updated, which in turn updates the product title `EditText` again. This isn't really necessary and is the reason the cursor position is reset to the end of the product title. This tiny PR fixes this by only updating the product title UI if the current text does not match the updated text.

#### To text
- Open product detail
- Tap in the middle of the product name
- Type a letter
- Notice that the cursor jumps to the end of the product title.
- Pull changes from this PR and follow the above steps again and notice that the cursor position is maintained.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
