### PR TITLE
Order detail/update fluxc changes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderShipmentTrackingPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderShipmentTrackingPresenter.kt
@@ -70,7 +70,7 @@ class AddOrderShipmentTrackingPresenter @Inject constructor(
         )
 
         val payload = AddOrderShipmentTrackingPayload(
-                selectedSite.get(), order, wcOrderShipmentTrackingModel, isCustomProvider
+                selectedSite.get(), order.id, order.remoteOrderId, wcOrderShipmentTrackingModel, isCustomProvider
         )
         dispatcher.dispatch(WCOrderActionBuilder.newAddOrderShipmentTrackingAction(payload))
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -200,7 +200,7 @@ class OrderDetailPresenter @Inject constructor(
      * for better ui testing
      */
     override fun fetchOrderNotesFromDb(order: WCOrderModel): List<WCOrderNoteModel> {
-        return orderStore.getOrderNotesForOrder(order)
+        return orderStore.getOrderNotesForOrder(order.id)
     }
 
     /**
@@ -224,7 +224,7 @@ class OrderDetailPresenter @Inject constructor(
      * for better ui testing
      */
     override fun getOrderShipmentTrackingsFromDb(order: WCOrderModel): List<WCOrderShipmentTrackingModel> {
-        return orderStore.getShipmentTrackingsForOrder(order)
+        return orderStore.getShipmentTrackingsForOrder(selectedSite.get(), order.id)
     }
 
     /**
@@ -269,7 +269,7 @@ class OrderDetailPresenter @Inject constructor(
         }
 
         orderModel?.let { order ->
-            val payload = UpdateOrderStatusPayload(order, selectedSite.get(), newStatus)
+            val payload = UpdateOrderStatusPayload(order.id, order.remoteOrderId, selectedSite.get(), newStatus)
             dispatcher.dispatch(WCOrderActionBuilder.newUpdateOrderStatusAction(payload))
         }
     }
@@ -339,7 +339,9 @@ class OrderDetailPresenter @Inject constructor(
             AnalyticsTracker.track(Stat.ORDER_TRACKING_DELETE, mapOf(
                     AnalyticsTracker.KEY_SOURCE to AnalyticsTracker.VALUE_ORDER_DETAIL
             ))
-            val payload = DeleteOrderShipmentTrackingPayload(selectedSite.get(), order, wcOrderShipmentTrackingModel)
+            val payload = DeleteOrderShipmentTrackingPayload(
+                selectedSite.get(), order.id, order.remoteOrderId, wcOrderShipmentTrackingModel
+            )
             dispatcher.dispatch(WCOrderActionBuilder.newDeleteOrderShipmentTrackingAction(payload))
         }
     }
@@ -373,7 +375,7 @@ class OrderDetailPresenter @Inject constructor(
                             mapOf(AnalyticsTracker.KEY_ID to order.remoteOrderId))
 
                     isUsingCachedNotes = false
-                    val notes = orderStore.getOrderNotesForOrder(order)
+                    val notes = orderStore.getOrderNotesForOrder(order.id)
                     orderView?.updateOrderNotes(notes)
                 }
             }
@@ -458,7 +460,7 @@ class OrderDetailPresenter @Inject constructor(
      * Request a fresh copy of order notes from the api.
      */
     fun requestOrderNotesFromApi(order: WCOrderModel) {
-        val payload = FetchOrderNotesPayload(order, selectedSite.get())
+        val payload = FetchOrderNotesPayload(order.id, order.remoteOrderId, selectedSite.get())
         dispatcher.dispatch(WCOrderActionBuilder.newFetchOrderNotesAction(payload))
     }
 
@@ -466,7 +468,7 @@ class OrderDetailPresenter @Inject constructor(
      * Request a fresh copy of order shipment tracking records from the api.
      */
     fun requestShipmentTrackingsFromApi(order: WCOrderModel) {
-        val payload = FetchOrderShipmentTrackingsPayload(selectedSite.get(), order)
+        val payload = FetchOrderShipmentTrackingsPayload(order.id, order.remoteOrderId, selectedSite.get())
         dispatcher.dispatch(WCOrderActionBuilder.newFetchOrderShipmentTrackingsAction(payload))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailRepository.kt
@@ -66,7 +66,7 @@ class OrderDetailRepository @Inject constructor(
                 .map { it.toAppModel() }
         } else emptyList()
 
-        val shipmentTrackingList = orderStore.getShipmentTrackingsForOrder(order)
+        val shipmentTrackingList = orderStore.getShipmentTrackingsForOrder(selectedSite.get(), order.id)
 
         return OrderDetailUiItem(
             orderModel = order,
@@ -106,7 +106,7 @@ class OrderDetailRepository @Inject constructor(
 
             val refunds = fetchedRefunds?.model?.map { it.toAppModel() } ?: emptyList()
             val shipmentTrackingList = if (fetchedShipmentTrackingList) {
-                orderStore.getShipmentTrackingsForOrder(order)
+                orderStore.getShipmentTrackingsForOrder(selectedSite.get(), order.id)
             } else emptyList()
 
             OrderDetailUiItem(
@@ -131,7 +131,7 @@ class OrderDetailRepository @Inject constructor(
             suspendCoroutineWithTimeout<Boolean>(ACTION_TIMEOUT) {
                 continuationFetchShipmentTrackingList = it
 
-                val payload = FetchOrderShipmentTrackingsPayload(selectedSite.get(), order)
+                val payload = FetchOrderShipmentTrackingsPayload(order.id, order.remoteOrderId, selectedSite.get())
                 dispatcher.dispatch(WCOrderActionBuilder.newFetchOrderShipmentTrackingsAction(payload))
             } ?: false // request timed out
         } catch (e: CancellationException) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentPresenter.kt
@@ -105,14 +105,16 @@ class OrderFulfillmentPresenter @Inject constructor(
     }
 
     override fun fetchShipmentTrackingsFromApi(order: WCOrderModel) {
-        val payload = FetchOrderShipmentTrackingsPayload(selectedSite.get(), order)
+        val payload = FetchOrderShipmentTrackingsPayload(order.id, order.remoteOrderId, selectedSite.get())
         dispatcher.dispatch(WCOrderActionBuilder.newFetchOrderShipmentTrackingsAction(payload))
     }
 
     /**
      * Segregating methods that request data from db for better ui testing
      */
-    override fun getShipmentTrackingsFromDb(order: WCOrderModel) = orderStore.getShipmentTrackingsForOrder(order)
+    override fun getShipmentTrackingsFromDb(order: WCOrderModel) = orderStore.getShipmentTrackingsForOrder(
+        selectedSite.get(), order.id
+    )
 
     override fun loadShipmentTrackingsFromDb() {
         orderModel?.let { order ->
@@ -166,7 +168,9 @@ class OrderFulfillmentPresenter @Inject constructor(
                     Stat.ORDER_TRACKING_DELETE, mapOf(
                     AnalyticsTracker.KEY_SOURCE to AnalyticsTracker.VALUE_ORDER_FULFILL
             ))
-            val payload = DeleteOrderShipmentTrackingPayload(selectedSite.get(), order, wcOrderShipmentTrackingModel)
+            val payload = DeleteOrderShipmentTrackingPayload(
+                selectedSite.get(), order.id, order.remoteOrderId, wcOrderShipmentTrackingModel
+            )
             dispatcher.dispatch(WCOrderActionBuilder.newDeleteOrderShipmentTrackingAction(payload))
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNotePresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNotePresenter.kt
@@ -59,7 +59,7 @@ class AddOrderNotePresenter @Inject constructor(
         noteModel.isCustomerNote = isCustomerNote
         noteModel.note = noteText
 
-        val payload = WCOrderStore.PostOrderNotePayload(order, selectedSite.get(), noteModel)
+        val payload = WCOrderStore.PostOrderNotePayload(order.id, order.remoteOrderId, selectedSite.get(), noteModel)
         dispatcher.dispatch(WCOrderActionBuilder.newPostOrderNoteAction(payload))
 
         addNoteView?.showAddOrderNoteSnack()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/OrderNoteRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/OrderNoteRepository.kt
@@ -24,7 +24,7 @@ class OrderNoteRepository @Inject constructor(
         noteModel.isCustomerNote = isCustomerNote
         noteModel.note = noteText
 
-        val payload = WCOrderStore.PostOrderNotePayload(order, selectedSite.get(), noteModel)
+        val payload = WCOrderStore.PostOrderNotePayload(order.id, order.remoteOrderId, selectedSite.get(), noteModel)
         dispatcher.dispatch(WCOrderActionBuilder.newPostOrderNoteAction(payload))
 
         return true

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentPresenterTest.kt
@@ -93,7 +93,7 @@ class OrderFulfillmentPresenterTest {
 
         presenter.takeView(view)
         doReturn(order).whenever(presenter).orderModel
-        doReturn(orderTrackingList).whenever(orderStore).getShipmentTrackingsForOrder(any())
+        doReturn(orderTrackingList).whenever(orderStore).getShipmentTrackingsForOrder(any(), any())
 
         // order shipment tracking is already fetched from api
         presenter.loadOrderDetail(order.getIdentifier(), true)
@@ -114,7 +114,7 @@ class OrderFulfillmentPresenterTest {
 
         presenter.takeView(view)
         doReturn(order).whenever(presenter).orderModel
-        doReturn(orderTrackingList).whenever(orderStore).getShipmentTrackingsForOrder(any())
+        doReturn(orderTrackingList).whenever(orderStore).getShipmentTrackingsForOrder(any(), any())
 
         // order shipment tracking is not fetched from api
         presenter.loadOrderDetail(order.getIdentifier(), false)
@@ -142,7 +142,7 @@ class OrderFulfillmentPresenterTest {
 
         presenter.takeView(view)
         doReturn(order).whenever(presenter).orderModel
-        doReturn(orderTrackingList).whenever(orderStore).getShipmentTrackingsForOrder(any())
+        doReturn(orderTrackingList).whenever(orderStore).getShipmentTrackingsForOrder(any(), any())
 
         // order shipment tracking is not fetched from api
         presenter.loadOrderDetail(order.getIdentifier(), false)

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.6.22-beta-1'
+    fluxCVersion = '78c6ab15b59d51fb18cbc04bcb2e783ed28b941a'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
This PR updates **some breaking changes in the Woo app** after this [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1689) was merged. 

#### To test
- Click on an order from the Orders tab.
- Click on Add note and verify that you are able to add a new note successfully.
- Click on `Add tracking` from the Order detail screen and verify that you are able to add a new shipment tracking successfully.
- Click on `Add tracking` from the Order Fulfill screen and verify that you are able to add a new shipment tracking successfully.
- Click on `Add tracking` and verify that you are able to add a new shipment tracking successfully.
- Click on `Delete tracking` from the Order detail screen and verify that the tracking is deleted successfully.
- Click on `Delete tracking` from the Order Fulfill screen and verify that the tracking is deleted successfully.
- Click on the `Edit` icon beside the Order status and update the status of the order. Verify that the status is updated successfully.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
