### PR TITLE
Issue/2504 discard dialog filter products

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dialog/CustomDiscardDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dialog/CustomDiscardDialog.kt
@@ -20,7 +20,9 @@ object CustomDiscardDialog {
         activity: Activity,
         posBtnAction: (OnClickListener)? = null,
         negBtnAction: (OnClickListener)? = null,
-        @StringRes messageId: Int? = null
+        @StringRes messageId: Int? = null,
+        @StringRes positiveButtonId: Int? = null,
+        @StringRes negativeButtonId: Int? = null
     ) {
         dialogRef?.get()?.let {
             // Dialog is already present
@@ -28,14 +30,17 @@ object CustomDiscardDialog {
         }
 
         val message = messageId?.let {
-            activity.applicationContext.getString(messageId)
+            activity.applicationContext.getString(it)
         } ?: activity.applicationContext.getString(string.discard_message)
+
+        val positiveButtonTextId = positiveButtonId ?: string.discard
+        val negativeButtonTextId = negativeButtonId ?: string.keep_editing
 
         val builder = MaterialAlertDialogBuilder(activity)
                 .setMessage(message)
                 .setCancelable(true)
-                .setPositiveButton(string.discard, posBtnAction)
-                .setNegativeButton(string.keep_editing, negBtnAction)
+                .setPositiveButton(positiveButtonTextId, posBtnAction)
+                .setNegativeButton(negativeButtonTextId, negBtnAction)
                 .setOnDismissListener { onCleared() }
 
         dialogRef = WeakReference(builder.show())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
@@ -130,7 +130,8 @@ class ProductFilterListFragment : BaseFragment(), OnProductFilterClickListener, 
                     requireActivity(),
                     event.positiveBtnAction,
                     event.negativeBtnAction,
-                    event.messageId
+                    event.messageId,
+                    negativeButtonId = event.negativeButtonId
                 )
                 else -> event.isHandled = false
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
@@ -20,18 +20,22 @@ import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.dialog.CustomDiscardDialog
 import com.woocommerce.android.ui.main.MainActivity
+import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.ProductFilterListAdapter.OnProductFilterClickListener
 import com.woocommerce.android.ui.products.ProductFilterListViewModel.Companion.ARG_PRODUCT_FILTER_STATUS
 import com.woocommerce.android.ui.products.ProductFilterListViewModel.Companion.ARG_PRODUCT_FILTER_STOCK_STATUS
 import com.woocommerce.android.ui.products.ProductFilterListViewModel.Companion.ARG_PRODUCT_FILTER_TYPE_STATUS
 import com.woocommerce.android.ui.products.ProductFilterListViewModel.FilterListItemUiModel
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.AlignedDividerDecoration
 import kotlinx.android.synthetic.main.fragment_product_filter_list.*
 import javax.inject.Inject
 
-class ProductFilterListFragment : BaseFragment(), OnProductFilterClickListener {
+class ProductFilterListFragment : BaseFragment(), OnProductFilterClickListener, BackPressListener {
     companion object {
         const val TAG = "ProductFilterListFragment"
     }
@@ -119,6 +123,19 @@ class ProductFilterListFragment : BaseFragment(), OnProductFilterClickListener {
         viewModel.filterListItems.observe(viewLifecycleOwner, Observer {
             showProductFilterList(it)
         })
+        viewModel.event.observe(viewLifecycleOwner, Observer { event ->
+            when (event) {
+                is Exit -> findNavController().navigateUp()
+                is ShowDiscardDialog -> CustomDiscardDialog.showDiscardDialog(
+                    requireActivity(),
+                    event.positiveBtnAction,
+                    event.negativeBtnAction,
+                    event.messageId
+                )
+                else -> event.isHandled = false
+            }
+        })
+
         viewModel.loadFilters()
     }
 
@@ -135,6 +152,8 @@ class ProductFilterListFragment : BaseFragment(), OnProductFilterClickListener {
                 .actionProductFilterListFragmentToProductFilterOptionListFragment(selectedFilterPosition)
         findNavController().navigateSafely(action)
     }
+
+    override fun onRequestAllowBackPress() = viewModel.onBackButtonClicked()
 
     override fun onResume() {
         super.onResume()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.products
 
+import android.content.DialogInterface
 import android.os.Parcelable
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -15,6 +16,8 @@ import kotlinx.android.parcel.Parcelize
 import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.products.ProductStockStatus.Companion.fromString
 import com.woocommerce.android.viewmodel.LiveDataDelegate
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption.STOCK_STATUS
@@ -92,6 +95,19 @@ class ProductFilterListViewModel @AssistedInject constructor(
             productFilterOptionListViewState = productFilterOptionListViewState.copy(
                     screenTitle = filterItem.filterItemName
             )
+        }
+    }
+
+    fun onBackButtonClicked(): Boolean {
+        return if (hasChanges()) {
+            triggerEvent(ShowDiscardDialog(
+                positiveBtnAction = DialogInterface.OnClickListener { _, _ ->
+                    triggerEvent(Exit)
+                }
+            ))
+            false
+        } else {
+            true
         }
     }
 
@@ -188,6 +204,14 @@ class ProductFilterListViewModel @AssistedInject constructor(
         }
     }
 
+    private fun hasChanges(): Boolean {
+        return (
+            arguments.selectedProductStatus != getFilterByProductStatus() ||
+                arguments.selectedProductType != getFilterByProductType() ||
+                arguments.selectedStockStatus != getFilterByStockStatus()
+            )
+    }
+
     @Parcelize
     data class ProductFilterListViewState(
         val screenTitle: String? = null,
@@ -223,7 +247,7 @@ class ProductFilterListViewModel @AssistedInject constructor(
          * Compares this filter's options with the passed list, returns true only if both lists contain
          * the same filter options in the same order
          */
-        fun List<FilterListOptionItemUiModel>.isSameFilterOptions(
+        private fun List<FilterListOptionItemUiModel>.isSameFilterOptions(
             updatedFilterOptions: List<FilterListOptionItemUiModel>
         ): Boolean {
             if (this.size != updatedFilterOptions.size) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -101,6 +101,7 @@ class ProductFilterListViewModel @AssistedInject constructor(
     fun onBackButtonClicked(): Boolean {
         return if (hasChanges()) {
             triggerEvent(ShowDiscardDialog(
+                negativeButtonId = string.keep_changes,
                 positiveBtnAction = DialogInterface.OnClickListener { _, _ ->
                     triggerEvent(Exit)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
@@ -82,12 +82,17 @@ open class MultiLiveEvent<T : Event> : MutableLiveData<T>() {
         data class ShowDiscardDialog(
             val positiveBtnAction: OnClickListener? = null,
             val negativeBtnAction: OnClickListener? = null,
-            @StringRes val messageId: Int? = null
+            @StringRes val messageId: Int? = null,
+            @StringRes val positiveButtonId: Int? = null,
+            @StringRes val negativeButtonId: Int? = null
         ) : Event() {
             override fun equals(other: Any?): Boolean {
                 if (this === other) return true
                 if (other !is ShowDiscardDialog) return false
 
+                if (messageId != other.messageId) return false
+                if (positiveButtonId != other.positiveButtonId) return false
+                if (negativeButtonId != other.negativeButtonId) return false
                 if (positiveBtnAction != other.positiveBtnAction) return false
                 if (negativeBtnAction != other.negativeBtnAction) return false
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -44,6 +44,7 @@
     <string name="untitled">Untitled</string>
     <string name="cancel">Cancel</string>
     <string name="keep_editing">Keep editing</string>
+    <string name="keep_changes">Keep changes</string>
     <string name="learn_more">Learn More</string>
     <string name="try_it_now">Try it now</string>
     <string name="offline_message">Offline \u2014 using cached data</string>


### PR DESCRIPTION
Fixes #2504 by adding a discard dialog when dismissing filter products screen with filter changes.

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/83489014-62bb9b80-a4cb-11ea-95b8-d5fbd79536af.gif" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/83489018-64855f00-a4cb-11ea-8be2-0e420e4ce43a.png" width="300"/>

#### To test
- Click on the `Filters` button from the Products tab.
- Select a filter from the list.
- Click on the `X` icon on the top left of the screen.
- Notice the discard dialog is displayed.
- Verify that clicking on `Keep changes` is dismisses the dialog.
- Verify that clicking on `Discard` dismisses the filters and redirects to the product list screen. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
