### PR TITLE
Added logic to display product list section for an order

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
@@ -7,6 +7,7 @@ import kotlinx.android.parcel.IgnoredOnParcel
 import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel.WCRefundItem
+import java.math.RoundingMode.HALF_UP
 import java.math.BigDecimal
 import java.util.Date
 
@@ -73,4 +74,42 @@ fun WCRefundItem.toAppModel(): Refund.Item {
             sku ?: "",
             price?.roundError() ?: BigDecimal.ZERO
     )
+}
+
+fun List<Refund>.hasNonRefundedProducts(products: List<Order.Item>) =
+    getMaxRefundQuantities(products).values.any { it > 0 }
+
+fun List<Refund>.getNonRefundedProducts(
+    products: List<Order.Item>
+): List<Order.Item> {
+    val leftoverProducts = getMaxRefundQuantities(products).filter { it.value > 0 }
+    return products
+        .filter { leftoverProducts.contains(it.uniqueId) }
+        .map {
+            val newQuantity = leftoverProducts[it.uniqueId]
+            val quantity = it.quantity.toBigDecimal()
+            val totalTax = if (quantity > BigDecimal.ZERO) {
+                it.totalTax.divide(quantity, 2, HALF_UP)
+            } else BigDecimal.ZERO
+
+            it.copy(
+                quantity = newQuantity ?: error("Missing product"),
+                total = it.price.times(newQuantity.toBigDecimal()),
+                totalTax = totalTax
+            )
+        }
+}
+
+/*
+ * Calculates the max quantity for each item by subtracting the number of already-refunded items
+ */
+private fun List<Refund>.getMaxRefundQuantities(
+    products: List<Order.Item>
+): Map<Long, Int> {
+    val map = mutableMapOf<Long, Int>()
+    val groupedRefunds = this.flatMap { it.items }.groupBy { it.uniqueId }
+    products.map { item ->
+        map[item.uniqueId] = item.quantity - (groupedRefunds[item.uniqueId]?.sumBy { it.quantity } ?: 0)
+    }
+    return map
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -238,16 +238,16 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
                 getString(R.string.orderdetail_shipping_label_unpackaged_products_header)
             } else null
 
