### PR TITLE
Issue/1926 new order notification bug fix

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 4.6
 -----
+* Added a fix to support multiple new order notifications for a store.
  
 4.5
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
@@ -46,6 +46,7 @@ import java.net.URLDecoder
 import java.util.concurrent.ExecutionException
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.random.Random
 
 @Singleton
 class NotificationHandler @Inject constructor(
@@ -295,8 +296,15 @@ class NotificationHandler @Inject constructor(
 
         val message = StringEscapeUtils.unescapeHtml4(data.getString(PUSH_ARG_MSG))
 
-        val localPushId = getLocalPushIdForWpComNoteId(wpComNoteId)
-        ACTIVE_NOTIFICATIONS_MAP[localPushId] = data
+        // New order notifications have the same notification_note_id. So if there is a new incoming notification
+        // when there is an existing new order notification in the notification tray,
+        // the cha ching sound is not played and the new notification replaces the existing notification
+        // See issue for more details: https://github.com/woocommerce/woocommerce-android/issues/1076
+        // This solution is a temporary HACK to generate a random number for each new order notification
+        // and use that number to group notifications along with notification_note_id
+        val randomNumber = if (noteType == NEW_ORDER) Random.nextInt() else 0
+        val localPushId = getLocalPushIdForWpComNoteId(wpComNoteId, randomNumber)
+        ACTIVE_NOTIFICATIONS_MAP[getLocalPushId(localPushId, randomNumber)] = data
 
         if (NotificationsUtils.isNotificationsEnabled(context)) {
             bumpPushNotificationsAnalytics(context, Stat.PUSH_NOTIFICATION_RECEIVED, data)
@@ -326,10 +334,10 @@ class NotificationHandler @Inject constructor(
      * For a given remote note ID, return a unique local ID to track that notification with, or return
      * the existing local ID if a notification matching the remote note ID is already being displayed.
      */
-    private fun getLocalPushIdForWpComNoteId(wpComNoteId: String): Int {
+    private fun getLocalPushIdForWpComNoteId(wpComNoteId: String, randomNumber: Int): Int {
         // Update notification content for the same noteId if it is already showing
         for (id in ACTIVE_NOTIFICATIONS_MAP.keys) {
-            val noteBundle = ACTIVE_NOTIFICATIONS_MAP[id]
+            val noteBundle = ACTIVE_NOTIFICATIONS_MAP[getLocalPushId(id, randomNumber)]
             if (noteBundle?.getString(PUSH_ARG_NOTE_ID, "") == wpComNoteId) {
                 return id
             }
@@ -338,6 +346,8 @@ class NotificationHandler @Inject constructor(
         // Notification isn't already showing
         return PUSH_NOTIFICATION_ID + ACTIVE_NOTIFICATIONS_MAP.size
     }
+
+    private fun getLocalPushId(wpComNoteId: Int, randomNumber: Int) = wpComNoteId + randomNumber
 
     private fun getLargeIconBitmap(context: Context, iconUrl: String?, shouldCircularizeIcon: Boolean): Bitmap? {
         iconUrl?.let {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationHandler.kt
@@ -497,7 +497,7 @@ class NotificationHandler @Inject constructor(
             }
         }
 
-        showWPComNotificationForBuilder(builder, context, wpComNoteId, pushId)
+        showWPComNotificationForBuilder(builder, context, wpComNoteId, pushId, noteType)
     }
 
     private fun showGroupNotificationForBuilder(
@@ -553,12 +553,12 @@ class NotificationHandler @Inject constructor(
                     .setSound(null)
                     .setVibrate(null)
 
-            showWPComNotificationForBuilder(groupBuilder, context, wpComNoteId, GROUP_NOTIFICATION_ID)
+            showWPComNotificationForBuilder(groupBuilder, context, wpComNoteId, GROUP_NOTIFICATION_ID, noteType)
         } else {
             // Set the individual notification we've already built as the group summary
             builder.setGroupSummary(true)
                     .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)
-            showWPComNotificationForBuilder(builder, context, wpComNoteId, GROUP_NOTIFICATION_ID)
+            showWPComNotificationForBuilder(builder, context, wpComNoteId, GROUP_NOTIFICATION_ID, noteType)
         }
     }
 
@@ -569,13 +569,15 @@ class NotificationHandler @Inject constructor(
         builder: NotificationCompat.Builder,
         context: Context,
         wpComNoteId: String,
-        pushId: Int
+        pushId: Int,
+        noteType: NotificationChannelType
     ) {
         // Open the app and load the notifications tab
         val resultIntent = Intent(context, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
             putExtra(MainActivity.FIELD_OPENED_FROM_PUSH, true)
             putExtra(MainActivity.FIELD_REMOTE_NOTE_ID, wpComNoteId.toLong())
+            putExtra(MainActivity.FIELD_NOTIFICATION_TYPE, noteType.name)
             if (pushId == GROUP_NOTIFICATION_ID) {
                 putExtra(MainActivity.FIELD_OPENED_FROM_PUSH_GROUP, true)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -32,6 +32,7 @@ import com.woocommerce.android.extensions.getRemoteOrderId
 import com.woocommerce.android.extensions.getWooType
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.push.NotificationHandler
+import com.woocommerce.android.push.NotificationHandler.NotificationChannelType
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
 import com.woocommerce.android.tools.SelectedSite
@@ -67,6 +68,7 @@ import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.login.LoginAnalyticsListener
 import org.wordpress.android.login.LoginMode
 import org.wordpress.android.util.NetworkUtils
+import java.util.Locale
 import javax.inject.Inject
 
 class MainActivity : AppUpgradeActivity(),
@@ -88,6 +90,7 @@ class MainActivity : AppUpgradeActivity(),
         const val FIELD_REMOTE_NOTE_ID = "remote-note-id"
         const val FIELD_OPENED_FROM_PUSH_GROUP = "opened-from-push-group"
         const val FIELD_OPENED_FROM_ZENDESK = "opened-from-zendesk"
+        const val FIELD_NOTIFICATION_TYPE = "notification-type"
 
         interface BackPressListener {
             fun onRequestAllowBackPress(): Boolean
@@ -665,8 +668,16 @@ class MainActivity : AppUpgradeActivity(),
                 // Clear unread messages from the system bar
                 NotificationHandler.removeAllNotificationsFromSystemBar(this)
 
-                // User clicked on a group of notifications. Just show the notifications tab.
-                bottomNavView.currentPosition = REVIEWS
+                // User clicked on a group of notifications. Redirect to the order list screen if
+                // the last notification received is a new order. Otherwise, redirect to the reviews screen
+                val notificationChannelType = intent.getStringExtra(FIELD_NOTIFICATION_TYPE)?.let {
+                    NotificationChannelType.valueOf(it.toUpperCase(Locale.US))
+                } ?: NotificationChannelType.REVIEW
+
+                bottomNavView.currentPosition = when (notificationChannelType) {
+                    NotificationChannelType.NEW_ORDER -> ORDERS
+                    else -> REVIEWS
+                }
             } else if (intent.getBooleanExtra(FIELD_OPENED_FROM_ZENDESK, false)) {
                 // Reset this flag now that it's being processed
                 intent.removeExtra(FIELD_OPENED_FROM_ZENDESK)


### PR DESCRIPTION
Fixes #1926. This PR fixes two things:
- Adds a hack to generate a unique notification id in order to support multiple new order notifications.
- Ensures that when two new order group notification is clicked, the order list screen is displayed.

#### Testing
- Generate a new order notification from your test site. Ensure that clicking on the notification redirects to the order detail screen.
- Generate 2 new order notifications from your test site. Verify that you are able to see both notifications in the notifications tray. Ensure that clicking on the notifications redirects to the order list screen.
- Generate a new review notification from your test site. Ensure that clicking on the notification redirects to the review detail screen.
- Generate 2 new review notifications from your test site. Verify that you are able to see both notifications in the notifications tray. Ensure that clicking on the notifications redirects to the review list screen.
- Generate a new order notification from your test site. Now add a review to your test site. Verify that you are able to see both notifications in the notification tray. Ensure that clicking on the notification redirects to the review list screen.
- Generate a new review notification from your test site. Now generate a new order to your test site. Verify that you are able to see both notifications in the notification tray. Ensure that clicking on the notification redirects to the order list screen now.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
