### PR TITLE
Issue/2641 show ratings dialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.ui.mystore.MyStoreStatsAvailabilityListener
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.widgets.AppRatingDialog
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_dashboard.*
@@ -90,6 +91,9 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
 
             if (FeatureFlag.APP_FEEDBACK.isEnabled()) {
                 dashboard_feedback_request_card.visibility = View.VISIBLE
+                val positiveCallback = { AppRatingDialog.showRateDialog(context) }
+                val negativeCallback = { /* TODO */ }
+                dashboard_feedback_request_card.initView(negativeCallback, positiveCallback)
             }
         }
         return view

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -20,10 +20,14 @@ import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.ui.mystore.MyStoreStatsAvailabilityListener
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_dashboard.*
 import kotlinx.android.synthetic.main.fragment_dashboard.view.*
+import kotlinx.android.synthetic.main.fragment_dashboard.view.dashboard_refresh_layout
+import kotlinx.android.synthetic.main.fragment_dashboard.view.scroll_view
+import kotlinx.android.synthetic.main.fragment_my_store.view.*
 import org.wordpress.android.fluxc.model.WCTopEarnerModel
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import javax.inject.Inject
@@ -82,6 +86,10 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
                     refreshDashboard(forced = true)
                 }
                 scrollUpChild = scroll_view
