### PR TITLE
Fix Jalapeno Build on CI

### DIFF
--- a/.configure
+++ b/.configure
@@ -1,7 +1,7 @@
 {
   "project_name": "woocommerce-android",
   "branch": "trunk",
-  "pinned_hash": "eafbf1c173ceab8dad8e446dec5655ed354afd87",
+  "pinned_hash": "bd7b5b47ee8236cc9fbc7b95dae537e4bde07a0b",
   "files_to_copy": [
     {
       "file": "android/WCAndroid/gradle.properties",

--- a/.configure
+++ b/.configure
@@ -1,7 +1,7 @@
 {
   "project_name": "woocommerce-android",
-  "branch": "main",
-  "pinned_hash": "64c79a7bf036a12c14e440496c347d0bfa74f919",
+  "branch": "trunk",
+  "pinned_hash": "eafbf1c173ceab8dad8e446dec5655ed354afd87",
   "files_to_copy": [
     {
       "file": "android/WCAndroid/gradle.properties",

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -271,8 +271,8 @@ dependencies {
 task copyGoogleServicesExampleFile(type: Copy) {
     from('.')
     into('.')
-    include('google-services.json')
-    rename('google-services.json', 'google-services.json')
+    include('google-services.json-example')
+    rename('google-services.json-example', 'google-services.json')
 }
 
 // Add properties named "wc.xxx" to our BuildConfig
@@ -296,7 +296,7 @@ android.buildTypes.all { buildType ->
     }
 
     // Print warning message if example Google services file is used.
-    if ((file("google-services.json").text) == (file("google-services.json").text)) {
+    if ((file("google-services.json").text) == (file("google-services.json-example").text)) {
         println("WARNING: You're using the example google-services.json file. Google login will fail.")
     }
 }


### PR DESCRIPTION
This PR fixes an error with the CI build for the Jalapeno setup by reintroducing the use of `google-services.json-example` file which was removed as a part of  https://github.com/woocommerce/woocommerce-android/pull/2427/commits/2e0be267872fc6f31faeb33126519e0e4460c184.

This PR also updates the configuration to use the `trunk` branch.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
