### PR TITLE
Pass missing navargs when opening ProductImagesFragment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesModule.kt
@@ -18,8 +18,8 @@ abstract class ProductImagesModule {
     companion object {
         @JvmStatic
         @Provides
-        fun provideDefaultArgs(): Bundle? {
-            return null
+        fun provideDefaultArgs(fragment: ProductImagesFragment): Bundle? {
+            return fragment.arguments
         }
 
         @JvmStatic


### PR DESCRIPTION
This tiny PR fixes #2764 by adding the missing navArgs when opening the `ProductImagesFragment`.

#### Testing
- Enable `Don't keep activities` in Developer options
- Go to Products -> Select a product
- Tap on "Add new image" button
- Tap on Add photos button
- Select the Take photo option
- Take a picture and confirm
- Notice the app no longer crashes.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
