### PR TITLE
Fix new build failures in androidTest

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentProductListCardTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentProductListCardTest.kt
@@ -144,17 +144,17 @@ class OrderFulfillmentProductListCardTest : TestBase() {
         redirectToOrderFulfillment()
 
         // verify that the product total is displayed correctly for multiple quantities
-        // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
+        // for single quantity: getString( R.string.orderdetail_product_lineitem_qty_and_price, orderTotal)
         onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
-                        R.string.orderdetail_product_lineitem_total_single,
+                        R.string.orderdetail_product_lineitem_qty_and_price,
                         "$${mockWCOrderModel.getLineItemList()[0].total}.00"
                 ))))
 
         // for multiple quantities: $13.00 ($11.00x2)
         onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
-                        R.string.orderdetail_product_lineitem_total_multiple,
+                        R.string.orderdetail_product_lineitem_qty_and_price,
                         "$${mockWCOrderModel.getLineItemList()[1].total}.00",
                         "$${mockWCOrderModel.getLineItemList()[1].price}.00",
                         mockWCOrderModel.getLineItemList()[1].quantity?.toInt().toString()
@@ -182,17 +182,17 @@ class OrderFulfillmentProductListCardTest : TestBase() {
         redirectToOrderFulfillment()
 
         // verify that the product total is displayed correctly for multiple quantities
-        // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
+        // for single quantity: getString( R.string.orderdetail_product_lineitem_qty_and_price, orderTotal)
         onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
-                        R.string.orderdetail_product_lineitem_total_single,
+                        R.string.orderdetail_product_lineitem_qty_and_price,
                         "€${mockWCOrderModel.getLineItemList()[0].total}.00"
                 ))))
 
         // for multiple quantities: €13.00 (€11.00x2)
         onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
-                        R.string.orderdetail_product_lineitem_total_multiple,
+                        R.string.orderdetail_product_lineitem_qty_and_price,
                         "€${mockWCOrderModel.getLineItemList()[1].total}.00",
                         "€${mockWCOrderModel.getLineItemList()[1].price}.00",
                         mockWCOrderModel.getLineItemList()[1].quantity?.toInt().toString()
@@ -220,17 +220,17 @@ class OrderFulfillmentProductListCardTest : TestBase() {
         redirectToOrderFulfillment()
 
         // verify that the product total is displayed correctly for multiple quantities
-        // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
+        // for single quantity: getString( R.string.orderdetail_product_lineitem_qty_and_price, orderTotal)
         onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
-                        R.string.orderdetail_product_lineitem_total_single,
+                        R.string.orderdetail_product_lineitem_qty_and_price,
                         "₹${mockWCOrderModel.getLineItemList()[0].total}.00"
                 ))))
 
         // for multiple quantities: ₹13.00 (₹11.00x2)
         onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
-                        R.string.orderdetail_product_lineitem_total_multiple,
+                        R.string.orderdetail_product_lineitem_qty_and_price,
                         "₹${mockWCOrderModel.getLineItemList()[1].total}.00",
                         "₹${mockWCOrderModel.getLineItemList()[1].price}.00",
                         mockWCOrderModel.getLineItemList()[1].quantity?.toInt().toString()
@@ -258,17 +258,17 @@ class OrderFulfillmentProductListCardTest : TestBase() {
         redirectToOrderFulfillment()
 
         // verify that the product total is displayed correctly for multiple quantities
-        // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
+        // for single quantity: getString( R.string.orderdetail_product_lineitem_qty_and_price, orderTotal)
         onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
-                        R.string.orderdetail_product_lineitem_total_single,
+                        R.string.orderdetail_product_lineitem_qty_and_price,
                         "A$${mockWCOrderModel.getLineItemList()[0].total}.00"
                 ))))
 
         // for multiple quantities: A$13.00 (A$11.00x2)
         onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
-                        R.string.orderdetail_product_lineitem_total_multiple,
+                        R.string.orderdetail_product_lineitem_qty_and_price,
                         "A\$${mockWCOrderModel.getLineItemList()[1].total}.00",
                         "A\$${mockWCOrderModel.getLineItemList()[1].price}.00",
                         mockWCOrderModel.getLineItemList()[1].quantity?.toInt().toString()

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/ProductListCardTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/products/ProductListCardTest.kt
@@ -142,17 +142,17 @@ class ProductListCardTest : TestBase() {
         onView(withId(R.id.productList_btnDetails)).perform(scrollTo(), click())
 
         // verify that the product total is displayed correctly for multiple quantities
-        // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
+        // for single quantity: getString( R.string.orderdetail_product_lineitem_qty_and_price, orderTotal)
         onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
-                        R.string.orderdetail_product_lineitem_total_single,
+                        R.string.orderdetail_product_lineitem_qty_and_price,
                         "$${mockWCOrderModel.getLineItemList()[0].total}.00"
                 ))))
 
         // for multiple quantities: $13.00 ($11.00x2)
         onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
