### PR TITLE
Added logic to calculate tax only if quantity is not zero

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductListView.kt
@@ -64,10 +64,15 @@ class OrderDetailProductListView @JvmOverloads constructor(
         val filteredItems = order.items.filter { leftoverProducts.contains(it.uniqueId) }
                 .map {
                     val newQuantity = leftoverProducts[it.uniqueId]
+                    val quantity = it.quantity.toBigDecimal()
+                    val totalTax = if (quantity > BigDecimal.ZERO) {
+                        it.totalTax.divide(quantity, 2, HALF_UP)
+                    } else BigDecimal.ZERO
+
                     it.copy(
                             quantity = newQuantity ?: error("Missing product"),
                             total = it.price.times(newQuantity.toBigDecimal()),
-                            totalTax = it.totalTax.divide(it.quantity.toBigDecimal(), 2, HALF_UP)
+                            totalTax = totalTax
                     )
                 }
 


### PR DESCRIPTION
Fixes #2183 by adding logic to calculate the tax total of a product only if the quantity is not 0.

I was not able to reproduce this crash and not really sure in which cases the quantity is 0 for a product (only 5 users have been affected so far so I am guessing it is a corner case). This fix should prevent this crash from happening and display 0 as tax total when the quantity is zero. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
