### PR TITLE
Fix bundletool installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,8 +120,9 @@ jobs:
           command: |
             /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
             eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
-            echo "export PATH='/home/linuxbrew/.linuxbrew/Cellar/bundletool/1.0.0/bin:$PATH'" >> $BASH_ENV
+            brew install openjdk
             brew install bundletool
+            echo "export PATH='/home/linuxbrew/.linuxbrew/Cellar/bundletool/1.2.0/bin:$PATH'" >> $BASH_ENV
       - android/restore-gradle-cache
       - run:
           name: Build APK


### PR DESCRIPTION
This PR fixes an issue with `bundletool` installation using the current version of `linuxbrew`. The issue is the same we found and fixed on Android: https://github.com/wordpress-mobile/WordPress-Android/pull/12681#issuecomment-684772057.

The fix has already been tested on WPAndroid and has been used for the latest 4.9-rc-3 release: https://app.circleci.com/pipelines/github/woocommerce/woocommerce-android/7278/workflows/e63df891-f9a1-4506-bcb4-bd07319e5b51. 

I'm targeting the release branch because it won't be possible to run the release build on CI without this fix.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
