### PR TITLE
Issue/2844 order detail refactor refunds card

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/SequenceExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/SequenceExt.kt
@@ -12,3 +12,24 @@ inline fun <reified T> Sequence<View>.containsInstanceOf(element: T) =
     filterIsInstance(T::class.java)
         .toList()
         .isNotEmpty()
+
+inline fun <E : Any, T : Collection<E>> T?.whenNotNullNorEmpty(func: (T) -> Unit): Otherwise {
+    return if (this != null && this.isNotEmpty()) {
+        func(this)
+        OtherwiseIgnore
+    } else {
+        OtherwiseInvoke
+    }
+}
+
+interface Otherwise {
+    fun otherwise(func: () -> Unit)
+}
+
+object OtherwiseInvoke : Otherwise {
+    override fun otherwise(func: () -> Unit) { func() }
+}
+
+object OtherwiseIgnore : Otherwise {
+    override fun otherwise(func: () -> Unit) { }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.model
 
 import android.os.Parcelable
+import com.woocommerce.android.extensions.CASH_PAYMENTS
 import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.roundError
 import com.woocommerce.android.model.Order.Item
@@ -39,6 +40,7 @@ data class Order(
     val discountCodes: String,
     val paymentMethod: String,
     val paymentMethodTitle: String,
+    val isCashPayment: Boolean,
     val pricesIncludeTax: Boolean,
     val multiShippingLinesAvailable: Boolean,
     val billingAddress: Address,
@@ -52,6 +54,12 @@ data class Order(
     @IgnoredOnParcel
     val isAwaitingPayment = status == CoreOrderStatus.PENDING ||
         status == CoreOrderStatus.ON_HOLD || datePaid == null
+
+    @IgnoredOnParcel
+    val isRefundAvailable = refundTotal < total
+
+    @IgnoredOnParcel
+    val availableRefundQuantity = items.sumBy { it.quantity }
 
     @Parcelize
     data class OrderStatus(
@@ -190,6 +198,7 @@ fun WCOrderModel.toAppModel(): Order {
             this.discountCodes,
             this.paymentMethod,
             this.paymentMethodTitle,
+            CASH_PAYMENTS.contains(this.paymentMethod),
             this.pricesIncludeTax,
             this.isMultiShippingLinesAvailable(),
             this.getBillingAddress().let {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
@@ -35,6 +35,18 @@ data class Refund(
         @IgnoredOnParcel
         val uniqueId: Long = ProductHelper.productOrVariationId(productId, variationId)
     }
+
+    fun getRefundMethod(
+        paymentMethodTitle: String,
+        isCashPayment: Boolean,
+        defaultValue: String
+    ): String {
+        return when {
+            paymentMethodTitle.isBlank() -> defaultValue
+            automaticGatewayRefund || isCashPayment -> paymentMethodTitle
+            else -> "$defaultValue - $paymentMethodTitle"
+        }
+    }
 }
 
 fun WCRefundModel.toAppModel(): Refund {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -201,12 +201,12 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
 
     override fun showRefunds(order: WCOrderModel, refunds: List<Refund>) {
         // show the refund products count if at least one refunded
-        if (refunds.any { refund -> refund.items.sumBy { it.quantity } > 0 }) {
-            orderDetail_refundsInfo.initView(refunds) { openRefundedProductList(order) }
-            orderDetail_refundsInfo.show()
-        } else {
-            orderDetail_refundsInfo.hide()
-        }
+//        if (refunds.any { refund -> refund.items.sumBy { it.quantity } > 0 }) {
+//            orderDetail_refundsInfo.initView(refunds) { openRefundedProductList(order) }
+//            orderDetail_refundsInfo.show()
+//        } else {
+//            orderDetail_refundsInfo.hide()
+//        }
 
 //        if (refunds.isNotEmpty()) {
 //            orderDetail_paymentInfo.showRefunds(refunds.sortedBy { it.id })

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailRefundsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailRefundsAdapter.kt
@@ -1,0 +1,92 @@
+package com.woocommerce.android.ui.orders.details.adapter
+
+import android.text.format.DateFormat
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.DiffUtil.Callback
+import androidx.recyclerview.widget.RecyclerView
+import com.woocommerce.android.R
+import com.woocommerce.android.extensions.isEqualTo
+import com.woocommerce.android.model.Refund
+import kotlinx.android.synthetic.main.order_detail_refund_payment_item.view.*
+import java.math.BigDecimal
+
+class OrderDetailRefundsAdapter(
+    private val isCashPayment: Boolean,
+    private val paymentMethodTitle: String,
+    private val formatCurrency: (BigDecimal) -> String
+) : RecyclerView.Adapter<OrderDetailRefundsAdapter.ViewHolder>() {
+    var refundList: List<Refund> = ArrayList()
+        set(value) {
+            val diffResult = DiffUtil.calculateDiff(
+                RefundModelDiffCallback(
+                    field,
+                    value
+                ), true)
+            field = value
+
+            diffResult.dispatchUpdatesTo(this)
+        }
+
+    override fun onCreateViewHolder(parent: ViewGroup, itemType: Int): ViewHolder {
+        return ViewHolder(parent, isCashPayment, paymentMethodTitle, formatCurrency)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(refundList[position])
+    }
+
+    override fun getItemCount(): Int = refundList.size
+
+    class ViewHolder(
+        parent: ViewGroup,
+        private val isCashPayment: Boolean,
+        private val paymentMethodTitle: String,
+        private val formatCurrency: (BigDecimal) -> String
+    ) : RecyclerView.ViewHolder(
+        LayoutInflater.from(parent.context).inflate(R.layout.order_detail_refund_payment_item, parent, false)
+    ) {
+        fun bind(refund: Refund) {
+            with(itemView.refundsList_refundAmount) {
+                text = context.getString(R.string.orderdetail_customer_note, formatCurrency(refund.amount))
+            }
+            with(itemView.refundsList_refundMethod) {
+                text = itemView.resources.getString(R.string.orderdetail_refund_detail).format(
+                    DateFormat.getMediumDateFormat(itemView.context).format(refund.dateCreated),
+                    refund.getRefundMethod(
+                        paymentMethodTitle = paymentMethodTitle,
+                        isCashPayment = isCashPayment,
+                        defaultValue = itemView.context.getString(R.string.order_refunds_manual_refund)
+                    )
+                )
+            }
+
+            itemView.refundsList_itemRoot.setOnClickListener {
+                // TODO: open refund detail screen
+            }
+        }
+    }
+
+    class RefundModelDiffCallback(
+        private val oldList: List<Refund>,
+        private val newList: List<Refund>
+    ) : Callback() {
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            return oldList[oldItemPosition].id == newList[newItemPosition].id
+        }
+
+        override fun getOldListSize(): Int = oldList.size
+
+        override fun getNewListSize(): Int = newList.size
+
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            val old = oldList[oldItemPosition]
+            val new = newList[newItemPosition]
+            return old.amount isEqualTo new.amount &&
+                old.dateCreated == new.dateCreated &&
+                old.reason == new.reason &&
+                old.items == new.items
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailRefundsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailRefundsAdapter.kt
@@ -49,7 +49,7 @@ class OrderDetailRefundsAdapter(
     ) {
         fun bind(refund: Refund) {
             with(itemView.refundsList_refundAmount) {
-                text = context.getString(R.string.orderdetail_customer_note, formatCurrency(refund.amount))
+                text = context.getString(R.string.orderdetail_refund_amount, formatCurrency(refund.amount))
             }
             with(itemView.refundsList_refundMethod) {
                 text = itemView.resources.getString(R.string.orderdetail_refund_detail).format(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
@@ -3,13 +3,17 @@ package com.woocommerce.android.ui.orders.details.views
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.getMediumDate
 import com.woocommerce.android.extensions.hide
+import com.woocommerce.android.extensions.isEqualTo
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.model.Refund
+import com.woocommerce.android.ui.orders.details.adapter.OrderDetailRefundsAdapter
 import kotlinx.android.synthetic.main.order_detail_payment_info.view.*
 import java.math.BigDecimal
 
@@ -61,5 +65,67 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
                 } else dateStr
             }
         }
+
+        // Populate or hide discounts section
+        if (order.discountTotal isEqualTo BigDecimal.ZERO) {
+            paymentInfo_discountSection.hide()
+        } else {
+            paymentInfo_discountSection.show()
+            paymentInfo_discountTotal.text = context.getString(
+                R.string.orderdetail_customer_note,
+                formatCurrencyForDisplay(order.discountTotal)
+            )
+            paymentInfo_discountItems.text = context.getString(
+                R.string.orderdetail_discount_items,
+                order.discountCodes
+            )
+        }
+
+        // Populate or hide refund section
+        if (order.refundTotal > BigDecimal.ZERO) {
+            paymentInfo_refundSection.show()
+            val newTotal = order.total - order.refundTotal
+            paymentInfo_newTotal.text = formatCurrencyForDisplay(newTotal)
+        } else {
+            paymentInfo_refundSection.hide()
+        }
+
+        paymentInfo_issueRefundButton.setOnClickListener {
+            // TODO: implement issue refund button in another PR
+        }
+    }
+
+    fun showRefunds(
+        order: Order,
+        refunds: List<Refund>,
+        formatCurrencyForDisplay: (BigDecimal) -> String
+    ) {
+        val adapter = paymentInfo_refunds.adapter as? OrderDetailRefundsAdapter
+            ?: OrderDetailRefundsAdapter(order.isCashPayment, order.paymentMethodTitle, formatCurrencyForDisplay)
+        paymentInfo_refunds.adapter = adapter
+        adapter.refundList = refunds
+
+        paymentInfo_refunds.show()
+        paymentInfo_refundTotalSection.hide()
+
+        var availableRefundQuantity = order.availableRefundQuantity
+        refunds.flatMap { it.items }.groupBy { it.uniqueId }.forEach { productRefunds ->
+            val refundedCount = productRefunds.value.sumBy { it.quantity }
+            availableRefundQuantity -= refundedCount
+        }
+
+        // TODO: Once the refund by amount is supported again, this condition will need to be updated
+        paymentInfo_issueRefundButtonSection.isVisible = availableRefundQuantity > 0 && order.isRefundAvailable
+    }
+
+    fun showRefundTotal(
+        show: Boolean,
+        refundTotal: BigDecimal,
+        formatCurrencyForDisplay: (BigDecimal) -> String
+    ) {
+        paymentInfo_refundTotal.text = formatCurrencyForDisplay(refundTotal)
+        paymentInfo_refunds.hide()
+        paymentInfo_refundTotalSection.show()
+        paymentInfo_issueRefundButtonSection.isVisible = show
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailRefundsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailRefundsView.kt
@@ -1,0 +1,26 @@
+package com.woocommerce.android.ui.orders.details.views
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import com.google.android.material.card.MaterialCardView
+import com.woocommerce.android.R
+import kotlinx.android.synthetic.main.order_detail_refunds_info.view.*
+
+class OrderDetailRefundsView @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : MaterialCardView(ctx, attrs, defStyleAttr) {
+    init {
+        View.inflate(context, R.layout.order_detail_refunds_info, this)
+    }
+
+    fun updateRefundCount(refundsCount: Int) {
+        refundsInfo_count.text = context.resources.getQuantityString(
+            R.plurals.order_refunds_refund_info_description,
+            refundsCount,
+            refundsCount
+        )
+    }
+}

--- a/WooCommerce/src/main/res/layout/fragment_order_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_detail.xml
@@ -61,7 +61,7 @@
                     android:contentDescription="@string/products"/>
 
                 <!-- Refunds Info -->
-                <com.woocommerce.android.ui.orders.RefundsInfoView
+                <com.woocommerce.android.ui.orders.details.views.OrderDetailRefundsView
                     android:id="@+id/orderDetail_refundsInfo"
                     style="@style/Woo.Card"
                     android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -243,6 +243,7 @@
     <string name="orderdetail_refund_detail">%1$s via %2$s</string>
     <string name="orderdetail_net">Net</string>
     <string name="orderdetail_discount_items">(%1$s)</string>
+    <string name="orderdetail_refund_amount" translatable="false">-%1$s</string>
     <string name="orderdetail_customer_provided_note">Customer provided note</string>
     <string name="orderdetail_customer_image_contentdesc">Customer profile image</string>
     <string name="orderdetail_note_hint">Compose an order note</string>


### PR DESCRIPTION
This PR takes care of the 6/13 step of the Order Detail refactoring #2844 .

#### Changes
- Adds the Order Refunds card (`OrderDetailRefundsView`) to the Order detail screen.
- Adds support to fetch and display refunds from FluxC.

#### Notes
- I have split this massive change into multiple small PRs in order to make reviews easier. 
- This PR is to be merged into a feature branch.
- This PR just adds the Order detail Refunds card to the Order detail screen. The remaining cards will be added in subsequent PRs along with unit tests and click actions for all the buttons in the Order detail.
- **This PR is in draft till this [Step 5 PR](https://github.com/woocommerce/woocommerce-android/pull/2866) can be merged.**

#### Testing
- Click on an order from the Orders tab with refunded status.
- Verify that the Order refunds section is displayed and the refunds list is displayed in the Order Payment Info section. 

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/93729469-32b31800-fbe2-11ea-82fe-179c936c4dbf.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/93729471-347cdb80-fbe2-11ea-816d-fe3f3514bb84.png" width="300"/>


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
