### PR TITLE
Add privacy notice for california users link

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 4.5
 -----
+* Added a link to the new privacy notice for california users
  
 4.4
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -7,6 +7,7 @@ object AppUrls {
     const val AUTOMATTIC_HOME = "https://www.automattic.com/"
     const val AUTOMATTIC_TOS = "https://woocommerce.com/terms-conditions/"
     const val AUTOMATTIC_PRIVACY_POLICY = "https://www.automattic.com/privacy"
+    const val AUTOMATTIC_PRIVACY_POLICY_CA = "https://automattic.com/privacy/#california-consumer-privacy-act-ccpa"
     const val AUTOMATTIC_COOKIE_POLICY = "https://www.automattic.com/cookies"
     const val AUTOMATTIC_HIRING = "https://automattic.com/work-with-us"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsContract.kt
@@ -15,5 +15,6 @@ interface PrivacySettingsContract {
     interface View : BaseView<Presenter> {
         fun showCookiePolicy()
         fun showPrivacyPolicy()
+        fun showPrivacyPolicyCA()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsFragment.kt
@@ -54,6 +54,9 @@ class PrivacySettingsFragment : androidx.fragment.app.Fragment(), PrivacySetting
             AnalyticsTracker.track(PRIVACY_SETTINGS_PRIVACY_POLICY_LINK_TAPPED)
             showPrivacyPolicy()
         }
+        buttonPrivacyPolicyCA.setOnClickListener {
+            showPrivacyPolicyCA()
+        }
         buttonTracking.setOnClickListener {
             AnalyticsTracker.track(PRIVACY_SETTINGS_THIRD_PARTY_TRACKING_INFO_LINK_TAPPED)
             showCookiePolicy()
@@ -100,5 +103,9 @@ class PrivacySettingsFragment : androidx.fragment.app.Fragment(), PrivacySetting
 
     override fun showPrivacyPolicy() {
         ChromeCustomTabUtils.launchUrl(activity as Context, AppUrls.AUTOMATTIC_PRIVACY_POLICY)
+    }
+
+    override fun showPrivacyPolicyCA() {
+        ChromeCustomTabUtils.launchUrl(activity as Context, AppUrls.AUTOMATTIC_PRIVACY_POLICY_CA)
     }
 }

--- a/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
@@ -47,6 +47,8 @@
         android:layout_marginEnd="@dimen/major_100"
         android:layout_marginStart="@dimen/major_100"
         android:layout_marginTop="@dimen/minor_100"
+        android:paddingEnd="0dp"
+        android:paddingStart="0dp"
         android:text="@string/learn_more"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/privacy_share_info"/>
@@ -81,9 +83,28 @@
         android:layout_marginEnd="@dimen/major_100"
         android:layout_marginStart="@dimen/major_100"
         android:layout_marginTop="@dimen/minor_100"
+        android:paddingEnd="0dp"
+        android:paddingStart="0dp"
         android:text="@string/settings_privacy_policy"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/privacy_policy_info"/>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/buttonPrivacyPolicyCA"
+        style="@style/Woo.Button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin_app_title_aligned"
+        android:layout_marginTop="@dimen/minor_100"
+        android:layout_marginEnd="@dimen/major_100"
+        android:paddingEnd="0dp"
+        android:paddingStart="0dp"
+        android:textAlignment="textEnd"
+        android:text="@string/settings_privacy_policy_ca"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/buttonPrivacyPolicy" />
 
     <View
         android:id="@+id/divider3"
@@ -91,7 +112,7 @@
         android:layout_marginTop="@dimen/minor_100"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/buttonPrivacyPolicy"/>
+        app:layout_constraintTop_toBottomOf="@+id/buttonPrivacyPolicyCA"/>
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/privacy_tracking_info"
@@ -115,6 +136,8 @@
         android:layout_marginStart="@dimen/major_100"
         android:layout_marginTop="@dimen/minor_100"
         android:layout_marginBottom="@dimen/minor_100"
+        android:paddingEnd="0dp"
+        android:paddingStart="0dp"
         android:text="@string/learn_more"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/privacy_tracking_info"/>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -603,6 +603,7 @@
     <string name="settings_send_stats_detail">Share information with our analytics tool about your use of services while logged in to your WordPress account</string>
     <string name="settings_privacy_detail">This information helps us improve our products, make marketing to you more relevant, personalize your WooCommerce experience, and more as detailed in our privacy policy</string>
     <string name="settings_privacy_policy">Read privacy policy</string>
+    <string name="settings_privacy_policy_ca">Privacy notice for California users</string>
     <string name="settings_tracking">We use other tracking tools, including some from third parties. Read about these and how to control them.</string>
     <string name="settings_footer">Made with love by Automattic. %1$s</string>
     <string name="settings_hiring">We\'re hiring!</string>


### PR DESCRIPTION
Fixes #2530 by adding a new link "Privacy notice for california users". I didn't have a design so I just added it under the current "Read Privacy Policy" link similar to [how this was handled in iOS](https://github.com/woocommerce/woocommerce-ios/pull/2412). Since this is a really long string to support I also ended up removing the start/end padding on all the buttons on this screen for a consistent look. 

**Note:** I did not add a tracks event for this button since it wasn't added on iOS. Since we're supposed to limit track events to places we are interested in tracking this will likely not need a track event anyway. 

<img src="https://user-images.githubusercontent.com/5810477/84448255-60fa8200-ac07-11ea-9226-8b34847cd679.png" width="330"/>



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
