### PR TITLE
DateUtils crash fix for Issue #2528

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailOrderStatusView.kt
@@ -53,7 +53,7 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
 
         orderStatus_edit.setOnClickListener {
             AnalyticsTracker.track(
-                Stat.ORDER_DETAIL_ORDER_STATUS_EDIT_BUTTON_TAPPED, mapOf("status" to orderModel.status))
+                    Stat.ORDER_DETAIL_ORDER_STATUS_EDIT_BUTTON_TAPPED, mapOf("status" to orderModel.status))
             listener.openOrderStatusSelector()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailOrderStatusView.kt
@@ -28,11 +28,14 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
     }
 
     fun initView(orderModel: WCOrderModel, orderStatus: WCOrderStatusModel, listener: OrderStatusListener) {
-        val dateStr = if (DateUtils.isToday(orderModel.dateCreated)) {
-            DateUtils.getTimeString(context, orderModel.dateCreated)
-        } else {
-            DateUtils.getMediumDateFromString(context, orderModel.dateCreated)
-        }
+        val dateStr = DateUtils.isToday(orderModel.dateCreated)
+            ?.let { isToday ->
+                when {
+                    isToday -> DateUtils.getTimeString(context, orderModel.dateCreated)
+                    else -> DateUtils.getMediumDateFromString(context, orderModel.dateCreated)
+                }
+            }.orEmpty()
+
         orderStatus_dateAndOrderNum.text = context.getString(
             R.string.orderdetail_orderstatus_date_and_ordernum,
             dateStr,
@@ -50,7 +53,8 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
 
         orderStatus_edit.setOnClickListener {
             AnalyticsTracker.track(
-                    Stat.ORDER_DETAIL_ORDER_STATUS_EDIT_BUTTON_TAPPED, mapOf("status" to orderModel.status))
+                Stat.ORDER_DETAIL_ORDER_STATUS_EDIT_BUTTON_TAPPED, mapOf("status" to orderModel.status)
+            )
             listener.openOrderStatusSelector()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailOrderStatusView.kt
@@ -53,8 +53,7 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
 
         orderStatus_edit.setOnClickListener {
             AnalyticsTracker.track(
-                Stat.ORDER_DETAIL_ORDER_STATUS_EDIT_BUTTON_TAPPED, mapOf("status" to orderModel.status)
-            )
+                Stat.ORDER_DETAIL_ORDER_STATUS_EDIT_BUTTON_TAPPED, mapOf("status" to orderModel.status))
             listener.openOrderStatusSelector()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailOrderStatusView.kt
@@ -30,9 +30,9 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
     fun initView(orderModel: WCOrderModel, orderStatus: WCOrderStatusModel, listener: OrderStatusListener) {
         val dateStr = DateUtils.isToday(orderModel.dateCreated)
             ?.let { isToday ->
-                when {
-                    isToday -> DateUtils.getTimeString(context, orderModel.dateCreated)
-                    else -> DateUtils.getMediumDateFromString(context, orderModel.dateCreated)
+                when(isToday) {
+                    true -> DateUtils.getTimeString(context, orderModel.dateCreated)
+                    false -> DateUtils.getMediumDateFromString(context, orderModel.dateCreated)
                 }
             }.orEmpty()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailOrderStatusView.kt
@@ -30,7 +30,7 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
     fun initView(orderModel: WCOrderModel, orderStatus: WCOrderStatusModel, listener: OrderStatusListener) {
         val dateStr = DateUtils.isToday(orderModel.dateCreated)
             ?.let { isToday ->
-                when(isToday) {
+                when (isToday) {
                     true -> DateUtils.getTimeString(context, orderModel.dateCreated)
                     false -> DateUtils.getMediumDateFromString(context, orderModel.dateCreated)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -241,7 +241,7 @@ object DateUtils {
             val then = DateTimeUtils.dateUTCFromIso8601(dateString)
             DateUtils.isSameDay(Date(), then)
         } catch (e: Exception) {
-            WooLog.e(T.UTILS, "Unable to match dateString value with today date", e)
+            WooLog.e(T.UTILS, "Unable to match dateString with today date. (current dateString value: $dateString)", e)
             null
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -232,10 +232,16 @@ object DateUtils {
 
     /**
      * Given a date of format MMMM d, YYYY, returns true if it's today
+     *
+     * returns false if the argument is not a valid date string.
      */
     fun isToday(dateString: String): Boolean {
-        val then = DateTimeUtils.dateUTCFromIso8601(dateString)
-        return DateUtils.isSameDay(Date(), then)
+        return try {
+            val then = DateTimeUtils.dateUTCFromIso8601(dateString)
+            DateUtils.isSameDay(Date(), then)
+        } catch (e: Exception) {
+            false
+        }
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -235,12 +235,12 @@ object DateUtils {
      *
      * returns false if the argument is not a valid date string.
      */
-    fun isToday(dateString: String): Boolean {
+    fun isToday(dateString: String): Boolean? {
         return try {
             val then = DateTimeUtils.dateUTCFromIso8601(dateString)
             DateUtils.isSameDay(Date(), then)
         } catch (e: Exception) {
-            false
+            null
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -5,6 +5,7 @@ import android.text.format.DateFormat
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.formatToYYYYmmDD
 import com.woocommerce.android.model.TimeGroup
+import com.woocommerce.android.util.WooLog.T
 import org.apache.commons.lang3.time.DateUtils
 import org.wordpress.android.util.DateTimeUtils
 import java.text.DateFormatSymbols
@@ -233,13 +234,14 @@ object DateUtils {
     /**
      * Given a date of format MMMM d, YYYY, returns true if it's today
      *
-     * returns false if the argument is not a valid date string.
+     * returns null if the argument is not a valid date string.
      */
     fun isToday(dateString: String): Boolean? {
         return try {
             val then = DateTimeUtils.dateUTCFromIso8601(dateString)
             DateUtils.isSameDay(Date(), then)
         } catch (e: Exception) {
+            WooLog.e(T.UTILS, "Unable to match dateString value with today date", e)
             null
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
@@ -11,7 +11,7 @@ import com.woocommerce.android.extensions.formatToMonthDateOnly
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertFalse
+import kotlin.test.assertNull
 
 class DateUtilsTest {
     @Test
@@ -489,7 +489,7 @@ class DateUtilsTest {
     }
 
     @Test
-    fun `isToday() returns false when the date is empty`() {
-        assertFalse(DateUtils.isToday(""))
+    fun `isToday() returns null when the date string is empty`() {
+        assertNull(DateUtils.isToday(""))
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateUtilsTest.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.extensions.formatToMonthDateOnly
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 
 class DateUtilsTest {
     @Test
@@ -485,5 +486,10 @@ class DateUtilsTest {
         assertFailsWith(IllegalArgumentException::class) {
             "21".formatToMonthDateOnly()
         }
+    }
+
+    @Test
+    fun `isToday() returns false when the date is empty`() {
+        assertFalse(DateUtils.isToday(""))
     }
 }


### PR DESCRIPTION
Summary
------------
This Pull Request suggests a fix for the Date crash within the `isToday` method from the `DateUtils` object. As described at [issue 2528](https://github.com/woocommerce/woocommerce-android/issues/2528).

The fix proposes the following implementation:

* Since the single purpose of the `isToday` method is to return a `Boolean` telling about if the string parameter is the current day date, I've decided to try to avoid keep throwing any exception directly from the method and allowing the `isToday` to return `null` if a failure happens as the default behavior in order to be resilience instead of crashing the app. This way the `isToday` method now returns a `Boolean?`

* The `isToday` method calls the `dateUTCFromIso8601` from the `DateTimeUtils`, which is part of the Android SDK, so on the JUnit environment this method will always return an empty String. So the only test added is about verifying if the `isToday` method returns null instead of throwing an exception since this method will always try to compare an empty String with the current date. This way the new test is verifying if the `isToday` won't break anything in a corner case.

* I couldn't find a strategy to reproduce this issue from the app, since this would require a natural bad formatted or empty string event.

