### PR TITLE
Fix Product details properties

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ProductPropertyExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ProductPropertyExt.kt
@@ -1,21 +1,14 @@
 package com.woocommerce.android.extensions
 
 import com.woocommerce.android.ui.products.models.ProductProperty
-import com.woocommerce.android.ui.products.models.ProductProperty.ComplexProperty
-import com.woocommerce.android.ui.products.models.ProductProperty.Property
-import com.woocommerce.android.ui.products.models.ProductProperty.PropertyGroup
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
 
-fun MutableList<ProductPropertyCard>.addIfNotEmpty(card: ProductPropertyCard) {
-    if (card.properties.isNotEmpty()) {
+fun MutableList<ProductPropertyCard>.addIfNotEmpty(card: ProductPropertyCard?) {
+    if (card != null && card.properties.isNotEmpty()) {
         add(card)
     }
 }
 
-fun MutableList<ProductProperty>.addPropertyIfNotEmpty(item: ProductProperty) {
-    when (item) {
-        is Property -> if (item.value.isNotBlank()) add(item)
-        is ComplexProperty -> if (item.value.isNotBlank()) add(item)
-        is PropertyGroup -> if (item.properties.filter { it.value.isNotBlank() }.isNotEmpty()) add(item)
-    }
+fun List<ProductProperty?>.filterNotEmpty(): List<ProductProperty> {
+    return this.filterNotNull().filter { it.isNotEmpty() }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -115,17 +115,6 @@ class ProductDetailCardBuilder(
             ))
         }
 
-        // we don't show reviews for variations because they're always empty
-        if (product.type != VARIABLE && product.reviewsAllowed) {
-            items.add(
-                RatingBar(
-                    R.string.product_reviews,
-                    StringUtils.formatCount(product.ratingCount),
-                    product.averageRating
-                )
-            )
-        }
-
         // show product variants only if product type is variable and if there are variations for the product
         if (product.type == VARIABLE && product.numVariations > 0) {
             val properties = mutableMapOf<String, String>()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -2,9 +2,10 @@ package com.woocommerce.android.ui.products
 
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_VIEW_PRODUCT_DESCRIPTION_TAPPED
 import com.woocommerce.android.extensions.addIfNotEmpty
-import com.woocommerce.android.extensions.addPropertyIfNotEmpty
 import com.woocommerce.android.extensions.fastStripHtml
+import com.woocommerce.android.extensions.filterNotEmpty
 import com.woocommerce.android.extensions.formatToMMMdd
 import com.woocommerce.android.extensions.formatToMMMddYYYY
 import com.woocommerce.android.extensions.offsetGmtDate
@@ -23,7 +24,6 @@ import com.woocommerce.android.ui.products.models.ProductProperty.Editable
 import com.woocommerce.android.ui.products.models.ProductProperty.Link
 import com.woocommerce.android.ui.products.models.ProductProperty.Property
 import com.woocommerce.android.ui.products.models.ProductProperty.PropertyGroup
-import com.woocommerce.android.ui.products.models.ProductProperty.RatingBar
 import com.woocommerce.android.ui.products.models.ProductProperty.ReadMore
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.PRICING
@@ -51,6 +51,7 @@ class ProductDetailCardBuilder(
 
     fun buildPropertyCards(product: Product): List<ProductPropertyCard> {
         val cards = mutableListOf<ProductPropertyCard>()
+
         cards.addIfNotEmpty(getPrimaryCard(product))
 
         // display pricing/inventory card only if product is not a variable product
@@ -68,92 +69,67 @@ class ProductDetailCardBuilder(
     }
 
     private fun getPrimaryCard(product: Product): ProductPropertyCard {
-        val items = mutableListOf<ProductProperty>()
+        return ProductPropertyCard(
+            type = PRIMARY,
+            properties = listOf(
+                product.title(),
+                product.description(),
+                product.totalOrders(),
+                product.variations(),
+                product.storeLink(),
+                product.affiliateLink()
+            ).filterNotEmpty()
+        )
+    }
 
-        val productName = product.name.fastStripHtml()
-
-        if (isAddEditProductRelease1Enabled(product.type)) {
-            items.add(Editable(
-                R.string.product_detail_title_hint,
-                productName,
-                onTextChanged = viewModel::onProductTitleChanged
-            ))
+    /**
+     * New product detail card UI slated for new products release 1
+     */
+    private fun getSecondaryCard(product: Product): ProductPropertyCard {
+        return ProductPropertyCard(
+            type = SECONDARY,
+            properties = listOf(
+                product.price(),
+                product.externalLink(),
+                product.shipping(),
+                product.inventory(),
+                product.shortDescription()
+            ).filterNotEmpty()
+        )
+    }
+    /**
+     * Existing product detail card UI which that will be replaced by the new design once
+     * Product Release 1 changes are completed.
+     */
+    private fun getPricingAndInventoryCard(product: Product): ProductPropertyCard {
+        // if we have pricing info this card is "Pricing and inventory" otherwise it's just "Inventory"
+        val hasPricingInfo = product.regularPrice != null || product.salePrice != null
+        val cardTitle = if (hasPricingInfo) {
+            resources.getString(R.string.product_pricing_and_inventory)
         } else {
-            items.addPropertyIfNotEmpty(ComplexProperty(R.string.product_name, productName))
+            resources.getString(R.string.product_inventory)
         }
 
-        if (isAddEditProductRelease1Enabled(product.type)) {
-            val productDescription = product.description
-            val showTitle = productDescription.isNotEmpty()
-            val description = if (productDescription.isEmpty()) {
-                resources.getString(R.string.product_description_empty)
-            } else {
-                productDescription
-            }
-            items.addPropertyIfNotEmpty(
-                ComplexProperty(
-                    R.string.product_description,
-                    description,
-                    showTitle = showTitle
-                ) {
-                    viewModel.onEditProductCardClicked(
-                        ViewProductDescriptionEditor(
-                            productDescription, resources.getString(R.string.product_description)
-                        ),
-                        Stat.PRODUCT_DETAIL_VIEW_PRODUCT_DESCRIPTION_TAPPED
-                    )
-                }
-            )
-        }
+        return ProductPropertyCard(
+            PRICING,
+            cardTitle,
+            listOf(
+                product.readOnlyPrice(),
+                product.readOnlyInventory()
+            ).filterNotEmpty()
+        )
+    }
 
-        // we don't show total sales for variations because they're always zero
-        // we are removing the total orders sections from products M2 release
-        if (product.type != VARIABLE && !FeatureFlag.PRODUCT_RELEASE_M2.isEnabled()) {
-            items.addPropertyIfNotEmpty(Property(
-                R.string.product_total_orders,
-                StringUtils.formatCount(product.totalSales)
-            ))
-        }
-
-        // show product variants only if product type is variable and if there are variations for the product
-        if (product.type == VARIABLE && product.numVariations > 0) {
-            val properties = mutableMapOf<String, String>()
-            for (attribute in product.attributes) {
-                properties[attribute.name] = attribute.options.size.toString()
-            }
-
-            items.addPropertyIfNotEmpty(
-                PropertyGroup(
-                    R.string.product_variations,
-                    properties
-                ) {
-                    viewModel.onEditProductCardClicked(
-                        ViewProductVariations(product.remoteId),
-                        Stat.PRODUCT_DETAIL_VIEW_PRODUCT_VARIANTS_TAPPED
-                    )
-                }
-            )
-        }
-
-        if (!FeatureFlag.PRODUCT_RELEASE_M2.isEnabled()) {
-            // display `View product on Store` (in M2 this is in the options menu)
-            items.add(
-                Link(R.string.product_view_in_store) {
-                    viewModel.onViewProductOnStoreLinkClicked(product.permalink)
-                }
-            )
-
-            // enable viewing affiliate link for external products (in M2 this is editable)
-            if (product.type == ProductType.EXTERNAL) {
-                items.add(
-                    Link(R.string.product_view_affiliate) {
-                        viewModel.onAffiliateLinkClicked(product.externalUrl)
-                    }
-                )
-            }
-        }
-
-        return ProductPropertyCard(type = PRIMARY, properties = items)
+    private fun getPurchaseDetailsCard(product: Product): ProductPropertyCard {
+        return ProductPropertyCard(
+            PURCHASE_DETAILS,
+            resources.getString(R.string.product_purchase_details),
+            listOf(
+                product.readOnlyShipping(),
+                product.downloads(),
+                product.purchaseNote()
+            ).filterNotEmpty()
+        )
     }
 
     private fun formatCurrency(amount: BigDecimal?, currencyCode: String?): String {
@@ -175,34 +151,249 @@ class ProductDetailCardBuilder(
         )
     }
 
-    /**
-     * New product detail card UI slated for new products release 1
-     */
-    private fun getSecondaryCard(product: Product): ProductPropertyCard {
-        val items = mutableListOf<ProductProperty>()
+    // if add/edit products is enabled, purchase note appears in product settings
+    private fun Product.purchaseNote(): ProductProperty? {
+        return if (this.purchaseNote.isNotBlank() && !isAddEditProductRelease1Enabled(this.type)) {
+            ReadMore(
+                R.string.product_purchase_note,
+                this.purchaseNote
+            )
+        } else {
+            null
+        }
+    }
 
+    private fun Product.downloads(): ProductProperty? {
+        return if (this.isDownloadable) {
+            val limit = if (this.downloadLimit > 0) String.format(
+                resources.getString(R.string.product_download_limit_count),
+                this.downloadLimit
+            ) else ""
+            val expiry = if (this.downloadExpiry > 0) String.format(
+                resources.getString(R.string.product_download_expiry_days),
+                this.downloadExpiry
+            ) else ""
+
+            val downloadGroup = mapOf(
+                Pair(resources.getString(R.string.product_downloadable_files), this.fileCount.toString()),
+                Pair(resources.getString(R.string.product_download_limit), limit),
+                Pair(resources.getString(R.string.product_download_expiry), expiry)
+            )
+            PropertyGroup(
+                R.string.product_downloads,
+                downloadGroup
+            )
+        } else {
+            null
+        }
+    }
+
+    // shipping group is part of the secondary card if edit product is enabled
+    private fun Product.readOnlyShipping(): ProductProperty? {
+        return if (!isAddEditProductRelease1Enabled(this.type)) {
+            val shippingGroup = mapOf(
+                Pair(resources.getString(R.string.product_weight), this.getWeightWithUnits(parameters.weightUnit)),
+                Pair(resources.getString(R.string.product_size), this.getSizeWithUnits(parameters.dimensionUnit)),
+                Pair(resources.getString(R.string.product_shipping_class), this.shippingClass)
+            )
+            PropertyGroup(
+                R.string.product_shipping,
+                shippingGroup
+            )
+        } else {
+            null
+        }
+    }
+
+    // show stock properties as a group if stock management is enabled, otherwise show sku separately
+    private fun Product.readOnlyInventory(): ProductProperty {
+        return if (this.manageStock) {
+            val group = mapOf(
+                Pair(resources.getString(R.string.product_stock_status),
+                    ProductStockStatus.stockStatusToDisplayString(resources, this.stockStatus)
+                ),
+                Pair(resources.getString(R.string.product_backorders),
+                    ProductBackorderStatus.backordersToDisplayString(resources, this.backorderStatus)
+                ),
+                Pair(resources.getString(R.string.product_stock_quantity),
+                    StringUtils.formatCount(this.stockQuantity)
+                ),
+                Pair(resources.getString(R.string.product_sku), this.sku)
+            )
+            PropertyGroup(
+                R.string.product_inventory,
+                group
+            )
+        } else {
+            ComplexProperty(
+                R.string.product_sku,
+                this.sku
+            )
+        }
+    }
+
+    private fun Product.readOnlyPrice(): ProductProperty? {
+        val hasPricingInfo = this.regularPrice != null || this.salePrice != null
+        return if (hasPricingInfo) {
+            // when there's a sale price show price & sales price as a group, otherwise show price separately
+            return if (this.isOnSale) {
+                val group = mapOf(
+                    resources.getString(R.string.product_regular_price)
+                        to formatCurrency(this.regularPrice, parameters.currencyCode),
+                    resources.getString(R.string.product_sale_price)
+                        to formatCurrency(this.salePrice, parameters.currencyCode)
+                )
+                PropertyGroup(R.string.product_price, group)
+            } else {
+                ComplexProperty(
+                    R.string.product_price,
+                    formatCurrency(this.regularPrice, parameters.currencyCode)
+                )
+            }
+        } else {
+            null
+        }
+    }
+
+    private fun Product.shortDescription(): ProductProperty? {
+        return if (FeatureFlag.PRODUCT_RELEASE_M2.isEnabled()) {
+            val shortDescription = if (this.shortDescription.isEmpty()) {
+                resources.getString(R.string.product_short_description_empty)
+            } else {
+                this.shortDescription
+            }
+
+            ComplexProperty(
+                R.string.product_short_description,
+                shortDescription,
+                R.drawable.ic_gridicons_align_left
+            ) {
+                viewModel.onEditProductCardClicked(
+                    ViewProductShortDescriptionEditor(
+                        this.shortDescription,
+                        resources.getString(R.string.product_short_description)
+                    ),
+                    Stat.PRODUCT_DETAIL_VIEW_SHORT_DESCRIPTION_TAPPED
+                )
+            }
+        } else {
+            null
+        }
+    }
+
+    // show stock properties as a group if stock management is enabled, otherwise show sku separately
+    private fun Product.inventory(): ProductProperty {
+        val inventoryGroup = when {
+            this.manageStock -> mapOf(
+                Pair(resources.getString(R.string.product_backorders),
+                    ProductBackorderStatus.backordersToDisplayString(resources, this.backorderStatus)),
+                Pair(resources.getString(R.string.product_stock_quantity),
+                    StringUtils.formatCount(this.stockQuantity)),
+                Pair(resources.getString(R.string.product_sku), this.sku)
+            )
+            this.sku.isNotEmpty() -> mapOf(
+                Pair(resources.getString(R.string.product_sku), this.sku),
+                Pair(resources.getString(R.string.product_stock_status),
+                    ProductStockStatus.stockStatusToDisplayString(resources, this.stockStatus))
+            )
+            else -> mapOf(
+                Pair("", ProductStockStatus.stockStatusToDisplayString(resources, this.stockStatus))
+            )
+        }
+
+        return PropertyGroup(
+            R.string.product_inventory,
+            inventoryGroup,
+            R.drawable.ic_gridicons_list_checkmark,
+            true
+        ) {
+            viewModel.onEditProductCardClicked(
+                ViewProductInventory(this.remoteId),
+                Stat.PRODUCT_DETAIL_VIEW_INVENTORY_SETTINGS_TAPPED
+            )
+        }
+    }
+
+    private fun Product.shipping(): ProductProperty? {
+        return if (!this.isVirtual) {
+            val weightWithUnits = this.getWeightWithUnits(parameters.weightUnit)
+            val sizeWithUnits = this.getSizeWithUnits(parameters.dimensionUnit)
+            val hasShippingInfo = weightWithUnits.isNotEmpty() ||
+                sizeWithUnits.isNotEmpty() ||
+                this.shippingClass.isNotEmpty()
+            val shippingGroup = if (hasShippingInfo) {
+                mapOf(
+                    Pair(resources.getString(R.string.product_weight), weightWithUnits),
+                    Pair(resources.getString(R.string.product_dimensions), sizeWithUnits),
+                    Pair(
+                        resources.getString(R.string.product_shipping_class),
+                        viewModel.getShippingClassByRemoteShippingClassId(this.shippingClassId)
+                    )
+                )
+            } else mapOf(Pair("", resources.getString(R.string.product_shipping_empty)))
+
+            PropertyGroup(
+                R.string.product_shipping,
+                shippingGroup,
+                R.drawable.ic_gridicons_shipping,
+                hasShippingInfo
+            ) {
+                viewModel.onEditProductCardClicked(
+                    ViewProductShipping(this.remoteId),
+                    Stat.PRODUCT_DETAIL_VIEW_SHIPPING_SETTINGS_TAPPED
+                )
+            }
+        } else {
+            null
+        }
+    }
+
+    // enable editing external product link
+    private fun Product.externalLink(): ProductProperty? {
+        return if (FeatureFlag.PRODUCT_RELEASE_M2.isEnabled() && this.type == ProductType.EXTERNAL) {
+            val hasExternalLink = this.externalUrl.isNotEmpty()
+            val externalGroup = if (hasExternalLink) {
+                mapOf(Pair("", this.externalUrl))
+            } else {
+                mapOf(Pair("", resources.getString(R.string.product_external_empty_link)))
+            }
+
+            PropertyGroup(
+                R.string.product_external_link,
+                externalGroup,
+                R.drawable.ic_gridicons_link,
+                hasExternalLink
+            ) {
+                viewModel.onEditProductCardClicked(ViewProductPricing(this.remoteId))
+            }
+        } else {
+            null
+        }
+    }
+
+    private fun Product.price(): ProductProperty {
         // If we have pricing info, show price & sales price as a group,
         // otherwise provide option to add pricing info for the product
-        val hasPricingInfo = product.regularPrice != null || product.salePrice != null
+        val hasPricingInfo = this.regularPrice != null || this.salePrice != null
         val pricingGroup = mutableMapOf<String, String>()
         if (hasPricingInfo) {
             // regular product price
             pricingGroup[resources.getString(R.string.product_regular_price)] = formatCurrency(
-                product.regularPrice,
+                this.regularPrice,
                 parameters.currencyCode
             )
             // display product sale price if it's on sale
-            if (product.isOnSale) {
+            if (this.isOnSale) {
                 pricingGroup[resources.getString(R.string.product_sale_price)] = formatCurrency(
-                    product.salePrice,
+                    this.salePrice,
                     parameters.currencyCode
                 )
             }
 
             // display product sale dates using the site's timezone, if available
-            if (product.isSaleScheduled) {
-                val dateOnSaleFrom = product.saleStartDateGmt?.offsetGmtDate(parameters.gmtOffset)
-                val dateOnSaleTo = product.saleEndDateGmt?.offsetGmtDate(parameters.gmtOffset)
+            if (this.isSaleScheduled) {
+                val dateOnSaleFrom = this.saleStartDateGmt?.offsetGmtDate(parameters.gmtOffset)
+                val dateOnSaleTo = this.saleEndDateGmt?.offsetGmtDate(parameters.gmtOffset)
 
                 val saleDates = when {
                     (dateOnSaleFrom != null && dateOnSaleTo != null) -> {
@@ -224,249 +415,110 @@ class ProductDetailCardBuilder(
             pricingGroup[""] = resources.getString(R.string.product_price_empty)
         }
 
-        items.addPropertyIfNotEmpty(
-            PropertyGroup(
-                R.string.product_price,
-                pricingGroup,
-                R.drawable.ic_gridicons_money,
-                hasPricingInfo
-            ) {
-                viewModel.onEditProductCardClicked(
-                    ViewProductPricing(product.remoteId),
-                    Stat.PRODUCT_DETAIL_VIEW_PRICE_SETTINGS_TAPPED
-                )
-            }
-        )
-
-        // enable editing external product link
-        if (FeatureFlag.PRODUCT_RELEASE_M2.isEnabled() && product.type == ProductType.EXTERNAL) {
-            val hasExternalLink = product.externalUrl.isNotEmpty()
-            val externalGroup = if (hasExternalLink) {
-                mapOf(Pair("", product.externalUrl))
-            } else {
-                mapOf(Pair("", resources.getString(R.string.product_external_empty_link)))
-            }
-
-            items.addPropertyIfNotEmpty(
-                PropertyGroup(
-                    R.string.product_external_link,
-                    externalGroup,
-                    R.drawable.ic_gridicons_link,
-                    hasExternalLink
-                ) {
-                    viewModel.onEditProductCardClicked(ViewProductPricing(product.remoteId))
-                }
+        return PropertyGroup(
+            R.string.product_price,
+            pricingGroup,
+            R.drawable.ic_gridicons_money,
+            hasPricingInfo
+        ) {
+            viewModel.onEditProductCardClicked(
+                ViewProductPricing(this.remoteId),
+                Stat.PRODUCT_DETAIL_VIEW_PRICE_SETTINGS_TAPPED
             )
         }
-
-        // show stock properties as a group if stock management is enabled, otherwise show sku separately
-        val inventoryGroup = when {
-            product.manageStock -> mapOf(
-                Pair(resources.getString(R.string.product_backorders),
-                    ProductBackorderStatus.backordersToDisplayString(resources, product.backorderStatus)),
-                Pair(resources.getString(R.string.product_stock_quantity),
-                    StringUtils.formatCount(product.stockQuantity)),
-                Pair(resources.getString(R.string.product_sku), product.sku)
-            )
-            product.sku.isNotEmpty() -> mapOf(
-                Pair(resources.getString(R.string.product_sku), product.sku),
-                Pair(resources.getString(R.string.product_stock_status),
-                    ProductStockStatus.stockStatusToDisplayString(resources, product.stockStatus))
-            )
-            else -> mapOf(
-                Pair("", ProductStockStatus.stockStatusToDisplayString(resources, product.stockStatus))
-            )
-        }
-
-        items.addPropertyIfNotEmpty(
-            PropertyGroup(
-                R.string.product_inventory,
-                inventoryGroup,
-                R.drawable.ic_gridicons_list_checkmark,
-                true
-            ) {
-                viewModel.onEditProductCardClicked(
-                    ViewProductInventory(product.remoteId),
-                    Stat.PRODUCT_DETAIL_VIEW_INVENTORY_SETTINGS_TAPPED
-                )
-            }
-        )
-
-        if (!product.isVirtual) {
-            val weightWithUnits = product.getWeightWithUnits(parameters.weightUnit)
-            val sizeWithUnits = product.getSizeWithUnits(parameters.dimensionUnit)
-            val hasShippingInfo = weightWithUnits.isNotEmpty() ||
-                sizeWithUnits.isNotEmpty() ||
-                product.shippingClass.isNotEmpty()
-            val shippingGroup = if (hasShippingInfo) {
-                mapOf(
-                    Pair(resources.getString(R.string.product_weight), weightWithUnits),
-                    Pair(resources.getString(R.string.product_dimensions), sizeWithUnits),
-                    Pair(
-                        resources.getString(R.string.product_shipping_class),
-                        viewModel.getShippingClassByRemoteShippingClassId(product.shippingClassId)
-                    )
-                )
-            } else mapOf(Pair("", resources.getString(R.string.product_shipping_empty)))
-
-            items.addPropertyIfNotEmpty(
-                PropertyGroup(
-                    R.string.product_shipping,
-                    shippingGroup,
-                    R.drawable.ic_gridicons_shipping,
-                    hasShippingInfo
-                ) {
-                    viewModel.onEditProductCardClicked(
-                        ViewProductShipping(product.remoteId),
-                        Stat.PRODUCT_DETAIL_VIEW_SHIPPING_SETTINGS_TAPPED
-                    )
-                }
-            )
-        }
-
-        if (FeatureFlag.PRODUCT_RELEASE_M2.isEnabled()) {
-            val shortDescription = if (product.shortDescription.isEmpty()) {
-                resources.getString(R.string.product_short_description_empty)
-            } else {
-                product.shortDescription
-            }
-
-            items.addPropertyIfNotEmpty(
-                ComplexProperty(
-                    R.string.product_short_description,
-                    shortDescription,
-                    R.drawable.ic_gridicons_align_left
-                ) {
-                    viewModel.onEditProductCardClicked(
-                        ViewProductShortDescriptionEditor(
-                            product.shortDescription,
-                            resources.getString(R.string.product_short_description)
-                        ),
-                        Stat.PRODUCT_DETAIL_VIEW_SHORT_DESCRIPTION_TAPPED
-                    )
-                }
-            )
-        }
-
-        return ProductPropertyCard(type = SECONDARY, properties = items)
     }
-    /**
-     * Existing product detail card UI which that will be replaced by the new design once
-     * Product Release 1 changes are completed.
-     */
-    private fun getPricingAndInventoryCard(product: Product): ProductPropertyCard {
-        val items = mutableListOf<ProductProperty>()
 
-        // if we have pricing info this card is "Pricing and inventory" otherwise it's just "Inventory"
-        val hasPricingInfo = product.regularPrice != null || product.salePrice != null
+    private fun Product.title(): ProductProperty {
+        val name = this.name.fastStripHtml()
+        return if (isAddEditProductRelease1Enabled(this.type)) {
+            Editable(
+                R.string.product_detail_title_hint,
+                name,
+                onTextChanged = viewModel::onProductTitleChanged
+            )
+        } else {
+            ComplexProperty(R.string.product_name, name)
+        }
+    }
 
-        val title: String
-        if (hasPricingInfo) {
-            title = resources.getString(R.string.product_pricing_and_inventory)
-            // when there's a sale price show price & sales price as a group, otherwise show price separately
-            if (product.isOnSale) {
-                val group = mapOf(
-                    resources.getString(R.string.product_regular_price)
-                        to formatCurrency(product.regularPrice, parameters.currencyCode),
-                    resources.getString(R.string.product_sale_price)
-                        to formatCurrency(product.salePrice, parameters.currencyCode)
-                )
-                items.addPropertyIfNotEmpty(PropertyGroup(R.string.product_price, group))
+    private fun Product.description(): ProductProperty? {
+        return if (isAddEditProductRelease1Enabled(this.type)) {
+            val productDescription = this.description
+            val showTitle = productDescription.isNotEmpty()
+            val description = if (productDescription.isEmpty()) {
+                resources.getString(R.string.product_description_empty)
             } else {
-                items.addPropertyIfNotEmpty(
-                    ComplexProperty(
-                        R.string.product_price,
-                        formatCurrency(product.regularPrice, parameters.currencyCode)
-                    )
+                productDescription
+            }
+
+            ComplexProperty(
+                R.string.product_description,
+                description,
+                showTitle = showTitle
+            ) {
+                viewModel.onEditProductCardClicked(
+                    ViewProductDescriptionEditor(
+                        productDescription, resources.getString(R.string.product_description)
+                    ),
+                    PRODUCT_DETAIL_VIEW_PRODUCT_DESCRIPTION_TAPPED
                 )
             }
         } else {
-            title = resources.getString(R.string.product_inventory)
+            null
         }
-
-        // show stock properties as a group if stock management is enabled, otherwise show sku separately
-        if (product.manageStock) {
-            val group = mapOf(
-                Pair(resources.getString(R.string.product_stock_status),
-                    ProductStockStatus.stockStatusToDisplayString(resources, product.stockStatus)
-                ),
-                Pair(resources.getString(R.string.product_backorders),
-                    ProductBackorderStatus.backordersToDisplayString(resources, product.backorderStatus)
-                ),
-                Pair(resources.getString(R.string.product_stock_quantity),
-                    StringUtils.formatCount(product.stockQuantity)
-                ),
-                Pair(resources.getString(R.string.product_sku), product.sku)
-            )
-            items.addPropertyIfNotEmpty(
-                PropertyGroup(
-                    R.string.product_inventory,
-                    group
-                )
-            )
-        } else {
-            items.addPropertyIfNotEmpty(
-                ComplexProperty(
-                    R.string.product_sku,
-                    product.sku
-                )
-            )
-        }
-
-        return ProductPropertyCard(PRICING, title, items)
     }
 
-    private fun getPurchaseDetailsCard(product: Product): ProductPropertyCard {
-        val items = mutableListOf<ProductProperty>()
-
-        // shipping group is part of the secondary card if edit product is enabled
-        if (!isAddEditProductRelease1Enabled(product.type)) {
-            val shippingGroup = mapOf(
-                Pair(resources.getString(R.string.product_weight), product.getWeightWithUnits(parameters.weightUnit)),
-                Pair(resources.getString(R.string.product_size), product.getSizeWithUnits(parameters.dimensionUnit)),
-                Pair(resources.getString(R.string.product_shipping_class), product.shippingClass)
-            )
-            items.addPropertyIfNotEmpty(
-                PropertyGroup(
-                    R.string.product_shipping,
-                    shippingGroup
-                )
-            )
+    // we don't show total sales for variations because they're always zero
+    // we are removing the total orders sections from products M2 release
+    private fun Product.totalOrders(): ProductProperty? {
+        return if (this.type != VARIABLE && !FeatureFlag.PRODUCT_RELEASE_M2.isEnabled()) {
+            Property(R.string.product_total_orders, StringUtils.formatCount(this.totalSales))
+        } else {
+            null
         }
+    }
 
-        if (product.isDownloadable) {
-            val limit = if (product.downloadLimit > 0) String.format(
-                resources.getString(R.string.product_download_limit_count),
-                product.downloadLimit
-            ) else ""
-            val expiry = if (product.downloadExpiry > 0) String.format(
-                resources.getString(R.string.product_download_expiry_days),
-                product.downloadExpiry
-            ) else ""
+    // show product variants only if product type is variable and if there are variations for the product
+    private fun Product.variations(): ProductProperty? {
+        return if (this.type == VARIABLE && this.numVariations > 0) {
+            val properties = mutableMapOf<String, String>()
+            for (attribute in this.attributes) {
+                properties[attribute.name] = attribute.options.size.toString()
+            }
 
-            val downloadGroup = mapOf(
-                Pair(resources.getString(R.string.product_downloadable_files), product.fileCount.toString()),
-                Pair(resources.getString(R.string.product_download_limit), limit),
-                Pair(resources.getString(R.string.product_download_expiry), expiry)
-            )
-            items.addPropertyIfNotEmpty(
-                PropertyGroup(
-                    R.string.product_downloads,
-                    downloadGroup
+            PropertyGroup(
+                R.string.product_variations,
+                properties
+            ) {
+                viewModel.onEditProductCardClicked(
+                    ViewProductVariations(this.remoteId),
+                    Stat.PRODUCT_DETAIL_VIEW_PRODUCT_VARIANTS_TAPPED
                 )
-            )
+            }
+        } else {
+            null
         }
+    }
 
-        // if add/edit products is enabled, purchase note appears in product settings
-        if (product.purchaseNote.isNotBlank() && !isAddEditProductRelease1Enabled(product.type)) {
-            items.add(
-                ReadMore(
-                    R.string.product_purchase_note,
-                    product.purchaseNote
-                )
-            )
+    // display `View product on Store` (in M2 this is in the options menu)
+    private fun Product.storeLink(): ProductProperty? {
+        return if (!FeatureFlag.PRODUCT_RELEASE_M2.isEnabled()) {
+            Link(R.string.product_view_in_store) {
+                viewModel.onViewProductOnStoreLinkClicked(this.permalink)
+            }
+        } else {
+            null
         }
+    }
 
-        return ProductPropertyCard(PURCHASE_DETAILS, resources.getString(R.string.product_purchase_details), items)
+    private fun Product.affiliateLink(): ProductProperty? {
+        // enable viewing affiliate link for external products (in M2 this is editable)
+        return if (!FeatureFlag.PRODUCT_RELEASE_M2.isEnabled() && this.type == ProductType.EXTERNAL) {
+            Link(R.string.product_view_affiliate) {
+                viewModel.onAffiliateLinkClicked(this.externalUrl)
+            }
+        } else {
+            null
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/models/ProductProperty.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/models/ProductProperty.kt
@@ -28,13 +28,21 @@ sealed class ProductProperty(val type: Type) {
     data class Property(
         @StringRes val title: Int,
         val value: String
-    ) : ProductProperty(PROPERTY)
+    ) : ProductProperty(PROPERTY) {
+        override fun isNotEmpty(): Boolean {
+            return this.value.isNotBlank()
+        }
+    }
 
     data class RatingBar(
         @StringRes val title: Int,
         val value: String,
         val rating: Float
-    ) : ProductProperty(RATING_BAR)
+    ) : ProductProperty(RATING_BAR) {
+        override fun isNotEmpty(): Boolean {
+            return this.value.isNotBlank()
+        }
+    }
 
     data class ComplexProperty(
         @StringRes val title: Int? = null,
@@ -42,7 +50,11 @@ sealed class ProductProperty(val type: Type) {
         @DrawableRes val icon: Int? = null,
         val showTitle: Boolean = true,
         val onClick: (() -> Unit)? = null
-    ) : ProductProperty(COMPLEX_PROPERTY)
+    ) : ProductProperty(COMPLEX_PROPERTY) {
+        override fun isNotEmpty(): Boolean {
+            return value.isNotBlank()
+        }
+    }
 
     data class Link(
         @StringRes val title: Int,
@@ -68,5 +80,13 @@ sealed class ProductProperty(val type: Type) {
         @DrawableRes val icon: Int? = null,
         val showTitle: Boolean = true,
         val onClick: (() -> Unit)? = null
-    ) : ProductProperty(PROPERTY_GROUP)
+    ) : ProductProperty(PROPERTY_GROUP) {
+        override fun isNotEmpty(): Boolean {
+            return this.properties.filter { it.value.isNotBlank() }.isNotEmpty()
+        }
+    }
+
+    open fun isNotEmpty(): Boolean {
+        return true
+    }
 }


### PR DESCRIPTION
Fixes #2489.

![image](https://user-images.githubusercontent.com/1522856/82915599-3eaf0600-9f71-11ea-8802-a6e27e604a25.png)

This PR updates the Product details property ordering to match the one used on iOS (see #2489).

**To test:**
I've refactored the `ProductDetailCardBuilder` to make it a bit more readable. Nothing should change except for the removed Rating property and reversed order of Shipping/Inventory. So a bit of smoke testing with editing on/off should do it.
