### PR TITLE
Edit variations: Title

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyEditableView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyEditableView.kt
@@ -20,13 +20,15 @@ class WCProductPropertyEditableView @JvmOverloads constructor(
     // Flag to check if [EditText] already has a [EditText.doAfterTextChanged] defined to avoid multiple callbacks
     private var isTextChangeListenerActive: Boolean = false
 
-    fun show(hint: String, detail: String?, isFocused: Boolean) {
+    fun show(hint: String, detail: String?, isFocused: Boolean, isReadOnly: Boolean) {
         editableText.hint = hint
 
         if (!detail.isNullOrEmpty() && detail != editableText.text.toString()) {
             editableText.setText(detail)
             editableText.setSelection(detail.length)
         }
+
+        editableText.isEnabled = !isReadOnly
 
         if (isFocused) {
             editableText.requestFocus()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/models/ProductProperty.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/models/ProductProperty.kt
@@ -74,6 +74,7 @@ sealed class ProductProperty(val type: Type) {
         @StringRes val hint: Int,
         val text: String = "",
         var shouldFocus: Boolean = false,
+        var isReadOnly: Boolean = false,
         val onTextChanged: ((String) -> Unit)? = null
     ) : ProductProperty(EDITABLE)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
@@ -10,7 +10,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_VARIATION
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_VARIATION_VIEW_PRICE_SETTINGS_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_VARIATION_VIEW_SHIPPING_SETTINGS_TAPPED
 import com.woocommerce.android.extensions.addIfNotEmpty
-import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.filterNotEmpty
 import com.woocommerce.android.extensions.isNotSet
 import com.woocommerce.android.extensions.isSet
@@ -36,7 +35,6 @@ import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.
 import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.ViewPricing
 import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.ViewShipping
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.FeatureFlag.PRODUCT_RELEASE_M3
 import com.woocommerce.android.util.PriceUtils
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -49,9 +47,15 @@ class VariationDetailCardBuilder(
     private val parameters: SiteParameters
 ) {
     private lateinit var originalSku: String
+    private var parentProduct: Product? = null
 
-    fun buildPropertyCards(variation: ProductVariation, originalSku: String): List<ProductPropertyCard> {
+    fun buildPropertyCards(
+        variation: ProductVariation,
+        originalSku: String,
+        parentProduct: Product?
+    ): List<ProductPropertyCard> {
         this.originalSku = originalSku
+        this.parentProduct = parentProduct
 
         val cards = mutableListOf<ProductPropertyCard>()
         cards.addIfNotEmpty(getPrimaryCard(variation))
@@ -84,7 +88,11 @@ class VariationDetailCardBuilder(
     }
 
     private fun ProductVariation.title(): ProductProperty {
-        return ComplexProperty(string.product_name, this.optionName)
+        return Editable(
+            string.product_detail_title_hint,
+            parentProduct?.name ?: optionName,
+            isReadOnly = true
+        )
     }
 
     private fun ProductVariation.description(): ProductProperty {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
@@ -166,6 +166,14 @@ class VariationDetailFragment : BaseFragment(), BackPressListener, NavigationRes
     private fun setupObservers(viewModel: VariationDetailViewModel) {
         viewModel.variationViewStateData.observe(viewLifecycleOwner) { old, new ->
             new.variation.takeIfNotEqualTo(old?.variation) { showVariationDetails(it) }
+            new.parentProduct.takeIfNotEqualTo(old?.parentProduct) { product ->
+                if (variationName.isEmpty()) {
+                    variationName = product?.attributes?.joinToString(
+                        separator = " - ",
+                        transform = { "Any ${it.name}" }
+                    ) ?: ""
+                }
+            }
             new.isSkeletonShown?.takeIfNotEqualTo(old?.isSkeletonShown) { showSkeleton(it) }
             new.isProgressDialogShown?.takeIfNotEqualTo(old?.isProgressDialogShown) { showProgressDialog(it) }
             new.isDoneButtonVisible?.takeIfNotEqualTo(old?.isDoneButtonVisible) { showUpdateMenuItem(it) }
@@ -194,7 +202,10 @@ class VariationDetailFragment : BaseFragment(), BackPressListener, NavigationRes
     }
 
     private fun showVariationDetails(variation: ProductVariation) {
-        variationName = variation.optionName.fastStripHtml()
+        val optionName = variation.optionName.fastStripHtml()
+        if (optionName.isNotBlank()) {
+            variationName = variation.optionName.fastStripHtml()
+        }
 
         if (variation.image == null) {
             variationImage.visibility = View.GONE

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -67,10 +67,6 @@ class VariationDetailViewModel @AssistedInject constructor(
         parameterRepository.getParameters(KEY_VARIATION_PARAMETERS, savedState)
     }
 
-    private val parentProduct: Product? by lazy {
-        productRepository.getProduct(viewState.variation.remoteProductId)
-    }
-
     // view state for the variation detail screen
     val variationViewStateData = LiveDataDelegate(savedState, VariationViewState(originalVariation)) { old, new ->
         if (old?.variation != new.variation) {
@@ -92,6 +88,7 @@ class VariationDetailViewModel @AssistedInject constructor(
     }
 
     init {
+        viewState = viewState.copy(parentProduct = productRepository.getProduct(viewState.variation.remoteProductId))
         showVariation(originalVariation.copy())
     }
 
@@ -263,7 +260,7 @@ class VariationDetailViewModel @AssistedInject constructor(
             _variationDetailCards.value = cardBuilder.buildPropertyCards(
                 variation,
                 originalVariation.sku,
-                parentProduct
+                viewState.parentProduct
             )
             viewState = viewState.copy(isSkeletonShown = false)
         }
@@ -292,7 +289,8 @@ class VariationDetailViewModel @AssistedInject constructor(
         val salePriceWithCurrency: String? = null,
         val regularPriceWithCurrency: String? = null,
         val gmtOffset: Float = 0f,
-        val shippingClass: String? = null
+        val shippingClass: String? = null,
+        val parentProduct: Product? = null
     ) : Parcelable
 
     @AssistedInject.Factory

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -67,6 +67,10 @@ class VariationDetailViewModel @AssistedInject constructor(
         parameterRepository.getParameters(KEY_VARIATION_PARAMETERS, savedState)
     }
 
+    private val parentProduct: Product? by lazy {
+        productRepository.getProduct(viewState.variation.remoteProductId)
+    }
+
     // view state for the variation detail screen
     val variationViewStateData = LiveDataDelegate(savedState, VariationViewState(originalVariation)) { old, new ->
         if (old?.variation != new.variation) {
@@ -256,7 +260,11 @@ class VariationDetailViewModel @AssistedInject constructor(
             if (_variationDetailCards.value == null) {
                 viewState = viewState.copy(isSkeletonShown = true)
             }
-            _variationDetailCards.value = cardBuilder.buildPropertyCards(variation, originalVariation.sku)
+            _variationDetailCards.value = cardBuilder.buildPropertyCards(
+                variation,
+                originalVariation.sku,
+                parentProduct
+            )
             viewState = viewState.copy(isSkeletonShown = false)
         }
     }
@@ -268,9 +276,6 @@ class VariationDetailViewModel @AssistedInject constructor(
         )
     }
 
-    /**
-     * Fetch the shipping class name of a product based on the remote shipping class id
-     */
     fun getShippingClassByRemoteShippingClassId(remoteShippingClassId: Long) =
         productRepository.getProductShippingClassByRemoteId(remoteShippingClassId)?.name
             ?: viewState.variation.shippingClass ?: ""

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListAdapter.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.di.GlideRequests
 import com.woocommerce.android.extensions.appendWithIfNotEmpty
 import com.woocommerce.android.extensions.isSet
+import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.ui.products.OnLoadMoreListener
 import com.woocommerce.android.ui.products.variations.VariationListAdapter.VariationViewHolder
@@ -27,6 +28,7 @@ class VariationListAdapter(
     private val context: Context,
     private val glideRequest: GlideRequests,
     private val loadMoreListener: OnLoadMoreListener,
+    private val parentProduct: Product?,
     private val onItemClick: (variation: ProductVariation) -> Unit
 ) : RecyclerView.Adapter<VariationViewHolder>() {
     private val imageSize = context.resources.getDimensionPixelSize(R.dimen.image_minor_100)
@@ -51,7 +53,11 @@ class VariationListAdapter(
     override fun onBindViewHolder(holder: VariationViewHolder, position: Int) {
         val variation = variationList[position]
 
-        holder.txtVariationOptionName.text = variation.optionName
+        holder.txtVariationOptionName.text = if (variation.optionName.isBlank()) {
+            parentProduct?.attributes?.joinToString(separator = " - ", transform = { "Any ${it.name}" }) ?: ""
+        } else {
+            variation.optionName
+        }
 
         if (variation.isVisible) {
             if (variation.regularPrice.isSet()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.di.GlideApp
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
+import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -129,7 +130,7 @@ class VariationListFragment : BaseFragment(),
         }
 
         viewModel.variationList.observe(viewLifecycleOwner, Observer {
-            showVariations(it)
+            showVariations(it, viewModel.viewStateLiveData.liveData.value?.parentProduct)
         })
 
         viewModel.event.observe(viewLifecycleOwner, Observer { event ->
@@ -168,11 +169,12 @@ class VariationListFragment : BaseFragment(),
         }
     }
 
-    private fun showVariations(variations: List<ProductVariation>) {
+    private fun showVariations(variations: List<ProductVariation>, parentProduct: Product?) {
         val adapter = (variationList.adapter ?: VariationListAdapter(
             requireContext(),
             GlideApp.with(this),
             this,
+            parentProduct,
             viewModel::onItemClick
         )) as VariationListAdapter
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
@@ -11,8 +11,10 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_VARIATION_VIEW_VARIATION_DETAIL_TAPPED
 import com.woocommerce.android.di.ViewModelAssistedFactory
 import com.woocommerce.android.extensions.isNotSet
+import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.ui.products.ProductDetailRepository
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.WooLog
@@ -29,6 +31,7 @@ class VariationListViewModel @AssistedInject constructor(
     @Assisted savedState: SavedStateWithArgs,
     dispatchers: CoroutineDispatchers,
     private val variationListRepository: VariationListRepository,
+    private val productRepository: ProductDetailRepository,
     private val networkStatus: NetworkStatus,
     private val currencyFormatter: CurrencyFormatter
 ) : ScopedViewModel(savedState, dispatchers) {
@@ -41,14 +44,13 @@ class VariationListViewModel @AssistedInject constructor(
         variations
     }
 
-    val viewStateLiveData = LiveDataDelegate(savedState,
-        ViewState()
-    )
+    val viewStateLiveData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateLiveData
 
     private var loadingJob: Job? = null
 
     fun start(remoteProductId: Long) {
+        viewState = viewState.copy(parentProduct = productRepository.getProduct(remoteProductId))
         loadVariations(remoteProductId)
     }
 
@@ -140,7 +142,8 @@ class VariationListViewModel @AssistedInject constructor(
         val isLoadingMore: Boolean? = null,
         val canLoadMore: Boolean? = null,
         val isEmptyViewVisible: Boolean? = null,
-        val isWarningVisible: Boolean? = null
+        val isWarningVisible: Boolean? = null,
+        val parentProduct: Product? = null
     ) : Parcelable
 
     data class ShowVariationDetail(val variation: ProductVariation) : Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/viewholders/EditableViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/viewholders/EditableViewHolder.kt
@@ -18,6 +18,6 @@ class EditableViewHolder(parent: ViewGroup) : ProductPropertyViewHolder(
             editableView.setOnTextChangedListener { text -> onTextChanged(text.toString()) }
         }
 
-        editableView.show(hint, item.text, item.shouldFocus)
+        editableView.show(hint, item.text, item.shouldFocus, item.isReadOnly)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/VariationListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/VariationListViewModelTest.kt
@@ -30,6 +30,7 @@ class VariationListViewModelTest : BaseUnitTest() {
     private val networkStatus: NetworkStatus = mock()
     private val variationListRepository: VariationListRepository = mock()
     private val currencyFormatter: CurrencyFormatter = mock()
+    private val productRepository: ProductDetailRepository = mock()
 
     private val productRemoteId = 1L
     private lateinit var viewModel: VariationListViewModel
@@ -50,6 +51,7 @@ class VariationListViewModelTest : BaseUnitTest() {
                 savedState,
                 coroutineDispatchers,
                 variationListRepository,
+                productRepository,
                 networkStatus,
                 currencyFormatter
             )


### PR DESCRIPTION
This PR makes some UI updates to the way variation titles are handled according to the designs. In variation details, the same title is shown as for the parent product.

In variation list, if there is no option selected, the "Any <attribute>" title is shown.

| List | Detail |
|-|-|
| ![image](https://user-images.githubusercontent.com/1522856/90895191-0da06f00-e3c2-11ea-9b77-01d9cdf8d9ae.png) | ![image](https://user-images.githubusercontent.com/1522856/90895228-1c872180-e3c2-11ea-8643-3780f446e969.png) |

**To test:**
1. Prepare a variable product that contains variations both with selected attribute options and without them
2. In the app, go to Products -> Open a variable product -> Tap on Variations
3. Verify that the variations with a selected options show its name
4. Verify that the variations without any options show the "Any <attribute>" title
5. Tap on any variation item
6. Verify that the same title is shown as the product's name
7. Notice that the variation title field is read-only (on prupose)