### PR TITLE
Hide the refund notice in refund details

### DIFF
--- a/WooCommerce/src/main/res/layout/refund_by_items_products.xml
+++ b/WooCommerce/src/main/res/layout/refund_by_items_products.xml
@@ -144,7 +144,7 @@
         android:id="@+id/issueRefund_totalsGroup"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:constraint_referenced_ids="issueRefund_dividerBelowList,issueRefund_dividerBelowTaxes,issueRefund_taxesTotal,issueRefund_subtotal,issueRefund_productsTotal,issueRefund_lblProductsTotal,issueRefund_lblTaxes,issueRefund_lblSubtotal" />
+        app:constraint_referenced_ids="issueRefund_shippingRefundNotice,issueRefund_dividerBelowList,issueRefund_dividerBelowTaxes,issueRefund_taxesTotal,issueRefund_subtotal,issueRefund_productsTotal,issueRefund_lblProductsTotal,issueRefund_lblTaxes,issueRefund_lblSubtotal" />
 
     <androidx.constraintlayout.widget.Group
         android:id="@+id/issueRefund_shippingRefundGroup"


### PR DESCRIPTION
Fixes #2563.

![Screenshot_1592826324](https://user-images.githubusercontent.com/1522856/85284001-a54f1300-b48e-11ea-924a-5ce8aed0a38b.png)

**To test**
1. Go to Orders
2. Tap on an order with refunded products
3. Tap on the Refunded products button
4. Notice there is no label below the product list