### PR TITLE
Issue/2745 Add ability to mark/unmark a product as downloadable from product settings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -140,7 +140,8 @@ data class Product(
             isSameTags(product.tags) &&
             downloads == product.downloads &&
             downloadLimit == product.downloadLimit &&
-            downloadExpiry == product.downloadExpiry
+            downloadExpiry == product.downloadExpiry &&
+            isDownloadable == product.isDownloadable
     }
 
     val hasCategories get() = categories.isNotEmpty()
@@ -234,7 +235,8 @@ data class Product(
                 reviewsAllowed != it.reviewsAllowed ||
                 purchaseNote != it.purchaseNote ||
                 menuOrder != it.menuOrder ||
-                isVirtual != it.isVirtual
+                isVirtual != it.isVirtual ||
+                isDownloadable != it.isDownloadable
         } ?: false
     }
 
@@ -474,6 +476,7 @@ fun Product.toDataModel(storedProductModel: WCProductModel?): WCProductModel {
         it.downloads = downloadsToJson()
         it.downloadLimit = downloadLimit
         it.downloadExpiry = downloadExpiry
+        it.downloadable = isDownloadable
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -685,7 +685,8 @@ class ProductDetailViewModel @AssistedInject constructor(
         type: ProductType? = null,
         downloads: List<ProductFile>? = null,
         downloadLimit: Int? = null,
-        downloadExpiry: Int? = null
+        downloadExpiry: Int? = null,
+        isDownloadable: Boolean? = null
     ) {
         viewState.productDraft?.let { product ->
             val currentProduct = product.copy()
@@ -735,7 +736,8 @@ class ProductDetailViewModel @AssistedInject constructor(
                     } else viewState.storedProduct?.saleStartDateGmt,
                     downloads = downloads ?: product.downloads,
                     downloadLimit = downloadLimit ?: product.downloadLimit,
-                    downloadExpiry = downloadExpiry ?: product.downloadExpiry
+                    downloadExpiry = downloadExpiry ?: product.downloadExpiry,
+                    isDownloadable = isDownloadable ?: product.isDownloadable
             )
             viewState = viewState.copy(productDraft = updatedProduct)
 

--- a/WooCommerce/src/main/res/layout/dialog_uncheck_is_downloadable_warning.xml
+++ b/WooCommerce/src/main/res/layout/dialog_uncheck_is_downloadable_warning.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="@dimen/major_100">
+
+    <com.google.android.material.textview.MaterialTextView
+        style="@style/Woo.Card.Title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/product_uncheck_is_downloadable_warning_title" />
+
+    <com.google.android.material.textview.MaterialTextView
+        style="@style/Woo.Card.Body"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/product_uncheck_is_downloadable_warning_message" />
+
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_settings.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_settings.xml
@@ -49,6 +49,16 @@
                 android:layout_height="wrap_content"
                 android:padding="@dimen/major_100"
                 android:text="@string/product_is_virtual" />
+
+            <View style="@style/Woo.Divider.TitleAligned" />
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/productIsDownloadable"
+                style="@style/Widget.Woo.Settings"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="@dimen/major_100"
+                android:text="@string/product_is_downloadable" />
         </com.woocommerce.android.widgets.WCElevatedLinearLayout>
 
         <com.woocommerce.android.widgets.WCElevatedLinearLayout
@@ -62,8 +72,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:padding="@dimen/major_100"
-                android:textColor="@color/color_on_surface_disabled"
-                android:text="@string/more_options" />
+                android:text="@string/more_options"
+                android:textColor="@color/color_on_surface_disabled" />
 
             <View style="@style/Woo.Divider.TitleAligned" />
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1251,4 +1251,8 @@
     <string name="product_downloadable_files_expiry">Download expiration</string>
     <string name="delete">Delete</string>
     <string name="product_is_downloadable">Downloadable product</string>
+    <string name="product_uncheck_is_downloadable_warning_title">Are you sure you want to remove the ability to download files when product is purchased?</string>
+    <string name="product_uncheck_is_downloadable_warning_message">All files currently attached to this product will be deleted.</string>
+    <string name="product_uncheck_is_downloadable_warning_yes_button">Yes, change</string>
+    <string name="product_uncheck_is_downloadable_warning_no_button">No</string>
 </resources>


### PR DESCRIPTION
Fixes #2745 

**Description**
This PR adds the ability to change the value of the flag `is_downloadable` for a product through the product settings.
List of changes:

- Adds a checkbox "Product Downloadable" in the product settings.
- Handle the visibility of the checkbox depending on the flag `PRODUCT_RELEASE_M4`.
- Created a custom layout for the modal UI, as the MaterialAlertDialog title's max lines is set to 2 lines, and AFAIK there is no easy way to customize this without a custom layout.
- Updates ProductDetailViewModel to reflect `isDownloadable` in changes checks, and to update its value when the product is being updated.

**Screenshots**
![Screen Shot 2020-08-19 at 15 28 14](https://user-images.githubusercontent.com/1657201/90648550-94721200-e231-11ea-9dd4-c18fc5e793eb.png)
![Screen Shot 2020-08-19 at 15 28 19](https://user-images.githubusercontent.com/1657201/90648558-963bd580-e231-11ea-8e10-b8c339bf1cae.png)
