### PR TITLE
Fix flaky variation list

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListAdapter.kt
@@ -91,7 +91,7 @@ class VariationListAdapter(
         override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
             val oldItem = oldList[oldItemPosition]
             val newItem = newList[newItemPosition]
-            return oldItem != newItem
+            return oldItem == newItem
         }
     }
 


### PR DESCRIPTION
This PR fixes an issue in variation list where sometimes it would hide some items after a list was opened. This was caused by launching 2 loading requests in parallel -- first the initial load and immediately a request to load more items. Depending on which response came back first, the list would now show some items.

**To test**
1. Go to `Products` -> `Variable product detail` -> `Variation list`
2. Go back to `Product detail`
3. Go back to `Variation list`
4. Repeat a couple of times
5. Verify the list is loaded always with the same items