### PR TITLE
Unified login: Hide TOS buttons if not in signup mode during login

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -584,7 +584,7 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
             slideInFragment(loginEmailFragment as Fragment, true, LoginEmailFragment.TAG)
         } else {
             val loginEmailFragment = getLoginEmailFragment(
-                useAltLayout = true) ?: LoginEmailFragment.newInstance(false, false, true)
+                useAltLayout = true) ?: LoginEmailFragment.newInstance(false, false, true, true)
             slideInFragment(
                 loginEmailFragment as Fragment, true, LoginEmailFragment.TAG_ALT_LAYOUT)
         }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -80,6 +80,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     private static final String ARG_SITE_LOGIN_ENABLED = "ARG_SITE_LOGIN_ENABLED";
     private static final String ARG_SHOULD_USE_NEW_LAYOUT = "ARG_SHOULD_USE_NEW_LAYOUT";
     private static final String ARG_OPTIONAL_SITE_CREDS_LAYOUT = "ARG_OPTIONAL_SITE_CREDS_LAYOUT";
+    private static final String ARG_HIDE_TOS = "ARG_HIDE_TOS";
 
     public static final String TAG = "login_email_fragment_tag";
     public static final String TAG_ALT_LAYOUT = "login_email_fragment_alternate_layout_tag";
@@ -95,6 +96,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     private boolean mIsSiteLoginEnabled;
     private boolean mShouldUseNewLayout;
     private boolean mOptionalSiteCredsLayout;
+    private boolean mHideTos;
 
     protected WPLoginInputRow mEmailInput;
     protected boolean mHasDismissedEmailHints;
@@ -118,13 +120,23 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
         return fragment;
     }
 
-    public static LoginEmailFragment newInstance(boolean isSignupFromLoginEnabled, boolean isSiteLoginEnabled,
+    public static LoginEmailFragment newInstance(boolean isSignupFromLoginEnabled,
+                                                 boolean isSiteLoginEnabled,
                                                  boolean shouldUseNewLayout) {
+        return newInstance(
+                isSignupFromLoginEnabled, isSiteLoginEnabled, shouldUseNewLayout, false);
+    }
+
+    public static LoginEmailFragment newInstance(boolean isSignupFromLoginEnabled,
+                                                 boolean isSiteLoginEnabled,
+                                                 boolean shouldUseNewLayout,
+                                                 boolean hideTos) {
         LoginEmailFragment fragment = new LoginEmailFragment();
         Bundle args = new Bundle();
         args.putBoolean(ARG_SIGNUP_FROM_LOGIN_ENABLED, isSignupFromLoginEnabled);
         args.putBoolean(ARG_SITE_LOGIN_ENABLED, isSiteLoginEnabled);
         args.putBoolean(ARG_SHOULD_USE_NEW_LAYOUT, shouldUseNewLayout);
+        args.putBoolean(ARG_HIDE_TOS, hideTos);
         fragment.setArguments(args);
         return fragment;
     }
@@ -256,20 +268,31 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     }
 
     private void setupTosButtons(Button continueTosButton, Button continueWithGoogleTosButton) {
-        OnClickListener onClickListener = new OnClickListener() {
-            public void onClick(View view) {
-                Context context = getContext();
-                if ((context instanceof SignupSheetListener)) {
-                    ((SignupSheetListener) context).onSignupSheetTermsOfServiceClicked();
+        if (mHideTos) {
+            // Hide the TOS buttons
+            continueTosButton.setVisibility(View.GONE);
+            continueWithGoogleTosButton.setVisibility(View.GONE);
+        } else {
+            // Show the TOS buttons
+            continueTosButton.setVisibility(View.VISIBLE);
+            continueWithGoogleTosButton.setVisibility(View.VISIBLE);
+
+            OnClickListener onClickListener = new OnClickListener() {
+                public void onClick(View view) {
+                    Context context = getContext();
+                    if ((context instanceof SignupSheetListener)) {
+                        ((SignupSheetListener) context).onSignupSheetTermsOfServiceClicked();
+                    }
                 }
-            }
-        };
+            };
 
-        continueTosButton.setOnClickListener(onClickListener);
-        continueTosButton.setText(formatTosText(R.string.continue_terms_of_service_text));
+            continueTosButton.setOnClickListener(onClickListener);
+            continueTosButton.setText(formatTosText(R.string.continue_terms_of_service_text));
 
-        continueWithGoogleTosButton.setOnClickListener(onClickListener);
-        continueWithGoogleTosButton.setText(formatTosText(R.string.continue_with_google_terms_of_service_text));
+            continueWithGoogleTosButton.setOnClickListener(onClickListener);
+            continueWithGoogleTosButton
+                    .setText(formatTosText(R.string.continue_with_google_terms_of_service_text));
+        }
     }
 
     private void setupSocialButtons(Button continueWithGoogleButton) {
@@ -452,6 +475,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
             mIsSiteLoginEnabled = args.getBoolean(ARG_SITE_LOGIN_ENABLED, true);
             mShouldUseNewLayout = args.getBoolean(ARG_SHOULD_USE_NEW_LAYOUT, false);
             mOptionalSiteCredsLayout = args.getBoolean(ARG_OPTIONAL_SITE_CREDS_LAYOUT, false);
+            mHideTos = args.getBoolean(ARG_HIDE_TOS, false);
         }
     }
 

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_screen.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_screen.xml
@@ -1,19 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/label"
         style="@style/Widget.LoginFlow.TextView.Label"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/margin_extra_large"
         android:layout_marginEnd="@dimen/margin_extra_large"
         android:layout_marginStart="@dimen/margin_extra_large"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         tools:text="@string/enter_email_wordpress_com" />
 
     <org.wordpress.android.login.widgets.WPLoginInputRow
