### PR TITLE
Add In-App Feedback Tracking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -599,7 +599,6 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_ORDER_DETAIL = "order_detail"
         const val VALUE_ORDER_FULFILL = "order_fulfill"
 
-
         const val KEY_FEEDBACK_ACTION = "action"
         const val KEY_FEEDBACK_CONTEXT = "context"
         const val VALUE_FEEDBACK_GENERAL_CONTEXT = "general"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -412,6 +412,12 @@ class AnalyticsTracker private constructor(private val context: Context) {
         REVIEW_DETAIL_SPAM_BUTTON_TAPPED,
         REVIEW_DETAIL_TRASH_BUTTON_TAPPED,
 
+        // -- In-App Feedback
+        APP_FEEDBACK_PROMPT,
+        APP_FEEDBACK_RATE_APP,
+        SURVEY_SCREEN,
+        FEATURE_FEEDBACK_BANNER,
+
         // -- Errors
         JETPACK_TUNNEL_TIMEOUT,
 
@@ -592,6 +598,25 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_REVIEW = "review"
         const val VALUE_ORDER_DETAIL = "order_detail"
         const val VALUE_ORDER_FULFILL = "order_fulfill"
+
+
+        const val KEY_FEEDBACK_ACTION = "action"
+        const val KEY_FEEDBACK_CONTEXT = "context"
+        const val VALUE_FEEDBACK_GENERAL_CONTEXT = "general"
+        const val VALUE_FEEDBACK_PRODUCT_M3_CONTEXT = "products_m3"
+        const val VALUE_FEEDBACK_SHOWN = "shown"
+        const val VALUE_FEEDBACK_LIKED = "liked"
+        const val VALUE_FEEDBACK_NOT_LIKED = "didnt_liked"
+        const val VALUE_FEEDBACK_LATER = "later"
+        const val VALUE_FEEDBACK_DECLINED = "declined"
+        const val VALUE_FEEDBACK_RATED = "rated"
+        const val VALUE_FEEDBACK_COMPLETED = "completed"
+        const val VALUE_FEEDBACK_OPENED = "opened"
+        const val VALUE_FEEDBACK_CANCELED = "canceled"
+        const val VALUE_FEEDBACK_DISMISSED = "dismissed"
+        const val VALUE_FEEDBACK_GIVEN = "gave_feedback"
+        const val VALUE_PRODUCT_M3_FEEDBACK = "products_m3"
+
         const val IMAGE_SOURCE_CAMERA = "camera"
         const val IMAGE_SOURCE_DEVICE = "device"
         const val IMAGE_SOURCE_WPMEDIA = "wpmedia"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -605,7 +605,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_FEEDBACK_PRODUCT_M3_CONTEXT = "products_m3"
         const val VALUE_FEEDBACK_SHOWN = "shown"
         const val VALUE_FEEDBACK_LIKED = "liked"
-        const val VALUE_FEEDBACK_NOT_LIKED = "didnt_liked"
+        const val VALUE_FEEDBACK_NOT_LIKED = "didnt_like"
         const val VALUE_FEEDBACK_LATER = "later"
         const val VALUE_FEEDBACK_DECLINED = "declined"
         const val VALUE_FEEDBACK_RATED = "rated"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
@@ -30,11 +30,12 @@ class FeedbackCompletedFragment : androidx.fragment.app.Fragment() {
         const val TAG = "survey_completed"
     }
 
-    private val feedbackContext =
+    private val feedbackContext by lazy {
         (navArgs<FeedbackCompletedFragmentArgs>().value).let {
             if (it.surveyType == MAIN) VALUE_FEEDBACK_GENERAL_CONTEXT
             else VALUE_FEEDBACK_PRODUCT_M3_CONTEXT
         }
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         setHasOptionsMenu(true)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
@@ -36,7 +36,6 @@ class FeedbackCompletedFragment : androidx.fragment.app.Fragment() {
             else VALUE_FEEDBACK_PRODUCT_M3_CONTEXT
         }
 
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         setHasOptionsMenu(true)
         return inflater.inflate(R.layout.fragment_feedback_completed, container, false)
@@ -101,7 +100,6 @@ class FeedbackCompletedFragment : androidx.fragment.app.Fragment() {
                 null
             )
         )
-
 
     private fun trackSurveyCompletedScreenAnalytics() {
         AnalyticsTracker.trackViewShown(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
@@ -10,10 +10,18 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.FragmentActivity
+import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_FEEDBACK_ACTION
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_FEEDBACK_CONTEXT
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_COMPLETED
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_GENERAL_CONTEXT
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_PRODUCT_M3_CONTEXT
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SURVEY_SCREEN
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
+import com.woocommerce.android.ui.feedback.SurveyType.MAIN
 import com.woocommerce.android.widgets.WooClickableSpan
 import kotlinx.android.synthetic.main.fragment_feedback_completed.*
 
@@ -22,6 +30,13 @@ class FeedbackCompletedFragment : androidx.fragment.app.Fragment() {
         const val TAG = "survey_completed"
     }
 
+    private val feedbackContext =
+        (navArgs<FeedbackCompletedFragmentArgs>().value).let {
+            if (it.surveyType == MAIN) VALUE_FEEDBACK_GENERAL_CONTEXT
+            else VALUE_FEEDBACK_PRODUCT_M3_CONTEXT
+        }
+
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         setHasOptionsMenu(true)
         return inflater.inflate(R.layout.fragment_feedback_completed, container, false)
@@ -29,7 +44,8 @@ class FeedbackCompletedFragment : androidx.fragment.app.Fragment() {
 
     override fun onResume() {
         super.onResume()
-        AnalyticsTracker.trackViewShown(this)
+
+        trackSurveyCompletedScreenAnalytics()
 
         activity?.let {
             it.invalidateOptionsMenu()
@@ -85,4 +101,14 @@ class FeedbackCompletedFragment : androidx.fragment.app.Fragment() {
                 null
             )
         )
+
+
+    private fun trackSurveyCompletedScreenAnalytics() {
+        AnalyticsTracker.trackViewShown(this)
+        AnalyticsTracker.track(
+            SURVEY_SCREEN, mapOf(
+            KEY_FEEDBACK_CONTEXT to feedbackContext,
+            KEY_FEEDBACK_ACTION to VALUE_FEEDBACK_COMPLETED
+        ))
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackRequestCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackRequestCard.kt
@@ -4,6 +4,12 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.View
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_FEEDBACK_ACTION
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_LIKED
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_NOT_LIKED
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_SHOWN
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.APP_FEEDBACK_PROMPT
 import com.woocommerce.android.widgets.WCElevatedConstraintLayout
 import kotlinx.android.synthetic.main.feedback_request_card.view.*
 
@@ -23,7 +29,25 @@ class FeedbackRequestCard @JvmOverloads constructor(
      * @param positiveButtonAction The action to perform when the user clicks "I like it"
      */
     fun initView(negativeButtonAction: (() -> Unit), positiveButtonAction: (() -> Unit)) {
-        btn_feedbackReq_negative.setOnClickListener { negativeButtonAction() }
-        btn_feedbackReq_positive.setOnClickListener { positiveButtonAction() }
+        AnalyticsTracker.track(
+            APP_FEEDBACK_PROMPT,
+            mapOf(KEY_FEEDBACK_ACTION to VALUE_FEEDBACK_SHOWN)
+        )
+
+        btn_feedbackReq_negative.setOnClickListener {
+            AnalyticsTracker.track(
+                APP_FEEDBACK_PROMPT,
+                mapOf(KEY_FEEDBACK_ACTION to VALUE_FEEDBACK_NOT_LIKED)
+            )
+            negativeButtonAction()
+        }
+
+        btn_feedbackReq_positive.setOnClickListener {
+            AnalyticsTracker.track(
+                APP_FEEDBACK_PROMPT,
+                mapOf(KEY_FEEDBACK_ACTION to VALUE_FEEDBACK_LIKED)
+            )
+            positiveButtonAction()
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
@@ -35,11 +35,13 @@ class FeedbackSurveyFragment : androidx.fragment.app.Fragment() {
     }
 
     private var progressDialog: CustomProgressDialog? = null
+    private var surveyCompleted: Boolean = false
     private val surveyWebViewClient = SurveyWebViewClient()
     private val arguments: FeedbackSurveyFragmentArgs by navArgs()
-    private val feedbackContext =
+    private val feedbackContext by lazy {
         if (arguments.surveyType == MAIN) VALUE_FEEDBACK_GENERAL_CONTEXT
         else VALUE_FEEDBACK_PRODUCT_M3_CONTEXT
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         setHasOptionsMenu(true)
@@ -90,13 +92,19 @@ class FeedbackSurveyFragment : androidx.fragment.app.Fragment() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
-            android.R.id.home -> AnalyticsTracker.track(
-                    SURVEY_SCREEN, mapOf(
-                    KEY_FEEDBACK_CONTEXT to feedbackContext,
-                    KEY_FEEDBACK_ACTION to VALUE_FEEDBACK_CANCELED
-                ))
         }
         return super.onOptionsItemSelected(item)
+    }
+
+    override fun onDestroy() {
+        if(surveyCompleted.not()) {
+            AnalyticsTracker.track(
+                SURVEY_SCREEN, mapOf(
+                KEY_FEEDBACK_CONTEXT to feedbackContext,
+                KEY_FEEDBACK_ACTION to VALUE_FEEDBACK_CANCELED
+            ))
+        }
+        super.onDestroy()
     }
 
     private fun showProgressDialog() {
@@ -124,6 +132,7 @@ class FeedbackSurveyFragment : androidx.fragment.app.Fragment() {
     }
 
     private fun completeSurvey() {
+        surveyCompleted = true
         FeedbackSurveyFragmentDirections
             .actionFeedbackSurveyFragmentToFeedbackCompletedFragment(arguments.surveyType)
             .apply { findNavController().navigateSafely(this) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
@@ -38,8 +38,8 @@ class FeedbackSurveyFragment : androidx.fragment.app.Fragment() {
     private val surveyWebViewClient = SurveyWebViewClient()
     private val arguments: FeedbackSurveyFragmentArgs by navArgs()
     private val feedbackContext =
-            if (arguments.surveyType == MAIN) VALUE_FEEDBACK_GENERAL_CONTEXT
-            else VALUE_FEEDBACK_PRODUCT_M3_CONTEXT
+        if (arguments.surveyType == MAIN) VALUE_FEEDBACK_GENERAL_CONTEXT
+        else VALUE_FEEDBACK_PRODUCT_M3_CONTEXT
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         setHasOptionsMenu(true)
@@ -61,7 +61,8 @@ class FeedbackSurveyFragment : androidx.fragment.app.Fragment() {
             SURVEY_SCREEN, mapOf(
             KEY_FEEDBACK_CONTEXT to feedbackContext,
             KEY_FEEDBACK_ACTION to VALUE_FEEDBACK_OPENED
-        ))
+        )
+        )
 
         activity?.let {
             it.invalidateOptionsMenu()
@@ -88,16 +89,14 @@ class FeedbackSurveyFragment : androidx.fragment.app.Fragment() {
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when(item.itemId) {
-            android.R.id.home -> {
-                AnalyticsTracker.track(
+        when (item.itemId) {
+            android.R.id.home -> AnalyticsTracker.track(
                     SURVEY_SCREEN, mapOf(
                     KEY_FEEDBACK_CONTEXT to feedbackContext,
                     KEY_FEEDBACK_ACTION to VALUE_FEEDBACK_CANCELED
-                )).let { true }
-            }
-            else -> super.onOptionsItemSelected(item)
+                ))
         }
+        return super.onOptionsItemSelected(item)
     }
 
     private fun showProgressDialog() {
@@ -125,9 +124,9 @@ class FeedbackSurveyFragment : androidx.fragment.app.Fragment() {
     }
 
     private fun completeSurvey() {
-        FeedbackSurveyFragmentDirections.actionFeedbackSurveyFragmentToFeedbackCompletedFragment(arguments.surveyType).apply {
-            findNavController().navigateSafely(this)
-        }
+        FeedbackSurveyFragmentDirections
+            .actionFeedbackSurveyFragmentToFeedbackCompletedFragment(arguments.surveyType)
+            .apply { findNavController().navigateSafely(this) }
     }
 
     private inner class SurveyWebViewClient : WebViewClient() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
@@ -97,12 +97,13 @@ class FeedbackSurveyFragment : androidx.fragment.app.Fragment() {
     }
 
     override fun onDestroy() {
-        if(surveyCompleted.not()) {
+        if (surveyCompleted.not()) {
             AnalyticsTracker.track(
                 SURVEY_SCREEN, mapOf(
                 KEY_FEEDBACK_CONTEXT to feedbackContext,
                 KEY_FEEDBACK_ACTION to VALUE_FEEDBACK_CANCELED
-            ))
+            )
+            )
         }
         super.onDestroy()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -98,15 +98,13 @@ class MyStoreFragment : TopLevelFragment(),
     ): View? {
         val view = inflater.inflate(R.layout.fragment_my_store, container, false)
         with(view) {
-            dashboard_refresh_layout.apply {
-                setOnRefreshListener {
+            dashboard_refresh_layout.setOnRefreshListener {
                     // Track the user gesture
                     AnalyticsTracker.track(Stat.DASHBOARD_PULLED_TO_REFRESH)
 
                     MyStorePresenter.resetForceRefresh()
                     dashboard_refresh_layout.isRefreshing = false
                     refreshMyStoreStats(forced = true)
-                }
             }
             setupFeedbackRequestCard()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductsWIPNoticeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductsWIPNoticeCard.kt
@@ -5,6 +5,11 @@ import android.util.AttributeSet
 import android.view.View
 import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_FEEDBACK_ACTION
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_FEEDBACK_CONTEXT
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_PRODUCT_M3_FEEDBACK
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.FEATURE_FEEDBACK_BANNER
 import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.PRODUCTS_M2
 import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.PRODUCTS_M3
 import com.woocommerce.android.util.FeatureFlag.PRODUCT_RELEASE_M3
@@ -52,7 +57,21 @@ class ProductsWIPNoticeCard @JvmOverloads constructor(
         products_wip_viewMore.text = title
         products_wip_message.text = message
 
-        btn_give_feedback.setOnClickListener(onGiveFeedbackClick)
-        btn_dismiss.setOnClickListener(onDismissClick)
+        btn_give_feedback.setOnClickListener {
+            AnalyticsTracker.track(
+                FEATURE_FEEDBACK_BANNER, mapOf(
+                KEY_FEEDBACK_CONTEXT to VALUE_PRODUCT_M3_FEEDBACK,
+                KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_GIVEN
+            ))
+            onGiveFeedbackClick(it)
+        }
+        btn_dismiss.setOnClickListener {
+            AnalyticsTracker.track(
+                FEATURE_FEEDBACK_BANNER, mapOf(
+                KEY_FEEDBACK_CONTEXT to VALUE_PRODUCT_M3_FEEDBACK,
+                KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_DISMISSED
+            ))
+            onDismissClick(it)
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/AppRatingDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/AppRatingDialog.kt
@@ -11,6 +11,12 @@ import android.net.Uri
 import androidx.appcompat.app.AlertDialog
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_FEEDBACK_ACTION
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_DECLINED
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_LATER
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_RATED
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.APP_FEEDBACK_RATE_APP
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import java.lang.ref.WeakReference
@@ -120,6 +126,7 @@ object AppRatingDialog {
                 .setMessage(R.string.app_rating_message)
                 .setCancelable(true)
                 .setPositiveButton(R.string.app_rating_rate_now) { _, _ ->
+                    AnalyticsTracker.track(APP_FEEDBACK_RATE_APP, mapOf(KEY_FEEDBACK_ACTION to VALUE_FEEDBACK_RATED))
                     ratingAccepted()
                     val appPackage = context.packageName
                     val url: String? = "market://details?id=$appPackage"
@@ -138,11 +145,13 @@ object AppRatingDialog {
                     setOptOut(true)
                 }
                 .setNeutralButton(R.string.app_rating_rate_later) { _, _ ->
+                    AnalyticsTracker.track(APP_FEEDBACK_RATE_APP, mapOf(KEY_FEEDBACK_ACTION to VALUE_FEEDBACK_LATER))
                     ratingPostponed()
                     clearSharedPreferences()
                     storeAskLaterDate()
                 }
                 .setNegativeButton(R.string.app_rating_rate_never) { _, _ ->
+                    AnalyticsTracker.track(APP_FEEDBACK_RATE_APP, mapOf(KEY_FEEDBACK_ACTION to VALUE_FEEDBACK_DECLINED))
                     ratingDeclined()
                     setOptOut(true)
                 }

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -33,7 +33,11 @@
     <fragment
         android:id="@+id/feedbackCompletedFragment"
         android:name="com.woocommerce.android.ui.feedback.FeedbackCompletedFragment"
-        android:label="FeedbackCompletedFragment"/>
+        android:label="FeedbackCompletedFragment">
+        <argument
+            android:name="surveyType"
+            app:argType="com.woocommerce.android.ui.feedback.SurveyType" />
+    </fragment>
 
     <fragment
         android:id="@+id/orderDetailFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -71,5 +71,9 @@
     <fragment
         android:id="@+id/feedbackCompletedFragment"
         android:name="com.woocommerce.android.ui.feedback.FeedbackCompletedFragment"
-        android:label="FeedbackCompletedFragment"/>
+        android:label="FeedbackCompletedFragment">
+        <argument
+            android:name="surveyType"
+            app:argType="com.woocommerce.android.ui.feedback.SurveyType" />
+    </fragment>
 </navigation>


### PR DESCRIPTION
Closes #2638. This adds tracking for the whole In-App Feedback feature

Event Name | Trigger | Custom Properties
--------|-------|--
`feature_feedback_banner` | When the **Give Feedback** button is activated. | `context="products_m3"` <br> `action="gave_feedback"`
`feature_feedback_banner` | When the **Dismissed** button is activated. | `context="products_m3"` <br> `action="dismissed"`
`survey_screen` | When the survey screen is shown. | `context="general"` <br> `action="opened"`
`survey_screen` | When the user closes the survey screen without finishing the survey.  | `context="general"` <br> `action="canceled"`
`survey_screen` | When this survey completion screen is shown.  | `context="general"` <br> `action="completed"`
`app_feedback_prompt`  |  When the “Enjoying the WooCommerce app?” and the buttons are displayed to the user. | `action="shown"`
`app_feedback_prompt` | When the **I Like It** button is activated. | `action="liked"`
`app_feedback_prompt` | When the **Could Be Better** button is activated. | `action="didnt_like"`
`app_feedback_rate_app` | When the **Later** button is activated. | `action="later"`
`app_feedback_rate_app` | When the **No Thanks** button is activated. | `action="declined"`
`app_feedback_rate_app` | When the **Rate Now** button is activated. | `action="rated"`

# Testing

## Product Feedback Banner

### Give Feedback

1. Delete the app to reset any saved settings
2. Open the app and login into a store
3. Navigate to products
4. Tap on the collapsed products banner
5. Tap on "Give Feedback"
6. Confirm that you see this logged in the console:

    ```
    🔵 Tracked: feature_feedback_banner, Properties: {"context":"products_m3","action":"gave_feedback","blog_id":,"is_wpcom_store":}
    ```

### Dismiss

1. Delete the app to reset any saved settings
2. Open the app and login into a store
3. Navigate to products
4. Tap on the collapsed products banner
5. Tap on "Dismiss"
6. Confirm that you see this logged in the console:

    ```
    🔵 Tracked: feature_feedback_banner, Properties: {"context":"products_m3","action":"dismissed","blog_id":,"is_wpcom_store":}

## Survey Screen

1. Delete the app from the device to reset any existing state. 
2. Run the app.
3. Navigate to Orders tab. 
4. Time travel to more than 3 months from now. 
5. Go back to the app and navigate to My Store. The In-app Feedback Card should be visible.
6. Tap on Could Be Better.
6. Confirm that you can see this log in the console:

    ```
    🔵 Tracked: survey_screen, Properties: {"context":"general","action":"opened","blog_id": ,"is_wpcom_store": }
    ```
8. Dismiss the survey window.
9. Confirm that you can see this log in the console:

    ````
    🔵 Tracked: survey_screen, Properties {"context":"general","action":"canceled","blog_id":,"is_wpcom_store":}
    ````
9. Navigate to Orders tab.
10. Time travel to 6 months from the current device's date. 
11. Go back to the app and navigate to My Store. The In-app Feedback Card should be visible again.
12. Tap on the Could Be Better button again.
13. Fill in and submit the survey.
13. Confirm that you can see this log in the console:
    ```
    🔵 Tracked: survey_screen, Properties: {"context":"general","action":"completed","blog_id": ,"is_wpcom_store": }
    ```

## In-App Feedback Card

1. Delete the app from the device to reset any existing state. 
2. Run the app.
3. Navigate to Orders tab. 
4. Time travel to more than 3 months from now. 
5. Go back to the app and navigate to My Store. The In-app Feedback Card should be visible.
6. Confirm that you can see this log in the console:

    ```
    🔵 Tracked: app_feedback_prompt, Properties: {"action":"shown","blog_id":,"is_wpcom_store":}
    ```
7. Tap on the Could Be Better button. 
8. Confirm that you can see this log in the console:

    ```
    🔵 Tracked: app_feedback_prompt, Properties: {"action":"didnt_like","blog_id":,"is_wpcom_store":}
    ```
9. Navigate to Orders tab.
10. Time travel to 6 months from the current device's date. 
11. Go back to the app and navigate to My Store. The In-app Feedback Card should be visible again.
12. Tap on the I Like It button. 
13. Confirm that you can see this log in the console:
    ```
    🔵 Tracked: app_feedback_prompt, Properties: {"action":"liked","blog_id":179016010,"is_wpcom_store":false}
    ```
14. Don't forget to travel back to the present.

## Review Card

### Later
1. Proceed with the same instructions detailed above to make the In-App Feedback Card visible again
2. Click on the `I like it` button on the card
3. Click on the `Later` button
4. Confirm that you can see this log in the console:
    ```
    🔵 Tracked: app_feedback_rate_app, Properties: {"action":"later","blog_id":,"is_wpcom_store":}
    ```


### No Thanks
1. Proceed with the same instructions detailed above to make the In-App Feedback Card visible again
2. Click on the `I like it` button on the card
3. Click on the `No Thanks` button
4. Confirm that you can see this log in the console:
    ```
    🔵 Tracked: app_feedback_rate_app, Properties: {"action":"declined","blog_id":,"is_wpcom_store":}
    ```

### Rate Now
1. Proceed with the same instructions detailed above to make the In-App Feedback Card visible again
2. Click on the `I like it` button on the card
3. Click on the `Rate Now` button
4. Confirm that you can see this log in the console:
    ```
    🔵 Tracked: app_feedback_rate_app, Properties: {"action":"rated","blog_id":,"is_wpcom_store":}
    ```