-                        R.string.orderdetail_product_lineitem_total_multiple,
+                        R.string.orderdetail_product_lineitem_qty_and_price,
                         "$${mockWCOrderModel.getLineItemList()[1].total}.00",
                         "$${mockWCOrderModel.getLineItemList()[1].price}.00",
                         mockWCOrderModel.getLineItemList()[1].quantity?.toInt().toString()
@@ -183,17 +183,17 @@ class ProductListCardTest : TestBase() {
         onView(withId(R.id.productList_btnDetails)).perform(scrollTo(), click())
 
         // verify that the product total is displayed correctly for multiple quantities
-        // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
+        // for single quantity: getString( R.string.orderdetail_product_lineitem_qty_and_price, orderTotal)
         onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
-                        R.string.orderdetail_product_lineitem_total_single,
+                        R.string.orderdetail_product_lineitem_qty_and_price,
                         "€${mockWCOrderModel.getLineItemList()[0].total}.00"
                 ))))
 
         // for multiple quantities: €13.00 (€11.00x2)
         onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
-                        R.string.orderdetail_product_lineitem_total_multiple,
+                        R.string.orderdetail_product_lineitem_qty_and_price,
                         "€${mockWCOrderModel.getLineItemList()[1].total}.00",
                         "€${mockWCOrderModel.getLineItemList()[1].price}.00",
                         mockWCOrderModel.getLineItemList()[1].quantity?.toInt().toString()
@@ -224,17 +224,17 @@ class ProductListCardTest : TestBase() {
         onView(withId(R.id.productList_btnDetails)).perform(scrollTo(), click())
 
         // verify that the product total is displayed correctly for multiple quantities
-        // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
+        // for single quantity: getString( R.string.orderdetail_product_lineitem_qty_and_price, orderTotal)
         onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
-                        R.string.orderdetail_product_lineitem_total_single,
+                        R.string.orderdetail_product_lineitem_qty_and_price,
                         "₹${mockWCOrderModel.getLineItemList()[0].total}.00"
                 ))))
 
         // for multiple quantities: ₹13.00 (₹11.00x2)
         onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
-                        R.string.orderdetail_product_lineitem_total_multiple,
+                        R.string.orderdetail_product_lineitem_qty_and_price,
                         "₹${mockWCOrderModel.getLineItemList()[1].total}.00",
                         "₹${mockWCOrderModel.getLineItemList()[1].price}.00",
                         mockWCOrderModel.getLineItemList()[1].quantity?.toInt().toString()
@@ -265,17 +265,17 @@ class ProductListCardTest : TestBase() {
         onView(withId(R.id.productList_btnDetails)).perform(scrollTo(), click())
 
         // verify that the product total is displayed correctly for multiple quantities
-        // for single quantity: getString( R.string.orderdetail_product_lineitem_total_single, orderTotal)
+        // for single quantity: getString( R.string.orderdetail_product_lineitem_qty_and_price, orderTotal)
         onView(withRecyclerView(R.id.productList_products).atPositionOnView(0, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
-                        R.string.orderdetail_product_lineitem_total_single,
+                        R.string.orderdetail_product_lineitem_qty_and_price,
                         "A$${mockWCOrderModel.getLineItemList()[0].total}.00"
                 ))))
 
         // for multiple quantities: A$13.00 (A$11.00x2)
         onView(withRecyclerView(R.id.productList_products).atPositionOnView(1, R.id.productInfo_productQtyAndPrice))
                 .check(matches(withText(appContext.getString(
-                        R.string.orderdetail_product_lineitem_total_multiple,
+                        R.string.orderdetail_product_lineitem_qty_and_price,
                         "A\$${mockWCOrderModel.getLineItemList()[1].total}.00",
                         "A\$${mockWCOrderModel.getLineItemList()[1].price}.00",
                         mockWCOrderModel.getLineItemList()[1].quantity?.toInt().toString()


### PR DESCRIPTION
I run a Git bisect and it identified 3463bbe58 as the breaking commit.

I'm not sure whether that's correct or not. Going by the diffs only, I would have said 269129e49 is the culprit.

Regardless, the tests now _build_ but they don't pass. I didn't spend time fixing them because the whole test suite doesn't get run anymore and as a team we're still trying to figure out what to do with it, whether to keep it and fix the issues, get rid of it, or something in between.

### To test

Run `./gradlew assembleVanillaDebugAndroidTest` on `develop` and you'll see it fails. Run it here and you'll see it passes.

---

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.