### PR TITLE
Display exact stock quantity in product detail

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * Adds a fix to retain the cursor position when updating product title
 * Fixed a potential memory leak while switching between stores
 * Reverted the notification icon back to the W for better visibility
+* Adds a fix to display the exact stock status for a product in Product detail
 
 4.3
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -35,6 +35,7 @@ import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.ResourceProvider
 import org.wordpress.android.util.DateTimeUtils
+import org.wordpress.android.util.FormatUtils
 import java.math.BigDecimal
 import java.util.Date
 
@@ -288,7 +289,7 @@ class ProductDetailCardBuilder(
                 Pair(resources.getString(R.string.product_backorders),
                     ProductBackorderStatus.backordersToDisplayString(resources, this.backorderStatus)),
                 Pair(resources.getString(R.string.product_stock_quantity),
-                    StringUtils.formatCount(this.stockQuantity)),
+                    FormatUtils.formatInt(this.stockQuantity)),
                 Pair(resources.getString(R.string.product_sku), this.sku)
             )
             this.sku.isNotEmpty() -> mapOf(


### PR DESCRIPTION
Fixes #2283. This tiny PR adds support to display the exact stock quantity instead of rounding off.

#### To test
- Click on a product with a stock quantity above 1,000, the stock quantity listed on the product detail screen should NOT be rounded down but the exact value should be displayed.

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/83126944-28cb4d80-a0f7-11ea-9dd8-c02806fce4b5.png" width="300" />. <img src="https://user-images.githubusercontent.com/22608780/83126955-2cf76b00-a0f7-11ea-9e8f-b8bbb1e9c1ef.png" width="300" />


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
