### PR TITLE
Issue/2469 no done for uploading images

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -225,8 +225,10 @@ class ProductImagesService : JobIntentService() {
                 handleSuccess(event.media)
             } else -> {
                 // otherwise this is an upload progress event
-                val progress = (event.progress * 100).toInt()
-                notifHandler.setProgress(progress)
+                if (!isCancelled) {
+                    val progress = (event.progress * 100).toInt()
+                    notifHandler.setProgress(progress)
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -258,6 +258,11 @@ class ProductImagesService : JobIntentService() {
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: OnUploadCancelled) {
         notifHandler.remove()
+        doneSignal?.let {
+            while (it.count > 0) {
+                it.countDown()
+            }
+        }
 
         currentMediaUpload?.let {
             val payload = CancelMediaPayload(selectedSite.get(), it, true)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -190,13 +190,12 @@ class ProductImagesService : JobIntentService() {
         if (isCancelled) {
             currentUploads.clear()
         } else {
+            notifHandler.remove()
             currentUploads.remove(remoteProductId)
             productImageMap.remove(remoteProductId)
         }
 
         currentMediaUpload = null
-        notifHandler.remove()
-
         EventBus.getDefault().post(OnProductImagesUpdateCompletedEvent(remoteProductId, isCancelled))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -74,8 +74,7 @@ class ProductImagesService : JobIntentService() {
 
         /**
          * A JobIntentService can't truly be cancelled, but we can at least set a flag that tells it
-         * to stop continuing its work. Note that the upload notification may appear for a short
-         * time after cancellation, but it will disappear at the next upload progress event.
+         * to stop continuing its work when the current task is done
          */
         fun cancel() {
             isCancelled = true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -412,14 +412,18 @@ class ProductDetailViewModel @AssistedInject constructor(
                     }
             ))
             return false
-        } else if (event is ExitImages && isUploadingImages) {
+        } else if ((event is ExitProductDetail || event is ExitImages) && isUploadingImages) {
             // images can't be assigned to the product until they finish uploading so ask whether
             // to discard the uploading images
             triggerEvent(ShowDiscardDialog(
                     messageId = string.discard_images_message,
                     positiveBtnAction = DialogInterface.OnClickListener { _, _ ->
                         ProductImagesService.cancel()
-                        triggerEvent(Exit)
+                        if (event is ExitProductDetail) {
+                            triggerEvent(ExitProduct)
+                        } else {
+                            triggerEvent(Exit)
+                        }
                     }
             ))
             return false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -206,7 +206,13 @@ class ProductDetailViewModel @AssistedInject constructor(
 
     fun hasShippingChanges() = viewState.storedProduct?.hasShippingChanges(viewState.productDraft) ?: false
 
-    fun hasImageChanges() = viewState.storedProduct?.hasImageChanges(viewState.productDraft) ?: false
+    fun hasImageChanges(): Boolean {
+        return if (ProductImagesService.isUploadingForProduct(getRemoteProductId())) {
+            true
+        } else {
+            viewState.storedProduct?.hasImageChanges(viewState.productDraft) ?: false
+        }
+    }
 
     fun hasSettingsChanges(): Boolean {
         return if (viewState.storedProduct?.hasSettingsChanges(viewState.productDraft) == true) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -412,18 +412,14 @@ class ProductDetailViewModel @AssistedInject constructor(
                     }
             ))
             return false
-        } else if ((event is ExitProductDetail || event is ExitImages) && isUploadingImages) {
+        } else if (event is ExitImages && isUploadingImages) {
             // images can't be assigned to the product until they finish uploading so ask whether
             // to discard the uploading images
             triggerEvent(ShowDiscardDialog(
                     messageId = string.discard_images_message,
                     positiveBtnAction = DialogInterface.OnClickListener { _, _ ->
                         ProductImagesService.cancel()
-                        if (event is ExitProductDetail) {
-                            triggerEvent(ExitProduct)
-                        } else {
-                            triggerEvent(Exit)
-                        }
+                        triggerEvent(Exit)
                     }
             ))
             return false


### PR DESCRIPTION
Fixes #2469 - Ensures the "Done" button appears in the product images screen, and that the user is asked whether to discard changes, when images are uploading.

I also added logic to cancel the upload if the user choose to discard changes.

To test:

- Choose to add a product image from your device
- While it's uploading, hit the back button
- Choose to discard changes
- Verify the upload is cancelled and the upload notification disappears

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
