### PR TITLE
Fix product reviews

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -458,7 +458,7 @@ class ProductDetailCardBuilder(
             RatingBar(
                 R.string.product_reviews,
                 resources.getString(R.string.product_reviews_count, ratingCount),
-                ratingCount.toFloat(),
+                this.averageRating,
                 R.drawable.ic_reviews
             ) {
                 viewModel.onEditProductCardClicked(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -15,10 +15,20 @@ enum class FeatureFlag {
         return when (this) {
             // This feature will live switched on from the
             // setting screen. i.e. check AppPrefs.isProductsFeatureEnabled() method
-            PRODUCT_RELEASE_M3, APP_FEEDBACK, SHIPPING_LABELS_M1 -> BuildConfig.DEBUG
+            // Also, turn on the feature during testing
+            PRODUCT_RELEASE_M3, APP_FEEDBACK, SHIPPING_LABELS_M1 -> BuildConfig.DEBUG || isTesting()
             DB_DOWNGRADE -> {
                 BuildConfig.DEBUG || context != null && PackageUtils.isBetaBuild(context)
             }
+        }
+    }
+
+    private fun isTesting(): Boolean {
+        return try {
+            Class.forName("com.woocommerce.android.viewmodel.BaseUnitTest")
+            true
+        } catch (e: ClassNotFoundException) {
+            false
         }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -36,6 +36,7 @@ import org.wordpress.android.fluxc.store.WooCommerceStore
 import com.woocommerce.android.ui.products.models.ProductProperty.Editable
 import com.woocommerce.android.ui.products.models.ProductProperty.Link
 import com.woocommerce.android.ui.products.models.ProductProperty.PropertyGroup
+import com.woocommerce.android.ui.products.models.ProductProperty.RatingBar
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.PRIMARY
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.SECONDARY
 import com.woocommerce.android.ui.products.tags.ProductTagsRepository
@@ -125,6 +126,12 @@ class ProductDetailViewModelTest : BaseUnitTest() {
                     ),
                     R.drawable.ic_gridicons_shipping,
                     true
+                ),
+                RatingBar(
+                    R.string.product_reviews,
+                    resources.getString(R.string.product_reviews_count, product.ratingCount),
+                    product.averageRating,
+                    R.drawable.ic_reviews
                 ),
                 PropertyGroup(
                     R.string.product_inventory,
@@ -235,6 +242,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
                 is Editable -> p.copy(onTextChanged = null)
                 is PropertyGroup -> p.copy(onClick = null)
                 is Link -> p.copy(onClick = null)
+                is RatingBar -> p.copy(onClick = null)
                 else -> p
             }
         })

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -221,23 +221,19 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Displays the product detail properties correctly`() = coroutinesTestRule.testDispatcher.runBlockingTest {
-        // This is still a feature flagged functionality => it'll fail on CircleCI
-        // TODO: Remove the check once it's available
-        if (BuildConfig.DEBUG) {
-            doReturn(true).whenever(networkStatus).isConnected()
-            doReturn(productWithTagsAndCategories).whenever(productRepository).getProduct(any())
+        doReturn(true).whenever(networkStatus).isConnected()
+        doReturn(productWithTagsAndCategories).whenever(productRepository).getProduct(any())
 
-            viewModel.productDetailViewStateData.observeForever { _, _ -> }
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
 
-            var cards: List<ProductPropertyCard>? = null
-            viewModel.productDetailCards.observeForever {
-                cards = it.map { card -> stripCallbacks(card) }
-            }
-
-            viewModel.start()
-
-            assertThat(cards).isEqualTo(expectedCards)
+        var cards: List<ProductPropertyCard>? = null
+        viewModel.productDetailCards.observeForever {
+            cards = it.map { card -> stripCallbacks(card) }
         }
+
+        viewModel.start()
+
+        assertThat(cards).isEqualTo(expectedCards)
     }
 
     private fun stripCallbacks(card: ProductPropertyCard): ProductPropertyCard {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -10,7 +10,6 @@ import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.media.ProductImagesServiceWrapper

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -61,6 +61,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     private val productTagsRepository: ProductTagsRepository = mock()
     private val resources: ResourceProvider = mock {
         on(it.getString(any())).thenAnswer { i -> i.arguments[0].toString() }
+        on(it.getString(any(), any())).thenAnswer { i -> i.arguments[0].toString() }
     }
     private val productImagesServiceWrapper: ProductImagesServiceWrapper = mock()
     private val currencyFormatter: CurrencyFormatter = mock {
@@ -79,6 +80,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     var coroutinesTestRule = CoroutineTestRule()
 
     private val product = ProductTestUtils.generateProduct(PRODUCT_REMOTE_ID)
+    private val productWithTagsAndCategories = ProductTestUtils.generateProductWithTagsAndCategories(PRODUCT_REMOTE_ID)
     private val offlineProduct = ProductTestUtils.generateProduct(OFFLINE_PRODUCT_REMOTE_ID)
     private val productCategories = ProductTestUtils.generateProductCategories()
     private lateinit var viewModel: ProductDetailViewModel
@@ -93,7 +95,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
             sizeWithUnits = "1 x 2 x 3 cm",
             salePriceWithCurrency = "CZK10.00",
             regularPriceWithCurrency = "CZK30.00",
-            showBottomSheetButton = false
+            showBottomSheetButton = true
     )
 
     private val expectedCards = listOf(
@@ -117,14 +119,10 @@ class ProductDetailViewModelTest : BaseUnitTest() {
                     ),
                     R.drawable.ic_gridicons_money
                 ),
-                PropertyGroup(
-                    R.string.product_shipping,
-                    mapOf(
-                        Pair(resources.getString(R.string.product_weight), productWithParameters.weightWithUnits!!),
-                        Pair(resources.getString(R.string.product_dimensions), productWithParameters.sizeWithUnits!!),
-                        Pair(resources.getString(R.string.product_shipping_class), "")
-                    ),
-                    R.drawable.ic_gridicons_shipping,
+                ComplexProperty(
+                    R.string.product_type,
+                    resources.getString(R.string.product_detail_product_type_hint),
+                    R.drawable.ic_gridicons_product,
                     true
                 ),
                 RatingBar(
@@ -141,25 +139,32 @@ class ProductDetailViewModelTest : BaseUnitTest() {
                     R.drawable.ic_gridicons_list_checkmark,
                     true
                 ),
-                ComplexProperty(
-                    R.string.product_short_description,
-                    product.shortDescription,
-                    R.drawable.ic_gridicons_align_left,
+                PropertyGroup(
+                    R.string.product_shipping,
+                    mapOf(
+                        Pair(resources.getString(R.string.product_weight), productWithParameters.weightWithUnits!!),
+                        Pair(resources.getString(R.string.product_dimensions), productWithParameters.sizeWithUnits!!),
+                        Pair(resources.getString(R.string.product_shipping_class), "")
+                    ),
+                    R.drawable.ic_gridicons_shipping,
                     true
                 ),
                 ComplexProperty(
                     R.string.product_categories,
-                    resources.getString(R.string.product_category_empty),
+                    productWithTagsAndCategories.categories.joinToString(transform = { it.name }),
                     R.drawable.ic_gridicons_folder,
-                    showTitle = false,
                     maxLines = 5
                 ),
                 ComplexProperty(
                     R.string.product_tags,
-                    resources.getString(R.string.product_tag_empty),
+                    productWithTagsAndCategories.tags.joinToString(transform = { it.name }),
                     R.drawable.ic_gridicons_tag,
-                    showTitle = false,
                     maxLines = 5
+                ),
+                ComplexProperty(
+                    R.string.product_short_description,
+                    product.shortDescription,
+                    R.drawable.ic_gridicons_align_left
                 )
             )
         )
@@ -220,7 +225,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         // TODO: Remove the check once it's available
         if (BuildConfig.DEBUG) {
             doReturn(true).whenever(networkStatus).isConnected()
-            doReturn(product).whenever(productRepository).getProduct(any())
+            doReturn(productWithTagsAndCategories).whenever(productRepository).getProduct(any())
 
             viewModel.productDetailViewStateData.observeForever { _, _ -> }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -31,6 +31,7 @@ object ProductTestUtils {
             attributes = "[]"
             categories = ""
             groupedProductIds = "[10,11]"
+            ratingCount = 4
             shortDescription = "short desc"
         }.toAppModel()
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.products
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.ProductCategory
 import com.woocommerce.android.model.ProductVariation
+import com.woocommerce.android.model.ProductTag
 import com.woocommerce.android.model.toAppModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
@@ -34,6 +35,10 @@ object ProductTestUtils {
             ratingCount = 4
             shortDescription = "short desc"
         }.toAppModel()
+    }
+
+    fun generateProductWithTagsAndCategories(productId: Long = 1L): Product {
+        return generateProduct(productId).copy(categories = generateProductCategories(), tags = generateTags())
     }
 
     fun generateProductList(): List<Product> {
@@ -71,6 +76,10 @@ object ProductTestUtils {
             add(generateProductVariation(productId, 5))
             return this
         }
+    }
+
+    fun generateTags(): List<ProductTag> {
+        return listOf(ProductTag(1, "Tag", "Slug", "Desc"))
     }
 
     fun generateProductCategories(): List<ProductCategory> {


### PR DESCRIPTION
This PR fixes the reviews/rating property in Product details. I noticed that the **rating count** was being displayed instead of the **average rating**. I've also fixed the unit tests.

**To test**
1. Go to `Products` -> Tap on a product with reviews
2. Verify the rating and review count match the actual values
3. Run `ProductDetailViewModelTest` and verify that all tests pass