### PR TITLE
Fix crashes in product detail sub-screens

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -31,7 +31,16 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
         </value>
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/WCSettingsOptionValueView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/WCSettingsOptionValueView.kt
@@ -90,7 +90,7 @@ class WCSettingsOptionValueView @JvmOverloads constructor(
 
     override fun setEnabled(enabled: Boolean) {
         super.setEnabled(enabled)
-        option_title.isEnabled = enabled
-        option_value.isEnabled = enabled
+        option_title?.isEnabled = enabled
+        option_value?.isEnabled = enabled
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
@@ -70,7 +70,7 @@ class WCMaterialOutlinedCurrencyEditTextView @JvmOverloads constructor(
     override fun setEnabled(enabled: Boolean) {
         super.setEnabled(enabled)
 
-        currency_edit_text.isEnabled = enabled
+        currency_edit_text?.isEnabled = enabled
     }
 
     fun getCurrencyEditText(): CurrencyEditText = currency_edit_text

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
@@ -113,7 +113,7 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
     override fun setEnabled(enabled: Boolean) {
         super.setEnabled(enabled)
 
-        edit_text.isEnabled = enabled
+        edit_text?.isEnabled = enabled
     }
 
     override fun onSaveInstanceState(): Parcelable? {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedSpinnerView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedSpinnerView.kt
@@ -54,7 +54,7 @@ class WCMaterialOutlinedSpinnerView @JvmOverloads constructor(
     override fun setEnabled(enabled: Boolean) {
         super.setEnabled(enabled)
 
-        spinner_edit_text.isEnabled = enabled
+        spinner_edit_text?.isEnabled = enabled
     }
 
     override fun onSaveInstanceState(): Parcelable? {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCToggleSingleOptionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCToggleSingleOptionView.kt
@@ -80,8 +80,9 @@ class WCToggleSingleOptionView @JvmOverloads constructor(
 
     override fun setEnabled(enabled: Boolean) {
         super.setEnabled(enabled)
-        switchSetting_switch.isEnabled = enabled
-        switchSetting_title.isEnabled = enabled
+
+        switchSetting_switch?.isEnabled = enabled
+        switchSetting_title?.isEnabled = enabled
     }
 
     private fun onCheckChanged() {


### PR DESCRIPTION
It seems like the memory leak fix PR #2855 introduced a bunch of NRE crash points in product detail sub-screens (pricing, inventory and shipping). This PR fixes them.

**To test:**
1. Go to Products -> Product detail
2. Tap on the Shipping property
3. Verify there is no crash
4. Repeat for Inventory & Pricing properties