+            }
+
+            if (FeatureFlag.APP_FEEDBACK.isEnabled()) {
+                dashboard_feedback_request_card.visibility = View.VISIBLE
             }
         }
         return view

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackRequestCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackRequestCard.kt
@@ -1,0 +1,17 @@
+package com.woocommerce.android.ui.feedback
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import com.woocommerce.android.R
+import com.woocommerce.android.widgets.WCElevatedConstraintLayout
+
+class FeedbackRequestCard @JvmOverloads constructor(
+    ctx: Context, attrs:
+    AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : WCElevatedConstraintLayout(ctx, attrs, defStyleAttr) {
+    init {
+        View.inflate(context, R.layout.feedback_request_card, this)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackRequestCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackRequestCard.kt
@@ -5,6 +5,7 @@ import android.util.AttributeSet
 import android.view.View
 import com.woocommerce.android.R
 import com.woocommerce.android.widgets.WCElevatedConstraintLayout
+import kotlinx.android.synthetic.main.feedback_request_card.view.*
 
 class FeedbackRequestCard @JvmOverloads constructor(
     ctx: Context, attrs:
@@ -13,5 +14,16 @@ class FeedbackRequestCard @JvmOverloads constructor(
 ) : WCElevatedConstraintLayout(ctx, attrs, defStyleAttr) {
     init {
         View.inflate(context, R.layout.feedback_request_card, this)
+    }
+
+    /**
+     * Sets the click listeners for the buttons on this card
+     *
+     * @param negativeButtonAction The action to perform when the user clicks "Could be better"
+     * @param positiveButtonAction The action to perform when the user clicks "I like it"
+     */
+    fun initView(negativeButtonAction: (() -> Unit), positiveButtonAction: (() -> Unit)) {
+        btn_feedbackReq_negative.setOnClickListener { negativeButtonAction() }
+        btn_feedbackReq_positive.setOnClickListener { positiveButtonAction() }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackRequestCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackRequestCard.kt
@@ -8,8 +8,8 @@ import com.woocommerce.android.widgets.WCElevatedConstraintLayout
 import kotlinx.android.synthetic.main.feedback_request_card.view.*
 
 class FeedbackRequestCard @JvmOverloads constructor(
-    ctx: Context, attrs:
-    AttributeSet? = null,
+    ctx: Context,
+    attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : WCElevatedConstraintLayout(ctx, attrs, defStyleAttr) {
     init {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -22,6 +22,7 @@ import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_my_store.*
@@ -94,6 +95,10 @@ class MyStoreFragment : TopLevelFragment(),
                     dashboard_refresh_layout.isRefreshing = false
                     refreshMyStoreStats(forced = true)
                 }
+            }
+
+            if (FeatureFlag.APP_FEEDBACK.isEnabled()) {
+                store_feedback_request_card.visibility = View.VISIBLE
             }
         }
         return view

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -23,6 +23,7 @@ import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.widgets.AppRatingDialog
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_my_store.*
@@ -99,6 +100,9 @@ class MyStoreFragment : TopLevelFragment(),
 
             if (FeatureFlag.APP_FEEDBACK.isEnabled()) {
                 store_feedback_request_card.visibility = View.VISIBLE
+                val positiveCallback = { AppRatingDialog.showRateDialog(context) }
+                val negativeCallback = { /* TODO */ }
+                store_feedback_request_card.initView(negativeCallback, positiveCallback)
             }
         }
         return view

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/AppRatingDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/AppRatingDialog.kt
@@ -104,7 +104,7 @@ object AppRatingDialog {
         }
     }
 
-    private fun showRateDialog(context: Context) {
+    fun showRateDialog(context: Context) {
         dialogRef?.get()?.let {
             // Dialog is already present
             return

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCElevatedConstraintLayout.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCElevatedConstraintLayout.kt
@@ -1,0 +1,52 @@
+package com.woocommerce.android.widgets
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.ViewGroup
+import androidx.constraintlayout.widget.ConstraintLayout
+import com.google.android.material.shape.MaterialShapeDrawable
+import com.woocommerce.android.R
+
+open class WCElevatedConstraintLayout @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : ConstraintLayout(context, attrs, defStyleAttr) {
+    private var shapeElevation = context.resources.getDimension(R.dimen.plane_01)
+    private var elevatedBackground: MaterialShapeDrawable
+
+    init {
+        attrs?.let {
+            val attrArray = context.obtainStyledAttributes(it, R.styleable.WCElevatedConstraintLayout)
+            try {
+                shapeElevation = attrArray.getDimension(
+                    R.styleable.WCElevatedConstraintLayout_wcElevation, shapeElevation)
+            } finally {
+                attrArray.recycle()
+            }
+        }
+
+        elevatedBackground = MaterialShapeDrawable.createWithElevationOverlay(context, shapeElevation)
+        elevatedBackground.shadowCompatibilityMode = MaterialShapeDrawable.SHADOW_COMPAT_MODE_ALWAYS
+    }
+
+    override fun onFinishInflate() {
+        super.onFinishInflate()
+
+        background = elevatedBackground
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+
+        // Automatically don't clip children for the parent view. This allows the shadow
+        // to be drawn outside the bounds.
+        if (parent is ViewGroup) {
+            (parent as ViewGroup).clipChildren = false
+        }
+    }
+
+    override fun setElevation(elevation: Float) {
+        elevatedBackground.elevation = elevation
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCElevatedConstraintLayout.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCElevatedConstraintLayout.kt
@@ -20,7 +20,7 @@ open class WCElevatedConstraintLayout @JvmOverloads constructor(
             val attrArray = context.obtainStyledAttributes(it, R.styleable.WCElevatedConstraintLayout)
             try {
                 shapeElevation = attrArray.getDimension(
-                    R.styleable.WCElevatedConstraintLayout_wcElevation, shapeElevation)
+                    R.styleable.WCElevatedConstraintLayout_android_elevation, shapeElevation)
             } finally {
                 attrArray.recycle()
             }
@@ -44,9 +44,5 @@ open class WCElevatedConstraintLayout @JvmOverloads constructor(
         if (parent is ViewGroup) {
             (parent as ViewGroup).clipChildren = false
         }
-    }
-
-    override fun setElevation(elevation: Float) {
-        elevatedBackground.elevation = elevation
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCElevatedConstraintLayout.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCElevatedConstraintLayout.kt
@@ -20,7 +20,7 @@ open class WCElevatedConstraintLayout @JvmOverloads constructor(
             val attrArray = context.obtainStyledAttributes(it, R.styleable.WCElevatedConstraintLayout)
             try {
                 shapeElevation = attrArray.getDimension(
-                    R.styleable.WCElevatedConstraintLayout_android_elevation, shapeElevation)
+                    R.styleable.WCElevatedConstraintLayout_wcElevation, shapeElevation)
             } finally {
                 attrArray.recycle()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCElevatedConstraintLayout.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCElevatedConstraintLayout.kt
@@ -20,7 +20,7 @@ open class WCElevatedConstraintLayout @JvmOverloads constructor(
             val attrArray = context.obtainStyledAttributes(it, R.styleable.WCElevatedConstraintLayout)
             try {
                 shapeElevation = attrArray.getDimension(
-                    R.styleable.WCElevatedConstraintLayout_wcElevation, shapeElevation)
+                    R.styleable.WCElevatedConstraintLayout_android_elevation, shapeElevation)
             } finally {
                 attrArray.recycle()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCElevatedLinearLayout.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCElevatedLinearLayout.kt
@@ -20,7 +20,8 @@ open class WCElevatedLinearLayout @JvmOverloads constructor(
         attrs?.let {
             val attrArray = context.obtainStyledAttributes(it, R.styleable.WCElevatedLinearLayout)
             try {
-                shapeElevation = attrArray.getDimension(R.styleable.WCElevatedLinearLayout_wcElevation, shapeElevation)
+                shapeElevation = attrArray.getDimension(
+                    R.styleable.WCElevatedLinearLayout_android_elevation, shapeElevation)
             } finally {
                 attrArray.recycle()
             }
@@ -44,9 +45,5 @@ open class WCElevatedLinearLayout @JvmOverloads constructor(
         if (parent is ViewGroup) {
             (parent as ViewGroup).clipChildren = false
         }
-    }
-
-    override fun setElevation(elevation: Float) {
-        elevatedBackground.elevation = elevation
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCElevatedLinearLayout.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCElevatedLinearLayout.kt
@@ -20,8 +20,7 @@ open class WCElevatedLinearLayout @JvmOverloads constructor(
         attrs?.let {
             val attrArray = context.obtainStyledAttributes(it, R.styleable.WCElevatedLinearLayout)
             try {
-                shapeElevation = attrArray.getDimension(
-                    R.styleable.WCElevatedLinearLayout_android_elevation, shapeElevation)
+                shapeElevation = attrArray.getDimension(R.styleable.WCElevatedLinearLayout_wcElevation, shapeElevation)
             } finally {
                 attrArray.recycle()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCElevatedLinearLayout.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCElevatedLinearLayout.kt
@@ -20,7 +20,8 @@ open class WCElevatedLinearLayout @JvmOverloads constructor(
         attrs?.let {
             val attrArray = context.obtainStyledAttributes(it, R.styleable.WCElevatedLinearLayout)
             try {
-                shapeElevation = attrArray.getDimension(R.styleable.WCElevatedLinearLayout_wcElevation, shapeElevation)
+                shapeElevation = attrArray.getDimension(
+                    R.styleable.WCElevatedLinearLayout_android_elevation, shapeElevation)
             } finally {
                 attrArray.recycle()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCElevatedLinearLayout.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCElevatedLinearLayout.kt
@@ -27,7 +27,7 @@ open class WCElevatedLinearLayout @JvmOverloads constructor(
         }
 
         elevatedBackground = MaterialShapeDrawable.createWithElevationOverlay(context, shapeElevation)
-        elevatedBackground.setShadowCompatibilityMode(MaterialShapeDrawable.SHADOW_COMPAT_MODE_ALWAYS)
+        elevatedBackground.shadowCompatibilityMode = MaterialShapeDrawable.SHADOW_COMPAT_MODE_ALWAYS
     }
 
     override fun onFinishInflate() {

--- a/WooCommerce/src/main/res/layout-land/view_login_epilogue_button_bar.xml
+++ b/WooCommerce/src/main/res/layout-land/view_login_epilogue_button_bar.xml
@@ -9,7 +9,7 @@
     android:clipToPadding="false"
     android:padding="@dimen/major_100"
     android:orientation="horizontal"
-    app:wcElevation="@dimen/plane_02"
+    android:elevation="@dimen/plane_02"
     tools:showIn="@layout/activity_site_picker">
 
     <com.google.android.material.button.MaterialButton

--- a/WooCommerce/src/main/res/layout-land/view_login_epilogue_button_bar.xml
+++ b/WooCommerce/src/main/res/layout-land/view_login_epilogue_button_bar.xml
@@ -9,7 +9,7 @@
     android:clipToPadding="false"
     android:padding="@dimen/major_100"
     android:orientation="horizontal"
-    android:elevation="@dimen/plane_02"
+    app:wcElevation="@dimen/plane_02"
     tools:showIn="@layout/activity_site_picker">
 
     <com.google.android.material.button.MaterialButton

--- a/WooCommerce/src/main/res/layout/feedback_request_card.xml
+++ b/WooCommerce/src/main/res/layout/feedback_request_card.xml
@@ -14,10 +14,10 @@
         android:layout_margin="@dimen/major_100"
         android:textAlignment="center"
         android:textStyle="bold"
+        android:text="@string/feedback_request_title"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="Enjoying the WooCommerce app?" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <Button
         style="@style/Woo.Button.Colored.White"
@@ -28,13 +28,13 @@
         android:layout_marginStart="@dimen/major_100"
         android:layout_marginEnd="@dimen/minor_100"
         android:layout_marginBottom="@dimen/major_75"
+        android:text="@string/feedback_request_make_better"
         android:textAllCaps="false"
         android:textColor="@color/color_secondary"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/lbl_feedbackReq_title"
         app:layout_constraintEnd_toStartOf="@+id/feedbackReq_guideline"
-        app:layout_constraintBottom_toBottomOf="parent"
-        tools:text="Could be better" />
+        app:layout_constraintBottom_toBottomOf="parent" />
 
     <Button
         style="@style/Woo.Button.Colored"
@@ -45,12 +45,12 @@
         android:layout_marginStart="@dimen/minor_100"
         android:layout_marginEnd="@dimen/major_100"
         android:layout_marginBottom="@dimen/major_75"
+        android:text="@string/feedback_request_like_it"
         android:textAllCaps="false"
         app:layout_constraintStart_toEndOf="@+id/feedbackReq_guideline"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/lbl_feedbackReq_title"
-        app:layout_constraintBottom_toBottomOf="parent"
-        tools:text="I like it" />
+        app:layout_constraintBottom_toBottomOf="parent" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/feedbackReq_guideline"

--- a/WooCommerce/src/main/res/layout/feedback_request_card.xml
+++ b/WooCommerce/src/main/res/layout/feedback_request_card.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/color_surface">
+
+    <com.google.android.material.textview.MaterialTextView
+        style="@style/Woo.TextView.Subtitle1"
+        android:id="@+id/lbl_feedbackReq_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/major_100"
+        android:textAlignment="center"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Enjoying the WooCommerce app?" />
+
+    <Button
+        style="@style/Woo.Button.Colored.White"
+        android:id="@+id/btn_feedbackReq_negative"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_75"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginEnd="@dimen/minor_100"
+        android:layout_marginBottom="@dimen/major_75"
+        android:textAllCaps="false"
+        android:textColor="@color/color_secondary"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/lbl_feedbackReq_title"
+        app:layout_constraintEnd_toStartOf="@+id/feedbackReq_guideline"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:text="Could be better" />
+
+    <Button
+        style="@style/Woo.Button.Colored"
+        android:id="@+id/btn_feedbackReq_positive"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_75"
+        android:layout_marginStart="@dimen/minor_100"
+        android:layout_marginEnd="@dimen/major_100"
+        android:layout_marginBottom="@dimen/major_75"
+        android:textAllCaps="false"
+        app:layout_constraintStart_toEndOf="@+id/feedbackReq_guideline"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/lbl_feedbackReq_title"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:text="I like it" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/feedbackReq_guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.5" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/feedback_request_card.xml
+++ b/WooCommerce/src/main/res/layout/feedback_request_card.xml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="@color/color_surface">
+    android:layout_height="wrap_content">
 
     <com.google.android.material.textview.MaterialTextView
         style="@style/Woo.TextView.Subtitle1"
@@ -20,7 +19,7 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <Button
-        style="@style/Woo.Button.Colored.White"
+        style="@style/Woo.Button.Outlined"
         android:id="@+id/btn_feedbackReq_negative"
         android:layout_width="0dp"
         android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/layout/fragment_dashboard.xml
+++ b/WooCommerce/src/main/res/layout/fragment_dashboard.xml
@@ -46,7 +46,19 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/dashboard_stats_reverted_card"
-                    app:layout_constraintBottom_toTopOf="@+id/dashboard_top_earners"/>
+                    app:layout_constraintBottom_toTopOf="@+id/dashboard_feedback_request_card"/>
+
+                <!-- Feedback Request Card -->
+                <com.woocommerce.android.ui.feedback.FeedbackRequestCard
+                    android:id="@+id/dashboard_feedback_request_card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/minor_100"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/dashboard_stats"
+                    app:layout_constraintBottom_toTopOf="@+id/dashboard_top_earners"
+                    android:visibility="gone"/>
 
                 <!-- Top earner stats -->
                 <com.woocommerce.android.ui.dashboard.DashboardTopEarnersView
@@ -56,7 +68,7 @@
                     android:layout_height="wrap_content"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/dashboard_stats"
+                    app:layout_constraintTop_toBottomOf="@+id/dashboard_feedback_request_card"
                     app:layout_constraintBottom_toBottomOf="parent"
                     tools:visibility="visible"/>
 

--- a/WooCommerce/src/main/res/layout/fragment_my_store.xml
+++ b/WooCommerce/src/main/res/layout/fragment_my_store.xml
@@ -50,6 +50,13 @@
                     android:layout_height="wrap_content"
                     android:orientation="vertical" />
 
+                <!-- Feedback Request Card -->
+                <com.woocommerce.android.ui.feedback.FeedbackRequestCard
+                    android:id="@+id/store_feedback_request_card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/minor_100"/>
+
                 <!-- Top earner stats -->
                 <com.woocommerce.android.ui.mystore.MyStoreTopEarnersView
                     android:id="@+id/my_store_top_earners"

--- a/WooCommerce/src/main/res/layout/fragment_my_store.xml
+++ b/WooCommerce/src/main/res/layout/fragment_my_store.xml
@@ -55,7 +55,8 @@
                     android:id="@+id/store_feedback_request_card"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/minor_100"/>
+                    android:layout_marginBottom="@dimen/minor_100"
+                    android:visibility="gone"/>
 
                 <!-- Top earner stats -->
                 <com.woocommerce.android.ui.mystore.MyStoreTopEarnersView

--- a/WooCommerce/src/main/res/layout/view_login_epilogue_button_bar.xml
+++ b/WooCommerce/src/main/res/layout/view_login_epilogue_button_bar.xml
@@ -9,7 +9,7 @@
     android:clipToPadding="false"
     android:padding="@dimen/major_100"
     android:orientation="vertical"
-    android:elevation="@dimen/plane_02"
+    app:wcElevation="@dimen/plane_02"
     tools:showIn="@layout/activity_site_picker">
 
     <com.google.android.material.button.MaterialButton

--- a/WooCommerce/src/main/res/layout/view_login_epilogue_button_bar.xml
+++ b/WooCommerce/src/main/res/layout/view_login_epilogue_button_bar.xml
@@ -9,7 +9,7 @@
     android:clipToPadding="false"
     android:padding="@dimen/major_100"
     android:orientation="vertical"
-    app:wcElevation="@dimen/plane_02"
+    android:elevation="@dimen/plane_02"
     tools:showIn="@layout/activity_site_picker">
 
     <com.google.android.material.button.MaterialButton

--- a/WooCommerce/src/main/res/values/attrs.xml
+++ b/WooCommerce/src/main/res/values/attrs.xml
@@ -106,12 +106,12 @@
 
     <declare-styleable name="WCElevatedLinearLayout">
         <!-- Optional: resource id of dimension -->
-        <attr name="wcElevation" format="reference"/>
+        <attr name="android:elevation"/>
     </declare-styleable>
 
     <declare-styleable name="WCElevatedConstraintLayout">
         <!-- Optional: resource id of dimension -->
-        <attr name="wcElevation" format="reference"/>
+        <attr name="android:elevation"/>
     </declare-styleable>
 
     <!--

--- a/WooCommerce/src/main/res/values/attrs.xml
+++ b/WooCommerce/src/main/res/values/attrs.xml
@@ -109,6 +109,11 @@
         <attr name="wcElevation" format="reference"/>
     </declare-styleable>
 
+    <declare-styleable name="WCElevatedConstraintLayout">
+        <!-- Optional: resource id of dimension -->
+        <attr name="wcElevation" format="reference"/>
+    </declare-styleable>
+
     <!--
         Badge attributes for the bottom bar
     -->

--- a/WooCommerce/src/main/res/values/attrs.xml
+++ b/WooCommerce/src/main/res/values/attrs.xml
@@ -106,12 +106,12 @@
 
     <declare-styleable name="WCElevatedLinearLayout">
         <!-- Optional: resource id of dimension -->
-        <attr name="wcElevation" format="reference"/>
+        <attr name="android:elevation" format="reference"/>
     </declare-styleable>
 
     <declare-styleable name="WCElevatedConstraintLayout">
         <!-- Optional: resource id of dimension -->
-        <attr name="wcElevation" format="reference"/>
+        <attr name="android:elevation" format="reference"/>
     </declare-styleable>
 
     <!--

--- a/WooCommerce/src/main/res/values/attrs.xml
+++ b/WooCommerce/src/main/res/values/attrs.xml
@@ -106,12 +106,12 @@
 
     <declare-styleable name="WCElevatedLinearLayout">
         <!-- Optional: resource id of dimension -->
-        <attr name="android:elevation" format="reference"/>
+        <attr name="wcElevation" format="reference"/>
     </declare-styleable>
 
     <declare-styleable name="WCElevatedConstraintLayout">
         <!-- Optional: resource id of dimension -->
-        <attr name="android:elevation" format="reference"/>
+        <attr name="wcElevation" format="reference"/>
     </declare-styleable>
 
     <!--

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -885,6 +885,11 @@
     <string name="product_type_physical">Physical</string>
     <string name="product_type_virtual">Virtual</string>
 
+    <!-- In-App Feedback -->
+    <string name="feedback_request_title">Enjoying the WooCommerce app?</string>
+    <string name="feedback_request_make_better">Could be better</string>
+    <string name="feedback_request_like_it">I like it</string>
+
     <!-- permissions -->
     <string name="permissions_denied_title">Permissions</string>
     <string name="permissions_denied_message">It looks like you turned off permissions required for this feature.&lt;br/&gt;&lt;br/&gt;To change this, edit your permissions and make sure &lt;strong&gt;%s&lt;/strong&gt; is enabled.</string>


### PR DESCRIPTION
Closes #2641 by displaying the `AppRatingDialog` when the user clicks on the **I like it** button on the App Feedback Request Card. Functionality added to both the v3 and v4 stats page.

v3 Stats | v4 Stats
-- | --
![Screenshot_1595979412](https://user-images.githubusercontent.com/5810477/88740058-65b4c000-d0f9-11ea-8407-d93eb3d6509c.png)|![Screenshot_1595979446](https://user-images.githubusercontent.com/5810477/88740065-6a797400-d0f9-11ea-9494-6fec7d07987f.png)

## To Test
Verify the **I like it** button opens the ratings dialog on both the v3 and v4 stats pages.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
