### PR TITLE
Show actual count of orders by order status in order search screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 5.1
 -----
 * Implemented new login flow complete with new screen designs! #2851
+* Orders by order status screen now displays actual order count instead of max 99. #2853
 
 5.0
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusListView.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.R
 import kotlinx.android.synthetic.main.order_status_list_item.view.*
 import kotlinx.android.synthetic.main.order_status_list_view.view.*
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
+import java.text.NumberFormat
 
 /**
  * Custom class that  displays a list of order statuses and allows for
@@ -26,11 +27,6 @@ class OrderStatusListView @JvmOverloads constructor(
 ) : ConstraintLayout(ctx, attrs, defStyleAttr) {
     init {
         View.inflate(context, R.layout.order_status_list_view, this)
-    }
-
-    companion object {
-        private const val ORDER_STATUS_COUNT_MAX = 99
-        private const val ORDER_STATUS_COUNT_MAX_LABEL = "$ORDER_STATUS_COUNT_MAX+"
     }
 
     interface OrderStatusListListener {
@@ -79,7 +75,7 @@ class OrderStatusListView @JvmOverloads constructor(
             holder.orderStatusNameText.text = orderStatusModel.label
 
             val count = orderStatusModel.statusCount
-            val label = if (count > ORDER_STATUS_COUNT_MAX) ORDER_STATUS_COUNT_MAX_LABEL else count.toString()
+            val label = NumberFormat.getInstance().format(count)
             holder.orderStatusCountText.text = label
 
             holder.itemView.setOnClickListener {


### PR DESCRIPTION
Closes #2544 by updating the orders by order status screen to display the actual order count instead of the max 99+

Before | After
-- | --
![before_framed](https://user-images.githubusercontent.com/5810477/93267708-121a3680-f77a-11ea-92f7-4a99be6875e6.png)|![after_framed](https://user-images.githubusercontent.com/5810477/93267711-12b2cd00-f77a-11ea-98c8-9b7a8c07eb1c.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
