### PR TITLE
Product details: Image Update 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -212,7 +212,7 @@ class ProductDetailViewModel @AssistedInject constructor(
         return if (ProductImagesService.isUploadingForProduct(getRemoteProductId())) {
             true
         } else {
-            viewState.storedProduct?.hasImageChanges(viewState.productDraft) ?: false
+            viewState.productBeforeEnteringFragment?.hasImageChanges(viewState.productDraft) ?: false
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -38,6 +38,7 @@ class ProductImagesFragment : BaseProductFragment(), OnGalleryImageClickListener
 
     private var imageSourceDialog: AlertDialog? = null
     private var capturedPhotoUri: Uri? = null
+    private var doneButton: MenuItem? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         setHasOptionsMenu(true)
@@ -60,7 +61,9 @@ class ProductImagesFragment : BaseProductFragment(), OnGalleryImageClickListener
 
     override fun onPrepareOptionsMenu(menu: Menu) {
         super.onPrepareOptionsMenu(menu)
-        menu.findItem(R.id.menu_done)?.isVisible = viewModel.hasImageChanges()
+        doneButton = menu.findItem(R.id.menu_done)
+
+        refreshDonButtonVisibility()
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -96,6 +99,10 @@ class ProductImagesFragment : BaseProductFragment(), OnGalleryImageClickListener
         }
     }
 
+    private fun refreshDonButtonVisibility() {
+        doneButton?.isVisible = viewModel.hasImageChanges()
+    }
+
     private fun setupObservers(viewModel: ProductDetailViewModel) {
         viewModel.event.observe(viewLifecycleOwner, Observer { event ->
             when (event) {
@@ -108,6 +115,8 @@ class ProductImagesFragment : BaseProductFragment(), OnGalleryImageClickListener
             new.isUploadingImages.takeIfNotEqualTo(old?.isUploadingImages) {
                 reloadImageGallery()
                 imageGallery.setPlaceholderImageUris(viewModel.getProduct().uploadingImageUris)
+
+                refreshDonButtonVisibility()
             }
         }
     }


### PR DESCRIPTION
Fixes #2681. This PR fixes a bug when a Done button wasn't shown after a new image was added to the product image gallery.

**To test:**
1. Go to Products -> Product detail
2. Tap on "Add new image" button
3. Tap on Add photos button
4. Select any image source type
5. Select an image
6. As soon as the upload starts, notice that the Done button appears
7. Tap on Done
8. Notice the new image is show in the Product detail screen