### PR TITLE
Remove the M2 feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.5
 -----
 * Added a link to the new privacy notice for california users
+* Products: now you can update product images, product settings, viewing and sharing a product
  
 4.4
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SETTINGS_BETA_FEATURES_NEW_STATS_UI_TOGGLED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SETTINGS_BETA_FEATURES_PRODUCTS_TOGGLED
+import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.ui.prefs.MainSettingsFragment.AppSettingsListener
 import com.woocommerce.android.util.AnalyticsUtils
 import kotlinx.android.synthetic.main.fragment_settings_beta.*
@@ -54,6 +55,9 @@ class BetaFeaturesFragment : Fragment() {
                     AnalyticsTracker.KEY_STATE to AnalyticsUtils.getToggleStateLabel(switchProductsUI.isChecked)))
             settingsListener.onProductsFeatureOptionChanged(isChecked)
         }
+
+        // hidden until we need it again for M3
+        switchProductsUI.hide()
     }
 
     override fun onResume() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -35,7 +35,6 @@ import com.woocommerce.android.ui.sitepicker.SitePickerActivity
 import com.woocommerce.android.util.AnalyticsUtils
 import com.woocommerce.android.util.AppThemeUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.ThemeOption
 import com.woocommerce.android.widgets.WCPromoTooltip
 import com.woocommerce.android.widgets.WCPromoTooltip.Feature

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -156,9 +156,7 @@ class MainSettingsFragment : androidx.fragment.app.Fragment(), MainSettingsContr
             findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_betaFeaturesFragment)
         }
 
-        val productsTeaser = getString(R.string.settings_enable_product_teaser_title)
-        val statsTeaser = getString(R.string.settings_enable_v4_stats_title)
-        option_beta_features.optionValue = "$productsTeaser, $statsTeaser"
+        option_beta_features.optionValue = getString(R.string.settings_enable_v4_stats_title)
 
         option_privacy.setOnClickListener {
             AnalyticsTracker.track(SETTINGS_PRIVACY_SETTINGS_BUTTON_TAPPED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -109,18 +109,14 @@ class MainSettingsFragment : androidx.fragment.app.Fragment(), MainSettingsContr
             movementMethod = LinkMovementMethod.getInstance()
         }
 
-        if (FeatureFlag.PRODUCT_RELEASE_M2.isEnabled(requireActivity())) {
-            option_image_optimization.visibility = View.VISIBLE
-            option_image_optimization.isChecked = AppPrefs.getImageOptimizationEnabled()
-            option_image_optimization.setOnCheckedChangeListener { _, isChecked ->
-                AnalyticsTracker.track(
-                        SETTINGS_IMAGE_OPTIMIZATION_TOGGLED,
-                        mapOf(AnalyticsTracker.KEY_STATE to AnalyticsUtils.getToggleStateLabel(isChecked))
-                )
-                AppPrefs.setImageOptimizationEnabled(isChecked)
-            }
-        } else {
-            option_image_optimization.visibility = View.GONE
+        option_image_optimization.visibility = View.VISIBLE
+        option_image_optimization.isChecked = AppPrefs.getImageOptimizationEnabled()
+        option_image_optimization.setOnCheckedChangeListener { _, isChecked ->
+            AnalyticsTracker.track(
+                    SETTINGS_IMAGE_OPTIMIZATION_TOGGLED,
+                    mapOf(AnalyticsTracker.KEY_STATE to AnalyticsUtils.getToggleStateLabel(isChecked))
+            )
+            AppPrefs.setImageOptimizationEnabled(isChecked)
         }
 
         // on API 26+ we show the device notification settings, on older devices we have in-app settings

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -21,8 +21,6 @@ import com.woocommerce.android.ui.products.ProductType.VARIABLE
 import com.woocommerce.android.ui.products.models.ProductProperty
 import com.woocommerce.android.ui.products.models.ProductProperty.ComplexProperty
 import com.woocommerce.android.ui.products.models.ProductProperty.Editable
-import com.woocommerce.android.ui.products.models.ProductProperty.Link
-import com.woocommerce.android.ui.products.models.ProductProperty.Property
 import com.woocommerce.android.ui.products.models.ProductProperty.PropertyGroup
 import com.woocommerce.android.ui.products.models.ProductProperty.ReadMore
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
@@ -31,7 +29,6 @@ import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.PRIMA
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.PURCHASE_DETAILS
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.SECONDARY
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.ResourceProvider
 import org.wordpress.android.util.DateTimeUtils

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -75,10 +75,7 @@ class ProductDetailCardBuilder(
             properties = listOf(
                 product.title(),
                 product.description(),
-                product.totalOrders(),
-                product.variations(),
-                product.storeLink(),
-                product.affiliateLink()
+                product.variations()
             ).filterNotEmpty()
         )
     }
@@ -256,29 +253,25 @@ class ProductDetailCardBuilder(
         }
     }
 
