### PR TITLE
Hotfix: Implement fix to set image property using new FluxC methods

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariant.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariant.kt
@@ -38,7 +38,7 @@ fun WCProductVariationModel.toAppModel(): ProductVariant {
     return ProductVariant(
             this.remoteProductId,
             this.remoteVariationId,
-            this.image,
+            this.getImage()?.src,
             this.price.toBigDecimalOrNull()?.roundError(),
             ProductStockStatus.fromString(this.stockStatus),
             this.stockQuantity,


### PR DESCRIPTION
Fixes #2589 by using the new `WCProductVariantsModel.getImage()` method to populate the `imageUrl` field. **This PR is a hotfix and is being merged into `release/4.6`. Please notify Platform 9 once approved so a new beta release can be cut.**

<img src="https://user-images.githubusercontent.com/5810477/86177573-21c3a080-bae4-11ea-9e21-deb4f9f354e6.gif" width="330"/>


**To Test**
1. Open a variable product to view it's details
2. Click the variants option to view the list of product variants -- verify doesn't crash -- verify images populate.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
