### PR TITLE
Revert notification icon to the W

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * Fixes text color on support ticket views for dark mode
 * Adds a fix to retain the cursor position when updating product title
 * Fixed a potential memory leak while switching between stores
+* Reverted the notification icon back to the W for better visibility
 
 4.3
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
@@ -451,7 +451,7 @@ class NotificationHandler @Inject constructor(
     ): NotificationCompat.Builder {
         val channelId = getChannelIdForNoteType(context, noteType)
         return NotificationCompat.Builder(context, channelId)
-                .setSmallIcon(R.drawable.img_woo_bubble_white)
+                .setSmallIcon(R.drawable.ic_woo_w_notification)
                 .setColor(ContextCompat.getColor(context, R.color.color_primary))
                 .setContentTitle(title)
                 .setContentText(message)
@@ -531,7 +531,7 @@ class NotificationHandler @Inject constructor(
             val subject = String.format(context.getString(R.string.new_notifications), notesMap.size)
             val groupBuilder = NotificationCompat.Builder(context, getChannelIdForNoteType(context, noteType))
                     .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)
-                    .setSmallIcon(R.drawable.img_woo_bubble_white)
+                    .setSmallIcon(R.drawable.ic_woo_w_notification)
                     .setColor(ContextCompat.getColor(context, R.color.color_primary))
                     .setGroup(NOTIFICATION_GROUP_KEY)
                     .setGroupSummary(true)


### PR DESCRIPTION
Fixes #2482  by reverting the notification icon back to the W since we've had several complaints from users that the new bubble icon is just too difficult to see in the notification tray.

In the screenshots below there is the previous bubble notification icon for the current production version, and the W icon for the dev version:

System | Light | Dark 
-- | -- | --
![Screenshot_1590177479](https://user-images.githubusercontent.com/5810477/82705369-c674d780-9c34-11ea-906b-203c2599c2ed.png)|![Screenshot_1590177231](https://user-images.githubusercontent.com/5810477/82705375-c83e9b00-9c34-11ea-834a-6cd8f527838d.png)|![Screenshot_1590177463](https://user-images.githubusercontent.com/5810477/82705377-ca085e80-9c34-11ea-8a6f-ed00adf2e364.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
