### PR TITLE
Issue/2844 order detail refactor add order note

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderNote.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderNote.kt
@@ -1,29 +1,37 @@
 package com.woocommerce.android.model
 
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.util.DateTimeUtils
 import java.util.Date
 
+@Parcelize
 data class OrderNote(
-    val remoteNoteId: Long,
-    val author: String,
-    val dateCreated: Date,
+    val remoteNoteId: Long = 0L,
+    val author: String = "",
+    val dateCreated: Date = Date(),
     val isCustomerNote: Boolean,
-    val isSystemNote: Boolean,
-    val localOrderId: Int,
-    val localSiteId: Int,
+    val isSystemNote: Boolean = false,
+    val localOrderId: Int = 0,
+    val localSiteId: Int = 0,
     val note: String
-)
+) : Parcelable {
+    fun toDataModel() = WCOrderNoteModel().also { orderNoteModel ->
+        orderNoteModel.isCustomerNote = this.isCustomerNote
+        orderNoteModel.note = this.note
+    }
+}
 
 fun WCOrderNoteModel.toAppModel(): OrderNote {
     return OrderNote(
-            remoteNoteId,
-            author,
-            DateTimeUtils.dateUTCFromIso8601(this.dateCreated) ?: Date(),
-            isCustomerNote,
-            isSystemNote,
-            localOrderId,
-            localSiteId,
-            note
+        remoteNoteId,
+        author,
+        DateTimeUtils.dateUTCFromIso8601(this.dateCreated) ?: Date(),
+        isCustomerNote,
+        isSystemNote,
+        localOrderId,
+        localSiteId,
+        note
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
@@ -28,4 +28,5 @@ sealed class OrderNavigationTarget : Event() {
 
     data class IssueOrderRefund(val remoteOrderId: Long) : OrderNavigationTarget()
     data class ViewRefundedProducts(val remoteOrderId: Long) : OrderNavigationTarget()
+    data class AddOrderNote(val orderIdentifier: String, val orderNumber: String) : OrderNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
@@ -29,4 +29,5 @@ sealed class OrderNavigationTarget : Event() {
     data class IssueOrderRefund(val remoteOrderId: Long) : OrderNavigationTarget()
     data class ViewRefundedProducts(val remoteOrderId: Long) : OrderNavigationTarget()
     data class AddOrderNote(val orderIdentifier: String, val orderNumber: String) : OrderNavigationTarget()
+    data class RefundShippingLabel(val remoteOrderId: Long, val shippingLabelId: Long) : OrderNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
@@ -5,6 +5,7 @@ import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.AddOrderNote
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.IssueOrderRefund
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.RefundShippingLabel
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewRefundedProducts
 import com.woocommerce.android.ui.orders.details.OrderDetailFragmentDirections
@@ -35,6 +36,13 @@ class OrderNavigator @Inject constructor() {
             is AddOrderNote -> {
                 val action = OrderDetailFragmentDirections
                     .actionOrderDetailFragmentToAddOrderNoteFragment(target.orderIdentifier, target.orderNumber)
+                fragment.findNavController().navigateSafely(action)
+            }
+            is RefundShippingLabel -> {
+                val action = OrderDetailFragmentDirections
+                    .actionOrderDetailFragmentToOrderShippingLabelRefundFragment(
+                        target.remoteOrderId, target.shippingLabelId
+                    )
                 fragment.findNavController().navigateSafely(action)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.AddOrderNote
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.IssueOrderRefund
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewRefundedProducts
@@ -29,6 +30,11 @@ class OrderNavigator @Inject constructor() {
             is ViewRefundedProducts -> {
                 val action = OrderDetailFragmentDirections
                     .actionOrderDetailFragmentToRefundDetailFragment(target.remoteOrderId)
+                fragment.findNavController().navigateSafely(action)
+            }
+            is AddOrderNote -> {
+                val action = OrderDetailFragmentDirections
+                    .actionOrderDetailFragmentToAddOrderNoteFragment(target.orderIdentifier, target.orderNumber)
                 fragment.findNavController().navigateSafely(action)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.orders.OrderNavigationTarget
 import com.woocommerce.android.ui.orders.OrderNavigator
+import com.woocommerce.android.ui.orders.notes.AddOrderNoteFragment
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUndoSnackbar
@@ -128,6 +129,9 @@ class OrderDetailFragment : BaseFragment() {
     private fun setupResultHandlers(viewModel: OrderDetailViewModel) {
         handleResult<String>(OrderStatusSelectorDialog.KEY_ORDER_STATUS_RESULT) {
             viewModel.onOrderStatusChanged(it)
+        }
+        handleResult<OrderNote>(AddOrderNoteFragment.KEY_ADD_NOTE_RESULT) {
+            viewModel.onNewOrderNoteAdded(it)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -28,6 +28,7 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.orders.OrderNavigationTarget
 import com.woocommerce.android.ui.orders.OrderNavigator
 import com.woocommerce.android.ui.orders.notes.AddOrderNoteFragment
+import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRefundFragment
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUndoSnackbar
@@ -132,6 +133,9 @@ class OrderDetailFragment : BaseFragment() {
         }
         handleResult<OrderNote>(AddOrderNoteFragment.KEY_ADD_NOTE_RESULT) {
             viewModel.onNewOrderNoteAdded(it)
+        }
+        handleResult<Boolean>(ShippingLabelRefundFragment.KEY_REFUND_SHIPPING_LABEL_RESULT) {
+            viewModel.onShippingLabelRefunded()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -229,7 +229,9 @@ class OrderDetailFragment : BaseFragment() {
                     shippingLabels = shippingLabels,
                     productImageMap = productImageMap,
                     formatCurrencyForDisplay = currencyFormatter.buildBigDecimalFormatter(order.currency)
-                )
+                ) {
+                    viewModel.onRefundShippingLabelClick(it.id)
+                }
             }
         }.otherwise { orderDetail_shippingLabelList.hide() }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -163,7 +163,9 @@ class OrderDetailFragment : BaseFragment() {
     }
 
     private fun showOrderNotes(orderNotes: List<OrderNote>) {
-        orderDetail_noteList.updateOrderNotesView(orderNotes)
+        orderDetail_noteList.updateOrderNotesView(orderNotes) {
+            viewModel.onAddOrderNoteClicked()
+        }
     }
 
     private fun showOrderRefunds(refunds: List<Refund>) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -137,6 +137,8 @@ class OrderDetailViewModel @AssistedInject constructor(
         order?.let { triggerEvent(RefundShippingLabel(remoteOrderId = it.remoteId, shippingLabelId = shippingLabelId)) }
     }
 
+    fun onShippingLabelRefunded() { launch { loadOrderShippingLabels() } }
+
     fun onOrderStatusChanged(newStatus: String) {
         val snackMessage = when (newStatus) {
             CoreOrderStatus.COMPLETED.value -> resourceProvider.getString(string.order_fulfill_marked_complete)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -87,15 +87,13 @@ class OrderDetailViewModel @AssistedInject constructor(
     }
 
     init {
-        launch {
-            orderDetailRepository.getOrder(navArgs.orderId)?.let { orderInDb ->
-                updateOrderState(orderInDb)
-                loadOrderNotes()
-                loadOrderRefunds()
-                loadShipmentTrackings()
-                loadOrderShippingLabels()
-            } ?: fetchOrder(true)
-        }
+        orderDetailRepository.getOrder(navArgs.orderId)?.let { orderInDb ->
+            updateOrderState(orderInDb)
+            loadOrderNotes()
+            loadOrderRefunds()
+            loadShipmentTrackings()
+            loadOrderShippingLabels()
+        } ?: launch { fetchOrder(true) }
     }
 
     fun onRefreshRequested() {
@@ -112,12 +110,12 @@ class OrderDetailViewModel @AssistedInject constructor(
     }
 
     fun onEditOrderStatusSelected() {
-        order?.let { order ->
+        orderDetailViewState.orderStatus?.let { orderStatus ->
             triggerEvent(
                 ViewOrderStatusSelector(
-                currentStatus = order.status.value,
-                orderStatusList = orderDetailRepository.getOrderStatusOptions().map { it.statusKey }.toTypedArray()
-            ))
+                    currentStatus = orderStatus.statusKey,
+                    orderStatusList = orderDetailRepository.getOrderStatusOptions().toTypedArray()
+                ))
         }
     }
 
@@ -138,6 +136,10 @@ class OrderDetailViewModel @AssistedInject constructor(
     }
 
     fun onShippingLabelRefunded() { launch { loadOrderShippingLabels() } }
+
+    fun onOrderItemRefunded() {
+        launch { fetchOrder(false) }
+    }
 
     fun onOrderStatusChanged(newStatus: String) {
         val snackMessage = when (newStatus) {
@@ -255,20 +257,24 @@ class OrderDetailViewModel @AssistedInject constructor(
         loadOrderProducts()
     }
 
-    private suspend fun loadOrderNotes() {
-        orderDetailViewState = orderDetailViewState.copy(isOrderNotesSkeletonShown = true)
-        if (!orderDetailRepository.fetchOrderNotes(orderIdSet.id, orderIdSet.remoteOrderId)) {
-            triggerEvent(ShowSnackbar(string.order_error_fetch_notes_generic))
+    private fun loadOrderNotes() {
+        launch {
+            orderDetailViewState = orderDetailViewState.copy(isOrderNotesSkeletonShown = true)
+            if (!orderDetailRepository.fetchOrderNotes(orderIdSet.id, orderIdSet.remoteOrderId)) {
+                triggerEvent(ShowSnackbar(string.order_error_fetch_notes_generic))
+            }
+            // fetch order notes from the local db and hide the skeleton view
+            _orderNotes.value = orderDetailRepository.getOrderNotes(orderIdSet.id)
+            orderDetailViewState = orderDetailViewState.copy(isOrderNotesSkeletonShown = false)
         }
-        // fetch order notes from the local db and hide the skeleton view
-        _orderNotes.value = orderDetailRepository.getOrderNotes(orderIdSet.id)
-        orderDetailViewState = orderDetailViewState.copy(isOrderNotesSkeletonShown = false)
     }
 
-    private suspend fun loadOrderRefunds() {
+    private fun loadOrderRefunds() {
         _orderRefunds.value = orderDetailRepository.getOrderRefunds(orderIdSet.remoteOrderId)
-        if (networkStatus.isConnected()) {
-            _orderRefunds.value = orderDetailRepository.fetchOrderRefunds(orderIdSet.remoteOrderId)
+        launch {
+            if (networkStatus.isConnected()) {
+                _orderRefunds.value = orderDetailRepository.fetchOrderRefunds(orderIdSet.remoteOrderId)
+            }
         }
 
         // display products only if there are some non refunded items in the list
@@ -285,28 +291,32 @@ class OrderDetailViewModel @AssistedInject constructor(
         } ?: emptyList()
     }
 
-    private suspend fun loadShipmentTrackings() {
-        when (orderDetailRepository.fetchOrderShipmentTrackingList(orderIdSet.id, orderIdSet.remoteOrderId)) {
-            RequestResult.SUCCESS -> {
-                _shipmentTrackings.value = orderDetailRepository.getOrderShipmentTrackings(orderIdSet.id)
-                orderDetailViewState = orderDetailViewState.copy(isShipmentTrackingAvailable = true)
-            }
-            else -> {
-                orderDetailViewState = orderDetailViewState.copy(isShipmentTrackingAvailable = false)
-                _shipmentTrackings.value = emptyList()
+    private fun loadShipmentTrackings() {
+        launch {
+            when (orderDetailRepository.fetchOrderShipmentTrackingList(orderIdSet.id, orderIdSet.remoteOrderId)) {
+                RequestResult.SUCCESS -> {
+                    _shipmentTrackings.value = orderDetailRepository.getOrderShipmentTrackings(orderIdSet.id)
+                    orderDetailViewState = orderDetailViewState.copy(isShipmentTrackingAvailable = true)
+                }
+                else -> {
+                    orderDetailViewState = orderDetailViewState.copy(isShipmentTrackingAvailable = false)
+                    _shipmentTrackings.value = emptyList()
+                }
             }
         }
     }
 
-    private suspend fun loadOrderShippingLabels() {
+    private fun loadOrderShippingLabels() {
         order?.let { order ->
             if (FeatureFlag.SHIPPING_LABELS_M1.isEnabled()) {
                 orderDetailRepository.getOrderShippingLabels(orderIdSet.remoteOrderId)
                     .whenNotNullNorEmpty { _shippingLabels.value = it.loadProducts(order.items) }
 
-                _shippingLabels.value = orderDetailRepository
-                    .fetchOrderShippingLabels(orderIdSet.remoteOrderId)
-                    .loadProducts(order.items)
+                launch {
+                    _shippingLabels.value = orderDetailRepository
+                        .fetchOrderShippingLabels(orderIdSet.remoteOrderId)
+                        .loadProducts(order.items)
+                }
             } else {
                 _shippingLabels.value = emptyList()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.model.getNonRefundedProducts
 import com.woocommerce.android.model.hasNonRefundedProducts
 import com.woocommerce.android.model.loadProducts
 import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.AddOrderNote
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.IssueOrderRefund
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewRefundedProducts
@@ -125,6 +126,10 @@ class OrderDetailViewModel @AssistedInject constructor(
 
     fun onViewRefundedProductsClicked() {
         order?.let { triggerEvent(ViewRefundedProducts(remoteOrderId = it.remoteId)) }
+    }
+
+    fun onAddOrderNoteClicked() {
+        order?.let { triggerEvent(AddOrderNote(orderIdentifier = it.identifier, orderNumber = it.number)) }
     }
 
     fun onOrderStatusChanged(newStatus: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.model.loadProducts
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.AddOrderNote
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.IssueOrderRefund
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.RefundShippingLabel
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewRefundedProducts
 import com.woocommerce.android.util.CoroutineDispatchers
@@ -130,6 +131,10 @@ class OrderDetailViewModel @AssistedInject constructor(
 
     fun onAddOrderNoteClicked() {
         order?.let { triggerEvent(AddOrderNote(orderIdentifier = it.identifier, orderNumber = it.number)) }
+    }
+
+    fun onRefundShippingLabelClick(shippingLabelId: Long) {
+        order?.let { triggerEvent(RefundShippingLabel(remoteOrderId = it.remoteId, shippingLabelId = shippingLabelId)) }
     }
 
     fun onOrderStatusChanged(newStatus: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -160,6 +160,27 @@ class OrderDetailViewModel @AssistedInject constructor(
         )
     }
 
+    fun onNewOrderNoteAdded(orderNote: OrderNote) {
+        if (networkStatus.isConnected()) {
+            val orderNotes = _orderNotes.value?.toMutableList() ?: mutableListOf()
+            orderNotes.add(0, orderNote)
+            _orderNotes.value = orderNotes
+
+            triggerEvent(ShowSnackbar(string.add_order_note_added))
+            launch {
+                if (!orderDetailRepository
+                        .addOrderNote(orderIdSet.id, orderIdSet.remoteOrderId, orderNote.toDataModel())
+                ) {
+                    triggerEvent(ShowSnackbar(string.add_order_note_error))
+                    orderNotes.remove(orderNote)
+                    _orderNotes.value = orderNotes
+                }
+            }
+        } else {
+            triggerEvent(ShowSnackbar(string.offline_error))
+        }
+    }
+
     private fun updateOrderStatus(newStatus: String) {
         if (networkStatus.isConnected()) {
             launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShippingLabelsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShippingLabelsAdapter.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.details.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.widget.PopupMenu
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.DiffUtil.Callback
@@ -24,7 +25,8 @@ import java.math.BigDecimal
 
 class OrderDetailShippingLabelsAdapter(
     private val formatCurrencyForDisplay: (BigDecimal) -> String,
-    private val productImageMap: ProductImageMap
+    private val productImageMap: ProductImageMap,
+    private val onRefundRequested: (shippingLabel: ShippingLabel) -> Unit
 ) : RecyclerView.Adapter<ShippingLabelsViewHolder>() {
     private val viewPool = RecyclerView.RecycledViewPool()
 
@@ -41,7 +43,9 @@ class OrderDetailShippingLabelsAdapter(
         }
 
     override fun onCreateViewHolder(parent: ViewGroup, itemType: Int): ShippingLabelsViewHolder {
-        return ShippingLabelsViewHolder(parent, viewPool, productImageMap, formatCurrencyForDisplay)
+        return ShippingLabelsViewHolder(
+            parent, viewPool, productImageMap, formatCurrencyForDisplay, onRefundRequested
+        )
     }
 
     override fun onBindViewHolder(holder: ShippingLabelsViewHolder, position: Int) {
@@ -54,7 +58,8 @@ class OrderDetailShippingLabelsAdapter(
         parent: ViewGroup,
         private val viewPool: RecyclerView.RecycledViewPool,
         private val productImageMap: ProductImageMap,
-        private val formatCurrencyForDisplay: (BigDecimal) -> String
+        private val formatCurrencyForDisplay: (BigDecimal) -> String,
+        private val onRefundRequested: (shippingLabel: ShippingLabel) -> Unit
     ) : RecyclerView.ViewHolder(
         LayoutInflater.from(parent.context).inflate(R.layout.order_detail_shipping_label_list_item, parent, false)
     ) {
@@ -111,7 +116,7 @@ class OrderDetailShippingLabelsAdapter(
                     ))
                     setShippingLabelValue(shippingLabel.trackingNumber)
                     itemView.shippingLabelList_btnMenu.setOnClickListener {
-                        // TODO: popup to request a refund
+                        showRefundPopup(shippingLabel, onRefundRequested)
                     }
 
                     // display tracking link if available
@@ -180,6 +185,20 @@ class OrderDetailShippingLabelsAdapter(
                     )
                 )
             }
+        }
+
+        private fun showRefundPopup(
+            shippingLabel: ShippingLabel,
+            onItemSelected: (shippingLabel: ShippingLabel) -> Unit
+        ) {
+            val popup = PopupMenu(itemView.context, itemView.shippingLabelList_btnMenu)
+            popup.menuInflater.inflate(R.menu.menu_shipping_label, popup.menu)
+
+            popup.menu.findItem(R.id.menu_refund)?.setOnMenuItemClickListener {
+                onItemSelected(shippingLabel)
+                true
+            }
+            popup.show()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderNotesView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderNotesView.kt
@@ -40,12 +40,17 @@ class OrderDetailOrderNotesView @JvmOverloads constructor(
         }
     }
 
-    fun updateOrderNotesView(orderNotes: List<OrderNote>) {
+    fun updateOrderNotesView(
+        orderNotes: List<OrderNote>,
+        onTapAddOrderNote: () -> Unit
+    ) {
         val adapter = notesList_notes.adapter as? OrderNotesAdapter ?: OrderNotesAdapter()
         enableItemAnimator(adapter.itemCount == 0)
 
         val notesWithHeaders = addHeaders(orderNotes)
         adapter.setNotes(notesWithHeaders)
+
+        noteList_addNoteContainer.setOnClickListener { onTapAddOrderNote() }
     }
 
     private fun addHeaders(notes: List<OrderNote>): List<OrderNoteListItem> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailShippingLabelsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailShippingLabelsView.kt
@@ -25,10 +25,15 @@ class OrderDetailShippingLabelsView @JvmOverloads constructor(
     fun updateShippingLabels(
         shippingLabels: List<ShippingLabel>,
         productImageMap: ProductImageMap,
-        formatCurrencyForDisplay: (BigDecimal) -> String
+        formatCurrencyForDisplay: (BigDecimal) -> String,
+        onRefundRequested: (shippingLabel: ShippingLabel) -> Unit
     ) {
         val viewAdapter = shippingLabel_list.adapter as? OrderDetailShippingLabelsAdapter
-            ?: OrderDetailShippingLabelsAdapter(formatCurrencyForDisplay, productImageMap)
+            ?: OrderDetailShippingLabelsAdapter(
+                formatCurrencyForDisplay = formatCurrencyForDisplay,
+                productImageMap = productImageMap,
+                onRefundRequested = onRefundRequested
+            )
         shippingLabel_list.apply {
             setHasFixedSize(true)
             layoutManager = LinearLayoutManager(context)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteFragment.kt
@@ -14,6 +14,8 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ADD_ORDER_NOTE_ADD_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ADD_ORDER_NOTE_EMAIL_NOTE_TO_CUSTOMER_TOGGLED
+import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.model.OrderNote
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.dialog.CustomDiscardDialog
@@ -31,6 +33,7 @@ class AddOrderNoteFragment : BaseFragment(), AddOrderNoteContract.View, BackPres
         private const val FIELD_NOTE_TEXT = "note_text"
         private const val FIELD_IS_CUSTOMER_NOTE = "is_customer_note"
         private const val FIELD_IS_CONFIRMING_DISCARD = "is_confirming_discard"
+        const val KEY_ADD_NOTE_RESULT = "key_add_note_result"
     }
 
     @Inject lateinit var presenter: Presenter
@@ -128,11 +131,12 @@ class AddOrderNoteFragment : BaseFragment(), AddOrderNoteContract.View, BackPres
                 AnalyticsTracker.track(ADD_ORDER_NOTE_ADD_BUTTON_TAPPED)
                 val noteText = getNoteText()
                 if (noteText.isNotEmpty()) {
-                    val isCustomerNote = addNote_switch.isChecked
-                    if (presenter.pushOrderNote(orderId, noteText, isCustomerNote)) {
-                        shouldShowDiscardDialog = false
-                        activity?.onBackPressed()
-                    }
+                    val orderNote = OrderNote(
+                        isCustomerNote = addNote_switch.isChecked,
+                        note = noteText
+                    )
+                    shouldShowDiscardDialog = false
+                    navigateBackWithResult(KEY_ADD_NOTE_RESULT, orderNote)
                 }
                 true
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRefundFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRefundFragment.kt
@@ -22,6 +22,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import kotlinx.android.synthetic.main.fragment_shipping_label_refund.*
+import dagger.Lazy
 import javax.inject.Inject
 
 class ShippingLabelRefundFragment : BaseFragment(), BackPressListener {
@@ -29,9 +30,9 @@ class ShippingLabelRefundFragment : BaseFragment(), BackPressListener {
         const val KEY_REFUND_SHIPPING_LABEL_RESULT = "key_refund_shipping_label_result"
     }
 
-    @Inject lateinit var viewModelFactory: ViewModelFactory
+    @Inject lateinit var viewModelFactory: Lazy<ViewModelFactory>
     val viewModel: ShippingLabelRefundViewModel
-        by navGraphViewModels(R.id.nav_graph_shipping_labels) { viewModelFactory }
+        by navGraphViewModels(R.id.nav_graph_shipping_labels) { viewModelFactory.get() }
 
     @Inject lateinit var uiMessageResolver: UIMessageResolver
     @Inject lateinit var currencyFormatter: CurrencyFormatter

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRefundFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRefundFragment.kt
@@ -9,7 +9,6 @@ import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.navGraphViewModels
 import com.woocommerce.android.R
-import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.extensions.formatToMMMddYYYYhhmm
 import com.woocommerce.android.extensions.navigateBackWithResult
@@ -26,6 +25,10 @@ import kotlinx.android.synthetic.main.fragment_shipping_label_refund.*
 import javax.inject.Inject
 
 class ShippingLabelRefundFragment : BaseFragment(), BackPressListener {
+    companion object {
+        const val KEY_REFUND_SHIPPING_LABEL_RESULT = "key_refund_shipping_label_result"
+    }
+
     @Inject lateinit var viewModelFactory: ViewModelFactory
     val viewModel: ShippingLabelRefundViewModel
         by navGraphViewModels(R.id.nav_graph_shipping_labels) { viewModelFactory }
@@ -60,14 +63,7 @@ class ShippingLabelRefundFragment : BaseFragment(), BackPressListener {
         viewModel.event.observe(viewLifecycleOwner, Observer { event ->
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.getSnack(event.message, *event.args).show()
-                is Exit -> {
-                    requireActivity().navigateBackWithResult(
-                        RequestCodes.ORDER_REFUND,
-                        Bundle(),
-                        R.id.nav_host_fragment_main,
-                        R.id.orderDetailFragment
-                    )
-                }
+                is Exit -> navigateBackWithResult(KEY_REFUND_SHIPPING_LABEL_RESULT, true)
                 else -> event.isHandled = false
             }
         })


### PR DESCRIPTION
This PR takes care of the 11/13 step of the Order Detail refactoring #2844 .

#### Changes
- Adds the option to add a new order note.
- Adds the option to request a refund for a shipping label.

#### Notes
- I have split this massive change into multiple small PRs in order to make reviews easier. 
- This PR is to be merged into a feature branch.
- **This PR is in draft till this [Step 10 PR](https://github.com/woocommerce/woocommerce-android/pull/2875) can be merged.**

#### Testing
- Click on an order from the Orders tab.
  - Click on the Add note button in the Order notes section.
  - Add a new order note and verify that the new note is added successfully.
- Click on the ellipsis icon of a shipping label item of an order.
  - Click on the **Request a refund** button.
  - Notice that the shipping label amount and date are displayed correctly.
  - Click on the Refund button.
  - Notice that a Snackbar message is displayed when the refund is initiated.
  - If the refund us successful, notice a SnackBar message is displayed and you are redirected to the Order detail screen. 
  - Notice the shipping label is updated to reflect the correct refunded status.
  - If the refund results in an error, notice a snackbar message is displayed. **In order to initiate an error scenario, create a shipping label and wait atleast 5 minutes before refunding the label from the app.** 
  - **Since shipping labels are tested against a staging WCS, please note that we need to refund a shipping label within 2 minutes of creating it. Otherwise, the refund API results in an error, whilst the refund itself is successful. To create shipping labels, please follow the instructions provided in the Shipping Labels Master Thread - p91TBi-2om**

#### Screenshots
##### Add order note
<img src="https://user-images.githubusercontent.com/22608780/93733500-2e432b00-fbf3-11ea-9ce8-a1216cb5b0db.gif" width="300"/>. 

##### Refund shipping label
<img src="https://user-images.githubusercontent.com/22608780/93733197-128b5500-fbf2-11ea-8e41-11ed04649ce0.gif" width="300"/>. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.