### PR TITLE
Hotfix: Hide M3 features if feature flag disabled

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -58,6 +58,7 @@ import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductSe
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductSlug
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductStatus
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductVisibility
+import com.woocommerce.android.ui.products.ProductType.SIMPLE
 import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
 import com.woocommerce.android.ui.products.categories.ProductCategoryItemUiModel
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
@@ -67,6 +68,7 @@ import com.woocommerce.android.ui.products.settings.ProductVisibility
 import com.woocommerce.android.ui.products.tags.ProductTagsRepository
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.Optional
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.LiveDataDelegate
@@ -691,12 +693,13 @@ class ProductDetailViewModel @AssistedInject constructor(
     }
 
     fun fetchBottomSheetList() {
+        val featureFlagCondition = FeatureFlag.PRODUCT_RELEASE_M3.isEnabled() || viewState.productDraft?.type == SIMPLE
         viewState.productDraft?.let {
             launch(dispatchers.computation) {
                 val detailList = productDetailBottomSheetBuilder.buildBottomSheetList(it)
                 withContext(dispatchers.main) {
                     _productDetailBottomSheetList.value = detailList
-                    viewState = viewState.copy(showBottomSheetButton = detailList.isNotEmpty())
+                    viewState = viewState.copy(showBottomSheetButton = detailList.isNotEmpty() && featureFlagCondition)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
@@ -98,7 +98,7 @@ class VariationDetailCardBuilder(
 
     // If we have pricing info, show price & sales price as a group,
     // otherwise provide option to add pricing info for the variation
-    private fun ProductVariation.price(): ProductProperty {
+    private fun ProductVariation.price(): ProductProperty? {
         val hasPricingInfo = this.regularPrice != null || this.salePrice != null
         val pricingGroup = PriceUtils.getPriceGroup(
             parameters,
@@ -112,12 +112,16 @@ class VariationDetailCardBuilder(
             saleEndDateGmt
         )
 
-        return PropertyGroup(
-            string.product_price,
-            pricingGroup,
-            drawable.ic_gridicons_money,
-            hasPricingInfo
-        )
+        return if (hasPricingInfo) {
+            PropertyGroup(
+                string.product_price,
+                pricingGroup,
+                drawable.ic_gridicons_money,
+                hasPricingInfo
+            )
+        } else {
+            null
+        }
         // TODO: This will be used once the variants are editable
 //            {
 //                viewModel.onEditVariationCardClicked(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
@@ -147,7 +147,11 @@ class VariationDetailCardBuilder(
                         viewModel.getShippingClassByRemoteShippingClassId(this.shippingClassId)
                     )
                 )
-            } else mapOf(Pair("", resources.getString(string.product_shipping_empty)))
+            } else {
+                return null
+                // TODO: M3 feature
+//                mapOf(Pair("", resources.getString(string.product_shipping_empty)))
+            }
 
             PropertyGroup(
                 string.product_shipping,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.ui.products.models.ProductPropertyCard
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.PRIMARY
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.FeatureFlag.PRODUCT_RELEASE_M3
 import com.woocommerce.android.util.PriceUtils
 import com.woocommerce.android.viewmodel.ResourceProvider
 
@@ -86,8 +87,12 @@ class VariationDetailCardBuilder(
             visibilityIcon = drawable.ic_gridicons_not_visible
         }
 
-        return Switch(visibility, this.isVisible, visibilityIcon) {
-            viewModel.onVisibilityChanged(it)
+        return if (PRODUCT_RELEASE_M3.isEnabled()) {
+            Switch(visibility, isVisible, visibilityIcon) {
+                viewModel.onVisibilityChanged(it)
+            }
+        } else {
+            Switch(visibility, isVisible, visibilityIcon)
         }
     }
 


### PR DESCRIPTION
This PR hides some features that were supposed to be behind a feature flag, namely:

- Variation detail visibility switch
- Add price button in variation detail
- Bottom sheets for non-simple products

**Test 1:**
1. Go to Products -> Select a variable product -> Tap on Variations -> Select a variation
2. Verify that the **Visibility** switch is disabled

**Test 2:**
1. Go to Products -> Select a variable product -> Tap on Variations -> Select a variation without price
2. Verify there is no **Price** property in the variation detail

**Test 3:**
1. Go to Products -> Select an External/Variable/Grouped product
2. Verify that the **Add more details** button is not visible

cc: @rachelmcr, @loremattei 