### PR TITLE
Multiple observers crash fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NavController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NavController.kt
@@ -8,12 +8,28 @@ import androidx.navigation.NavDirections
  * Prevents crashes caused by rapidly double-clicking views which navigate to the same
  * destination twice
  */
+object CallThrottler {
+    private const val DELAY = 200
+    private var lastTime: Long = 0
+
+    fun throttle(call: () -> Unit) {
+        if (System.currentTimeMillis() - lastTime > DELAY) {
+            lastTime = System.currentTimeMillis()
+            call()
+        }
+    }
+}
+
 fun NavController.navigateSafely(directions: NavDirections) {
-    currentDestination?.getAction(directions.actionId)?.let { navigate(directions) }
+    CallThrottler.throttle {
+        currentDestination?.getAction(directions.actionId)?.let { navigate(directions) }
+    }
 }
 
 fun NavController.navigateSafely(@IdRes resId: Int) {
-    if (currentDestination?.id != resId) {
-        navigate(resId, null)
+    CallThrottler.throttle {
+        if (currentDestination?.id != resId) {
+            navigate(resId, null)
+        }
     }
 }


### PR DESCRIPTION
Fixes #2074 (hopefully). 

I was testing a feature I was working on today when I suddenly saw the app crash. After looking at the logcat I noticed it was the most common bug in WCAndroid -- `IllegalStateException: Multiple observers registered but only one is supported`. 

This got me curious and after some fiddling I was able to reliably reproduce the exception:

1. I created 2 calls in code to navigate to a product detail screen from the product list item click listener 
2. Then I ran the app, opened up the product list, tapped on a product and the detail screen showed up (no crash yet)
3. However, when I tapped on the back button, the error occurred

After I debugged the app, I saw that the `ProductDetailFragment.onCreateView()` was called immediately after tapping on the back button. It seems like both calls to open the detail got put on the backstack and when the fragment got created for the 2nd time, the `ProductDetailViewModel` instance was still alive with observers from the first one.

So I came up with a hack to throttle the navigation calls. I chose 200ms because it's short enough that a user (probably) wouldn't purposely navigate that quickly. This fixed the crash for the scenario above and I'm hoping it could work in general.