### PR TITLE
Feat/add new product api call

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -15,6 +15,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.LayoutManager
 import com.woocommerce.android.R
+import com.woocommerce.android.R.string
 import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
@@ -176,7 +177,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
     }
 
     private fun showProductDetails(product: Product) {
-        productName = product.name.fastStripHtml()
+        productName = updateProductNameFromDetails(product)
 
         if (product.images.isEmpty() && !viewModel.isUploadingImages(product.remoteId)) {
             imageGallery.visibility = View.GONE
@@ -205,6 +206,12 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
                 ViewProductDetailBottomSheet(product.remoteId)
             )
         }
+    }
+
+    private fun updateProductNameFromDetails(product: Product): String {
+        return if (navArgs.isAddProduct && product.name.isEmpty()) {
+            getString(string.product_add_tool_bar_title)
+        } else product.name.fastStripHtml()
     }
 
     private fun startAddImageContainer() {
@@ -244,7 +251,8 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
             }
 
             R.id.menu_done -> {
-                startMenuDoneAction()
+                ActivityUtils.hideKeyboard(activity)
+                viewModel.onUpdateButtonClicked()
                 true
             }
 
@@ -261,16 +269,6 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         }
     }
 
-    private fun startMenuDoneAction() {
-        when (navArgs.isAddProduct) {
-            true -> Unit
-            else -> {
-                ActivityUtils.hideKeyboard(activity)
-                viewModel.onUpdateButtonClicked()
-            }
-        }
-    }
-
     private fun showSkeleton(show: Boolean) {
         if (show) {
             skeletonView.show(app_bar_layout, R.layout.skeleton_product_detail, delayed = true)
@@ -282,14 +280,29 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
     private fun showProgressDialog(show: Boolean) {
         if (show) {
             hideProgressDialog()
-            progressDialog = CustomProgressDialog.show(
-                    getString(R.string.product_update_dialog_title),
-                    getString(R.string.product_update_dialog_message)
-            ).also { it.show(parentFragmentManager, CustomProgressDialog.TAG) }
+            progressDialog = getSubmitDetailProgressDialog().also {
+                it.show(parentFragmentManager, CustomProgressDialog.TAG)
+            }
             progressDialog?.isCancelable = false
         } else {
             hideProgressDialog()
         }
+    }
+
+    private fun getSubmitDetailProgressDialog(): CustomProgressDialog {
+        val title: Int
+        val message: Int
+         when (navArgs.isAddProduct) {
+            true -> {
+                title = R.string.product_publish_dialog_title
+                message = R.string.product_publish_dialog_message
+            }
+            else -> {
+                title = R.string.product_update_dialog_title
+                message = R.string.product_update_dialog_message
+            }
+        }
+        return CustomProgressDialog.show(getString(title), getString(message))
     }
 
     private fun hideProgressDialog() {
@@ -354,12 +367,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         viewModel.onAddImageClicked()
     }
 
-    override fun getFragmentTitle(): String {
-        return when (navArgs.isAddProduct) {
-            true -> getString(R.string.product_add_tool_bar_title)
-            else -> productName
-        }
-    }
+    override fun getFragmentTitle(): String =  productName
 
     /**
      * Override the BaseProductFragment's fun since we want to return True if any changes have been

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -292,7 +292,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
     private fun getSubmitDetailProgressDialog(): CustomProgressDialog {
         val title: Int
         val message: Int
-         when (navArgs.isAddProduct) {
+        when (navArgs.isAddProduct) {
             true -> {
                 title = R.string.product_publish_dialog_title
                 message = R.string.product_publish_dialog_message
@@ -367,7 +367,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         viewModel.onAddImageClicked()
     }
 
-    override fun getFragmentTitle(): String =  productName
+    override fun getFragmentTitle(): String = productName
 
     /**
      * Override the BaseProductFragment's fun since we want to return True if any changes have been

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
@@ -137,12 +137,11 @@ class ProductDetailRepository @Inject constructor(
      *
      * @return the result of the action as a [Boolean]
      */
-    suspend fun addProduct(product: Product): Pair<Boolean,Long> {
+    suspend fun addProduct(product: Product): Pair<Boolean, Long> {
         return try {
             suspendCoroutineWithTimeout<Pair<Boolean, Long>>(ACTION_TIMEOUT) {
                 continuationAddProduct = it
-                val cachedModel = getCachedWCProductModel(product.remoteId)
-                val model = product.toDataModel(cachedModel)
+                val model = product.toDataModel(null)
                 val payload = WCProductStore.AddProductPayload(selectedSite.get(), model)
                 dispatcher.dispatch(WCProductActionBuilder.newAddProductAction(payload))
             } ?: Pair(false, 0L) // request timed out

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
@@ -21,8 +21,10 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.WCProductAction.ADDED_PRODUCT
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_PASSWORD
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_SKU_AVAILABILITY
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT
@@ -33,6 +35,7 @@ import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductSkuAvailabilityPayload
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
+import org.wordpress.android.fluxc.store.WCProductStore.OnProductCreated
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductPasswordChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductShippingClassesChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductSkuAvailabilityChanged
@@ -59,6 +62,7 @@ class ProductDetailRepository @Inject constructor(
     private var continuationUpdateProductPassword: CancellableContinuation<Boolean>? = null
     private var continuationFetchProductShippingClass: CancellableContinuation<Boolean>? = null
     private var continuationVerifySku: CancellableContinuation<Boolean>? = null
+    private var continuationAddProduct: Continuation<Boolean>? = null
 
     private var isFetchingTaxClassList = false
     private var remoteProductId: Long = 0L
@@ -123,6 +127,25 @@ class ProductDetailRepository @Inject constructor(
             } ?: false // request timed out
         } catch (e: CancellationException) {
             WooLog.e(PRODUCTS, "Exception encountered while updating product", e)
+            false
+        }
+    }
+
+    /**
+     * Fires the request to add a product
+     *
+     * @return the result of the action as a [Boolean]
+     */
+    suspend fun addProduct(product: Product): Boolean {
+        return try {
+            suspendCoroutineWithTimeout<Boolean>(ACTION_TIMEOUT) {
+                continuationAddProduct = it
+                val model = product.toDataModel(null)
+                val payload = WCProductStore.AddProductPayload(selectedSite.get(), model)
+                dispatcher.dispatch(WCProductActionBuilder.newAddProductAction(payload))
+            } ?: false // request timed out
+        } catch (e: CancellationException) {
+            WooLog.e(PRODUCTS, "Exception encountered while adding a product", e)
             false
         }
     }
@@ -314,6 +337,23 @@ class ProductDetailRepository @Inject constructor(
             } else {
                 continuationFetchProductShippingClass?.resume(true)
             }
+        }
+    }
+
+    /**
+     * A new product has been added
+     */
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onProductCreated(event: OnProductCreated) {
+        if (event.causeOfChange == ADDED_PRODUCT) {
+            if (event.isError) {
+                continuationAddProduct?.resume(false)
+            } else {
+                continuationAddProduct?.resume(true)
+            }
+            continuationAddProduct = null
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -285,7 +285,7 @@ class ProductDetailViewModel @AssistedInject constructor(
      * Displays a progress dialog and updates/publishes the product
      */
     fun onUpdateButtonClicked() {
-        when (navArgs.isAddProduct){
+        when (viewState.productDraft?.remoteId == 0L) {
             true -> startPublishProduct()
             else -> startUpdateProduct()
         }
@@ -768,14 +768,16 @@ class ProductDetailViewModel @AssistedInject constructor(
     private suspend fun addProduct(product: Product) {
         if (networkStatus.isConnected()) {
             val result = productRepository.addProduct(product)
-            if (result.first) {
+            val isSuccess = result.first
+            val newProductRemoteId = result.second
+            if (isSuccess) {
                 triggerEvent(ShowSnackbar(string.product_detail_publish_product_success))
                 viewState = viewState.copy(
                     productDraft = null,
                     productBeforeEnteringFragment = getProduct().storedProduct,
                     isProductUpdated = false
                 )
-                loadRemoteProduct(result.second)
+                loadRemoteProduct(newProductRemoteId)
             } else {
                 triggerEvent(ShowSnackbar(string.product_detail_publish_product_error))
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -746,6 +746,21 @@ class ProductDetailViewModel @AssistedInject constructor(
     }
 
     /**
+     * Add a new product to the backend only if network is connected.
+     * Otherwise, an offline snackbar is displayed.
+     */
+    private suspend fun addProduct(product: Product) {
+        if (networkStatus.isConnected()) {
+            if (productRepository.updateProduct(product)) {
+
+            }
+        } else {
+            triggerEvent(ShowSnackbar(string.offline_error))
+        }
+        viewState = viewState.copy(isProgressDialogShown = false)
+    }
+
+    /**
      * Fetch the shipping class name of a product based on the remote shipping class id
      */
     fun getShippingClassByRemoteShippingClassId(remoteShippingClassId: Long) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductHelper.kt
@@ -2,9 +2,11 @@ package com.woocommerce.android.ui.products
 
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.products.ProductBackorderStatus.NotAvailable
+import com.woocommerce.android.ui.products.ProductStatus.PUBLISH
 import com.woocommerce.android.ui.products.ProductStockStatus.InStock
 import com.woocommerce.android.ui.products.ProductTaxStatus.None
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
+import com.woocommerce.android.ui.products.settings.ProductCatalogVisibility.VISIBLE
 import java.math.BigDecimal
 import java.util.Date
 
@@ -38,8 +40,8 @@ object ProductHelper {
             description = "",
             shortDescription = "",
             type = type,
-            status = null,
-            catalogVisibility = null,
+            status = PUBLISH,
+            catalogVisibility = VISIBLE,
             isFeatured = false,
             stockStatus = InStock,
             backorderStatus = NotAvailable,

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -938,6 +938,10 @@
     <!-- New Product screen -->
     <string name="product_add_tool_bar_title">New Product</string>
     <string name="product_add_tool_bar_menu_button_done">PUBLISH</string>
+    <string name="product_publish_dialog_title">Publishing product</string>
+    <string name="product_publish_dialog_message">@string/product_update_dialog_message</string>
+    <string name="product_detail_publish_product_error">Error publishing product</string>
+    <string name="product_detail_publish_product_success">Product published</string>
 
     <!-- In-App Feedback -->
     <string name="feedback_request_title">Enjoying the WooCommerce app?</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -549,7 +549,7 @@
     <string name="product_detail_update_product_error">Error updating product</string>
     <string name="product_detail_update_product_success">Product updated</string>
     <string name="product_detail_update_product_password_error">Error updating password</string>
-    <string name="product_detail_title_hint">Product title</string>
+    <string name="product_detail_title_hint">Enter Product Title</string>
     <string name="product_detail_editable_text_hint">Enter text</string>
     <string name="product_detail_product_type_hint">%1$s product</string>
     <string name="product_detail_add_more">Add more details</string>

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '975aca60a8acfd594e8f81941c68f20dc9d60e1d'
+    fluxCVersion = 'dab84df30e5dad81f6db9ada42906679df28e414' //'975aca60a8acfd594e8f81941c68f20dc9d60e1d'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
## RESOURCES
[The Figma file](https://www.figma.com/file/QAkdm5HZdLlG0b8vUkv1pX/Products---Add-%26-Edit-Products?node-id=460%3A1760&viewport=-1704%2C1577%2C0.5334523320198059) and [the initial issue](https://github.com/woocommerce/woocommerce-android/issues/2707)

## CHANGES / DESCRIPTION

This PR will contain the following:
- added the linking up with the FluxC for **add product**
- added the repository + view model to trigger the **add product** action correctly and wait for the response
- added the missing setup of a product to enable the `keep editing/discard` validations

In order to achieve the functionalities added in the **FluxC** repo (thank you @anitaa1990 🙌 ) I added the commit hash of `dab84df30e5dad81f6db9ada42906679df28e414` to the `build.gradle`. This enabled the pull of the code [opened in this PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1676).

With that enabled, I then added the new `addProduct` method in the `Repository` to trigger the `WCProductActionBuilder.newAddProductAction` and start the flow for a remote publish of a new product. To handle the result, I added a continuation in the form of:
```
continuationAddProduct: Continuation<Pair<Boolean, Long>>? = null 
```
This goes a bit out of the ordinary, comparing to the rest of the existing continuations, but the goal here was to return a `Pair` information:
- a **boolean** flag for success/error of the request, so that the view model could know how to behave from that result
- a **long** that is the new generated `remote product id` for the new Product, also to be used by the view model to then load the current generated product from remote 👍 

I also added the event listening of `OnProductCreated` to correctly call the continuation with the correct information.
```
Suppress("unused")
@Subscribe(threadMode = ThreadMode.MAIN)
fun onProductCreated(event: OnProductCreated) {
   // code code code
}
```

The `ViewModel`, in its `addProduct(product: Product)` method will handle the result accordingly and present the UI with the correct information (loading, success or error 👌 ).

To finish up, I added the missing validation of the done button, to show `PUBLISH` correctly and added the `updateProductState()` call on the `start` of the `ViewModel` so that there is a product to compare to and allow the correct validations of **keep editing OR discard** throughout the journey. 

As always, let me know your thoughts on it 🙏 

**NOTE**
The biggest caveat in this PR is that the actual publish of a new product is not being properly accepted from the remote communication 😞 as in, it always fails. I am chasing that error in the Slack channels, but as it stands, **should block this merge**.

## TESTING
- Click on the PRODUCT bottom nav bar button
    - Wait for the screen to finish loading
    - Click on the FAB button
    - Notice the add new product screen with the options and validations in place

## SCREENSHOTS

Complete new Product + Publishing states
-
<img width="200" alt="Screenshot 2020-08-27 at 17 32 23" src="https://user-images.githubusercontent.com/7058393/91470639-dda70f00-e88c-11ea-8356-2f243b0294cb.png"><img src="https://user-images.githubusercontent.com/7058393/91470641-ded83c00-e88c-11ea-8491-a9b2890f53f6.png" width="200" /><img src="https://user-images.githubusercontent.com/7058393/91470889-31b1f380-e88d-11ea-85ee-14a05334ab9e.png" width="200" /><img src="https://user-images.githubusercontent.com/7058393/91470643-ded83c00-e88c-11ea-9160-01f5e9407171.png" width="200" />

Simple Product flow (in order)
-
<img src="https://user-images.githubusercontent.com/7058393/91470958-49897780-e88d-11ea-9d5b-684048a62677.gif" width="200" /><img src="https://user-images.githubusercontent.com/7058393/91470968-5017ef00-e88d-11ea-92cf-896c1a4c9382.gif" width="200" /><img src="https://user-images.githubusercontent.com/7058393/91470974-50b08580-e88d-11ea-8e1a-870bda1d4403.gif" width="200" /><img src="https://user-images.githubusercontent.com/7058393/91471128-8a818c00-e88d-11ea-828d-cd44bade8c1d.gif" width="200" /><img src="https://user-images.githubusercontent.com/7058393/91471151-8fded680-e88d-11ea-98bc-a54bceffc5ae.gif" width="200" /><img src="https://user-images.githubusercontent.com/7058393/91471155-91100380-e88d-11ea-947b-771a3abe8a17.gif" width="200" /><img src="https://user-images.githubusercontent.com/7058393/91471241-b3098600-e88d-11ea-8b17-4e0f0ba93151.gif" width="200" /><img src="https://user-images.githubusercontent.com/7058393/91471254-b7ce3a00-e88d-11ea-8228-353ac5bc5d3a.gif" width="200" />

