### PR TITLE
Issue/2476 product sale date fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -212,14 +212,11 @@ class ProductDetailCardBuilder(
 
             // display product sale dates using the site's timezone, if available
             if (product.isSaleScheduled) {
-                var dateOnSaleFrom = product.saleStartDateGmt?.let {
+                val dateOnSaleFrom = product.saleStartDateGmt?.let {
                     DateUtils.offsetGmtDate(it, parameters.gmtOffset)
                 }
                 val dateOnSaleTo = product.saleEndDateGmt?.let {
                     DateUtils.offsetGmtDate(it, parameters.gmtOffset)
-                }
-                if (dateOnSaleTo != null && dateOnSaleFrom == null) {
-                    dateOnSaleFrom = DateUtils.offsetGmtDate(Date(), parameters.gmtOffset)
                 }
                 val saleDates = when {
                     (dateOnSaleFrom != null && dateOnSaleTo != null) -> {
@@ -227,6 +224,9 @@ class ProductDetailCardBuilder(
                     }
                     (dateOnSaleFrom != null && dateOnSaleTo == null) -> {
                         resources.getString(R.string.product_sale_date_from, dateOnSaleFrom.formatToMMMddYYYY())
+                    }
+                    (dateOnSaleFrom == null && dateOnSaleTo != null) -> {
+                        resources.getString(R.string.product_sale_date_to, dateOnSaleTo.formatToMMMddYYYY())
                     }
                     else -> null
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.extensions.addPropertyIfNotEmpty
 import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.formatToMMMdd
 import com.woocommerce.android.extensions.formatToMMMddYYYY
+import com.woocommerce.android.extensions.offsetGmtDate
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.products.ProductDetailViewModel.Parameters
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductDescriptionEditor
@@ -16,7 +17,6 @@ import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductSh
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductShortDescriptionEditor
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductVariations
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
-import com.woocommerce.android.ui.products.models.ProductPropertyCard
 import com.woocommerce.android.ui.products.models.ProductProperty
 import com.woocommerce.android.ui.products.models.ProductProperty.ComplexProperty
 import com.woocommerce.android.ui.products.models.ProductProperty.Editable
@@ -25,12 +25,12 @@ import com.woocommerce.android.ui.products.models.ProductProperty.Property
 import com.woocommerce.android.ui.products.models.ProductProperty.PropertyGroup
 import com.woocommerce.android.ui.products.models.ProductProperty.RatingBar
 import com.woocommerce.android.ui.products.models.ProductProperty.ReadMore
+import com.woocommerce.android.ui.products.models.ProductPropertyCard
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.PRICING
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.PRIMARY
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.PURCHASE_DETAILS
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.SECONDARY
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -212,12 +212,9 @@ class ProductDetailCardBuilder(
 
             // display product sale dates using the site's timezone, if available
             if (product.isSaleScheduled) {
-                val dateOnSaleFrom = product.saleStartDateGmt?.let {
-                    DateUtils.offsetGmtDate(it, parameters.gmtOffset)
-                }
-                val dateOnSaleTo = product.saleEndDateGmt?.let {
-                    DateUtils.offsetGmtDate(it, parameters.gmtOffset)
-                }
+                val dateOnSaleFrom = product.saleStartDateGmt?.offsetGmtDate(parameters.gmtOffset)
+                val dateOnSaleTo = product.saleEndDateGmt?.offsetGmtDate(parameters.gmtOffset)
+
                 val saleDates = when {
                     (dateOnSaleFrom != null && dateOnSaleTo != null) -> {
                         getProductSaleDates(dateOnSaleFrom, dateOnSaleTo)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
@@ -172,7 +172,7 @@ class ProductPricingFragment : BaseProductFragment(), ProductInventorySelectorDi
             }
         }
 
-        updateSaleStartDate(product.saleStartDateGmt, productData.gmtOffset)
+        updateSaleStartDate(product.saleStartDateGmt, product.saleEndDateGmt, productData.gmtOffset)
         with(scheduleSale_startDate) {
             setClickListener {
                 startDatePickerDialog = displayDatePickerDialog(scheduleSale_startDate, OnDateSetListener {
@@ -181,7 +181,7 @@ class ProductPricingFragment : BaseProductFragment(), ProductInventorySelectorDi
                             selectedYear, selectedMonth, dayOfMonth, gmtOffset, true
                     )
 
-                    updateSaleStartDate(selectedDate, gmtOffset)
+                    updateSaleStartDate(selectedDate, product.saleEndDateGmt, gmtOffset)
                     changesMade()
                 })
             }
@@ -221,10 +221,29 @@ class ProductPricingFragment : BaseProductFragment(), ProductInventorySelectorDi
         }
     }
 
-    private fun updateSaleStartDate(selectedDate: Date?, offset: Float) {
-        val date = selectedDate ?: Date()
-        scheduleSale_startDate.setText(formatSaleDateForDisplay(date, offset))
-        viewModel.onStartDateChanged(date)
+    /**
+     * Method to update the start date of a sale using the [offset]
+     *
+     * If the [selectedStartDate] is empty or null, then the default is set to the current date,
+     * only if the [endDate] > the current date.
+     *
+     * The [viewModel] is only updated if the [selectedStartDate] is not null. This is to prevent
+     * the discard dialog from being displayed when there have been no user initiated changes made
+     * to the screen.
+     */
+    private fun updateSaleStartDate(
+        selectedStartDate: Date?,
+        endDate: Date?,
+        offset: Float
+    ) {
+        val currentDate = Date()
+        val date = selectedStartDate
+            ?: if (endDate?.after(currentDate) == true) {
+                currentDate
+            } else null
+
+        date?.let { scheduleSale_startDate.setText(formatSaleDateForDisplay(it, offset)) }
+        selectedStartDate?.let { viewModel.onStartDateChanged(it) }
     }
 
     private fun updateSaleEndDate(selectedDate: Date?, offset: Float) {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -429,6 +429,7 @@
     <string name="product_sale_dates">Sale dates</string>
     <string name="product_sale_date_from_to">%1$s - %2$s</string>
     <string name="product_sale_date_from">from %1$s</string>
+    <string name="product_sale_date_to">Until %1$s</string>
     <string name="product_tax_settings">Tax settings</string>
     <string name="product_tax_status">Tax status</string>
     <string name="product_tax_class">Tax class</string>


### PR DESCRIPTION
Fixes #2476. This PR modifies the logic behind displaying sale dates for a product. The below logic is modified based on the iOS implementation of the same. 

#### Changes
- When there is no start date for a sale, it should not be displayed in the product detail screen. Instead, we should display `Until {end date}`).
- When there is no start date for a sale, the start date should be set to the current day in the Pricing screen, **IF the end date is > the current date.** Otherwise, it should be empty.
- When there is no end date for a sale, it should not be displayed in the product detail screen or the pricing screen.

#### Screenshots
##### No start date available but end date > current date
The current date will be displayed as the start date.
<img src="https://user-images.githubusercontent.com/22608780/82891797-fe00be00-9f6b-11ea-8439-5c6818503b20.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/82891801-ffca8180-9f6b-11ea-880f-d0744f215c7b.png" width="300"/>


##### No End Date Available
No end date should be displayed in both Product detail and Pricing screen.
<img src="https://user-images.githubusercontent.com/22608780/82891661-bda14000-9f6b-11ea-8f16-7bb0eaa88d89.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/82891706-d1e53d00-9f6b-11ea-814f-9f6a43bb5dae.png" width="300"/>

##### No start date available but end date < current date
No start date will be displayed in both Product detail and Pricing screen.
<img src="https://user-images.githubusercontent.com/22608780/82891739-e4f80d00-9f6b-11ea-807d-b984309d1a16.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/82891744-e75a6700-9f6b-11ea-9091-be4ba8e0ccc7.png" width="300"/>

#### To test
- Open `wp-admin` and schedule a sale for a product without an end date. Verify that in the Product Detail screen and in the Pricing screen, the end date is NOT displayed. The **Remove End Date** link button should NOT be displayed.
- Open `wp-admin` and schedule a sale for a product without a start date. Enter an end date > the current date. Verify in the app that the start date for the product in Product Detail screen is NOT displayed. The start date for the product in Pricing screen is set to the current date.
- Open `wp-admin` and schedule a sale for a product without a start date. Enter an end date < the current date. Verify in the app that the start date for the product in Product detail and in the Pricing screen is NOT displayed.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
