### PR TITLE
Issue/2737 Fix the behavior of the "discard changes" dialog in product details

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BaseFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BaseFragment.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.base
 
+import android.content.Context
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
@@ -18,6 +19,11 @@ abstract class BaseFragment : Fragment(), BaseFragmentView, HasAndroidInjector {
 
     companion object {
         private const val KEY_TITLE = "title"
+    }
+
+    override fun onAttach(context: Context) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BaseFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BaseFragment.kt
@@ -27,8 +27,6 @@ abstract class BaseFragment : Fragment(), BaseFragmentView, HasAndroidInjector {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        AndroidSupportInjection.inject(this)
-
         super.onViewCreated(view, savedInstanceState)
         savedInstanceState?.let {
             activity?.title = it.getString(KEY_TITLE)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
@@ -32,16 +32,19 @@ abstract class BaseProductFragment : BaseFragment(), BackPressListener {
 
     private var doneOrUpdateMenuItem: MenuItem? = null
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        setupObservers(viewModel)
-
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
         // if this is the initial creation of this fragment, tell the viewModel to make a copy of the product
         // as it exists now so we can easily discard changes are determine if any changes were made inside
         // this fragment
         if (savedInstanceState == null) {
             viewModel.updateProductBeforeEnteringFragment()
         }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupObservers(viewModel)
     }
 
     private fun setupObservers(viewModel: ProductDetailViewModel) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
@@ -29,7 +29,9 @@ abstract class BaseProductFragment : BaseFragment(), BackPressListener {
     @Inject lateinit var uiMessageResolver: UIMessageResolver
     @Inject lateinit var viewModelFactory: Lazy<ViewModelFactory>
 
-    protected val viewModel: ProductDetailViewModel by navGraphViewModels(R.id.nav_graph_products) { viewModelFactory.get() }
+    protected val viewModel: ProductDetailViewModel by navGraphViewModels(R.id.nav_graph_products) {
+        viewModelFactory.get()
+    }
 
     private var doneOrUpdateMenuItem: MenuItem? = null
 
@@ -54,10 +56,10 @@ abstract class BaseProductFragment : BaseFragment(), BackPressListener {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is Exit -> requireActivity().onBackPressed()
                 is ShowDiscardDialog -> CustomDiscardDialog.showDiscardDialog(
-                        requireActivity(),
-                        event.positiveBtnAction,
-                        event.negativeBtnAction,
-                        event.messageId
+                    requireActivity(),
+                    event.positiveBtnAction,
+                    event.negativeBtnAction,
+                    event.messageId
                 )
                 is ProductNavigationTarget -> navigator.navigate(this, event)
                 else -> event.isHandled = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ViewModelFactory
+import dagger.Lazy
 import org.wordpress.android.util.ActivityUtils
 import javax.inject.Inject
 
@@ -26,9 +27,9 @@ import javax.inject.Inject
 abstract class BaseProductFragment : BaseFragment(), BackPressListener {
     @Inject lateinit var navigator: ProductNavigator
     @Inject lateinit var uiMessageResolver: UIMessageResolver
-    @Inject lateinit var viewModelFactory: ViewModelFactory
+    @Inject lateinit var viewModelFactory: Lazy<ViewModelFactory>
 
-    protected val viewModel: ProductDetailViewModel by navGraphViewModels(R.id.nav_graph_products) { viewModelFactory }
+    protected val viewModel: ProductDetailViewModel by navGraphViewModels(R.id.nav_graph_products) { viewModelFactory.get() }
 
     private var doneOrUpdateMenuItem: MenuItem? = null
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundFragment.kt
@@ -23,14 +23,17 @@ import com.woocommerce.android.ui.refunds.IssueRefundViewModel.RefundType
 import com.woocommerce.android.ui.refunds.IssueRefundViewModel.RefundType.AMOUNT
 import com.woocommerce.android.ui.refunds.IssueRefundViewModel.RefundType.ITEMS
 import com.woocommerce.android.viewmodel.ViewModelFactory
+import dagger.Lazy
 import kotlinx.android.synthetic.main.fragment_refund_by_amount.*
 import org.wordpress.android.util.ActivityUtils
 
 class IssueRefundFragment : BaseFragment() {
-    @Inject lateinit var viewModelFactory: ViewModelFactory
+    @Inject lateinit var viewModelFactory: Lazy<ViewModelFactory>
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
-    private val viewModel: IssueRefundViewModel by navGraphViewModels(R.id.nav_graph_refunds) { viewModelFactory }
+    private val viewModel: IssueRefundViewModel by navGraphViewModels(R.id.nav_graph_refunds) {
+        viewModelFactory.get()
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         super.onCreate(savedInstanceState)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundAmountDialog.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.CurrencyAmountDialog
+import dagger.Lazy
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
@@ -18,9 +19,11 @@ import javax.inject.Inject
 class RefundAmountDialog : CurrencyAmountDialog(), HasAndroidInjector {
     @Inject lateinit var currencyFormatter: CurrencyFormatter
     @Inject internal lateinit var childInjector: DispatchingAndroidInjector<Any>
-    @Inject lateinit var viewModelFactory: ViewModelFactory
+    @Inject lateinit var viewModelFactory: Lazy<ViewModelFactory>
 
-    private val viewModel: IssueRefundViewModel by navGraphViewModels(R.id.nav_graph_refunds) { viewModelFactory }
+    private val viewModel: IssueRefundViewModel by navGraphViewModels(R.id.nav_graph_refunds) {
+        viewModelFactory.get()
+    }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         AndroidSupportInjection.inject(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByAmountFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByAmountFragment.kt
@@ -14,14 +14,17 @@ import com.woocommerce.android.ui.refunds.IssueRefundViewModel.IssueRefundEvent.
 import com.woocommerce.android.ui.refunds.IssueRefundViewModel.IssueRefundEvent.ShowValidationError
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.ViewModelFactory
+import dagger.Lazy
 import kotlinx.android.synthetic.main.fragment_refund_by_amount.*
 import javax.inject.Inject
 
 class RefundByAmountFragment : BaseFragment() {
-    @Inject lateinit var viewModelFactory: ViewModelFactory
+    @Inject lateinit var viewModelFactory: Lazy<ViewModelFactory>
     @Inject lateinit var currencyFormatter: CurrencyFormatter
 
-    private val viewModel: IssueRefundViewModel by navGraphViewModels(R.id.nav_graph_refunds) { viewModelFactory }
+    private val viewModel: IssueRefundViewModel by navGraphViewModels(R.id.nav_graph_refunds) {
+        viewModelFactory.get()
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         super.onCreate(savedInstanceState)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByItemsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByItemsFragment.kt
@@ -27,17 +27,20 @@ import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.WooClickableSpan
+import dagger.Lazy
 import kotlinx.android.synthetic.main.fragment_refund_by_items.*
 import kotlinx.android.synthetic.main.refund_by_items_products.*
 import java.math.BigDecimal
 import javax.inject.Inject
 
 class RefundByItemsFragment : BaseFragment() {
-    @Inject lateinit var viewModelFactory: ViewModelFactory
+    @Inject lateinit var viewModelFactory: Lazy<ViewModelFactory>
     @Inject lateinit var currencyFormatter: CurrencyFormatter
     @Inject lateinit var imageMap: ProductImageMap
 
-    private val viewModel: IssueRefundViewModel by navGraphViewModels(R.id.nav_graph_refunds) { viewModelFactory }
+    private val viewModel: IssueRefundViewModel by navGraphViewModels(R.id.nav_graph_refunds) {
+        viewModelFactory.get()
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         super.onCreate(savedInstanceState)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundConfirmationDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundConfirmationDialog.kt
@@ -6,6 +6,7 @@ import androidx.navigation.navGraphViewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.ConfirmationDialog
+import dagger.Lazy
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
@@ -14,9 +15,11 @@ import javax.inject.Inject
 
 class RefundConfirmationDialog : ConfirmationDialog(), HasAndroidInjector {
     @Inject internal lateinit var childInjector: DispatchingAndroidInjector<Any>
-    @Inject lateinit var viewModelFactory: ViewModelFactory
+    @Inject lateinit var viewModelFactory: Lazy<ViewModelFactory>
 
-    private val viewModel: IssueRefundViewModel by navGraphViewModels(R.id.nav_graph_refunds) { viewModelFactory }
+    private val viewModel: IssueRefundViewModel by navGraphViewModels(R.id.nav_graph_refunds) {
+        viewModelFactory.get()
+    }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         AndroidSupportInjection.inject(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundItemsPickerDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundItemsPickerDialog.kt
@@ -7,6 +7,7 @@ import androidx.navigation.navGraphViewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.NumberPickerDialog
+import dagger.Lazy
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
@@ -15,9 +16,11 @@ import javax.inject.Inject
 
 class RefundItemsPickerDialog : NumberPickerDialog(), HasAndroidInjector {
     @Inject internal lateinit var childInjector: DispatchingAndroidInjector<Any>
-    @Inject lateinit var viewModelFactory: ViewModelFactory
+    @Inject lateinit var viewModelFactory: Lazy<ViewModelFactory>
 
-    private val viewModel: IssueRefundViewModel by navGraphViewModels(R.id.nav_graph_refunds) { viewModelFactory }
+    private val viewModel: IssueRefundViewModel by navGraphViewModels(R.id.nav_graph_refunds) {
+        viewModelFactory.get()
+    }
     private val navArgs: RefundItemsPickerDialogArgs by navArgs()
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundSummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundSummaryFragment.kt
@@ -24,14 +24,17 @@ import com.woocommerce.android.ui.refunds.IssueRefundViewModel.IssueRefundEvent.
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ViewModelFactory
+import dagger.Lazy
 import kotlinx.android.synthetic.main.fragment_refund_summary.*
 import javax.inject.Inject
 
 class RefundSummaryFragment : BaseFragment(), BackPressListener {
-    @Inject lateinit var viewModelFactory: ViewModelFactory
+    @Inject lateinit var viewModelFactory: Lazy<ViewModelFactory>
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
-    private val viewModel: IssueRefundViewModel by navGraphViewModels(R.id.nav_graph_refunds) { viewModelFactory }
+    private val viewModel: IssueRefundViewModel by navGraphViewModels(R.id.nav_graph_refunds) {
+        viewModelFactory.get()
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         super.onCreate(savedInstanceState)


### PR DESCRIPTION
fixes #2737 

**Changes**
As explained on #2737, the fact that `productBeforeEnteringFragment` is updated in `onViewCreated` causes an issue when there is a multi-level navigation, as its value is being reset when navigating back, and this prevents the "discard changes" dialog from being shown.
To fix this I moved the update logic to `onCreate`:
https://github.com/woocommerce/woocommerce-android/blob/e8cfdf17b80ffd389fa6868ee0841f65ac2f58d2/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt#L36-L44

Then I noticed that the injection is done in `onViewCreated`, so `viewModelFactory` wasn't initialized there. To fix this, and to align with official recommendation (https://dagger.dev/dev-guide/android.html#when-to-inject), I moved the injection to `onAttach`: 
https://github.com/woocommerce/woocommerce-android/blob/e8cfdf17b80ffd389fa6868ee0841f65ac2f58d2/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BaseFragment.kt#L24-L27

With these changes, @anitaa1990 noticed that the app crashes if we enable "Do not keep activities" option, and the issue was in the fragments that use a navgraph scoped viewmodel (ProductDetails, and Refunds), as their viewModels depends on `findNavController` which is not available before onCreate.
To fix this, we should inject `viewModelFactory` in those fragments lazily using the `Lazy` object.

**Testing**

1. Open product details screen.
2. Open categories list.
3. Make some changes.
4. Click on "Add Category", and then go back.
5. Make sure that the "Done" button is visible.
6. Click on the back arrow to quit, make sure that the dialog is shown.

And do some smoking testing for the refunds screens to confirm non-regression.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
