### PR TITLE
Added logic to display shipping lines warning card for an order

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -43,6 +43,7 @@ data class Order(
     val paymentMethod: String,
     val paymentMethodTitle: String,
     val pricesIncludeTax: Boolean,
+    val multiShippingLinesAvailable: Boolean,
     val billingAddress: Address,
     val shippingAddress: Address,
     val items: List<Item>
@@ -184,6 +185,7 @@ fun WCOrderModel.toAppModel(): Order {
             this.paymentMethod,
             this.paymentMethodTitle,
             this.pricesIncludeTax,
+            this.isMultiShippingLinesAvailable(),
             this.getBillingAddress().let {
                 Address(
                         it.address1,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -61,6 +62,7 @@ class OrderDetailFragment : BaseFragment() {
 
     private fun showOrderDetail(order: Order) {
         orderDetail_orderStatus.updateOrder(order)
+        orderDetail_shippingMethodNotice.isVisible = order.multiShippingLinesAvailable
     }
 
     private fun showOrderStatus(orderStatus: OrderStatus) {


### PR DESCRIPTION
This PR takes care of the second step of the Order Detail refactoring #2844 . 

####  Changes
- Adds a new variable `multiShippingLinesAvailable` to the `Order` model.
- Displays the shipping method warning card if an order contains multiple shipping methods. Just for some background, there are plugins such as the [Local Pickup Plus](https://woocommerce.com/products/local-pickup-plus/), that allow multiple shipping methods for an order. We would ideally display a warning notice to the user, if an order contains multiple shipping methods.

#### Notes
- I have split this massive change into multiple small PRs in order to make reviews easier. 
- This PR is to be merged into a feature branch.
- This PR just adds the Order detail warning card to the Order detail screen. The remaining cards will be added in subsequent PRs along with unit tests and click actions for all the buttons in the Order detail.
**- This PR is in draft till this [Step 1 PR](https://github.com/woocommerce/woocommerce-android/pull/2856) can be merged.**

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/93466259-9818b780-f909-11ea-89d4-62dc255947b3.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/93466269-9bac3e80-f909-11ea-960e-f73057aeaf65.png" width="300"/>

#### Testing
- Click on an order from the Orders tab that contains more than one shipping method. (Install the `Local Pickup Plus` plugin on your test site and create a new order with multiple shipping methods and click on the same order from the app).
- Notice the shipping method warning card displayed. 
- Now click on an order with no or one shipping method only.
- Notice the shipping method warning card is not displayed.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
