### PR TITLE
Fix ambiguous reference error in FluxC

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -431,7 +431,7 @@ fun WCProductModel.toAppModel(): Product {
         downloadExpiry = this.downloadExpiry,
         purchaseNote = this.purchaseNote,
         numVariations = this.getNumVariations(),
-        images = this.getImages().map {
+        images = this.getImagesList().map {
             Product.Image(
                 it.id,
                 it.name,
@@ -439,7 +439,7 @@ fun WCProductModel.toAppModel(): Product {
                 DateTimeUtils.dateFromIso8601(this.dateCreated) ?: Date()
             )
         },
-        attributes = this.getAttributes().map {
+        attributes = this.getAttributesList().map {
             Product.Attribute(
                 it.id,
                 it.name,
@@ -453,21 +453,21 @@ fun WCProductModel.toAppModel(): Product {
         taxStatus = ProductTaxStatus.fromString(this.taxStatus),
         isSaleScheduled = this.dateOnSaleFromGmt.isNotEmpty() || this.dateOnSaleToGmt.isNotEmpty(),
         menuOrder = this.menuOrder,
-        categories = this.getCategories().map {
+        categories = this.getCategoriesList().map {
             ProductCategory(
                 it.id,
                 it.name,
                 it.slug
             )
         },
-        tags = this.getTags().map {
+        tags = this.getTagsList().map {
             ProductTag(
                 it.id,
                 it.name,
                 it.slug
             )
         },
-        groupedProductIds = this.getGroupedProductIds()
+        groupedProductIds = this.getGroupedProductIdsList()
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -431,7 +431,7 @@ fun WCProductModel.toAppModel(): Product {
         downloadExpiry = this.downloadExpiry,
         purchaseNote = this.purchaseNote,
         numVariations = this.getNumVariations(),
-        images = this.getImagesList().map {
+        images = this.getImageList().map {
             Product.Image(
                 it.id,
                 it.name,
@@ -439,7 +439,7 @@ fun WCProductModel.toAppModel(): Product {
                 DateTimeUtils.dateFromIso8601(this.dateCreated) ?: Date()
             )
         },
-        attributes = this.getAttributesList().map {
+        attributes = this.getAttributeList().map {
             Product.Attribute(
                 it.id,
                 it.name,
@@ -453,21 +453,21 @@ fun WCProductModel.toAppModel(): Product {
         taxStatus = ProductTaxStatus.fromString(this.taxStatus),
         isSaleScheduled = this.dateOnSaleFromGmt.isNotEmpty() || this.dateOnSaleToGmt.isNotEmpty(),
         menuOrder = this.menuOrder,
-        categories = this.getCategoriesList().map {
+        categories = this.getCategoryList().map {
             ProductCategory(
                 it.id,
                 it.name,
                 it.slug
             )
         },
-        tags = this.getTagsList().map {
+        tags = this.getTagList().map {
             ProductTag(
                 it.id,
                 it.name,
                 it.slug
             )
         },
-        groupedProductIds = this.getGroupedProductIdsList()
+        groupedProductIds = this.getGroupedProductIdList()
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariation.kt
@@ -138,7 +138,7 @@ fun WCProductVariationModel.toAppModel(): ProductVariation {
         this.remoteProductId,
         this.remoteVariationId,
         this.sku,
-        this.getImage()?.let {
+        this.getImageModel()?.let {
             Product.Image(
                 it.id,
                 it.name,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabel.kt
@@ -108,7 +108,7 @@ fun WCShippingLabelModel.toAppModel(): ShippingLabel {
         refundableAmount.toBigDecimal(),
         currency,
         paperSize,
-        getProductNamesList().map { it.trim() },
+        getProductNameList().map { it.trim() },
         getOriginAddress()?.toAppModel(),
         getDestinationAddress()?.toAppModel(),
         getRefundModel()?.toAppModel()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabel.kt
@@ -108,10 +108,10 @@ fun WCShippingLabelModel.toAppModel(): ShippingLabel {
         refundableAmount.toBigDecimal(),
         currency,
         paperSize,
-        getProductNames().map { it.trim() },
+        getProductNamesList().map { it.trim() },
         getOriginAddress()?.toAppModel(),
         getDestinationAddress()?.toAppModel(),
-        getRefund()?.toAppModel()
+        getRefundModel()?.toAppModel()
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -342,16 +342,17 @@ class MyStoreStatsView @JvmOverloads constructor(
     private fun updateChartView() {
         val wasEmpty = chart.barData?.let { it.dataSetCount == 0 } ?: true
 
-        val grossRevenue = revenueStatsModel?.getTotal()?.totalSales ?: 0.0
+        val totalModel = revenueStatsModel?.parseTotal()
+        val grossRevenue = totalModel?.totalSales ?: 0.0
         val revenue = formatCurrencyForDisplay(grossRevenue, chartCurrencyCode.orEmpty())
 
-        val orderCount = revenueStatsModel?.getTotal()?.ordersCount ?: 0
+        val orderCount = totalModel?.ordersCount ?: 0
         val orders = orderCount.toString()
 
         fadeInLabelValue(revenue_value, revenue)
         fadeInLabelValue(orders_value, orders)
 
-        if (chartRevenueStats.isEmpty() || revenueStatsModel?.getTotal()?.totalSales?.toInt() == 0) {
+        if (chartRevenueStats.isEmpty() || totalModel?.totalSales?.toInt() == 0) {
             clearLastUpdated()
             isRequestingStats = false
             return

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'a107aa70044042b642059434fc997cabc8ac4a3c'
+    fluxCVersion = ' 1.6.22-beta-1'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'ea89d133db62920d27d60b287d3b32d79d9605aa'
+    fluxCVersion = 'a107aa70044042b642059434fc997cabc8ac4a3c'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.6.21'
+    fluxCVersion = 'ea89d133db62920d27d60b287d3b32d79d9605aa'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = ' 1.6.22-beta-1'
+    fluxCVersion = '1.6.22-beta-1'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
This PR fixes "reference to xyz is ambiguous" error. 

Corresponding FluxC PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1687.

Merge instructions:
1. Review [FluxC's PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1687)
2. Review this PR 
3. Merge FluxC's PR
4. Create a new FluxC's version
5. Update FluxC's version in this repo
6. Remove "Not Ready for merge" tag
7. Merge this PR

**What is the root cause of the issue:**
Some models have getters (methods with "get" prefix) which seem like they are getters for fields but their return type is not the same as the type of the fields.

**Example:**
A field is called "tags" and its type is "String". However, "getTags" method doesn't return "String" but it returns "ArrayList<WCProductImageModel>". This is not allowed in Java-Kotlin code. The reason is simple - the compiler doesn't know if you want to access the field or the method. It seems JDK8 uses a default behavior which accesses the field when "o.field" syntax is used and it accesses the method when "o.getField()" syntax is used. 

**Why we need to update this code**
The issue isn't breaking the build on JDK8 - it's reported by AS as an error but it doesn't fail the build. However, with JDK11 this issue breaks the build. Since CircleCI dropped support for JDK8 we need to update all our projects to JDK11 and this issue is blocking the migration.

<img width="700" alt="Screenshot 2020-09-15 at 13 58 54" src="https://user-images.githubusercontent.com/2261188/93207917-f7d16000-f75b-11ea-989d-42b9eb764d60.png">


To Test:
There should be no user facing changes -> smoke test the app.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
