### PR TITLE
Merge Release/4.6 back into develop

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,6 @@
+4.7
+-----
+ 
 4.6
 -----
 * Added a fix to support multiple new order notifications for a store.

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -47,9 +47,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "4.5"
+            versionName "4.6-rc-1"
         }
-        versionCode 136
+        versionCode 137
 
         minSdkVersion 21
         targetSdkVersion 29

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '06084045c40ec37806d6d4edaea644a7ee5a0edb'
+    fluxCVersion = '1.6.15'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Merge Release/4.6 back into develop

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
