### PR TITLE
Added card and bottom builders logic to handle a new product

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -239,7 +239,7 @@ object AppPrefs {
 
     fun setSelectedProductType(type: ProductType) = setString(DeletablePrefKey.SELECTED_PRODUCT_TYPE, type.value)
 
-    fun getSelectedProductType(): String = getString(DeletablePrefKey.SELECTED_PRODUCT_TYPE, "")
+    fun getSelectedProductType(): String = getString(DeletablePrefKey.SELECTED_PRODUCT_TYPE, "SIMPLE")
 
     /**
      * Checks if the user has a saved order list tab position yet. If no position has been saved,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -149,6 +149,7 @@ data class Product(
                 length > 0 || width > 0 || height > 0 ||
                 shippingClass.isNotEmpty()
         }
+    val hasInventory get() = sku.isNotEmpty() || stockStatus != ProductStockStatus.InStock
 
     /**
      * Verifies if there are any changes made to the inventory fields

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductAddDetailBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductAddDetailBottomSheetBuilder.kt
@@ -30,11 +30,8 @@ constructor(resources: ResourceProvider) : ProductDetailBottomSheetBuilder(resou
                     stockStatus = stockStatus,
                     stockQuantity = stockQuantity,
                     backorderStatus = backorderStatus
-                )
-                , sku
-            )
-            ,
-            Stat.PRODUCT_DETAIL_VIEW_INVENTORY_SETTINGS_TAPPED
+                ), sku
+            ), Stat.PRODUCT_DETAIL_VIEW_INVENTORY_SETTINGS_TAPPED
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductAddDetailBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductAddDetailBottomSheetBuilder.kt
@@ -1,0 +1,40 @@
+package com.woocommerce.android.ui.products
+
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.model.Product
+import com.woocommerce.android.ui.products.ProductInventoryViewModel.InventoryData
+import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductInventory
+import com.woocommerce.android.viewmodel.ResourceProvider
+
+class ProductAddDetailBottomSheetBuilder
+constructor(resources: ResourceProvider) : ProductDetailBottomSheetBuilder(resources) {
+    override fun getSimpleProductList(product: Product): List<ProductDetailBottomSheetUiItem> {
+        return listOfNotNull(
+            product.getInventory(),
+            product.getShipping(),
+            product.getCategories(),
+            product.getTags(),
+            product.getShortDescription()
+        )
+    }
+
+    private fun Product.getInventory(): ProductDetailBottomSheetUiItem? {
+        if (hasInventory) return null
+        return ProductDetailBottomSheetUiItem(
+            ProductDetailBottomSheetType.PRODUCT_INVENTORY,
+            ViewProductInventory(
+                InventoryData(
+                    sku = sku,
+                    isStockManaged = isStockManaged,
+                    isSoldIndividually = isSoldIndividually,
+                    stockStatus = stockStatus,
+                    stockQuantity = stockQuantity,
+                    backorderStatus = backorderStatus
+                )
+                , sku
+            )
+            ,
+            Stat.PRODUCT_DETAIL_VIEW_INVENTORY_SETTINGS_TAPPED
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductAddDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductAddDetailCardBuilder.kt
@@ -1,0 +1,23 @@
+package com.woocommerce.android.ui.products
+
+import com.woocommerce.android.R
+import com.woocommerce.android.model.Product
+import com.woocommerce.android.ui.products.models.ProductProperty
+import com.woocommerce.android.ui.products.models.SiteParameters
+import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.viewmodel.ResourceProvider
+
+class ProductAddDetailCardBuilder(
+    viewModel: ProductDetailViewModel,
+    resources: ResourceProvider,
+    currencyFormatter: CurrencyFormatter,
+    parameters: SiteParameters
+) : ProductDetailCardBuilder(viewModel, resources, currencyFormatter, parameters) {
+    override fun getProductTitlePlaceholder(): Int =
+        R.string.product_add_card_placeholder_title
+
+    override fun getProductInventory(product: Product): ProductProperty? {
+        if (product.sku.isEmpty()) return null
+        return super.getProductInventory(product)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
@@ -4,7 +4,9 @@ import androidx.annotation.StringRes
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.ui.products.ProductInventoryViewModel.InventoryData
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductCategories
+import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductInventory
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductShipping
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductShortDescriptionEditor
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductTags
@@ -16,7 +18,7 @@ import com.woocommerce.android.ui.products.ProductType.VARIABLE
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.ResourceProvider
 
-class ProductDetailBottomSheetBuilder(
+open class ProductDetailBottomSheetBuilder(
     private val resources: ResourceProvider
 ) {
     enum class ProductDetailBottomSheetType(
@@ -26,7 +28,8 @@ class ProductDetailBottomSheetBuilder(
         PRODUCT_SHIPPING(string.product_shipping, string.bottom_sheet_shipping_desc),
         PRODUCT_CATEGORIES(string.product_categories, string.bottom_sheet_categories_desc),
         PRODUCT_TAGS(string.product_tags, string.bottom_sheet_tags_desc),
-        SHORT_DESCRIPTION(string.product_short_description, string.bottom_sheet_short_description_desc)
+        SHORT_DESCRIPTION(string.product_short_description, string.bottom_sheet_short_description_desc),
+        PRODUCT_INVENTORY(string.product_inventory, string.bottom_sheet_inventory_desc)
     }
 
     data class ProductDetailBottomSheetUiItem(
@@ -38,12 +41,7 @@ class ProductDetailBottomSheetBuilder(
     fun buildBottomSheetList(product: Product): List<ProductDetailBottomSheetUiItem> {
         return when (product.type) {
             SIMPLE -> {
-                listOfNotNull(
-                    product.getShipping(),
-                    product.getCategories(),
-                    product.getTags(),
-                    product.getShortDescription()
-                )
+                getSimpleProductList(product)
             }
             EXTERNAL -> {
                 listOfNotNull(
@@ -71,7 +69,16 @@ class ProductDetailBottomSheetBuilder(
         }
     }
 
-    private fun Product.getShipping(): ProductDetailBottomSheetUiItem? {
+    open fun getSimpleProductList(product: Product): List<ProductDetailBottomSheetUiItem> {
+        return listOfNotNull(
+            product.getShipping(),
+            product.getCategories(),
+            product.getTags(),
+            product.getShortDescription()
+        )
+    }
+
+    protected fun Product.getShipping(): ProductDetailBottomSheetUiItem? {
         return if (!isVirtual && !hasShipping) {
             ProductDetailBottomSheetUiItem(
                 ProductDetailBottomSheetType.PRODUCT_SHIPPING,
@@ -92,7 +99,7 @@ class ProductDetailBottomSheetBuilder(
         }
     }
 
-    private fun Product.getCategories(): ProductDetailBottomSheetUiItem? {
+    protected fun Product.getCategories(): ProductDetailBottomSheetUiItem? {
         return if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled() && !hasCategories) {
             ProductDetailBottomSheetUiItem(
                 ProductDetailBottomSheetType.PRODUCT_CATEGORIES,
@@ -104,7 +111,7 @@ class ProductDetailBottomSheetBuilder(
         }
     }
 
-    private fun Product.getTags(): ProductDetailBottomSheetUiItem? {
+    protected fun Product.getTags(): ProductDetailBottomSheetUiItem? {
         return if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled() && !hasTags) {
             ProductDetailBottomSheetUiItem(
                 ProductDetailBottomSheetType.PRODUCT_TAGS,
@@ -115,7 +122,7 @@ class ProductDetailBottomSheetBuilder(
         }
     }
 
-    private fun Product.getShortDescription(): ProductDetailBottomSheetUiItem? {
+    protected fun Product.getShortDescription(): ProductDetailBottomSheetUiItem? {
         return if (!hasShortDescription) {
             ProductDetailBottomSheetUiItem(
                 ProductDetailBottomSheetType.SHORT_DESCRIPTION,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
@@ -4,9 +4,7 @@ import androidx.annotation.StringRes
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.model.Product
-import com.woocommerce.android.ui.products.ProductInventoryViewModel.InventoryData
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductCategories
-import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductInventory
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductShipping
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductShortDescriptionEditor
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductTags

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -249,16 +249,13 @@ open class ProductDetailCardBuilder(
         return when {
             this.isStockManaged -> {
                 val group = mapOf(
-                    Pair(
-                        resources.getString(R.string.product_stock_status),
+                    Pair(resources.getString(R.string.product_stock_status),
                         ProductStockStatus.stockStatusToDisplayString(resources, this.stockStatus)
                     ),
-                    Pair(
-                        resources.getString(R.string.product_backorders),
+                    Pair(resources.getString(R.string.product_backorders),
                         ProductBackorderStatus.backordersToDisplayString(resources, this.backorderStatus)
                     ),
-                    Pair(
-                        resources.getString(R.string.product_stock_quantity),
+                    Pair(resources.getString(R.string.product_stock_quantity),
                         StringUtils.formatCount(this.stockQuantity)
                     ),
                     Pair(resources.getString(R.string.product_sku), this.sku)
@@ -340,12 +337,10 @@ open class ProductDetailCardBuilder(
                     Pair(resources.getString(R.string.product_sku), product.sku)
                 )
             product.isStockManaged -> mapOf(
-                Pair(
-                    resources.getString(R.string.product_backorders),
+                Pair(resources.getString(R.string.product_backorders),
                     ProductBackorderStatus.backordersToDisplayString(resources, product.backorderStatus)
                 ),
-                Pair(
-                    resources.getString(R.string.product_stock_quantity),
+                Pair(resources.getString(R.string.product_stock_quantity),
                     FormatUtils.formatInt(product.stockQuantity)
                 ),
                 Pair(resources.getString(R.string.product_sku), product.sku)
@@ -392,8 +387,7 @@ open class ProductDetailCardBuilder(
             val shippingGroup = mapOf(
                 Pair(resources.getString(R.string.product_weight), weightWithUnits),
                 Pair(resources.getString(R.string.product_dimensions), sizeWithUnits),
-                Pair(
-                    resources.getString(R.string.product_shipping_class),
+                Pair(resources.getString(R.string.product_shipping_class),
                     viewModel.getShippingClassByRemoteShippingClassId(this.shippingClassId)
                 )
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -463,17 +463,15 @@ open class ProductDetailCardBuilder(
             showTitle = this.regularPrice.isSet()
         ) {
             viewModel.onEditProductCardClicked(
-                ViewProductPricing(
-                    PricingData(
-                        taxClass,
-                        taxStatus,
-                        isSaleScheduled,
-                        saleStartDateGmt,
-                        saleEndDateGmt,
-                        regularPrice,
-                        salePrice
-                    )
-                ),
+                ViewProductPricing(PricingData(
+                    taxClass,
+                    taxStatus,
+                    isSaleScheduled,
+                    saleStartDateGmt,
+                    saleEndDateGmt,
+                    regularPrice,
+                    salePrice
+                )),
                 Stat.PRODUCT_DETAIL_VIEW_PRICE_SETTINGS_TAPPED
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -156,7 +156,7 @@ class ProductDetailViewModel @AssistedInject constructor(
     val productDetailBottomSheetList: LiveData<List<ProductDetailBottomSheetUiItem>> = _productDetailBottomSheetList
 
     private val productDetailBottomSheetBuilder by lazy {
-         when (navArgs.isAddProduct) {
+        when (navArgs.isAddProduct) {
             true -> ProductAddDetailBottomSheetBuilder(resources)
             else -> ProductDetailBottomSheetBuilder(resources)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -146,14 +146,20 @@ class ProductDetailViewModel @AssistedInject constructor(
     val productDetailCards: LiveData<List<ProductPropertyCard>> = _productDetailCards
 
     private val cardBuilder by lazy {
-        ProductDetailCardBuilder(this, resources, currencyFormatter, parameters)
+        when (navArgs.isAddProduct) {
+            true -> ProductAddDetailCardBuilder(this, resources, currencyFormatter, parameters)
+            else -> ProductDetailCardBuilder(this, resources, currencyFormatter, parameters)
+        }
     }
 
     private val _productDetailBottomSheetList = MutableLiveData<List<ProductDetailBottomSheetUiItem>>()
     val productDetailBottomSheetList: LiveData<List<ProductDetailBottomSheetUiItem>> = _productDetailBottomSheetList
 
     private val productDetailBottomSheetBuilder by lazy {
-        ProductDetailBottomSheetBuilder(resources)
+         when (navArgs.isAddProduct) {
+            true -> ProductAddDetailBottomSheetBuilder(resources)
+            else -> ProductDetailBottomSheetBuilder(resources)
+        }
     }
 
     init {
@@ -547,7 +553,6 @@ class ProductDetailViewModel @AssistedInject constructor(
             }
         }
     }
-
     fun onProductDetailBottomSheetItemSelected(uiItem: ProductDetailBottomSheetUiItem) {
         onEditProductCardClicked(uiItem.clickEvent, uiItem.stat)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -101,11 +101,11 @@ class ProductNavigator @Inject constructor() {
 
             is ViewProductInventory -> {
                 val action = ProductDetailFragmentDirections
-                        .actionProductDetailFragmentToProductInventoryFragment(
-                            RequestCodes.PRODUCT_DETAIL_INVENTORY,
-                            target.inventoryData,
-                            target.sku
-                        )
+                    .actionGlobalProductInventoryFragment(
+                        RequestCodes.PRODUCT_DETAIL_INVENTORY,
+                        target.inventoryData,
+                        target.sku
+                    )
                 fragment.findNavController().navigateSafely(action)
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
@@ -114,7 +114,7 @@ class ProductTypesBottomSheetFragment : BottomSheetDialogFragment(), HasAndroidI
 
     private fun getProductTypeListBuilder(): ProductTypeBottomSheetBuilder {
         return when (navArgs.isAddProduct) {
-            true -> ProductAddTypeBottomSheetBuilder()
+            true -> StartProductAddTypeBottomSheetBuilder()
             else -> ProductDetailTypeBottomSheetBuilder()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/StartProductAddTypeBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/StartProductAddTypeBottomSheetBuilder.kt
@@ -9,7 +9,7 @@ import com.woocommerce.android.ui.products.ProductType.SIMPLE
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
 import com.woocommerce.android.ui.products.ProductTypesBottomSheetViewModel.ProductTypesBottomSheetUiItem
 
-class ProductAddTypeBottomSheetBuilder : ProductTypeBottomSheetBuilder {
+class StartProductAddTypeBottomSheetBuilder : ProductTypeBottomSheetBuilder {
     override fun buildBottomSheetList(): List<ProductTypesBottomSheetUiItem> {
         return listOf(
             ProductTypesBottomSheetUiItem(

--- a/WooCommerce/src/main/res/navigation/nav_graph_products.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_products.xml
@@ -32,11 +32,6 @@
                 app:argType="long" />
         </action>
         <action
-            android:id="@+id/action_productDetailFragment_to_productInventoryFragment"
-            app:destination="@id/productInventoryFragment"
-            app:enterAnim="@anim/activity_fade_in"
-            app:popExitAnim="@anim/activity_fade_out" />
-        <action
             android:id="@+id/action_productDetailFragment_to_productPricingFragment"
             app:destination="@id/productPricingFragment"
             app:enterAnim="@anim/activity_fade_in"
@@ -286,6 +281,11 @@
     <action
         android:id="@+id/action_global_productCategoriesFragment"
         app:destination="@id/productCategoriesFragment"
+        app:enterAnim="@anim/activity_scale_in"
+        app:popExitAnim="@anim/activity_scale_out" />
+    <action
+        android:id="@+id/action_global_productInventoryFragment"
+        app:destination="@id/productInventoryFragment"
         app:enterAnim="@anim/activity_scale_in"
         app:popExitAnim="@anim/activity_scale_out" />
     <action

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -620,6 +620,7 @@
     <string name="bottom_sheet_categories_desc">Organise your products into related groups</string>
     <string name="bottom_sheet_tags_desc">Make your products easier to find with tags</string>
     <string name="bottom_sheet_short_description_desc">A brief excerpt about your product</string>
+    <string name="bottom_sheet_inventory_desc">Update product inventory and SKU</string>
 
     <!--
         Variations
@@ -934,6 +935,9 @@
     <string name="product_add_type_variable_desc">A product with variations like color or size</string>
     <string name="product_add_type_grouped_desc">@string/product_type_grouped_desc</string>
     <string name="product_add_type_external_desc">@string/product_type_external_desc</string>
+
+    <!-- New Product cards-->
+    <string name="product_add_card_placeholder_title">Enter title</string>
 
     <!-- New Product screen -->
     <string name="product_add_tool_bar_title">New Product</string>


### PR DESCRIPTION
## RESOURCES
[The Figma file](https://www.figma.com/file/QAkdm5HZdLlG0b8vUkv1pX/Products---Add-%26-Edit-Products?node-id=460%3A1760&viewport=-1704%2C1577%2C0.5334523320198059) and [the initial issue](https://github.com/woocommerce/woocommerce-android/issues/2707)

## CHANGES / DESCRIPTION

This PR will contain the following:
- **add** product card default list logic
- **add** product bottom details list logic
- the way the cards list and the bottom list are in sync

In this PR I added the logic to match the Figma designs regarding the **cards** and the the **bottom** list details.

Taking the cards part, I opened and extended `ProductDetailCardBuilder` to a new `ProductAddDetailCardBuilder` that will simply get the correct details presented if in the **add** path - this is done at the lazy initialisation level of the `ViewModel`
```
private val cardBuilder by lazy {
    when (navArgs.isAddProduct) {
      true -> ProductAddDetailCardBuilder(this, resources, currencyFormatter, parameters)
      else -> ProductDetailCardBuilder(this, resources, currencyFormatter, parameters)
    }
}
```

For the bottom details part, I extended `ProductDetailBottomSheetBuilder` into a new`ProductAddDetailBottomSheetBuilder` that also follows a similar check as the above cards, in the `ViewModel`. 
```
private val productDetailBottomSheetBuilder by lazy {
    when (navArgs.isAddProduct) {
      true -> ProductAddDetailBottomSheetBuilder(resources)
      else -> ProductDetailBottomSheetBuilder(resources)
    }
}
```

This way, for both steps, the **add** flow UI will present properly 👌 

I also made the `InventoryFragment` to become a `global action` so it could be presented from the bottom sheet options.

**NOTE**
I was looking to add some tests on the view models, to validate the presented cards but I stumbled upon an issue with the `AppPrefs` usage. I couldn't mock it properly during the `setup` of the tests, causing the run to crash. I reverted my changes for now, but this is something I would like to add soon, to make sure the **add** path presents the correct details.


As always, let me know your thoughts on it 🙏 

## TESTING
- Click on the PRODUCT bottom nav bar button
    - Wait for the screen to finish loading
    - Click on the FAB button
    - Notice the product detail for a new product flow with: title, description, price and product type options
    - Click the "Add more details"
    - Notice the inventory, shipping, categories, tags and short description options
- Scenario 1:
    - Click "Inventory"
    - Notice the inventory screen showing
    - Fill in the details and press done
    - Notice the card added in the list and removed from the "Add more details"
- Scenario 2:
    - Click "Shipping"
    - Notice the shipping screen showing
    - Fill in the details and press done
    - Notice the card added in the list and removed from the "Add more details"
- Scenario 3:
    - Click "Categories"
    - Notice the categories screen showing
    - Fill in the details and press done
    - Notice the card added in the list and removed from the "Add more details"
- Scenario 4:
    - Click "Tags"
    - Notice the tags screen showing
    - Fill in the details and press done
    - Notice the card added in the list and removed from the "Add more details"
- Scenario 5:
    - Click "Short description"
    - Notice the description screen showing
    - Fill in the details and press done
    - Notice the card added in the list and removed from the "Add more details"

## SCREENSHOTS

<image src="https://user-images.githubusercontent.com/7058393/91369867-c1f82600-e804-11ea-9cab-2cd1f33fc1fb.gif" width="320"/><image src="https://user-images.githubusercontent.com/7058393/91369878-c7557080-e804-11ea-9636-0010587eca17.gif" width="320"/><image src="https://user-images.githubusercontent.com/7058393/91369879-c8869d80-e804-11ea-9556-9d33710d93ce.gif" width="320"/><image src="https://user-images.githubusercontent.com/7058393/91369880-c91f3400-e804-11ea-9e2c-77a7656c0171.gif" width="320"/><image src="https://user-images.githubusercontent.com/7058393/91369881-c9b7ca80-e804-11ea-8c2f-baa894463e81.gif" width="320"/>



