### PR TITLE
Merge 4.6 release notes into develop

### DIFF
--- a/WooCommerce/metadata/PlayStoreStrings.pot
+++ b/WooCommerce/metadata/PlayStoreStrings.pot
@@ -11,19 +11,21 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_046"
+msgid ""
+"4.6:\n"
+"New: Added placeholder for orders missing a customer’s name.\n"
+"\n"
+"Fix: Multiple new order notifications are now viewable.\n"
+"\n"
+"Adjustments: Updated background color of login views and moved privacy notice for CA users to “About App” screen.\n"
+msgstr ""
+
 msgctxt "release_note_045"
 msgid ""
 "4.5:\n"
 "- Product enhancements: Update product images, product settings, and share product links right from the app.\n"
 "- California users can view a new privacy notice.\n"
-msgstr ""
-
-msgctxt "release_note_044"
-msgid ""
-"4.4:\n"
-"* <b>New</b>: Added functionality to image and product management. Head to “Settings” in “My Store” to turn on new features!\n"
-"* <b>UI improvements</b>: Brought back the W notification icon for better visibility, fixed the text color on support tickets in dark mode, minor style tweaks to login screens.\n"
-"* <b>Fixes</b>: Product details display exact stock status, plugged a potential memory leak when switching between stores.\n"
 msgstr ""
 
 #. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,2 +1,5 @@
-- Product enhancements: Update product images, product settings, and share product links right from the app.
-- California users can view a new privacy notice.
+New: Added placeholder for orders missing a customer’s name.
+
+Fix: Multiple new order notifications are now viewable.
+
+Adjustments: Updated background color of login views and moved privacy notice for CA users to “About App” screen.


### PR DESCRIPTION
Merge Release/4.6 into develop

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
