### PR TITLE
Issue/2566 order open event - Take 2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
@@ -11,6 +11,7 @@ import androidx.paging.PagedListAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
+import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.R
 import com.woocommerce.android.model.TimeGroup
 import com.woocommerce.android.ui.orders.OrderStatusTag
@@ -65,16 +66,20 @@ class OrderListAdapter(
         val item = getItem(position)
         when (holder) {
             is OrderItemUIViewHolder -> {
-                assert(item is OrderListItemUI) {
-                    "If we are presenting WCOrderItemUIViewHolder, the item has to be of type WCOrderListUIItem " +
+                if (BuildConfig.DEBUG && item !is OrderListItemUI) {
+                    error(
+                        "If we are presenting WCOrderItemUIViewHolder, the item has to be of type WCOrderListUIItem " +
                             "for position: $position"
+                    )
                 }
                 holder.onBind((item as OrderListItemUI))
             }
             is SectionHeaderViewHolder -> {
-                assert(item is SectionHeader) {
-                    "If we are presenting SectionHeaderViewHolder, the item has to be of type SectionHeader " +
+                if (BuildConfig.DEBUG && item !is SectionHeader) {
+                    error(
+                        "If we are presenting SectionHeaderViewHolder, the item has to be of type SectionHeader " +
                             "for position: $position"
+                    )
                 }
                 holder.onBind((item as SectionHeader))
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
@@ -134,7 +134,7 @@ class OrderListAdapter(
             processTagView(orderItemUI.status, this)
 
             this.itemView.setOnClickListener {
-                listener.openOrderDetail(orderItemUI.remoteOrderId.value)
+                listener.openOrderDetail(orderItemUI.remoteOrderId.value, orderItemUI.status)
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -458,7 +458,14 @@ class OrderListFragment : TopLevelFragment(),
         }
     }
 
-    override fun openOrderDetail(remoteOrderId: Long) {
+    override fun openOrderDetail(remoteOrderId: Long, orderStatus: String) {
+        // Track user clicked to open an order and the status of that order
+        AnalyticsTracker.track(
+            Stat.ORDER_OPEN, mapOf(
+            AnalyticsTracker.KEY_ID to remoteOrderId,
+            AnalyticsTracker.KEY_STATUS to orderStatus)
+        )
+
         showOptionsMenu(false)
         (activity as? MainNavigationRouter)?.showOrderDetail(selectedSite.get().id, remoteOrderId)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListListener.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListListener.kt
@@ -1,5 +1,5 @@
 package com.woocommerce.android.ui.orders.list
 
 interface OrderListListener {
-    fun openOrderDetail(remoteOrderId: Long)
+    fun openOrderDetail(remoteOrderId: Long, orderStatus: String)
 }


### PR DESCRIPTION
Closes #2566 The `ORDER_OPEN` track event was erroneously removed in [PR 1559](https://github.com/woocommerce/woocommerce-android/pull/1559) when the `OrderListPresenter` was deleted. I had originally opened this PR to send the event whenever the order detail view is opened, but iOS only sends this event when the order is opened from the order list so that other PR was closed and this new one implements this to better match iOS. 


## Testing
1. From the Order List screen, tap an order. -> Check that in the console you are able to see the `order_open` event logged.  You should see something similar to this: `Tracked: order_open, Properties: {"id":9121,"status":"processing","blog_id":1111,"is_wpcom_store":false}`
2. No app changes should be introduced, please feel free to sanity check that you are able to open an order detail from all the entry points.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
