### PR TITLE
Add support for jdk11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,9 @@ orbs:
 version: 2.1
 jobs:
   Lint:
-    docker:
-      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
+    executor:
+      name: android/default
+      api-version: "28"
     steps:
       - checkout
       - android/restore-gradle-cache:
@@ -41,8 +42,9 @@ jobs:
           path: WooCommerce/build/reports
           destination: reports
   Test:
-    docker:
-      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
+    executor:
+      name: android/default
+      api-version: "28"
     steps:
       - checkout
       - android/restore-gradle-cache:
@@ -55,8 +57,9 @@ jobs:
           cache-prefix: tests-cache-v1
       - android/save-test-results
   Ensure Screenshots Tests Build:
-    docker:
-      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
+    executor:
+      name: android/default
+      api-version: "28"
     steps:
       - checkout
       - android/restore-gradle-cache:
@@ -76,8 +79,9 @@ jobs:
           command: ./gradlew assembleVanillaDebugAndroidTest
 
   Installable Build:
-    docker:
-      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
+    executor:
+      name: android/default
+      api-version: "28"
     steps:
       - checkout
       - bundle-install/bundle-install
@@ -107,8 +111,9 @@ jobs:
           path: Artifacts
           destination: Artifacts
   Release Build:
-    docker:
-      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
+    executor:
+      name: android/default
+      api-version: "28"
     steps:
       - git/shallow-checkout
       - bundle-install/bundle-install

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -186,8 +186,8 @@ dependencies {
     compileOnly 'org.glassfish:javax.annotation:10.0-b28'
     implementation "com.google.dagger:dagger-android-support:$daggerVersion"
     kapt "com.google.dagger:dagger-android-processor:$daggerVersion"
-    compileOnly("com.squareup.inject:assisted-inject-annotations-dagger2:0.3.3")
-    kapt("com.squareup.inject:assisted-inject-processor-dagger2:0.3.3")
+    compileOnly("com.squareup.inject:assisted-inject-annotations-dagger2:0.6.0")
+    kapt("com.squareup.inject:assisted-inject-processor-dagger2:0.6.0")
 
     implementation 'com.github.PhilJay:MPAndroidChart:v3.0.3'
 
@@ -234,8 +234,8 @@ dependencies {
     androidTestImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$mockitoKotlinVersion"
     androidTestImplementation "org.mockito:mockito-android:$mockitoVersion"
     kaptAndroidTest "com.google.dagger:dagger-compiler:$daggerVersion"
-    kaptAndroidTest("com.squareup.inject:assisted-inject-processor-dagger2:0.3.3")
-    androidTestCompileOnly("com.squareup.inject:assisted-inject-annotations-dagger2:0.3.3")
+    kaptAndroidTest("com.squareup.inject:assisted-inject-processor-dagger2:0.6.0")
+    androidTestCompileOnly("com.squareup.inject:assisted-inject-annotations-dagger2:0.6.0")
 
     // Dependencies for screenshots
     androidTestImplementation 'tools.fastlane:screengrab:2.0.0'


### PR DESCRIPTION
Fixes #2754

CircleCI Android docker images were updated to JDK 11 on August 17. Since the project was failing we decided to pinpoint a docker image which was still using JDK8 as a temporary workaround. This PR fixes the root cause of the failures on JDK11 and reverts this temporary workaround.

To test
- CircleCI build
- run `./gradlew :WooCommerce:connectedVanillaDebugAndroidTest`
- Smoke test the app

