### PR TITLE
Added logic to display M3 banner only if M3 features are enabled

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -32,6 +32,7 @@ import com.woocommerce.android.ui.products.ProductFilterListViewModel.Companion.
 import com.woocommerce.android.ui.products.ProductListAdapter.OnProductClickListener
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ScrollToTop
 import com.woocommerce.android.ui.products.ProductSortAndFiltersCard.ProductSortAndFilterListener
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.SkeletonView
@@ -337,10 +338,14 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener, ProductS
 
     private fun showProductWIPNoticeCard(show: Boolean) {
         if (show) {
+            val wipCardMessageId = if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled()) {
+                R.string.product_wip_message_m3
+            } else R.string.product_wip_message_m2
+
             products_wip_card.visibility = View.VISIBLE
             products_wip_card.initView(
                 getString(R.string.product_wip_title),
-                getString(R.string.product_wip_message)
+                getString(wipCardMessageId)
             )
         } else {
             products_wip_card.visibility = View.GONE

--- a/WooCommerce/src/main/res/layout/products_wip_notice.xml
+++ b/WooCommerce/src/main/res/layout/products_wip_notice.xml
@@ -33,7 +33,7 @@
             android:layout_marginTop="@dimen/minor_00"
             android:layout_marginBottom="@dimen/major_100"
             android:visibility="gone"
-            tools:text="@string/product_wip_message"
+            tools:text="@string/product_wip_message_m2"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="@+id/guideline7"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -535,7 +535,8 @@
     <string name="product_limited_editing_title">Limited editing available</string>
     <string name="product_limited_editing_message">We\'ve added editing functionality to simple products. Keep an eye out for more options soon!</string>
     <string name="product_wip_title">New editing options available</string>
-    <string name="product_wip_message">You can now edit grouped, external and variable products, change product type and update categories and tags</string>
+    <string name="product_wip_message_m2">We\'ve added more editing functionalities to products! You can now update images, see previews and share your products.</string>
+    <string name="product_wip_message_m3">You can now edit grouped, external and variable products, change product type and update categories and tags.</string>
     <string name="product_bullet" translatable="false"> \u2022 </string>
     <string name="product_variant_list_empty">Add options like size and color from web. These will show up as options on the product page of your site</string>
     <string name="product_description_hint">Start writing…</string>


### PR DESCRIPTION
Fixes #2802 by adding logic to display the M3 editing message in the WIP banner only if the M3 features have been enabled.

#### To test
- Go to Settings > Beta Features and make sure Product Editing is disabled.
- Go to the Products tab.
- Expand the banner at the top of the screen and check the message there. The message should read: `We've added more editing functionalities to products! You can now update images, see previews and share your products.`
- Go to Settings > Beta Features and make sure Product Editing is enabled now.
- Go to the Products tab.
- Expand the banner at the top of the screen and check the message there. The message should read: `You can now edit grouped, external and variable products, ...`


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
