### PR TITLE
Hack week: Android TV support

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.woocommerce.android"
-          xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.woocommerce.android">
+
+    <uses-feature
+        android:name="android.hardware.touchscreen"
+        android:required="false" />
+    <uses-feature
+        android:name="android.software.leanback"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
 
     <!-- Normal permissions, access automatically granted to app -->
     <uses-permission android:name="android.permission.INTERNET" />
@@ -13,27 +24,32 @@
     <uses-permission android:name="android.permission.CAMERA" />
 
     <application
+        android:name=".WooCommerce"
         android:allowBackup="true"
         android:fullBackupContent="@xml/backup_scheme"
         android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:largeHeap="true"
-        android:name=".WooCommerce"
         android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Woo.Splash">
 
         <!-- TODO: we eventually want to drop support for Apache, but for now it's used by FluxC -->
-        <uses-library android:name="org.apache.http.legacy" android:required="false"/>
+        <uses-library
+            android:name="org.apache.http.legacy"
+            android:required="false" />
 
         <activity
             android:name=".ui.main.MainActivity"
+            android:banner="@drawable/img_woo_bubble_colored"
+            android:logo="@drawable/img_woo_logo"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
         </activity>
 
@@ -130,7 +146,7 @@
             android:grantUriPermissions="true">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/provider_paths"/>
+                android:resource="@xml/provider_paths" />
         </provider>
     </application>
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -32,7 +32,6 @@ import com.woocommerce.android.extensions.getRemoteOrderId
 import com.woocommerce.android.extensions.getWooType
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateSafely
-import com.woocommerce.android.extensions.show
 import com.woocommerce.android.push.NotificationHandler
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
@@ -149,6 +148,9 @@ class MainActivity : AppUpgradeActivity(),
         super.onCreate(savedInstanceState)
 
         setContentView(R.layout.activity_main)
+
+        // Set the toolbar
+        setSupportActionBar(toolbar as Toolbar)
 
         presenter.takeView(this)
 
@@ -395,8 +397,6 @@ class MainActivity : AppUpgradeActivity(),
             hideBottomNav()
         }
 
-        // Set the toolbar
-        setSupportActionBar(toolbar as Toolbar)
         getActiveTopLevelFragment()?.let {
             if (isAtRoot) {
                 it.updateActivityTitle()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -30,6 +30,7 @@ import com.woocommerce.android.extensions.active
 import com.woocommerce.android.extensions.getCommentId
 import com.woocommerce.android.extensions.getRemoteOrderId
 import com.woocommerce.android.extensions.getWooType
+import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.push.NotificationHandler
 import com.woocommerce.android.support.HelpActivity
@@ -50,6 +51,7 @@ import com.woocommerce.android.ui.orders.list.OrderListFragment
 import com.woocommerce.android.ui.prefs.AppSettingsActivity
 import com.woocommerce.android.ui.reviews.ReviewDetailFragmentDirections
 import com.woocommerce.android.ui.sitepicker.SitePickerActivity
+import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
 import com.woocommerce.android.widgets.AppRatingDialog
@@ -133,7 +135,8 @@ class MainActivity : AppUpgradeActivity(),
             if (!isMainThemeApplied) {
                 it.applyStyle(R.style.Theme_Woo_DayNight, true)
                 isMainThemeApplied = true
-            } }
+            }
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -142,12 +145,17 @@ class MainActivity : AppUpgradeActivity(),
 
         setContentView(R.layout.activity_main)
 
-        // Set the toolbar
-        setSupportActionBar(toolbar as Toolbar)
-
         presenter.takeView(this)
 
         bottomNavView = bottom_nav.also { it.init(supportFragmentManager, this) }
+
+        // Set the toolbar
+        if (ActivityUtils.isRunningOnTv(this)) {
+            toolbar.hide()
+            bottomNavView.hide()
+        } else {
+            setSupportActionBar(toolbar as Toolbar)
+        }
 
         val navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment_main) as NavHostFragment
         navController = navHostFragment.navController

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -32,6 +32,7 @@ import com.woocommerce.android.extensions.getRemoteOrderId
 import com.woocommerce.android.extensions.getWooType
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.extensions.show
 import com.woocommerce.android.push.NotificationHandler
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
@@ -122,6 +123,10 @@ class MainActivity : AppUpgradeActivity(),
     // TODO: Using deprecated ProgressDialog temporarily - a proper post-login experience will replace this
     private var progressDialog: ProgressDialog? = null
 
