### PR TITLE
Issue/2566 order open event

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -65,6 +65,7 @@ import dagger.android.HasAndroidInjector
 import kotlinx.android.synthetic.main.activity_main.*
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.login.LoginAnalyticsListener
 import org.wordpress.android.login.LoginMode
 import org.wordpress.android.util.NetworkUtils
@@ -739,7 +740,7 @@ class MainActivity : AppUpgradeActivity(),
                 NEW_ORDER -> {
                     selectedSite.getIfExists()?.let { site ->
                         note.getRemoteOrderId()?.let { orderId ->
-                            showOrderDetail(site.id, orderId, note.remoteNoteId)
+                            showOrderDetail(site.id, orderId, note.remoteNoteId, CoreOrderStatus.PROCESSING.value)
                         }
                     }
                 }
@@ -776,7 +777,7 @@ class MainActivity : AppUpgradeActivity(),
         navController.navigateSafely(action)
     }
 
-    override fun showOrderDetail(localSiteId: Int, remoteOrderId: Long, remoteNoteId: Long, markComplete: Boolean) {
+    override fun showOrderDetail(localSiteId: Int, remoteOrderId: Long, remoteNoteId: Long, orderStatus: String, markComplete: Boolean) {
         if (bottomNavView.currentPosition != ORDERS) {
             bottomNavView.currentPosition = ORDERS
             val navPos = ORDERS.position
@@ -793,6 +794,11 @@ class MainActivity : AppUpgradeActivity(),
                 showOrderBadge(unfilledOrderCount - 1)
             }
         }
+
+        // Send tracks event
+        AnalyticsTracker.track(Stat.ORDER_OPEN, mapOf(
+            AnalyticsTracker.KEY_ID to remoteOrderId,
+            AnalyticsTracker.KEY_STATUS to orderStatus))
 
         val orderId = OrderIdentifier(localSiteId, remoteOrderId)
         val action = OrderDetailFragmentDirections.actionGlobalOrderDetailFragment(orderId, remoteNoteId, markComplete)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -777,7 +777,13 @@ class MainActivity : AppUpgradeActivity(),
         navController.navigateSafely(action)
     }
 
