### PR TITLE
Update finalize lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -154,6 +154,7 @@ end
   desc "Updates store metadata and runs the release checks"
   lane :finalize_release do | options |
     android_finalize_prechecks(options)
+    configure_apply(force: is_ci)
     hotfix = android_current_branch_is_hotfix
     android_update_metadata(options) unless hotfix
     android_bump_version_final_release() unless hotfix
@@ -164,8 +165,8 @@ end
     # Wrap up
     removebranchprotection(repository:GHHELPER_REPO, branch: "release/#{version["name"]}")
     setfrozentag(repository:GHHELPER_REPO, milestone: version["name"], freeze: false)
-    close_milestone(repository:GHHELPER_REPO, milestone: version["name"])
     create_new_milestone(repository:GHHELPER_REPO)
+    close_milestone(repository:GHHELPER_REPO, milestone: version["name"])
   end
 
   #####################################################################################


### PR DESCRIPTION
This PR makes two small tweaks for the `finalize` lane:
1. _Add `configure_apply`_: after the translations are downloaded, they are checked and validate by linting and building. It the configuration is not up to date, the build phase can fail. 
2. _Switch `close_milestone` and `create_milestone`_: in the unlikely case that there are no others milestones in the repository other than the current one, `create_milestone` would fail if the current milestone is closed before the new one is created. Not an actual problem on this repository, but since we noticed it in other less organized repos and we're updating the lane, it doesn't hurt. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
