### PR TITLE
Check for null before accessing views inside onTabSelected handler

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -136,9 +136,9 @@ class MyStoreFragment : TopLevelFragment(),
         tabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
             override fun onTabSelected(tab: TabLayout.Tab) {
                 tabStatsPosition = tab.position
-                my_store_date_bar.clearDateRangeValues()
-                my_store_stats.loadDashboardStats(activeGranularity)
-                my_store_top_earners.loadTopEarnerStats(activeGranularity)
+                my_store_date_bar?.clearDateRangeValues()
+                my_store_stats?.loadDashboardStats(activeGranularity)
+                my_store_top_earners?.loadTopEarnerStats(activeGranularity)
             }
 
             override fun onTabUnselected(tab: TabLayout.Tab) {}


### PR DESCRIPTION
Fixes #2419 by checking if the views in this handler are null before
attempting to perform actions on them. This is important because this
listener is being set on the tablayout, but the user currently has the
ability to switch between two different versions of this view, the
old one and the v4 version.

I wasn't able to reproduce this crash, but I'm confident this will fix it. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. This crash effects so few users I don't believe a release note is needed since we only get 500 characters in the google play store for release notes. 
