### PR TITLE
Tests: Fix connected screenshot test

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/mystore/StatsComponent.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/mystore/StatsComponent.kt
@@ -5,7 +5,7 @@ import com.woocommerce.android.screenshots.util.Screen
 
 class StatsComponent : Screen {
     companion object {
-        const val STATS_DASHBOARD = R.id.dashboard_stats
+        const val STATS_DASHBOARD = R.id.dashboardStats_root
     }
 
     constructor(): super(STATS_DASHBOARD)
@@ -34,7 +34,7 @@ class StatsComponent : Screen {
     }
 
     fun switchToStatsDashboardYearsTab() {
-        selectItemWithTitleInTabLayout(R.string.dashboard_stats_granularity_years, R.id.tab_layout, STATS_DASHBOARD)
+        selectItemWithTitleInTabLayout(R.string.this_year, R.id.stats_tab_layout, R.id.app_bar_layout)
         waitForGraphToLoad()
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/mystore/settings/SettingsScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/mystore/settings/SettingsScreen.kt
@@ -9,13 +9,14 @@ import com.woocommerce.android.screenshots.util.Screen
 
 class SettingsScreen : Screen {
     companion object {
+        const val SELECTED_STORE = R.id.option_store
         const val BETA_FEATURES_BUTTON = R.id.option_beta_features
         const val LOG_OUT_BUTTON = R.id.btn_option_logout
     }
 
-    // Using BETA_FEATURES_BUTTON even if we don't need to interact with it because for some reason Espresso can't find
+    // Using SELECTED_STORE even if we don't need to interact with it because for some reason Espresso can't find
     // LOG_OUT_BUTTON
-    constructor(): super(BETA_FEATURES_BUTTON)
+    constructor(): super(SELECTED_STORE)
 
     fun openBetaFeatures(): BetaFeaturesScreen {
         clickOn(BETA_FEATURES_BUTTON)
@@ -35,7 +36,7 @@ class SettingsScreen : Screen {
             //
             // But since the merge of the dark mode UI changes, it doesn't work anymore. Reading through the test
             // failure, it looks like it's failing because it can't find the LOG_OUT_BUTTON element. This is consistent
-            // with the behavior that required the workaround in the in to use BETA_FEATURES_BUTTON.
+            // with the behavior that required the workaround to use SELECTED_STORE.
             //
             // Immediately attempting a scroll solves the issue.
             Espresso.onView(ViewMatchers.withId(LOG_OUT_BUTTON)).perform(NestedScrollViewExtension())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -140,6 +140,7 @@ class MyStoreFragment : TopLevelFragment(),
                 tab.select()
             }
         }
+        tabLayout.setId(R.id.stats_tab_layout)
 
         my_store_date_bar.initView()
         my_store_stats.initView(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -69,7 +69,9 @@ class MyStoreFragment : TopLevelFragment(),
         }
 
     private val tabLayout: TabLayout by lazy {
-        TabLayout(requireContext(), null, R.attr.scrollableTabStyle)
+        TabLayout(requireContext(), null, R.attr.scrollableTabStyle).also {
+            it.setId(R.id.stats_tab_layout)
+        }
     }
 
     private val appBarLayout
@@ -140,7 +142,6 @@ class MyStoreFragment : TopLevelFragment(),
                 tab.select()
             }
         }
-        tabLayout.setId(R.id.stats_tab_layout)
 
         my_store_date_bar.initView()
         my_store_stats.initView(

--- a/WooCommerce/src/main/res/values/ids.xml
+++ b/WooCommerce/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item type="id" name="stats_tab_layout" />
+</resources>


### PR DESCRIPTION
## Changes

The connected screenshot test has been broken since we started showing v4 stats by default.

This PR fixes the screenshot test with a few changes:

* Add a new `ids.xml` resource so we can add a resource ID to the TabLayout on the v4 stats screen, to use in connected tests.
* Update the `SettingsScreen` screen object so it works even if the beta features section is disabled.
* Update the resources IDs used in the `StatsComponent` screen object to match the v4 stats screen.

## Testing

1. Ensure your `gradle.properties` file includes real values for `wc.screenshots.url`, `wc.screenshots.username`, and `wc.screenshots.password`.
2. Run `ScreenshotTest` in `com.woocommerce.android.screenshots` and confirm it passes. (Or you can run connected tests from the command line with `./gradlew :WooCommerce:connectedVanillaDebugAndroidTest`.)

## Review

Only one reviewer is needed. I'm especially interested in making sure that my changes to the app itself (to add the TabLayout resource ID) are ok.
@mokagio I added you as an additional reviewer since you've worked on the screenshot test before.

## Submitter checklist

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
