### PR TITLE
issue/2455-sentry-additional-data

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -50,6 +50,7 @@ import com.woocommerce.android.ui.orders.list.OrderListFragment
 import com.woocommerce.android.ui.prefs.AppSettingsActivity
 import com.woocommerce.android.ui.reviews.ReviewDetailFragmentDirections
 import com.woocommerce.android.ui.sitepicker.SitePickerActivity
+import com.woocommerce.android.util.CrashUtils
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
 import com.woocommerce.android.widgets.AppRatingDialog
@@ -164,10 +165,9 @@ class MainActivity : AppUpgradeActivity(),
             return
         }
 
-        // we only have to check the new revenue stats availability
-        // if the activity is starting for the first time
         if (savedInstanceState == null) {
             fetchRevenueStatsAvailability(selectedSite.get())
+            CrashUtils.setCurrentSite(selectedSite.get())
         }
 
         initFragment(savedInstanceState)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CrashUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CrashUtils.kt
@@ -3,26 +3,24 @@ package com.woocommerce.android.util
 import android.content.Context
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
-import com.woocommerce.android.AppPrefs
-import com.woocommerce.android.util.WooLog.T
-import org.wordpress.android.fluxc.model.AccountModel
-import org.wordpress.android.fluxc.model.SiteModel
-
 import com.automattic.android.tracks.CrashLogging.CrashLogging
 import com.automattic.android.tracks.CrashLogging.CrashLoggingDataProvider
 import com.automattic.android.tracks.TracksUser
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig
+import com.woocommerce.android.util.WooLog.T
+import org.wordpress.android.fluxc.model.AccountModel
+import org.wordpress.android.fluxc.model.SiteModel
 import java.util.Locale
 
 object CrashUtils : CrashLoggingDataProvider {
     private const val TAG_KEY = "tag"
     private const val MESSAGE_KEY = "message"
     private const val SITE_ID_KEY = "site_id"
-    private const val SITE_URL_KEY = "site_url"
 
     private var locale: Locale? = null
     private var currentAccount: AccountModel? = null
-    private var currentSite: SiteModel? = null
+    private var currentSiteId: Long? = null
     private var isInitialized = false
 
     fun initCrashLogging(context: Context) {
@@ -43,24 +41,22 @@ object CrashUtils : CrashLoggingDataProvider {
     }
 
     fun setCurrentSite(site: SiteModel?) {
-        this.currentSite = site
+        this.currentSiteId = site?.siteId
         CrashLogging.setNeedsDataRefresh()
     }
 
     fun resetAccountAndSite() {
         this.currentAccount = null
-        this.currentSite = null
+        this.currentSiteId = null
 
         CrashLogging.setNeedsDataRefresh()
     }
 
     override fun applicationContext(): MutableMap<String, Any> {
-        val siteID = this.currentSite?.siteId ?: 0
-        val siteURL = this.currentSite?.url ?: ""
+        val siteID = this.currentSiteId ?: 0
 
         return mutableMapOf(
-                SITE_ID_KEY to siteID,
-                SITE_URL_KEY to siteURL
+            SITE_ID_KEY to siteID
         )
     }
 


### PR DESCRIPTION
Fixes #2455 - prior to this PR, we were only letting `CrashUtils` know the current site after it was chosen from the site picker. This meant Sentry issues didn't include that helpful bit of info. This PR addresses it by telling `CrashUtils` the site at startup.

Also, after a discussion with @jkmassel, we decided to pass only the siteID and not the URL.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
