### PR TITLE
Issue/2710 Delete downloadable files

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/AztecEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/AztecEditorFragment.kt
@@ -16,7 +16,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.AZTEC_EDITOR_DONE_BUTTON_TAPPED
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
-import com.woocommerce.android.ui.dialog.CustomDiscardDialog
+import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import kotlinx.android.synthetic.main.fragment_aztec_editor.*
@@ -125,7 +125,7 @@ class AztecEditorFragment : BaseFragment(), IAztecToolbarClickListener, BackPres
 
     override fun onStop() {
         super.onStop()
-        CustomDiscardDialog.onCleared()
+        WooDialog.onCleared()
         activity?.let {
             ActivityUtils.hideKeyboard(it)
         }
@@ -145,12 +145,15 @@ class AztecEditorFragment : BaseFragment(), IAztecToolbarClickListener, BackPres
 
     private fun confirmDiscard() {
         isConfirmingDiscard = true
-        CustomDiscardDialog.showDiscardDialog(
+        WooDialog.showDialog(
                 requireActivity(),
+                messageId = R.string.discard_message,
+                positiveButtonId = R.string.discard,
                 posBtnAction = DialogInterface.OnClickListener { _, _ ->
                     isConfirmingDiscard = false
                     navigateBackWithResult(false)
                 },
+                negativeButtonId = R.string.keep_editing,
                 negBtnAction = DialogInterface.OnClickListener { _, _ ->
                     isConfirmingDiscard = false
                 })

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BaseFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BaseFragment.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
+import com.woocommerce.android.ui.dialog.WooDialog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
@@ -68,5 +70,17 @@ abstract class BaseFragment : Fragment(), BaseFragmentView, HasAndroidInjector {
 
     override fun androidInjector(): AndroidInjector<Any> {
         return androidInjector
+    }
+
+    protected fun ShowDialog.showDialog() {
+        WooDialog.showDialog(
+            activity = requireActivity(),
+            titleId = this.titleId,
+            messageId = this.messageId,
+            positiveButtonId = this.positiveButtonId,
+            posBtnAction = this.positiveBtnAction,
+            negativeButtonId = this.negativeButtonId,
+            negBtnAction = this.negativeBtnAction
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dialog/WooDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dialog/WooDialog.kt
@@ -12,18 +12,18 @@ import java.lang.ref.WeakReference
  * Used to display discard dialog across the app.
  * Currently used in Products and Orders
  */
-object CustomDiscardDialog {
+object WooDialog {
     // Weak ref to avoid leaking the context
     private var dialogRef: WeakReference<AlertDialog>? = null
 
-    fun showDiscardDialog(
+    fun showDialog(
         activity: Activity,
-        posBtnAction: (OnClickListener)? = null,
-        negBtnAction: (OnClickListener)? = null,
         @StringRes titleId: Int? = null,
-        @StringRes messageId: Int? = null,
-        @StringRes positiveButtonId: Int? = null,
-        @StringRes negativeButtonId: Int? = null
+        @StringRes messageId: Int,
+        @StringRes positiveButtonId: Int,
+        posBtnAction: OnClickListener,
+        @StringRes negativeButtonId: Int? = null,
+        negBtnAction: OnClickListener? = null
     ) {
         dialogRef?.get()?.let {
             // Dialog is already present
@@ -41,8 +41,9 @@ object CustomDiscardDialog {
                 .setMessage(message)
                 .setCancelable(true)
                 .setPositiveButton(positiveButtonTextId, posBtnAction)
-                .setNegativeButton(negativeButtonTextId, negBtnAction)
                 .setOnDismissListener { onCleared() }
+
+        negativeButtonId?.let { builder.setNegativeButton(it, negBtnAction) }
 
         titleId?.let { builder.setTitle(activity.applicationContext.getString(it)) }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderShipmentTrackingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderShipmentTrackingFragment.kt
@@ -17,7 +17,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_SHIPMENT_TR
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.dialog.CustomDiscardDialog
+import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.widgets.AppRatingDialog
@@ -146,7 +146,7 @@ class AddOrderShipmentTrackingFragment : BaseFragment(), AddOrderShipmentTrackin
 
     override fun onStop() {
         super.onStop()
-        CustomDiscardDialog.onCleared()
+        WooDialog.onCleared()
         activity?.let {
             ActivityUtils.hideKeyboard(it)
         }
@@ -265,12 +265,15 @@ class AddOrderShipmentTrackingFragment : BaseFragment(), AddOrderShipmentTrackin
 
     override fun confirmDiscard() {
         isConfirmingDiscard = true
-        CustomDiscardDialog.showDiscardDialog(
+        WooDialog.showDialog(
                 requireActivity(),
+                messageId = R.string.discard_message,
+                positiveButtonId = R.string.discard,
                 posBtnAction = DialogInterface.OnClickListener { _, _ ->
                     shouldShowDiscardDialog = false
                     activity?.onBackPressed()
                 },
+                negativeButtonId = R.string.keep_editing,
                 negBtnAction = DialogInterface.OnClickListener { _, _ ->
                     isConfirmingDiscard = false
                 })

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteFragment.kt
@@ -16,7 +16,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ADD_ORDER_NOTE_AD
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ADD_ORDER_NOTE_EMAIL_NOTE_TO_CUSTOMER_TOGGLED
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.dialog.CustomDiscardDialog
+import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.notes.AddOrderNoteContract.Presenter
 import com.woocommerce.android.util.AnalyticsUtils
@@ -105,7 +105,7 @@ class AddOrderNoteFragment : BaseFragment(), AddOrderNoteContract.View, BackPres
 
     override fun onStop() {
         super.onStop()
-        CustomDiscardDialog.onCleared()
+        WooDialog.onCleared()
         activity?.let {
             ActivityUtils.hideKeyboard(it)
         }
@@ -163,12 +163,15 @@ class AddOrderNoteFragment : BaseFragment(), AddOrderNoteContract.View, BackPres
 
     override fun confirmDiscard() {
         isConfirmingDiscard = true
-        CustomDiscardDialog.showDiscardDialog(
+        WooDialog.showDialog(
                 requireActivity(),
+                messageId = R.string.discard_message,
+                positiveButtonId = R.string.discard,
                 posBtnAction = DialogInterface.OnClickListener { _, _ ->
                     shouldShowDiscardDialog = false
                     activity?.onBackPressed()
                 },
+                negativeButtonId = R.string.keep_editing,
                 negBtnAction = DialogInterface.OnClickListener { _, _ ->
                     isConfirmingDiscard = false
                 })

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
@@ -10,10 +10,10 @@ import androidx.navigation.navGraphViewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.dialog.CustomDiscardDialog
+import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import dagger.Lazy
@@ -55,12 +55,7 @@ abstract class BaseProductFragment : BaseFragment(), BackPressListener {
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is Exit -> requireActivity().onBackPressed()
-                is ShowDiscardDialog -> CustomDiscardDialog.showDiscardDialog(
-                    requireActivity(),
-                    event.positiveBtnAction,
-                    event.negativeBtnAction,
-                    event.messageId
-                )
+                is ShowDialog -> event.showDialog()
                 is ProductNavigationTarget -> navigator.navigate(this, event)
                 else -> event.isHandled = false
             }
@@ -87,7 +82,7 @@ abstract class BaseProductFragment : BaseFragment(), BackPressListener {
 
     override fun onStop() {
         super.onStop()
-        CustomDiscardDialog.onCleared()
+        WooDialog.onCleared()
         activity?.let {
             ActivityUtils.hideKeyboard(it)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
@@ -18,7 +18,6 @@ import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
@@ -18,11 +18,11 @@ import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.dialog.CustomDiscardDialog
+import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.SkeletonView
@@ -113,13 +113,7 @@ class GroupedProductListFragment : BaseFragment(), BackPressListener {
         viewModel.event.observe(viewLifecycleOwner, Observer { event ->
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
-                is ShowDiscardDialog -> CustomDiscardDialog.showDiscardDialog(
-                    requireActivity(),
-                    event.positiveBtnAction,
-                    event.negativeBtnAction,
-                    event.messageId,
-                    negativeButtonId = event.negativeButtonId
-                )
+                is ShowDialog -> event.showDialog()
                 is Exit -> findNavController().navigateUp()
                 is ExitWithResult<*> -> {
                     navigateBackWithResult(KEY_GROUPED_PRODUCT_IDS_RESULT, event.item as? List<*>)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModel.kt
@@ -17,7 +17,7 @@ import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -67,11 +67,11 @@ class GroupedProductListViewModel @AssistedInject constructor(
 
     fun onBackButtonClicked(): Boolean {
         return if (productListViewState.hasChanges == true) {
-            triggerEvent(ShowDiscardDialog(
-                negativeButtonId = string.keep_changes,
+            triggerEvent(ShowDialog.buildDiscardDialogEvent(
                 positiveBtnAction = DialogInterface.OnClickListener { _, _ ->
                     triggerEvent(Exit)
-                }
+                },
+                negativeButtonId = string.keep_changes
             ))
             false
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -45,6 +45,7 @@ import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEve
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitPricing
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitProductCategories
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitProductDetail
+import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitProductDownloads
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitProductTags
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitSettings
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitShipping
@@ -281,6 +282,15 @@ class ProductDetailViewModel @AssistedInject constructor(
             val mutableDownloadsList = it.downloads.toMutableList()
             Collections.swap(mutableDownloadsList, from, to)
             updateProductDraft(downloads = mutableDownloadsList)
+        }
+    }
+
+    fun deleteDownloadableFile(file: ProductFile) {
+        viewState.productDraft?.let {
+            val updatedDownloads = it.downloads - file
+            updateProductDraft(downloads = updatedDownloads)
+            // If the downloads list is empty now, go directly to the product details screen
+            if(updatedDownloads.isEmpty()) triggerEvent(ExitProductDownloads(shouldShowDiscardDialog = false))
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -78,7 +78,7 @@ import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
@@ -535,34 +535,34 @@ class ProductDetailViewModel @AssistedInject constructor(
             else -> isProductDetailUpdated && isProductSubDetailUpdated
         }
         if (isProductUpdated && event.shouldShowDiscardDialog) {
-            triggerEvent(ShowDiscardDialog(
-                    positiveBtnAction = DialogInterface.OnClickListener { _, _ ->
-                        // discard changes made to the current screen
-                        discardEditChanges(event)
+            triggerEvent(ShowDialog.buildDiscardDialogEvent(
+                positiveBtnAction = DialogInterface.OnClickListener { _, _ ->
+                    // discard changes made to the current screen
+                    discardEditChanges(event)
 
-                        // If user in Product detail screen, exit product detail,
-                        // otherwise, redirect to Product Detail screen
-                        if (event is ExitProductDetail) {
-                            triggerEvent(ExitProduct)
-                        } else {
-                            triggerEvent(event)
-                        }
+                    // If user in Product detail screen, exit product detail,
+                    // otherwise, redirect to Product Detail screen
+                    if (event is ExitProductDetail) {
+                        triggerEvent(ExitProduct)
+                    } else {
+                        triggerEvent(event)
                     }
+                }
             ))
             return false
         } else if ((event is ExitProductDetail || event is ExitImages) && isUploadingImages) {
             // images can't be assigned to the product until they finish uploading so ask whether
             // to discard the uploading images
-            triggerEvent(ShowDiscardDialog(
-                    messageId = string.discard_images_message,
-                    positiveBtnAction = DialogInterface.OnClickListener { _, _ ->
-                        ProductImagesService.cancel()
-                        if (event is ExitProductDetail) {
-                            triggerEvent(ExitProduct)
-                        } else {
-                            triggerEvent(event)
-                        }
+            triggerEvent(ShowDialog.buildDiscardDialogEvent(
+                messageId = string.discard_images_message,
+                positiveBtnAction = DialogInterface.OnClickListener { _, _ ->
+                    ProductImagesService.cancel()
+                    if (event is ExitProductDetail) {
+                        triggerEvent(ExitProduct)
+                    } else {
+                        triggerEvent(event)
                     }
+                }
             ))
             return false
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -290,7 +290,7 @@ class ProductDetailViewModel @AssistedInject constructor(
             val updatedDownloads = it.downloads - file
             updateProductDraft(downloads = updatedDownloads)
             // If the downloads list is empty now, go directly to the product details screen
-            if(updatedDownloads.isEmpty()) triggerEvent(ExitProductDownloads(shouldShowDiscardDialog = false))
+            if (updatedDownloads.isEmpty()) triggerEvent(ExitProductDownloads(shouldShowDiscardDialog = false))
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
@@ -20,7 +20,7 @@ import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
-import com.woocommerce.android.ui.dialog.CustomDiscardDialog
+import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.ProductFilterListAdapter.OnProductFilterClickListener
@@ -29,7 +29,7 @@ import com.woocommerce.android.ui.products.ProductFilterListViewModel.Companion.
 import com.woocommerce.android.ui.products.ProductFilterListViewModel.Companion.ARG_PRODUCT_FILTER_TYPE_STATUS
 import com.woocommerce.android.ui.products.ProductFilterListViewModel.FilterListItemUiModel
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.AlignedDividerDecoration
 import kotlinx.android.synthetic.main.fragment_product_filter_list.*
@@ -126,13 +126,7 @@ class ProductFilterListFragment : BaseFragment(), OnProductFilterClickListener, 
         viewModel.event.observe(viewLifecycleOwner, Observer { event ->
             when (event) {
                 is Exit -> findNavController().navigateUp()
-                is ShowDiscardDialog -> CustomDiscardDialog.showDiscardDialog(
-                    requireActivity(),
-                    event.positiveBtnAction,
-                    event.negativeBtnAction,
-                    event.messageId,
-                    negativeButtonId = event.negativeButtonId
-                )
+                is ShowDialog -> event.showDialog()
                 else -> event.isHandled = false
             }
         })

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
@@ -20,7 +20,6 @@ import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
-import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.ProductFilterListAdapter.OnProductFilterClickListener

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -16,7 +16,7 @@ import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.products.ProductStockStatus.Companion.fromString
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption.STOCK_STATUS
@@ -98,11 +98,11 @@ class ProductFilterListViewModel @AssistedInject constructor(
 
     fun onBackButtonClicked(): Boolean {
         return if (hasChanges()) {
-            triggerEvent(ShowDiscardDialog(
-                negativeButtonId = string.keep_changes,
+            triggerEvent(ShowDialog.buildDiscardDialogEvent(
                 positiveBtnAction = DialogInterface.OnClickListener { _, _ ->
                     triggerEvent(Exit)
-                }
+                },
+                negativeButtonId = string.keep_changes
             ))
             false
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
@@ -11,11 +11,11 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateBackWithResult
-import com.woocommerce.android.ui.dialog.CustomDiscardDialog
+import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.products.ProductTypesBottomSheetViewModel.ProductTypesBottomSheetUiItem
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
@@ -78,14 +78,14 @@ class ProductTypesBottomSheetFragment : BottomSheetDialogFragment(), HasAndroidI
                 is Exit -> {
                     dismiss()
                 }
-                is ShowDiscardDialog -> CustomDiscardDialog.showDiscardDialog(
-                    requireActivity(),
-                    event.positiveBtnAction,
-                    event.negativeBtnAction,
-                    event.titleId,
-                    event.messageId,
-                    event.positiveButtonId,
-                    event.negativeButtonId
+                is ShowDialog -> WooDialog.showDialog(
+                    activity = requireActivity(),
+                    titleId = event.titleId,
+                    messageId = event.messageId,
+                    positiveButtonId = event.positiveButtonId,
+                    posBtnAction = event.positiveBtnAction,
+                    negativeButtonId = event.negativeButtonId,
+                    negBtnAction = event.negativeBtnAction
                 )
                 is ExitWithResult<*> -> {
                     navigateBackWithResult(KEY_PRODUCT_TYPE_RESULT, event.item as? ProductTypesBottomSheetUiItem)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
@@ -16,7 +16,7 @@ import com.woocommerce.android.ui.products.ProductType.GROUPED
 import com.woocommerce.android.ui.products.ProductType.SIMPLE
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import kotlinx.android.parcel.Parcelize
@@ -34,14 +34,14 @@ class ProductTypesBottomSheetViewModel @AssistedInject constructor(
     }
 
     fun onProductTypeSelected(productTypeUiItem: ProductTypesBottomSheetUiItem) {
-        triggerEvent(ShowDiscardDialog(
+        triggerEvent(ShowDialog(
             titleId = R.string.product_type_confirm_dialog_title,
             messageId = R.string.product_type_confirm_dialog_message,
             positiveButtonId = R.string.product_type_confirm_button,
-            negativeButtonId = R.string.cancel,
             positiveBtnAction = DialogInterface.OnClickListener { _, _ ->
                 triggerEvent(ExitWithResult(productTypeUiItem))
-            }
+            },
+            negativeButtonId = R.string.cancel
         ))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
@@ -20,11 +20,11 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.ProductCategory
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.dialog.CustomDiscardDialog
+import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.CustomProgressDialog
@@ -128,12 +128,7 @@ class AddProductCategoryFragment : BaseFragment(), BackPressListener {
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is Exit -> requireActivity().onBackPressed()
-                is ShowDiscardDialog -> CustomDiscardDialog.showDiscardDialog(
-                    requireActivity(),
-                    event.positiveBtnAction,
-                    event.negativeBtnAction,
-                    event.messageId
-                )
+                is ShowDialog -> event.showDialog()
                 is ExitWithResult<*> -> {
                     val bundle = Bundle()
                     bundle.putParcelable(ARG_ADDED_CATEGORY, event.item as? ProductCategory)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
@@ -20,7 +20,6 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.ProductCategory
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
@@ -16,7 +16,7 @@ import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
@@ -50,7 +50,7 @@ class AddProductCategoryViewModel @AssistedInject constructor(
     fun onBackButtonClicked(categoryName: String, parentId: String): Boolean {
         val hasChanges = categoryName.isNotEmpty() || parentId.isNotEmpty()
         return if (hasChanges && addProductCategoryViewState.shouldShowDiscardDialog) {
-            triggerEvent(ShowDiscardDialog(
+            triggerEvent(ShowDialog.buildDiscardDialogEvent(
                 positiveBtnAction = DialogInterface.OnClickListener { _, _ ->
                     addProductCategoryViewState = addProductCategoryViewState.copy(shouldShowDiscardDialog = false)
                     triggerEvent(Exit)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsFragment.kt
@@ -7,17 +7,22 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.view.ContextThemeWrapper
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.observe
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.navGraphViewModels
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.woocommerce.android.R
+import com.woocommerce.android.R.style
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.dialog.CustomDiscardDialog
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.ProductDetailViewModel
+import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewModel.ProductDownloadDetailsEvent.DeleteFileEvent
+import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewModel.ProductDownloadDetailsEvent.ShowDeleteFileConfirmationEvent
 import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewModel.ProductDownloadDetailsEvent.UpdateFileAndExitEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
@@ -52,6 +57,10 @@ class ProductDownloadDetailsFragment : BaseFragment(), BackPressListener {
         return when (item.itemId) {
             R.id.menu_done -> {
                 viewModel.onDoneOrUpdateClicked()
+                true
+            }
+            R.id.menu_delete -> {
+                viewModel.onDeleteButtonClicked()
                 true
             }
             else -> super.onOptionsItemSelected(item)
@@ -94,10 +103,28 @@ class ProductDownloadDetailsFragment : BaseFragment(), BackPressListener {
                     parentViewModel.updateDownloadableFileInDraft(event.updatedFile)
                     findNavController().navigateUp()
                 }
+                is ShowDeleteFileConfirmationEvent -> {
+                    showDeleteConfirmationDialog()
+                }
+                is DeleteFileEvent -> {
+                    parentViewModel.deleteDownloadableFile(event.file)
+                    findNavController().navigateUp()
+                }
             }
         })
 
         initListeners()
+    }
+
+    private fun showDeleteConfirmationDialog() {
+        MaterialAlertDialogBuilder(ContextThemeWrapper(requireActivity(), style.Theme_Woo_Dialog))
+            .setMessage(R.string.product_downloadable_files_delete_confirmation)
+            .setCancelable(true)
+            .setPositiveButton(R.string.delete) { _, _ ->
+                viewModel.triggerFileDeletion()
+            }
+            .setNegativeButton(R.string.cancel, null)
+            .show()
     }
 
     private fun initListeners() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsFragment.kt
@@ -7,25 +7,20 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import androidx.appcompat.view.ContextThemeWrapper
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.observe
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.navGraphViewModels
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.woocommerce.android.R
-import com.woocommerce.android.R.style
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.dialog.CustomDiscardDialog
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.ProductDetailViewModel
 import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewModel.ProductDownloadDetailsEvent.DeleteFileEvent
-import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewModel.ProductDownloadDetailsEvent.ShowDeleteFileConfirmationEvent
 import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewModel.ProductDownloadDetailsEvent.UpdateFileAndExitEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import kotlinx.android.synthetic.main.fragment_product_download_details.*
@@ -92,19 +87,11 @@ class ProductDownloadDetailsFragment : BaseFragment(), BackPressListener {
                     ActivityUtils.hideKeyboard(requireActivity())
                     findNavController().navigateUp()
                 }
-                is ShowDiscardDialog -> CustomDiscardDialog.showDiscardDialog(
-                    requireActivity(),
-                    event.positiveBtnAction,
-                    event.negativeBtnAction,
-                    event.messageId
-                )
+                is ShowDialog -> event.showDialog()
                 is UpdateFileAndExitEvent -> {
                     ActivityUtils.hideKeyboard(requireActivity())
                     parentViewModel.updateDownloadableFileInDraft(event.updatedFile)
                     findNavController().navigateUp()
-                }
-                is ShowDeleteFileConfirmationEvent -> {
-                    showDeleteConfirmationDialog()
                 }
                 is DeleteFileEvent -> {
                     parentViewModel.deleteDownloadableFile(event.file)
@@ -114,17 +101,6 @@ class ProductDownloadDetailsFragment : BaseFragment(), BackPressListener {
         })
 
         initListeners()
-    }
-
-    private fun showDeleteConfirmationDialog() {
-        MaterialAlertDialogBuilder(ContextThemeWrapper(requireActivity(), style.Theme_Woo_Dialog))
-            .setMessage(R.string.product_downloadable_files_delete_confirmation)
-            .setCancelable(true)
-            .setPositiveButton(R.string.delete) { _, _ ->
-                viewModel.triggerFileDeletion()
-            }
-            .setNegativeButton(R.string.cancel, null)
-            .show()
     }
 
     private fun initListeners() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsViewModel.kt
@@ -4,6 +4,7 @@ import android.content.DialogInterface
 import android.os.Parcelable
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
+import com.woocommerce.android.R
 import com.woocommerce.android.di.ViewModelAssistedFactory
 import com.woocommerce.android.model.ProductFile
 import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewModel.ProductDownloadDetailsEvent.DeleteFileEvent
@@ -14,13 +15,15 @@ import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
+import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import kotlinx.android.parcel.Parcelize
 
 class ProductDownloadDetailsViewModel @AssistedInject constructor(
     @Assisted savedState: SavedStateWithArgs,
-    dispatchers: CoroutineDispatchers
+    dispatchers: CoroutineDispatchers,
+    private val resourceProvider: ResourceProvider
 ) : ScopedViewModel(savedState, dispatchers) {
     private val navArgs: ProductDownloadDetailsFragmentArgs by savedState.navArgs()
 
@@ -37,7 +40,8 @@ class ProductDownloadDetailsViewModel @AssistedInject constructor(
         get() = productDownloadDetailsViewState.hasChanges
 
     val screenTitle
-        get() = navArgs.productFile?.name ?: TODO("Should be implemented for files creation")
+        get() = navArgs.productFile?.name?.ifEmpty { resourceProvider.getString(R.string.product_downloadable_files_edit_title) }
+            ?: TODO("Should be implemented for files creation")
 
     fun onFileUrlChanged(url: String) {
         val updatedDraft = productDownloadDetailsViewState.fileDraft.copy(url = url)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsViewModel.kt
@@ -40,7 +40,8 @@ class ProductDownloadDetailsViewModel @AssistedInject constructor(
         get() = productDownloadDetailsViewState.hasChanges
 
     val screenTitle
-        get() = navArgs.productFile?.name?.ifEmpty { resourceProvider.getString(R.string.product_downloadable_files_edit_title) }
+        get() = navArgs.productFile?.name
+            ?.ifEmpty { resourceProvider.getString(R.string.product_downloadable_files_edit_title) }
             ?: TODO("Should be implemented for files creation")
 
     fun onFileUrlChanged(url: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsViewModel.kt
@@ -8,13 +8,12 @@ import com.woocommerce.android.R
 import com.woocommerce.android.di.ViewModelAssistedFactory
 import com.woocommerce.android.model.ProductFile
 import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewModel.ProductDownloadDetailsEvent.DeleteFileEvent
-import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewModel.ProductDownloadDetailsEvent.ShowDeleteFileConfirmationEvent
 import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewModel.ProductDownloadDetailsEvent.UpdateFileAndExitEvent
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -60,12 +59,19 @@ class ProductDownloadDetailsViewModel @AssistedInject constructor(
     }
 
     fun onDeleteButtonClicked() {
-        triggerEvent(ShowDeleteFileConfirmationEvent)
+        triggerEvent(
+            ShowDialog(
+                messageId = R.string.product_downloadable_files_delete_confirmation,
+                positiveButtonId = R.string.delete,
+                positiveBtnAction = DialogInterface.OnClickListener { _, _ -> triggerFileDeletion() },
+                negativeButtonId = R.string.cancel
+            )
+        )
     }
 
     fun onBackButtonClicked(): Boolean {
         return if (hasChanges) {
-            triggerEvent(ShowDiscardDialog(
+            triggerEvent(ShowDialog.buildDiscardDialogEvent(
                 positiveBtnAction = DialogInterface.OnClickListener { _, _ ->
                     triggerEvent(Exit)
                 }
@@ -93,7 +99,6 @@ class ProductDownloadDetailsViewModel @AssistedInject constructor(
             val updatedFile: ProductFile
         ) : ProductDownloadDetailsEvent()
 
-        object ShowDeleteFileConfirmationEvent : ProductDownloadDetailsEvent()
         class DeleteFileEvent(val file: ProductFile) : ProductDownloadDetailsEvent()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsViewModel.kt
@@ -6,6 +6,8 @@ import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import com.woocommerce.android.di.ViewModelAssistedFactory
 import com.woocommerce.android.model.ProductFile
+import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewModel.ProductDownloadDetailsEvent.DeleteFileEvent
+import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewModel.ProductDownloadDetailsEvent.ShowDeleteFileConfirmationEvent
 import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewModel.ProductDownloadDetailsEvent.UpdateFileAndExitEvent
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.LiveDataDelegate
@@ -52,6 +54,10 @@ class ProductDownloadDetailsViewModel @AssistedInject constructor(
         triggerEvent(UpdateFileAndExitEvent(productDownloadDetailsViewState.fileDraft))
     }
 
+    fun onDeleteButtonClicked() {
+        triggerEvent(ShowDeleteFileConfirmationEvent)
+    }
+
     fun onBackButtonClicked(): Boolean {
         return if (hasChanges) {
             triggerEvent(ShowDiscardDialog(
@@ -68,10 +74,22 @@ class ProductDownloadDetailsViewModel @AssistedInject constructor(
         productDownloadDetailsViewState = updatedState.copy(hasChanges = hasChanges)
     }
 
+    fun triggerFileDeletion() {
+        triggerEvent(
+            DeleteFileEvent(
+                navArgs.productFile
+                    ?: throw IllegalStateException("The delete action can't be invoked if the file to edit is null")
+            )
+        )
+    }
+
     sealed class ProductDownloadDetailsEvent : Event() {
         data class UpdateFileAndExitEvent(
             val updatedFile: ProductFile
         ) : ProductDownloadDetailsEvent()
+
+        object ShowDeleteFileConfirmationEvent : ProductDownloadDetailsEvent()
+        class DeleteFileEvent(val file: ProductFile) : ProductDownloadDetailsEvent()
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsFragment.kt
@@ -108,10 +108,10 @@ class ProductDownloadsFragment : BaseProductFragment() {
     }
 
     override fun hasChanges(): Boolean {
-        return viewModel.hasDownloadsChanges()
+        return viewModel.hasDownloadsChanges() || viewModel.hasDownloadsSettingsChanges()
     }
 
     override fun onRequestAllowBackPress(): Boolean {
-        return viewModel.onBackButtonClicked(ExitProductDownloads(shouldShowDiscardDialog = hasChanges()))
+        return viewModel.onBackButtonClicked(ExitProductDownloads())
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/BaseProductSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/BaseProductSettingsFragment.kt
@@ -10,7 +10,7 @@ import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
-import com.woocommerce.android.ui.dialog.CustomDiscardDialog
+import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 
 /**
@@ -72,7 +72,7 @@ abstract class BaseProductSettingsFragment : BaseFragment(), BackPressListener {
 
     override fun onStop() {
         super.onStop()
-        CustomDiscardDialog.onCleared()
+        WooDialog.onCleared()
     }
 
     override fun onRequestAllowBackPress(): Boolean {
@@ -85,12 +85,15 @@ abstract class BaseProductSettingsFragment : BaseFragment(), BackPressListener {
 
     private fun confirmDiscard() {
         isConfirmingDiscard = true
-        CustomDiscardDialog.showDiscardDialog(
+        WooDialog.showDialog(
                 requireActivity(),
+                messageId = R.string.discard_message,
+                positiveButtonId = R.string.discard,
                 posBtnAction = DialogInterface.OnClickListener { _, _ ->
                     isConfirmingDiscard = false
                     findNavController().navigateUp()
                 },
+                negativeButtonId = R.string.keep_editing,
                 negBtnAction = DialogInterface.OnClickListener { _, _ ->
                     isConfirmingDiscard = false
                 })

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
@@ -24,7 +24,6 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.variations.VariationDetailViewModel.ShowImage
 import com.woocommerce.android.ui.products.adapters.ProductPropertyCardsAdapter

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
@@ -24,13 +24,13 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.dialog.CustomDiscardDialog
+import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.variations.VariationDetailViewModel.ShowImage
 import com.woocommerce.android.ui.products.adapters.ProductPropertyCardsAdapter
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.CustomProgressDialog
@@ -145,12 +145,7 @@ class VariationDetailFragment : BaseFragment(), BackPressListener {
                     )
                     findNavController().navigateSafely(action)
                 }
-                is ShowDiscardDialog -> CustomDiscardDialog.showDiscardDialog(
-                    requireActivity(),
-                    event.positiveBtnAction,
-                    event.negativeBtnAction,
-                    event.messageId
-                )
+                is ShowDialog -> event.showDialog()
                 is Exit -> requireActivity().onBackPressed()
                 else -> event.isHandled = false
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -25,7 +25,7 @@ import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
@@ -102,7 +102,7 @@ class VariationDetailViewModel @AssistedInject constructor(
         when {
             ProductImagesService.isUploadingForProduct(viewState.variation.remoteVariationId) -> {
                 // images can't be assigned to the product until they finish uploading so ask whether to discard images.
-                triggerEvent(ShowDiscardDialog(
+                triggerEvent(ShowDialog.buildDiscardDialogEvent(
                     messageId = string.discard_images_message,
                     positiveBtnAction = DialogInterface.OnClickListener { _, _ ->
                         triggerEvent(Exit)
@@ -110,7 +110,7 @@ class VariationDetailViewModel @AssistedInject constructor(
                 ))
             }
             viewState.variation != originalVariation -> {
-                triggerEvent(ShowDiscardDialog(
+                triggerEvent(ShowDialog.buildDiscardDialogEvent(
                     positiveBtnAction = DialogInterface.OnClickListener { _, _ ->
                         triggerEvent(Exit)
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaPickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaPickerFragment.kt
@@ -22,7 +22,7 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.dialog.CustomDiscardDialog
+import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.ProductDetailFragmentDirections
 import com.woocommerce.android.ui.wpmediapicker.WPMediaGalleryView.WPMediaGalleryListener
@@ -73,7 +73,7 @@ class WPMediaPickerFragment : BaseFragment(), WPMediaGalleryListener, BackPressL
 
     override fun onStop() {
         super.onStop()
-        CustomDiscardDialog.onCleared()
+        WooDialog.onCleared()
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -180,12 +180,15 @@ class WPMediaPickerFragment : BaseFragment(), WPMediaGalleryListener, BackPressL
 
     private fun confirmDiscard() {
         isConfirmingDiscard = true
-        CustomDiscardDialog.showDiscardDialog(
+        WooDialog.showDialog(
                 requireActivity(),
+                messageId = R.string.discard_message,
+                positiveButtonId = R.string.discard,
                 posBtnAction = DialogInterface.OnClickListener { _, _ ->
                     isConfirmingDiscard = false
                     findNavController().navigateUp()
                 },
+                negativeButtonId = R.string.keep_editing,
                 negBtnAction = DialogInterface.OnClickListener { _, _ ->
                     isConfirmingDiscard = false
                 })

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
@@ -6,6 +6,7 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
+import com.woocommerce.android.R.string
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -80,32 +81,28 @@ open class MultiLiveEvent<T : Event> : MutableLiveData<T>() {
         object Exit : Event()
         data class ExitWithResult<T>(val item: T) : Event()
 
-        data class ShowDiscardDialog(
-            val positiveBtnAction: OnClickListener? = null,
-            val negativeBtnAction: OnClickListener? = null,
-            @StringRes val messageId: Int? = null,
+        data class ShowDialog(
             @StringRes val titleId: Int? = null,
-            @StringRes val positiveButtonId: Int? = null,
-            @StringRes val negativeButtonId: Int? = null
+            @StringRes val messageId: Int,
+            @StringRes val positiveButtonId: Int,
+            val positiveBtnAction: OnClickListener,
+            @StringRes val negativeButtonId: Int? = null,
+            val negativeBtnAction: OnClickListener? = null
         ) : Event() {
-            override fun equals(other: Any?): Boolean {
-                if (this === other) return true
-                if (other !is ShowDiscardDialog) return false
-
-                if (titleId != other.titleId) return false
-                if (messageId != other.messageId) return false
-                if (positiveButtonId != other.positiveButtonId) return false
-                if (negativeButtonId != other.negativeButtonId) return false
-                if (positiveBtnAction != other.positiveBtnAction) return false
-                if (negativeBtnAction != other.negativeBtnAction) return false
-
-                return true
-            }
-
-            override fun hashCode(): Int {
-                var result = positiveBtnAction?.hashCode() ?: 0
-                result = 31 * result + (negativeBtnAction?.hashCode() ?: 0)
-                return result
+            companion object {
+                fun buildDiscardDialogEvent(
+                    messageId: Int = string.discard_message,
+                    positiveButtonId: Int = string.discard,
+                    negativeButtonId: Int = string.keep_editing,
+                    positiveBtnAction: OnClickListener,
+                    negativeBtnAction: OnClickListener? = null
+                ) = ShowDialog(
+                    messageId = messageId,
+                    positiveButtonId = positiveButtonId,
+                    positiveBtnAction = positiveBtnAction,
+                    negativeButtonId = negativeButtonId,
+                    negativeBtnAction = negativeBtnAction
+                )
             }
         }
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1256,4 +1256,5 @@
     <string name="delete">Delete</string>
     <string name="product_is_downloadable">Downloadable product</string>
     <string name="product_downloadable_files_delete_confirmation">Are you sure you want to remove this file?</string>
+    <string name="product_downloadable_files_edit_title">File</string>
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1255,4 +1255,5 @@
     <string name="product_downloadable_files_expiry">Download expiration</string>
     <string name="delete">Delete</string>
     <string name="product_is_downloadable">Downloadable product</string>
+    <string name="product_downloadable_files_delete_confirmation">Are you sure you want to remove this file?</string>
 </resources>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsViewModelTest.kt
@@ -6,12 +6,12 @@ import com.nhaarman.mockitokotlin2.mock
 import com.woocommerce.android.R
 import com.woocommerce.android.model.ProductFile
 import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewModel.ProductDownloadDetailsEvent.DeleteFileEvent
-import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewModel.ProductDownloadDetailsEvent.ShowDeleteFileConfirmationEvent
 import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewModel.ProductDownloadDetailsEvent.UpdateFileAndExitEvent
 import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewModel.ProductDownloadDetailsViewState
 import com.woocommerce.android.util.CoroutineTestRule
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -142,7 +142,7 @@ class ProductDownloadDetailsViewModelTest : BaseUnitTest() {
         viewModel.onDeleteButtonClicked()
         viewModel.triggerFileDeletion()
 
-        assertThat(events[0]).isInstanceOf(ShowDeleteFileConfirmationEvent::class.java)
+        assertThat(events[0]).isInstanceOf(ShowDialog::class.java)
         assertThat(events[1]).isInstanceOf(DeleteFileEvent::class.java)
         assertThat((events[1] as DeleteFileEvent).file).isEqualTo(file)
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsViewModelTest.kt
@@ -1,6 +1,9 @@
 package com.woocommerce.android.ui.products.downloads
 
 import androidx.lifecycle.SavedStateHandle
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.woocommerce.android.R
 import com.woocommerce.android.model.ProductFile
 import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewModel.ProductDownloadDetailsEvent.DeleteFileEvent
 import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewModel.ProductDownloadDetailsEvent.ShowDeleteFileConfirmationEvent
@@ -9,6 +12,7 @@ import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewM
 import com.woocommerce.android.util.CoroutineTestRule
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -29,11 +33,16 @@ class ProductDownloadDetailsViewModelTest : BaseUnitTest() {
     @get:Rule
     var coroutinesTestRule = CoroutineTestRule()
 
+    private val resourceProvider: ResourceProvider = mock() {
+        on { getString(R.string.product_downloadable_files_edit_title) } doReturn "file"
+    }
+
     @Test
     fun `test has the correct init state`() {
         viewModel = ProductDownloadDetailsViewModel(
             savedStateForEditing,
-            coroutinesTestRule.testDispatchers
+            coroutinesTestRule.testDispatchers,
+            resourceProvider
         )
 
         var state: ProductDownloadDetailsViewState? = null
@@ -44,10 +53,30 @@ class ProductDownloadDetailsViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `test display the correct title if name is empty`() {
+        val file = file.copy(name = "")
+        val savedStateWithArgs = SavedStateWithArgs(
+            SavedStateHandle(),
+            null,
+            ProductDownloadDetailsFragmentArgs(file)
+        )
+        viewModel = ProductDownloadDetailsViewModel(
+            savedStateWithArgs,
+            coroutinesTestRule.testDispatchers,
+            resourceProvider
+        )
+
+        val title = viewModel.screenTitle
+
+        assertThat(title).isEqualTo("file")
+    }
+
+    @Test
     fun `test file name edit`() {
         viewModel = ProductDownloadDetailsViewModel(
             savedStateForEditing,
-            coroutinesTestRule.testDispatchers
+            coroutinesTestRule.testDispatchers,
+            resourceProvider
         )
 
         val newName = "new name"
@@ -64,7 +93,8 @@ class ProductDownloadDetailsViewModelTest : BaseUnitTest() {
     fun `test file url edit`() {
         viewModel = ProductDownloadDetailsViewModel(
             savedStateForEditing,
-            coroutinesTestRule.testDispatchers
+            coroutinesTestRule.testDispatchers,
+            resourceProvider
         )
 
         val newUrl = "new url"
@@ -81,7 +111,8 @@ class ProductDownloadDetailsViewModelTest : BaseUnitTest() {
     fun `test dispatch update event`() {
         viewModel = ProductDownloadDetailsViewModel(
             savedStateForEditing,
-            coroutinesTestRule.testDispatchers
+            coroutinesTestRule.testDispatchers,
+            resourceProvider
         )
 
         val newUrl = "new url"
@@ -102,7 +133,8 @@ class ProductDownloadDetailsViewModelTest : BaseUnitTest() {
     fun `test delete file`() {
         viewModel = ProductDownloadDetailsViewModel(
             savedStateForEditing,
-            coroutinesTestRule.testDispatchers
+            coroutinesTestRule.testDispatchers,
+            resourceProvider
         )
 
         val events = mutableListOf<Event>()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsViewModelTest.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.ui.products.downloads
 
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.model.ProductFile
+import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewModel.ProductDownloadDetailsEvent.DeleteFileEvent
+import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewModel.ProductDownloadDetailsEvent.ShowDeleteFileConfirmationEvent
 import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewModel.ProductDownloadDetailsEvent.UpdateFileAndExitEvent
 import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewModel.ProductDownloadDetailsViewState
 import com.woocommerce.android.util.CoroutineTestRule
@@ -94,5 +96,22 @@ class ProductDownloadDetailsViewModelTest : BaseUnitTest() {
         assertThat(event).isInstanceOf(UpdateFileAndExitEvent::class.java)
         assertEquals(newName, (event as UpdateFileAndExitEvent).updatedFile.name)
         assertEquals(newUrl, (event as UpdateFileAndExitEvent).updatedFile.url)
+    }
+
+    @Test
+    fun `test delete file`() {
+        viewModel = ProductDownloadDetailsViewModel(
+            savedStateForEditing,
+            coroutinesTestRule.testDispatchers
+        )
+
+        val events = mutableListOf<Event>()
+        viewModel.event.observeForever { new -> events.add(new) }
+        viewModel.onDeleteButtonClicked()
+        viewModel.triggerFileDeletion()
+
+        assertThat(events[0]).isInstanceOf(ShowDeleteFileConfirmationEvent::class.java)
+        assertThat(events[1]).isInstanceOf(DeleteFileEvent::class.java)
+        assertThat((events[1] as DeleteFileEvent).file).isEqualTo(file)
     }
 }


### PR DESCRIPTION
Fixes #2710 

**Description**
Adds ability to delete individual downloadable files for products.
The main changes are:
1. Update `ProductDownloadDetailsFragment` to handle the click on the option menu "Delete"
2. Update `ProductDownloadDetailsViewModel` to handle handle the file deletion, and trigger a confirmation dialog.
3. Add a test case for the file deletion.
4. Handled the case if a file's name is empty: https://github.com/woocommerce/woocommerce-android/pull/2742/commits/00340ee6dd28b186c33297384a306537b8076540
5. Updated the logic to show the `done` button in the files list if the settings were changed: https://github.com/woocommerce/woocommerce-android/pull/2742/commits/ffe7abaa41ae02ff17442f5c3f8c153a82ee68a3

**Screenshots**
![Screen Shot 2020-08-18 at 19 14 07](https://user-images.githubusercontent.com/1657201/90550756-435a1380-e188-11ea-8cfc-e2f242ea2af1.png)
![Screen Shot 2020-08-18 at 19 14 13](https://user-images.githubusercontent.com/1657201/90550781-4e14a880-e188-11ea-8020-e2e46764a191.png)
![delete-files](https://user-images.githubusercontent.com/1657201/90550804-566ce380-e188-11ea-96b4-fa6ee245c957.gif)

**Testing**
1. Make sure your product is downloadable and has some downloadable files added in Core.
2. Go to the product details, then click on "Downloadable files"
3. Click on the file title.
4. Click on the overflow button to see the option "Delete"
5. Click on Delete and confirm that the confirmation dialog is shown.
6. Click on Yes, and confirm that you are taken back to:
      a. The list of files if your product has more files.
      b. The product details if this is the last file.
