### PR TITLE
Issue/wellsql 1.6

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
@@ -42,14 +42,6 @@ class WooWellSqlConfig(context: Context) : WellSqlConfig(context, ADDON_WOOCOMME
     }
 
     /**
-     * For debug builds we want a cursor window size of 5MB so we can test for any problems caused by
-     * a larger size. Once we're confident this works we'll return 5MB in release builds to hopefully
-     * reduce the number of SQLiteBlobTooBigExceptions. Note that this is only called on API 28 and
-     * above since earlier versions don't allow adjusting the cursor window size.
-     */
-    override fun getCursorWindowSize() = if (BuildConfig.DEBUG) (1024L * 1024L * 5L) else 0L
-
-    /**
      * Useful during development when we want to test features with a "fresh" database. This can be
      * called from WooCommerce.onCreate() after we initialize the database. For safety, this has no
      * effect when called from a release build.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
@@ -42,6 +42,14 @@ class WooWellSqlConfig(context: Context) : WellSqlConfig(context, ADDON_WOOCOMME
     }
 
     /**
+     * For debug builds we want a cursor window size of 5MB so we can test for any problems caused by
+     * a larger size. Once we're confident this works we'll return 5MB in release builds to hopefully
+     * reduce the number of SQLiteBlobTooBigExceptions. Note that this is only called on API 28 and
+     * above since earlier versions don't allow adjusting the cursor window size.
+     */
+    override fun getCursorWindowSize() = if (BuildConfig.DEBUG) (1024L * 1024L * 5L) else 0L
+
+    /**
      * Useful during development when we want to test features with a "fresh" database. This can be
      * called from WooCommerce.onCreate() after we initialize the database. For safety, this has no
      * effect when called from a release build.

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.6.11'
+    fluxCVersion = '53d1bb7ce49e368690501dc1fc76e88f6a6206b4'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '53d1bb7ce49e368690501dc1fc76e88f6a6206b4'
+    fluxCVersion = '6092e266915428f8b2fa5c9634847271e7f64ae4'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Updates the FluxC hash to include [this WellSql change](https://github.com/wordpress-mobile/wellsql/pull/18) that enables enlarging the cursor window size, which hopefully will cut back on SQLiteBlobTooBigExceptions.

For now we're only enlarging the cursor window size in debug builds, just be sure there aren't unintended side effects. Once we're sure the fix is good, we'll enlarge the size in production builds,

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
