### PR TITLE
Merge Release/4.5 back into develop

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,6 @@
+4.6
+-----
+ 
 4.5
 -----
 * Added a link to the new privacy notice for california users

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -47,9 +47,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "4.4"
+            versionName "4.5-rc-1"
         }
-        versionCode 134
+        versionCode 135
 
         minSdkVersion 21
         targetSdkVersion 29


### PR DESCRIPTION
Merge Release/4.5 back into develop.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
