### PR TITLE
Added logic to display view product on store menu button only for published products

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -47,6 +47,8 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
     private var progressDialog: CustomProgressDialog? = null
     private var layoutManager: LayoutManager? = null
 
+    private var viewProductOnStoreMenuItem: MenuItem? = null
+
     private val navArgs: ProductDetailFragmentArgs by navArgs()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -137,6 +139,11 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
                 frameStatusBadge.visibility = View.VISIBLE
                 textStatusBadge.text = status.toLocalizedString(requireActivity())
             }
+
+            // display View Product on Store menu button only if the Product status is published,
+            // otherwise the page is redirected to a 404
+            viewProductOnStoreMenuItem?.isVisible = FeatureFlag.PRODUCT_RELEASE_M2.isEnabled() &&
+                status == ProductStatus.PUBLISH
         }
     }
 
@@ -144,7 +151,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         menu.clear()
         inflater.inflate(R.menu.menu_product_detail_fragment, menu)
 
-        menu.findItem(R.id.menu_view_product).isVisible = FeatureFlag.PRODUCT_RELEASE_M2.isEnabled()
+        viewProductOnStoreMenuItem = menu.findItem(R.id.menu_view_product)
         menu.findItem(R.id.menu_product_settings).isVisible = FeatureFlag.PRODUCT_RELEASE_M2.isEnabled()
 
         super.onCreateOptionsMenu(menu, inflater)


### PR DESCRIPTION
Fixes #2471. This tiny PR adds logic to display the `View product in Store` menu button only if the Product status is Published. This is because the product redirects to a 404 page if the status is not published.

#### To test
- Enable Product editing under Settings > Beta features.
- Go to the Products tab.
- Select a draft product to edit it. (If you don't have a draft product, select a product and go to the ellipsis menu > Product settings and change the Status to Draft. Update the product to save the draft status.)
- Go to the ellipsis menu > View product on store.
- Pull changes from this PR and notice that the `View product on Store` is not displayed if the product status is `DRAFT`, `Pending Review` or `Private`.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