-    private fun Product.shortDescription(): ProductProperty? {
-        return if (FeatureFlag.PRODUCT_RELEASE_M2.isEnabled()) {
-            val shortDescription = if (this.shortDescription.isEmpty()) {
-                resources.getString(R.string.product_short_description_empty)
-            } else {
-                this.shortDescription
-            }
-
-            ComplexProperty(
-                R.string.product_short_description,
-                shortDescription,
-                R.drawable.ic_gridicons_align_left
-            ) {
-                viewModel.onEditProductCardClicked(
-                    ViewProductShortDescriptionEditor(
-                        this.shortDescription,
-                        resources.getString(R.string.product_short_description)
-                    ),
-                    Stat.PRODUCT_DETAIL_VIEW_SHORT_DESCRIPTION_TAPPED
-                )
-            }
+    private fun Product.shortDescription(): ProductProperty {
+        val shortDescription = if (this.shortDescription.isEmpty()) {
+            resources.getString(R.string.product_short_description_empty)
         } else {
-            null
+            this.shortDescription
+        }
+
+        return ComplexProperty(
+            R.string.product_short_description,
+            shortDescription,
+            R.drawable.ic_gridicons_align_left
+        ) {
+            viewModel.onEditProductCardClicked(
+                ViewProductShortDescriptionEditor(
+                    this.shortDescription,
+                    resources.getString(R.string.product_short_description)
+                ),
+                Stat.PRODUCT_DETAIL_VIEW_SHORT_DESCRIPTION_TAPPED
+            )
         }
     }
 
@@ -351,7 +344,7 @@ class ProductDetailCardBuilder(
 
     // enable editing external product link
     private fun Product.externalLink(): ProductProperty? {
-        return if (FeatureFlag.PRODUCT_RELEASE_M2.isEnabled() && this.type == ProductType.EXTERNAL) {
+        return if (this.type == ProductType.EXTERNAL) {
             val hasExternalLink = this.externalUrl.isNotEmpty()
             val externalGroup = if (hasExternalLink) {
                 mapOf(Pair("", this.externalUrl))
@@ -469,16 +462,6 @@ class ProductDetailCardBuilder(
         }
     }
 
-    // we don't show total sales for variations because they're always zero
-    // we are removing the total orders sections from products M2 release
-    private fun Product.totalOrders(): ProductProperty? {
-        return if (this.type != VARIABLE && !FeatureFlag.PRODUCT_RELEASE_M2.isEnabled()) {
-            Property(R.string.product_total_orders, StringUtils.formatCount(this.totalSales))
-        } else {
-            null
-        }
-    }
-
     // show product variants only if product type is variable and if there are variations for the product
     private fun Product.variations(): ProductProperty? {
         return if (this.type == VARIABLE && this.numVariations > 0) {
@@ -495,28 +478,6 @@ class ProductDetailCardBuilder(
                     ViewProductVariations(this.remoteId),
                     Stat.PRODUCT_DETAIL_VIEW_PRODUCT_VARIANTS_TAPPED
                 )
-            }
-        } else {
-            null
-        }
-    }
-
-    // display `View product on Store` (in M2 this is in the options menu)
-    private fun Product.storeLink(): ProductProperty? {
-        return if (!FeatureFlag.PRODUCT_RELEASE_M2.isEnabled()) {
-            Link(R.string.product_view_in_store) {
-                viewModel.onViewProductOnStoreLinkClicked(this.permalink)
-            }
-        } else {
-            null
-        }
-    }
-
-    private fun Product.affiliateLink(): ProductProperty? {
-        // enable viewing affiliate link for external products (in M2 this is editable)
-        return if (!FeatureFlag.PRODUCT_RELEASE_M2.isEnabled() && this.type == ProductType.EXTERNAL) {
-            Link(R.string.product_view_affiliate) {
-                viewModel.onAffiliateLinkClicked(this.externalUrl)
             }
         } else {
             null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -120,12 +120,10 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
 
         if (product.images.isEmpty() && !viewModel.isUploadingImages(product.remoteId)) {
             imageGallery.visibility = View.GONE
-            if (FeatureFlag.PRODUCT_RELEASE_M2.isEnabled(requireActivity())) {
-                addImageContainer.visibility = View.VISIBLE
-                addImageContainer.setOnClickListener {
-                    AnalyticsTracker.track(Stat.PRODUCT_DETAIL_ADD_IMAGE_TAPPED)
-                    viewModel.onAddImageClicked()
-                }
+            addImageContainer.visibility = View.VISIBLE
+            addImageContainer.setOnClickListener {
+                AnalyticsTracker.track(Stat.PRODUCT_DETAIL_ADD_IMAGE_TAPPED)
+                viewModel.onAddImageClicked()
             }
         } else {
             addImageContainer.visibility = View.GONE
@@ -142,8 +140,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
 
             // display View Product on Store menu button only if the Product status is published,
             // otherwise the page is redirected to a 404
-            viewProductOnStoreMenuItem?.isVisible = FeatureFlag.PRODUCT_RELEASE_M2.isEnabled() &&
-                status == ProductStatus.PUBLISH
+            viewProductOnStoreMenuItem?.isVisible = status == ProductStatus.PUBLISH
         }
     }
 
@@ -152,7 +149,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         inflater.inflate(R.menu.menu_product_detail_fragment, menu)
 
         viewProductOnStoreMenuItem = menu.findItem(R.id.menu_view_product)
-        menu.findItem(R.id.menu_product_settings).isVisible = FeatureFlag.PRODUCT_RELEASE_M2.isEnabled()
+        menu.findItem(R.id.menu_product_settings).isVisible = true
 
         super.onCreateOptionsMenu(menu, inflater)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -32,7 +32,6 @@ import com.woocommerce.android.ui.products.adapters.ProductPropertyCardsAdapter
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
 import com.woocommerce.android.ui.wpmediapicker.WPMediaPickerFragment
 import com.woocommerce.android.util.ChromeCustomTabUtils
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.widgets.CustomProgressDialog
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageClickListener

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImageViewerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImageViewerFragment.kt
@@ -24,7 +24,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.products.ImageViewerFragment.Companion.ImageViewerListener
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.WooAnimUtils
 import kotlinx.android.synthetic.main.fragment_product_image_viewer.*
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImageViewerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImageViewerFragment.kt
@@ -65,13 +65,9 @@ class ProductImageViewerFragment : BaseProductFragment(), ImageViewerListener {
             findNavController().navigateUp()
         }
 
-        if (FeatureFlag.PRODUCT_RELEASE_M2.isEnabled()) {
-            iconTrash.setOnClickListener {
-                AnalyticsTracker.track(Stat.PRODUCT_IMAGE_SETTINGS_DELETE_IMAGE_BUTTON_TAPPED)
-                confirmRemoveProductImage()
-            }
-        } else {
-            iconTrash.visibility = View.GONE
+        iconTrash.setOnClickListener {
+            AnalyticsTracker.track(Stat.PRODUCT_IMAGE_SETTINGS_DELETE_IMAGE_BUTTON_TAPPED)
+            confirmRemoveProductImage()
         }
 
         savedInstanceState?.let { bundle ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -331,8 +331,7 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener, ProductS
             listState = null
         }
 
-        // hidden until we need it again for M3
-//        showProductWIPNoticeCard(true)
+        showProductWIPNoticeCard(true)
     }
 
     private fun showProductWIPNoticeCard(show: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -31,7 +31,6 @@ import com.woocommerce.android.ui.products.ProductFilterListViewModel.Companion.
 import com.woocommerce.android.ui.products.ProductListAdapter.OnProductClickListener
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ScrollToTop
 import com.woocommerce.android.ui.products.ProductSortAndFiltersCard.ProductSortAndFilterListener
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.SkeletonView

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -330,7 +330,9 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener, ProductS
             productsRecycler.layoutManager?.onRestoreInstanceState(it)
             listState = null
         }
-        showProductWIPNoticeCard(true)
+
+        // hidden until we need it again for M3
+//        showProductWIPNoticeCard(true)
     }
 
     private fun showProductWIPNoticeCard(show: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -337,17 +337,10 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener, ProductS
     private fun showProductWIPNoticeCard(show: Boolean) {
         if (show) {
             products_wip_card.visibility = View.VISIBLE
-            if (FeatureFlag.PRODUCT_RELEASE_M2.isEnabled()) {
-                products_wip_card.initView(
-                    getString(R.string.product_wip_title),
-                    getString(R.string.product_wip_message)
-                )
-            } else {
-                products_wip_card.initView(
-                    getString(R.string.product_limited_editing_title),
-                    getString(R.string.product_limited_editing_message)
-                )
-            }
+            products_wip_card.initView(
+                getString(R.string.product_wip_title),
+                getString(R.string.product_wip_message)
+            )
         } else {
             products_wip_card.visibility = View.GONE
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -25,7 +25,6 @@ import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductSt
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductVariations
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductVisibility
 import com.woocommerce.android.ui.products.settings.ProductSettingsFragmentDirections
-import com.woocommerce.android.util.FeatureFlag
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -153,11 +153,7 @@ class ProductNavigator @Inject constructor() {
             }
 
             is ViewProductImages -> {
-                if (FeatureFlag.PRODUCT_RELEASE_M2.isEnabled()) {
-                    viewProductImageChooser(fragment, target.product.remoteId)
-                } else if (target.imageModel != null) {
-                    viewProductImageViewer(fragment, target.product.remoteId)
-                }
+                viewProductImageChooser(fragment, target.product.remoteId)
             }
 
             is ViewProductMenuOrder -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.util
 
 import android.content.Context
-import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig
 
 /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -8,14 +8,12 @@ import com.woocommerce.android.BuildConfig
  * "Feature flags" are used to hide in-progress features from release versions
  */
 enum class FeatureFlag {
-    PRODUCT_RELEASE_M2,
     PRODUCT_RELEASE_M3,
     DB_DOWNGRADE;
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
             // This feature will live switched on from the
             // setting screen. i.e. check AppPrefs.isProductsFeatureEnabled() method
-            PRODUCT_RELEASE_M2 -> AppPrefs.isProductsFeatureEnabled()
             PRODUCT_RELEASE_M3 -> BuildConfig.DEBUG
             DB_DOWNGRADE -> {
                 BuildConfig.DEBUG || context != null && PackageUtils.isBetaBuild(context)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -20,7 +20,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.di.GlideApp
 import com.woocommerce.android.di.GlideRequest
 import com.woocommerce.android.model.Product
-import com.woocommerce.android.util.FeatureFlag
 import kotlinx.android.synthetic.main.image_gallery_item.view.*
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.PhotonUtils

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -64,12 +64,10 @@ class WCProductImageGalleryView @JvmOverloads constructor(
             val attrArray = context.obtainStyledAttributes(it, R.styleable.WCProductImageGalleryView)
             try {
                 isGridView = attrArray.getBoolean(R.styleable.WCProductImageGalleryView_isGridView, false)
-                if (FeatureFlag.PRODUCT_RELEASE_M2.isEnabled(context)) {
-                    showAddImageIcon = attrArray.getBoolean(
-                            R.styleable.WCProductImageGalleryView_showAddImageIcon,
-                            false
-                    )
-                }
+                showAddImageIcon = attrArray.getBoolean(
+                        R.styleable.WCProductImageGalleryView_showAddImageIcon,
+                        false
+                )
             } finally {
                 attrArray.recycle()
             }


### PR DESCRIPTION
This PR removes the M2 feature flag, deletes obsolete code that was run when it was disabled, updates the product list banner and removes the products beta switch.

**Testing**

1. Make sure that you can update product images, product settings, viewing, and sharing a product
2. Make sure that the product switch under the Beta features screen disappeared
3. Make sure that the banner message in the product list is updated ("New editing options available")
4. Make sure you can update product images, product settings, viewing, and sharing a product

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
