### PR TITLE
Issue/2630 display grouped products

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -545,7 +545,7 @@ fun WCProductModel.toAppModel(): Product {
                 it.slug
             )
         },
-        groupedProductIds = this.getGroupedProductIds().map { it.toLong() }
+        groupedProductIds = this.getGroupedProductIds()
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -73,6 +73,7 @@ data class Product(
     val menuOrder: Int,
     val categories: List<ProductCategory>,
     val tags: List<ProductTag>,
+    val groupedProductIds: List<Int>,
     override val length: Float,
     override val width: Float,
     override val height: Float,
@@ -536,7 +537,8 @@ fun WCProductModel.toAppModel(): Product {
                 it.name,
                 it.slug
             )
-        }
+        },
+        groupedProductIds = this.getGroupedProductIds()
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -551,6 +551,20 @@ fun MediaModel.toAppModel(): Product.Image {
     )
 }
 
+fun List<Product>.isSameList(productList: List<Product>): Boolean {
+    if (this.size != productList.size) {
+        return false
+    }
+    for (index in this.indices) {
+        val oldItem = productList[index]
+        val newItem = this[index]
+        if (!oldItem.isSameProduct(newItem)) {
+            return false
+        }
+    }
+    return true
+}
+
 /**
  * Returns the product as a [ProductReviewProduct] for use with the product reviews feature.
  */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -137,7 +137,8 @@ data class Product(
             menuOrder == product.menuOrder &&
             isSameImages(product.images) &&
             isSameCategories(product.categories) &&
-            isSameTags(product.tags)
+            isSameTags(product.tags) &&
+            groupedProductIds == product.groupedProductIds
     }
 
     val hasCategories get() = categories.isNotEmpty()
@@ -355,7 +356,8 @@ data class Product(
                 menuOrder = updatedProduct.menuOrder,
                 categories = updatedProduct.categories,
                 tags = updatedProduct.tags,
-                type = updatedProduct.type
+                type = updatedProduct.type,
+                groupedProductIds = updatedProduct.groupedProductIds
             )
         } ?: this.copy()
     }
