### PR TITLE
Change background color to surface to match dark mode

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_about.xml
+++ b/WooCommerce/src/main/res/layout/fragment_about.xml
@@ -5,7 +5,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:background="@color/color_surface">
 
     <ImageView
         android:id="@+id/about_image"


### PR DESCRIPTION
Fixes #2605 by making the background of the about screen use the `color_surface` color.

Before | After
-- | --
![Screenshot_1593799738](https://user-images.githubusercontent.com/5810477/86490865-2bd4e180-bd26-11ea-9d78-0f32049c0c0a.png)|![Screenshot_1593799680](https://user-images.githubusercontent.com/5810477/86490868-2ecfd200-bd26-11ea-8e67-a1737e9583ff.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
