### PR TITLE
Issue/2449 Fix OutOfMemoryError crashes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -15,6 +15,7 @@
 * Fixed crash in order detail after returning from the refund screen
 * You can now filter and sort Products by clicking on the Products tab!
 * Fixes text color on support ticket views for dark mode
+* Fixed crash happening on Android 5.1 caused by new dynamic theme
  
 4.2
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.4
 -----
 * Fixes text color on support ticket views for dark mode
+* Adds a fix to retain the cursor position when updating product title
 
 4.3
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * Fixes text color on support ticket views for dark mode
 * Adds a fix to retain the cursor position when updating product title
+* Fixed a potential memory leak
 
 4.3
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -82,7 +82,7 @@ class DashboardStatsView @JvmOverloads constructor(
     private var skeletonView = SkeletonView()
 
     private lateinit var lastUpdatedRunnable: Runnable
-    private var lastUpdatedHandler: Handler? = null
+    private val lastUpdatedHandler = Handler()
     private var lastUpdated: Date? = null
 
     private var isRequestingStats = false
@@ -144,20 +144,20 @@ class DashboardStatsView @JvmOverloads constructor(
 
         initChart()
 
-        lastUpdatedHandler = Handler()
         lastUpdatedRunnable = Runnable {
             updateRecencyMessage()
-            lastUpdatedHandler?.postDelayed(lastUpdatedRunnable, UPDATE_DELAY_TIME_MS)
+            lastUpdatedHandler.postDelayed(lastUpdatedRunnable, UPDATE_DELAY_TIME_MS)
         }
     }
 
-    override fun onVisibilityChanged(changedView: View, visibility: Int) {
-        super.onVisibilityChanged(changedView, visibility)
-        if (visibility == View.VISIBLE) {
-            updateRecencyMessage()
-        } else {
-            lastUpdatedHandler?.removeCallbacks(lastUpdatedRunnable)
-        }
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        updateRecencyMessage()
+    }
+
+    override fun onDetachedFromWindow() {
+        lastUpdatedHandler.removeCallbacks(lastUpdatedRunnable)
+        super.onDetachedFromWindow()
     }
 
     fun showSkeleton(show: Boolean) {
@@ -548,10 +548,10 @@ class DashboardStatsView @JvmOverloads constructor(
 
     private fun updateRecencyMessage() {
         dashboard_recency_text.text = getRecencyMessage()
-        lastUpdatedHandler?.removeCallbacks(lastUpdatedRunnable)
+        lastUpdatedHandler.removeCallbacks(lastUpdatedRunnable)
 
         if (lastUpdated != null) {
-            lastUpdatedHandler?.postDelayed(lastUpdatedRunnable, UPDATE_DELAY_TIME_MS)
+            lastUpdatedHandler.postDelayed(lastUpdatedRunnable, UPDATE_DELAY_TIME_MS)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -112,6 +112,7 @@ class MainActivity : AppUpgradeActivity(),
     private var isBottomNavShowing = true
     private var previousDestinationId: Int? = null
     private var unfilledOrderCount: Int = 0
+    private var isMainThemeApplied = false
 
     private lateinit var bottomNavView: MainBottomNavigationView
     private lateinit var navController: NavController
@@ -125,7 +126,14 @@ class MainActivity : AppUpgradeActivity(),
      * use this theme at runtime (in the case of switching the theme at runtime).
      */
     override fun getTheme(): Theme {
-        return super.getTheme().also { it.applyStyle(R.style.Theme_Woo_DayNight, true) }
+        return super.getTheme().also {
+            // Since applying the theme overwrites all theme properties and then applies,
+            // we only want to do this once per session to avoid unnecessary GC as well as
+            // OOM crashes in older versions of Android.
+            if (!isMainThemeApplied) {
+                it.applyStyle(R.style.Theme_Woo_DayNight, true)
+                isMainThemeApplied = true
+            } }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -494,8 +494,6 @@ class MainActivity : AppUpgradeActivity(),
      * Called when the user switches sites - restarts the activity so all fragments and child fragments are reset
      */
     private fun restart() {
-        bottomNavView.removeFragments()
-
         val intent = intent
         intent.addFlags(
                 Intent.FLAG_ACTIVITY_CLEAR_TOP or

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -494,7 +494,7 @@ class MainActivity : AppUpgradeActivity(),
      * Called when the user switches sites - restarts the activity so all fragments and child fragments are reset
      */
     private fun restart() {
-        bottomNavView.reset()
+        bottomNavView.removeFragments()
 
         val intent = intent
         intent.addFlags(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -494,6 +494,8 @@ class MainActivity : AppUpgradeActivity(),
      * Called when the user switches sites - restarts the activity so all fragments and child fragments are reset
      */
     private fun restart() {
+        bottomNavView.reset()
+
         val intent = intent
         intent.addFlags(
                 Intent.FLAG_ACTIVITY_CLEAR_TOP or

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -69,18 +69,6 @@ class MainBottomNavigationView @JvmOverloads constructor(
     }
 
     /**
-     * Removes all the fragments - this is necessary to avoid leaks when the main activity
-     * is restarted after changing the selected site
-     */
-    fun removeFragments() {
-        val ft = fragmentManager.beginTransaction()
-        for (fragment in fragmentManager.fragments) {
-            ft.remove(fragment)
-        }
-        ft.commitNow()
-    }
-
-    /**
      * When we changed the background to white, the top shadow provided by BottomNavigationView wasn't
      * dark enough to provide enough separation between the bar and the content above it. For this
      * reason we add a darker top divider here.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -29,10 +29,9 @@ class MainBottomNavigationView @JvmOverloads constructor(
         OnNavigationItemSelectedListener, OnNavigationItemReselectedListener {
     private lateinit var navAdapter: NavAdapter
     private lateinit var fragmentManager: FragmentManager
+    private lateinit var listener: MainNavigationListener
     private lateinit var ordersBadge: BadgeDrawable
     private lateinit var reviewsBadge: BadgeDrawable
-
-    private var listener: MainNavigationListener? = null
 
     companion object {
         private var previousNavPos: BottomNavigationPosition? = null
@@ -47,7 +46,7 @@ class MainBottomNavigationView @JvmOverloads constructor(
         get() = findNavigationPositionById(selectedItemId)
         set(navPos) = updateCurrentPosition(navPos)
 
-    fun init(fm: FragmentManager, listener: MainNavigationListener?) {
+    fun init(fm: FragmentManager, listener: MainNavigationListener) {
         this.fragmentManager = fm
         this.listener = listener
 
@@ -177,13 +176,13 @@ class MainBottomNavigationView @JvmOverloads constructor(
         val navPos = findNavigationPositionById(item.itemId)
         currentPosition = navPos
 
-        listener?.onNavItemSelected(navPos)
+        listener.onNavItemSelected(navPos)
         return true
     }
 
     override fun onNavigationItemReselected(item: MenuItem) {
         val navPos = findNavigationPositionById(item.itemId)
-        listener?.onNavItemReselected(navPos)
+        listener.onNavItemReselected(navPos)
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -70,9 +70,10 @@ class MainBottomNavigationView @JvmOverloads constructor(
     }
 
     /**
-     * Resets the fragment manager by removing all the fragments
+     * Removes all the fragments - this is necessary to avoid leaks when the main activity
+     * is restarted after changing the selected site
      */
-    fun reset() {
+    fun removeFragments() {
         val ft = fragmentManager.beginTransaction()
         for (fragment in fragmentManager.fragments) {
             ft.remove(fragment)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -29,9 +29,10 @@ class MainBottomNavigationView @JvmOverloads constructor(
         OnNavigationItemSelectedListener, OnNavigationItemReselectedListener {
     private lateinit var navAdapter: NavAdapter
     private lateinit var fragmentManager: FragmentManager
-    private lateinit var listener: MainNavigationListener
     private lateinit var ordersBadge: BadgeDrawable
     private lateinit var reviewsBadge: BadgeDrawable
+
+    private var listener: MainNavigationListener? = null
 
     companion object {
         private var previousNavPos: BottomNavigationPosition? = null
@@ -46,7 +47,7 @@ class MainBottomNavigationView @JvmOverloads constructor(
         get() = findNavigationPositionById(selectedItemId)
         set(navPos) = updateCurrentPosition(navPos)
 
-    fun init(fm: FragmentManager, listener: MainNavigationListener) {
+    fun init(fm: FragmentManager, listener: MainNavigationListener?) {
         this.fragmentManager = fm
         this.listener = listener
 
@@ -66,6 +67,17 @@ class MainBottomNavigationView @JvmOverloads constructor(
 
         // Default to the dashboard position
         active(DASHBOARD.position)
+    }
+
+    /**
+     * Resets the fragment manager by removing all the fragments
+     */
+    fun reset() {
+        val ft = fragmentManager.beginTransaction()
+        for (fragment in fragmentManager.fragments) {
+            ft.remove(fragment)
+        }
+        ft.commitNow()
     }
 
     /**
@@ -164,13 +176,13 @@ class MainBottomNavigationView @JvmOverloads constructor(
         val navPos = findNavigationPositionById(item.itemId)
         currentPosition = navPos
 
-        listener.onNavItemSelected(navPos)
+        listener?.onNavItemSelected(navPos)
         return true
     }
 
     override fun onNavigationItemReselected(item: MenuItem) {
         val navPos = findNavigationPositionById(item.itemId)
-        listener.onNavItemReselected(navPos)
+        listener?.onNavItemReselected(navPos)
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyEditableView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyEditableView.kt
@@ -23,7 +23,7 @@ class WCProductPropertyEditableView @JvmOverloads constructor(
     fun show(hint: String, detail: String?, isFocused: Boolean) {
         editableText.hint = hint
 
-        if (!detail.isNullOrEmpty()) {
+        if (!detail.isNullOrEmpty() && detail != editableText.text.toString()) {
             editableText.setText(detail)
             editableText.setSelection(detail.length)
         }

--- a/WooCommerce/src/main/res/layout/fragment_add_shipment_tracking.xml
+++ b/WooCommerce/src/main/res/layout/fragment_add_shipment_tracking.xml
@@ -109,7 +109,7 @@
             <com.google.android.material.textfield.TextInputLayout
                 style="@style/Woo.TextInputLayout"
                 android:layout_marginTop="@dimen/minor_00"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="?attr/selectableItemBackground"
                 android:hint="@string/order_shipment_tracking_date_label"


### PR DESCRIPTION
Fixes #2449 by only forcing the `DayNight` theme in `MainActivity` once per session.

**NOTE: Targeting the 4.3 release branch since this bug would effectively make the app useless for users using Android 5.1**

The actual cause of the crash in the ticket is an `OutOfMemoryError` caused by the new logic that applies the `DayNight` theme in the `MainActivity` to allow for displaying a splash screen while the main activity loads:

```
override fun getTheme(): Theme {
    return super.getTheme().also { it.applyStyle(R.style.Theme_Woo_DayNight, true) }
}
```

This is because every time a new view is loaded that `getTheme()` method is called and this was leading to a TON of overhead as the current theme was completely overwritten and applied over and over again for every view rendered. This led to eventual OOM crashes on Android 5.1 and heavy GC in all versions of Android.

This crash can be reproduced on an android emulator running API 5.1 w/ 512 MB of RAM. Load the `develop` branch and then:
1. Navigate to the orders list
2. Click on an order to view the detail
3. Click back to return to the orders list
4. Repeat steps 2 and 3 until the app crashes (took me about 15 orders to crash)

The fix was to ensure this theme is only applied once per session. 

## To Test
- Try the same steps outlined above to verify the issue is fixed.
- Also verify the correct light/dark theme loads throughout the app across configuration changes (API 21 and API 28, 29)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

cc: @oguzkocer 
