### PR TITLE
issue/2615-runtime-exception

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 5.0
 -----
 * Fixed an issue where switching between light and dark themes on older Android versions made the app unresponsive.
+* Fixed a common crash when choosing a product image
  
 4.9
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -178,6 +178,7 @@ class ProductImagesFragment : BaseProductFragment(), OnGalleryImageClickListener
         val intent = Intent(Intent.ACTION_GET_CONTENT).also {
             it.type = "image/*"
             it.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+            it.addCategory(Intent.CATEGORY_OPENABLE)
         }
         val chooser = Intent.createChooser(intent, null)
         activity?.startActivityFromFragment(this, chooser, RequestCodes.CHOOSE_PHOTO)


### PR DESCRIPTION
Resolves #2615 - this PR hopefully fixes a common crash that occurs when selecting product images. This took a bit of detective work, the details of which are [in the issue's comments](https://github.com/woocommerce/woocommerce-android/issues/2615), but the short story is the crash occurs [here](https://github.com/wordpress-mobile/WordPress-Android/blob/49b98b649f59753d1ad18ba70f3bf4253d6e5d9e/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java#L211) in the `MediaUtils` class we share with WPAndroid.

That line uses a content resolver to read image files, and according to [the docs](https://developer.android.com/guide/components/intents-common#GetFile) we should use [CATEGORY_OPENABLE](https://developer.android.com/reference/android/content/Intent#CATEGORY_OPENABLE) to restrict selectable files to only those that are accessible from a content provider. So, this PR simply adds that category.

Once 5.0 is released we can check if we're still getting Sentry events for this crash, and if not I'll suggest the same change on the WPAndroid side.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
