### PR TITLE
Update FluxC to 1.6.18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '9b15109795ef28c77c581d8a5810fa809ef304d9'
+    fluxCVersion = '1.6.18'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ allprojects {
         maven {
             url 'http://www.idescout.com/maven/repo/'
         }
+        maven { url "http://dl.bintray.com/terl/lazysodium-maven" }
     }
 
     task checkstyle(type: Checkstyle) {

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -14,6 +14,7 @@ repositories {
     google()
     jcenter()
     maven { url "https://www.jitpack.io" }
+    maven { url "http://dl.bintray.com/terl/lazysodium-maven" }
 }
 
 android {


### PR DESCRIPTION
This PR updates FluxC to the latest release and adds the required dependences.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
