### PR TITLE
Issue/2630 search grouped products

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -311,6 +311,8 @@ class AnalyticsTracker private constructor(private val context: Context) {
         // -- Grouped products
         GROUPED_PRODUCT_LINKED_PRODUCTS_DELETE_TAPPED,
         GROUPED_PRODUCT_LINKED_PRODUCTS_DONE_BUTTON_TAPPED,
+        GROUPED_PRODUCT_LINKED_PRODUCTS_ADD_TAPPED,
+        GROUPED_PRODUCT_LINKED_PRODUCTS_ADDED,
 
         // -- Product external link
         PRODUCT_DETAIL_VIEW_EXTERNAL_PRODUCT_LINK_TAPPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModel.kt
@@ -62,6 +62,7 @@ class GroupedProductListViewModel @AssistedInject constructor(
         productListViewState = productListViewState.copy(
             selectedGroupedProductIds = selectedGroupedProductIds + selectedProductIds
         )
+        AnalyticsTracker.track(Stat.GROUPED_PRODUCT_LINKED_PRODUCTS_ADDED)
         updateGroupedProductList()
     }
 
@@ -69,6 +70,7 @@ class GroupedProductListViewModel @AssistedInject constructor(
         productListViewState = productListViewState.copy(
             selectedGroupedProductIds = selectedGroupedProductIds - product.remoteId
         )
+        AnalyticsTracker.track(Stat.GROUPED_PRODUCT_LINKED_PRODUCTS_DELETE_TAPPED)
         updateGroupedProductList()
     }
 
@@ -78,6 +80,7 @@ class GroupedProductListViewModel @AssistedInject constructor(
     }
 
     fun onAddProductButtonClicked() {
+        AnalyticsTracker.track(Stat.GROUPED_PRODUCT_LINKED_PRODUCTS_ADD_TAPPED)
         triggerEvent(ViewProductSelectionList(navArgs.remoteProductId))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModel.kt
@@ -59,8 +59,10 @@ class GroupedProductListViewModel @AssistedInject constructor(
     }
 
     fun onGroupedProductsAdded(selectedProductIds: List<Long>) {
+        // ignore already added products
+        val uniqueSelectedProductIds = selectedProductIds.minus(selectedGroupedProductIds)
         productListViewState = productListViewState.copy(
-            selectedGroupedProductIds = selectedGroupedProductIds + selectedProductIds
+            selectedGroupedProductIds = selectedGroupedProductIds + uniqueSelectedProductIds
         )
         AnalyticsTracker.track(Stat.GROUPED_PRODUCT_LINKED_PRODUCTS_ADDED)
         updateGroupedProductList()


### PR DESCRIPTION
Fixes part 2/2 of #2630 by adding the search functionality in this PR when adding a grouped product.

#### Changes
- Fixed a bug as mentioned in #2774 by ensuring that an already added product is not added again.
- Added search functionality to the `ProductSelectionListViewModel`.
- Added missing analytic events: `GROUPED_PRODUCT_LINKED_PRODUCTS_ADD_TAPPED` (when the "Add product" button is clicked)  and `GROUPED_PRODUCT_LINKED_PRODUCTS_ADDED ` (when a product is selected from the list).

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/91140526-4a73ab00-e6cd-11ea-89f7-2d56159520b8.gif" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/91140551-4c3d6e80-e6cd-11ea-8315-084e047df5c4.gif" width="300"/>

#### Testing
- Click on a grouped product -> `Grouped products` section -> `Add product`.
  - Click on the search icon and enter a valid product.
    - Verify that the product is displayed. 
    - **Long press** on the product and click on the `Done` menu button and verify the product is added successfully.
  - Click on the search icon and enter an invalid product.
    - Verify that the empty view is displayed correctly.
- Click on a grouped product -> `Grouped products` section -> `Add product`.
  - **Long press** on an already selected product and click on the "Done" menu button.
  - Verify that the already added product is not displayed in the grouped product list and that the "Done" menu button is NOT displayed.
  
~**This PR is in draft till this [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1675) and this [Woo PR](https://github.com/woocommerce/woocommerce-android/pull/2774) can be reviewed and merged.**~


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
