### PR TITLE
Issue/2667 shipment tracking bug fix

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 4.8
 -----
+* Added a fix to display the Add shipment tracking section only if the Shipment Tracking plugin is available
  
 4.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailContract.kt
@@ -29,7 +29,6 @@ interface OrderDetailContract {
         fun fetchOrderDetailInfo(order: WCOrderModel)
         fun fetchOrderNotesFromDb(order: WCOrderModel): List<WCOrderNoteModel>
         fun fetchAndLoadOrderNotesFromDb()
-        fun loadOrderShipmentTrackings()
         fun getOrderShipmentTrackingsFromDb(order: WCOrderModel): List<WCOrderShipmentTrackingModel>
         fun loadShipmentTrackingsFromDb()
         fun doChangeOrderStatus(newStatus: String)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -165,8 +165,8 @@ class OrderDetailPresenter @Inject constructor(
             orderView?.showProductList(order, orderDetailUiItem.refunds, orderDetailUiItem.shippingLabels)
         }
 
-        // if shipping labels are available, we don't need to display shipment tracking information separately
-        if (orderDetailUiItem.shippingLabels.isEmpty()) {
+        // Display the shipment tracking list only if it's available and if there are no shipping labels available
+        if (orderDetailUiItem.shippingLabels.isEmpty() && orderDetailUiItem.shipmentTrackingList.isNotEmpty()) {
             orderView?.showOrderShipmentTrackings(orderDetailUiItem.shipmentTrackingList)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -218,18 +218,6 @@ class OrderDetailPresenter @Inject constructor(
         }
     }
 
-    override fun loadOrderShipmentTrackings() {
-        orderModel?.let { order ->
-            // Preload trackings from the db if we've already fetched it
-            if (isShipmentTrackingsFetched) {
-                loadShipmentTrackingsFromDb()
-            } else if (networkStatus.isConnected() && !isShipmentTrackingsFailed) {
-                // Attempt to refresh trackings from api in the background
-                requestShipmentTrackingsFromApi(order)
-            }
-        }
-    }
-
     /**
      * Fetch the order shipment trackings from the device database
      * Segregating the fetching from db and displaying to UI into two separate methods


### PR DESCRIPTION
Fixes #2667 by hiding the "Add shipment Tracking" section from the Order Detail screen, if the there are no shipment trackings to display.

#### To test
- Click on an Order without any shipping labels.
- Notice the "Add shipment tracking" section is displayed.
- Pull changes from this PR and notice that the "Add shipment" section is NOT displayed.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
