### PR TITLE
Issue/2844 order detail refactor update order status

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderCustomerHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderCustomerHelper.kt
@@ -7,8 +7,9 @@ import android.net.Uri
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
-import org.wordpress.android.fluxc.model.WCOrderModel
+import com.woocommerce.android.model.Order
 import org.wordpress.android.util.ToastUtils
+import java.util.Locale
 
 object OrderCustomerHelper {
     enum class Action {
@@ -17,33 +18,17 @@ object OrderCustomerHelper {
         SMS
     }
 
-    fun dialPhone(context: Context, order: WCOrderModel, phone: String) {
+    fun createEmail(
+        context: Context,
+        order: Order,
+        emailAddr: String
+    ) {
         AnalyticsTracker.track(
-                Stat.ORDER_CONTACT_ACTION, mapOf(
-                AnalyticsTracker.KEY_ID to order.remoteOrderId,
-                AnalyticsTracker.KEY_STATUS to order.status,
-                AnalyticsTracker.KEY_TYPE to Action.CALL.name.toLowerCase()))
-
-        val intent = Intent(Intent.ACTION_DIAL)
-        intent.data = Uri.parse("tel:$phone")
-        try {
-            context.startActivity(intent)
-        } catch (e: ActivityNotFoundException) {
-            AnalyticsTracker.track(
-                    Stat.ORDER_CONTACT_ACTION_FAILED,
-                    this.javaClass.simpleName,
-                    e.javaClass.simpleName, "No phone app was found")
-
-            ToastUtils.showToast(context, R.string.error_no_phone_app)
-        }
-    }
-
-    fun createEmail(context: Context, order: WCOrderModel, emailAddr: String) {
-        AnalyticsTracker.track(
-                Stat.ORDER_CONTACT_ACTION, mapOf(
-                AnalyticsTracker.KEY_ID to order.remoteOrderId,
-                AnalyticsTracker.KEY_STATUS to order.status,
-                AnalyticsTracker.KEY_TYPE to Action.EMAIL.name.toLowerCase()))
+            Stat.ORDER_CONTACT_ACTION, mapOf(
+            AnalyticsTracker.KEY_ID to order.remoteId,
+            AnalyticsTracker.KEY_STATUS to order.status,
+            AnalyticsTracker.KEY_TYPE to Action.EMAIL.name.toLowerCase(Locale.US))
+        )
 
         val intent = Intent(Intent.ACTION_SENDTO)
         intent.data = Uri.parse("mailto:$emailAddr") // only email apps should handle this
@@ -51,20 +36,50 @@ object OrderCustomerHelper {
             context.startActivity(intent)
         } catch (e: ActivityNotFoundException) {
             AnalyticsTracker.track(
-                    Stat.ORDER_CONTACT_ACTION_FAILED,
-                    this.javaClass.simpleName,
-                    e.javaClass.simpleName, "No e-mail app was found")
+                Stat.ORDER_CONTACT_ACTION_FAILED,
+                this.javaClass.simpleName,
+                e.javaClass.simpleName, "No e-mail app was found")
 
             ToastUtils.showToast(context, R.string.error_no_email_app)
         }
     }
 
-    fun sendSms(context: Context, order: WCOrderModel, phone: String) {
+    fun dialPhone(
+        context: Context,
+        order: Order,
+        phone: String
+    ) {
         AnalyticsTracker.track(
-                Stat.ORDER_CONTACT_ACTION, mapOf(
-                AnalyticsTracker.KEY_ID to order.remoteOrderId,
-                AnalyticsTracker.KEY_STATUS to order.status,
-                AnalyticsTracker.KEY_TYPE to Action.SMS.name.toLowerCase()))
+            Stat.ORDER_CONTACT_ACTION, mapOf(
+            AnalyticsTracker.KEY_ID to order.remoteId,
+            AnalyticsTracker.KEY_STATUS to order.status,
+            AnalyticsTracker.KEY_TYPE to Action.CALL.name.toLowerCase(Locale.US))
+        )
+
+        val intent = Intent(Intent.ACTION_DIAL)
+        intent.data = Uri.parse("tel:$phone")
+        try {
+            context.startActivity(intent)
+        } catch (e: ActivityNotFoundException) {
+            AnalyticsTracker.track(
+                Stat.ORDER_CONTACT_ACTION_FAILED,
+                this.javaClass.simpleName,
+                e.javaClass.simpleName, "No phone app was found")
+
+            ToastUtils.showToast(context, R.string.error_no_phone_app)
+        }
+    }
+
+    fun sendSms(
+        context: Context,
+        order: Order,
+        phone: String
+    ) {
+        AnalyticsTracker.track(
+            Stat.ORDER_CONTACT_ACTION, mapOf(
+            AnalyticsTracker.KEY_ID to order.remoteId,
+            AnalyticsTracker.KEY_STATUS to order.status,
+            AnalyticsTracker.KEY_TYPE to Action.SMS.name.toLowerCase(Locale.US)))
 
         val intent = Intent(Intent.ACTION_SENDTO)
         intent.data = Uri.parse("smsto:$phone")
@@ -72,9 +87,9 @@ object OrderCustomerHelper {
             context.startActivity(intent)
         } catch (e: ActivityNotFoundException) {
             AnalyticsTracker.track(
-                    Stat.ORDER_CONTACT_ACTION_FAILED,
-                    this.javaClass.simpleName,
-                    e.javaClass.simpleName, "No SMS app was found")
+                Stat.ORDER_CONTACT_ACTION_FAILED,
+                this.javaClass.simpleName,
+                e.javaClass.simpleName, "No SMS app was found")
 
             ToastUtils.showToast(context, R.string.error_no_sms_app)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailCustomerInfoView.kt
@@ -88,7 +88,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
                 customerInfo_emailBtn.visibility = View.VISIBLE
                 customerInfo_emailBtn.setOnClickListener {
                     AnalyticsTracker.track(Stat.ORDER_DETAIL_CUSTOMER_INFO_EMAIL_MENU_EMAIL_TAPPED)
-                    OrderCustomerHelper.createEmail(context, order, order.billingEmail)
+                    OrderCustomerHelper.createEmail(context, order.toAppModel(), order.billingEmail)
                     AppRatingDialog.incrementInteractions()
                 }
             } else {
@@ -163,14 +163,14 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
 
         popup.menu.findItem(R.id.menu_call)?.setOnMenuItemClickListener {
             AnalyticsTracker.track(Stat.ORDER_DETAIL_CUSTOMER_INFO_PHONE_MENU_PHONE_TAPPED)
-            OrderCustomerHelper.dialPhone(context, order, order.billingPhone)
+            OrderCustomerHelper.dialPhone(context, order.toAppModel(), order.billingPhone)
             AppRatingDialog.incrementInteractions()
             true
         }
 
         popup.menu.findItem(R.id.menu_message)?.setOnMenuItemClickListener {
             AnalyticsTracker.track(Stat.ORDER_DETAIL_CUSTOMER_INFO_PHONE_MENU_SMS_TAPPED)
-            OrderCustomerHelper.sendSms(context, order, order.billingPhone)
+            OrderCustomerHelper.sendSms(context, order.toAppModel(), order.billingPhone)
             AppRatingDialog.incrementInteractions()
             true
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
@@ -25,4 +25,6 @@ sealed class OrderNavigationTarget : Event() {
             return result
         }
     }
+
+    data class IssueOrderRefund(val remoteOrderId: Long) : OrderNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
@@ -1,11 +1,12 @@
 package com.woocommerce.android.ui.orders
 
+import com.woocommerce.android.model.Order
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 
 sealed class OrderNavigationTarget : Event() {
     data class ViewOrderStatusSelector(
         val currentStatus: String,
-        val orderStatusList: Array<String>
+        val orderStatusList: Array<Order.OrderStatus>
     ) : OrderNavigationTarget() {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
@@ -27,4 +27,5 @@ sealed class OrderNavigationTarget : Event() {
     }
 
     data class IssueOrderRefund(val remoteOrderId: Long) : OrderNavigationTarget()
+    data class ViewRefundedProducts(val remoteOrderId: Long) : OrderNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.ui.orders
+
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+
+sealed class OrderNavigationTarget : Event() {
+    data class ViewOrderStatusSelector(
+        val currentStatus: String,
+        val orderStatusList: Array<String>
+    ) : OrderNavigationTarget() {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as ViewOrderStatusSelector
+
+            if (currentStatus != other.currentStatus) return false
+            if (!orderStatusList.contentEquals(other.orderStatusList)) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = currentStatus.hashCode()
+            result = 31 * result + orderStatusList.contentHashCode()
+            return result
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
@@ -1,0 +1,24 @@
+package com.woocommerce.android.ui.orders
+
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
+import com.woocommerce.android.ui.orders.details.OrderDetailFragmentDirections
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class OrderNavigator @Inject constructor() {
+    fun navigate(fragment: Fragment, target: OrderNavigationTarget) {
+        when (target) {
+            is ViewOrderStatusSelector -> {
+                val action = OrderDetailFragmentDirections
+                    .actionOrderDetailFragmentToOrderStatusSelectorDialog(
+                        target.currentStatus, target.orderStatusList
+                    )
+                fragment.findNavController().navigateSafely(action)
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
@@ -5,6 +5,7 @@ import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.IssueOrderRefund
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewRefundedProducts
 import com.woocommerce.android.ui.orders.details.OrderDetailFragmentDirections
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -23,6 +24,11 @@ class OrderNavigator @Inject constructor() {
             is IssueOrderRefund -> {
                 val action = OrderDetailFragmentDirections
                     .actionOrderDetailFragmentToIssueRefund(target.remoteOrderId)
+                fragment.findNavController().navigateSafely(action)
+            }
+            is ViewRefundedProducts -> {
+                val action = OrderDetailFragmentDirections
+                    .actionOrderDetailFragmentToRefundDetailFragment(target.remoteOrderId)
                 fragment.findNavController().navigateSafely(action)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.IssueOrderRefund
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
 import com.woocommerce.android.ui.orders.details.OrderDetailFragmentDirections
 import javax.inject.Inject
@@ -17,6 +18,11 @@ class OrderNavigator @Inject constructor() {
                     .actionOrderDetailFragmentToOrderStatusSelectorDialog(
                         target.currentStatus, target.orderStatusList
                     )
+                fragment.findNavController().navigateSafely(action)
+            }
+            is IssueOrderRefund -> {
+                val action = OrderDetailFragmentDirections
+                    .actionOrderDetailFragmentToIssueRefund(target.remoteOrderId)
                 fragment.findNavController().navigateSafely(action)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -171,7 +171,9 @@ class OrderDetailFragment : BaseFragment() {
         val refundsCount = refunds.sumBy { refund -> refund.items.sumBy { it.quantity } }
         if (refundsCount > 0) {
             orderDetail_refundsInfo.show()
-            orderDetail_refundsInfo.updateRefundCount(refundsCount)
+            orderDetail_refundsInfo.updateRefundCount(refundsCount) {
+                viewModel.onViewRefundedProductsClicked()
+            }
         } else {
             orderDetail_refundsInfo.hide()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -140,7 +140,8 @@ class OrderDetailFragment : BaseFragment() {
         )
         orderDetail_paymentInfo.updatePaymentInfo(
             order = order,
-            formatCurrencyForDisplay = currencyFormatter.buildBigDecimalFormatter(order.currency)
+            formatCurrencyForDisplay = currencyFormatter.buildBigDecimalFormatter(order.currency),
+            onIssueRefundClickListener = { viewModel.onIssueOrderRefundClicked() }
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -63,6 +63,14 @@ class OrderDetailFragment : BaseFragment() {
         setupObservers(viewModel)
     }
 
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        orderRefreshLayout?.apply {
+            scrollUpChild = scrollView
+            setOnRefreshListener { viewModel.onRefreshRequested() }
+        }
+    }
+
     private fun setupObservers(viewModel: OrderDetailViewModel) {
         viewModel.orderDetailViewStateData.observe(viewLifecycleOwner) { old, new ->
             new.order?.takeIfNotEqualTo(old?.order) { showOrderDetail(it) }
@@ -75,6 +83,9 @@ class OrderDetailFragment : BaseFragment() {
             new.isShipmentTrackingAvailable?.takeIfNotEqualTo(old?.isShipmentTrackingAvailable) {
                 orderDetail_shipmentList.isVisible = it
                 orderDetail_shipmentList.showAddTrackingButton(it)
+            }
+            new.isRefreshing?.takeIfNotEqualTo(old?.isRefreshing) {
+                orderRefreshLayout.isRefreshing = it
             }
         }
 
@@ -93,7 +104,6 @@ class OrderDetailFragment : BaseFragment() {
         viewModel.shippingLabels.observe(viewLifecycleOwner, Observer {
             showShippingLabels(it)
         })
-        viewModel.loadOrderDetail()
     }
 
     private fun showOrderDetail(order: Order) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -10,6 +10,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.R
+import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.hide
@@ -25,6 +26,7 @@ import com.woocommerce.android.model.ShippingLabel
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.main.MainActivity.NavigationResult
 import com.woocommerce.android.ui.orders.OrderNavigationTarget
 import com.woocommerce.android.ui.orders.OrderNavigator
 import com.woocommerce.android.util.CurrencyFormatter
@@ -37,7 +39,7 @@ import kotlinx.android.synthetic.main.fragment_order_detail.*
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import javax.inject.Inject
 
-class OrderDetailFragment : BaseFragment() {
+class OrderDetailFragment : BaseFragment(), NavigationResult {
     @Inject lateinit var viewModelFactory: ViewModelFactory
     private val viewModel: OrderDetailViewModel by viewModels { viewModelFactory }
 
@@ -76,6 +78,12 @@ class OrderDetailFragment : BaseFragment() {
         orderRefreshLayout?.apply {
             scrollUpChild = scrollView
             setOnRefreshListener { viewModel.onRefreshRequested() }
+        }
+    }
+
+    override fun onNavigationResult(requestCode: Int, result: Bundle) {
+        if (requestCode == RequestCodes.ORDER_REFUND) {
+            viewModel.onOrderItemRefunded()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -23,6 +23,8 @@ import com.woocommerce.android.model.ShippingLabel
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.orders.OrderNavigationTarget
+import com.woocommerce.android.ui.orders.OrderNavigator
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.SkeletonView
@@ -35,6 +37,7 @@ class OrderDetailFragment : BaseFragment() {
     @Inject lateinit var viewModelFactory: ViewModelFactory
     private val viewModel: OrderDetailViewModel by viewModels { viewModelFactory }
 
+    @Inject lateinit var navigator: OrderNavigator
     @Inject lateinit var currencyFormatter: CurrencyFormatter
     @Inject lateinit var uiMessageResolver: UIMessageResolver
     @Inject lateinit var productImageMap: ProductImageMap
@@ -104,6 +107,13 @@ class OrderDetailFragment : BaseFragment() {
         viewModel.shippingLabels.observe(viewLifecycleOwner, Observer {
             showShippingLabels(it)
         })
+
+        viewModel.event.observe(viewLifecycleOwner, Observer { event ->
+            when (event) {
+                is OrderNavigationTarget -> navigator.navigate(this, event)
+                else -> event.isHandled = false
+            }
+        })
     }
 
     private fun showOrderDetail(order: Order) {
@@ -120,7 +130,9 @@ class OrderDetailFragment : BaseFragment() {
     }
 
     private fun showOrderStatus(orderStatus: OrderStatus) {
-        orderDetail_orderStatus.updateStatus(orderStatus)
+        orderDetail_orderStatus.updateStatus(orderStatus) {
+            viewModel.onEditOrderStatusSelected()
+        }
     }
 
     private fun showSkeleton(show: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -135,6 +135,8 @@ class OrderDetailRepository @Inject constructor(
         }).toOrderStatus()
     }
 
+    fun getOrderStatusOptions() = orderStore.getOrderStatusOptionsForSite(selectedSite.get()).map { it.toOrderStatus() }
+
     fun getOrderNotes(localOrderId: Int) =
         orderStore.getOrderNotesForOrder(localOrderId).map { it.toAppModel() }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -22,6 +22,7 @@ import com.woocommerce.android.model.getNonRefundedProducts
 import com.woocommerce.android.model.hasNonRefundedProducts
 import com.woocommerce.android.model.loadProducts
 import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.LiveDataDelegate
@@ -99,6 +100,17 @@ class OrderDetailViewModel @AssistedInject constructor(
             val remoteProductIds = lineItems.map { it.productId }
             orderDetailRepository.getProductsByRemoteIds(remoteProductIds).any { it.virtual }
         } ?: false
+    }
+
+    fun onEditOrderStatusSelected() {
+        order?.let { order ->
+            triggerEvent(
+                ViewOrderStatusSelector(
+                currentStatus = order.status.value,
+                orderStatusList = orderDetailRepository.getOrderStatusOptions().map { it.statusKey }.toTypedArray()
+            )
+            )
+        }
     }
 
     private suspend fun fetchOrder(showSkeleton: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -127,6 +127,10 @@ class OrderDetailViewModel @AssistedInject constructor(
         order?.let { triggerEvent(ViewRefundedProducts(remoteOrderId = it.remoteId)) }
     }
 
+    fun onOrderItemRefunded() {
+        launch { fetchOrder(false) }
+    }
+
     fun onOrderStatusChanged(newStatus: String) {
         val snackMessage = when (newStatus) {
             CoreOrderStatus.COMPLETED.value -> resourceProvider.getString(string.order_fulfill_marked_complete)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.model.getNonRefundedProducts
 import com.woocommerce.android.model.hasNonRefundedProducts
 import com.woocommerce.android.model.loadProducts
 import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.IssueOrderRefund
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.FeatureFlag
@@ -115,6 +116,10 @@ class OrderDetailViewModel @AssistedInject constructor(
                 orderStatusList = orderDetailRepository.getOrderStatusOptions().map { it.statusKey }.toTypedArray()
             ))
         }
+    }
+
+    fun onIssueOrderRefundClicked() {
+        order?.let { triggerEvent(IssueOrderRefund(remoteOrderId = it.remoteId)) }
     }
 
     fun onOrderStatusChanged(newStatus: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.model.loadProducts
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.IssueOrderRefund
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewRefundedProducts
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.LiveDataDelegate
@@ -120,6 +121,10 @@ class OrderDetailViewModel @AssistedInject constructor(
 
     fun onIssueOrderRefundClicked() {
         order?.let { triggerEvent(IssueOrderRefund(remoteOrderId = it.remoteId)) }
+    }
+
+    fun onViewRefundedProductsClicked() {
+        order?.let { triggerEvent(ViewRefundedProducts(remoteOrderId = it.remoteId)) }
     }
 
     fun onOrderStatusChanged(newStatus: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -110,11 +110,11 @@ class OrderDetailViewModel @AssistedInject constructor(
     }
 
     fun onEditOrderStatusSelected() {
-        order?.let { order ->
+        orderDetailViewState.orderStatus?.let { orderStatus ->
             triggerEvent(
                 ViewOrderStatusSelector(
-                currentStatus = order.status.value,
-                orderStatusList = orderDetailRepository.getOrderStatusOptions().map { it.statusKey }.toTypedArray()
+                currentStatus = orderStatus.statusKey,
+                orderStatusList = orderDetailRepository.getOrderStatusOptions().toTypedArray()
             ))
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderStatusSelectorDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderStatusSelectorDialog.kt
@@ -1,5 +1,63 @@
 package com.woocommerce.android.ui.orders.details
 
+import android.app.Dialog
+import android.os.Bundle
 import androidx.fragment.app.DialogFragment
+import androidx.navigation.fragment.navArgs
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.extensions.navigateBackWithResult
 
-class OrderStatusSelectorDialog : DialogFragment()
+/**
+ * Dialog displays a list of order statuses and allows for selecting a single order status for
+ * manually changing order statuses.
+ *
+ */
+class OrderStatusSelectorDialog : DialogFragment() {
+    companion object {
+        const val KEY_ORDER_STATUS_RESULT = "key_order_status_result"
+    }
+
+    private var selectedOrderStatus: String? = null
+    private val navArgs: OrderStatusSelectorDialogArgs by navArgs()
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        selectedOrderStatus = navArgs.currentStatus
+        val selectedIndex = getCurrentOrderStatusIndex()
+
+        return MaterialAlertDialogBuilder(requireActivity())
+            .setTitle(resources.getString(R.string.orderstatus_select_status))
+            .setCancelable(true)
+            .setSingleChoiceItems(navArgs.orderStatusList, selectedIndex) { _, which ->
+                selectedOrderStatus = navArgs.orderStatusList[which]
+                AnalyticsTracker.track(
+                    Stat.FILTER_ORDERS_BY_STATUS_DIALOG_OPTION_SELECTED,
+                    mapOf("status" to selectedOrderStatus)
+                )
+            }
+            .setPositiveButton(R.string.apply) { _, _ ->
+                val newSelectedIndex = getCurrentOrderStatusIndex()
+                if (newSelectedIndex != selectedIndex) {
+                    AnalyticsTracker.track(
+                        Stat.SET_ORDER_STATUS_DIALOG_APPLY_BUTTON_TAPPED,
+                        mapOf("status" to selectedOrderStatus)
+                    )
+                    navigateBackWithResult(KEY_ORDER_STATUS_RESULT, selectedOrderStatus)
+                }
+            }
+            .setNegativeButton(R.string.cancel) { dialog, _ ->
+                dialog.dismiss()
+            }
+            .create()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        AnalyticsTracker.trackViewShown(this)
+    }
+
+    private fun getCurrentOrderStatusIndex() =
+        navArgs.orderStatusList.indexOfFirst { it == selectedOrderStatus }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderStatusSelectorDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderStatusSelectorDialog.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.model.Order
 
 /**
  * Dialog displays a list of order statuses and allows for selecting a single order status for
@@ -22,10 +23,11 @@ class OrderStatusSelectorDialog : DialogFragment() {
     }
 
     private var selectedOrderStatus: String? = null
-    private val orderStatusList: Array<String> by lazy {
+    private val orderStatusList: Array<Order.OrderStatus> by lazy {
         // remove the Refunded status from the dialog to avoid reporting problems (unless it's already Refunded)
         navArgs.orderStatusList
-            .filter { selectedOrderStatus == REFUNDED_ID || it != REFUNDED_ID }
+            .filter { selectedOrderStatus == REFUNDED_ID || it.statusKey != REFUNDED_ID }
+//            .map { it.statusKey }
             .toTypedArray()
     }
     private val navArgs: OrderStatusSelectorDialogArgs by navArgs()
@@ -37,8 +39,8 @@ class OrderStatusSelectorDialog : DialogFragment() {
         return MaterialAlertDialogBuilder(requireActivity())
             .setTitle(resources.getString(R.string.orderstatus_select_status))
             .setCancelable(true)
-            .setSingleChoiceItems(orderStatusList, selectedIndex) { _, which ->
-                selectedOrderStatus = orderStatusList[which]
+            .setSingleChoiceItems(orderStatusList.map { it.label }.toTypedArray(), selectedIndex) { _, which ->
+                selectedOrderStatus = orderStatusList[which].statusKey
                 AnalyticsTracker.track(
                     Stat.FILTER_ORDERS_BY_STATUS_DIALOG_OPTION_SELECTED,
                     mapOf("status" to selectedOrderStatus)
@@ -66,5 +68,5 @@ class OrderStatusSelectorDialog : DialogFragment() {
     }
 
     private fun getCurrentOrderStatusIndex() =
-        orderStatusList.indexOfFirst { it == selectedOrderStatus }
+        orderStatusList.indexOfFirst { it.statusKey == selectedOrderStatus }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderStatusSelectorDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderStatusSelectorDialog.kt
@@ -1,0 +1,5 @@
+package com.woocommerce.android.ui.orders.details
+
+import androidx.fragment.app.DialogFragment
+
+class OrderStatusSelectorDialog : DialogFragment()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderStatusSelectorDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderStatusSelectorDialog.kt
@@ -18,9 +18,16 @@ import com.woocommerce.android.extensions.navigateBackWithResult
 class OrderStatusSelectorDialog : DialogFragment() {
     companion object {
         const val KEY_ORDER_STATUS_RESULT = "key_order_status_result"
+        private const val REFUNDED_ID: String = "refunded"
     }
 
     private var selectedOrderStatus: String? = null
+    private val orderStatusList: Array<String> by lazy {
+        // remove the Refunded status from the dialog to avoid reporting problems (unless it's already Refunded)
+        navArgs.orderStatusList
+            .filter { selectedOrderStatus == REFUNDED_ID || it != REFUNDED_ID }
+            .toTypedArray()
+    }
     private val navArgs: OrderStatusSelectorDialogArgs by navArgs()
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
@@ -30,8 +37,8 @@ class OrderStatusSelectorDialog : DialogFragment() {
         return MaterialAlertDialogBuilder(requireActivity())
             .setTitle(resources.getString(R.string.orderstatus_select_status))
             .setCancelable(true)
-            .setSingleChoiceItems(navArgs.orderStatusList, selectedIndex) { _, which ->
-                selectedOrderStatus = navArgs.orderStatusList[which]
+            .setSingleChoiceItems(orderStatusList, selectedIndex) { _, which ->
+                selectedOrderStatus = orderStatusList[which]
                 AnalyticsTracker.track(
                     Stat.FILTER_ORDERS_BY_STATUS_DIALOG_OPTION_SELECTED,
                     mapOf("status" to selectedOrderStatus)
@@ -59,5 +66,5 @@ class OrderStatusSelectorDialog : DialogFragment() {
     }
 
     private fun getCurrentOrderStatusIndex() =
-        navArgs.orderStatusList.indexOfFirst { it == selectedOrderStatus }
+        orderStatusList.indexOfFirst { it == selectedOrderStatus }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.details.views
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
+import android.widget.PopupMenu
 import androidx.core.view.isVisible
 import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
@@ -13,7 +14,9 @@ import com.woocommerce.android.extensions.expand
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.orders.OrderCustomerHelper
 import com.woocommerce.android.util.PhoneUtils
+import com.woocommerce.android.widgets.AppRatingDialog
 import kotlinx.android.synthetic.main.order_detail_customer_info.view.*
 
 class OrderDetailCustomerInfoView @JvmOverloads constructor(
@@ -79,6 +82,9 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
                 customerInfo_phone.visibility = View.VISIBLE
                 customerInfo_divider3.visibility = View.VISIBLE
                 customerInfo_callOrMessageBtn.visibility = View.VISIBLE
+                customerInfo_callOrMessageBtn.setOnClickListener {
+                    showCallOrMessagePopup(order)
+                }
             } else {
                 customerInfo_phone.visibility = View.GONE
                 customerInfo_divider3.visibility = View.GONE
@@ -91,7 +97,9 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
                 customerInfo_emailAddr.visibility = View.VISIBLE
                 customerInfo_emailBtn.visibility - View.VISIBLE
                 customerInfo_emailBtn.setOnClickListener {
-                    // TODO: add click event to open email here
+                    AnalyticsTracker.track(Stat.ORDER_DETAIL_CUSTOMER_INFO_EMAIL_MENU_EMAIL_TAPPED)
+                    OrderCustomerHelper.createEmail(context, order, order.billingAddress.email)
+                    AppRatingDialog.incrementInteractions()
                 }
             } else {
                 customerInfo_emailAddr.visibility = View.GONE
@@ -118,5 +126,26 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
             customerInfo_morePanel.hide()
             customerInfo_viewMore.setOnClickListener(null)
         }
+    }
+
+    private fun showCallOrMessagePopup(order: Order) {
+        val popup = PopupMenu(context, customerInfo_callOrMessageBtn)
+        popup.menuInflater.inflate(R.menu.menu_order_detail_phone_actions, popup.menu)
+
+        popup.menu.findItem(R.id.menu_call)?.setOnMenuItemClickListener {
+            AnalyticsTracker.track(Stat.ORDER_DETAIL_CUSTOMER_INFO_PHONE_MENU_PHONE_TAPPED)
+            OrderCustomerHelper.dialPhone(context, order, order.billingAddress.phone)
+            AppRatingDialog.incrementInteractions()
+            true
+        }
+
+        popup.menu.findItem(R.id.menu_message)?.setOnMenuItemClickListener {
+            AnalyticsTracker.track(Stat.ORDER_DETAIL_CUSTOMER_INFO_PHONE_MENU_SMS_TAPPED)
+            OrderCustomerHelper.sendSms(context, order, order.billingAddress.phone)
+            AppRatingDialog.incrementInteractions()
+            true
+        }
+
+        popup.show()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
@@ -24,9 +24,10 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
         View.inflate(context, R.layout.order_detail_order_status, this)
     }
 
-    fun updateStatus(orderStatus: OrderStatus) {
+    fun updateStatus(orderStatus: OrderStatus, onTap: ((view: View) -> Unit)) {
         orderStatus_orderTags.removeAllViews()
         orderStatus_orderTags.addView(getTagView(orderStatus))
+        orderStatus_edit.setOnClickListener(onTap)
     }
 
     fun updateOrder(order: Order) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
@@ -28,7 +28,8 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
 
     fun updatePaymentInfo(
         order: Order,
-        formatCurrencyForDisplay: (BigDecimal) -> String
+        formatCurrencyForDisplay: (BigDecimal) -> String,
+        onIssueRefundClickListener: ((view: View) -> Unit)
     ) {
         paymentInfo_productsTotal.text = formatCurrencyForDisplay(order.productsTotal)
         paymentInfo_shippingTotal.text = formatCurrencyForDisplay(order.shippingTotal)
@@ -90,9 +91,7 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
             paymentInfo_refundSection.hide()
         }
 
-        paymentInfo_issueRefundButton.setOnClickListener {
-            // TODO: implement issue refund button in another PR
-        }
+        paymentInfo_issueRefundButton.setOnClickListener(onIssueRefundClickListener)
     }
 
     fun showRefunds(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailRefundsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailRefundsView.kt
@@ -16,11 +16,17 @@ class OrderDetailRefundsView @JvmOverloads constructor(
         View.inflate(context, R.layout.order_detail_refunds_info, this)
     }
 
-    fun updateRefundCount(refundsCount: Int) {
-        refundsInfo_count.text = context.resources.getQuantityString(
-            R.plurals.order_refunds_refund_info_description,
-            refundsCount,
-            refundsCount
-        )
+    fun updateRefundCount(
+        refundsCount: Int,
+        onTap: () -> Unit
+    ) {
+        with(refundsInfo_count) {
+            text = context.resources.getQuantityString(
+                R.plurals.order_refunds_refund_info_description,
+                refundsCount,
+                refundsCount
+            )
+            setOnClickListener { onTap() }
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
@@ -1,11 +1,13 @@
 package com.woocommerce.android.viewmodel
 
 import android.content.DialogInterface.OnClickListener
+import android.view.View
 import androidx.annotation.MainThread
 import androidx.annotation.StringRes
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
+import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -73,6 +75,33 @@ open class MultiLiveEvent<T : Event> : MutableLiveData<T>() {
                 var result = message
                 result = 31 * result + args.contentHashCode()
                 result = 31 * result + (undoAction?.hashCode() ?: 0)
+                return result
+            }
+        }
+
+        data class ShowUndoSnackbar(
+            val message: String,
+            val args: Array<String> = arrayOf(),
+            val undoAction: View.OnClickListener,
+            val dismissAction: Snackbar.Callback
+        ) : Event() {
+            override fun equals(other: Any?): Boolean {
+                if (this === other) return true
+                if (other !is ShowUndoSnackbar) return false
+
+                if (message != other.message) return false
+                if (!args.contentEquals(other.args)) return false
+                if (undoAction != other.undoAction) return false
+                if (dismissAction != other.dismissAction) return false
+
+                return true
+            }
+
+            override fun hashCode(): Int {
+                var result = message.hashCode()
+                result = 31 * result + args.contentHashCode()
+                result = 31 * result + undoAction.hashCode()
+                result = 31 * result + dismissAction.hashCode()
                 return result
             }
         }

--- a/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
@@ -313,6 +313,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
+            android:visibility="gone"
             tools:visibility="visible">
 
             <!-- Divider -->

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -100,7 +100,23 @@
             app:destination="@id/refundDetailFragment"
             app:enterAnim="@anim/activity_fade_in"
             app:popExitAnim="@anim/activity_fade_out" />
+        <action
+            android:id="@+id/action_orderDetailFragment_to_orderStatusSelectorDialog"
+            app:destination="@id/orderStatusSelectorDialog"
+            app:enterAnim="@anim/activity_fade_in"
+            app:popExitAnim="@anim/activity_fade_out" />
     </fragment>
+    <dialog
+        android:id="@+id/orderStatusSelectorDialog"
+        android:name="com.woocommerce.android.ui.orders.details.OrderStatusSelectorDialog">
+        <argument
+            android:name="currentStatus"
+            app:nullable="false"
+            app:argType="string" />
+        <argument
+            android:name="orderStatusList"
+            app:argType="string[]" />
+    </dialog>
     <fragment
         android:id="@+id/addOrderNoteFragment"
         android:name="com.woocommerce.android.ui.orders.notes.AddOrderNoteFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -115,7 +115,7 @@
             app:argType="string" />
         <argument
             android:name="orderStatusList"
-            app:argType="string[]" />
+            app:argType="com.woocommerce.android.model.Order$OrderStatus[]" />
     </dialog>
     <fragment
         android:id="@+id/addOrderNoteFragment"


### PR DESCRIPTION
This PR takes care of the 10/13 step of the Order Detail refactoring #2844 .

#### Changes
- Adds the option to update order status.
- Adds the option to Issue Refund for an order.
- Adds the option to view the Refund detail screen for an order.
- Adds the option to send an sms to the billing phone, if available.
- Adds the option to call the billing phone, if available.
- Adds the option to send email to the billing email, if available.

#### Notes
- I have split this massive change into multiple small PRs in order to make reviews easier. 
- This PR is to be merged into a feature branch.
- **This PR is in draft till this [Step 9 PR](https://github.com/woocommerce/woocommerce-android/pull/2874) can be merged.**

#### Testing
- Click on an order from the Orders tab.
  - Click on the Edit icon beside the Order status.
  - Change the order status to some other status and notice the Undo snackbar is displayed.
  - Click on the Undo Snackbar and notice the status is reverted.
  - Change the status again.
  - Notice that the status is updated successfully once the SnackBar is dismissed.
- Click on an order from the Orders tab.
  - Click on the Issue Refund button.
  - Notice that once the products are refunded, the order detail is refreshed to reflect that change.
  - Notice that a new order note is added to the order after a successful refund.
- Click on an order from the Orders tab.
  - Click on the Refunds section and notice the refund detail screen is displayed.

#### Screenshots
##### Update order status
<img src="https://user-images.githubusercontent.com/22608780/93732308-5c723c00-fbee-11ea-9233-dfba2cd5d217.gif" width="300"/>. 

##### Open Refund detail
<img src="https://user-images.githubusercontent.com/22608780/93732344-76138380-fbee-11ea-9c5e-97f96322897c.gif" width="300"/>. 

##### Issue refund
<img src="https://user-images.githubusercontent.com/22608780/93846545-f9ea7000-fcc1-11ea-9c02-47627df072c9.gif" width="300"/>. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.