### PR TITLE
Bump Tracks library version to 1.2.1

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -145,7 +145,7 @@ dependencies {
         exclude group: "com.android.support"
     }
 
-    implementation 'com.github.Automattic:Automattic-Tracks-Android:52d3e23406'
+    implementation 'com.automattic:tracks:1.2.1'
 
     implementation("com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:$fluxCVersion") {
         exclude group: "com.android.support"


### PR DESCRIPTION
Updates to the latest version of the Tracks library, `1.2.1`.

This includes a fix to height/width tracking, which was using deprecated params which were being ignored server-side. See Automattic/Automattic-Tracks-Android#48 for the details and behavior changes.

To test: Follow the same steps laid out in Automattic/Automattic-Tracks-Android#48 to verify that the `commonProps` sent to tracks reflect the changes.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
