### PR TITLE
Issue/2188 display product tags

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -73,7 +73,8 @@ data class Product(
     val taxStatus: ProductTaxStatus,
     val isSaleScheduled: Boolean,
     val menuOrder: Int,
-    val categories: List<ProductCategory>
+    val categories: List<ProductCategory>,
+    val tags: List<ProductTag>
 ) : Parcelable {
     companion object {
         const val TAX_CLASS_DEFAULT = "standard"
@@ -488,6 +489,13 @@ fun WCProductModel.toAppModel(): Product {
         menuOrder = this.menuOrder,
         categories = this.getCategories().map {
             ProductCategory(
+                it.id,
+                it.name,
+                it.slug
+            )
+        },
+        tags = this.getTags().map {
+            ProductTag(
                 it.id,
                 it.name,
                 it.slug

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductTag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductTag.kt
@@ -1,0 +1,30 @@
+package com.woocommerce.android.model
+
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+import org.wordpress.android.fluxc.model.WCProductTagModel
+
+@Parcelize
+data class ProductTag(
+    val remoteTagId: Long = 0L,
+    val name: String,
+    val slug: String = "",
+    val description: String = ""
+) : Parcelable {
+    fun toProductTag(): ProductTag {
+        return ProductTag(
+            this.remoteTagId,
+            this.name,
+            this.slug
+        )
+    }
+}
+
+fun WCProductTagModel.toProductTag(): ProductTag {
+    return ProductTag(
+        remoteTagId = this.remoteTagId,
+        name = this.name,
+        slug = this.slug,
+        description = this.description
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -91,7 +91,8 @@ class ProductDetailCardBuilder(
                 product.shipping(),
                 product.inventory(),
                 product.shortDescription(),
-                product.categories()
+                product.categories(),
+                product.tags()
             ).filterNotEmpty()
         )
     }
@@ -506,6 +507,28 @@ class ProductDetailCardBuilder(
                     Stat.PRODUCT_DETAIL_VIEW_CATEGORIES_TAPPED
                 )
             }
+        } else {
+            null
+        }
+    }
+
+    private fun Product.tags(): ProductProperty? {
+        return if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled()) {
+            val productTags = this.tags
+            val showTitle = productTags.isNotEmpty()
+            val tags = if (showTitle) {
+                productTags.joinToString(transform = { it.name })
+            } else {
+                resources.getString(R.string.product_tag_empty)
+            }
+
+            ComplexProperty(
+                R.string.product_tags,
+                tags,
+                R.drawable.ic_gridicons_tag,
+                showTitle = showTitle,
+                maxLines = 5
+            )
         } else {
             null
         }

--- a/WooCommerce/src/main/res/drawable/ic_gridicons_tag.xml
+++ b/WooCommerce/src/main/res/drawable/ic_gridicons_tag.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/color_icon"
+        android:pathData="M20,2.007h-7.087c-0.53,0 -1.04,0.21 -1.414,0.586L2.592,11.5c-0.78,0.78 -0.78,2.046 0,2.827l7.086,7.086c0.78,0.78 2.046,0.78 2.827,0l8.906,-8.906c0.376,-0.374 0.587,-0.883 0.587,-1.413V4.007c0,-1.105 -0.895,-2 -2,-2zM17.007,9c-1.105,0 -2,-0.895 -2,-2s0.895,-2 2,-2 2,0.895 2,2 -0.895,2 -2,2z" />
+</vector>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -560,6 +560,8 @@
     <string name="product_category_parent">Parent category</string>
     <string name="product_add_category_dialog_title">Adding category</string>
     <string name="product_add_category_dialog_message">Please wait…</string>
+    <string name="product_tag_empty">Add tag</string>
+    <string name="product_tags">Tags</string>
     <!--
         Product images
     -->

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '06084045c40ec37806d6d4edaea644a7ee5a0edb'
+    fluxCVersion = 'e8b2f8127d4cc4fd546dddc3643204b56068a469'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Fixes #2188 by adding logic to display existing tags for a product.

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/85977172-aab1dd80-b9f9-11ea-8310-5c830a1a5967.png" width="300" />. <img src="https://user-images.githubusercontent.com/22608780/85977187-b7363600-b9f9-11ea-86f4-c0d77a6ec307.png" width="300" />

<img src="https://user-images.githubusercontent.com/22608780/85977381-22800800-b9fa-11ea-9b6b-4a9fce4f9c79.png" width="300" />. <img src="https://user-images.githubusercontent.com/22608780/85977387-2449cb80-b9fa-11ea-912e-65b638ff152e.png" width="300" />

#### To test
- Click on a product from the Products tab that has tags added to it.
- Notice the tags section displayed in the app.
- Now click on a product from that Products tab that does NOT have tags added to it.
- Notice the tags section displayed with "Add tag" option.

Note that the design specifies a bottom sheet to be displayed for editing fields such as categories and tags. This is tracked in #2410 and will be taken care of in another PR. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
