### PR TITLE
Do not attempt to hide a null empty_view

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.8
 -----
 * Added a fix to display the Add shipment tracking section only if the Shipment Tracking plugin is available
+* Fixed a rare crash caused by attempting to hide a non-active view
  
 4.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -436,7 +436,7 @@ class OrderListFragment : TopLevelFragment(),
     }
 
     private fun hideEmptyView() {
-        empty_view.hide()
+        empty_view?.hide()
     }
 
     private fun updatePagedListData(pagedListData: PagedList<OrderListItemUIType>?) {


### PR DESCRIPTION
Fixes #2698 by checking if `empty_view` is `null` before attempting to hide it. If it is `null`, then there is no reason to hide it 😄 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
