### PR TITLE
issue/2466-review-badge-on-rotation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Paint
 import android.graphics.Rect
+import android.os.Parcelable
 import android.util.AttributeSet
 import android.util.SparseArray
 import android.view.MenuItem
@@ -52,7 +53,32 @@ class MainBottomNavigationView @JvmOverloads constructor(
 
         navAdapter = NavAdapter()
         addTopDivider()
+        createBadges()
 
+        assignNavigationListeners(true)
+
+        // Default to the dashboard position
+        active(DASHBOARD.position)
+    }
+
+    /**
+     * HACK alert! The bottom nav's presenter stores the badges in its saved state and recreates them
+     * in onRestoreInstanceState, which should be fine but instead it ends up creating duplicates
+     * of our badges. To work around this we remove the badges before state is saved and recreate
+     * them ourselves when state is restored.
+     */
+    override fun onSaveInstanceState(): Parcelable? {
+        removeBadge(R.id.orders)
+        removeBadge(R.id.reviews)
+        return super.onSaveInstanceState()
+    }
+
+    override fun onRestoreInstanceState(state: Parcelable?) {
+        super.onRestoreInstanceState(state)
+        createBadges()
+    }
+
+    private fun createBadges() {
         ordersBadge = getOrCreateBadge(R.id.orders)
         ordersBadge.isVisible = false
         ordersBadge.backgroundColor = ContextCompat.getColor(context, R.color.color_primary)
@@ -61,11 +87,6 @@ class MainBottomNavigationView @JvmOverloads constructor(
         reviewsBadge = getOrCreateBadge(R.id.reviews)
         reviewsBadge.isVisible = false
         reviewsBadge.backgroundColor = ContextCompat.getColor(context, R.color.color_primary)
-
-        assignNavigationListeners(true)
-
-        // Default to the dashboard position
-        active(DASHBOARD.position)
     }
 
     /**


### PR DESCRIPTION
Fixes #2466 - I'm not entirely sure I like my solution - it seems kind of hacky - but it does have the benefit of working :)

The issue is that when the device is rotated, the reviews badge always re-appears. When debugging the problem, I didn't see anywhere that we were telling the badge to appear - just the opposite, in fact.

Then I ran across [this issue](https://github.com/material-components/material-components-android/issues/1247) in the Material Components repo that suggested duplicate badges were being created because the bottom nav presenter was saving the badges in `onSaveInstanceState()` and restoring them in `onRestoreInstanceState()`.

The solution was to override `onSaveInstanceState()` and remove the badges before the state is saved, then recreate them when the state is restored.



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