+    private val isOnTv by lazy {
+        ActivityUtils.isRunningOnTv(this)
+    }
+
     /**
      * Manually set the theme here so the splash screen will be visible while this activity
      * is loading. Also setting it here ensures all fragments used in this activity will also
@@ -148,14 +153,6 @@ class MainActivity : AppUpgradeActivity(),
         presenter.takeView(this)
 
         bottomNavView = bottom_nav.also { it.init(supportFragmentManager, this) }
-
-        // Set the toolbar
-        if (ActivityUtils.isRunningOnTv(this)) {
-            toolbar.hide()
-            bottomNavView.hide()
-        } else {
-            setSupportActionBar(toolbar as Toolbar)
-        }
 
         val navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment_main) as NavHostFragment
         navController = navHostFragment.navController
@@ -349,11 +346,9 @@ class MainActivity : AppUpgradeActivity(),
 
         val showUpIcon: Boolean
         val showCrossIcon: Boolean
-        val showBottomNav: Boolean
         if (isAtRoot) {
             showUpIcon = false
             showCrossIcon = false
-            showBottomNav = true
         } else {
             showUpIcon = true
             showCrossIcon = when (destination.id) {
@@ -400,6 +395,8 @@ class MainActivity : AppUpgradeActivity(),
             hideBottomNav()
         }
 
+        // Set the toolbar
+        setSupportActionBar(toolbar as Toolbar)
         getActiveTopLevelFragment()?.let {
             if (isAtRoot) {
                 it.updateActivityTitle()
@@ -715,7 +712,13 @@ class MainActivity : AppUpgradeActivity(),
                 }
             }
         } else {
-            bottomNavView.currentPosition = DASHBOARD
+            if (isOnTv) {
+                bottomNavView.currentPosition = ORDERS
+                hideBottomNav()
+                toolbar.hide()
+            } else {
+                bottomNavView.currentPosition = DASHBOARD
+            }
         }
     }
     // endregion

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -26,6 +26,8 @@ import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.extensions.hide
+import com.woocommerce.android.extensions.show
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -33,6 +35,7 @@ import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.ui.orders.OrderStatusListView
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowErrorSnack
+import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.StringUtils
@@ -40,6 +43,7 @@ import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.fragment_order_list.*
 import kotlinx.android.synthetic.main.fragment_order_list.view.*
 import kotlinx.android.synthetic.main.order_list_view.*
@@ -249,6 +253,10 @@ class OrderListFragment : TopLevelFragment(),
             searchHandler.postDelayed({ searchView?.setQuery(searchQuery, true) }, 100)
         } else {
             loadListForActiveTab()
+        }
+
+        if (ActivityUtils.isRunningOnTv(requireContext())) {
+            tabLayout.hide()
         }
     }
 
@@ -498,7 +506,9 @@ class OrderListFragment : TopLevelFragment(),
      */
     private fun calculateStartupTabPosition(): Int {
         val orderStatusOptions = getOrderStatusOptions()
-        return if (orderStatusFilter == PROCESSING.value) {
+        return if (ActivityUtils.isRunningOnTv(requireContext())) {
+            TAB_INDEX_ALL
+        } else if (orderStatusFilter == PROCESSING.value) {
             TAB_INDEX_PROCESSING
         } else if (AppPrefs.hasSelectedOrderListTabPosition()) {
             // If the user has already changed tabs once then select

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -28,6 +28,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.show
+import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -44,6 +45,7 @@ import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.activity_main.*
+import kotlinx.android.synthetic.main.dashboard_main_stats_row.*
 import kotlinx.android.synthetic.main.fragment_order_list.*
 import kotlinx.android.synthetic.main.fragment_order_list.view.*
 import kotlinx.android.synthetic.main.order_list_view.*
@@ -383,6 +385,18 @@ class OrderListFragment : TopLevelFragment(),
         }
 
         // setup observers
+        viewModel.viewStateLiveData.observe(viewLifecycleOwner) { old, new ->
+            new.orderStats?.takeIfNotEqualTo(old?.orderStats) {
+                orders_value.text = it.toString()
+            }
+            new.revenueStats?.takeIfNotEqualTo(old?.revenueStats) {
+                revenue_value.text = it
+            }
+            new.visitorStats?.takeIfNotEqualTo(old?.visitorStats) {
+                visitors_value.text = it.toString()
+            }
+        }
+
         viewModel.isFetchingFirstPage.observe(viewLifecycleOwner, Observer {
             orderRefreshLayout?.isRefreshing = it == true
         })

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -91,6 +91,10 @@ class OrderListFragment : TopLevelFragment(),
     private val viewModel: OrderListViewModel by viewModels { viewModelFactory }
     private var listState: Parcelable? = null // Save the state of the recycler view
 
+    private val isOnTv by lazy {
+        ActivityUtils.isRunningOnTv(requireContext())
+    }
+
     // Alias for interacting with [viewModel.orderStatusFilter] so the value is always
     // identical to the real value on the UI side.
     private var orderStatusFilter: String
@@ -257,8 +261,9 @@ class OrderListFragment : TopLevelFragment(),
             loadListForActiveTab()
         }
 
-        if (ActivityUtils.isRunningOnTv(requireContext())) {
+        if (isOnTv) {
             tabLayout.hide()
+            stats_view.show()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ActivityUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ActivityUtils.kt
@@ -1,10 +1,13 @@
 package com.woocommerce.android.util
 
 import android.app.Activity
+import android.app.UiModeManager
 import android.content.ActivityNotFoundException
 import android.content.Context
+import android.content.Context.UI_MODE_SERVICE
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.net.Uri
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
@@ -82,5 +85,10 @@ object ActivityUtils {
             window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
             window.statusBarColor = ContextCompat.getColor(activity, colorRes)
         }
+    }
+
+    fun isRunningOnTv(context: Context): Boolean {
+        val uiModeManager = context.getSystemService(UI_MODE_SERVICE) as UiModeManager
+        return uiModeManager.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION
     }
 }

--- a/WooCommerce/src/main/res/layout/dashboard_main_stats_tv.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_main_stats_tv.xml
@@ -3,28 +3,41 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/label_layout"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
     android:baselineAligned="false"
-    android:background="@color/color_surface"
     android:gravity="center_horizontal"
-    android:padding="@dimen/major_300"
     android:orientation="vertical">
 
-    <LinearLayout
-        android:id="@+id/visitors_layout"
+    <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/orderListHeader"
+            style="@style/Woo.ListHeader"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/dashboard_stats_todays_stats"/>
+
+    </FrameLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
         android:layout_weight="1"
-        android:gravity="center_horizontal"
+        android:gravity="center"
+        android:background="@color/color_surface"
         android:orientation="vertical">
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/visitors_label"
-            android:textAppearance="?attr/textAppearanceHeadline4"
+            android:textAppearance="?attr/textAppearanceHeadline5"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
+            android:paddingStart="@dimen/major_300"
+            android:paddingEnd="@dimen/major_300"
             android:text="@string/dashboard_stats_visitors"
             tools:text="Visitors"/>
 
@@ -34,21 +47,28 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
+            android:textColor="@color/color_primary"
+            android:textStyle="bold"
             android:text="\?"/>
 
     </LinearLayout>
 
+    <View
+        style="@style/Woo.Divider" />
+
     <LinearLayout
-        android:id="@+id/orders_layout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         android:layout_weight="1"
-        android:gravity="center_horizontal"
+        android:gravity="center"
+        android:background="@color/color_surface"
         android:orientation="vertical">
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/orders_label"
-            android:textAppearance="?attr/textAppearanceHeadline4"
+            android:textAppearance="?attr/textAppearanceHeadline5"
+            android:paddingStart="@dimen/major_300"
+            android:paddingEnd="@dimen/major_300"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
@@ -61,21 +81,28 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
+            android:textColor="@color/color_primary"
+            android:textStyle="bold"
             tools:text="10"/>
 
     </LinearLayout>
 
+    <View
+        style="@style/Woo.Divider" />
+
     <LinearLayout
-        android:id="@+id/revenue_layout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
         android:layout_weight="1"
-        android:gravity="center_horizontal"
+        android:gravity="center"
+        android:background="@color/color_surface"
         android:orientation="vertical">
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/revenue_label"
-            android:textAppearance="?attr/textAppearanceHeadline4"
+            android:textAppearance="?attr/textAppearanceHeadline5"
+            android:paddingStart="@dimen/major_300"
+            android:paddingEnd="@dimen/major_300"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
@@ -87,6 +114,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
+            android:textColor="@color/color_primary"
+            android:textStyle="bold"
             tools:text="$1.6k"/>
 
     </LinearLayout>

--- a/WooCommerce/src/main/res/layout/dashboard_main_stats_tv.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_main_stats_tv.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/label_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:baselineAligned="false"
+    android:background="@color/color_surface"
+    android:gravity="center_horizontal"
+    android:padding="@dimen/major_300"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:id="@+id/visitors_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="center_horizontal"
+        android:orientation="vertical">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/visitors_label"
+            android:textAppearance="?attr/textAppearanceHeadline4"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:text="@string/dashboard_stats_visitors"
+            tools:text="Visitors"/>
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/visitors_value"
+            android:textAppearance="?attr/textAppearanceHeadline5"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            tools:text="400"/>
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/orders_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="center_horizontal"
+        android:orientation="vertical">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/orders_label"
+            android:textAppearance="?attr/textAppearanceHeadline4"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:text="@string/dashboard_stats_orders"
+            tools:text="Orders"/>
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/orders_value"
+            android:textAppearance="?attr/textAppearanceHeadline5"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            tools:text="10"/>
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/revenue_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="center_horizontal"
+        android:orientation="vertical">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/revenue_label"
+            android:textAppearance="?attr/textAppearanceHeadline4"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:text="@string/dashboard_stats_revenue"/>
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/revenue_value"
+            android:textAppearance="?attr/textAppearanceHeadline5"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            tools:text="$1.6k"/>
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/dashboard_main_stats_tv.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_main_stats_tv.xml
@@ -34,7 +34,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
-            tools:text="400"/>
+            android:text="\?"/>
 
     </LinearLayout>
 

--- a/WooCommerce/src/main/res/layout/dashboard_stats.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_stats.xml
@@ -31,7 +31,7 @@
         <View
             style="@style/Woo.Divider"/>
 
-        <include android:id="@+id/stats_view_row" layout="@layout/dashboard_main_stats_row" />
+        <include android:id="@+id/stats_view" layout="@layout/dashboard_main_stats_row" />
 
         <FrameLayout
             android:id="@+id/chart_container"

--- a/WooCommerce/src/main/res/layout/fragment_order_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_list.xml
@@ -24,7 +24,7 @@
                 android:layout_height="0dp"
                 android:layout_width="0dp"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toStartOf="@+id/stats_view_row"
+                app:layout_constraintEnd_toStartOf="@+id/stats_view"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_behavior="@string/appbar_scrolling_view_behavior"
@@ -42,13 +42,14 @@
                 tools:visibility="visible"/>
 
             <include
-                android:id="@+id/stats_view_row"
+                android:id="@+id/stats_view"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 layout="@layout/dashboard_main_stats_tv"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
+                android:visibility="gone"
                 app:layout_constraintStart_toEndOf="@id/order_list_view" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/fragment_order_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_list.xml
@@ -49,6 +49,7 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
+                android:layout_marginStart="@dimen/minor_100"
                 android:visibility="gone"
                 app:layout_constraintStart_toEndOf="@id/order_list_view" />
 

--- a/WooCommerce/src/main/res/layout/fragment_order_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_list.xml
@@ -21,14 +21,14 @@
 
             <com.woocommerce.android.ui.orders.list.OrderListView
                 android:id="@+id/order_list_view"
-                android:layout_width="match_parent"
                 android:layout_height="0dp"
+                android:layout_width="0dp"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/stats_view_row"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_behavior="@string/appbar_scrolling_view_behavior"
-                tools:visibility="gone"/>
+                tools:visibility="visible"/>
 
             <com.woocommerce.android.ui.orders.OrderStatusListView
                 android:id="@+id/order_status_list_view"
@@ -40,6 +40,16 @@
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"
                 tools:visibility="visible"/>
+
+            <include
+                android:id="@+id/stats_view_row"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                layout="@layout/dashboard_main_stats_tv"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toEndOf="@id/order_list_view" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/WooCommerce/src/main/res/layout/my_store_stats.xml
+++ b/WooCommerce/src/main/res/layout/my_store_stats.xml
@@ -18,7 +18,7 @@
             android:layout_height="wrap_content"
             android:orientation="vertical"/>
 
-        <include android:id="@+id/stats_view_row" layout="@layout/dashboard_main_stats_row" />
+        <include android:id="@+id/stats_view" layout="@layout/dashboard_main_stats_row" />
 
         <FrameLayout
             android:id="@+id/chart_container"


### PR DESCRIPTION
This PR adds the necessary configuration that makes the app available on Android TV Play Store. It also adds a _presentation mode_ that hides the toolbar & the bottom navigation and shows the live feed of **All orders** and **Today's stats**.

<img width="2090" alt="Screenshot 2020-06-15 at 9 44 04 PM" src="https://user-images.githubusercontent.com/1522856/84699246-78ac7000-af51-11ea-91d3-6a4ac9a2fe30.png">

Note: This work was meant as an experiment and isn't really ready to be used in production.