### PR TITLE
Fixed bug where the product onSale was set to true when sale price was 0

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -15,7 +15,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_VI
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_VIEW_EXTERNAL_TAPPED
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.di.ViewModelAssistedFactory
-import com.woocommerce.android.extensions.isEqualTo
+import com.woocommerce.android.extensions.isNotEqualTo
 import com.woocommerce.android.extensions.isNumeric
 import com.woocommerce.android.media.ProductImagesService
 import com.woocommerce.android.media.ProductImagesService.Companion.OnProductImageUploaded
@@ -519,7 +519,7 @@ class ProductDetailViewModel @AssistedInject constructor(
         productPricingViewState = if (inputValue > regularPrice) {
             productPricingViewState.copy(salePriceErrorMessage = string.product_pricing_update_sale_price_error)
         } else {
-            val isOnSale = !(inputValue isEqualTo BigDecimal.ZERO)
+            val isOnSale = inputValue isNotEqualTo BigDecimal.ZERO
             updateProductDraft(salePrice = inputValue, isOnSale = isOnSale)
             productPricingViewState.copy(salePriceErrorMessage = 0)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_VI
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_VIEW_EXTERNAL_TAPPED
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.di.ViewModelAssistedFactory
+import com.woocommerce.android.extensions.isEqualTo
 import com.woocommerce.android.extensions.isNumeric
 import com.woocommerce.android.media.ProductImagesService
 import com.woocommerce.android.media.ProductImagesService.Companion.OnProductImageUploaded
@@ -518,7 +519,8 @@ class ProductDetailViewModel @AssistedInject constructor(
         productPricingViewState = if (inputValue > regularPrice) {
             productPricingViewState.copy(salePriceErrorMessage = string.product_pricing_update_sale_price_error)
         } else {
-            updateProductDraft(salePrice = inputValue, isOnSale = true)
+            val isOnSale = !(inputValue isEqualTo BigDecimal.ZERO)
+            updateProductDraft(salePrice = inputValue, isOnSale = isOnSale)
             productPricingViewState.copy(salePriceErrorMessage = 0)
         }
     }


### PR DESCRIPTION
This tiny PR fixes #2524 by adding logic to set `isOnSale` to true only if the sale price is > 0.

#### To Reproduce and Test
- Click on a product from the products tab with sale price = 0.
- Notice that sale price is not displayed.
- Click on the Pricing section.
- Modify the **regular price** field and click on `Done` menu button.
- Notice that the sale price is displayed even when it was not updated.
- Pull changes from this PR and follow the above steps. Notice that the sale price is NOT displayed.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
