### PR TITLE
Unified Login: Add tracks for login w/ site address - flow and interaction events

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -109,6 +109,9 @@ class AnalyticsTracker private constructor(private val context: Context) {
         LOGIN_MAGIC_LINK_FETCH_ACCOUNT_SUCCESS(siteless = true),
         LOGIN_MAGIC_LINK_FETCH_ACCOUNT_SETTINGS_SUCCESS(siteless = true),
         LOGIN_MAGIC_LINK_FETCH_SITES_SUCCESS(siteless = true),
+        UNIFIED_LOGIN_STEP(siteless = true),
+        UNIFIED_LOGIN_FAILURE(siteless = true),
+        UNIFIED_LOGIN_INTERACTION(siteless = true),
 
         // -- Site Picker
         SITE_PICKER_STORES_SHOWN(siteless = true),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTrackerWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTrackerWrapper.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.analytics
+
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import dagger.Reusable
+import javax.inject.Inject
+
+@Reusable
+class AnalyticsTrackerWrapper
+@Inject constructor() {
+    fun track(stat: Stat) {
+        AnalyticsTracker.track(stat)
+    }
+
+    fun track(stat: Stat, properties: Map<String, *>) {
+        AnalyticsTracker.track(stat, properties)
+    }
+
+    /**
+     * A convenience method for logging an error event with some additional meta data.
+     * @param stat The stat to track.
+     * @param errorContext A string providing additional context (if any) about the error.
+     * @param errorType The type of error.
+     * @param errorDescription The error text or other description.
+     */
+    fun track(stat: Stat, errorContext: String, errorType: String, errorDescription: String) {
+        AnalyticsTracker.track(stat, errorContext, errorType, errorDescription)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ActivityBindingModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ActivityBindingModule.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.ui.aztec.AztecModule
 import com.woocommerce.android.ui.dashboard.DashboardModule
 import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.LoginNoJetpackFragmentModule
+import com.woocommerce.android.ui.login.LoginPrologueModule
 import com.woocommerce.android.ui.login.MagicLinkInterceptActivity
 import com.woocommerce.android.ui.login.MagicLinkInterceptFragmentModule
 import com.woocommerce.android.ui.main.MainActivity
@@ -48,7 +49,8 @@ abstract class ActivityBindingModule {
     @ContributesAndroidInjector(modules = [
         LoginFragmentModule::class,
         MagicLinkInterceptFragmentModule::class,
-        LoginNoJetpackFragmentModule::class])
+        LoginNoJetpackFragmentModule::class,
+        LoginPrologueModule::class])
     abstract fun provideLoginActivityInjector(): LoginActivity
 
     @ActivityScope

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -292,6 +292,7 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
 
     override fun usePasswordInstead(email: String?) {
         loginAnalyticsListener.trackLoginMagicLinkExited()
+        unifiedLoginTracker.trackClick(Click.LOGIN_WITH_PASSWORD)
         val loginEmailPasswordFragment = LoginEmailPasswordFragment.newInstance(email, null, null, null, false)
         slideInFragment(loginEmailPasswordFragment, true, LoginEmailPasswordFragment.TAG)
     }
@@ -378,6 +379,7 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
      * in the login process.
      */
     override fun loginViaSiteCredentials(inputSiteAddress: String?) {
+        unifiedLoginTracker.trackClick(Click.LOGIN_WITH_SITE_CREDS)
         showUsernamePasswordScreen(inputSiteAddress, null, null, null)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -22,7 +22,7 @@ import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.ui.login.LoginPrologueFragment.PrologueFinishedListener
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Click
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Flow.LOGIN_SITE_ADDRESS
-import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step.ENTER_EMAIL_ADDRESS
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Source
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step.ENTER_SITE_ADDRESS
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.util.ActivityUtils
@@ -59,6 +59,9 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
         private const val FORGOT_PASSWORD_URL_SUFFIX = "wp-login.php?action=lostpassword"
         private const val MAGIC_LOGIN = "magic-login"
         private const val TOKEN_PARAMETER = "token"
+
+        private const val KEY_UNIFIED_TRACKER_SOURCE = "KEY_UNIFIED_TRACKER_SOURCE"
+        private const val KEY_UNIFIED_TRACKER_FLOW = "KEY_UNIFIED_TRACKER_FLOW"
     }
 
     @Inject internal lateinit var androidInjector: DispatchingAndroidInjector<Any>
@@ -82,11 +85,25 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
             loginAnalyticsListener.trackLoginAccessed()
             showPrologueFragment()
         }
+
+        savedInstanceState?.let { ss ->
+            unifiedLoginTracker.setSource(ss.getString(KEY_UNIFIED_TRACKER_SOURCE, Source.DEFAULT.value))
+            unifiedLoginTracker.setFlow(ss.getString(KEY_UNIFIED_TRACKER_FLOW))
+        }
     }
 
     override fun onResume() {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+
+        outState.putString(KEY_UNIFIED_TRACKER_SOURCE, unifiedLoginTracker.getSource().value)
+        unifiedLoginTracker.getFlow()?.value?.let {
+            outState.putString(KEY_UNIFIED_TRACKER_FLOW, it)
+        }
     }
 
     private fun showPrologueFragment() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -20,6 +20,10 @@ import com.woocommerce.android.support.HelpActivity.Origin
 import com.woocommerce.android.support.ZendeskExtraTags
 import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.ui.login.LoginPrologueFragment.PrologueFinishedListener
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Click
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Flow.LOGIN_SITE_ADDRESS
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step.ENTER_EMAIL_ADDRESS
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step.ENTER_SITE_ADDRESS
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
@@ -59,6 +63,7 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
 
     @Inject internal lateinit var androidInjector: DispatchingAndroidInjector<Any>
     @Inject internal lateinit var loginAnalyticsListener: LoginAnalyticsListener
