### PR TITLE
Added logic to display bottom sheet button if some product info is not available

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.ui.products.ProductType.EXTERNAL
 import com.woocommerce.android.ui.products.ProductType.GROUPED
 import com.woocommerce.android.ui.products.ProductType.SIMPLE
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.ResourceProvider
 
 class ProductDetailBottomSheetBuilder(
@@ -71,7 +72,7 @@ class ProductDetailBottomSheetBuilder(
     }
 
     private fun Product.getShipping(): ProductDetailBottomSheetUiItem? {
-        return if (!hasShipping) {
+        return if (!isVirtual && !hasShipping) {
             ProductDetailBottomSheetUiItem(
                 ProductDetailBottomSheetType.PRODUCT_SHIPPING,
                 ViewProductShipping(remoteId),
@@ -83,7 +84,7 @@ class ProductDetailBottomSheetBuilder(
     }
 
     private fun Product.getCategories(): ProductDetailBottomSheetUiItem? {
-        return if (!hasCategories) {
+        return if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled() && !hasCategories) {
             ProductDetailBottomSheetUiItem(
                 ProductDetailBottomSheetType.PRODUCT_CATEGORIES,
                 ViewProductCategories(remoteId),
@@ -95,7 +96,7 @@ class ProductDetailBottomSheetBuilder(
     }
 
     private fun Product.getTags(): ProductDetailBottomSheetUiItem? {
-        return if (!hasTags) {
+        return if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled() && !hasTags) {
             ProductDetailBottomSheetUiItem(
                 ProductDetailBottomSheetType.PRODUCT_TAGS,
                 ViewProductTags(remoteId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -32,7 +32,6 @@ import com.woocommerce.android.ui.products.adapters.ProductPropertyCardsAdapter
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
 import com.woocommerce.android.ui.wpmediapicker.WPMediaPickerFragment
 import com.woocommerce.android.util.ChromeCustomTabUtils
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.widgets.CustomProgressDialog
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageClickListener
@@ -103,6 +102,9 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
             new.uploadingImageUris?.takeIfNotEqualTo(old?.uploadingImageUris) {
                 imageGallery.setPlaceholderImageUris(it)
             }
+            new.showBottomSheetButton?.takeIfNotEqualTo(old?.showBottomSheetButton) {
+                productDetail_addMoreContainer.visibility = if (it) View.VISIBLE else View.GONE
+            }
         }
 
         viewModel.productDetailCards.observe(viewLifecycleOwner, Observer {
@@ -147,9 +149,6 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
             viewProductOnStoreMenuItem?.isVisible = status == ProductStatus.PUBLISH
         }
 
-        productDetail_addMoreContainer.visibility = if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled()) {
-            View.VISIBLE
-        } else View.GONE
         productDetail_addMoreContainer.setOnClickListener {
             // TODO: add tracking events here
             viewModel.onEditProductCardClicked(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -677,6 +677,7 @@ class ProductDetailViewModel @AssistedInject constructor(
                 }
             }
         }
+        fetchBottomSheetList()
     }
 
     fun fetchBottomSheetList() {
@@ -685,6 +686,7 @@ class ProductDetailViewModel @AssistedInject constructor(
                 val detailList = productDetailBottomSheetBuilder.buildBottomSheetList(it)
                 withContext(dispatchers.main) {
                     _productDetailBottomSheetList.value = detailList
+                    viewState = viewState.copy(showBottomSheetButton = detailList.isNotEmpty())
                 }
             }
         }
@@ -1345,7 +1347,8 @@ class ProductDetailViewModel @AssistedInject constructor(
         val isProductUpdated: Boolean? = null,
         val gmtOffset: Float = 0f,
         val storedPassword: String? = null,
-        val draftPassword: String? = null
+        val draftPassword: String? = null,
+        val showBottomSheetButton: Boolean? = null
     ) : Parcelable {
         val isPasswordChanged: Boolean
             get() = storedPassword != draftPassword

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -92,7 +92,8 @@ class ProductDetailViewModelTest : BaseUnitTest() {
             weightWithUnits = "10kg",
             sizeWithUnits = "1 x 2 x 3 cm",
             salePriceWithCurrency = "CZK10.00",
-            regularPriceWithCurrency = "CZK30.00"
+            regularPriceWithCurrency = "CZK30.00",
+            showBottomSheetButton = false
     )
 
     private val expectedCards = listOf(


### PR DESCRIPTION
Fixes #2669. The bottom sheet button was initially only displayed for M3 release. But this meant if there was no shipping or short description available for a product, there was no option to add those details. This PR adds logic to display the "Add more details" button if some product info for M1 and M2 release is not available.

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/89003146-97f23780-d31c-11ea-8bb9-b2460002b9f6.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/89003148-9a549180-d31c-11ea-8a1f-b2add50c6be9.png" width="300"/>

#### To test
- Click on a Physical product with no shipping info.
- Notice the **Add More details** button is visible.
- Click on the button and notice Shipping section.
- Click on the Shipping section and update some details.
- Notice now that the bottom sheet button is no longer visible and a new shipping section is displayed in the Product Detail screen.

**Please be sure to test this change in a release version as well since the M3 features should not be visible in the release version.** 

This is a hotfix and warrants a new beta release since users would no longer be able to add shipping info for a product in the 4.7 beta. cc @oguzkocer and @loremattei 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
