### PR TITLE
Update appcompat library to latest stable version: 1.2.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 5.0
 -----
+* Fixed an issue where switching between light and dark themes on older Android versions made the app unresponsive.
  
 4.9
 -----

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -130,7 +130,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:1.1.3"
     implementation "androidx.recyclerview:recyclerview:1.1.0"
     implementation "androidx.multidex:multidex:2.0.1"
-    implementation "androidx.appcompat:appcompat:1.1.0"
+    implementation "androidx.appcompat:appcompat:1.2.0"
     implementation "com.google.android.material:material:1.1.0"
     implementation "androidx.cardview:cardview:1.0.0"
     implementation ("androidx.browser:browser:1.2.0") {

--- a/WooCommerce/src/main/res/layout/fragment_review_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_review_detail.xml
@@ -56,7 +56,7 @@
                     android:layout_height="@dimen/image_minor_50"
                     android:layout_marginEnd="@dimen/minor_100"
                     android:contentDescription="@string/wc_view_the_product_external"
-                    android:tint="@color/color_secondary"
+                    app:tint="@color/color_secondary"
                     app:srcCompat="@drawable/ic_external" />
             </LinearLayout>
 

--- a/WooCommerce/src/main/res/layout/product_property_link_view_layout.xml
+++ b/WooCommerce/src/main/res/layout/product_property_link_view_layout.xml
@@ -26,7 +26,7 @@
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/major_100"
         android:importantForAccessibility="no"
-        android:tint="@color/color_secondary"
+        app:tint="@color/color_secondary"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toTopOf="@+id/divider"

--- a/WooCommerce/src/main/res/layout/product_property_warning_layout.xml
+++ b/WooCommerce/src/main/res/layout/product_property_warning_layout.xml
@@ -17,7 +17,7 @@
         android:layout_marginEnd="@dimen/major_100"
         android:contentDescription="@string/product_property_edit"
         android:src="@drawable/ic_info_outline_24dp"
-        android:tint="@color/warning_foreground_color"
+        app:tint="@color/warning_foreground_color"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
This fixes #1972 where the app would become unresponsive when switching between light/dark themes on API's 21 and 22.

<img src="https://user-images.githubusercontent.com/5810477/91482751-901ea800-e874-11ea-9067-094d11d22e15.gif" width="330"/>



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