-            orderDetail_productList.initView(
-                orderModel = order,
-                orderItems = unpackagedAndNonRefundedProducts,
-                productImageMap = productImageMap,
-                expanded = false,
-                formatCurrencyForDisplay = currencyFormatter.buildBigDecimalFormatter(order.currency),
-                orderListener = this,
-                productListener = this,
-                listTitle = listTitle
-            )
+//            orderDetail_productList.initView(
+//                orderModel = order,
+//                orderItems = unpackagedAndNonRefundedProducts,
+//                productImageMap = productImageMap,
+//                expanded = false,
+//                formatCurrencyForDisplay = currencyFormatter.buildBigDecimalFormatter(order.currency),
+//                orderListener = this,
+//                productListener = this,
+//                listTitle = listTitle
+//            )
             orderDetail_productList.show()
         } else {
             orderDetail_productList.hide()
@@ -379,7 +379,7 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
             val orderStatus = presenter.getOrderStatusForStatusKey(newStatus)
 //            orderDetail_orderStatus.updateStatus(orderStatus)
             presenter.orderModel?.let {
-                orderDetail_productList.updateView(it, this)
+//                orderDetail_productList.updateView(it, this)
 //                orderDetail_paymentInfo.initView(
 //                        it.toAppModel(),
 //                        currencyFormatter.buildBigDecimalFormatter(it.currency),
@@ -486,7 +486,7 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
 
     override fun refreshProductImages() {
         if (isAdded) {
-            orderDetail_productList.refreshProductImages()
+//            orderDetail_productList.refreshProductImages()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.model.OrderNote
 import com.woocommerce.android.model.Refund
+import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.util.CurrencyFormatter
@@ -25,6 +26,7 @@ import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.SkeletonView
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_order_detail.*
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import javax.inject.Inject
 
 class OrderDetailFragment : BaseFragment() {
@@ -33,6 +35,7 @@ class OrderDetailFragment : BaseFragment() {
 
     @Inject lateinit var currencyFormatter: CurrencyFormatter
     @Inject lateinit var uiMessageResolver: UIMessageResolver
+    @Inject lateinit var productImageMap: ProductImageMap
 
     private val skeletonView = SkeletonView()
 
@@ -74,6 +77,9 @@ class OrderDetailFragment : BaseFragment() {
         })
         viewModel.orderRefunds.observe(viewLifecycleOwner, Observer {
             showOrderRefunds(it)
+        })
+        viewModel.productList.observe(viewLifecycleOwner, Observer {
+            showOrderProducts(it)
         })
         viewModel.loadOrderDetail()
     }
@@ -133,5 +139,20 @@ class OrderDetailFragment : BaseFragment() {
                 formatCurrencyForDisplay = formatCurrency
             )
         }
+    }
+
+    private fun showOrderProducts(products: List<Order.Item>) {
+        products.whenNotNullNorEmpty {
+            val order = requireNotNull(viewModel.order)
+            with(orderDetail_productList) {
+                show()
+                updateProductList(
+                    orderItems = products,
+                    productImageMap = productImageMap,
+                    formatCurrencyForDisplay = currencyFormatter.buildBigDecimalFormatter(order.currency)
+                )
+                showOrderFulfillOption(order.status == CoreOrderStatus.PROCESSING)
+            }
+        }.otherwise { orderDetail_productList.hide() }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -12,6 +12,8 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.model.OrderNote
 import com.woocommerce.android.model.Refund
+import com.woocommerce.android.model.getNonRefundedProducts
+import com.woocommerce.android.model.hasNonRefundedProducts
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.LiveDataDelegate
@@ -51,6 +53,9 @@ class OrderDetailViewModel @AssistedInject constructor(
 
     private val _orderRefunds = MutableLiveData<List<Refund>>()
     val orderRefunds: LiveData<List<Refund>> = _orderRefunds
+
+    private val _productList = MutableLiveData<List<Order.Item>>()
+    val productList: LiveData<List<Order.Item>> = _productList
 
     override fun onCleared() {
         super.onCleared()
@@ -100,6 +105,7 @@ class OrderDetailViewModel @AssistedInject constructor(
                 string.orderdetail_orderstatus_ordernum, order.number
             )
         )
+        loadOrderProducts()
     }
 
     private suspend fun loadOrderNotes() {
@@ -117,6 +123,19 @@ class OrderDetailViewModel @AssistedInject constructor(
         if (networkStatus.isConnected()) {
             _orderRefunds.value = orderDetailRepository.fetchOrderRefunds(orderIdSet.remoteOrderId)
         }
+
+        // display products only if there are some non refunded items in the list
+        loadOrderProducts()
+    }
+
+    private fun loadOrderProducts() {
+        _productList.value = order?.let { order ->
+            _orderRefunds.value?.let { refunds ->
+                if (refunds.hasNonRefundedProducts(order.items)) {
+                    refunds.getNonRefundedProducts(order.items)
+                } else emptyList()
+            } ?: order.items
+        } ?: emptyList()
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailProductListAdapter.kt
@@ -1,0 +1,41 @@
+package com.woocommerce.android.ui.orders.details.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_DETAIL_PRODUCT_TAPPED
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.tools.ProductImageMap
+import com.woocommerce.android.ui.orders.OrderDetailProductItemView
+import com.woocommerce.android.ui.products.ProductHelper
+import java.math.BigDecimal
+
+class OrderDetailProductListAdapter(
+    private val orderItems: List<Order.Item>,
+    private val productImageMap: ProductImageMap,
+    private val formatCurrencyForDisplay: (BigDecimal) -> String
+) : RecyclerView.Adapter<OrderDetailProductListAdapter.ViewHolder>() {
+    class ViewHolder(val view: OrderDetailProductItemView) : RecyclerView.ViewHolder(view)
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view: OrderDetailProductItemView = LayoutInflater.from(parent.context)
+            .inflate(R.layout.order_detail_product_list_item, parent, false)
+            as OrderDetailProductItemView
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val item = orderItems[position]
+        val productId = ProductHelper.productOrVariationId(item.productId, item.variationId)
+        val productImage = productImageMap.get(productId)
+        holder.view.initView(orderItems[position], productImage, false, formatCurrencyForDisplay)
+        holder.view.setOnClickListener {
+            AnalyticsTracker.track(ORDER_DETAIL_PRODUCT_TAPPED)
+            // TODO: add click listener
+        }
+    }
+
+    override fun getItemCount() = orderItems.size
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailProductListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailProductListView.kt
@@ -1,0 +1,85 @@
+package com.woocommerce.android.ui.orders.details.views
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import androidx.recyclerview.widget.DefaultItemAnimator
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.card.MaterialCardView
+import com.woocommerce.android.R
+import com.woocommerce.android.R.dimen
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.tools.ProductImageMap
+import com.woocommerce.android.ui.orders.details.adapter.OrderDetailProductListAdapter
+import com.woocommerce.android.util.StringUtils
+import com.woocommerce.android.widgets.AlignedDividerDecoration
+import kotlinx.android.synthetic.main.order_detail_product_list.view.*
+import java.math.BigDecimal
+
+class OrderDetailProductListView @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : MaterialCardView(ctx, attrs, defStyleAttr) {
+    init {
+        View.inflate(context, R.layout.order_detail_product_list, this)
+    }
+
+    fun updateProductList(
+        orderItems: List<Order.Item>,
+        productImageMap: ProductImageMap,
+        formatCurrencyForDisplay: (BigDecimal) -> String
+    ) {
+        productList_lblProduct.text = StringUtils.getQuantityString(
+            context,
+            orderItems.size,
+            R.string.orderdetail_product_multiple,
+            R.string.orderdetail_product
+        )
+
+        productList_products.apply {
+            setHasFixedSize(false)
+            layoutManager = LinearLayoutManager(context)
+            itemAnimator = DefaultItemAnimator()
+            adapter = OrderDetailProductListAdapter(
+                orderItems, productImageMap, formatCurrencyForDisplay
+            )
+
+            if (itemDecorationCount == 0) {
+                addItemDecoration(
+                    AlignedDividerDecoration(
+                        context,
+                        DividerItemDecoration.VERTICAL,
+                        R.id.productInfo_name,
+                        padding = context.resources.getDimensionPixelSize(dimen.major_100)
+                    )
+                )
+            }
+
+            // Setting this field to false ensures that the RecyclerView children do NOT receive the multiple clicks,
+            // and only processes the first click event. More details on this issue can be found here:
+            // https://github.com/woocommerce/woocommerce-android/issues/2074
+            isMotionEventSplittingEnabled = false
+        }
+    }
+
+    fun showOrderFulfillOption(show: Boolean) {
+        if (show) {
+            productList_btnFulfill.visibility = View.VISIBLE
+            productList_btnDetails.visibility = View.GONE
+            productList_btnDetails.setOnClickListener(null)
+            productList_btnFulfill.setOnClickListener {
+                AnalyticsTracker.track(Stat.ORDER_DETAIL_FULFILL_ORDER_BUTTON_TAPPED)
+                // TODO: add click event to open order fulfill
+            }
+        } else {
+            productList_btnFulfill.visibility = View.GONE
+            productList_btnDetails.visibility = View.GONE
+            productList_btnDetails.setOnClickListener(null)
+            productList_btnFulfill.setOnClickListener(null)
+        }
+    }
+}

--- a/WooCommerce/src/main/res/layout/fragment_order_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_detail.xml
@@ -50,7 +50,7 @@
                     android:contentDescription="@string/shipping_labels"/>
 
                 <!-- Product List -->
-                <com.woocommerce.android.ui.orders.OrderDetailProductListView
+                <com.woocommerce.android.ui.orders.details.views.OrderDetailProductListView
                     android:id="@+id/orderDetail_productList"
                     style="@style/Woo.Card"
                     android:visibility="gone"


### PR DESCRIPTION
This PR takes care of the 7/13 step of the Order Detail refactoring #2844 .

#### Changes
- Adds the Products list card (`OrderDetailProductsView`) to the Order detail screen.
- Ensure that the Products card is not displayed when all of the products in the order are refunded.
- There has been [some discussion](https://github.com/woocommerce/woocommerce-android/issues/2584) to not display the `Details` section anymore in the Order detail screen since it just displays the same information as the Order detail. This PR also removes that `DETAILS` button from the Products card.

#### Notes
- I have split this massive change into multiple small PRs in order to make reviews easier. 
- This PR is to be merged into a feature branch.
- This PR just adds the Order detail Products card to the Order detail screen. The remaining cards will be added in subsequent PRs along with unit tests and click actions for all the buttons in the Order detail.
- **This PR is in draft till this [Step 6 PR](https://github.com/woocommerce/woocommerce-android/pull/2871) can be merged.**

#### Testing
- Click on an order from the Orders tab that is still `Processing`.
- Verify that the Products section is displayed correctly. 
- Click on an order from the Orders tab that is `Refunded`.
- Verify that the Products section is NOT displayed. 

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/93729655-1368ba80-fbe3-11ea-935b-b14c8fd52b4a.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/93729661-15327e00-fbe3-11ea-8714-c6b98bc12a6e.png" width="300"/>

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.