### PR TITLE
Merge Release/4.4 back into develop

### DIFF
--- a/WooCommerce/metadata/PlayStoreStrings.pot
+++ b/WooCommerce/metadata/PlayStoreStrings.pot
@@ -11,6 +11,14 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_044"
+msgid ""
+"4.4:\n"
+"* <b>New</b>: Added functionality to image and product management. Head to “Settings” in “My Store” to turn on new features!\n"
+"* <b>UI improvements</b>: Brought back the W notification icon for better visibility, fixed the text color on support tickets in dark mode, minor style tweaks to login screens.\n"
+"* <b>Fixes</b>: Product details display exact stock status, plugged a potential memory leak when switching between stores.\n"
+msgstr ""
+
 msgctxt "release_note_043"
 msgid ""
 "4.3:\n"
@@ -18,12 +26,6 @@ msgid ""
 "* Shipment tracking appears on the order detail screen. Future-dated orders appear on the All orders tab.\n"
 "* Our new product editing functionality is in beta. Try it!\n"
 "* Fixed multiple crashes and the text color on support tickets in dark mode.\n"
-msgstr ""
-
-msgctxt "release_note_042"
-msgid ""
-"4.2:\n"
-"* Fixed a few issues and irregularities with the new dark mode theme with, login screens, and the app icon for a more consistent user experience.\n"
 msgstr ""
 
 #. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,4 +1,3 @@
-* Filter and sort Products from the Products tab.
-* Shipment tracking appears on the order detail screen. Future-dated orders appear on the All orders tab.
-* Our new product editing functionality is in beta. Try it!
-* Fixed multiple crashes and the text color on support tickets in dark mode.
+* <b>New</b>: Added functionality to image and product management. Head to “Settings” in “My Store” to turn on new features!
+* <b>UI improvements</b>: Brought back the W notification icon for better visibility, fixed the text color on support tickets in dark mode, minor style tweaks to login screens.
+* <b>Fixes</b>: Product details display exact stock status, plugged a potential memory leak when switching between stores.


### PR DESCRIPTION
Merge Release/4.4 back into develop

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
