### PR TITLE
Move CCPA link to About Screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.6
 -----
 * Added a fix to support multiple new order notifications for a store.
+* Moved privacy notice for CA users to the About App screen.
  
 4.5
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AboutFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AboutFragment.kt
@@ -48,6 +48,10 @@ class AboutFragment : androidx.fragment.app.Fragment() {
             ChromeCustomTabUtils.launchUrl(activity as Context, AppUrls.AUTOMATTIC_PRIVACY_POLICY)
         }
 
+        about_privacy_ca.setOnClickListener {
+            ChromeCustomTabUtils.launchUrl(activity as Context, AppUrls.AUTOMATTIC_PRIVACY_POLICY_CA)
+        }
+
         about_tos.setOnClickListener {
             ChromeCustomTabUtils.launchUrl(activity as Context, AppUrls.AUTOMATTIC_TOS)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsContract.kt
@@ -15,6 +15,5 @@ interface PrivacySettingsContract {
     interface View : BaseView<Presenter> {
         fun showCookiePolicy()
         fun showPrivacyPolicy()
-        fun showPrivacyPolicyCA()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsFragment.kt
@@ -54,9 +54,6 @@ class PrivacySettingsFragment : androidx.fragment.app.Fragment(), PrivacySetting
             AnalyticsTracker.track(PRIVACY_SETTINGS_PRIVACY_POLICY_LINK_TAPPED)
             showPrivacyPolicy()
         }
-        buttonPrivacyPolicyCA.setOnClickListener {
-            showPrivacyPolicyCA()
-        }
         buttonTracking.setOnClickListener {
             AnalyticsTracker.track(PRIVACY_SETTINGS_THIRD_PARTY_TRACKING_INFO_LINK_TAPPED)
             showCookiePolicy()
@@ -103,9 +100,5 @@ class PrivacySettingsFragment : androidx.fragment.app.Fragment(), PrivacySetting
 
     override fun showPrivacyPolicy() {
         ChromeCustomTabUtils.launchUrl(activity as Context, AppUrls.AUTOMATTIC_PRIVACY_POLICY)
-    }
-
-    override fun showPrivacyPolicyCA() {
-        ChromeCustomTabUtils.launchUrl(activity as Context, AppUrls.AUTOMATTIC_PRIVACY_POLICY_CA)
     }
 }

--- a/WooCommerce/src/main/res/layout/fragment_about.xml
+++ b/WooCommerce/src/main/res/layout/fragment_about.xml
@@ -26,6 +26,18 @@
         android:background="?attr/colorSurface">
 
         <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+            android:id="@+id/about_tos"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingStart="@dimen/major_100"
+            android:paddingEnd="@dimen/minor_00"
+            app:optionTitle="@string/about_tos"/>
+
+        <View
+            style="@style/Woo.Divider"
+            android:layout_marginStart="@dimen/major_100" />
+
+        <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
             android:id="@+id/about_privacy"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -38,16 +50,16 @@
             android:layout_marginStart="@dimen/major_100"/>
 
         <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-            android:id="@+id/about_tos"
+            android:id="@+id/about_privacy_ca"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingStart="@dimen/major_100"
             android:paddingEnd="@dimen/minor_00"
-            app:optionTitle="@string/about_tos"/>
+            app:optionTitle="@string/settings_privacy_policy_ca"/>
 
         <View
             style="@style/Woo.Divider"
-            android:layout_marginStart="@dimen/major_100" />
+            android:layout_marginStart="@dimen/major_100"/>
     </LinearLayout>
 
     <com.google.android.material.textview.MaterialTextView

--- a/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
@@ -89,30 +89,13 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/privacy_policy_info"/>
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/buttonPrivacyPolicyCA"
-        style="@style/Woo.Button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/margin_app_title_aligned"
-        android:layout_marginTop="@dimen/minor_100"
-        android:layout_marginEnd="@dimen/major_100"
-        android:paddingEnd="0dp"
-        android:paddingStart="0dp"
-        android:textAlignment="textEnd"
-        android:text="@string/settings_privacy_policy_ca"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="1.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/buttonPrivacyPolicy" />
-
     <View
         android:id="@+id/divider3"
         style="@style/Woo.Divider.TitleAligned"
         android:layout_marginTop="@dimen/minor_100"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/buttonPrivacyPolicyCA"/>
+        app:layout_constraintTop_toBottomOf="@+id/buttonPrivacyPolicy"/>
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/privacy_tracking_info"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -607,7 +607,7 @@
     <string name="settings_send_stats_detail">Share information with our analytics tool about your use of services while logged in to your WordPress account</string>
     <string name="settings_privacy_detail">This information helps us improve our products, make marketing to you more relevant, personalize your WooCommerce experience, and more as detailed in our privacy policy</string>
     <string name="settings_privacy_policy">Read privacy policy</string>
-    <string name="settings_privacy_policy_ca">Privacy notice for California users</string>
+    <string name="settings_privacy_policy_ca">Privacy Notice for California Users</string>
     <string name="settings_tracking">We use other tracking tools, including some from third parties. Read about these and how to control them.</string>
     <string name="settings_footer">Made with love by Automattic. %1$s</string>
     <string name="settings_hiring">We\'re hiring!</string>
@@ -673,7 +673,7 @@
     <string name="logviewer_share_error">Unable to share log</string>
     <string name="about_appname">WooCommerce for Android</string>
     <string name="about_publisher">Publisher: Automattic, Inc</string>
-    <string name="about_tos">Terms of service</string>
+    <string name="about_tos">Terms of Service</string>
     <string name="about_url_text" translatable="false">automattic.com</string>
     <string name="about_version">Version %s</string>
     <string name="about_copyright" translatable="false">© %1$d Automattic, Inc</string>


### PR DESCRIPTION
Fixes #2556 by moving the CCPA link from the Settings -> Privacy Settings screen to the About screen to match iOS. I also rearranged the links and updated the case of the labels to match iOS:

Before | After 
-- | --
![Screenshot_1592585542](https://user-images.githubusercontent.com/5810477/85161657-56e70d80-b21d-11ea-83ab-4e24535c6a8e.png)|![Screenshot_1592585888](https://user-images.githubusercontent.com/5810477/85161666-5a7a9480-b21d-11ea-8b55-6fa9208e4f5b.png)
![Screenshot_1592585559](https://user-images.githubusercontent.com/5810477/85161676-60707580-b21d-11ea-92f1-80bcda40bba4.png)|![Screenshot_1592586346](https://user-images.githubusercontent.com/5810477/85161682-623a3900-b21d-11ea-834b-78d1e92ebe17.png)

## To Test

- Verify link removed from the Privacy Settings screen
- Verify link added to the About screen
- Verify link loads the privacy notice for California users

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
