### PR TITLE
Unified Login: Store picker and error screens

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -179,6 +179,9 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
     }
 
     override fun startOver() {
+        // Clear logged in url from AppPrefs
+        AppPrefs.removeLoginSiteAddress()
+
         showPrologueFragment()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -239,6 +239,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
 
                 // Make "show connected stores" visible to the user
                 button_secondary.visibility = View.VISIBLE
+                button_secondary.text = getString(R.string.login_view_connected_stores)
             } else {
                 hasConnectedStores = false
 
@@ -249,9 +250,14 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             loginSiteUrl?.let { processLoginSite(it) }
             return
         }
-        // Hide "show connected stores" button now that we're displaying
-        // the store list.
-        button_secondary.visibility = View.GONE
+
+        // Show the 'try another account' button in case the user
+        // doesn't see the store they want to log into.
+        with(button_secondary) {
+            visibility = View.VISIBLE
+            text = getString(R.string.login_try_another_account)
+            setOnClickListener { presenter.logout() }
+        }
 
         AnalyticsTracker.track(
                 Stat.SITE_PICKER_STORES_SHOWN,
@@ -282,10 +288,12 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             selectedSite.getIfExists()?.siteId ?: wcSites[0].siteId
         }
 
-        button_primary.text = getString(R.string.done)
-        button_primary.isEnabled = true
-        button_primary.setOnClickListener {
-            presenter.getSiteBySiteId(siteAdapter.selectedSiteId)?.let { site -> siteSelected(site) }
+        with(button_primary) {
+            text = getString(R.string.done)
+            isEnabled = true
+            setOnClickListener {
+                presenter.getSiteBySiteId(siteAdapter.selectedSiteId)?.let { site -> siteSelected(site) }
+            }
         }
     }
 
@@ -379,10 +387,14 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         site_list_container.visibility = View.GONE
         no_stores_view.visibility = View.VISIBLE
 
-        button_primary.text = getString(R.string.login_try_another_account)
-        button_primary.isEnabled = true
-        button_primary.setOnClickListener {
-            presenter.logout()
+        with(button_primary) {
+            text = getString(R.string.login_try_another_account)
+            isEnabled = true
+            setOnClickListener { presenter.logout() }
+        }
+
+        with(button_secondary) {
+            visibility = View.GONE
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerContract.kt
@@ -24,7 +24,6 @@ interface SitePickerContract {
     }
 
     interface View : BaseView<Presenter> {
-        fun showUserInfo()
         fun showStoreList(wcSites: List<SiteModel>)
         fun showNoStoresView()
         fun showSiteNotConnectedAccountView(url: String)

--- a/WooCommerce/src/main/res/layout/activity_site_picker.xml
+++ b/WooCommerce/src/main/res/layout/activity_site_picker.xml
@@ -57,12 +57,11 @@
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/site_list_label"
-                    android:textAppearance="@style/TextAppearance.Woo.Button"
+                    android:textAppearance="@style/TextAppearance.Woo.Body2"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_margin="@dimen/major_100"
                     android:text="@string/login_pick_store"
-                    android:textColor="?attr/colorSecondary"
                     android:textAllCaps="true"/>
 
                 <androidx.recyclerview.widget.RecyclerView


### PR DESCRIPTION
Closes #2818 by implementing design updates for the store picker view and error views related to the final login screen. This includes:
- Add the "Log in with another account" button when the store list is being displayed
- Update the style of the "SELECT STORE TO CONNECT" label.
- Left-align the user info views when the store list is being displayed and center the user info in all the error views.
- Make the gravatar bigger when left-aligned and smaller when centered. 

### Screenshots

Store picker | Not a Woo Store | Wrong account | No Stores
-- | -- | -- | -- 
![store-picker](https://user-images.githubusercontent.com/5810477/92662561-1a332b80-f2cd-11ea-934e-8d3f7fd21b7f.png)|![not-woo](https://user-images.githubusercontent.com/5810477/92662563-1bfcef00-f2cd-11ea-904b-c644ce336214.png)|![wrong-account](https://user-images.githubusercontent.com/5810477/92662568-1e5f4900-f2cd-11ea-8a98-79d68182c7d2.png)|![no-stores](https://user-images.githubusercontent.com/5810477/92662571-1f907600-f2cd-11ea-88a6-6cbee211c0ba.png)

### To Test

**Store Picker**
1. Tap "Continue with WordPress.com"
2. Log in with a WPcom account that has 1 or more Woo stores active.
3. Verify store picker is displayed and matches screenshot
4. Verify "done" and "Log in with another account" both work as expected. 

**Not a Woo Store**
1. Tap "Enter your store address"
2. Enter a WordPress url that does not have Woo installed and finish login
3. Verify "not a woo store" view is displayed
4. Verify "View connected stores" and "Log in with another account" both work as expected. 

**Wrong Account**
1. Tap "Enter your store address"
2. Enter a WordPress site
3. Log in with a WPcom account that is not connected to the site in the previous step
4. Verify "wrong account" view is displayed
5. Verify "View connected stores" and "Log in with another account" both work as expected. 

**No Stores**
1. Tap "Continue with WordPress.com"
2. Log in with a WPcom account that has no Woo stores connected to it.
3. Verify the "No Stores" view is displayed
4. Verify "Log in with another account" works as expected. 


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
