### PR TITLE
Edit Products M3: bug fixes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -57,8 +57,6 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
     private var progressDialog: CustomProgressDialog? = null
     private var layoutManager: LayoutManager? = null
 
-    private var viewProductOnStoreMenuItem: MenuItem? = null
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         setHasOptionsMenu(true)
         return inflater.inflate(R.layout.fragment_product_detail, container, false)
@@ -192,10 +190,6 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
                 frameStatusBadge.visibility = View.VISIBLE
                 textStatusBadge.text = status.toLocalizedString(requireActivity())
             }
-
-            // display View Product on Store menu button only if the Product status is published,
-            // otherwise the page is redirected to a 404
-            viewProductOnStoreMenuItem?.isVisible = status == ProductStatus.PUBLISH
         }
 
         productDetail_addMoreContainer.setOnClickListener {
@@ -210,7 +204,9 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         menu.clear()
         inflater.inflate(R.menu.menu_product_detail_fragment, menu)
 
-        viewProductOnStoreMenuItem = menu.findItem(R.id.menu_view_product)
+        // display View Product on Store menu button only if the Product status is published,
+        // otherwise the page is redirected to a 404
+        menu.findItem(R.id.menu_view_product).isVisible = viewModel.isProductPublished
         menu.findItem(R.id.menu_product_settings).isVisible = true
 
         super.onCreateOptionsMenu(menu, inflater)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -155,6 +155,9 @@ class ProductDetailViewModel @AssistedInject constructor(
         ProductDetailBottomSheetBuilder(resources)
     }
 
+    val isProductPublished: Boolean
+    get() = viewState.productDraft?.status == ProductStatus.PUBLISH
+
     init {
         start()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/BaseProductSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/BaseProductSettingsFragment.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.dialog.CustomDiscardDialog
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
+import org.wordpress.android.util.ActivityUtils
 
 /**
  * All fragments shown from the main product settings fragment should extend this class.
@@ -73,6 +74,7 @@ abstract class BaseProductSettingsFragment : BaseFragment(), BackPressListener {
     override fun onStop() {
         super.onStop()
         CustomDiscardDialog.onCleared()
+        activity?.let { ActivityUtils.hideKeyboard(it) }
     }
 
     override fun onRequestAllowBackPress(): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSettingsFragment.kt
@@ -23,6 +23,7 @@ import com.woocommerce.android.ui.products.BaseProductFragment
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitSettings
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductPurchaseNoteEditor
 import com.woocommerce.android.ui.products.ProductStatus
+import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.settings.ProductCatalogVisibilityFragment.Companion.ARG_CATALOG_VISIBILITY
 import com.woocommerce.android.ui.products.settings.ProductCatalogVisibilityFragment.Companion.ARG_IS_FEATURED
 import com.woocommerce.android.ui.products.settings.ProductSlugFragment.Companion.ARG_SLUG
@@ -63,7 +64,8 @@ class ProductSettingsFragment : BaseProductFragment(), NavigationResult {
             viewModel.onSettingsMenuOrderButtonClicked()
         }
 
-        if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled()) {
+        val isSimple = viewModel.getProduct().productDraft?.type == ProductType.SIMPLE
+        if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled() && isSimple) {
             productIsVirtual.visibility = View.VISIBLE
             productIsVirtual.setOnCheckedChangeListener { _, isChecked ->
                 AnalyticsTracker.track(Stat.PRODUCT_SETTINGS_VIRTUAL_TOGGLED)

--- a/WooCommerce/src/main/res/layout/fragment_product_visibility.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_visibility.xml
@@ -37,7 +37,8 @@
             android:layout_marginBottom="@dimen/major_100"
             android:inputType="textPassword"
             android:visibility="gone"
-            app:hintEnabled="false"
+            android:hint="@string/product_visibility_password_protected_hint"
+            app:hintEnabled="true"
             tools:visibility="visible" />
 
         <View

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -564,6 +564,7 @@
     <string name="product_visibility">Visibility</string>
     <string name="product_visibility_public">Public</string>
     <string name="product_visibility_private">Private</string>
+    <string name="product_visibility_password_protected_hint">Enter password</string>
     <string name="product_visibility_password_protected">Password protected</string>
     <string name="product_visibility_password_required">Password is required</string>
     <string name="product_catalog_visibility">Catalog visibility</string>


### PR DESCRIPTION
This PR fixes #2792, #2785, #2609 and #2608. 

#### Issue 2972:
I see the `Virtual product` setting in the Product settings for any product type in the app. I can toggle that setting for any product, but it doesn't do anything unless I'm editing a simple product.

Fixed in 9385ae4

##### To test
- Go to Settings > Beta features and enable Product Editing.
- Go to the Products tab.
- Select a simple product from the product list.
- Open the product settings and toggle the Virtual Product setting. Notice that in the product details, this changes the product type between Physical and Virtual.
- Go back to the product list and select a variable product.
- Open the product settings and verify that the Virtual setting is no longer visible.

#### Issue 2785:
When I first open the product details for a product, if that product is visible on my store I'll see a "View Product in Store" link in the ellipsis menu.

Fixed in f8f3868

##### To test
- Open the Products tab.
- Select a product.
- Tap the ellipsis menu and confirm you see a "View Product in Store" link.
- Select "Product Settings."
- Tap the X button to close the product settings screen without making any changes.
- Tap the ellipsis menu again and notice you the "View Product in Store" is still visible.

#### Issue 2609:
When I select the password-protected option, edit the field and dismiss my changes, I keep seeing the keyboard overlapping the Settings screen.

Fixed in 9ac2f6e

##### To test
- Select a product
- Open Product Settings
- Select "Visibility"
- Select "Password Protected"
- Edit Password
- Select back button
- Select dismiss changes
- Notice the keyboard is no longer displayed.

#### Issue 2608:
Currently, when selecting "Password-protected", there's a blank text input field. Can we add a text label placeholder to guide users more about what they should be doing?

Fixed in 7e51717

##### To test
- Select a product
- Open product Settings
- Select "Visibility"
- Select "Password protected"
- Notice the hint in the "Password protected" EditText.

cc @Garance91540 and @rachelmcr I have added you as reviewers since you both caught the initial bug. Thanks 🙏 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
