### PR TITLE
Woo/order detail shipment fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailContract.kt
@@ -55,6 +55,7 @@ interface OrderDetailContract {
         fun showAddOrderNoteScreen(order: WCOrderModel)
         fun updateOrderNotes(notes: List<WCOrderNoteModel>)
         fun showOrderShipmentTrackings(trackings: List<WCOrderShipmentTrackingModel>)
+        fun hideOrderShipmentTrackings()
         fun setOrderStatus(newStatus: String)
         fun showChangeOrderStatusSnackbar(newStatus: String)
         fun showNotesErrorSnack()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -322,6 +322,12 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
         }
     }
 
+    override fun hideOrderShipmentTrackings() {
+        if (orderDetail_shipmentList.visibility != View.GONE) {
+            WooAnimUtils.scaleOut(orderDetail_shipmentList, WooAnimUtils.Duration.MEDIUM)
+        }
+    }
+
     override fun showOrderNotesSkeleton(show: Boolean) {
         orderDetail_noteList.showSkeleton(show)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -133,37 +133,32 @@ class OrderDetailPresenter @Inject constructor(
     }
 
     override fun loadOrderDetailInfo(order: WCOrderModel) {
-        orderModel?.let {
-            val cachedOrderDetailUiItem = orderDetailRepository.getOrderDetailInfoFromDb(it)
+        val cachedOrderDetailUiItem = orderDetailRepository.getOrderDetailInfoFromDb(order)
 
-            // if there are no shipping labels cached in the db, we prefer not to show the product list
-            // till it can be fetched from the API
-            displayOrderDetailInfo(order, cachedOrderDetailUiItem, cachedOrderDetailUiItem.shippingLabels.isNotEmpty())
+        // if there are no shipping labels cached in the db, we prefer not to show the product list
+        // till it can be fetched from the API
+        displayOrderDetailInfo(order, cachedOrderDetailUiItem)
 
-            fetchOrderDetailInfo(it)
-        }
+        fetchOrderDetailInfo(order)
     }
 
     override fun fetchOrderDetailInfo(order: WCOrderModel) {
         coroutineScope.launch {
             val freshOrderDetailUiItem = orderDetailRepository.fetchOrderDetailInfo(order)
-            displayOrderDetailInfo(order, freshOrderDetailUiItem, true)
+            displayOrderDetailInfo(order, freshOrderDetailUiItem)
         }
     }
 
     private fun displayOrderDetailInfo(
         order: WCOrderModel,
-        orderDetailUiItem: OrderDetailUiItem,
-        displayProductList: Boolean
+        orderDetailUiItem: OrderDetailUiItem
     ) {
         orderView?.showRefunds(orderDetailUiItem.orderModel, orderDetailUiItem.refunds)
         orderView?.showShippingLabels(orderDetailUiItem.orderModel, orderDetailUiItem.shippingLabels)
 
         // display the product list only if we know for sure,
         // that there are no shipping labels available for the order
-        if (displayProductList) {
-            orderView?.showProductList(order, orderDetailUiItem.refunds, orderDetailUiItem.shippingLabels)
-        }
+        orderView?.showProductList(order, orderDetailUiItem.refunds, orderDetailUiItem.shippingLabels)
 
         // Display the shipment tracking list only if it's available and if there are no shipping labels available
         if (orderDetailUiItem.shippingLabels.isEmpty() && orderDetailUiItem.isShipmentTrackingAvailable) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -60,7 +60,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
 import javax.inject.Inject
 
 class OrderDetailPresenter @Inject constructor(
-    private val dispatchers: CoroutineDispatchers,
+    dispatchers: CoroutineDispatchers,
     private val dispatcher: Dispatcher,
     private val orderStore: WCOrderStore,
     private val productStore: WCProductStore,
@@ -102,7 +102,6 @@ class OrderDetailPresenter @Inject constructor(
     }
 
     override fun dropView() {
-        super.dropView()
         orderView = null
         isNotesInit = false
         dispatcher.unregister(this)
@@ -163,6 +162,8 @@ class OrderDetailPresenter @Inject constructor(
         // Display the shipment tracking list only if it's available and if there are no shipping labels available
         if (orderDetailUiItem.shippingLabels.isEmpty() && orderDetailUiItem.isShipmentTrackingAvailable) {
             orderView?.showOrderShipmentTrackings(orderDetailUiItem.shipmentTrackingList)
+        } else {
+            orderView?.hideOrderShipmentTrackings()
         }
     }
 
@@ -352,8 +353,8 @@ class OrderDetailPresenter @Inject constructor(
                 orderModel?.let { order ->
                     orderView?.showOrderDetail(order, isFreshData = true)
                     orderView?.showSkeleton(false)
+                    loadOrderDetailInfo(order)
                     loadOrderNotes()
-                    fetchOrderDetailInfo(order)
                 } ?: orderView?.showLoadOrderError()
             }
         } else if (event.causeOfChange == WCOrderAction.FETCH_ORDER_NOTES) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -166,7 +166,7 @@ class OrderDetailPresenter @Inject constructor(
         }
 
         // Display the shipment tracking list only if it's available and if there are no shipping labels available
-        if (orderDetailUiItem.shippingLabels.isEmpty() && orderDetailUiItem.shipmentTrackingList.isNotEmpty()) {
+        if (orderDetailUiItem.shippingLabels.isEmpty() && orderDetailUiItem.isShipmentTrackingAvailable) {
             orderView?.showOrderShipmentTrackings(orderDetailUiItem.shipmentTrackingList)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -353,7 +353,7 @@ class OrderDetailPresenter @Inject constructor(
                 orderModel?.let { order ->
                     orderView?.showOrderDetail(order, isFreshData = true)
                     orderView?.showSkeleton(false)
-                    loadOrderDetailInfo(order)
+                    fetchOrderDetailInfo(order)
                     loadOrderNotes()
                 } ?: orderView?.showLoadOrderError()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -354,14 +354,12 @@ class OrderDetailPresenter @Inject constructor(
                 WooLog.e(T.ORDERS, "$TAG - Error fetching order : $message")
             } else {
                 orderModel = loadOrderDetailFromDb(orderIdentifier!!)
-                coroutineScope.launch {
-                    orderModel?.let { order ->
-                        orderView?.showOrderDetail(order, isFreshData = true)
-                        orderView?.showSkeleton(false)
-                        loadOrderNotes()
-                        fetchOrderDetailInfo(order)
-                    } ?: orderView?.showLoadOrderError()
-                }
+                orderModel?.let { order ->
+                    orderView?.showOrderDetail(order, isFreshData = true)
+                    orderView?.showSkeleton(false)
+                    loadOrderNotes()
+                    fetchOrderDetailInfo(order)
+                } ?: orderView?.showLoadOrderError()
             }
         } else if (event.causeOfChange == WCOrderAction.FETCH_ORDER_NOTES) {
             orderView?.showOrderNotesSkeleton(false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailRepository.kt
@@ -72,7 +72,8 @@ class OrderDetailRepository @Inject constructor(
             orderModel = order,
             refunds = refunds,
             shippingLabels = shippingLabels,
-            shipmentTrackingList = shipmentTrackingList
+            shipmentTrackingList = shipmentTrackingList,
+            isShipmentTrackingAvailable = shipmentTrackingList.isNotEmpty()
         )
     }
 
@@ -109,10 +110,11 @@ class OrderDetailRepository @Inject constructor(
             } else emptyList()
 
             OrderDetailUiItem(
-                order,
-                refunds,
-                shippingLabels,
-                shipmentTrackingList
+                orderModel = order,
+                refunds = refunds,
+                shippingLabels = shippingLabels,
+                shipmentTrackingList = shipmentTrackingList,
+                isShipmentTrackingAvailable = fetchedShipmentTrackingList
             )
         }
     }
@@ -157,6 +159,7 @@ class OrderDetailRepository @Inject constructor(
         val orderModel: WCOrderModel,
         val refunds: List<Refund>,
         val shippingLabels: List<ShippingLabel>,
-        val shipmentTrackingList: List<WCOrderShipmentTrackingModel>
+        val shipmentTrackingList: List<WCOrderShipmentTrackingModel>,
+        val isShipmentTrackingAvailable: Boolean
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderTestUtils.kt
@@ -202,7 +202,8 @@ object OrderTestUtils {
             orderModel = order,
             refunds = generateRefunds(),
             shippingLabels = generateShippingLabels(lOrderId = order.remoteOrderId),
-            shipmentTrackingList = generateOrderShipmentTrackings(5, order.remoteOrderId.toInt())
+            shipmentTrackingList = generateOrderShipmentTrackings(5, order.remoteOrderId.toInt()),
+            isShipmentTrackingAvailable = true
         )
     }
 }


### PR DESCRIPTION
Fixes #2801 and #2800.  

#### Issue 2800
Show option to add tracking in order details if plugin is available. Fixed in 666147c.

##### To test
- Enable the Shipment Tracking plugin on your test site.
- Click on an order from the app.
- Notice the "Add tracking" section in the Order Detail screen.
- Disable the Shipment Tracking plugin on your test site.
- Click on an order from the app.
- Notice that the "Add tracking" section is no longer displayed in the Order Detail screen.

#### Issue 2801
After changing an order's details (e.g. adding an order note or issuing a refund) the Products section disappears from the order details screen. If I try to pull to refresh the screen at that point, I see loading indicators but it never stops loading.

Fixed in 464d2ce

##### To test
- Go to the Orders tab and select an order.
- Confirm the order details screen includes all the expected information.
- Go to the order notes section and add a note.
- Scroll back up and notice the Products section is now visible.
- Pull to refresh and notice the screen loads as expected.

Thank you for flagging these issues @rachelmcr! I have added you as a reviewer since you caught the initial issue. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
