### PR TITLE
Build instrumentation tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ orbs:
 version: 2.1
 jobs:
   Lint:
-    executor: 
+    executor:
       name: android/default
       api-version: "28"
     steps:
@@ -33,14 +33,14 @@ jobs:
               ./gradlew violationCommentsToGitHub -DGITHUB_PULLREQUESTID=${CIRCLE_PULL_REQUEST##*/} -DGITHUB_OAUTH2TOKEN=$GITHUB_API_TOKEN
             else
               echo "Not posting lint errors to Github because \$GITHUB_API_TOKEN is not found"
-            fi 
+            fi
       - android/save-gradle-cache:
           cache-prefix: lint-cache-v1
       - store_artifacts:
           path: WooCommerce/build/reports
           destination: reports
   Test:
-    executor: 
+    executor:
       name: android/default
       api-version: "28"
     steps:
@@ -55,7 +55,7 @@ jobs:
           cache-prefix: tests-cache-v1
       - android/save-test-results
   Installable Build:
-    executor: 
+    executor:
       name: android/default
       api-version: "28"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,19 @@ jobs:
       - android/save-gradle-cache:
           cache-prefix: tests-cache-v1
       - android/save-test-results
+      - run:
+          # The instrumentation tests are not currently used and do tend to get
+          # out of date when the UI changes, failing to build.
+          #
+          # This is a problem for the screenshots automation, which depends on
+          # those tests.
+          #
+          # This check lets developers know when they accidentally broke the
+          # instrumentation tests build, giving them a chance to either fix the
+          # build or remove the broken tests if they are now obsolete.
+          name: Check instrumentation tests build
+          command: ./gradlew --stacktrace assembleVanillaDebugAndroidTest
+
   Installable Build:
     executor:
       name: android/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,15 @@ jobs:
       - android/save-gradle-cache:
           cache-prefix: tests-cache-v1
       - android/save-test-results
+  Ensure Screenshots Tests Build:
+    executor:
+      name: android/default
+      api-version: "28"
+    steps:
+      - checkout
+      - android/restore-gradle-cache:
+          cache-prefix: tests-cache-v1
+      - <<: *copy_gradle_properties
       - run:
           # The instrumentation tests are not currently used and do tend to get
           # out of date when the UI changes, failing to build.
@@ -106,3 +115,4 @@ workflows:
       - Lint
       - Test
       - Installable Build
+      - Ensure Screenshots Tests Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
           # instrumentation tests build, giving them a chance to either fix the
           # build or remove the broken tests if they are now obsolete.
           name: Check instrumentation tests build
-          command: ./gradlew --stacktrace assembleVanillaDebugAndroidTest
+          command: ./gradlew assembleVanillaDebugAndroidTest
 
   Installable Build:
     executor:

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,3 +2,6 @@
 max_line_length=120
 indent_style=space
 indent_size=4
+
+[*.yml]
+trim_trailing_whitespace=true

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -32,6 +32,10 @@ wc.zendesk.domain = http://www.google.com/
 wc.zendesk.oauth_client_id = woocommerce
 wc.sentry.dsn = https://00000000000000000000000000000000@sentry.io/0000000
 
+wc.screenshots.url = example.com
+wc.screenshots.username = user@example.com
+wc.screenshots.password = password
+
 # The type of in app update FLEXIBLE = 0; IMMEDIATE = 1
 wc.in_app_update_type = 0
 


### PR DESCRIPTION
### Suggestion

Build the instrumentation tests in CI to learn when they break faster.

<img width="1528" alt="Screen Shot 2020-05-21 at 8 18 53 pm" src="https://user-images.githubusercontent.com/1218433/82549470-5288ef80-9ba0-11ea-9102-520082e7eac8.png">

### Context

While working on the screenshots automation, the test script for which lives in `androidTest`, I've bumped a few times into broken builds due to changes that made it into the base branch while my PRs were waiting for review.

I'd like to add a step in CI to build the instrumentation tests, so that if something in a PR breaks them, we can discover it earlier and either fix the test or make the call to remove it because it's obsolete.

I think the person whose change break the tests is the one in the best position to fix them, because they'll have context on the change ready at hand.

### Possible alternative

If the team feels this is too much of a burden, or that those tests are a lost cause I could take care of:

- Moving the screenshots test in a dedicated module (is module the right term?), so that they don't need `androidTest` to build; or
- Leave the screenshots tests where they are, but remove all the tests we don't care about anymore.

### Feedback please 🙏 

There are two things I don't like:

- It's by far the slowest step in the build, which is no good, builds should be as fast as possible. _Suggestion:_ maybe this step should only run on `develop`? Slower feedback loop to learn if the tests are broken, but overall faster feedback loop while working on the PR
- The output doesn't show the failure reason clearly. _Can you point me towards how to make this better?_

---

Note that CI is failing right now. Once #2465 will be merged into the base branch and picked here, the build will pass. I've done this intentionally to show how a real world failure would look like.


---

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.