### PR TITLE
Issue/2844 order detail refactor shipment trakings card

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
@@ -43,6 +43,8 @@ fun Date.getTimeString(context: Context): String = DateFormat.getTimeFormat(cont
 
 fun Date.getMediumDate(context: Context): String = DateFormat.getMediumDateFormat(context).format(this)
 
+fun Date.getLongDate(context: Context) = DateFormat.getLongDateFormat(context).format(this)
+
 fun Date?.offsetGmtDate(gmtOffset: Float) = this?.let { DateUtils.offsetGmtDate(it, gmtOffset) }
 
 fun Date.formatToYYYYmmDDhhmmss(): String =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderShipmentTracking.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderShipmentTracking.kt
@@ -1,0 +1,30 @@
+package com.woocommerce.android.model
+
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
+import org.wordpress.android.util.DateTimeUtils
+import java.util.Date
+
+@Parcelize
+data class OrderShipmentTracking(
+    val localSiteId: Int,
+    val localOrderId: Int,
+    val remoteTrackingId: String,
+    val trackingNumber: String,
+    val trackingProvider: String,
+    val trackingLink: String,
+    val dateShipped: Date
+) : Parcelable
+
+fun WCOrderShipmentTrackingModel.toAppModel(): OrderShipmentTracking {
+    return OrderShipmentTracking(
+        localSiteId,
+        localOrderId,
+        remoteTrackingId,
+        trackingNumber,
+        trackingProvider,
+        trackingLink,
+        DateTimeUtils.dateUTCFromIso8601(this.dateShipped) ?: Date()
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -303,12 +303,6 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
     }
 
     override fun showOrderShipmentTrackings(trackings: List<WCOrderShipmentTrackingModel>) {
-        orderDetail_shipmentList.initView(
-            trackings = trackings,
-            uiMessageResolver = uiMessageResolver,
-            isOrderDetail = true,
-            shipmentTrackingActionListener = this
-        )
         if (orderDetail_shipmentList.visibility != View.VISIBLE) {
             WooAnimUtils.scaleIn(orderDetail_shipmentList, WooAnimUtils.Duration.MEDIUM)
         }
@@ -572,7 +566,7 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
      */
     override fun undoDeletedTrackingOnError(wcOrderShipmentTrackingModel: WCOrderShipmentTrackingModel?) {
         wcOrderShipmentTrackingModel?.let {
-            orderDetail_shipmentList.undoDeleteTrackingRecord(it)
+//            orderDetail_shipmentList.undoDeleteTrackingRecord(it)
             orderDetail_shipmentList.visibility = View.VISIBLE
         }
     }
@@ -642,18 +636,18 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
         }
 
         deleteOrderShipmentTrackingSet.add(item)
-        orderDetail_shipmentList.deleteTrackingProvider(item)
-        orderDetail_shipmentList.getShipmentTrackingCount()?.let {
-            if (it == 0) {
-                orderDetail_shipmentList.visibility = View.GONE
-            }
-        }
+//        orderDetail_shipmentList.deleteTrackingProvider(item)
+//        orderDetail_shipmentList.getShipmentTrackingCount()?.let {
+//            if (it == 0) {
+//                orderDetail_shipmentList.visibility = View.GONE
+//            }
+//        }
 
         // Listener for the UNDO button in the snackbar
         val actionListener = View.OnClickListener {
             // User canceled the action to delete the shipment tracking
             deleteOrderShipmentTrackingSet.remove(item)
-            orderDetail_shipmentList.undoDeleteTrackingRecord(item)
+//            orderDetail_shipmentList.undoDeleteTrackingRecord(item)
             orderDetail_shipmentList.visibility = View.VISIBLE
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.extensions.whenNotNullNorEmpty
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.model.OrderNote
+import com.woocommerce.android.model.OrderShipmentTracking
 import com.woocommerce.android.model.Refund
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.base.BaseFragment
@@ -70,6 +71,10 @@ class OrderDetailFragment : BaseFragment() {
             new.isOrderNotesSkeletonShown?.takeIfNotEqualTo(old?.isOrderNotesSkeletonShown) {
                 showOrderNotesSkeleton(it)
             }
+            new.isShipmentTrackingAvailable?.takeIfNotEqualTo(old?.isShipmentTrackingAvailable) {
+                orderDetail_shipmentList.isVisible = it
+                orderDetail_shipmentList.showAddTrackingButton(it)
+            }
         }
 
         viewModel.orderNotes.observe(viewLifecycleOwner, Observer {
@@ -80,6 +85,9 @@ class OrderDetailFragment : BaseFragment() {
         })
         viewModel.productList.observe(viewLifecycleOwner, Observer {
             showOrderProducts(it)
+        })
+        viewModel.shipmentTrackings.observe(viewLifecycleOwner, Observer {
+            showShipmentTrackings(it)
         })
         viewModel.loadOrderDetail()
     }
@@ -154,5 +162,11 @@ class OrderDetailFragment : BaseFragment() {
                 showOrderFulfillOption(order.status == CoreOrderStatus.PROCESSING)
             }
         }.otherwise { orderDetail_productList.hide() }
+    }
+
+    private fun showShipmentTrackings(shipmentTrackings: List<OrderShipmentTracking>) {
+        shipmentTrackings.whenNotNullNorEmpty {
+            orderDetail_shipmentList.updateShipmentTrackingList(shipmentTrackings)
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShipmentTrackingListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShipmentTrackingListAdapter.kt
@@ -1,0 +1,67 @@
+package com.woocommerce.android.ui.orders.details.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.DiffUtil.Callback
+import androidx.recyclerview.widget.RecyclerView
+import com.woocommerce.android.R
+import com.woocommerce.android.extensions.getLongDate
+import com.woocommerce.android.model.OrderShipmentTracking
+import com.woocommerce.android.ui.orders.details.adapter.OrderDetailShipmentTrackingListAdapter.OrderDetailShipmentTrackingViewHolder
+import kotlinx.android.synthetic.main.order_detail_shipment_tracking_list_item.view.*
+
+class OrderDetailShipmentTrackingListAdapter : RecyclerView.Adapter<OrderDetailShipmentTrackingViewHolder>() {
+    var shipmentTrackingList: List<OrderShipmentTracking> = ArrayList()
+        set(value) {
+            val diffResult = DiffUtil.calculateDiff(
+                ShipmentTrackingDiffCallback(
+                    field,
+                    value
+                ), true)
+            field = value
+
+            diffResult.dispatchUpdatesTo(this)
+        }
+
+    override fun onCreateViewHolder(parent: ViewGroup, itemType: Int): OrderDetailShipmentTrackingViewHolder {
+        return OrderDetailShipmentTrackingViewHolder(parent)
+    }
+
+    override fun onBindViewHolder(holder: OrderDetailShipmentTrackingViewHolder, position: Int) {
+        holder.bind(shipmentTrackingList[position])
+    }
+
+    override fun getItemCount(): Int = shipmentTrackingList.size
+
+    class OrderDetailShipmentTrackingViewHolder(
+        parent: ViewGroup
+    ) : RecyclerView.ViewHolder(
+        LayoutInflater.from(parent.context).inflate(R.layout.order_detail_shipment_tracking_list_item, parent, false)
+    ) {
+        fun bind(shipmentTracking: OrderShipmentTracking) {
+            with(itemView.tracking_type) { text = shipmentTracking.trackingProvider }
+            with(itemView.tracking_number) { text = shipmentTracking.trackingNumber }
+            with(itemView.tracking_dateShipped) { text = shipmentTracking.dateShipped.getLongDate(context) }
+        }
+    }
+
+    class ShipmentTrackingDiffCallback(
+        private val oldList: List<OrderShipmentTracking>,
+        private val newList: List<OrderShipmentTracking>
+    ) : Callback() {
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            return oldList[oldItemPosition].remoteTrackingId == newList[newItemPosition].remoteTrackingId
+        }
+
+        override fun getOldListSize(): Int = oldList.size
+
+        override fun getNewListSize(): Int = newList.size
+
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            val old = oldList[oldItemPosition]
+            val new = newList[newItemPosition]
+            return old == new
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailShipmentTrackingListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailShipmentTrackingListView.kt
@@ -1,0 +1,41 @@
+package com.woocommerce.android.ui.orders.details.views
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.DefaultItemAnimator
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.card.MaterialCardView
+import com.woocommerce.android.R
+import com.woocommerce.android.model.OrderShipmentTracking
+import com.woocommerce.android.ui.orders.details.adapter.OrderDetailShipmentTrackingListAdapter
+import kotlinx.android.synthetic.main.order_detail_shipment_tracking_list.view.*
+
+class OrderDetailShipmentTrackingListView @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : MaterialCardView(ctx, attrs, defStyleAttr) {
+    init {
+        View.inflate(context, R.layout.order_detail_shipment_tracking_list, this)
+    }
+
+    fun updateShipmentTrackingList(shipmentTrackings: List<OrderShipmentTracking>) {
+        val shipmentTrackingAdapter =
+            shipmentTrack_items.adapter as? OrderDetailShipmentTrackingListAdapter
+                ?: OrderDetailShipmentTrackingListAdapter()
+
+        shipmentTrack_items.apply {
+            setHasFixedSize(true)
+            layoutManager = LinearLayoutManager(context)
+            itemAnimator = DefaultItemAnimator()
+            adapter = shipmentTrackingAdapter
+        }
+        shipmentTrackingAdapter.shipmentTrackingList = shipmentTrackings
+    }
+
+    fun showAddTrackingButton(show: Boolean) {
+        shipmentTrack_btnAddTracking.isVisible = show
+    }
+}

--- a/WooCommerce/src/main/res/layout/fragment_order_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_detail.xml
@@ -87,7 +87,7 @@
                     android:layout_height="wrap_content"/>
 
                 <!-- Shipment Tracking -->
-                <com.woocommerce.android.ui.orders.OrderDetailShipmentTrackingListView
+                <com.woocommerce.android.ui.orders.details.views.OrderDetailShipmentTrackingListView
                     android:id="@+id/orderDetail_shipmentList"
                     style="@style/Woo.Card"
                     android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_list.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_list.xml
@@ -35,9 +35,7 @@
         <View
             android:id="@+id/shipmentTrack_divider"
             style="@style/Woo.Divider"
-            android:layout_marginStart="@dimen/major_100"
-            android:visibility="gone"
-            tools:visibility="visible" />
+            android:layout_marginStart="@dimen/major_100" />
 
         <!-- Button: Add Tracking -->
         <com.google.android.material.button.MaterialButton

--- a/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_list_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_list_item.xml
@@ -1,5 +1,69 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.woocommerce.android.ui.orders.OrderDetailShipmentTrackingItemView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"/>
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:id="@+id/tracking_copyNumber"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_75"
+        android:layout_marginBottom="@dimen/major_75"
+        android:background="?android:attr/selectableItemBackground"
+        android:clickable="true"
+        android:contentDescription="@string/order_shipment_tracking_copy_to_clipboard"
+        android:focusable="true"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/tracking_btnTrack"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/tracking_type"
+            style="@style/Woo.Card.Body.High"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            tools:text="USPS" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/tracking_number"
+            style="@style/Woo.Card.Body.Bold"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            tools:text="111222 3334 4444Z" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/tracking_dateShipped"
+            style="@style/Woo.Card.Body"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            tools:text="Shipped February 27, 2019" />
+    </LinearLayout>
+
+    <ImageButton
+        android:id="@+id/tracking_btnTrack"
+        style="@style/Woo.ImageButton.More"
+        android:contentDescription="@string/order_detail_shipment_tracking_button_contentdesc"
+        android:scaleType="centerInside"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/tracking_copyNumber"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="gone" />
+
+    <ImageButton
+        android:id="@+id/tracking_btnDelete"
+        style="@style/Woo.ImageButton.Delete"
+        android:contentDescription="@string/orderdetail_delete_tracking"
+        android:scaleType="centerInside"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This PR takes care of the 8/13 step of the Order Detail refactoring #2844 .

#### Changes
- Adds the Shipment Trackings card (`OrderDetailShipmentTrackingListView`) to the Order detail screen. This card will always be visible when the Shipment Tracking plugin is available for the store.

#### Notes
- I have split this massive change into multiple small PRs in order to make reviews easier. 
- This PR is to be merged into a feature branch.
- This PR just adds the Order detail Products card to the Order detail screen. The remaining cards will be added in subsequent PRs along with unit tests and click actions for all the buttons in the Order detail.
- **This PR is in draft till this [Step 7 PR](https://github.com/woocommerce/woocommerce-android/pull/2872) can be merged.**

#### Testing
- Click on an order from the Orders tab that does not have any Shipment Trackings.
- Notice the `Add tracking` section displayed.
- - Click on an order from the Orders tab that has some Shipment Trackings.
- Notice the Shipment trackings section displayed.
- Deactivate the Shipment Tracking plugin from the store.
- Open the app again and notice the shipment trackings section is no longer displayed.

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/93730304-aefb2a80-fbe5-11ea-9f7d-9cc0eb0c4dd1.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/93730307-b0c4ee00-fbe5-11ea-85b9-ce034d7d9ef3.png" width="300"/>


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.