### PR TITLE
Added logic to display keypad when aztec editor is first opened

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/AztecEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/AztecEditorFragment.kt
@@ -83,6 +83,11 @@ class AztecEditorFragment : BaseFragment(), IAztecToolbarClickListener, BackPres
                 confirmDiscard()
             }
         }
+
+        aztec.visualEditor.post {
+            aztec.visualEditor.requestFocus()
+            ActivityUtils.showKeyboard(aztec.visualEditor)
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {


### PR DESCRIPTION
Fixes #2468. This tiny PR adds logic to display the keypad when the Aztec editor is opened. 

#### To test
- Click on a product description, product short description or purchase note (from Product Settings).
- Notice that the keypad is displayed when the Aztec editor screen is opened.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