+    @Inject internal lateinit var unifiedLoginTracker: UnifiedLoginTracker
     @Inject internal lateinit var zendeskHelper: ZendeskHelper
 
     private var loginMode: LoginMode? = null
@@ -228,6 +233,7 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
     }
 
     override fun loginViaSiteAddress() {
+        unifiedLoginTracker.setFlowAndStep(LOGIN_SITE_ADDRESS, ENTER_SITE_ADDRESS)
         val loginSiteAddressFragment = getLoginViaSiteAddressFragment() ?: LoginSiteAddressFragment()
         slideInFragment(loginSiteAddressFragment, true, LoginSiteAddressFragment.TAG)
     }
@@ -385,6 +391,7 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
     }
 
     override fun helpFindingSiteAddress(username: String?, siteStore: SiteStore?) {
+        unifiedLoginTracker.trackClick(Click.HELP_FINDING_SITE_ADDRESS)
         zendeskHelper.createNewTicket(this, Origin.LOGIN_SITE_ADDRESS, null)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginAnalyticsModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginAnalyticsModule.kt
@@ -9,7 +9,11 @@ import org.wordpress.android.login.LoginAnalyticsListener
 @Module
 class LoginAnalyticsModule {
     @Provides
-    fun provideAnalyticsListener(accountStore: AccountStore, siteStore: SiteStore): LoginAnalyticsListener {
-        return LoginAnalyticsTracker(accountStore, siteStore)
+    fun provideAnalyticsListener(
+        accountStore: AccountStore,
+        siteStore: SiteStore,
+        unifiedLoginTracker: UnifiedLoginTracker
+    ): LoginAnalyticsListener {
+        return LoginAnalyticsTracker(accountStore, siteStore, unifiedLoginTracker)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginAnalyticsTracker.kt
@@ -34,6 +34,7 @@ class LoginAnalyticsTracker(
 
     override fun trackEmailFormViewed() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_EMAIL_FORM_VIEWED)
+        unifiedLoginTracker.track(step = Step.ENTER_EMAIL_ADDRESS)
     }
 
     override fun trackInsertedInvalidUrl() {
@@ -70,6 +71,7 @@ class LoginAnalyticsTracker(
 
     override fun trackLoginMagicLinkOpenEmailClientClicked() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_OPEN_EMAIL_CLIENT_CLICKED)
+        unifiedLoginTracker.track(step = Step.EMAIL_OPENED)
     }
 
     override fun trackLoginMagicLinkSucceeded() {
@@ -94,10 +96,12 @@ class LoginAnalyticsTracker(
 
     override fun trackMagicLinkRequestFormViewed() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_REQUEST_FORM_VIEWED)
+        unifiedLoginTracker.track(Flow.LOGIN_MAGIC_LINK, Step.START)
     }
 
     override fun trackPasswordFormViewed() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_PASSWORD_FORM_VIEWED)
+        unifiedLoginTracker.track(Flow.LOGIN_PASSWORD, Step.START)
     }
 
     override fun trackSignupCanceled() {
@@ -186,6 +190,7 @@ class LoginAnalyticsTracker(
 
     override fun trackUrlFormViewed() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_URL_FORM_VIEWED)
+        unifiedLoginTracker.track(Flow.LOGIN_SITE_ADDRESS, Step.START)
     }
 
     override fun trackUrlHelpScreenViewed() {
@@ -194,6 +199,7 @@ class LoginAnalyticsTracker(
 
     override fun trackUsernamePasswordFormViewed() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_USERNAME_PASSWORD_FORM_VIEWED)
+        unifiedLoginTracker.track(Flow.LOGIN_STORE_CREDS, Step.USERNAME_PASSWORD)
     }
 
     override fun trackWpComBackgroundServiceUpdate(properties: Map<String, *>) {
@@ -231,7 +237,7 @@ class LoginAnalyticsTracker(
 
     override fun trackLoginMagicLinkOpenEmailClientViewed() {
         AnalyticsTracker.track(LOGIN_MAGIC_LINK_OPEN_EMAIL_CLIENT_VIEWED)
-        unifiedLoginTracker.track(Flow.LOGIN_MAGIC_LINK, Step.MAGIC_LINK_REQUESTED)
+        unifiedLoginTracker.track(step = Step.MAGIC_LINK_REQUESTED)
     }
 
     override fun trackSocialButtonStart() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginAnalyticsTracker.kt
@@ -59,6 +59,7 @@ class LoginAnalyticsTracker(
 
     override fun trackLoginForgotPasswordClicked() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_FORGOT_PASSWORD_CLICKED)
+        unifiedLoginTracker.trackClick(Click.FORGOTTEN_PASSWORD)
     }
 
     override fun trackLoginMagicLinkExited() {
@@ -72,6 +73,7 @@ class LoginAnalyticsTracker(
     override fun trackLoginMagicLinkOpenEmailClientClicked() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_OPEN_EMAIL_CLIENT_CLICKED)
         unifiedLoginTracker.track(step = Step.EMAIL_OPENED)
+        unifiedLoginTracker.trackClick(Click.OPEN_EMAIL_CLIENT)
     }
 
     override fun trackLoginMagicLinkSucceeded() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginAnalyticsTracker.kt
@@ -1,6 +1,10 @@
 package com.woocommerce.android.ui.login
 
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_OPEN_EMAIL_CLIENT_VIEWED
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Click
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Flow
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.login.LoginAnalyticsListener
@@ -9,7 +13,11 @@ import java.util.HashMap
 import javax.inject.Singleton
 
 @Singleton
-class LoginAnalyticsTracker(val accountStore: AccountStore, val siteStore: SiteStore) : LoginAnalyticsListener {
+class LoginAnalyticsTracker(
+    val accountStore: AccountStore,
+    val siteStore: SiteStore,
+    val unifiedLoginTracker: UnifiedLoginTracker
+) : LoginAnalyticsListener {
     override fun trackAnalyticsSignIn(isWpcomLogin: Boolean) {
         AnalyticsTracker.refreshMetadata(accountStore.account?.userName)
         val properties = HashMap<String, Boolean>()
@@ -194,8 +202,9 @@ class LoginAnalyticsTracker(val accountStore: AccountStore, val siteStore: SiteS
 
     override fun trackConnectedSiteInfoRequested(url: String?) {
         AnalyticsTracker.track(
-                AnalyticsTracker.Stat.LOGIN_CONNECTED_SITE_INFO_REQUESTED,
-                mapOf(AnalyticsTracker.KEY_URL to url))
+            AnalyticsTracker.Stat.LOGIN_CONNECTED_SITE_INFO_REQUESTED,
+            mapOf(AnalyticsTracker.KEY_URL to url)
+        )
     }
 
     override fun trackConnectedSiteInfoFailed(
@@ -205,10 +214,11 @@ class LoginAnalyticsTracker(val accountStore: AccountStore, val siteStore: SiteS
         errorDescription: String?
     ) {
         AnalyticsTracker.track(
-                AnalyticsTracker.Stat.LOGIN_CONNECTED_SITE_INFO_FAILED,
-                errorContext,
-                errorType,
-                errorDescription)
+            AnalyticsTracker.Stat.LOGIN_CONNECTED_SITE_INFO_FAILED,
+            errorContext,
+            errorType,
+            errorDescription
+        )
     }
 
     override fun trackConnectedSiteInfoSucceeded(properties: Map<String, *>) {
@@ -220,59 +230,61 @@ class LoginAnalyticsTracker(val accountStore: AccountStore, val siteStore: SiteS
     }
 
     override fun trackLoginMagicLinkOpenEmailClientViewed() {
-        // TODO AMANDA - implement track event
+        AnalyticsTracker.track(LOGIN_MAGIC_LINK_OPEN_EMAIL_CLIENT_VIEWED)
+        unifiedLoginTracker.track(Flow.LOGIN_MAGIC_LINK, Step.MAGIC_LINK_REQUESTED)
     }
 
     override fun trackSocialButtonStart() {
-        // TODO AMANDA - implement track event
+        unifiedLoginTracker.track(Flow.GOOGLE_LOGIN, Step.START)
     }
 
     override fun trackFailure(message: String?) {
-        // TODO AMANDA - implement track event
+        unifiedLoginTracker.trackFailure(message)
     }
 
     override fun trackSendCodeWithTextClicked() {
-        // TODO AMANDA - implement track event
+        unifiedLoginTracker.trackClick(Click.SEND_CODE_WITH_TEXT)
     }
 
     override fun trackSubmit2faCodeClicked() {
-        // TODO AMANDA - implement track event
+        unifiedLoginTracker.trackClick(Click.SUBMIT_2FA_CODE)
     }
 
     override fun trackSubmitClicked() {
-        // TODO AMANDA - implement track event
+        unifiedLoginTracker.trackClick(Click.SUBMIT)
     }
 
     override fun trackRequestMagicLinkClick() {
-        // TODO AMANDA - implement track event
+        unifiedLoginTracker.trackClick(Click.REQUEST_MAGIC_LINK)
     }
 
     override fun trackLoginWithPasswordClick() {
-        // TODO AMANDA - implement track event
+        unifiedLoginTracker.trackClick(Click.LOGIN_WITH_PASSWORD)
     }
 
     override fun trackShowHelpClick() {
-        // TODO AMANDA - implement track event
+        unifiedLoginTracker.trackClick(Click.SHOW_HELP)
+        unifiedLoginTracker.track(step = Step.HELP)
     }
 
     override fun trackDismissDialog() {
-        // TODO AMANDA - implement track event
+        unifiedLoginTracker.trackClick(Click.DISMISS)
     }
 
     override fun trackSelectEmailField() {
-        // TODO AMANDA - implement track event
+        unifiedLoginTracker.trackClick(Click.SELECT_EMAIL_FIELD)
     }
 
     override fun trackPickEmailFromHint() {
-        TODO("Not yet implemented")
+        unifiedLoginTracker.trackClick(Click.PICK_EMAIL_FROM_HINT)
     }
 
     override fun trackShowEmailHints() {
-        TODO("Not yet implemented")
+        unifiedLoginTracker.track(step = Step.SHOW_EMAIL_HINTS)
     }
 
     override fun emailFormScreenResumed() {
-        // TODO AMANDA - implement track event
+        unifiedLoginTracker.setFlowAndStep(Flow.WORDPRESS_COM, Step.START)
     }
 
     override fun trackEmailSignupConfirmationViewed() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
@@ -7,7 +7,9 @@ import android.view.View
 import android.view.ViewGroup
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Click
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Flow
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_login_prologue.*
 import javax.inject.Inject
@@ -45,6 +47,7 @@ class LoginPrologueFragment : androidx.fragment.app.Fragment() {
     override fun onResume() {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
+        unifiedLoginTracker.setFlowAndStep(Flow.PROLOGUE, Step.PROLOGUE)
     }
 
     override fun onDetach() {
@@ -55,14 +58,15 @@ class LoginPrologueFragment : androidx.fragment.app.Fragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         button_login_store.setOnClickListener {
+            // Login with site address
+            unifiedLoginTracker.trackClick(Click.LOGIN_WITH_SITE_ADDRESS)
             prologueFinishedListener?.onPrimaryButtonClicked()
-            AnalyticsTracker.track(Stat.LOGIN_PROLOGUE_JETPACK_LOGIN_BUTTON_TAPPED)
         }
 
         button_login_wpcom.setOnClickListener {
+            // Login with WordPress.com account
+            unifiedLoginTracker.trackClick(Click.CONTINUE_WITH_WORDPRESS_COM)
             prologueFinishedListener?.onSecondaryButtonClicked()
-
-            // TODO AMANDA - add new tracks event
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Click
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Flow
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step.PROLOGUE
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_login_prologue.*
 import javax.inject.Inject
@@ -33,6 +34,14 @@ class LoginPrologueFragment : androidx.fragment.app.Fragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_login_prologue, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        if (savedInstanceState == null) {
+            unifiedLoginTracker.track(Flow.PROLOGUE, PROLOGUE)
+        }
     }
 
     override fun onAttach(context: Context) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
@@ -8,7 +8,9 @@ import android.view.ViewGroup
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_login_prologue.*
+import javax.inject.Inject
 
 class LoginPrologueFragment : androidx.fragment.app.Fragment() {
     companion object {
@@ -24,6 +26,7 @@ class LoginPrologueFragment : androidx.fragment.app.Fragment() {
         fun onSecondaryButtonClicked()
     }
 
+    @Inject lateinit var unifiedLoginTracker: UnifiedLoginTracker
     private var prologueFinishedListener: PrologueFinishedListener? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -31,6 +34,7 @@ class LoginPrologueFragment : androidx.fragment.app.Fragment() {
     }
 
     override fun onAttach(context: Context) {
+        AndroidSupportInjection.inject(this)
         super.onAttach(context)
 
         if (activity is PrologueFinishedListener) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueModule.kt
@@ -1,0 +1,10 @@
+package com.woocommerce.android.ui.login
+
+import dagger.Module
+import dagger.android.ContributesAndroidInjector
+
+@Module
+abstract class LoginPrologueModule {
+    @ContributesAndroidInjector
+    abstract fun loginPrologueFragment(): LoginPrologueFragment
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/MagicLinkInterceptFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/MagicLinkInterceptFragment.kt
@@ -11,7 +11,6 @@ import android.widget.Button
 import android.widget.ScrollView
 import android.widget.TextView
 import androidx.core.view.isVisible
-import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/UnifiedLoginTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/UnifiedLoginTracker.kt
@@ -123,6 +123,7 @@ class UnifiedLoginTracker
         GOOGLE_LOGIN("google_login"),
         LOGIN_MAGIC_LINK("login_magic_link"),
         LOGIN_PASSWORD("login_password"),
+        LOGIN_STORE_CREDS("login_store_creds"),
         LOGIN_SITE_ADDRESS("login_site_address"),
         SIGNUP("signup"),
         GOOGLE_SIGNUP("google_signup")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/UnifiedLoginTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/UnifiedLoginTracker.kt
@@ -1,0 +1,180 @@
+package com.woocommerce.android.ui.login
+
+import com.woocommerce.android.BuildConfig
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Source.DEFAULT
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T.LOGIN
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UnifiedLoginTracker
+@Inject constructor(private val analyticsTracker: AnalyticsTrackerWrapper) {
+    private var currentSource: Source = DEFAULT
+    private var currentFlow: Flow? = null
+    private var currentStep: Step? = null
+
+    @JvmOverloads
+    fun track(
+        flow: Flow? = currentFlow,
+        step: Step
+    ) {
+        currentFlow = flow
+        currentStep = step
+        if (currentFlow != null && currentStep != null) {
+            analyticsTracker.track(
+                stat = Stat.UNIFIED_LOGIN_STEP,
+                properties = buildDefaultParams()
+            )
+        } else {
+            handleMissingFlowOrStep("step: ${step.value}")
+        }
+    }
+
+    fun trackFailure(error: String?) {
+        if (currentFlow != null && currentStep != null) {
+            currentFlow.let {
+                analyticsTracker.track(
+                    stat = Stat.UNIFIED_LOGIN_FAILURE,
+                    properties = buildDefaultParams().apply {
+                        error?.let {
+                            put(FAILURE, error)
+                        }
+                    }
+                )
+            }
+        } else {
+            handleMissingFlowOrStep("failure: $error")
+        }
+    }
+
+    fun trackClick(click: Click) {
+        if (currentFlow != null && currentStep != null) {
+            currentFlow.let {
+                analyticsTracker.track(
+                    stat = Stat.UNIFIED_LOGIN_INTERACTION,
+                    properties = buildDefaultParams().apply {
+                        put(CLICK, click.value)
+                    }
+                )
+            }
+        } else {
+            handleMissingFlowOrStep("click: ${click.value}")
+        }
+    }
+
+    private fun buildDefaultParams(): MutableMap<String, String> {
+        val params = mutableMapOf(SOURCE to currentSource.value)
+        currentFlow?.let {
+            params[FLOW] = it.value
+        }
+        currentStep?.let {
+            params[STEP] = it.value
+        }
+        return params
+    }
+
+    private fun handleMissingFlowOrStep(value: String?) {
+        val errorMessage = "Trying to log an event $value with a missing ${if (currentFlow == null) "flow" else "step"}"
+        if (BuildConfig.DEBUG) {
+            throw IllegalStateException(errorMessage)
+        } else {
+            WooLog.e(LOGIN, errorMessage)
+        }
+    }
+
+    fun setSource(source: Source) {
+        currentSource = source
+    }
+
+    fun setSource(value: String) {
+        Source.values().find { it.value == value }?.let {
+            currentSource = it
+        }
+    }
+
+    fun setFlow(value: String?) {
+        currentFlow = Flow.values().find { it.value == value }
+    }
+
+    fun setFlowAndStep(flow: Flow, step: Step) {
+        currentFlow = flow
+        currentStep = step
+    }
+
+    fun getSource(): Source = currentSource
+    fun getFlow(): Flow? = currentFlow
+
+    enum class Source(val value: String) {
+        JETPACK("jetpack"),
+        SHARE("share"),
+        DEEPLINK("deeplink"),
+        REAUTHENTICATION("reauthentication"),
+        SELF_HOSTED("self_hosted"),
+        ADD_WORDPRESS_COM_ACCOUNT("add_wordpress_com_account"),
+        DEFAULT("default")
+    }
+
+    enum class Flow(val value: String) {
+        PROLOGUE("prologue"),
+        WORDPRESS_COM("wordpress_com"),
+        GOOGLE_LOGIN("google_login"),
+        LOGIN_MAGIC_LINK("login_magic_link"),
+        LOGIN_PASSWORD("login_password"),
+        LOGIN_SITE_ADDRESS("login_site_address"),
+        SIGNUP("signup"),
+        GOOGLE_SIGNUP("google_signup")
+    }
+
+    enum class Step(val value: String) {
+        PROLOGUE("prologue"),
+        START("start"),
+        MAGIC_LINK_REQUESTED("magic_link_requested"),
+        ENTER_SITE_ADDRESS("enter_site_address"),
+        ENTER_EMAIL_ADDRESS("enter_email_address"),
+        EMAIL_OPENED("email_opened"),
+        USERNAME_PASSWORD("username_password"),
+        SUCCESS("success"),
+        HELP("help"),
+        TWO_FACTOR_AUTHENTICATION("2fa"),
+        SHOW_EMAIL_HINTS("SHOW_EMAIL_HINTS")
+    }
+
+    enum class Click(val value: String) {
+        SUBMIT("submit"),
+        CONTINUE("continue"),
+        DISMISS("dismiss"),
+        CONTINUE_WITH_WORDPRESS_COM("continue_with_wordpress_com"),
+        LOGIN_WITH_SITE_ADDRESS("login_with_site_address"),
+        LOGIN_WITH_GOOGLE("login_with_google"),
+        FORGOTTEN_PASSWORD("forgotten_password"),
+        TERMS_OF_SERVICE_CLICKED("terms_of_service_clicked"),
+        SIGNUP_WITH_EMAIL("signup_with_email"),
+        SIGNUP_WITH_GOOGLE("signup_with_google"),
+        OPEN_EMAIL_CLIENT("open_email_client"),
+        SHOW_HELP("show_help"),
+        SEND_CODE_WITH_TEXT("send_code_with_text"),
+        SUBMIT_2FA_CODE("submit_2fa_code"),
+        REQUEST_MAGIC_LINK("request_magic_link"),
+        LOGIN_WITH_PASSWORD("login_with_password"),
+        CREATE_NEW_SITE("create_new_site"),
+        ADD_SELF_HOSTED_SITE("add_self_hosted_site"),
+        CONNECT_SITE("connect_site"),
+        SELECT_AVATAR("select_avatar"),
+        EDIT_USERNAME("edit_username"),
+        HELP_FINDING_SITE_ADDRESS("help_finding_site_address"),
+        SELECT_EMAIL_FIELD("select_email_field"),
+        PICK_EMAIL_FROM_HINT("pick_email_from_hint"),
+        CREATE_ACCOUNT("create_account")
+    }
+
+    companion object {
+        private const val SOURCE = "source"
+        private const val FLOW = "flow"
+        private const val STEP = "step"
+        private const val FAILURE = "failure"
+        private const val CLICK = "click"
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/UnifiedLoginTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/UnifiedLoginTracker.kt
@@ -168,7 +168,8 @@ class UnifiedLoginTracker
         HELP_FINDING_SITE_ADDRESS("help_finding_site_address"),
         SELECT_EMAIL_FIELD("select_email_field"),
         PICK_EMAIL_FROM_HINT("pick_email_from_hint"),
-        CREATE_ACCOUNT("create_account")
+        CREATE_ACCOUNT("create_account"),
+        LOGIN_WITH_SITE_CREDS("login_with_site_creds")
     }
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -31,6 +31,8 @@ import com.woocommerce.android.support.HelpActivity.Origin
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.LoginEmailHelpDialogFragment
+import com.woocommerce.android.ui.login.UnifiedLoginTracker
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.mystore.RevenueStatsAvailabilityFetcher
 import com.woocommerce.android.ui.sitepicker.SitePickerAdapter.OnSiteClickListener
@@ -69,6 +71,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
 
     @Inject lateinit var presenter: SitePickerContract.Presenter
     @Inject lateinit var selectedSite: SelectedSite
+    @Inject lateinit var unifiedLoginTracker: UnifiedLoginTracker
 
     @Inject lateinit var revenueStatsAvailabilityFetcher: RevenueStatsAvailabilityFetcher
 
@@ -336,6 +339,9 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
 
         // if we came here from login, start the main activity
         if (calledFromLogin) {
+            // Track login flow completed successfully
+            unifiedLoginTracker.track(step = Step.SUCCESS)
+
             val intent = Intent(this, MainActivity::class.java)
             startActivity(intent)
         }


### PR DESCRIPTION
This PR partially closes #2721 by doing the following:
- Implementing a new unified login tracks class and wrapper mimicking [WPAndroids PR](https://github.com/wordpress-mobile/WordPress-Android/pull/12089). 
- Adds three new track events:
  - `unified_login_step` (`source`: String, `flow`: String, `step`: String)
  - `unified_login_interaction` (`source`: String, `flow`: String, `step`: String, `click`: String)
  - `unified_login_failure` (`source`: String, `flow`: String, `step`: String, `failure`: String)

**NOTE:** _These events have been added to the tracks spreadsheet under a new "Unified Login" tab._

Additional details about this new way of tracking can be found at pbArwn-AP-p2, but here's a summary. The event `unified_login_step` tracks each step in a particular login flow. The flow changes each time a new login type is selected for example login with store creds, magic link, etc. This event contains 3 properties:
- `source`: Origin of login flow. For now ours will always be `default`. 
- `flow`: The current login flow the user is in (magic link, login by password, etc)
- `step`: A single screen view. 

If the login is successful the final step will be `success`. This event does not track failures - there will be a different event for that. Here's a flow diagram of how these events play out:

![UL-site-address-flow(1)](https://user-images.githubusercontent.com/5810477/92813190-bd984500-f38e-11ea-9536-e8f6d134a50c.png)


This PR also includes a few `unified_login_interaction` events. These are events fired when the user interacts with the app (such as a click event). For more information on these types of events see pbArwn-I6-p2. The following items have these events associated with them:
- help finding site address button tapped
- send 2FA code button tapped
- submit 2FA button tapped
- login with password link tapped
- show help button tapped
- dialog dismissed
- email address picked from hint
- login with site address button tapped
- continue with wordpress.com button tapped
- login with site credentials tapped
- request magic link
- anytime a `continue` button is clicked - which is logged as `submit`
- magic link open email client button tapped
- reset password link clicked

### Example Output
**Login with password**
```
Tracked: unified_login_step, Properties: {"source":"default","flow":"prologue","step":"prologue"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"prologue","step":"prologue","click":"login_with_site_address"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_site_address","step":"start"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_site_address","step":"start","click":"submit"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_site_address","step":"enter_email_address"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"wordpress_com","step":"start","click":"submit"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_magic_link","step":"start"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_magic_link","step":"start","click":"login_with_password"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_magic_link","step":"start","click":"login_with_password"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_password","step":"start"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_password","step":"start","click":"submit"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_password","step":"success"}
```
**Login w/ Magic Link**
```
Tracked: unified_login_step, Properties: {"source":"default","flow":"prologue","step":"prologue"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"prologue","step":"prologue","click":"login_with_site_address"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_site_address","step":"start"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_site_address","step":"start","click":"submit"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_site_address","step":"enter_email_address"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"wordpress_com","step":"start","click":"submit"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_magic_link","step":"start"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_magic_link","step":"start","click":"request_magic_link"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_magic_link","step":"magic_link_requested"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_magic_link","step":"email_opened"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_magic_link","step":"email_opened","click":"open_email_client"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_magic_link","step":"success"}
```

**Login w/ Store Creds + Magic Link**
```
Tracked: unified_login_step, Properties: {"source":"default","flow":"prologue","step":"prologue"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"prologue","step":"prologue","click":"login_with_site_address"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_site_address","step":"start"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_site_address","step":"start","click":"submit"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_site_address","step":"enter_email_address"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"wordpress_com","step":"start","click":"login_with_site_creds"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_store_creds","step":"username_password"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_store_creds","step":"username_password","click":"submit"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_magic_link","step":"start"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_magic_link","step":"start","click":"request_magic_link"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_magic_link","step":"magic_link_requested"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_magic_link","step":"email_opened"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_magic_link","step":"email_opened","click":"open_email_client"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_magic_link","step":"success"}
```

**Failure**
```
Tracked: unified_login_failure, Properties: {"source":"default","flow":"login_store_creds","step":"username_password","failure":"The username or password you entered is incorrect"}
```

**Some interactions**
```
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"prologue","step":"prologue","click":"login_with_site_address"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_site_address","step":"start","click":"submit"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"wordpress_com","step":"start","click":"submit"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_magic_link","step":"start","click":"request_magic_link"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_magic_link","step":"email_opened","click":"open_email_client"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"prologue","step":"prologue","click":"login_with_site_address"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_site_address","step":"start","click":"submit"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"wordpress_com","step":"start","click":"login_with_site_creds"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_store_creds","step":"username_password","click":"submit"}
```

### To Test
Please test the following scenarios:
- site login with email + password
- site login with email + magic link
- site login with store creds + password
- site login with store creds + magic link

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