@@ -22,10 +24,14 @@
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/margin_extra_large"
         android:layout_marginStart="@dimen/margin_extra_large"
+        android:layout_marginTop="@dimen/margin_extra_large"
         android:hint="@string/email_address"
         android:imeOptions="actionNext"
         android:importantForAutofill="noExcludeDescendants"
         android:inputType="textEmailAddress"
+        app:layout_constraintTop_toBottomOf="@+id/label"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         tools:ignore="UnusedAttribute" />
 
     <com.google.android.material.button.MaterialButton
@@ -35,7 +41,11 @@
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/margin_extra_large"
         android:layout_marginStart="@dimen/margin_extra_large"
-        android:text="@string/continue_terms_of_service_text" />
+        android:text="@string/continue_terms_of_service_text"
+        app:layout_constraintTop_toBottomOf="@+id/login_email_row"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:visibility="gone"/>
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/login_continue_button"
@@ -44,17 +54,29 @@
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/margin_extra_large"
         android:layout_marginStart="@dimen/margin_extra_large"
-        android:text="@string/login_continue" />
+        android:text="@string/login_continue"
+        app:layout_goneMarginTop="@dimen/margin_extra_large"
+        app:layout_constraintTop_toBottomOf="@+id/continue_tos"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
 
     <Space
+        android:id="@+id/spacer"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1" />
+        android:layout_weight="1"
+        app:layout_constraintTop_toBottomOf="@+id/login_continue_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
 
     <FrameLayout
+        android:id="@+id/orLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/margin_small_medium">
+        android:layout_marginBottom="@dimen/margin_small_medium"
+        app:layout_constraintBottom_toTopOf="@+id/continue_with_google"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
 
         <View
             android:layout_width="match_parent"
@@ -87,7 +109,10 @@
         app:iconGravity="textStart"
         app:iconPadding="@dimen/margin_small_medium"
         app:iconSize="14dp"
-        app:iconTint="@null" />
+        app:iconTint="@null"
+        app:layout_constraintBottom_toTopOf="@+id/continue_with_google_tos"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/continue_with_google_tos"
@@ -96,6 +121,9 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/margin_extra_large"
         android:layout_marginEnd="@dimen/margin_extra_large"
-        android:text="@string/continue_with_google_terms_of_service_text" />
+        android:text="@string/continue_with_google_terms_of_service_text"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This PR closes #2837 by hiding the Terms of Service buttons when not in a "Signup" flow. WooCommerce app does not currently support signup during login. 

Before | After 
-- | --
![Screenshot_1600087617](https://user-images.githubusercontent.com/5810477/93088051-6e406600-f667-11ea-9921-894649542c28.png)|![Screenshot_1600087642](https://user-images.githubusercontent.com/5810477/93088058-6f719300-f667-11ea-98ae-fe47efe86226.png)

### To Test
1. Click **Continue with WordPress.com**
2. Notice the TOS text is not visible in the email form view. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
