### PR TITLE
Support new MimeType declaration on MediaStore calls

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaPickerRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaPickerRepository.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.MediaActionBuilder
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaListFetched
+import org.wordpress.android.fluxc.utils.MimeType
 import javax.inject.Inject
 import kotlin.coroutines.resume
 
@@ -54,7 +55,7 @@ class WPMediaPickerRepository @Inject constructor(
                         selectedSite.get(),
                         MEDIA_PAGE_SIZE,
                         loadMore,
-                        MEDIA_MIME_TYPE
+                        MimeType.Type.IMAGE
                 )
                 dispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(payload))
             }

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '315ef997965b0c5882b3b2439e9a073f49088d96'
+    fluxCVersion = '1.6.18-beta-3'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Summary
==========
Fixes issue #2671. FluxC has changed how it organizes itself around the MimeType declaration and organization through this PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1634, as it is right now, changes are required in order to avoid build problems in the Woo app, these changes are available through the beta version `1.6.18-beta-3`.

Changelog
==========
| Description | Commit |
| ------------- | ------------- |
| Adjust `WPMediaPickerRepository` to support new `MimeType` parameter on `MediaStore` calls, also update the `fluxCVersion` to reference the recently MimeType merged changes | 4e85f58347089ec9f7a59bac86e3f299d23ee269 |

Screenshots
==========
![untitled](https://user-images.githubusercontent.com/5920403/89019341-85afd380-d2f3-11ea-9fe3-c8af35de3533.gif)

How to Test
==========
1. Go for any Product Details View
2. Click on the Media Icon to edit the product pictures
3. Click on `Add Photos`
4. Choose the `WordPress Media Library` option
5. Make sure the photo selection and browsing are working just fine

Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
