### PR TITLE
Issue/2781 incorrect product type fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -479,7 +479,7 @@ class ProductDetailCardBuilder(
                 R.drawable.ic_gridicons_product
             ) {
                 viewModel.onEditProductCardClicked(
-                    ViewProductTypes(this.remoteId),
+                    ViewProductTypes(this.type),
                     Stat.PRODUCT_DETAIL_VIEW_PRODUCT_TYPE_TAPPED
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -30,7 +30,6 @@ import com.woocommerce.android.ui.products.ProductInventoryViewModel.InventoryDa
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductDetailBottomSheet
 import com.woocommerce.android.ui.products.ProductPricingViewModel.PricingData
 import com.woocommerce.android.ui.products.ProductShippingViewModel.ShippingData
-import com.woocommerce.android.ui.products.ProductTypesBottomSheetViewModel.ProductTypesBottomSheetUiItem
 import com.woocommerce.android.ui.products.adapters.ProductPropertyCardsAdapter
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
 import com.woocommerce.android.ui.wpmediapicker.WPMediaPickerFragment
@@ -99,8 +98,8 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
     }
 
     private fun setupResultHandlers(viewModel: ProductDetailViewModel) {
-        handleResult<ProductTypesBottomSheetUiItem>(ProductTypesBottomSheetFragment.KEY_PRODUCT_TYPE_RESULT) {
-            viewModel.updateProductDraft(type = it.type, isVirtual = it.isVirtual)
+        handleResult<ProductType>(ProductTypesBottomSheetFragment.KEY_PRODUCT_TYPE_RESULT) {
+            viewModel.updateProductDraft(type = it)
             changesMade()
         }
         handleResult<List<Long>>(GroupedProductListFragment.KEY_GROUPED_PRODUCT_IDS_RESULT) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
@@ -50,7 +50,7 @@ sealed class ProductNavigationTarget : Event() {
     object AddProductCategory : ProductNavigationTarget()
     data class ViewProductTags(val remoteId: Long) : ProductNavigationTarget()
     data class ViewProductDetailBottomSheet(val remoteId: Long) : ProductNavigationTarget()
-    data class ViewProductTypes(val remoteId: Long) : ProductNavigationTarget()
+    data class ViewProductTypes(val productType: ProductType) : ProductNavigationTarget()
     data class ViewProductReviews(val remoteId: Long) : ProductNavigationTarget()
     data class ViewGroupedProducts(val groupedProductIds: String) : ProductNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -205,7 +205,7 @@ class ProductNavigator @Inject constructor() {
 
             is ViewProductTypes -> {
                 val action = ProductDetailFragmentDirections
-                    .actionProductDetailFragmentToProductTypesBottomSheetFragment(target.remoteId)
+                    .actionProductDetailFragmentToProductTypesBottomSheetFragment(target.productType)
                 fragment.findNavController().navigateSafely(action)
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
@@ -43,7 +43,7 @@ class ProductTypesBottomSheetViewModel @AssistedInject constructor(
             positiveButtonId = R.string.product_type_confirm_button,
             negativeButtonId = R.string.cancel,
             positiveBtnAction = DialogInterface.OnClickListener { _, _ ->
-                triggerEvent(ExitWithResult(productTypeUiItem))
+                triggerEvent(ExitWithResult(productTypeUiItem.type))
             }
         ))
     }
@@ -66,7 +66,6 @@ class ProductTypesBottomSheetViewModel @AssistedInject constructor(
     @Parcelize
     data class ProductTypesBottomSheetUiItem(
         val type: ProductType,
-        val isVirtual: Boolean = false,
         @StringRes val titleResource: Int,
         @StringRes val descResource: Int,
         @DrawableRes val iconResource: Int
@@ -81,7 +80,6 @@ class ProductTypesBottomSheetViewModel @AssistedInject constructor(
 
     fun ProductType.getVariableProductType() = ProductTypesBottomSheetUiItem(
         type = VARIABLE,
-        isVirtual = true,
         titleResource = R.string.product_type_variable,
         descResource = R.string.product_type_variation_desc,
         iconResource = R.drawable.ic_gridicons_types

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
@@ -27,6 +27,8 @@ class ProductTypesBottomSheetViewModel @AssistedInject constructor(
     @Assisted savedState: SavedStateWithArgs,
     dispatchers: CoroutineDispatchers
 ) : ScopedViewModel(savedState, dispatchers) {
+    private val navArgs: ProductTypesBottomSheetFragmentArgs by savedState.navArgs()
+
     private val _productTypesBottomSheetList = MutableLiveData<List<ProductTypesBottomSheetUiItem>>()
     val productTypesBottomSheetList: LiveData<List<ProductTypesBottomSheetUiItem>> = _productTypesBottomSheetList
 
@@ -47,33 +49,18 @@ class ProductTypesBottomSheetViewModel @AssistedInject constructor(
     }
 
     private fun buildProductTypeList(): List<ProductTypesBottomSheetUiItem> {
-        return listOf(
-            ProductTypesBottomSheetUiItem(
-                type = SIMPLE,
-                titleResource = R.string.product_type_physical,
-                descResource = R.string.product_type_physical_desc,
-                iconResource = R.drawable.ic_gridicons_product
-            ),
-            ProductTypesBottomSheetUiItem(
-                type = VARIABLE,
-                isVirtual = true,
-                titleResource = R.string.product_type_variable,
-                descResource = R.string.product_type_variation_desc,
-                iconResource = R.drawable.ic_gridicons_types
-            ),
-            ProductTypesBottomSheetUiItem(
-                type = GROUPED,
-                titleResource = R.string.product_type_grouped,
-                descResource = R.string.product_type_grouped_desc,
-                iconResource = R.drawable.ic_widgets
-            ),
-            ProductTypesBottomSheetUiItem(
-                type = EXTERNAL,
-                titleResource = R.string.product_type_external,
-                descResource = R.string.product_type_external_desc,
-                iconResource = R.drawable.ic_gridicons_up_right
-            )
-        )
+        val productTypesList = mutableListOf<ProductTypesBottomSheetUiItem>()
+        ProductType.values().forEach {
+            if (it != navArgs.productType) {
+                when (it) {
+                    SIMPLE -> productTypesList.add(it.getSimpleProductType())
+                    VARIABLE -> productTypesList.add(it.getVariableProductType())
+                    GROUPED -> productTypesList.add(it.getGroupedProductType())
+                    EXTERNAL -> productTypesList.add(it.getExternalProductType())
+                }
+            }
+        }
+        return productTypesList
     }
 
     @Parcelize
@@ -84,6 +71,35 @@ class ProductTypesBottomSheetViewModel @AssistedInject constructor(
         @StringRes val descResource: Int,
         @DrawableRes val iconResource: Int
     ) : Parcelable
+
+    fun ProductType.getSimpleProductType() = ProductTypesBottomSheetUiItem(
+        type = SIMPLE,
+        titleResource = R.string.product_type_physical,
+        descResource = R.string.product_type_physical_desc,
+        iconResource = R.drawable.ic_gridicons_product
+    )
+
+    fun ProductType.getVariableProductType() = ProductTypesBottomSheetUiItem(
+        type = VARIABLE,
+        isVirtual = true,
+        titleResource = R.string.product_type_variable,
+        descResource = R.string.product_type_variation_desc,
+        iconResource = R.drawable.ic_gridicons_types
+    )
+
+    fun ProductType.getGroupedProductType() = ProductTypesBottomSheetUiItem(
+        type = GROUPED,
+        titleResource = R.string.product_type_grouped,
+        descResource = R.string.product_type_grouped_desc,
+        iconResource = R.drawable.ic_widgets
+    )
+
+    fun ProductType.getExternalProductType() = ProductTypesBottomSheetUiItem(
+        type = EXTERNAL,
+        titleResource = R.string.product_type_external,
+        descResource = R.string.product_type_external_desc,
+        iconResource = R.drawable.ic_gridicons_up_right
+    )
 
     @AssistedInject.Factory
     interface Factory : ViewModelAssistedFactory<ProductTypesBottomSheetViewModel>

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
@@ -73,7 +73,7 @@ class ProductTypesBottomSheetViewModel @AssistedInject constructor(
 
     fun ProductType.getSimpleProductType() = ProductTypesBottomSheetUiItem(
         type = SIMPLE,
-        titleResource = R.string.product_type_physical,
+        titleResource = R.string.product_type_simple,
         descResource = R.string.product_type_physical_desc,
         iconResource = R.drawable.ic_gridicons_product
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.di.ViewModelAssistedFactory
 import com.woocommerce.android.ui.products.ProductType.EXTERNAL
 import com.woocommerce.android.ui.products.ProductType.GROUPED
 import com.woocommerce.android.ui.products.ProductType.SIMPLE
+import com.woocommerce.android.ui.products.ProductType.VARIABLE
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
@@ -54,11 +55,11 @@ class ProductTypesBottomSheetViewModel @AssistedInject constructor(
                 iconResource = R.drawable.ic_gridicons_product
             ),
             ProductTypesBottomSheetUiItem(
-                type = SIMPLE,
+                type = VARIABLE,
                 isVirtual = true,
-                titleResource = R.string.product_type_virtual,
-                descResource = R.string.product_type_virtual_desc,
-                iconResource = R.drawable.ic_gridicons_cloud_outline
+                titleResource = R.string.product_type_variable,
+                descResource = R.string.product_type_variation_desc,
+                iconResource = R.drawable.ic_gridicons_types
             ),
             ProductTypesBottomSheetUiItem(
                 type = GROUPED,

--- a/WooCommerce/src/main/res/drawable/ic_gridicons_types.xml
+++ b/WooCommerce/src/main/res/drawable/ic_gridicons_types.xml
@@ -1,9 +1,11 @@
+
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
+    android:autoMirrored="true"
     android:viewportWidth="24"
     android:viewportHeight="24">
-  <path
-      android:fillColor="@color/color_icon"
-      android:pathData="M22,17c0,2.76 -2.24,5 -5,5s-5,-2.24 -5,-5 2.24,-5 5,-5 5,2.24 5,5zM6.5,6.5h3.8L7,1 1,11h5.5L6.5,6.5zM16,10.585L16,8L8,8v8h2.585c0.433,-2.783 2.632,-4.982 5.415,-5.415z"/>
+    <path
+        android:fillColor="@color/color_icon"
+        android:pathData="M22,17c0,2.76 -2.24,5 -5,5s-5,-2.24 -5,-5 2.24,-5 5,-5 5,2.24 5,5zM6.5,6.5h3.8L7,1 1,11h5.5L6.5,6.5zM16,10.585L16,8L8,8v8h2.585c0.433,-2.783 2.632,-4.982 5.415,-5.415z" />
 </vector>

--- a/WooCommerce/src/main/res/navigation/nav_graph_products.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_products.xml
@@ -208,9 +208,8 @@
         android:name="com.woocommerce.android.ui.products.ProductTypesBottomSheetFragment"
         tools:layout="@layout/dialog_product_detail_bottom_sheet_list">
         <argument
-            android:name="remoteProductId"
-            android:defaultValue="0L"
-            app:argType="long" />
+            android:name="productType"
+            app:argType="com.woocommerce.android.ui.products.ProductType" />
     </dialog>
     <fragment
         android:id="@+id/productReviewsFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -917,6 +917,7 @@
     <!-- Product Add more details Bottom sheet -->
     <string name="product_type_list_header">Select a product type</string>
     <string name="product_type_physical_desc">An item you ship to the customer</string>
+    <string name="product_type_variation_desc">A product with variations like color or size</string>
     <string name="product_type_virtual_desc">A service or digital download</string>
     <string name="product_type_grouped_desc">A collection of related products</string>
     <string name="product_type_external_desc">Link a product to an external website</string>


### PR DESCRIPTION
Fixes #2781. This PR fixes three issues:
- Based on the designs, Physical and Virtual should be grouped as Simple in the product type selector. I should be able to switch a simple product between physical and virtual using the virtual product option in Product Settings. The fix is to remove the Virtual product option from the product list selector.
- I never see the Variable option, so I can't change a product to variable. The fix is to include the variable option in the product list selector.
- I can see and select the current product type in that selector. I get a prompt asking me if I'm sure I want to change the product type, even though it doesn't actually change anything if I'm choosing the current product type. The fix is to ensure that the current product type is not included in the product list selector.

#### To test
- Click on a PHYSICAL product from the Products tab.
  - Click on the Product Type section.
  - Notice that the product type selection includes: "Variable", "Grouped" and "External" options only.
  - Change the product type to anything else and verify that a confirmation dialog is displayed.
  - Click on Cancel and notice that the dialog is dismissed.
  - Change the product type to anything else and verify that a confirmation dialog is displayed.
  - Click on Change and notice that the product type is changed in the Product Detail screen.
  - Notice the "UPDATE" menu button is displayed.
  - Click on the "Update" menu button and verify that the product type is updated successfully.
- Follow the above steps for a Variable, Grouped and External products.

cc @rachelmcr I added you as a reviewer since you found the original bug. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
