### PR TITLE
Issue/2523 add guest as customer name

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.6
 -----
 * Added a fix to support multiple new order notifications for a store.
+* Added a placeholder for orders without a customer name.
  
 4.5
 -----

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/MockedOrderListModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/MockedOrderListModule.kt
@@ -22,6 +22,7 @@ import com.woocommerce.android.ui.orders.list.OrderListRepository
 import com.woocommerce.android.ui.orders.list.OrderListViewModel
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.ViewState
 import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.woocommerce.android.viewmodel.ViewModelKey
 import dagger.Binds
@@ -67,6 +68,7 @@ abstract class MockedOrderListModule {
             val repository = spy(OrderListRepository(mockDispatcher, testDispatchers, orderStore, gatewayStore, site))
             val mockSavedState: SavedStateWithArgs = mock()
             val orderFetcher: OrderFetcher = mock()
+            val mockResourceProvider: ResourceProvider = mock()
             doReturn(MutableLiveData(ViewState())).whenever(mockSavedState).getLiveData<ViewState>(any(), any())
 
             val viewModel = spy(MockedOrderListViewModel(
@@ -78,6 +80,7 @@ abstract class MockedOrderListModule {
                     dispatcher = mockDispatcher,
                     selectedSite = site,
                     fetcher = orderFetcher,
+                    resourceProvider = mockResourceProvider,
                     arg0 = mockSavedState
             ))
             viewModel.testOrderData = this.testOrders

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/list/MockedOrderListViewModel.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/list/MockedOrderListViewModel.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.WcOrderTestUtils
 import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
@@ -26,6 +27,7 @@ class MockedOrderListViewModel @AssistedInject constructor(
     dispatcher: Dispatcher,
     selectedSite: SelectedSite,
     fetcher: OrderFetcher,
+    resourceProvider: ResourceProvider,
     @Assisted arg0: SavedStateWithArgs
 ) : OrderListViewModel(
         arg0,
@@ -36,7 +38,8 @@ class MockedOrderListViewModel @AssistedInject constructor(
         networkStatus,
         dispatcher,
         selectedSite,
-        fetcher
+        fetcher,
+        resourceProvider
 ) {
     override fun getLifecycle(): Lifecycle = mock()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCOrderModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCOrderModelExt.kt
@@ -37,3 +37,9 @@ fun isVirtualProduct(
 
 val String.isCashPayment: Boolean
     get() = CASH_PAYMENTS.contains(this)
+
+fun WCOrderModel.getBillingName(defaultValue: String): String {
+    return if (billingFirstName.isEmpty() && billingLastName.isEmpty()) {
+        defaultValue
+    } else "$billingFirstName $billingLastName"
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailOrderStatusView.kt
@@ -8,6 +8,7 @@ import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.extensions.getBillingName
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.widgets.tags.TagView
 import kotlinx.android.synthetic.main.order_detail_order_status.view.*
@@ -39,11 +40,7 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
             orderModel.number
         )
 
-        orderStatus_name.text = context.getString(
-            R.string.orderdetail_orderstatus_name,
-            orderModel.billingFirstName,
-            orderModel.billingLastName
-        )
+        orderStatus_name.text = orderModel.getBillingName(context.getString(R.string.orderdetail_customer_name_default))
 
         orderStatus_orderTags.removeAllViews()
         orderStatus_orderTags.addView(getTagView(orderStatus))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemDataSource.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.orders.list
 
+import com.woocommerce.android.R
+import com.woocommerce.android.extensions.getBillingName
 import com.woocommerce.android.model.TimeGroup
 import com.woocommerce.android.model.TimeGroup.GROUP_FUTURE
 import com.woocommerce.android.model.TimeGroup.GROUP_OLDER_MONTH
@@ -14,6 +16,7 @@ import com.woocommerce.android.ui.orders.list.OrderListItemUIType.LoadingItem
 import com.woocommerce.android.ui.orders.list.OrderListItemUIType.OrderListItemUI
 import com.woocommerce.android.ui.orders.list.OrderListItemUIType.SectionHeader
 import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.viewmodel.ResourceProvider
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
@@ -36,7 +39,8 @@ class OrderListItemDataSource(
     private val dispatcher: Dispatcher,
     private val orderStore: WCOrderStore,
     private val networkStatus: NetworkStatus,
-    private val fetcher: OrderFetcher
+    private val fetcher: OrderFetcher,
+    private val resourceProvider: ResourceProvider
 ) : ListItemDataSourceInterface<WCOrderListDescriptor, OrderListItemIdentifier, OrderListItemUIType> {
     override fun getItemsAndFetchIfNecessary(
         listDescriptor: WCOrderListDescriptor,
@@ -62,7 +66,9 @@ class OrderListItemDataSource(
                     OrderListItemUI(
                             remoteOrderId = RemoteId(order.remoteOrderId),
                             orderNumber = order.number,
-                            orderName = "${order.billingFirstName} ${order.billingLastName}",
+                            orderName = order.getBillingName(
+                                resourceProvider.getString(R.string.orderdetail_customer_name_default)
+                            ),
                             orderTotal = order.total,
                             status = order.status,
                             dateCreated = order.dateCreated,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.ThrottleLiveData
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
@@ -63,7 +64,8 @@ class OrderListViewModel @AssistedInject constructor(
     private val networkStatus: NetworkStatus,
     private val dispatcher: Dispatcher,
     private val selectedSite: SelectedSite,
-    private val fetcher: OrderFetcher
+    private val fetcher: OrderFetcher,
+    private val resourceProvider: ResourceProvider
 ) : ScopedViewModel(savedState, coroutineDispatchers), LifecycleOwner {
     protected val lifecycleRegistry: LifecycleRegistry by lazy {
         LifecycleRegistry(this)
@@ -75,7 +77,7 @@ class OrderListViewModel @AssistedInject constructor(
     internal var activePagedListWrapper: PagedListWrapper<OrderListItemUIType>? = null
 
     private val dataSource by lazy {
-        OrderListItemDataSource(dispatcher, orderStore, networkStatus, fetcher)
+        OrderListItemDataSource(dispatcher, orderStore, networkStatus, fetcher, resourceProvider)
     }
 
     final val viewStateLiveData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -211,6 +211,7 @@
     -->
     <string name="customer_information">Customer information</string>
     <string name="customer_full_name">%1$s %2$s</string>
+    <string name="orderdetail_customer_name_default">Guest</string>
     <string name="orderdetail_orderstatus_ordernum">Order #%s</string>
     <string name="orderdetail_orderstatus_date_and_ordernum">%1$s \u2022 #%2$s</string>
     <string name="orderdetail_orderstatus_name">%1$s %2$s</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.util.observeForTesting
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.woocommerce.android.viewmodel.TEST_DISPATCHER
 import com.woocommerce.android.viewmodel.test
@@ -52,6 +53,7 @@ class OrderListViewModelTest : BaseUnitTest() {
     private val repository: OrderListRepository = mock()
     private val dispatcher: Dispatcher = mock()
     private val orderStore: WCOrderStore = mock()
+    private val resourceProvider: ResourceProvider = mock()
     private val coroutineDispatchers = CoroutineDispatchers(
             TEST_DISPATCHER,
             TEST_DISPATCHER,
@@ -91,7 +93,9 @@ class OrderListViewModelTest : BaseUnitTest() {
                 networkStatus = networkStatus,
                 dispatcher = dispatcher,
                 selectedSite = selectedSite,
-                fetcher = orderFetcher)
+                fetcher = orderFetcher,
+                resourceProvider = resourceProvider
+        )
     }
 
     /**


### PR DESCRIPTION
Fixes #2523 by adding logic to display "Guest" as customer name, if no customer name is available for an order.

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/85279261-c40bd480-b4a3-11ea-8a6a-6caae1f7ade0.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/85279255-c0784d80-b4a3-11ea-939a-01e13e0e7f5a.png" width="300"/>

#### Testing
- Add/edit an order from your test site and remove the billing first and last name from the order.
- Open the app and click on the `Orders` tab.
- Notice that the order you edited has the `Guest` value as the customer name.
- Click on the order. Notice that the customer name has the `Guest` value as the customer name.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