@@ -455,6 +457,11 @@ fun Product.toDataModel(storedProductModel: WCProductModel?): WCProductModel {
         it.categories = categoriesToJson()
         it.tags = tagsToJson()
         it.type = type.value
+        it.groupedProductIds = groupedProductIds.joinToString(
+            separator = ",",
+            prefix = "[",
+            postfix = "]"
+        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -73,7 +73,7 @@ data class Product(
     val menuOrder: Int,
     val categories: List<ProductCategory>,
     val tags: List<ProductTag>,
-    val groupedProductIds: List<Int>,
+    val groupedProductIds: List<Long>,
     override val length: Float,
     override val width: Float,
     override val height: Float,
@@ -538,7 +538,7 @@ fun WCProductModel.toAppModel(): Product {
                 it.slug
             )
         },
-        groupedProductIds = this.getGroupedProductIds()
+        groupedProductIds = this.getGroupedProductIds().map { it.toLong() }
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListAdapter.kt
@@ -7,8 +7,7 @@ import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.isSameList
 
 class GroupedProductListAdapter(
-    private val onItemDeleted: (product: Product) -> Unit,
-    private val loadMoreListener: OnLoadMoreListener
+    private val onItemDeleted: (product: Product) -> Unit
 ) : RecyclerView.Adapter<ProductItemViewHolder>() {
     private val productList = ArrayList<Product>()
 
@@ -27,10 +26,6 @@ class GroupedProductListAdapter(
 
         holder.bind(product)
         holder.setOnDeleteClickListener(product, onItemDeleted)
-
-        if (position == itemCount - 1) {
-            loadMoreListener.onRequestLoadMore()
-        }
     }
 
     fun setProductList(products: List<Product>) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListAdapter.kt
@@ -1,0 +1,44 @@
+package com.woocommerce.android.ui.products
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import com.woocommerce.android.model.Product
+import com.woocommerce.android.model.isSameList
+
+class GroupedProductListAdapter(
+    private val onItemDeleted: (product: Product) -> Unit,
+    private val loadMoreListener: OnLoadMoreListener
+) : RecyclerView.Adapter<ProductItemViewHolder>() {
+    private val productList = ArrayList<Product>()
+
+    init {
+        setHasStableIds(true)
+    }
+
+    override fun getItemId(position: Int) = productList[position].remoteId
+
+    override fun getItemCount() = productList.size
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = ProductItemViewHolder(parent)
+
+    override fun onBindViewHolder(holder: ProductItemViewHolder, position: Int) {
+        val product = productList[position]
+
+        holder.bind(product)
+        holder.setOnDeleteClickListener(product, onItemDeleted)
+
+        if (position == itemCount - 1) {
+            loadMoreListener.onRequestLoadMore()
+        }
+    }
+
+    fun setProductList(products: List<Product>) {
+        if (!productList.isSameList(products)) {
+            val diffResult = DiffUtil.calculateDiff(ProductItemDiffUtil(productList, products))
+            productList.clear()
+            productList.addAll(products)
+            diffResult.dispatchUpdatesTo(this)
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
@@ -1,11 +1,87 @@
 package com.woocommerce.android.ui.products
 
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Observer
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.woocommerce.android.R
+import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ViewModelFactory
+import com.woocommerce.android.widgets.SkeletonView
+import kotlinx.android.synthetic.main.fragment_grouped_product_list.*
 import javax.inject.Inject
 
-class GroupedProductListFragment : BaseFragment() {
+class GroupedProductListFragment : BaseFragment(), OnLoadMoreListener {
+    @Inject lateinit var uiMessageResolver: UIMessageResolver
+
     @Inject lateinit var viewModelFactory: ViewModelFactory
     val viewModel: GroupedProductListViewModel by viewModels { viewModelFactory }
+
+    private val skeletonView = SkeletonView()
+    private val productListAdapter: GroupedProductListAdapter by lazy {
+        GroupedProductListAdapter(viewModel::onGroupedProductDeleted, this)
+    }
+
+    override fun getFragmentTitle() = getString(R.string.grouped_products)
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_grouped_product_list, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupObservers()
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+
+        val activity = requireActivity()
+
+        productsRecycler.layoutManager = LinearLayoutManager(activity)
+        productsRecycler.adapter = productListAdapter
+        productsRecycler.isMotionEventSplittingEnabled = false
+    }
+
+    private fun setupObservers() {
+        viewModel.productListViewStateData.observe(viewLifecycleOwner) { old, new ->
+            new.isSkeletonShown?.takeIfNotEqualTo(old?.isSkeletonShown) { showSkeleton(it) }
+            new.isLoadingMore?.takeIfNotEqualTo(old?.isLoadingMore) { loadMoreProgress.isVisible = it }
+        }
+
+        viewModel.event.observe(viewLifecycleOwner, Observer { event ->
+            when (event) {
+                is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+                else -> event.isHandled = false
+            }
+        })
+
+        viewModel.productList.observe(viewLifecycleOwner, Observer {
+            productListAdapter.setProductList(it)
+        })
+    }
+
+    private fun showSkeleton(show: Boolean) {
+        when (show) {
+            true -> {
+                skeletonView.show(productsRecycler, R.layout.skeleton_product_list, delayed = true)
+            }
+            false -> skeletonView.hide()
+        }
+    }
+
+    override fun onRequestLoadMore() {
+        viewModel.onLoadMoreRequested()
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
@@ -1,0 +1,5 @@
+package com.woocommerce.android.ui.products
+
+import com.woocommerce.android.ui.base.BaseFragment
+
+class GroupedProductListFragment : BaseFragment()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
@@ -1,5 +1,11 @@
 package com.woocommerce.android.ui.products
 
+import androidx.fragment.app.viewModels
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.viewmodel.ViewModelFactory
+import javax.inject.Inject
 
-class GroupedProductListFragment : BaseFragment()
+class GroupedProductListFragment : BaseFragment() {
+    @Inject lateinit var viewModelFactory: ViewModelFactory
+    val viewModel: GroupedProductListViewModel by viewModels { viewModelFactory }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
@@ -2,23 +2,38 @@ package com.woocommerce.android.ui.products
 
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.dialog.CustomDiscardDialog
+import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.SkeletonView
 import kotlinx.android.synthetic.main.fragment_grouped_product_list.*
 import javax.inject.Inject
 
-class GroupedProductListFragment : BaseFragment(), OnLoadMoreListener {
+class GroupedProductListFragment : BaseFragment(), BackPressListener {
+    companion object {
+        const val KEY_GROUPED_PRODUCT_IDS_RESULT = "key_grouped_product_ids_result"
+    }
+
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     @Inject lateinit var viewModelFactory: ViewModelFactory
@@ -26,8 +41,10 @@ class GroupedProductListFragment : BaseFragment(), OnLoadMoreListener {
 
     private val skeletonView = SkeletonView()
     private val productListAdapter: GroupedProductListAdapter by lazy {
-        GroupedProductListAdapter(viewModel::onGroupedProductDeleted, this)
+        GroupedProductListAdapter(viewModel::onGroupedProductDeleted)
     }
+
+    private var doneMenuItem: MenuItem? = null
 
     override fun getFragmentTitle() = getString(R.string.grouped_products)
 
@@ -36,7 +53,37 @@ class GroupedProductListFragment : BaseFragment(), OnLoadMoreListener {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
+        setHasOptionsMenu(true)
         return inflater.inflate(R.layout.fragment_grouped_product_list, container, false)
+    }
+
+    override fun onDestroyView() {
+        // hide the skeleton view if fragment is destroyed
+        skeletonView.hide()
+        super.onDestroyView()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        AnalyticsTracker.trackViewShown(this)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        menu.clear()
+        inflater.inflate(R.menu.menu_done, menu)
+        doneMenuItem = menu.findItem(R.id.menu_done)
+        doneMenuItem?.isVisible = false
+        super.onCreateOptionsMenu(menu, inflater)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.menu_done -> {
+                viewModel.onDoneButtonClicked()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -58,11 +105,25 @@ class GroupedProductListFragment : BaseFragment(), OnLoadMoreListener {
         viewModel.productListViewStateData.observe(viewLifecycleOwner) { old, new ->
             new.isSkeletonShown?.takeIfNotEqualTo(old?.isSkeletonShown) { showSkeleton(it) }
             new.isLoadingMore?.takeIfNotEqualTo(old?.isLoadingMore) { loadMoreProgress.isVisible = it }
+            new.hasChanges?.takeIfNotEqualTo(old?.hasChanges) {
+                doneMenuItem?.isVisible = it
+            }
         }
 
         viewModel.event.observe(viewLifecycleOwner, Observer { event ->
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+                is ShowDiscardDialog -> CustomDiscardDialog.showDiscardDialog(
+                    requireActivity(),
+                    event.positiveBtnAction,
+                    event.negativeBtnAction,
+                    event.messageId,
+                    negativeButtonId = event.negativeButtonId
+                )
+                is Exit -> findNavController().navigateUp()
+                is ExitWithResult<*> -> {
+                    navigateBackWithResult(KEY_GROUPED_PRODUCT_IDS_RESULT, event.item as? List<*>)
+                }
                 else -> event.isHandled = false
             }
         })
@@ -81,7 +142,5 @@ class GroupedProductListFragment : BaseFragment(), OnLoadMoreListener {
         }
     }
 
-    override fun onRequestLoadMore() {
-        viewModel.onLoadMoreRequested()
-    }
+    override fun onRequestAllowBackPress() = viewModel.onBackButtonClicked()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListModule.kt
@@ -1,0 +1,31 @@
+package com.woocommerce.android.ui.products
+
+import android.os.Bundle
+import androidx.lifecycle.ViewModel
+import androidx.savedstate.SavedStateRegistryOwner
+import com.woocommerce.android.di.ViewModelAssistedFactory
+import com.woocommerce.android.viewmodel.ViewModelKey
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.multibindings.IntoMap
+
+@Module
+abstract class GroupedProductListModule {
+    @Module
+    companion object {
+        @JvmStatic
+        @Provides
+        fun provideDefaultArgs(fragment: GroupedProductListFragment): Bundle? {
+            return fragment.arguments
+        }
+    }
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(GroupedProductListViewModel::class)
+    abstract fun bindFactory(factory: GroupedProductListViewModel.Factory): ViewModelAssistedFactory<out ViewModel>
+
+    @Binds
+    abstract fun bindSavedStateRegistryOwner(fragment: GroupedProductListFragment): SavedStateRegistryOwner
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListRepository.kt
@@ -1,12 +1,104 @@
 package com.woocommerce.android.ui.products
 
+import com.woocommerce.android.model.Product
+import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T
+import com.woocommerce.android.util.suspendCancellableCoroutineWithTimeout
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.CancellationException
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCTS
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCProductStore.FetchProductsPayload
+import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
 import javax.inject.Inject
+import kotlin.coroutines.resume
 
 class GroupedProductListRepository @Inject constructor(
     private val dispatcher: Dispatcher,
     private val selectedSite: SelectedSite,
     private val productStore: WCProductStore
-)
+) {
+    companion object {
+        private const val ACTION_TIMEOUT = 10L * 1000
+        private const val PRODUCT_PAGE_SIZE = WCProductStore.DEFAULT_PRODUCT_PAGE_SIZE
+    }
+
+    private var loadContinuation: CancellableContinuation<Boolean>? = null
+    private var offset = 0
+
+    var canLoadMoreProducts = true
+        private set
+
+    init {
+        dispatcher.register(this)
+    }
+
+    fun onCleanup() {
+        dispatcher.unregister(this)
+    }
+
+    /**
+     * Submits a fetch request to get a page of products for the [groupedProductIds] and returns the full
+     * list of products from the database
+     */
+    suspend fun fetchGroupedProductList(
+        groupedProductIds: List<Long>,
+        loadMore: Boolean = false
+    ): List<Product> {
+        try {
+            suspendCancellableCoroutineWithTimeout<Boolean>(ACTION_TIMEOUT) {
+                offset = if (loadMore) offset + PRODUCT_PAGE_SIZE else 0
+                loadContinuation = it
+                val payload = FetchProductsPayload(
+                    selectedSite.get(),
+                    PRODUCT_PAGE_SIZE,
+                    offset,
+                    remoteProductIds = groupedProductIds
+                )
+                dispatcher.dispatch(WCProductActionBuilder.newFetchProductsAction(payload))
+            }
+        } catch (e: CancellationException) {
+            WooLog.d(T.PRODUCTS, "CancellationException while fetching grouped products")
+        }
+
+        return getGroupedProductList(groupedProductIds)
+    }
+
+    /**
+     * Returns all products for the [groupedProductIds] that are in the database
+     */
+    fun getGroupedProductList(groupedProductIds: List<Long>): List<Product> {
+        return if (selectedSite.exists()) {
+            val wcProducts = productStore.getProductsByRemoteIds(
+                selectedSite.get(),
+                remoteProductIds = groupedProductIds
+            )
+            wcProducts.map { it.toAppModel() }
+        } else {
+            WooLog.w(T.PRODUCTS, "No site selected - unable to load products")
+            emptyList()
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onProductChanged(event: OnProductChanged) {
+        if (event.causeOfChange == FETCH_PRODUCTS) {
+            if (event.isError) {
+                // TODO: add tracking event
+                loadContinuation?.resume(false)
+            } else {
+                // TODO: add tracking event
+                canLoadMoreProducts = event.canLoadMore
+                loadContinuation?.resume(true)
+            }
+            loadContinuation = null
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListRepository.kt
@@ -1,0 +1,12 @@
+package com.woocommerce.android.ui.products
+
+import com.woocommerce.android.tools.SelectedSite
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.store.WCProductStore
+import javax.inject.Inject
+
+class GroupedProductListRepository @Inject constructor(
+    private val dispatcher: Dispatcher,
+    private val selectedSite: SelectedSite,
+    private val productStore: WCProductStore
+)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModel.kt
@@ -1,0 +1,21 @@
+package com.woocommerce.android.ui.products
+
+import com.squareup.inject.assisted.Assisted
+import com.squareup.inject.assisted.AssistedInject
+import com.woocommerce.android.annotations.OpenClassOnDebug
+import com.woocommerce.android.di.ViewModelAssistedFactory
+import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.viewmodel.SavedStateWithArgs
+import com.woocommerce.android.viewmodel.ScopedViewModel
+
+@OpenClassOnDebug
+class GroupedProductListViewModel @AssistedInject constructor(
+    @Assisted savedState: SavedStateWithArgs,
+    dispatchers: CoroutineDispatchers,
+    private val networkStatus: NetworkStatus,
+    private val groupedProductListRepository: GroupedProductListRepository
+) : ScopedViewModel(savedState, dispatchers) {
+    @AssistedInject.Factory
+    interface Factory : ViewModelAssistedFactory<GroupedProductListViewModel>
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModel.kt
@@ -1,13 +1,22 @@
 package com.woocommerce.android.ui.products
 
+import android.os.Parcelable
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.di.ViewModelAssistedFactory
+import com.woocommerce.android.model.Product
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.viewmodel.LiveDataDelegate
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import kotlinx.android.parcel.Parcelize
+import kotlinx.coroutines.launch
+import com.woocommerce.android.R.string
 
 @OpenClassOnDebug
 class GroupedProductListViewModel @AssistedInject constructor(
@@ -16,6 +25,71 @@ class GroupedProductListViewModel @AssistedInject constructor(
     private val networkStatus: NetworkStatus,
     private val groupedProductListRepository: GroupedProductListRepository
 ) : ScopedViewModel(savedState, dispatchers) {
+    private val navArgs: GroupedProductListFragmentArgs by savedState.navArgs()
+
+    private val _productList = MutableLiveData<List<Product>>()
+    val productList: LiveData<List<Product>> = _productList
+
+    final val productListViewStateData = LiveDataDelegate(savedState, GroupedProductListViewState())
+    private var productListViewState by productListViewStateData
+
+    override fun onCleared() {
+        super.onCleared()
+        groupedProductListRepository.onCleanup()
+    }
+
+    init {
+        if (_productList.value == null) {
+            loadGroupedProducts()
+        }
+    }
+
+    fun onLoadMoreRequested() {
+        loadGroupedProducts(loadMore = true)
+    }
+
+    fun onGroupedProductDeleted(product: Product) {
+        // TODO:
+    }
+
+    private fun loadGroupedProducts(loadMore: Boolean = false) {
+        val groupedProductIds = getGroupedProductIds()
+        val productsInDb = groupedProductListRepository.getGroupedProductList(groupedProductIds)
+        if (productsInDb.isNotEmpty()) {
+            _productList.value = productsInDb
+            productListViewState = productListViewState.copy(isSkeletonShown = false)
+        } else {
+            productListViewState = productListViewState.copy(isSkeletonShown = true)
+        }
+
+        launch { fetchGroupedProducts(groupedProductIds, loadMore = loadMore) }
+    }
+
+    private suspend fun fetchGroupedProducts(
+        groupedProductIds: List<Long>,
+        loadMore: Boolean
+    ) {
+        if (networkStatus.isConnected()) {
+            _productList.value = groupedProductListRepository.fetchGroupedProductList(groupedProductIds, loadMore)
+        } else {
+            // Network is not connected
+            triggerEvent(ShowSnackbar(string.offline_error))
+        }
+
+        productListViewState = productListViewState.copy(
+            isSkeletonShown = false,
+            isLoadingMore = false
+        )
+    }
+
+    private fun getGroupedProductIds() = navArgs.groupedProductIds.split(",").map { it.toLong() }
+
+    @Parcelize
+    data class GroupedProductListViewState(
+        val isSkeletonShown: Boolean? = null,
+        val isLoadingMore: Boolean? = null
+    ) : Parcelable
+
     @AssistedInject.Factory
     interface Factory : ViewModelAssistedFactory<GroupedProductListViewModel>
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -481,7 +481,7 @@ class ProductDetailCardBuilder(
             ) {
                 // TODO: add click event
                 viewModel.onEditProductCardClicked(
-                    ViewGroupedProducts(this.remoteId)
+                    ViewGroupedProducts(this.groupedProductIds.joinToString(","))
                 )
             }
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -104,6 +104,7 @@ class ProductDetailCardBuilder(
         return ProductPropertyCard(
             type = SECONDARY,
             properties = listOf(
+                product.groupedProducts(),
                 product.productType(),
                 product.productReviews(),
                 product.inventory(),
@@ -464,6 +465,19 @@ class ProductDetailCardBuilder(
                     Stat.PRODUCT_DETAIL_VIEW_PRODUCT_REVIEWS_TAPPED
                 )
             }
+        } else {
+            null
+        }
+    }
+
+    private fun Product.groupedProducts(): ProductProperty? {
+        val groupedProductsSize = this.groupedProductIds.size
+        return if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled() && groupedProductsSize > 0) {
+            ComplexProperty(
+                R.string.grouped_products,
+                resources.getString(R.string.grouped_products_count, groupedProductsSize),
+                R.drawable.ic_widgets
+            )
         } else {
             null
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -474,9 +474,11 @@ class ProductDetailCardBuilder(
     private fun Product.groupedProducts(): ProductProperty? {
         val groupedProductsSize = this.groupedProductIds.size
         return if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled() && groupedProductsSize > 0) {
+            val groupedProductResourceId = if (groupedProductsSize == 1) R.string.grouped_products_single
+            else R.string.grouped_products_count
             ComplexProperty(
                 R.string.grouped_products,
-                resources.getString(R.string.grouped_products_count, groupedProductsSize),
+                resources.getString(groupedProductResourceId, groupedProductsSize),
                 R.drawable.ic_widgets
             ) {
                 // TODO: add click event

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.extensions.addIfNotEmpty
 import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.filterNotEmpty
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewGroupedProducts
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductCategories
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductDescriptionEditor
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductExternalLink
@@ -477,7 +478,12 @@ class ProductDetailCardBuilder(
                 R.string.grouped_products,
                 resources.getString(R.string.grouped_products_count, groupedProductsSize),
                 R.drawable.ic_widgets
-            )
+            ) {
+                // TODO: add click event
+                viewModel.onEditProductCardClicked(
+                    ViewGroupedProducts(this.remoteId)
+                )
+            }
         } else {
             null
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -101,6 +101,10 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
             viewModel.updateProductDraft(type = it.type, isVirtual = it.isVirtual)
             changesMade()
         }
+        handleResult<List<Long>>(GroupedProductListFragment.KEY_GROUPED_PRODUCT_IDS_RESULT) {
+            viewModel.updateProductDraft(groupedProductIds = it)
+            changesMade()
+        }
     }
 
     private fun setupObservers(viewModel: ProductDetailViewModel) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -617,7 +617,8 @@ class ProductDetailViewModel @AssistedInject constructor(
         menuOrder: Int? = null,
         categories: List<ProductCategory>? = null,
         tags: List<ProductTag>? = null,
-        type: ProductType? = null
+        type: ProductType? = null,
+        groupedProductIds: List<Long>? = null
     ) {
         viewState.productDraft?.let { product ->
             val currentProduct = product.copy()
@@ -657,6 +658,7 @@ class ProductDetailViewModel @AssistedInject constructor(
                     categories = categories ?: product.categories,
                     tags = tags ?: product.tags,
                     type = type ?: product.type,
+                    groupedProductIds = groupedProductIds ?: product.groupedProductIds,
                     saleEndDateGmt = if (isSaleScheduled == true ||
                             (isSaleScheduled == null && currentProduct.isSaleScheduled)) {
                         if (saleEndDate != null) saleEndDate.value else product.saleEndDateGmt

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemDiffUtil.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemDiffUtil.kt
@@ -1,0 +1,19 @@
+package com.woocommerce.android.ui.products
+
+import androidx.recyclerview.widget.DiffUtil
+import com.woocommerce.android.model.Product
+
+class ProductItemDiffUtil(val items: List<Product>, val result: List<Product>) : DiffUtil.Callback() {
+    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int) =
+        items[oldItemPosition].remoteId == result[newItemPosition].remoteId
+
+    override fun getOldListSize(): Int = items.size
+
+    override fun getNewListSize(): Int = result.size
+
+    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        val oldItem = items[oldItemPosition]
+        val newItem = result[newItemPosition]
+        return oldItem.isSameProduct(newItem)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
@@ -1,0 +1,126 @@
+package com.woocommerce.android.ui.products
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.core.text.HtmlCompat
+import androidx.recyclerview.widget.RecyclerView
+import com.woocommerce.android.R
+import com.woocommerce.android.di.GlideApp
+import com.woocommerce.android.model.Product
+import com.woocommerce.android.ui.products.ProductStockStatus.InStock
+import com.woocommerce.android.ui.products.ProductStockStatus.OnBackorder
+import com.woocommerce.android.ui.products.ProductStockStatus.OutOfStock
+import com.woocommerce.android.ui.products.ProductType.VARIABLE
+import kotlinx.android.synthetic.main.product_list_item.view.*
+import org.wordpress.android.util.FormatUtils
+import org.wordpress.android.util.HtmlUtils
+import org.wordpress.android.util.PhotonUtils
+
+class ProductItemViewHolder(parent: ViewGroup) : RecyclerView.ViewHolder(
+    LayoutInflater.from(
+        parent.context
+    ).inflate(R.layout.product_list_item, parent, false)
+) {
+    private val imageSize = parent.context.resources.getDimensionPixelSize(R.dimen.image_minor_100)
+    private val bullet = "\u2022"
+    private val statusColor = ContextCompat.getColor(parent.context, R.color.product_status_fg_other)
+    private val statusPendingColor = ContextCompat.getColor(parent.context, R.color.product_status_fg_pending)
+
+    fun bind(product: Product) {
+        val context = itemView.context
+
+        itemView.productName.text = if (product.name.isEmpty()) {
+            context.getString(R.string.untitled)
+        } else {
+            HtmlUtils.fastStripHtml(product.name)
+        }
+
+        val stockAndStatus = getProductStockStatusText(context, product)
+        with(itemView.productStockAndStatus) {
+            if (stockAndStatus != null) {
+                visibility = View.VISIBLE
+                text = HtmlCompat.fromHtml(
+                    stockAndStatus,
+                    HtmlCompat.FROM_HTML_MODE_LEGACY
+                )
+            } else {
+                visibility = View.GONE
+            }
+        }
+
+        val firstImage = product.firstImageUrl
+        val size: Int
+        if (firstImage.isNullOrEmpty()) {
+            size = imageSize / 2
+            itemView.productImage.setImageResource(R.drawable.ic_product)
+        } else {
+            size = imageSize
+            val imageUrl = PhotonUtils.getPhotonImageUrl(firstImage, imageSize, imageSize)
+            GlideApp.with(context)
+                .load(imageUrl)
+                .placeholder(R.drawable.ic_product)
+                .into(itemView.productImage)
+        }
+        itemView.productImage.layoutParams.apply {
+            height = size
+            width = size
+        }
+    }
+
+    private fun getProductStockStatusText(
+        context: Context,
+        product: Product
+    ): String? {
+        val statusHtml = product.status?.let {
+            when {
+                it == ProductStatus.PENDING -> {
+                    "<font color=$statusPendingColor>${product.status.toLocalizedString(context)}</font>"
+                }
+                it != ProductStatus.PUBLISH -> {
+                    "<font color=$statusColor>${product.status.toLocalizedString(context)}</font>"
+                }
+                else -> {
+                    null
+                }
+            }
+        }
+
+        val stock = when (product.stockStatus) {
+            InStock -> {
+                if (product.type == VARIABLE) {
+                    if (product.numVariations > 0) {
+                        context.getString(
+                            R.string.product_stock_status_instock_with_variations,
+                            product.numVariations
+                        )
+                    } else {
+                        context.getString(R.string.product_stock_status_instock)
+                    }
+                } else {
+                    if (product.stockQuantity > 0) {
+                        context.getString(
+                            R.string.product_stock_count,
+                            FormatUtils.formatInt(product.stockQuantity)
+                        )
+                    } else {
+                        context.getString(R.string.product_stock_status_instock)
+                    }
+                }
+            }
+            OutOfStock -> {
+                context.getString(R.string.product_stock_status_out_of_stock)
+            }
+            OnBackorder -> {
+                context.getString(R.string.product_stock_status_on_backorder)
+            }
+            else -> {
+                product.stockStatus.value
+            }
+        }
+
+        return if (statusHtml != null) "$statusHtml $bullet $stock" else stock
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.core.text.HtmlCompat
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.R
 import com.woocommerce.android.di.GlideApp
@@ -67,6 +68,16 @@ class ProductItemViewHolder(parent: ViewGroup) : RecyclerView.ViewHolder(
         itemView.productImage.layoutParams.apply {
             height = size
             width = size
+        }
+    }
+
+    fun setOnDeleteClickListener(
+        product: Product,
+        onItemDeleted: (product: Product) -> Unit
+    ) {
+        with(itemView.product_btnDelete) {
+            isVisible = true
+            setOnClickListener { onItemDeleted(product) }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
@@ -77,7 +77,7 @@ class ProductItemViewHolder(parent: ViewGroup) : RecyclerView.ViewHolder(
     ) {
         with(itemView.product_btnDelete) {
             isVisible = true
-            setOnClickListener { onItemDeleted(product) }
+            setOnClickListener { onItemDeleted.invoke(product) }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListAdapter.kt
@@ -1,40 +1,18 @@
 package com.woocommerce.android.ui.products
 
-import android.content.Context
-import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
-import android.widget.TextView
-import androidx.core.content.ContextCompat
-import androidx.core.text.HtmlCompat
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
-import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_LIST_PRODUCT_TAPPED
-import com.woocommerce.android.di.GlideApp
 import com.woocommerce.android.model.Product
-import com.woocommerce.android.ui.products.ProductListAdapter.ProductViewHolder
-import com.woocommerce.android.ui.products.ProductStockStatus.InStock
-import com.woocommerce.android.ui.products.ProductStockStatus.OnBackorder
-import com.woocommerce.android.ui.products.ProductStockStatus.OutOfStock
-import com.woocommerce.android.ui.products.ProductType.VARIABLE
-import kotlinx.android.synthetic.main.product_list_item.view.*
-import org.wordpress.android.util.FormatUtils
-import org.wordpress.android.util.HtmlUtils
-import org.wordpress.android.util.PhotonUtils
+import com.woocommerce.android.model.isSameList
 
 class ProductListAdapter(
-    private val context: Context,
     private val clickListener: OnProductClickListener,
     private val loadMoreListener: OnLoadMoreListener
-) : RecyclerView.Adapter<ProductViewHolder>() {
-    private val imageSize = context.resources.getDimensionPixelSize(R.dimen.image_minor_100)
+) : RecyclerView.Adapter<ProductItemViewHolder>() {
     private val productList = ArrayList<Product>()
-    private val bullet = "\u2022"
-    private val statusColor = ContextCompat.getColor(context, R.color.product_status_fg_other)
-    private val statusPendingColor = ContextCompat.getColor(context, R.color.product_status_fg_pending)
 
     interface OnProductClickListener {
         fun onProductClick(remoteProductId: Long)
@@ -48,101 +26,12 @@ class ProductListAdapter(
 
     override fun getItemCount() = productList.size
 
-    private fun getProductStockStatusText(product: Product): String? {
-        val statusHtml = product.status?.let {
-            when {
-                it == ProductStatus.PENDING -> {
-                    "<font color=$statusPendingColor>${product.status.toLocalizedString(context)}</font>"
-                }
-                it != ProductStatus.PUBLISH -> {
-                    "<font color=$statusColor>${product.status.toLocalizedString(context)}</font>"
-                }
-                else -> {
-                    null
-                }
-            }
-        }
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = ProductItemViewHolder(parent)
 
-        val stock = when (product.stockStatus) {
-            InStock -> {
-                if (product.type == VARIABLE) {
-                    if (product.numVariations > 0) {
-                        context.getString(
-                                R.string.product_stock_status_instock_with_variations,
-                                product.numVariations
-                        )
-                    } else {
-                        context.getString(R.string.product_stock_status_instock)
-                    }
-                } else {
-                    if (product.stockQuantity > 0) {
-                        context.getString(
-                                R.string.product_stock_count,
-                                FormatUtils.formatInt(product.stockQuantity)
-                        )
-                    } else {
-                        context.getString(R.string.product_stock_status_instock)
-                    }
-                }
-            }
-            OutOfStock -> {
-                context.getString(R.string.product_stock_status_out_of_stock)
-            }
-            OnBackorder -> {
-                context.getString(R.string.product_stock_status_on_backorder)
-            }
-            else -> {
-                product.stockStatus.value
-            }
-        }
-        val stockHtml = "$stock"
-
-        return if (statusHtml != null) "$statusHtml $bullet $stockHtml" else stockHtml
-    }
-
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProductViewHolder {
-        val holder = ProductViewHolder(LayoutInflater.from(context).inflate(R.layout.product_list_item, parent, false))
-        holder.imgProduct.clipToOutline = true
-        return holder
-    }
-
-    override fun onBindViewHolder(holder: ProductViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: ProductItemViewHolder, position: Int) {
         val product = productList[position]
 
-        holder.txtProductName.text = if (product.name.isEmpty()) {
-            context.getString(R.string.untitled)
-        } else {
-            HtmlUtils.fastStripHtml(product.name)
-        }
-
-        val stockAndStatus = getProductStockStatusText(product)
-        if (stockAndStatus != null) {
-            holder.txtProductStockAndStatus.visibility = View.VISIBLE
-            holder.txtProductStockAndStatus.text = HtmlCompat.fromHtml(
-                    stockAndStatus,
-                    HtmlCompat.FROM_HTML_MODE_LEGACY
-            )
-        } else {
-            holder.txtProductStockAndStatus.visibility = View.GONE
-        }
-
-        val firstImage = product.firstImageUrl
-        val size: Int
-        if (firstImage.isNullOrEmpty()) {
-            size = imageSize / 2
-            holder.imgProduct.setImageResource(R.drawable.ic_product)
-        } else {
-            size = imageSize
-            val imageUrl = PhotonUtils.getPhotonImageUrl(firstImage, imageSize, imageSize)
-            GlideApp.with(context)
-                    .load(imageUrl)
-                    .placeholder(R.drawable.ic_product)
-                    .into(holder.imgProduct)
-        }
-        holder.imgProduct.layoutParams.apply {
-            height = size
-            width = size
-        }
+        holder.bind(product)
 
         holder.itemView.setOnClickListener {
             AnalyticsTracker.track(PRODUCT_LIST_PRODUCT_TAPPED)
@@ -155,46 +44,11 @@ class ProductListAdapter(
     }
 
     fun setProductList(products: List<Product>) {
-        fun isSameList(): Boolean {
-            if (products.size != productList.size) {
-                return false
-            }
-            for (index in products.indices) {
-                val oldItem = productList[index]
-                val newItem = products[index]
-                if (!oldItem.isSameProduct(newItem)) {
-                    return false
-                }
-            }
-            return true
-        }
-
-        if (!isSameList()) {
+        if (!productList.isSameList(products)) {
             val diffResult = DiffUtil.calculateDiff(ProductItemDiffUtil(productList, products))
             productList.clear()
             productList.addAll(products)
             diffResult.dispatchUpdatesTo(this)
-        }
-    }
-
-    class ProductViewHolder(view: View) : RecyclerView.ViewHolder(view) {
-        val imgProduct: ImageView = view.productImage
-        val txtProductName: TextView = view.productName
-        val txtProductStockAndStatus: TextView = view.productStockAndStatus
-    }
-
-    private class ProductItemDiffUtil(val items: List<Product>, val result: List<Product>) : DiffUtil.Callback() {
-        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int) =
-                items[oldItemPosition].remoteId == result[newItemPosition].remoteId
-
-        override fun getOldListSize(): Int = items.size
-
-        override fun getNewListSize(): Int = result.size
-
-        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-            val oldItem = items[oldItemPosition]
-            val newItem = result[newItemPosition]
-            return oldItem.isSameProduct(newItem)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -79,7 +79,7 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener, ProductS
 
         listState = savedInstanceState?.getParcelable(KEY_LIST_STATE)
 
-        productAdapter = ProductListAdapter(activity, this, this)
+        productAdapter = ProductListAdapter(this, this)
         productsRecycler.layoutManager = LinearLayoutManager(activity)
         productsRecycler.adapter = productAdapter
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListRepository.kt
@@ -148,7 +148,7 @@ class ProductListRepository @Inject constructor(
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onProductChanged(event: OnProductChanged) {
-        if (event.causeOfChange == FETCH_PRODUCTS) {
+        if (event.causeOfChange == FETCH_PRODUCTS && loadContinuation != null) {
             if (event.isError) {
                 loadContinuation?.resume(false)
                 AnalyticsTracker.track(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
@@ -49,4 +49,5 @@ sealed class ProductNavigationTarget : Event() {
     data class ViewProductDetailBottomSheet(val remoteId: Long) : ProductNavigationTarget()
     data class ViewProductTypes(val remoteId: Long) : ProductNavigationTarget()
     data class ViewProductReviews(val remoteId: Long) : ProductNavigationTarget()
+    data class ViewGroupedProducts(val remoteId: Long) : ProductNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
@@ -49,5 +49,5 @@ sealed class ProductNavigationTarget : Event() {
     data class ViewProductDetailBottomSheet(val remoteId: Long) : ProductNavigationTarget()
     data class ViewProductTypes(val remoteId: Long) : ProductNavigationTarget()
     data class ViewProductReviews(val remoteId: Long) : ProductNavigationTarget()
-    data class ViewGroupedProducts(val remoteId: Long) : ProductNavigationTarget()
+    data class ViewGroupedProducts(val groupedProductIds: String) : ProductNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.products.ProductNavigationTarget.AddProductCategory
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ExitProduct
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ShareProduct
+import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewGroupedProducts
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductCatalogVisibility
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductCategories
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductDescriptionEditor
@@ -171,37 +172,43 @@ class ProductNavigator @Inject constructor() {
             is ViewProductCategories -> {
                 val action = ProductDetailFragmentDirections
                     .actionGlobalProductCategoriesFragment(target.remoteId)
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is AddProductCategory -> {
                 val action = ProductCategoriesFragmentDirections
                     .actionProductCategoriesFragmentToAddProductCategoryFragment()
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ViewProductTags -> {
                 val action = ProductDetailFragmentDirections
                     .actionGlobalProductTagsFragment(target.remoteId)
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ViewProductDetailBottomSheet -> {
                 val action = ProductDetailFragmentDirections
                     .actionGlobalProductDetailBottomSheetFragment(target.remoteId)
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ViewProductTypes -> {
                 val action = ProductDetailFragmentDirections
                     .actionProductDetailFragmentToProductTypesBottomSheetFragment(target.remoteId)
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ViewProductReviews -> {
                 val action = ProductDetailFragmentDirections
                     .actionProductDetailFragmentToProductReviewsFragment(target.remoteId)
-                fragment.findNavController().navigate(action)
+                fragment.findNavController().navigateSafely(action)
+            }
+
+            is ViewGroupedProducts -> {
+                val action = ProductDetailFragmentDirections
+                    .actionGlobalGroupedProductListFragment(target.remoteId)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ExitProduct -> fragment.findNavController().navigateUp()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -207,7 +207,7 @@ class ProductNavigator @Inject constructor() {
 
             is ViewGroupedProducts -> {
                 val action = ProductDetailFragmentDirections
-                    .actionGlobalGroupedProductListFragment(target.remoteId)
+                    .actionGlobalGroupedProductListFragment(target.groupedProductIds)
                 fragment.findNavController().navigateSafely(action)
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
@@ -12,9 +12,9 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.dialog.CustomDiscardDialog
-import com.woocommerce.android.ui.products.ProductTypesBottomSheetViewModel.ExitWithResult
 import com.woocommerce.android.ui.products.ProductTypesBottomSheetViewModel.ProductTypesBottomSheetUiItem
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import dagger.android.AndroidInjector
@@ -87,8 +87,8 @@ class ProductTypesBottomSheetFragment : BottomSheetDialogFragment(), HasAndroidI
                     event.positiveButtonId,
                     event.negativeButtonId
                 )
-                is ExitWithResult -> {
-                    navigateBackWithResult(KEY_PRODUCT_TYPE_RESULT, event.productTypeUiItem)
+                is ExitWithResult<*> -> {
+                    navigateBackWithResult(KEY_PRODUCT_TYPE_RESULT, event.item as? ProductTypesBottomSheetUiItem)
                 }
                 else -> event.isHandled = false
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
@@ -15,7 +15,7 @@ import com.woocommerce.android.ui.products.ProductType.EXTERNAL
 import com.woocommerce.android.ui.products.ProductType.GROUPED
 import com.woocommerce.android.ui.products.ProductType.SIMPLE
 import com.woocommerce.android.util.CoroutineDispatchers
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -74,8 +74,6 @@ class ProductTypesBottomSheetViewModel @AssistedInject constructor(
             )
         )
     }
-
-    data class ExitWithResult(val productTypeUiItem: ProductTypesBottomSheetUiItem) : Event()
 
     @Parcelize
     data class ProductTypesBottomSheetUiItem(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductsModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductsModule.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.products
 
 import com.woocommerce.android.di.FragmentScope
 import com.woocommerce.android.ui.products.ProductsModule.AddProductCategoryFragmentModule
+import com.woocommerce.android.ui.products.ProductsModule.GroupedProductListFragmentModule
 import com.woocommerce.android.ui.products.ProductsModule.ParentCategoryListFragmentModule
 import com.woocommerce.android.ui.products.ProductsModule.ProductCatalogVisibilityFragmentModule
 import com.woocommerce.android.ui.products.ProductsModule.ProductCategoriesFragmentModule
@@ -88,7 +89,8 @@ import dagger.android.ContributesAndroidInjector
     ProductTagsFragmentModule::class,
     ProductDetailBottomSheetFragmentModule::class,
     ProductTypesBottomSheetFragmentModule::class,
-    ProductReviewsFragmentModule::class
+    ProductReviewsFragmentModule::class,
+    GroupedProductListFragmentModule::class
 ])
 object ProductsModule {
     @Module
@@ -285,5 +287,12 @@ object ProductsModule {
         @FragmentScope
         @ContributesAndroidInjector(modules = [ProductReviewsModule::class])
         abstract fun productReviewsFragment(): ProductReviewsFragment
+    }
+
+    @Module
+    internal abstract class GroupedProductListFragmentModule {
+        @FragmentScope
+        @ContributesAndroidInjector(modules = [GroupedProductListModule::class])
+        abstract fun groupedProductListFragment(): GroupedProductListFragment
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
@@ -17,12 +17,13 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
+import com.woocommerce.android.model.ProductCategory
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.dialog.CustomDiscardDialog
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
-import com.woocommerce.android.ui.products.categories.AddProductCategoryViewModel.AddProductCategoryEvent.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ViewModelFactory
@@ -133,9 +134,9 @@ class AddProductCategoryFragment : BaseFragment(), BackPressListener {
                     event.negativeBtnAction,
                     event.messageId
                 )
-                is ExitWithResult -> {
+                is ExitWithResult<*> -> {
                     val bundle = Bundle()
-                    bundle.putParcelable(ARG_ADDED_CATEGORY, event.addedCategory)
+                    bundle.putParcelable(ARG_ADDED_CATEGORY, event.item as? ProductCategory)
                     requireActivity().navigateBackWithResult(
                         RequestCodes.PRODUCT_ADD_CATEGORY,
                         bundle,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
@@ -8,16 +8,14 @@ import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import com.woocommerce.android.R.string
 import com.woocommerce.android.di.ViewModelAssistedFactory
-import com.woocommerce.android.model.ProductCategory
 import com.woocommerce.android.model.RequestResult
 import com.woocommerce.android.model.sortCategories
 import com.woocommerce.android.tools.NetworkStatus
-import com.woocommerce.android.ui.products.categories.AddProductCategoryViewModel.AddProductCategoryEvent.ExitWithResult
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.LiveDataDelegate
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -216,10 +214,6 @@ class AddProductCategoryViewModel @AssistedInject constructor(
             isLoadingMore = false,
             isRefreshing = false
         )
-    }
-
-    sealed class AddProductCategoryEvent(val addedCategory: ProductCategory?) : Event() {
-        class ExitWithResult(addedCategory: ProductCategory?) : AddProductCategoryEvent(addedCategory)
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
@@ -78,6 +78,7 @@ open class MultiLiveEvent<T : Event> : MutableLiveData<T>() {
         }
 
         object Exit : Event()
+        data class ExitWithResult<T>(val item: T) : Event()
 
         data class ShowDiscardDialog(
             val positiveBtnAction: OnClickListener? = null,

--- a/WooCommerce/src/main/res/drawable/ic_gridicons_cross_grey_24dp.xml
+++ b/WooCommerce/src/main/res/drawable/ic_gridicons_cross_grey_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/color_icon"
+        android:pathData="M18.36,19.78L12,13.41l-6.36,6.37 -1.42,-1.42L10.59,12 4.22,5.64l1.42,-1.42L12,10.59l6.36,-6.36 1.41,1.41L13.41,12l6.36,6.36z" />
+</vector>

--- a/WooCommerce/src/main/res/layout/fragment_grouped_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_grouped_product_list.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/productsRefreshLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.woocommerce.android.ui.products.GroupedProductListFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/productsRecycler"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:background="?attr/colorSurface"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:itemCount="5"
+            tools:listitem="@layout/product_list_item"
+            tools:visibility="visible" />
+
+        <ProgressBar
+            android:id="@+id/loadMoreProgress"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:layout_centerHorizontal="true"
+            android:layout_marginBottom="@dimen/major_75"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            tools:visibility="gone" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>

--- a/WooCommerce/src/main/res/layout/fragment_grouped_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_grouped_product_list.xml
@@ -1,42 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/productsRefreshLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="com.woocommerce.android.ui.products.GroupedProductListFragment">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/productsRecycler"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="0dp"
+        android:background="?attr/colorSurface"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:itemCount="5"
+        tools:listitem="@layout/product_list_item"
+        tools:visibility="visible" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/productsRecycler"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:background="?attr/colorSurface"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:itemCount="5"
-            tools:listitem="@layout/product_list_item"
-            tools:visibility="visible" />
-
-        <ProgressBar
-            android:id="@+id/loadMoreProgress"
-            style="?android:attr/progressBarStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
-            android:layout_centerHorizontal="true"
-            android:layout_marginBottom="@dimen/major_75"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            tools:visibility="gone" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
+    <ProgressBar
+        android:id="@+id/loadMoreProgress"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:layout_marginBottom="@dimen/major_75"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:visibility="gone" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/product_list_item.xml
+++ b/WooCommerce/src/main/res/layout/product_list_item.xml
@@ -44,7 +44,7 @@
         android:orientation="vertical"
         app:layout_constrainedWidth="true"
         app:layout_constraintBottom_toTopOf="@+id/divider"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/product_btnDelete"
         app:layout_constraintStart_toEndOf="@+id/productImageFrame"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.50">
@@ -69,6 +69,18 @@
             tools:text="Out of stock this is a really long version to see what happens when we move o"
             tools:visibility="visible" />
     </LinearLayout>
+
+    <ImageButton
+        android:id="@+id/product_btnDelete"
+        style="@style/Woo.ImageButton.Close"
+        android:contentDescription="@string/grouped_product_btn_delete"
+        android:scaleType="centerInside"
+        android:layout_margin="@dimen/minor_100"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:visibility="gone"
+        tools:visibility="visible"/>
 
     <View
         android:id="@+id/divider"

--- a/WooCommerce/src/main/res/navigation/nav_graph_products.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_products.xml
@@ -212,6 +212,15 @@
             android:defaultValue="0L"
             app:argType="long" />
     </fragment>
+    <fragment
+        android:id="@+id/groupedProductListFragment"
+        android:name="com.woocommerce.android.ui.products.GroupedProductListFragment"
+        tools:layout="@layout/fragment_product_list">
+        <argument
+            android:name="remoteProductId"
+            android:defaultValue="0L"
+            app:argType="long" />
+    </fragment>
 
     <include app:graph="@navigation/nav_graph_add_product_category" />
     <include app:graph="@navigation/nav_graph_product_settings" />
@@ -264,6 +273,11 @@
     <action
         android:id="@+id/action_global_productTagsFragment"
         app:destination="@id/productTagsFragment"
+        app:enterAnim="@anim/activity_scale_in"
+        app:popExitAnim="@anim/activity_scale_out" />
+    <action
+        android:id="@+id/action_global_groupedProductListFragment"
+        app:destination="@id/groupedProductListFragment"
         app:enterAnim="@anim/activity_scale_in"
         app:popExitAnim="@anim/activity_scale_out" />
     <fragment

--- a/WooCommerce/src/main/res/navigation/nav_graph_products.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_products.xml
@@ -217,9 +217,9 @@
         android:name="com.woocommerce.android.ui.products.GroupedProductListFragment"
         tools:layout="@layout/fragment_product_list">
         <argument
-            android:name="remoteProductId"
-            android:defaultValue="0L"
-            app:argType="long" />
+            android:name="groupedProductIds"
+            android:defaultValue='""'
+            app:argType="string" />
     </fragment>
 
     <include app:graph="@navigation/nav_graph_add_product_category" />

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -606,6 +606,8 @@
     <string name="product_add_tag_dialog_title">Adding tag</string>
     <string name="product_add_tag_error">Error occurred when adding tags</string>
     <string name="product_type_edit">Change product type</string>
+    <string name="grouped_products">Grouped products</string>
+    <string name="grouped_products_count">%d products</string>
     <!--
         Product Add more details Bottom sheet
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -608,6 +608,7 @@
     <string name="product_type_edit">Change product type</string>
     <string name="grouped_products">Grouped products</string>
     <string name="grouped_products_count">%d products</string>
+    <string name="grouped_products_single">%d product</string>
     <string name="grouped_product_btn_delete">Delete the grouped product</string>
     <!--
         Product Add more details Bottom sheet

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -608,6 +608,7 @@
     <string name="product_type_edit">Change product type</string>
     <string name="grouped_products">Grouped products</string>
     <string name="grouped_products_count">%d products</string>
+    <string name="grouped_product_btn_delete">Delete the grouped product</string>
     <!--
         Product Add more details Bottom sheet
     -->

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -424,6 +424,11 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:src">@drawable/ic_menu_more_vert_compat</item>
     </style>
 
+    <style name="Woo.ImageButton.Close">
+        <item name="android:src">@drawable/ic_gridicons_cross_grey_24dp</item>
+        <item name="android:padding">@dimen/major_85</item>
+    </style>
+
     <!-- Set at the theme level so no need to set directly on the component -->
     <style name="Widget.Woo.WCToggleOutlinedButton" parent="Widget.MaterialComponents.Button.OutlinedButton">
         <item name="android:paddingStart">@dimen/major_100</item>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -50,7 +50,6 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     companion object {
         private const val PRODUCT_REMOTE_ID = 1L
         private const val OFFLINE_PRODUCT_REMOTE_ID = 2L
-        private const val TEST_STRING = "test"
     }
 
     private val wooCommerceStore: WooCommerceStore = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -30,6 +30,7 @@ object ProductTestUtils {
             variations = "[]"
             attributes = "[]"
             categories = ""
+            groupedProductIds = "[10,11]"
             shortDescription = "short desc"
         }.toAppModel()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '77cdfadfb143902d4eb082c19d1b484b81b20e61'
+    fluxCVersion = '046bc88f114d2e650d188417ea4068f2f949d3e6'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '47a21773fd50db0cad7b783b4fdef09092cdff22'
+    fluxCVersion = '975aca60a8acfd594e8f81941c68f20dc9d60e1d'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '046bc88f114d2e650d188417ea4068f2f949d3e6'
+    fluxCVersion = '47a21773fd50db0cad7b783b4fdef09092cdff22'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Part 1/3 of #2630. This PR adds logic to display products associated with grouped products.

#### Changes
- Added logic to display the product count for a grouped product, if the count > 0.
- Created a new fragment, module and View Model to handle the changes needed to show only the products for a specific grouped product.
- Split the `ProductListViewHolder` and `ProductListDiffUtil` to separate classes so that they can be reused by `GroupedProductListAdapter` as well as `ProductListAdapter`

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/90363796-e9225b00-e080-11ea-907c-52b25781f17c.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/90363801-eaec1e80-e080-11ea-8ffa-dcb06e289c86.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/90363810-ecb5e200-e080-11ea-9af2-63de5c973b40.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/90363813-ee7fa580-e080-11ea-8b7e-af5ac392e90c.png" width="300"/>


#### Testing
- Click on a grouped product with atleast 2 associated products.
- Notice the grouped products section in the Product Detail screen.
- Click on the grouped products section and notice the list of products associated with this product, displayed correctly.
- Click on the `delete` icon for one of the items and verify:
  - that the "Done" menu button is displayed correctly.
  - that clicking on the back button displays the discard dialog.
- Click on the "Done" menu button and notice that 
  - the "Update" button is displayed correctly in the Product detail screen.
  - the grouped products section displays the correct count.
- Click on the "Update" menu button and verify that the product is updated correctly.

#### Notes
- ~This PR is in draft till this [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1668) can be reviewed and merged.~
- The option to add a grouped product will take place in a subsequent PR.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