-    override fun showOrderDetail(localSiteId: Int, remoteOrderId: Long, remoteNoteId: Long, orderStatus: String, markComplete: Boolean) {
+    override fun showOrderDetail(
+        localSiteId: Int,
+        remoteOrderId: Long,
+        remoteNoteId: Long,
+        orderStatus: String,
+        markComplete: Boolean
+    ) {
         if (bottomNavView.currentPosition != ORDERS) {
             bottomNavView.currentPosition = ORDERS
             val navPos = ORDERS.position

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -799,12 +799,15 @@ class MainActivity : AppUpgradeActivity(),
             if (unfilledOrderCount > 0) {
                 showOrderBadge(unfilledOrderCount - 1)
             }
+        } else {
+            // Only send a tracks event if it's the original request to open the order to view the detail.
+            // When `markComplete` is true that means this is just a return from order fulfillment screen.
+            AnalyticsTracker.track(
+                Stat.ORDER_OPEN, mapOf(
+                AnalyticsTracker.KEY_ID to remoteOrderId,
+                AnalyticsTracker.KEY_STATUS to orderStatus)
+            )
         }
-
-        // Send tracks event
-        AnalyticsTracker.track(Stat.ORDER_OPEN, mapOf(
-            AnalyticsTracker.KEY_ID to remoteOrderId,
-            AnalyticsTracker.KEY_STATUS to orderStatus))
 
         val orderId = OrderIdentifier(localSiteId, remoteOrderId)
         val action = OrderDetailFragmentDirections.actionGlobalOrderDetailFragment(orderId, remoteNoteId, markComplete)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
@@ -4,7 +4,14 @@ interface MainNavigationRouter {
     fun isAtNavigationRoot(): Boolean
     fun isChildFragmentShowing(): Boolean
 
-    fun showOrderDetail(localSiteId: Int, remoteOrderId: Long, remoteNoteId: Long = 0, orderStatus:String, markComplete: Boolean = false)
+    fun showOrderDetail(
+        localSiteId: Int,
+        remoteOrderId: Long,
+        remoteNoteId: Long = 0,
+        orderStatus: String,
+        markComplete: Boolean = false
+    )
+
     fun showProductDetail(remoteProductId: Long)
     fun showReviewDetail(remoteReviewId: Long, launchedFromNotification: Boolean, tempStatus: String? = null)
     fun showProductFilters(stockStatus: String?, productType: String?, productStatus: String?)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
@@ -4,7 +4,7 @@ interface MainNavigationRouter {
     fun isAtNavigationRoot(): Boolean
     fun isChildFragmentShowing(): Boolean
 
-    fun showOrderDetail(localSiteId: Int, remoteOrderId: Long, remoteNoteId: Long = 0, markComplete: Boolean = false)
+    fun showOrderDetail(localSiteId: Int, remoteOrderId: Long, remoteNoteId: Long = 0, orderStatus:String, markComplete: Boolean = false)
     fun showProductDetail(remoteProductId: Long)
     fun showReviewDetail(remoteReviewId: Long, launchedFromNotification: Boolean, tempStatus: String? = null)
     fun showProductFilters(stockStatus: String?, productType: String?, productStatus: String?)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragment.kt
@@ -190,6 +190,7 @@ class OrderFulfillmentFragment : BaseFragment(), OrderFulfillmentContract.View, 
             (activity as? MainNavigationRouter)?.showOrderDetail(
                     localSiteId = order.localSiteId,
                     remoteOrderId = order.remoteOrderId,
+                    orderStatus = order.status,
                     markComplete = true
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
@@ -11,6 +11,7 @@ import androidx.paging.PagedListAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
+import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.R
 import com.woocommerce.android.model.TimeGroup
 import com.woocommerce.android.ui.orders.OrderStatusTag
@@ -65,16 +66,20 @@ class OrderListAdapter(
         val item = getItem(position)
         when (holder) {
             is OrderItemUIViewHolder -> {
-                assert(item is OrderListItemUI) {
-                    "If we are presenting WCOrderItemUIViewHolder, the item has to be of type WCOrderListUIItem " +
+                if (BuildConfig.DEBUG && item !is OrderListItemUI) {
+                    error(
+                        "If we are presenting WCOrderItemUIViewHolder, the item has to be of type WCOrderListUIItem " +
                             "for position: $position"
+                    )
                 }
                 holder.onBind((item as OrderListItemUI))
             }
             is SectionHeaderViewHolder -> {
-                assert(item is SectionHeader) {
-                    "If we are presenting SectionHeaderViewHolder, the item has to be of type SectionHeader " +
+                if (BuildConfig.DEBUG && item !is SectionHeader) {
+                    error(
+                        "If we are presenting SectionHeaderViewHolder, the item has to be of type SectionHeader " +
                             "for position: $position"
+                    )
                 }
                 holder.onBind((item as SectionHeader))
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
@@ -134,7 +134,7 @@ class OrderListAdapter(
             processTagView(orderItemUI.status, this)
 
             this.itemView.setOnClickListener {
-                listener.openOrderDetail(orderItemUI.remoteOrderId.value)
+                listener.openOrderDetail(orderItemUI.remoteOrderId.value, orderItemUI.status)
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -458,9 +458,13 @@ class OrderListFragment : TopLevelFragment(),
         }
     }
 
-    override fun openOrderDetail(remoteOrderId: Long) {
+    override fun openOrderDetail(remoteOrderId: Long, orderStatus: String) {
         showOptionsMenu(false)
-        (activity as? MainNavigationRouter)?.showOrderDetail(selectedSite.get().id, remoteOrderId)
+        (activity as? MainNavigationRouter)?.showOrderDetail(
+            localSiteId = selectedSite.get().id,
+            remoteOrderId = remoteOrderId,
+            orderStatus = orderStatus
+        )
     }
 
     private fun updateOrderStatusList(orderStatusList: Map<String, WCOrderStatusModel>) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListListener.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListListener.kt
@@ -1,5 +1,5 @@
 package com.woocommerce.android.ui.orders.list
 
 interface OrderListListener {
-    fun openOrderDetail(remoteOrderId: Long)
+    fun openOrderDetail(remoteOrderId: Long, orderStatus: String)
 }


### PR DESCRIPTION
Closes #2566 The `ORDER_OPEN` track event was erroneously removed in [PR 1559](https://github.com/woocommerce/woocommerce-android/pull/1559) when the `OrderListPresenter` was deleted. All requests to open an order are routed through `MainActivity` so I've added the logic there to send the track event.


## Testing
1. From the Order List screen, tap an order. -> Check that in the console you are able to see the `order_open` event logged.  You should see something similar to this: `Tracked: order_open, Properties: {"id":9121,"status":"processing","blog_id":1111,"is_wpcom_store":false}`
2. No app changes should be introduced, please feel free to sanity check that you are able to open an order detail from all the entry points.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
