### PR TITLE
Update Product details screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -422,7 +422,7 @@ class ProductDetailCardBuilder(
 
     // show product variants only if product type is variable and if there are variations for the product
     private fun Product.variations(): ProductProperty? {
-        return if (this.type == VARIABLE && this.numVariations > 0) {
+        return if (this.numVariations > 0) {
             val properties = mutableMapOf<String, String>()
             for (attribute in this.attributes) {
                 properties[attribute.name] = attribute.options.size.toString()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -373,7 +373,7 @@ class ProductDetailCardBuilder(
                 R.drawable.ic_gridicons_link,
                 hasExternalLink
             ) {
-                viewModel.onEditProductCardClicked(ViewProductPricing(this.remoteId))
+                viewModel.onEditProductCardClicked(ViewProductExternalLink(this.remoteId))
             }
         } else {
             null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -111,6 +111,7 @@ class ProductDetailCardBuilder(
         return ProductPropertyCard(
             type = SECONDARY,
             properties = listOf(
+                product.price(),
                 product.externalLink(),
                 product.shortDescription(),
                 product.readOnlyInventory(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -397,30 +397,26 @@ class ProductDetailCardBuilder(
         )
     }
 
-    private fun Product.description(): ProductProperty? {
-        return if (isAddEditProductRelease1Enabled(this.type)) {
-            val productDescription = this.description
-            val showTitle = productDescription.isNotEmpty()
-            val description = if (productDescription.isEmpty()) {
-                resources.getString(R.string.product_description_empty)
-            } else {
-                productDescription
-            }
-
-            ComplexProperty(
-                R.string.product_description,
-                description,
-                showTitle = showTitle
-            ) {
-                viewModel.onEditProductCardClicked(
-                    ViewProductDescriptionEditor(
-                        productDescription, resources.getString(R.string.product_description)
-                    ),
-                    PRODUCT_DETAIL_VIEW_PRODUCT_DESCRIPTION_TAPPED
-                )
-            }
+    private fun Product.description(): ProductProperty {
+        val productDescription = this.description
+        val showTitle = productDescription.isNotEmpty()
+        val description = if (productDescription.isEmpty()) {
+            resources.getString(R.string.product_description_empty)
         } else {
-            null
+            productDescription
+        }
+
+        return ComplexProperty(
+            R.string.product_description,
+            description,
+            showTitle = showTitle
+        ) {
+            viewModel.onEditProductCardClicked(
+                ViewProductDescriptionEditor(
+                    productDescription, resources.getString(R.string.product_description)
+                ),
+                PRODUCT_DETAIL_VIEW_PRODUCT_DESCRIPTION_TAPPED
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -58,7 +58,10 @@ class ProductDetailCardBuilder(
             } else {
                 cards.addIfNotEmpty(getPricingAndInventoryCard(product))
             }
+        } else {
+            cards.addIfNotEmpty(getVariableSecondaryCard(product))
         }
+
         cards.addIfNotEmpty(getPurchaseDetailsCard(product))
 
         return cards
@@ -92,6 +95,20 @@ class ProductDetailCardBuilder(
             ).filterNotEmpty()
         )
     }
+
+    private fun getVariableSecondaryCard(product: Product): ProductPropertyCard {
+        return ProductPropertyCard(
+            type = SECONDARY,
+            properties = listOf(
+                product.variations(),
+                product.externalLink(),
+                product.shortDescription(),
+                product.categories(),
+                product.tags()
+            ).filterNotEmpty()
+        )
+    }
+
     /**
      * Existing product detail card UI which that will be replaced by the new design once
      * Product Release 1 changes are completed.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -391,15 +391,11 @@ class ProductDetailCardBuilder(
 
     private fun Product.title(): ProductProperty {
         val name = this.name.fastStripHtml()
-        return if (isAddEditProductRelease1Enabled(this.type)) {
-            Editable(
-                R.string.product_detail_title_hint,
-                name,
-                onTextChanged = viewModel::onProductTitleChanged
-            )
-        } else {
-            ComplexProperty(R.string.product_name, name)
-        }
+        return Editable(
+            R.string.product_detail_title_hint,
+            name,
+            onTextChanged = viewModel::onProductTitleChanged
+        )
     }
 
     private fun Product.description(): ProductProperty? {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -72,8 +72,7 @@ class ProductDetailCardBuilder(
             type = PRIMARY,
             properties = listOf(
                 product.title(),
-                product.description(),
-                product.variations()
+                product.description()
             ).filterNotEmpty()
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductExternalLinkFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductExternalLinkFragment.kt
@@ -44,9 +44,11 @@ class ProductExternalLinkFragment : BaseProductFragment() {
 
         product_url.setOnTextChangedListener {
             viewModel.updateProductDraft(externalUrl = it.toString())
+            changesMade()
         }
         product_button_text.setOnTextChangedListener {
             viewModel.updateProductDraft(buttonText = it.toString())
+            changesMade()
         }
     }
 


### PR DESCRIPTION
Fixes #2521, #2192, #2324. This PR updates the Product detail screen for variable, grouped and external product types. They all used to have a different card layout and the properties were read-only. When the M3 feature flag is enabled, these products will be come editable.

| Before        | After           | Dark  |
| ------------- |:-------------:|:-----:|
| ![image](https://user-images.githubusercontent.com/1522856/87709483-a0873180-c7a4-11ea-9ff8-4c2b618498b4.png) | ![image](https://user-images.githubusercontent.com/1522856/87709522-b137a780-c7a4-11ea-8aee-66a5bb799cb5.png) | ![image](https://user-images.githubusercontent.com/1522856/87709566-c1e81d80-c7a4-11ea-8a93-1bdcfc4bf3f4.png) |
| ![image](https://user-images.githubusercontent.com/1522856/87709661-e0e6af80-c7a4-11ea-8c4b-494000095eea.png) | ![image](https://user-images.githubusercontent.com/1522856/87709726-f5c34300-c7a4-11ea-982a-4a60d2946b76.png) | ![image](https://user-images.githubusercontent.com/1522856/87709755-05428c00-c7a5-11ea-9787-5b2f006c3e99.png) |
| ![image](https://user-images.githubusercontent.com/1522856/87709777-0f648a80-c7a5-11ea-8ae8-c2fbfa739a42.png) | ![image](https://user-images.githubusercontent.com/1522856/87709797-1ab7b600-c7a5-11ea-8504-2e60ad880412.png) | ![image](https://user-images.githubusercontent.com/1522856/87709816-24d9b480-c7a5-11ea-8eba-c128ddc314d2.png) |

**To test:**
1. Disable the M3 feature flag
2. Verify the external, grouped and variable products have read-only properties on the product detail screens
3. Enabled the M3 feature flag
4. Verify the properties are now editable (except for SKU)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
