### PR TITLE
Review List: Add Bottom Margin to All Reviews in List

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListAdapter.kt
@@ -362,7 +362,10 @@ class ReviewListAdapter(
             }
 
             itemHolder.desc.text = StringUtils.getRawTextFromHtml(review.review)
-            itemHolder.divider.isVisible = position < getContentItemsTotal() - 1
+
+            if (position == getContentItemsTotal() - 1) {
+                itemHolder.divider.visibility = View.INVISIBLE
+            }
 
             itemHolder.itemView.setOnClickListener {
                 clickListener.onReviewClick(review)

--- a/WooCommerce/src/main/res/layout/notifs_list_item.xml
+++ b/WooCommerce/src/main/res/layout/notifs_list_item.xml
@@ -55,7 +55,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/minor_100"
-            android:layout_marginBottom="@dimen/major_100"
             android:isIndicator="true"
             android:visibility="gone"
             app:layout_constraintBottom_toTopOf="@+id/notif_divider"
@@ -68,9 +67,11 @@
             android:id="@+id/notif_divider"
             style="@style/Woo.Divider"
             android:layout_width="0dp"
+            android:layout_marginTop="@dimen/major_100"
             app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="@+id/notif_title"
-            app:layout_constraintEnd_toEndOf="parent"/>
+            app:layout_constraintTop_toBottomOf="@+id/notif_rating" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
Fixes #2453. Reviews without ratings/stars currently don't have any bottom margin in the review list. This PR addresses that by adding top margin to the divider. I also used `View.INVISIBLE` to hide the divider from the last review in each list, to keep the divider's space/margin intact. 

Before | After 
-- | --
![Screenshot_1599772983](https://user-images.githubusercontent.com/2998162/93111542-af0f9d80-f6ae-11ea-99f9-50351a115eb7.png)|![Screenshot_1600099966](https://user-images.githubusercontent.com/2998162/93111360-6952d500-f6ae-11ea-9a5f-5034a3d39cc9.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
