### PR TITLE
issue/2659 track shipments

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabel.kt
@@ -164,8 +164,12 @@ fun List<ShippingLabel>.appendTrackingUrls(
             )
         } else {
             orderShipmentTrackings.forEach { shipmentTracking ->
-                if (shipmentTracking.trackingNumber == shippingLabel.trackingNumber) {
-                    shippingLabel.trackingLink = shipmentTracking.trackingLink
+                shippingLabel.trackingLink = if (shipmentTracking.trackingNumber == shippingLabel.trackingNumber) {
+                    shipmentTracking.trackingLink
+                } else {
+                    ShipmentTrackingUrls.fromCarrier(
+                        shippingLabel.carrierId, shippingLabel.trackingNumber
+                    )
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabel.kt
@@ -5,6 +5,7 @@ import com.google.i18n.addressinput.common.AddressData
 import com.google.i18n.addressinput.common.FormOptions
 import com.google.i18n.addressinput.common.FormatInterpreter
 import com.woocommerce.android.extensions.appendWithIfNotEmpty
+import com.woocommerce.android.ui.orders.shippinglabels.ShipmentTrackingUrls
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import kotlinx.android.parcel.IgnoredOnParcel
@@ -145,15 +146,29 @@ fun ShippingLabel.loadProductItems(orderItems: List<Order.Item>) =
     orderItems.filter { it.name in productNames }
 
 /**
- * Method matches the tracking link from the [WCOrderShipmentTrackingModel] to the
- * corresponding tracking number of a [ShippingLabel]
- */
-fun ShippingLabel.fetchTrackingLinks(
+ * Shipment tracking links are not available by default from the shipping label API.
+ * Until this is available on the API side, we need to fetch the tracking link from the
+ * shipment tracking API (if available) and link the tracking link to the corresponding
+ * tracking number of a shipping label.
+ *
+ * In cases where the ST plugin is not available, we need to fetch the tracking url based on the
+ * carrierId, mapped in [ShipmentTrackingUrls]. This is currently how WCS is handling it
+*/
+fun List<ShippingLabel>.appendTrackingUrls(
     orderShipmentTrackings: List<WCOrderShipmentTrackingModel>
-) {
-    orderShipmentTrackings.forEach { shipmentTracking ->
-        if (shipmentTracking.trackingNumber == this.trackingNumber) {
-            this.trackingLink = shipmentTracking.trackingLink
+): List<ShippingLabel> {
+    this.map { shippingLabel ->
+        if (orderShipmentTrackings.isEmpty()) {
+            shippingLabel.trackingLink = ShipmentTrackingUrls.fromCarrier(
+                shippingLabel.carrierId, shippingLabel.trackingNumber
+            )
+        } else {
+            orderShipmentTrackings.forEach { shipmentTracking ->
+                if (shipmentTracking.trackingNumber == shippingLabel.trackingNumber) {
+                    shippingLabel.trackingLink = shipmentTracking.trackingLink
+                }
+            }
         }
     }
+    return this
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -22,7 +22,6 @@ import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.Order
-import com.woocommerce.android.model.Order.Item
 import com.woocommerce.android.model.Refund
 import com.woocommerce.android.model.ShippingLabel
 import com.woocommerce.android.model.fetchTrackingLinks
@@ -240,9 +239,7 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
             val unpackagedAndNonRefundedProducts =
                 orderModel.getUnpackagedAndNonRefundedProducts(refunds, shippingLabels)
 
-            val listTitle = if (hasVirtualProductsOnly(unpackagedAndNonRefundedProducts)) {
-                getString(R.string.orderdetail_shipping_label_virtual_products_header)
-            } else if (shippingLabels.isNotEmpty() && hasUnpackagedProducts) {
+            val listTitle = if (shippingLabels.isNotEmpty() && hasUnpackagedProducts) {
                 getString(R.string.orderdetail_shipping_label_unpackaged_products_header)
             } else null
 
@@ -713,7 +710,7 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
                             orderStatus,
                             false,
                             listener = this)
-                    .also { it.show(requireFragmentManager(), OrderStatusSelectorDialog.TAG) }
+                    .also { it.show(parentFragmentManager, OrderStatusSelectorDialog.TAG) }
         }
     }
 
@@ -724,23 +721,5 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
     private fun showOrderShippingNotice(isVirtualProduct: Boolean, order: WCOrderModel) {
         val hideShippingMethodNotice = isVirtualProduct || !order.isMultiShippingLinesAvailable()
         orderDetail_shippingMethodNotice.visibility = if (hideShippingMethodNotice) View.GONE else View.VISIBLE
-    }
-
-    private fun hasVirtualProductsOnly(
-        orderItems: List<Item>
-    ): Boolean {
-        val remoteProductIds: List<Long> = orderItems.map { it.productId }
-        if (remoteProductIds.isNullOrEmpty()) {
-            return false
-        }
-
-        // verify that the LineItem product is in the local cache and
-        // that the product count in the local cache matches the lineItem count.
-        val productModels = presenter.getProductsByIds(remoteProductIds)
-        if (productModels.isNullOrEmpty() || productModels.count() != remoteProductIds.count()) {
-            return false
-        }
-
-        return productModels.none { !it.virtual }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -24,7 +24,6 @@ import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Refund
 import com.woocommerce.android.model.ShippingLabel
-import com.woocommerce.android.model.fetchTrackingLinks
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.ProductImageMap
@@ -214,13 +213,6 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
     }
 
     override fun showShippingLabels(order: WCOrderModel, shippingLabels: List<ShippingLabel>) {
-        // Shipment tracking links are not available by default from the shipping label API
-        // Until this is available on the API side, we need to fetch the tracking link from the
-        // shipment tracking API (if available) and link the tracking link to the corresponding
-        // tracking number of a shipping label
-        val shipmentTrackingList = presenter.getOrderShipmentTrackingsFromDb(order)
-        shippingLabels.map { it.fetchTrackingLinks(shipmentTrackingList) }
-
         orderDetail_shippingLabelList.initView(
             order.toAppModel(),
             shippingLabels,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_TRACKING_AD
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_TRACKING_DELETE_FAILED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_TRACKING_DELETE_SUCCESS
 import com.woocommerce.android.extensions.isVirtualProduct
+import com.woocommerce.android.model.appendTrackingUrls
 import com.woocommerce.android.network.ConnectionChangeReceiver
 import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
 import com.woocommerce.android.push.NotificationHandler
@@ -157,7 +158,10 @@ class OrderDetailPresenter @Inject constructor(
         displayProductList: Boolean
     ) {
         orderView?.showRefunds(orderDetailUiItem.orderModel, orderDetailUiItem.refunds)
-        orderView?.showShippingLabels(orderDetailUiItem.orderModel, orderDetailUiItem.shippingLabels)
+        orderView?.showShippingLabels(
+            order = orderDetailUiItem.orderModel,
+            shippingLabels = orderDetailUiItem.shippingLabels.appendTrackingUrls(orderDetailUiItem.shipmentTrackingList)
+        )
 
         // display the product list only if we know for sure,
         // that there are no shipping labels available for the order

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShipmentTrackingUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShipmentTrackingUrls.kt
@@ -1,0 +1,25 @@
+package com.woocommerce.android.ui.orders.shippinglabels
+
+/**
+ * Maps the shipping carriers with the corresponding tracking urls since it is currently not possible
+ * from the API to fetch tracking urls for a shipment without the Shipment Tracking plugin.
+ */
+enum class ShipmentTrackingUrls(val trackingUrl: String) {
+    USPS("https://tools.usps.com/go/TrackConfirmAction.action?tLabels=%s"),
+    FEDEX("https://www.fedex.com/apps/fedextrack/?action=track&tracknumbers=%s"),
+    UPS("https://www.ups.com/track?loc=en_US&tracknum=%s"),
+    DHL("https://www.dhl.com/en/express/tracking.html?AWB=%s&brand=DHL");
+
+    companion object {
+        fun fromCarrier(carrierId: String, trackingNumber: String): String? {
+            val shippingCarrier = when (carrierId) {
+                "usps" -> USPS
+                "fedex" -> FEDEX
+                "ups" -> UPS
+                "dhl" -> DHL
+                else -> null
+            }
+            return shippingCarrier?.trackingUrl?.format(trackingNumber)
+        }
+    }
+}

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -38,7 +38,6 @@ Language: sv_SE
     <string name="product_detail_product_type_hint">%1$s produkt</string>
     <string name="product_type_downloadable">nedladdningsbar</string>
     <string name="product_type_description">%s produkt</string>
-    <string name="orderdetail_shipping_label_virtual_products_header">Återstående produkter</string>
     <string name="orderdetail_shipping_label_unpackaged_products_header">Resterande artiklar som ska skickas</string>
     <string name="orderdetail_shipping_label_refund_subtitle">%1$s \u2022 %2$s</string>
     <string name="orderdetail_shipping_label_refund_title">%1$s returetikett</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -276,8 +276,7 @@
     <string name="orderdetail_shipping_label_refund_title">%1$s label refunded</string>
     <string name="orderdetail_shipping_label_refund_subtitle">%1$s \u2022 %2$s</string>
     <string name="orderdetail_shipping_label_request_refund">Request a refund</string>
-    <string name="orderdetail_shipping_label_unpackaged_products_header">Remaining items to ship</string>
-    <string name="orderdetail_shipping_label_virtual_products_header">Remaining products</string>
+    <string name="orderdetail_shipping_label_unpackaged_products_header">Remaining products</string>
     <string name="order_begin_fulfillment">Begin fulfillment</string>
     <string name="order_fulfill_mark_complete">Mark Order Complete</string>
     <string name="order_fulfill_marked_complete">Order Marked Complete</string>


### PR DESCRIPTION
Fixes #2654 and part 1/2 of #2659 by providing the option to track shipments when the Shipment Tracking plugin is not available.

#### Issue #2654 
We need to display the header for products not associated with any shipping labels as "Remaining Products" since it can include both virtual and physical products. Fixed in 69a144f.

##### Testing
- Create an order from your test site with atleast 2 products.
- Follow the instructions provided in the Shipping Labels Master Thread - `p91TBi-2om` to create a shipping label for the order, with only 1 product.
- Open the app and click on the order.
- Notice that product header for the shipping label is displayed as `Package 1` and the second product heading is displayed as `Remaining items`.

#### Issue 2659
**Tracking shipment**
- With the Shipment Tracking plugin available: Calling the GET shipment tracking list API endpoint will provide the list of shipment trackings for the order. We can then match the shipping label tracking number with the shipment tracking number to display the corresponding tracking link.
- Without the Shipment Tracking plugin: If the shipment tracking plugin is not available, we won't be able to use the GET shipmen tracking API endpoint. But WCS still displays the tracking link in wp-admin. We need to [store the tracking link for each carrier in the app and we just need append the tracking Id for that shipping label to that link](https://github.com/Automattic/woocommerce-services/blob/develop/client/extensions/woocommerce/woocommerce-services/views/shipping-label/tracking-link.js), if the tracking link icon is clicked from the app.

Fixed in 1bd2f93

##### Testing
- Enable the Shipment Tracking plugin and WooCommerce Services plugin on your test site.
- Create an order from your test site with atleast 2 products.
- Follow the instructions provided in the Shipping Labels Master Thread - `p91TBi-2om` to create a shipping label for the order, with only 1 product.
- Click on the order from the app that has the shipping label.
- Notice the tracking number displayed for the shipping label and the tracking icon displayed. Clicking on the tracking link should open the tracking link for the carrier.
- Disable the Shipment Tracking plugin for the test site.
- Open the same order from the app.
- Notice the tracking number displayed for the shipping label and the tracking icon is also displayed. Clicking on the tracking link should open the tracking link for the carrier.

<img src="https://user-images.githubusercontent.com/22608780/91711901-5ca98980-eba4-11ea-9aac-2a68e5e3c2a2.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/91711904-5e734d00-eba4-11ea-9497-5f0ff89f5069.png" width="300"/>

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
