### PR TITLE
Added logic to add images to a product only if it does not already exist

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -949,13 +949,14 @@ class ProductDetailViewModel @AssistedInject constructor(
      * Adds multiple images to the list of product draft's images
      */
     fun addProductImageListToDraft(imageList: ArrayList<Product.Image>) {
-        // add the existing images to the passed list...
+        // add the existing images to the passed list only
+        // if it does not exist in the list already
         viewState.productDraft?.let {
-            imageList.addAll(it.images)
-        }
+            val updatedImageList = (it.images + imageList).distinct().toList()
 
-        // ...then update the draft's images  with the combined list
-        updateProductDraft(images = imageList)
+            // ...then update the draft's images  with the combined list
+            updateProductDraft(images = updatedImageList)
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #2479 by adding logic to check if an image already exists in the product before adding it a second time.

#### To test
##### Scenario 1:
- Enable Product Editing under Settings > Beta features.
- Go to the products tab and select a product with any images added to it.
- Tap the product photo section to edit the photos.
- Select "Add Photos."
- Select "WordPress media library."
- Select an image.
- Repeat the last three steps again, selecting the same image (so the product now has two copies of the same image from the media library.)
- Remove one of the photos from the product. Notice that after you confirm you want to remove the photo, you're left on a black screen.
- Tap the trash icon again and confirm you want to remove the photo again.
- Notice the app crashes.
- Pull changes from this PR and follow the above steps again and notice the app does not crash and the same image cannot be added twice to the product.

##### Scenario 2:
- Enable Product Editing under Settings > Beta features.
- Go to the products tab and select a product that has a single image already assigned.
- Tap the product photo section to edit the photos.
- Select "Add Photos."
- Select "WordPress media library."
- Select an image.
- Repeat steps 3-6, selecting the same image (so the product now has two copies of the same image from the media library.)
- Remove one of the photos just added from the product. Notice that after you confirm you want to remove the photo, the original product photo is now displayed.
- Tap the trash icon to delete the original product photo.
- You get returned back to the product detail view with the original product photo still attached to the product and the UPDATE product is invisible so no product changes.
- Pull changes from this PR and verify that a duplicate image is no longer added to a product.

##### Smoke testing
- Since this affects the entire image upload process, it would be great if you could smoke test the image upload feature. 
  - Try uploading/deleting multiple images to a product with already has some images.
  - Try deleting all images of a product and updating the product.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
