### PR TITLE
Convert orderStatusOptions property to private nullable map

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusSelectorDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusSelectorDialog.kt
@@ -45,8 +45,8 @@ class OrderStatusSelectorDialog : androidx.fragment.app.DialogFragment() {
     private val orderStatusMap: Map<String, String> by lazy {
         // remove the Refunded status from the dialog to avoid reporting problems (unless it's already Refunded)
         val statusesWithoutRefunded = orderStatusOptions
-                .filter { selectedOrderStatus == REFUNDED_ID || it.key != REFUNDED_ID }
-                .values.associate { it.statusKey to it.label }
+                ?.filter { selectedOrderStatus == REFUNDED_ID || it.key != REFUNDED_ID }
+                ?.values?.associate { it.statusKey to it.label } ?: emptyMap()
 
         if (isFilter) {
             mapOf(ALL_FILTER_ID to getString(R.string.all)).plus(statusesWithoutRefunded)
@@ -58,7 +58,7 @@ class OrderStatusSelectorDialog : androidx.fragment.app.DialogFragment() {
     var listener: OrderStatusDialogListener? = null
     var selectedOrderStatus: String? = null
     var isFilter: Boolean = false
-    lateinit var orderStatusOptions: Map<String, WCOrderStatusModel>
+    private var orderStatusOptions: Map<String, WCOrderStatusModel>? = null
 
     private fun getCurrentOrderStatusIndex(): Int {
         return orderStatusMap.keys.indexOfFirst { it == selectedOrderStatus }


### PR DESCRIPTION
This fixes #2463 where a rare crash would happen due to this property not being initialized. I was unable to reproduce this crash and logically it shouldn't happen since it's happening inside the `OrderStatusSelectorDialog` but that dialog gets dismissed the moment the user navigates away from the view either by putting the app in the background or clicking outside the dialog. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary - this crash happens so rarely I wouldn't include it in the release notes. 
