### PR TITLE
Make background color of login views white for light mode

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,8 @@
 4.6
 -----
 * Added a fix to support multiple new order notifications for a store.
- 
+* Updated the background color of the login views.
+
 4.5
 -----
 * Added a link to the new privacy notice for california users

--- a/WooCommerce/src/main/res/values/styles_login.xml
+++ b/WooCommerce/src/main/res/values/styles_login.xml
@@ -5,6 +5,7 @@
      -->
     <style name="LoginTheme" parent="Theme.Woo.DayNight">
         <item name="android:statusBarColor">@color/color_status_bar</item>
+        <item name="android:colorBackground">@color/color_surface</item>
     </style>
 
     <style name="LoginTheme.Toolbar">


### PR DESCRIPTION
Fixes #2553 by using `surface_color` as the default window background color for the login views. This keeps it the same for dark mode but updates it for light mode so the background is white instead of gray. 

Before | After
-- | --
![Screenshot_1592600006](https://user-images.githubusercontent.com/5810477/85179008-15665a80-b23d-11ea-8778-123b0ef408cc.png)|![Screenshot_1592599869](https://user-images.githubusercontent.com/5810477/85179017-17c8b480-b23d-11ea-8143-86820dcacfa4.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
