### PR TITLE
Issue/2755 add m3 switch

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 4.9
 -----
+* Products: now you can edit grouped, external and variable products, including updating product type, categories and tags.
  
 4.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
@@ -9,7 +9,6 @@ import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SETTINGS_BETA_FEATURES_PRODUCTS_TOGGLED
-import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.ui.prefs.MainSettingsFragment.AppSettingsListener
 import com.woocommerce.android.util.AnalyticsUtils
 import kotlinx.android.synthetic.main.fragment_settings_beta.*
@@ -40,9 +39,6 @@ class BetaFeaturesFragment : Fragment() {
                     AnalyticsTracker.KEY_STATE to AnalyticsUtils.getToggleStateLabel(switchProductsUI.isChecked)))
             settingsListener.onProductsFeatureOptionChanged(isChecked)
         }
-
-        // hidden until we need it again for M3
-        switchProductsUI.hide()
     }
 
     override fun onResume() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -155,7 +155,7 @@ class MainSettingsFragment : androidx.fragment.app.Fragment(), MainSettingsContr
             findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_betaFeaturesFragment)
         }
 
-        option_beta_features.optionValue = getString(R.string.settings_enable_v4_stats_title)
+        option_beta_features.optionValue = getString(R.string.settings_enable_product_teaser_title)
 
         option_privacy.setOnClickListener {
             AnalyticsTracker.track(SETTINGS_PRIVACY_SETTINGS_BUTTON_TAPPED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.util
 
 import android.content.Context
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig
 
 /**
@@ -16,7 +17,8 @@ enum class FeatureFlag {
             // This feature will live switched on from the
             // setting screen. i.e. check AppPrefs.isProductsFeatureEnabled() method
             // Also, turn on the feature during testing
-            PRODUCT_RELEASE_M3, APP_FEEDBACK, SHIPPING_LABELS_M1 -> BuildConfig.DEBUG || isTesting()
+            APP_FEEDBACK, SHIPPING_LABELS_M1 -> BuildConfig.DEBUG || isTesting()
+            PRODUCT_RELEASE_M3 -> AppPrefs.isProductsFeatureEnabled()
             DB_DOWNGRADE -> {
                 BuildConfig.DEBUG || context != null && PackageUtils.isBetaBuild(context)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -18,7 +18,7 @@ enum class FeatureFlag {
             // setting screen. i.e. check AppPrefs.isProductsFeatureEnabled() method
             // Also, turn on the feature during testing
             APP_FEEDBACK, SHIPPING_LABELS_M1 -> BuildConfig.DEBUG || isTesting()
-            PRODUCT_RELEASE_M3 -> AppPrefs.isProductsFeatureEnabled()
+            PRODUCT_RELEASE_M3 -> isTesting() || AppPrefs.isProductsFeatureEnabled()
             DB_DOWNGRADE -> {
                 BuildConfig.DEBUG || context != null && PackageUtils.isBetaBuild(context)
             }

--- a/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
@@ -4,7 +4,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:tools="http://schemas.android.com/tools"
     android:background="?attr/colorSurface">
 
     <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -113,7 +113,6 @@
         android:id="@+id/option_beta_features"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:visibility="gone"
         app:optionTitle="@string/beta_features"/>
 
     <!--

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -535,7 +535,7 @@
     <string name="product_limited_editing_title">Limited editing available</string>
     <string name="product_limited_editing_message">We\'ve added editing functionality to simple products. Keep an eye out for more options soon!</string>
     <string name="product_wip_title">New editing options available</string>
-    <string name="product_wip_message">We\'ve added more editing functionalities to products. You can now update images, edit product settings &amp; share products!</string>
+    <string name="product_wip_message">You can now edit grouped, external and variable products, change product type and update categories and tags</string>
     <string name="product_bullet" translatable="false"> \u2022 </string>
     <string name="product_variant_list_empty">Add options like size and color from web. These will show up as options on the product page of your site</string>
     <string name="product_description_hint">Start writing…</string>


### PR DESCRIPTION
Fixes #2755 by adding the beta switch back to the settings page and updating the products WIP banner.

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/90855496-69a4cc80-e39d-11ea-8fc3-695d3405b238.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/90855499-6d385380-e39d-11ea-9afb-9ef337c93f48.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/90855515-74f7f800-e39d-11ea-9a7d-33efcbd48c7c.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/90855520-77f2e880-e39d-11ea-93e1-66523bcad7fe.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/90855526-7b866f80-e39d-11ea-976f-34cc37718c47.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/90855523-79bcac00-e39d-11ea-958c-69c0b570f81a.png" width="300"/>

#### Testing
- Go to the Products tab --> the top banner should show the M2 messaging (`We've added more editing functionalities to products! You can now update images, see previews and share your products.`)

##### Feature switch off
- Go to Settings > Beta Features --> make sure the Products feature switch is off by default (before any actions on the switch; you can also delete the app to reset)
- Tap on a simple product --> it should be editable like before
- Tap on a variable product --> it should not be editable
- Tap on a grouped product --> it should not be editable
- Tap on an external product --> it should not be editable

##### Feature switch on
- Go to Settings > Beta Features
- Turn on the feature switch
- Tap on a simple product --> it should be editable like before, and the product settings should show the product reviews switch and virtual switch
- Tap on a variable product --> it should be editable, and the product settings should show the product reviews switch.
- Tap on a grouped product --> it should be editable, and the product settings should show the product reviews switch.
- Tap on an external product --> it should be editable, and the product settings should show the product reviews switch.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
