### PR TITLE
Added logic to refresh product list only if filters change

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -106,13 +106,17 @@ class ProductListViewModel @AssistedInject constructor(
         productStatus: String?,
         productType: String?
     ) {
-        productFilterOptions.clear()
-        stockStatus?.let { productFilterOptions[ProductFilterOption.STOCK_STATUS] = it }
-        productStatus?.let { productFilterOptions[ProductFilterOption.STATUS] = it }
-        productType?.let { productFilterOptions[ProductFilterOption.TYPE] = it }
+        if (stockStatus != productFilterOptions[ProductFilterOption.STOCK_STATUS] ||
+            productStatus != productFilterOptions[ProductFilterOption.STATUS] ||
+            productType != productFilterOptions[ProductFilterOption.TYPE]) {
+            productFilterOptions.clear()
+            stockStatus?.let { productFilterOptions[ProductFilterOption.STOCK_STATUS] = it }
+            productStatus?.let { productFilterOptions[ProductFilterOption.STATUS] = it }
+            productType?.let { productFilterOptions[ProductFilterOption.TYPE] = it }
 
-        viewState = viewState.copy(filterCount = productFilterOptions.size)
-        refreshProducts()
+            viewState = viewState.copy(filterCount = productFilterOptions.size)
+            refreshProducts()
+        }
     }
 
     fun getFilterByStockStatus() = productFilterOptions[ProductFilterOption.STOCK_STATUS]


### PR DESCRIPTION
Fixes #2487 by adding logic to check if there have been changes made to the filters before requesting a refresh.

#### To test
- Click on the `Filters` option from the Products tab.
- Select a few filters and click on `Show Products`.
- Notice that the products are refreshed based on the filter selection.
- Click on `Filters` again.
- Click on `Show Products` button.
- Notice that the product list is NOT refreshed.
- Click on `Filters` again.
- Click on `Clear` menu button.
- Click on `Show Products` button again.
- Notice that the products are refreshed again.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
