### PR TITLE
Added fix to update the product title only if there are any changes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.di.ViewModelAssistedFactory
 import com.woocommerce.android.extensions.addNewItem
 import com.woocommerce.android.extensions.clearList
 import com.woocommerce.android.extensions.containsItem
+import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.getList
 import com.woocommerce.android.extensions.isEmpty
 import com.woocommerce.android.extensions.removeItem
@@ -404,7 +405,9 @@ class ProductDetailViewModel @AssistedInject constructor(
     }
 
     fun onProductTitleChanged(title: String) {
-        updateProductDraft(title = title)
+        if (title != viewState.productDraft?.name?.fastStripHtml()) {
+            updateProductDraft(title = title)
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #2777. The app was crashing when adding an `&` symbol to the product title and updating the product. 

This was because the title was updated as `test &` to the API but the API response received was `test &amp;`. Since we added `TextWatcher` to the product title EditText and the EditText was displaying `test &` and trying to update the title to `test &amp;` at the same time. 

This PR adds logic to ensure that the title displayed is not equal to the `productDraft?.name` before actually updating the product.

#### To test
- Click on a product from the Products TAB.
- Add `&` to the product title and click on Update.
- Click on the back icon.
- Click on the same product from Step 1.
- Notice the app does not crash anymore.

cc @loremattei and @oguzkocer this fix would require a new beta to be released since this is causing a crash in the 4.9 beta release. Thank you 🙇‍♀️!!  

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
