### PR TITLE
Expand cursor window to 5mb for production builds running API 28+

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * Disabled beta options and removed Improved Stats as selectable option from it
 * Set Stats V4 as the default choice
 * Update Stats V3 due date warning message to September 1, 2020
+* Fixed cursor window size-related crashes for device running Android P and above
  
 4.6
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
@@ -59,4 +59,11 @@ class WooWellSqlConfig(context: Context) : WellSqlConfig(context, ADDON_WOOCOMME
             reset()
         }
     }
+
+    /**
+     * Increase the cursor window size to 5MB for devices running API 28 and above. This should reduce the
+     * number of SQLiteBlobTooBigExceptions. Note that this is only called on API 28 and
+     * above since earlier versions don't allow adjusting the cursor window size.
+     */
+    override fun getCursorWindowSize() = (1024L * 1024L * 5L)
 }


### PR DESCRIPTION
Partially fixes #572 by overriding the WellSql method `getCursorWindowSize()` and returning a size of 5mb. This method was [added to WellSQL in this PR](https://github.com/wordpress-mobile/wellsql/pull/18) by @nbradbury and has been in production for `DEBUG` WCAndroid builds for the last two releases. Since there haven't been any issues this PR simply makes it available to production. **Please note this fix only works on Android P and above.** 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
