### PR TITLE
Fix the failing product detail unit tests

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -15,10 +15,20 @@ enum class FeatureFlag {
         return when (this) {
             // This feature will live switched on from the
             // setting screen. i.e. check AppPrefs.isProductsFeatureEnabled() method
-            PRODUCT_RELEASE_M3, APP_FEEDBACK, SHIPPING_LABELS_M1 -> BuildConfig.DEBUG
+            // Also, turn on the feature during testing
+            PRODUCT_RELEASE_M3, APP_FEEDBACK, SHIPPING_LABELS_M1 -> BuildConfig.DEBUG || isTesting()
             DB_DOWNGRADE -> {
                 BuildConfig.DEBUG || context != null && PackageUtils.isBetaBuild(context)
             }
+        }
+    }
+
+    private fun isTesting(): Boolean {
+        return try {
+            Class.forName("com.woocommerce.android.viewmodel.BaseUnitTest")
+            true
+        } catch (e: ClassNotFoundException) {
+            false
         }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -10,7 +10,6 @@ import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.media.ProductImagesServiceWrapper

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -214,23 +214,19 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Displays the product detail properties correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
-        // This is still a feature flagged functionality => it'll fail on CircleCI
-        // TODO: Remove the check once it's available
-        if (BuildConfig.DEBUG) {
-            doReturn(true).whenever(networkStatus).isConnected()
-            doReturn(productWithTagsAndCategories).whenever(productRepository).getProduct(any())
+        doReturn(true).whenever(networkStatus).isConnected()
+        doReturn(productWithTagsAndCategories).whenever(productRepository).getProduct(any())
 
-            viewModel.productDetailViewStateData.observeForever { _, _ -> }
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
 
-            var cards: List<ProductPropertyCard>? = null
-            viewModel.productDetailCards.observeForever {
-                cards = it.map { card -> stripCallbacks(card) }
-            }
-
-            viewModel.start()
-
-            assertThat(cards).isEqualTo(expectedCards)
+        var cards: List<ProductPropertyCard>? = null
+        viewModel.productDetailCards.observeForever {
+            cards = it.map { card -> stripCallbacks(card) }
         }
+
+        viewModel.start()
+
+        assertThat(cards).isEqualTo(expectedCards)
     }
 
     private fun stripCallbacks(card: ProductPropertyCard): ProductPropertyCard {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.products
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.ProductCategory
 import com.woocommerce.android.model.ProductVariation
+import com.woocommerce.android.model.ProductTag
 import com.woocommerce.android.model.toAppModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
@@ -32,6 +33,10 @@ object ProductTestUtils {
             categories = ""
             shortDescription = "short desc"
         }.toAppModel()
+    }
+
+    fun generateProductWithTagsAndCategories(productId: Long = 1L): Product {
+        return generateProduct(productId).copy(categories = generateProductCategories(), tags = generateTags())
     }
 
     fun generateProductList(): List<Product> {
@@ -69,6 +74,10 @@ object ProductTestUtils {
             add(generateProductVariation(productId, 5))
             return this
         }
+    }
+
+    fun generateTags(): List<ProductTag> {
+        return listOf(ProductTag(1, "Tag", "Slug", "Desc"))
     }
 
     fun generateProductCategories(): List<ProductCategory> {


### PR DESCRIPTION
This PR fixes the failing unit tests due to some changes/reordering in the product detail screen.

**To test:**
1. Run tests in `ProductDetailViewModelTest` and make sure all tests pass