### PR TITLE
Woo/add flipper

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -202,8 +202,14 @@ dependencies {
     releaseImplementation 'com.idescout.sql:sqlscout-server-noop:4.1'
 
     // Debug dependencies
-    debugImplementation 'com.facebook.stetho:stetho:1.5.0'
-    debugImplementation 'com.facebook.stetho:stetho-okhttp3:1.5.0'
+    debugImplementation "com.facebook.flipper:flipper:$flipperVersion"
+    debugImplementation "com.facebook.soloader:soloader:0.9.0"
+    debugImplementation ("com.facebook.flipper:flipper-network-plugin:$flipperVersion") {
+        // Force Flipper to use the okhttp version defined in the fluxc module
+        // okhttp versions higher than 3.9.0 break handling for self-signed SSL sites
+        // See https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/919
+        exclude group: 'com.squareup.okhttp3'
+    }
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.0-alpha-3'
 
     // Dependencies for local unit tests

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -202,8 +202,6 @@ dependencies {
     releaseImplementation 'com.idescout.sql:sqlscout-server-noop:4.1'
 
     // Debug dependencies
-    debugImplementation 'com.facebook.stetho:stetho:1.5.0'
-    debugImplementation 'com.facebook.stetho:stetho-okhttp3:1.5.0'
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.0-alpha-3'
 
     // Dependencies for local unit tests

--- a/WooCommerce/src/debug/kotlin/com.woocommerce.android/WooCommerceDebug.kt
+++ b/WooCommerce/src/debug/kotlin/com.woocommerce.android/WooCommerceDebug.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android
 
-import com.facebook.stetho.Stetho
 import com.woocommerce.android.di.AppComponent
 import com.woocommerce.android.di.DaggerAppComponentDebug
 
@@ -13,6 +12,5 @@ open class WooCommerceDebug : WooCommerce() {
 
     override fun onCreate() {
         super.onCreate()
-        Stetho.initializeWithDefaults(this)
     }
 }

--- a/WooCommerce/src/debug/kotlin/com.woocommerce.android/WooCommerceDebug.kt
+++ b/WooCommerce/src/debug/kotlin/com.woocommerce.android/WooCommerceDebug.kt
@@ -1,10 +1,15 @@
 package com.woocommerce.android
 
-import com.facebook.stetho.Stetho
+import com.facebook.flipper.android.AndroidFlipperClient
+import com.facebook.flipper.android.utils.FlipperUtils
+import com.facebook.flipper.plugins.inspector.DescriptorMapping
+import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin
+import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
+import com.facebook.soloader.SoLoader
 import com.woocommerce.android.di.AppComponent
 import com.woocommerce.android.di.DaggerAppComponentDebug
 
-open class WooCommerceDebug : WooCommerce() {
+class WooCommerceDebug : WooCommerce() {
     override val component: AppComponent by lazy {
         DaggerAppComponentDebug.builder()
                 .application(this)
@@ -12,7 +17,13 @@ open class WooCommerceDebug : WooCommerce() {
     }
 
     override fun onCreate() {
+        if (FlipperUtils.shouldEnableFlipper(this)) {
+            SoLoader.init(this, false)
+            AndroidFlipperClient.getInstance(this).apply {
+                addPlugin(InspectorFlipperPlugin(applicationContext, DescriptorMapping.withDefaults()))
+                addPlugin(NetworkFlipperPlugin())
+            }.start()
+        }
         super.onCreate()
-        Stetho.initializeWithDefaults(this)
     }
 }

--- a/WooCommerce/src/debug/kotlin/com.woocommerce.android/WooCommerceDebug.kt
+++ b/WooCommerce/src/debug/kotlin/com.woocommerce.android/WooCommerceDebug.kt
@@ -6,6 +6,7 @@ import com.facebook.flipper.plugins.databases.DatabasesFlipperPlugin
 import com.facebook.flipper.plugins.inspector.DescriptorMapping
 import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin
 import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
+import com.facebook.flipper.plugins.sharedpreferences.SharedPreferencesFlipperPlugin
 import com.facebook.soloader.SoLoader
 import com.woocommerce.android.di.AppComponent
 import com.woocommerce.android.di.DaggerAppComponentDebug
@@ -24,6 +25,7 @@ class WooCommerceDebug : WooCommerce() {
                 addPlugin(InspectorFlipperPlugin(applicationContext, DescriptorMapping.withDefaults()))
                 addPlugin(NetworkFlipperPlugin())
                 addPlugin(DatabasesFlipperPlugin(this@WooCommerceDebug))
+                addPlugin(SharedPreferencesFlipperPlugin(this@WooCommerceDebug))
             }.start()
         }
         super.onCreate()

--- a/WooCommerce/src/debug/kotlin/com.woocommerce.android/WooCommerceDebug.kt
+++ b/WooCommerce/src/debug/kotlin/com.woocommerce.android/WooCommerceDebug.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android
 
 import com.facebook.flipper.android.AndroidFlipperClient
 import com.facebook.flipper.android.utils.FlipperUtils
+import com.facebook.flipper.plugins.databases.DatabasesFlipperPlugin
 import com.facebook.flipper.plugins.inspector.DescriptorMapping
 import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin
 import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
@@ -22,6 +23,7 @@ class WooCommerceDebug : WooCommerce() {
             AndroidFlipperClient.getInstance(this).apply {
                 addPlugin(InspectorFlipperPlugin(applicationContext, DescriptorMapping.withDefaults()))
                 addPlugin(NetworkFlipperPlugin())
+                addPlugin(DatabasesFlipperPlugin(this@WooCommerceDebug))
             }.start()
         }
         super.onCreate()

--- a/WooCommerce/src/debug/kotlin/com.woocommerce.android/di/InterceptorModule.kt
+++ b/WooCommerce/src/debug/kotlin/com.woocommerce.android/di/InterceptorModule.kt
@@ -1,7 +1,8 @@
 package com.woocommerce.android.di
 
-import com.facebook.stetho.okhttp3.StethoInterceptor
-
+import com.facebook.flipper.android.AndroidFlipperClient
+import com.facebook.flipper.plugins.network.FlipperOkhttpInterceptor
+import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoSet
@@ -11,5 +12,7 @@ import javax.inject.Named
 @Module
 class InterceptorModule {
     @Provides @IntoSet @Named("network-interceptors")
-    fun provideNetworkInterceptor(): Interceptor = StethoInterceptor()
+    fun provideNetworkInterceptor(): Interceptor = FlipperOkhttpInterceptor(
+        AndroidFlipperClient.getInstanceIfInitialized()?.getPlugin(NetworkFlipperPlugin.ID)
+    )
 }

--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,7 @@ ext {
     archComponentsVersion = '2.2.0'
     assertjVersion = '3.11.1'
     aztecVersion = 'v1.3.40'
+    flipperVersion = '0.52.0'
 }
 
 tasks.getByPath('WooCommerce:preBuild').dependsOn installGitHooks


### PR DESCRIPTION
Stetho has been deprecated and Flipper is the new Stetho, It comes with a Mac binary as a debugging tool. This PR replaces Stetho with Flipper. The following plugins are added to the debug build of the app:

#### Layout Inspector: 
<img width="1399" alt="Screenshot 2020-08-28 at 11 01 28 AM" src="https://user-images.githubusercontent.com/22608780/91524958-193de980-e91e-11ea-9932-1c2ad35d9397.png">

#### Network: 
<img width="1402" alt="Screenshot 2020-08-28 at 11 02 12 AM" src="https://user-images.githubusercontent.com/22608780/91524981-21962480-e91e-11ea-878e-47186b3b1806.png">

#### Database: 
<img width="1401" alt="Screenshot 2020-08-28 at 11 03 12 AM" src="https://user-images.githubusercontent.com/22608780/91524992-278c0580-e91e-11ea-811e-55c9b2fe9421.png">

#### Shared Preferences: 
<img width="1251" alt="Screenshot 2020-08-28 at 11 02 42 AM" src="https://user-images.githubusercontent.com/22608780/91524990-25c24200-e91e-11ea-85b3-8336d5b1987a.png">


#### To test:
- Install the desktop app: https://www.facebook.com/fbflipper/public/mac and run it.
- Run the app.
- Make sure the Flipper app connects to the device/emulator.
- Enable the layout inspector and make sure you are able to inspect the layout using the Flipper Desktop app.
- Enable the network plugin and verify that the network requests are logged in the Flipper Desktop app.
- Enable the databases plugin and verify that the databases are displayed in Flipper Desktop app.
- Enable the SharedPreferences plugin and verify that the SharedPreference file is displayed in Flipper Desktop app.

More about Flipper here: https://fbflipper.com/

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
