### PR TITLE
Merge Release/4.8 into develop

### DIFF
--- a/WooCommerce/metadata/PlayStoreStrings.pot
+++ b/WooCommerce/metadata/PlayStoreStrings.pot
@@ -11,22 +11,20 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_048"
+msgid ""
+"4.8:\n"
+"* Updated the “Add shipment tracking” section to display only if the Shipment Tracking plugin is available.\n"
+"* Fixed a crash when double-tapping a navigation element, and another (rare) crash caused by trying to hide a non-active view.\n"
+"\n"
+msgstr ""
+
 msgctxt "release_note_047"
 msgid ""
 "4.7:\n"
 "<b>Stats:</b> Your stats graph will now match what you see in wp-admin. As you need to be running WooCommerce 4.0 or greater make sure you update.\n"
 "\n"
 "<b>Crash Fix:</b> Crashes were happening with large amounts of data being transferred. We fixed this on devices running Android P and higher with a larger buffer.\n"
-msgstr ""
-
-msgctxt "release_note_046"
-msgid ""
-"4.6:\n"
-"New: Added placeholder for orders missing a customer’s name.\n"
-"\n"
-"Fix: Multiple new order notifications are now viewable.\n"
-"\n"
-"Adjustments: Updated background color of login views and moved privacy notice for CA users to “About App” screen.\n"
 msgstr ""
 
 #. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,3 +1,3 @@
-* Added a fix to display the Add shipment tracking section only if the Shipment Tracking plugin is available
-* Fixed a rare crash caused by attempting to hide a non-active view
+* Updated the “Add shipment tracking” section to display only if the Shipment Tracking plugin is available.
+* Fixed a crash when double-tapping a navigation element, and another (rare) crash caused by trying to hide a non-active view.
  


### PR DESCRIPTION
Merge Release/4.8 into develop in order to make the new release notes available for translation.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
