### PR TITLE
Issue/2488 image delete confirmation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -407,7 +407,7 @@ class ProductDetailViewModel @AssistedInject constructor(
                         if (event is ExitProductDetail) {
                             triggerEvent(ExitProduct)
                         } else {
-                            triggerEvent(Exit)
+                            triggerEvent(event)
                         }
                     }
             ))
@@ -422,7 +422,7 @@ class ProductDetailViewModel @AssistedInject constructor(
                         if (event is ExitProductDetail) {
                             triggerEvent(ExitProduct)
                         } else {
-                            triggerEvent(Exit)
+                            triggerEvent(event)
                         }
                     }
             ))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -393,7 +393,7 @@ class ProductDetailViewModel @AssistedInject constructor(
 
         val isProductUpdated = when (event) {
             is ExitProductDetail -> isProductDetailUpdated || isUploadingImages
-            is ExitImages -> isUploadingImages
+            is ExitImages -> isUploadingImages || hasImageChanges()
             else -> isProductDetailUpdated == true && isProductSubDetailUpdated == true
         }
         if (isProductUpdated == true && event.shouldShowDiscardDialog) {


### PR DESCRIPTION
Fixes #2488 - Previously the product images screen wouldn't show the discard dialog when hitting the back button after images have been removed. This PR resolves this.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
