### PR TITLE
Hotfix: OutOfMemory crashes - Take 2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -111,6 +111,7 @@ class MainActivity : AppUpgradeActivity(),
     private var isBottomNavShowing = true
     private var previousDestinationId: Int? = null
     private var unfilledOrderCount: Int = 0
+    private var isMainThemeApplied = false
 
     private lateinit var bottomNavView: MainBottomNavigationView
     private lateinit var navController: NavController
@@ -124,7 +125,14 @@ class MainActivity : AppUpgradeActivity(),
      * use this theme at runtime (in the case of switching the theme at runtime).
      */
     override fun getTheme(): Theme {
-        return super.getTheme().also { it.applyStyle(R.style.Theme_Woo_DayNight, true) }
+        return super.getTheme().also {
+            // Since applying the theme overwrites all theme properties and then applies,
+            // we only want to do this once per session to avoid unnecessary GC as well as
+            // OOM crashes in older versions of Android.
+            if (!isMainThemeApplied) {
+                it.applyStyle(R.style.Theme_Woo_DayNight, true)
+                isMainThemeApplied = true
+            } }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
_This is the second attempt to release a hotfix for these crashes. The first PR didn't get released as it was [found to have issues during the final testing before release](https://github.com/woocommerce/woocommerce-android/pull/2460#issuecomment-631719718)._ 

Fixes #2449 and #2417 by only force applying the `DayNight` theme in `MainActivity` once per session.

**Note:** Sentry has a bunch of `OutOfMemory` crash events logged with stacktraces showing the crash happening in different areas of the app, but you'll know if the crash is related to this fix if you see `MainActivity.getTheme(...)` in the stack dump. 

**This is being submitted as a hotfix because this bug essentially breaks the app for users running Android Lollipop, as well as crashes and poor performance on newer versions of Android.** 

The actual cause of the crash in the ticket is an `OutOfMemoryError` caused by the new logic that applies the `DayNight` theme in the `MainActivity` to allow for displaying a splash screen while the main activity loads:

```
override fun getTheme(): Theme {
    return super.getTheme().also { it.applyStyle(R.style.Theme_Woo_DayNight, true) }
}
```

Every time a new view is loaded the above `getTheme()` method is called and this was leading to a TON of overhead as the current theme was completely overwritten and applied over and over again for _every view rendered_. This led to eventual OOM crashes on Android 5.1 and heavy GC and possible crashes in all versions of Android.

This crash can be reproduced on an android emulator running API 5.1 w/ 512 MB of RAM. Load the previous version of the app and then:
1. Navigate to the orders list
2. Click on an order to view the detail
3. Click back to return to the orders list
4. Repeat steps 2 and 3 until the app crashes (took me about 15 orders to crash)

The fix was to ensure this theme is only applied once per session: 
```
if (!isMainThemeApplied) {
    it.applyStyle(R.style.Theme_Woo_DayNight, true)
    isMainThemeApplied = true
} }
```

## To Test
- Try the same steps outlined above to verify the issue is fixed.
- Also verify the correct light/dark theme loads throughout the app across configuration changes (API 21 and API 28, 29)
- Follow these steps to ensure the theme doesn't revert like it did [in the previous PR](https://github.com/woocommerce/woocommerce-android/pull/2460#issuecomment-631719718):
     1. log into the app
     2. click on the orders tab
     3. while the orders are loading, rotate the device - verify theme is correct
     4. rotate again and verify theme is still correct. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

cc: @oguzkocer 
