### PR TITLE
Issue/2844 order detail refactor shipping labels card

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Address.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Address.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.extensions.appendWithIfNotEmpty
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import kotlinx.android.parcel.Parcelize
+import java.util.Locale
 
 @Parcelize
 data class Address(
@@ -64,5 +65,10 @@ data class Address(
         if (address.isNotBlank()) fullAddr += "$address\n"
         if (country.isNotBlank()) fullAddr += country
         return fullAddr
+    }
+
+    fun getCountryLabelByCountryCode(): String {
+        val locale = Locale(Locale.getDefault().language, country)
+        return locale.displayCountry
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -16,7 +16,6 @@ import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.util.DateTimeUtils
 import java.math.BigDecimal
-import java.math.RoundingMode.HALF_UP
 import java.util.Date
 
 @Parcelize
@@ -82,72 +81,6 @@ data class Order(
     ) : Parcelable {
         @IgnoredOnParcel
         val uniqueId: Long = ProductHelper.productOrVariationId(productId, variationId)
-    }
-
-    /*
-     * Calculates the max quantity for each item by subtracting the number of already-refunded items
-     */
-    fun getMaxRefundQuantities(
-        refunds: List<Refund>,
-        unpackagedOrderItems: List<Item> = this.items
-    ): Map<Long, Int> {
-        val map = mutableMapOf<Long, Int>()
-        val groupedRefunds = refunds.flatMap { it.items }.groupBy { it.uniqueId }
-        unpackagedOrderItems.map { item ->
-            map[item.uniqueId] = item.quantity - (groupedRefunds[item.uniqueId]?.sumBy { it.quantity } ?: 0)
-        }
-        return map
-    }
-
-    fun hasNonRefundedItems(refunds: List<Refund>): Boolean = getMaxRefundQuantities(refunds).values.any { it > 0 }
-
-    fun hasUnpackagedProducts(shippingLabels: List<ShippingLabel>): Boolean {
-        val productNames = mutableSetOf<String>()
-        shippingLabels.map { productNames.addAll(it.productNames) }
-        return this.items.size != productNames.size
-    }
-
-    /**
-     * Returns products from an order that is not associated with any shipping labels
-     * AND is also not refunded
-     */
-    fun getUnpackagedAndNonRefundedProducts(
-        refunds: List<Refund>,
-        shippingLabels: List<ShippingLabel>
-    ): List<Item> {
-        val productNames = mutableSetOf<String>()
-        shippingLabels.map { productNames.addAll(it.productNames) }
-
-        val unpackagedProducts = this.items.filter { !productNames.contains(it.name) }
-        return getNonRefundedProducts(refunds, unpackagedProducts)
-    }
-
-    /**
-     * Returns products that are not refunded in an order
-     * @param [refunds] List of refunds for the order
-     * @param [unpackagedProducts] list of products not associated with any shipping labels.
-     * This is left null, in cases where we only want to fetch non refunded products from an order.
-     */
-    fun getNonRefundedProducts(
-        refunds: List<Refund>,
-        unpackagedProducts: List<Item> = this.items
-    ): List<Item> {
-        val leftoverProducts = getMaxRefundQuantities(refunds, unpackagedProducts).filter { it.value > 0 }
-        val filteredItems = unpackagedProducts.filter { leftoverProducts.contains(it.uniqueId) }
-            .map {
-                val newQuantity = leftoverProducts[it.uniqueId]
-                val quantity = it.quantity.toBigDecimal()
-                val totalTax = if (quantity > BigDecimal.ZERO) {
-                    it.totalTax.divide(quantity, 2, HALF_UP)
-                } else BigDecimal.ZERO
-
-                it.copy(
-                    quantity = newQuantity ?: error("Missing product"),
-                    total = it.price.times(newQuantity.toBigDecimal()),
-                    totalTax = totalTax
-                )
-            }
-        return filteredItems
     }
 
     fun getBillingName(defaultValue: String): String {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
@@ -103,7 +103,7 @@ fun List<Refund>.getNonRefundedProducts(
 /*
  * Calculates the max quantity for each item by subtracting the number of already-refunded items
  */
-private fun List<Refund>.getMaxRefundQuantities(
+fun List<Refund>.getMaxRefundQuantities(
     products: List<Order.Item>
 ): Map<Long, Int> {
     val map = mutableMapOf<Long, Int>()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -23,7 +23,6 @@ import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Refund
 import com.woocommerce.android.model.ShippingLabel
-import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.base.BaseFragment
@@ -215,13 +214,13 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
     }
 
     override fun showShippingLabels(order: WCOrderModel, shippingLabels: List<ShippingLabel>) {
-        orderDetail_shippingLabelList.initView(
-            order.toAppModel(),
-            shippingLabels,
-            productImageMap,
-            currencyFormatter.buildBigDecimalFormatter(order.currency),
-            this
-        )
+//        orderDetail_shippingLabelList.initView(
+//            order.toAppModel(),
+//            shippingLabels,
+//            productImageMap,
+//            currencyFormatter.buildBigDecimalFormatter(order.currency),
+//            this
+//        )
     }
 
     override fun showProductList(order: WCOrderModel, refunds: List<Refund>, shippingLabels: List<ShippingLabel>) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailFragment.kt
@@ -18,7 +18,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_DETAIL_TRAC
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_DETAIL_TRACKING_DELETE_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_DETAIL_VIEW_REFUND_DETAILS_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SNACK_ORDER_MARKED_COMPLETE_UNDO_BUTTON_TAPPED
-import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.Order
@@ -228,15 +227,15 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
     override fun showProductList(order: WCOrderModel, refunds: List<Refund>, shippingLabels: List<ShippingLabel>) {
         // populate the Order Product List Card if not all products are associated with any of the shipping labels
         // available or if there is at least 1 product that is not refunded
-        val orderModel = order.toAppModel()
-        val hasUnpackagedProducts = orderModel.hasUnpackagedProducts(shippingLabels)
-        if (hasUnpackagedProducts && orderModel.hasNonRefundedItems(refunds)) {
-            val unpackagedAndNonRefundedProducts =
-                orderModel.getUnpackagedAndNonRefundedProducts(refunds, shippingLabels)
-
-            val listTitle = if (shippingLabels.isNotEmpty() && hasUnpackagedProducts) {
-                getString(R.string.orderdetail_shipping_label_unpackaged_products_header)
-            } else null
+//        val orderModel = order.toAppModel()
+//        val hasUnpackagedProducts = orderModel.hasUnpackagedProducts(shippingLabels)
+//        if (hasUnpackagedProducts && orderModel.hasNonRefundedItems(refunds)) {
+//            val unpackagedAndNonRefundedProducts =
+//                orderModel.getUnpackagedAndNonRefundedProducts(refunds, shippingLabels)
+//
+//            val listTitle = if (shippingLabels.isNotEmpty() && hasUnpackagedProducts) {
+//                getString(R.string.orderdetail_shipping_label_unpackaged_products_header)
+//            } else null
 
 //            orderDetail_productList.initView(
 //                orderModel = order,
@@ -249,9 +248,9 @@ class OrderDetailFragment : BaseFragment(), OrderDetailContract.View, OrderDetai
 //                listTitle = listTitle
 //            )
             orderDetail_productList.show()
-        } else {
-            orderDetail_productList.hide()
-        }
+//        } else {
+//            orderDetail_productList.hide()
+//        }
     }
 
     override fun showOrderDetail(order: WCOrderModel?, isFreshData: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenter.kt
@@ -11,7 +11,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_TRACKING_AD
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_TRACKING_DELETE_FAILED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_TRACKING_DELETE_SUCCESS
 import com.woocommerce.android.extensions.isVirtualProduct
-import com.woocommerce.android.model.appendTrackingUrls
 import com.woocommerce.android.network.ConnectionChangeReceiver
 import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
 import com.woocommerce.android.push.NotificationHandler
@@ -154,10 +153,10 @@ class OrderDetailPresenter @Inject constructor(
         orderDetailUiItem: OrderDetailUiItem
     ) {
         orderView?.showRefunds(orderDetailUiItem.orderModel, orderDetailUiItem.refunds)
-        orderView?.showShippingLabels(
-            order = orderDetailUiItem.orderModel,
-            shippingLabels = orderDetailUiItem.shippingLabels.appendTrackingUrls(orderDetailUiItem.shipmentTrackingList)
-        )
+//        orderView?.showShippingLabels(
+//            order = orderDetailUiItem.orderModel,
+//            shippingLabels = orderDetailUiItem.shippingLabels.appendTrackingUrls(orderDetailUiItem.shipmentTrackingList)
+//        )
 
         // display the product list only if we know for sure,
         // that there are no shipping labels available for the order

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShippingLabelListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShippingLabelListView.kt
@@ -18,7 +18,6 @@ import com.woocommerce.android.extensions.expand
 import com.woocommerce.android.extensions.formatToMMMddYYYYhhmm
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.ShippingLabel
-import com.woocommerce.android.model.loadProductItems
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelActionListener
 import com.woocommerce.android.util.AddressUtils
@@ -92,7 +91,7 @@ class OrderDetailShippingLabelListView @JvmOverloads constructor(
             holder.bindProductItems(
                 context,
                 productImageMap,
-                shippingLabel.loadProductItems(order.items),
+                emptyList(),
                 formatCurrencyForDisplay,
                 viewPool
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderFulfillmentFragment.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_FULFILLMENT
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_FULFILLMENT_TRACKING_DELETE_BUTTON_TAPPED
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.Refund
+import com.woocommerce.android.model.getNonRefundedProducts
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.ProductImageMap
@@ -89,7 +90,7 @@ class OrderFulfillmentFragment : BaseFragment(), OrderFulfillmentContract.View, 
         // Populate the Order Product List Card
         orderFulfill_products.initView(
                 orderModel = order,
-                orderItems = order.toAppModel().getNonRefundedProducts(refunds),
+                orderItems = refunds.getNonRefundedProducts(order.toAppModel().items),
                 productImageMap = productImageMap,
                 expanded = true,
                 formatCurrencyForDisplay = currencyFormatter.buildBigDecimalFormatter(order.currency),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderProductListFragment.kt
@@ -8,6 +8,7 @@ import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.model.Refund
+import com.woocommerce.android.model.getNonRefundedProducts
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.base.BaseFragment
@@ -50,7 +51,7 @@ class OrderProductListFragment : BaseFragment(), OrderProductListContract.View {
     override fun showOrderProducts(order: WCOrderModel, refunds: List<Refund>) {
         orderProducts_list.initView(
                 orderModel = order,
-                orderItems = order.toAppModel().getNonRefundedProducts(refunds),
+                orderItems = refunds.getNonRefundedProducts(order.toAppModel().items),
                 productImageMap = productImageMap,
                 expanded = true,
                 formatCurrencyForDisplay = currencyFormatter.buildBigDecimalFormatter(order.currency),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.model.OrderNote
 import com.woocommerce.android.model.OrderShipmentTracking
 import com.woocommerce.android.model.Refund
+import com.woocommerce.android.model.ShippingLabel
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -88,6 +89,9 @@ class OrderDetailFragment : BaseFragment() {
         })
         viewModel.shipmentTrackings.observe(viewLifecycleOwner, Observer {
             showShipmentTrackings(it)
+        })
+        viewModel.shippingLabels.observe(viewLifecycleOwner, Observer {
+            showShippingLabels(it)
         })
         viewModel.loadOrderDetail()
     }
@@ -168,5 +172,19 @@ class OrderDetailFragment : BaseFragment() {
         shipmentTrackings.whenNotNullNorEmpty {
             orderDetail_shipmentList.updateShipmentTrackingList(shipmentTrackings)
         }
+    }
+
+    private fun showShippingLabels(shippingLabels: List<ShippingLabel>) {
+        shippingLabels.whenNotNullNorEmpty {
+            val order = requireNotNull(viewModel.order)
+            with(orderDetail_shippingLabelList) {
+                show()
+                updateShippingLabels(
+                    shippingLabels = shippingLabels,
+                    productImageMap = productImageMap,
+                    formatCurrencyForDisplay = currencyFormatter.buildBigDecimalFormatter(order.currency)
+                )
+            }
+        }.otherwise { orderDetail_shippingLabelList.hide() }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.model.Refund
 import com.woocommerce.android.model.RequestResult
+import com.woocommerce.android.model.ShippingLabel
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.model.toOrderStatus
 import com.woocommerce.android.tools.SelectedSite
@@ -30,6 +31,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCRefundStore
+import org.wordpress.android.fluxc.store.WCShippingLabelStore
 import javax.inject.Inject
 import kotlin.coroutines.resume
 
@@ -39,6 +41,7 @@ class OrderDetailRepository @Inject constructor(
     private val orderStore: WCOrderStore,
     private val productStore: WCProductStore,
     private val refundStore: WCRefundStore,
+    private val shippingLabelStore: WCShippingLabelStore,
     private val selectedSite: SelectedSite
 ) {
     companion object {
@@ -117,6 +120,12 @@ class OrderDetailRepository @Inject constructor(
         }.model?.map { it.toAppModel() } ?: emptyList()
     }
 
+    suspend fun fetchOrderShippingLabels(remoteOrderId: Long): List<ShippingLabel> {
+        return withContext(Dispatchers.IO) {
+            shippingLabelStore.fetchShippingLabelsForOrder(selectedSite.get(), remoteOrderId)
+        }.model?.map { it.toAppModel() } ?: emptyList()
+    }
+
     fun getOrder(orderIdentifier: OrderIdentifier) = orderStore.getOrderByIdentifier(orderIdentifier)?.toAppModel()
 
     fun getOrderStatus(key: String): OrderStatus {
@@ -140,6 +149,9 @@ class OrderDetailRepository @Inject constructor(
 
     fun getOrderShipmentTrackings(localOrderId: Int) =
         orderStore.getShipmentTrackingsForOrder(selectedSite.get(), localOrderId).map { it.toAppModel() }
+
+    fun getOrderShippingLabels(remoteOrderId: Long) = shippingLabelStore
+        .getShippingLabelsForOrder(selectedSite.get(), remoteOrderId).map { it.toAppModel() }
 
     @Suppress("unused")
     @Subscribe(threadMode = MAIN)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShippingLabelsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShippingLabelsAdapter.kt
@@ -1,0 +1,204 @@
+package com.woocommerce.android.ui.orders.details.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.DiffUtil.Callback
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.woocommerce.android.R
+import com.woocommerce.android.R.dimen
+import com.woocommerce.android.extensions.collapse
+import com.woocommerce.android.extensions.expand
+import com.woocommerce.android.extensions.formatToMMMddYYYYhhmm
+import com.woocommerce.android.model.ShippingLabel
+import com.woocommerce.android.tools.ProductImageMap
+import com.woocommerce.android.ui.orders.details.adapter.OrderDetailShippingLabelsAdapter.ShippingLabelsViewHolder
+import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.widgets.AlignedDividerDecoration
+import com.woocommerce.android.widgets.AppRatingDialog
+import kotlinx.android.synthetic.main.order_detail_shipping_label_list_item.view.*
+import java.math.BigDecimal
+
+class OrderDetailShippingLabelsAdapter(
+    private val formatCurrencyForDisplay: (BigDecimal) -> String,
+    private val productImageMap: ProductImageMap
+) : RecyclerView.Adapter<ShippingLabelsViewHolder>() {
+    private val viewPool = RecyclerView.RecycledViewPool()
+
+    var shippingLabels: List<ShippingLabel> = ArrayList()
+        set(value) {
+            val diffResult = DiffUtil.calculateDiff(
+                ShippingLabelDiffCallback(
+                    field,
+                    value
+                ), true)
+            field = value
+
+            diffResult.dispatchUpdatesTo(this)
+        }
+
+    override fun onCreateViewHolder(parent: ViewGroup, itemType: Int): ShippingLabelsViewHolder {
+        return ShippingLabelsViewHolder(parent, viewPool, productImageMap, formatCurrencyForDisplay)
+    }
+
+    override fun onBindViewHolder(holder: ShippingLabelsViewHolder, position: Int) {
+        holder.bind(shippingLabels[position])
+    }
+
+    override fun getItemCount(): Int = shippingLabels.size
+
+    class ShippingLabelsViewHolder(
+        parent: ViewGroup,
+        private val viewPool: RecyclerView.RecycledViewPool,
+        private val productImageMap: ProductImageMap,
+        private val formatCurrencyForDisplay: (BigDecimal) -> String
+    ) : RecyclerView.ViewHolder(
+        LayoutInflater.from(parent.context).inflate(R.layout.order_detail_shipping_label_list_item, parent, false)
+    ) {
+        fun bind(shippingLabel: ShippingLabel) {
+            // display product list
+            with(itemView.shippingLabelList_products) {
+                layoutManager = LinearLayoutManager(context)
+                adapter = OrderDetailProductListAdapter(
+                    shippingLabel.products,
+                    productImageMap,
+                    formatCurrencyForDisplay
+                )
+
+                if (itemDecorationCount == 0) {
+                    addItemDecoration(
+                        AlignedDividerDecoration(
+                            context,
+                            DividerItemDecoration.VERTICAL,
+                            R.id.productInfo_name,
+                            padding = context.resources.getDimensionPixelSize(dimen.major_100)
+                        )
+                    )
+                }
+                setRecycledViewPool(viewPool)
+            }
+
+            if (shippingLabel.id == 0L) {
+                itemView.shippingLabelItem_trackingNumber.isVisible = false
+                itemView.shippingLabelItem_morePanel.isVisible = false
+                with(itemView.shippingLabelList_lblPackage) {
+                    text = context.getString(R.string.orderdetail_shipping_label_unpackaged_products_header)
+                }
+                return
+            }
+
+            // display tracking number details if shipping label is not refunded
+            itemView.shippingLabelList_btnMenu.isVisible = shippingLabel.refund == null
+            with(itemView.shippingLabelItem_trackingNumber) {
+                if (shippingLabel.refund != null) {
+                    setShippingLabelTitle(
+                        context.getString(
+                            R.string.orderdetail_shipping_label_refund_title,
+                            shippingLabel.serviceName
+                        ))
+                    setShippingLabelValue(
+                        context.getString(R.string.orderdetail_shipping_label_refund_subtitle,
+                            formatCurrencyForDisplay(shippingLabel.rate),
+                            shippingLabel.refund.refundDate?.formatToMMMddYYYYhhmm() ?: ""
+                        ))
+                    showTrackingLinkButton(false)
+                } else {
+                    setShippingLabelTitle(context.getString(
+                        R.string.order_shipment_tracking_number_label
+                    ))
+                    setShippingLabelValue(shippingLabel.trackingNumber)
+                    itemView.shippingLabelList_btnMenu.setOnClickListener {
+                        // TODO: popup to request a refund
+                    }
+
+                    // display tracking link if available
+                    showTrackingLinkButton(true)
+                    setTrackingLinkClickListener {
+                        ChromeCustomTabUtils.launchUrl(context, shippingLabel.trackingLink)
+                        AppRatingDialog.incrementInteractions()
+                    }
+                }
+            }
+
+            // click on view more details section
+            itemView.shippingLabelItem_viewMore.setOnClickListener {
+                val isChecked = itemView.shippingLabelItem_viewMoreButtonImage.rotation == 0F
+                if (isChecked) {
+                    itemView.shippingLabelItem_morePanel.expand()
+                    itemView.shippingLabelItem_viewMoreButtonImage.animate().rotation(180F).setDuration(200).start()
+                    with(itemView.shippingLabelItem_viewMoreButtonTitle) {
+                        text = context.getString(R.string.orderdetail_shipping_label_item_hide_shipping)
+                    }
+                } else {
+                    itemView.shippingLabelItem_morePanel.collapse()
+                    itemView.shippingLabelItem_viewMoreButtonImage.animate().rotation(0F).setDuration(200).start()
+                    with(itemView.shippingLabelItem_viewMoreButtonTitle) {
+                        text = context.getString(R.string.orderdetail_shipping_label_item_show_shipping)
+                    }
+                }
+            }
+
+            // Shipping label header
+            with(itemView.shippingLabelList_lblPackage) {
+                text = context.getString(
+                    R.string.orderdetail_shipping_label_item_header,
+                    adapterPosition + 1
+                )
+            }
+
+            // display origin address
+            shippingLabel.originAddress?.let {
+                itemView.shippingLabelItem_shipFrom.setShippingLabelValue(
+                    it.getFullAddress(
+                        it.firstName, it.getEnvelopeAddress(), it.getCountryLabelByCountryCode()
+                    )
+                )
+            }
+
+            // display destination address
+            shippingLabel.destinationAddress?.let {
+                itemView.shippingLabelItem_shipTo.setShippingLabelValue(
+                    it.getFullAddress(
+                        it.firstName, it.getEnvelopeAddress(), it.getCountryLabelByCountryCode()
+                    )
+                )
+            }
+
+            // Shipping label package info
+            with(itemView.shippingLabelItem_packageInfo) { setShippingLabelValue(shippingLabel.packageName) }
+
+            // Shipping label carrier info
+            with(itemView.shippingLabelItem_carrierInfo) {
+                setShippingLabelValue(
+                    context.getString(
+                        R.string.orderdetail_shipping_label_carrier_info,
+                        shippingLabel.serviceName,
+                        formatCurrencyForDisplay(shippingLabel.rate)
+                    )
+                )
+            }
+        }
+    }
+
+    class ShippingLabelDiffCallback(
+        private val oldList: List<ShippingLabel>,
+        private val newList: List<ShippingLabel>
+    ) : Callback() {
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            return oldList[oldItemPosition].id == newList[newItemPosition].id
+        }
+
+        override fun getOldListSize(): Int = oldList.size
+
+        override fun getNewListSize(): Int = newList.size
+
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            val old = oldList[oldItemPosition]
+            val new = newList[newItemPosition]
+            return old == new
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailShippingLabelsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailShippingLabelsView.kt
@@ -1,0 +1,40 @@
+package com.woocommerce.android.ui.orders.details.views
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.recyclerview.widget.DefaultItemAnimator
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.woocommerce.android.R
+import com.woocommerce.android.model.ShippingLabel
+import com.woocommerce.android.tools.ProductImageMap
+import com.woocommerce.android.ui.orders.details.adapter.OrderDetailShippingLabelsAdapter
+import kotlinx.android.synthetic.main.order_detail_shipping_label_list.view.*
+import java.math.BigDecimal
+
+class OrderDetailShippingLabelsView @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : ConstraintLayout(ctx, attrs, defStyleAttr) {
+    init {
+        View.inflate(context, R.layout.order_detail_shipping_label_list, this)
+    }
+
+    fun updateShippingLabels(
+        shippingLabels: List<ShippingLabel>,
+        productImageMap: ProductImageMap,
+        formatCurrencyForDisplay: (BigDecimal) -> String
+    ) {
+        val viewAdapter = shippingLabel_list.adapter as? OrderDetailShippingLabelsAdapter
+            ?: OrderDetailShippingLabelsAdapter(formatCurrencyForDisplay, productImageMap)
+        shippingLabel_list.apply {
+            setHasFixedSize(true)
+            layoutManager = LinearLayoutManager(context)
+            itemAnimator = DefaultItemAnimator()
+            adapter = viewAdapter
+        }
+        viewAdapter.shippingLabels = shippingLabels
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -31,6 +31,7 @@ import com.woocommerce.android.util.max
 import com.woocommerce.android.ui.orders.notes.OrderNoteRepository
 import com.woocommerce.android.model.PaymentGateway
 import com.woocommerce.android.model.Refund
+import com.woocommerce.android.model.getMaxRefundQuantities
 import com.woocommerce.android.ui.refunds.IssueRefundViewModel.IssueRefundEvent.HideValidationError
 import com.woocommerce.android.ui.refunds.IssueRefundViewModel.InputValidationState.TOO_HIGH
 import com.woocommerce.android.ui.refunds.IssueRefundViewModel.InputValidationState.TOO_LOW
@@ -133,7 +134,7 @@ class IssueRefundViewModel @AssistedInject constructor(
 
         formatCurrency = currencyFormatter.buildBigDecimalFormatter(order.currency)
         maxRefund = order.total - order.refundTotal
-        maxQuantities = order.getMaxRefundQuantities(refunds)
+        maxQuantities = refunds.getMaxRefundQuantities(order.items)
         gateway = loadPaymentGateway()
 
         initRefundByAmountState()

--- a/WooCommerce/src/main/res/layout/fragment_order_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_detail.xml
@@ -41,7 +41,7 @@
                     tools:visibility="visible" />
 
                 <!-- Product List -->
-                <com.woocommerce.android.ui.orders.OrderDetailShippingLabelListView
+                <com.woocommerce.android.ui.orders.details.views.OrderDetailShippingLabelsView
                     android:id="@+id/orderDetail_shippingLabelList"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailPresenterTest.kt
@@ -525,7 +525,6 @@ class OrderDetailPresenterTest {
 
         verify(orderDetailView, times(1)).showOrderDetail(order, true)
         verify(orderDetailView, times(1)).showRefunds(order, orderDetailUiItem.refunds)
-        verify(orderDetailView, times(1)).showShippingLabels(order, orderDetailUiItem.shippingLabels)
         verify(orderDetailView, times(1)).showProductList(
             order, orderDetailUiItem.refunds, orderDetailUiItem.shippingLabels
         )


### PR DESCRIPTION
This PR takes care of the 9/13 step of the Order Detail refactoring #2844 .

#### Changes
- Adds the Shipping labels card (`OrderDetailShippingLabelsView`) to the Order detail screen. This card will be visible only in debug build and when the WooCommerce Services plugin is available for the store.

#### Notes
- I have split this massive change into multiple small PRs in order to make reviews easier. 
- This PR is to be merged into a feature branch.
- **This PR is in draft till this [Step 8 PR](https://github.com/woocommerce/woocommerce-android/pull/2873) can be merged.**

#### Testing
- Click on an order from the Orders tab that has some shipping labels associated with it. (To create shipping labels, please follow the instructions provided in the Shipping Labels Master Thread - `p91TBi-2om`)
- Notice the shipping labels section displayed.


#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/93732166-c4745280-fbed-11ea-9b4b-796cfb022bec.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/93732169-c63e1600-fbed-11ea-8ce5-85880a385822.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/93732187-d655f580-fbed-11ea-872a-3a940827c9e6.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/93732190-d8b84f80-fbed-11ea-9cfe-19587bc6ec8e.png" width="300"/>

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.