### PR TITLE
Products m3 crash fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ParentCategoryListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ParentCategoryListAdapter.kt
@@ -35,7 +35,7 @@ class ParentCategoryListAdapter(
     override fun getItemCount() = parentCategoryList.size
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ParentCategoryListViewHolder {
-        return ParentCategoryListViewHolder(LayoutInflater.from(context)
+        return ParentCategoryListViewHolder(LayoutInflater.from(parent.context)
             .inflate(R.layout.parent_category_list_item, parent, false))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ProductCategoriesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ProductCategoriesAdapter.kt
@@ -31,7 +31,7 @@ class ProductCategoriesAdapter(
     override fun getItemCount() = productCategoryList.size
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProductCategoryViewHolder {
-        return ProductCategoryViewHolder(LayoutInflater.from(context)
+        return ProductCategoryViewHolder(LayoutInflater.from(parent.context)
             .inflate(R.layout.product_category_list_item, parent, false))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsAdapter.kt
@@ -35,7 +35,7 @@ class ProductTagsAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProductTagViewHolder {
         return ProductTagViewHolder(
-            LayoutInflater.from(context)
+            LayoutInflater.from(parent.context)
             .inflate(R.layout.product_tag_list_item, parent, false)
         )
     }

--- a/WooCommerce/src/main/res/layout/parent_category_list_item.xml
+++ b/WooCommerce/src/main/res/layout/parent_category_list_item.xml
@@ -6,7 +6,7 @@
     android:id="@+id/categoryItemLayout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?android:attr/selectableItemBackground">
+    android:background="?attr/selectableItemBackground">
 
     <CheckedTextView
         android:id="@+id/parentCategoryName"

--- a/WooCommerce/src/main/res/layout/product_category_list_item.xml
+++ b/WooCommerce/src/main/res/layout/product_category_list_item.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/categoryItemLayout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?android:attr/selectableItemBackground">
+    android:background="?attr/selectableItemBackground">
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/categoryName"
@@ -14,14 +15,14 @@
         android:layout_height="wrap_content"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/categorySelected"
+        app:layout_constraintEnd_toStartOf="@+id/categorySelected"
         tools:text="Category" />
 
     <com.google.android.material.checkbox.MaterialCheckBox
         android:id="@+id/categorySelected"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintStart_toEndOf="@id/categoryName"
+        app:layout_constraintStart_toEndOf="@+id/categoryName"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 


### PR DESCRIPTION
Fixes #2830 and #2831 by adding logic to use the `ViewGroup` parent's `context` when initialising `ProductCategoriesAdapter` and `ProductTagsAdapter`.

#### To test
- Enable Product Editing under Settings > Beta Features. 
- Open a product from the Products tab.
- Click on the Categories section and notice that the app no longer crashes.

#### To test
- Enable Product Editing under Settings > Beta Features. 
- Open a product from the Products tab.
- Click on the Tags section and notice that the app no longer crashes.

@rachelmcr I have added you as a reviewer as well since you were able to reproduce the crash! Thanks 😊 
@loremattei, this would require another beta release once PR is merged! Thank you 🙇‍♀️  

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
