### PR TITLE
issue/2467-wpmedia-null-url

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaPickerRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaPickerRepository.kt
@@ -69,7 +69,21 @@ class WPMediaPickerRepository @Inject constructor(
     /**
      * Returns all media for the current site that are in the database
      */
-    fun getSiteMediaList(): List<Product.Image> = mediaStore.getSiteImages(selectedSite.get()).map { it.toAppModel() }
+    fun getSiteMediaList(): List<Product.Image> {
+        val mediaList = mediaStore.getSiteImages(selectedSite.get())
+        val imageList = ArrayList<Product.Image>()
+
+        for (media in mediaList) {
+            // skip media with empty URLs - these are media that are still being uploaded
+            if (media.url.isNullOrEmpty()) {
+                WooLog.w(WooLog.T.MEDIA, "Empty media url")
+            } else {
+                imageList.add(media.toAppModel())
+            }
+        }
+
+        return imageList
+    }
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)


### PR DESCRIPTION
Fixes #2467 - the crash was happening because media that are still uploading have a null URL assigned to them, and our app requires non-null URLs so it crashed. The fix was to skip these uploading media when returning or list of images, since we don't want to show uploading media in the picker.

To test:

- Tap to add a product image
- Choose to add it by taking picture
- Immediately after - and while that image is still uploading - tap again to add an image and choose the WP media library
- Verify the app doesn't crash and there's no placeholder for the uploading image

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
