### PR TITLE
Issue/2844 order detail refactor shipment tracking actions

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderShipmentTracking.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderShipmentTracking.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 
 @Parcelize
 data class OrderShipmentTracking(
+    val id: Int = 0,
     val localSiteId: Int = 0,
     val localOrderId: Int = 0,
     val remoteTrackingId: String = "",
@@ -16,6 +17,7 @@ data class OrderShipmentTracking(
     val isCustomProvider: Boolean = false
 ) : Parcelable {
     fun toDataModel() = WCOrderShipmentTrackingModel().also { orderShipmentTrackingModel ->
+        orderShipmentTrackingModel.id = this.id
         orderShipmentTrackingModel.localOrderId = this.localOrderId
         orderShipmentTrackingModel.localSiteId = this.localSiteId
         orderShipmentTrackingModel.remoteTrackingId = this.remoteTrackingId
@@ -27,6 +29,7 @@ data class OrderShipmentTracking(
 
 fun WCOrderShipmentTrackingModel.toAppModel(): OrderShipmentTracking {
     return OrderShipmentTracking(
+        id,
         localSiteId,
         localOrderId,
         remoteTrackingId,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderShipmentTracking.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderShipmentTracking.kt
@@ -16,6 +16,9 @@ data class OrderShipmentTracking(
     val isCustomProvider: Boolean = false
 ) : Parcelable {
     fun toDataModel() = WCOrderShipmentTrackingModel().also { orderShipmentTrackingModel ->
+        orderShipmentTrackingModel.localOrderId = this.localOrderId
+        orderShipmentTrackingModel.localSiteId = this.localSiteId
+        orderShipmentTrackingModel.remoteTrackingId = this.remoteTrackingId
         orderShipmentTrackingModel.trackingNumber = this.trackingNumber
         orderShipmentTrackingModel.dateShipped = this.dateShipped
         orderShipmentTrackingModel.trackingProvider = this.trackingProvider

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderShipmentTracking.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderShipmentTracking.kt
@@ -3,19 +3,24 @@ package com.woocommerce.android.model
 import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
-import org.wordpress.android.util.DateTimeUtils
-import java.util.Date
 
 @Parcelize
 data class OrderShipmentTracking(
-    val localSiteId: Int,
-    val localOrderId: Int,
-    val remoteTrackingId: String,
+    val localSiteId: Int = 0,
+    val localOrderId: Int = 0,
+    val remoteTrackingId: String = "",
     val trackingNumber: String,
     val trackingProvider: String,
-    val trackingLink: String,
-    val dateShipped: Date
-) : Parcelable
+    val trackingLink: String = "",
+    val dateShipped: String,
+    val isCustomProvider: Boolean = false
+) : Parcelable {
+    fun toDataModel() = WCOrderShipmentTrackingModel().also { orderShipmentTrackingModel ->
+        orderShipmentTrackingModel.trackingNumber = this.trackingNumber
+        orderShipmentTrackingModel.dateShipped = this.dateShipped
+        orderShipmentTrackingModel.trackingProvider = this.trackingProvider
+    }
+}
 
 fun WCOrderShipmentTrackingModel.toAppModel(): OrderShipmentTracking {
     return OrderShipmentTracking(
@@ -25,6 +30,6 @@ fun WCOrderShipmentTrackingModel.toAppModel(): OrderShipmentTracking {
         trackingNumber,
         trackingProvider,
         trackingLink,
-        DateTimeUtils.dateUTCFromIso8601(this.dateShipped) ?: Date()
+        dateShipped
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabel.kt
@@ -82,12 +82,6 @@ fun WCShippingLabelModel.WCShippingLabelRefundModel.toAppModel(): ShippingLabel.
     )
 }
 
-fun List<ShippingLabel>.getUnPackagedProducts(products: List<Order.Item>): List<Order.Item> {
-    val productNames = mutableSetOf<String>()
-    this.map { productNames.addAll(it.productNames) }
-    return products.filter { !productNames.contains(it.name) }
-}
-
 /**
  * Method fetches a list of product details for the product names associated with each shipping label
  */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShippingLabelListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailShippingLabelListView.kt
@@ -142,7 +142,7 @@ class OrderDetailShippingLabelListView @JvmOverloads constructor(
                             shippingLabel.refund.refundDate?.formatToMMMddYYYYhhmm() ?: ""
                         )
                     )
-                    itemView.shippingLabelItem_trackingNumber.showTrackingLinkButton(false)
+                    itemView.shippingLabelItem_trackingNumber.showTrackingItemButton(false)
                     itemView.shippingLabelList_btnMenu.visibility = View.GONE
                 } else {
                     itemView.shippingLabelItem_trackingNumber.setShippingLabelTitle(context.getString(
@@ -154,13 +154,15 @@ class OrderDetailShippingLabelListView @JvmOverloads constructor(
                         showRefundPopup(context, shippingLabel, order, shippingLabelActionListener)
                     }
 
-                    shippingLabel.trackingLink?.let {
-                        itemView.shippingLabelItem_trackingNumber.showTrackingLinkButton(true)
-                        itemView.shippingLabelItem_trackingNumber.setTrackingLinkClickListener {
-                            ChromeCustomTabUtils.launchUrl(context, it)
+                    if (shippingLabel.trackingLink.isNotEmpty()) {
+                        itemView.shippingLabelItem_trackingNumber.showTrackingItemButton(true)
+                        itemView.shippingLabelItem_trackingNumber.setTrackingItemClickListener {
+                            ChromeCustomTabUtils.launchUrl(context, shippingLabel.trackingNumber)
                             AppRatingDialog.incrementInteractions()
                         }
-                    } ?: itemView.shippingLabelItem_trackingNumber.showTrackingLinkButton(false)
+                    } else {
+                        itemView.shippingLabelItem_trackingNumber.showTrackingItemButton(false)
+                    }
                 }
 
                 itemView.shippingLabelItem_packageInfo.setShippingLabelValue(shippingLabel.packageName)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
@@ -30,4 +30,9 @@ sealed class OrderNavigationTarget : Event() {
     data class ViewRefundedProducts(val remoteOrderId: Long) : OrderNavigationTarget()
     data class AddOrderNote(val orderIdentifier: String, val orderNumber: String) : OrderNavigationTarget()
     data class RefundShippingLabel(val remoteOrderId: Long, val shippingLabelId: Long) : OrderNavigationTarget()
+    data class AddOrderShipmentTracking(
+        val orderIdentifier: String,
+        val orderTrackingProvider: String,
+        val isCustomProvider: Boolean
+    ) : OrderNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
@@ -4,6 +4,7 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.AddOrderNote
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.AddOrderShipmentTracking
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.IssueOrderRefund
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.RefundShippingLabel
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
@@ -42,6 +43,13 @@ class OrderNavigator @Inject constructor() {
                 val action = OrderDetailFragmentDirections
                     .actionOrderDetailFragmentToOrderShippingLabelRefundFragment(
                         target.remoteOrderId, target.shippingLabelId
+                    )
+                fragment.findNavController().navigateSafely(action)
+            }
+            is AddOrderShipmentTracking -> {
+                val action = OrderDetailFragmentDirections
+                    .actionOrderDetailFragmentToAddOrderShipmentTrackingFragment(
+                        target.orderIdentifier, target.orderTrackingProvider, target.isCustomProvider
                     )
                 fragment.findNavController().navigateSafely(action)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderShipmentTrackingHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderShipmentTrackingHelper.kt
@@ -1,0 +1,73 @@
+package com.woocommerce.android.ui.orders
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.view.View
+import android.widget.PopupMenu
+import com.woocommerce.android.R
+import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.widgets.AppRatingDialog
+import org.wordpress.android.util.ToastUtils
+
+object OrderShipmentTrackingHelper {
+    private fun copyTrackingNumber(
+        context: Context,
+        trackingNumber: String
+    ) {
+        try {
+            val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+            clipboard.setPrimaryClip(ClipData.newPlainText(
+                context.getString(R.string.order_shipment_tracking_number), trackingNumber)
+            )
+            ToastUtils.showToast(context, R.string.order_shipment_tracking_number_clipboard)
+        } catch (e: Exception) {
+            WooLog.e(WooLog.T.UTILS, e)
+            ToastUtils.showToast(context, R.string.error_copy_to_clipboard)
+        }
+    }
+
+    fun trackShipment(
+        context: Context,
+        trackingLink: String
+    ) {
+        ChromeCustomTabUtils.launchUrl(context, trackingLink)
+        AppRatingDialog.incrementInteractions()
+    }
+
+    fun showTrackingOrDeleteOptionPopup(
+        anchor: View,
+        context: Context,
+        trackingLink: String,
+        trackingNumber: String,
+        onDeleteTrackingClicked: ((trackingNumber: String) -> Unit)? = null
+    ) {
+        val popup = PopupMenu(context, anchor)
+        popup.menuInflater.inflate(R.menu.menu_order_detail_shipment_tracking_actions, popup.menu)
+
+        with(popup.menu.findItem(R.id.menu_track_shipment)) {
+            isVisible = trackingLink.isNotEmpty()
+            setOnMenuItemClickListener {
+                trackShipment(context, trackingLink)
+                true
+            }
+        }
+
+        popup.menu.findItem(R.id.menu_copy_tracking)?.setOnMenuItemClickListener {
+            copyTrackingNumber(context, trackingNumber)
+            true
+        }
+
+        popup.menu.findItem(R.id.menu_delete_shipment)?.isVisible = onDeleteTrackingClicked != null
+        onDeleteTrackingClicked?.let {
+            popup.menu.findItem(R.id.menu_delete_shipment)?.setOnMenuItemClickListener {
+                onDeleteTrackingClicked(trackingNumber)
+                AppRatingDialog.incrementInteractions()
+                true
+            }
+        }
+
+        popup.show()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -91,8 +91,7 @@ class OrderDetailFragment : BaseFragment() {
                 showOrderNotesSkeleton(it)
             }
             new.isShipmentTrackingAvailable?.takeIfNotEqualTo(old?.isShipmentTrackingAvailable) {
-                orderDetail_shipmentList.isVisible = it
-                orderDetail_shipmentList.showAddTrackingButton(it)
+                showAddShipmentTracking(it)
             }
             new.isRefreshing?.takeIfNotEqualTo(old?.isRefreshing) {
                 orderRefreshLayout.isRefreshing = it
@@ -216,6 +215,13 @@ class OrderDetailFragment : BaseFragment() {
                 showOrderFulfillOption(order.status == CoreOrderStatus.PROCESSING)
             }
         }.otherwise { orderDetail_productList.hide() }
+    }
+
+    private fun showAddShipmentTracking(show: Boolean) {
+        with(orderDetail_shipmentList) {
+            isVisible = show
+            showAddTrackingButton(show) { viewModel.onAddShipmentTrackingClicked() }
+        }
     }
 
     private fun showShipmentTrackings(shipmentTrackings: List<OrderShipmentTracking>) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -119,7 +119,7 @@ class OrderDetailFragment : BaseFragment() {
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is ShowUndoSnackbar -> {
-                    displayOrderStatusChangeSnackbar(event.message, event.undoAction, event.dismissAction)
+                    displayUndoSnackbar(event.message, event.undoAction, event.dismissAction)
                 }
                 is OrderNavigationTarget -> navigator.navigate(this, event)
                 else -> event.isHandled = false
@@ -228,9 +228,11 @@ class OrderDetailFragment : BaseFragment() {
         }
     }
 
-    private fun showShipmentTrackings(shipmentTrackings: List<OrderShipmentTracking>) {
-        shipmentTrackings.whenNotNullNorEmpty {
-            orderDetail_shipmentList.updateShipmentTrackingList(shipmentTrackings)
+    private fun showShipmentTrackings(
+        shipmentTrackings: List<OrderShipmentTracking>
+    ) {
+        orderDetail_shipmentList.updateShipmentTrackingList(shipmentTrackings) {
+            viewModel.onDeleteShipmentTrackingClicked(it)
         }
     }
 
@@ -250,7 +252,7 @@ class OrderDetailFragment : BaseFragment() {
         }.otherwise { orderDetail_shippingLabelList.hide() }
     }
 
-    private fun displayOrderStatusChangeSnackbar(
+    private fun displayUndoSnackbar(
         message: String,
         actionListener: View.OnClickListener,
         dismissCallback: Snackbar.Callback

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.model.ShippingLabel
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.orders.AddOrderShipmentTrackingFragment
 import com.woocommerce.android.ui.orders.OrderNavigationTarget
 import com.woocommerce.android.ui.orders.OrderNavigator
 import com.woocommerce.android.ui.orders.notes.AddOrderNoteFragment
@@ -135,6 +136,9 @@ class OrderDetailFragment : BaseFragment() {
         }
         handleResult<Boolean>(ShippingLabelRefundFragment.KEY_REFUND_SHIPPING_LABEL_RESULT) {
             viewModel.onShippingLabelRefunded()
+        }
+        handleResult<OrderShipmentTracking>(AddOrderShipmentTrackingFragment.KEY_ADD_SHIPMENT_TRACKING_RESULT) {
+            viewModel.onNewShipmentTrackingAdded(it)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -10,6 +10,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.R
+import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.hide
@@ -25,6 +26,7 @@ import com.woocommerce.android.model.ShippingLabel
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.main.MainActivity.NavigationResult
 import com.woocommerce.android.ui.orders.AddOrderShipmentTrackingFragment
 import com.woocommerce.android.ui.orders.OrderNavigationTarget
 import com.woocommerce.android.ui.orders.OrderNavigator
@@ -40,7 +42,7 @@ import kotlinx.android.synthetic.main.fragment_order_detail.*
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import javax.inject.Inject
 
-class OrderDetailFragment : BaseFragment() {
+class OrderDetailFragment : BaseFragment(), NavigationResult {
     @Inject lateinit var viewModelFactory: ViewModelFactory
     private val viewModel: OrderDetailViewModel by viewModels { viewModelFactory }
 
@@ -79,6 +81,12 @@ class OrderDetailFragment : BaseFragment() {
         orderRefreshLayout?.apply {
             scrollUpChild = scrollView
             setOnRefreshListener { viewModel.onRefreshRequested() }
+        }
+    }
+
+    override fun onNavigationResult(requestCode: Int, result: Bundle) {
+        if (requestCode == RequestCodes.ORDER_REFUND) {
+            viewModel.onOrderItemRefunded()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -151,6 +151,31 @@ class OrderDetailViewModel @AssistedInject constructor(
         }
     }
 
+    fun onNewShipmentTrackingAdded(shipmentTracking: OrderShipmentTracking) {
+        if (networkStatus.isConnected()) {
+            val shipmentTrackings = _shipmentTrackings.value?.toMutableList() ?: mutableListOf()
+            shipmentTrackings.add(0, shipmentTracking)
+            _shipmentTrackings.value = shipmentTrackings
+
+            triggerEvent(ShowSnackbar(string.order_shipment_tracking_added))
+            launch {
+                val addedShipmentTracking = orderDetailRepository.addOrderShipmentTracking(
+                    orderIdSet.id,
+                    orderIdSet.remoteOrderId,
+                    shipmentTracking.toDataModel(),
+                    shipmentTracking.isCustomProvider
+                )
+                if (!addedShipmentTracking) {
+                    triggerEvent(ShowSnackbar(string.order_shipment_tracking_error))
+                    shipmentTrackings.remove(shipmentTracking)
+                    _shipmentTrackings.value = shipmentTrackings
+                }
+            }
+        } else {
+            triggerEvent(ShowSnackbar(string.offline_error))
+        }
+    }
+
     fun onShippingLabelRefunded() { launch { loadOrderShippingLabels() } }
 
     fun onOrderStatusChanged(newStatus: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -8,6 +8,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.snackbar.Snackbar.Callback
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
@@ -26,6 +27,7 @@ import com.woocommerce.android.model.hasNonRefundedProducts
 import com.woocommerce.android.model.loadProducts
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.AddOrderNote
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.AddOrderShipmentTracking
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.IssueOrderRefund
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.RefundShippingLabel
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
@@ -48,6 +50,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 class OrderDetailViewModel @AssistedInject constructor(
     @Assisted savedState: SavedStateWithArgs,
     dispatchers: CoroutineDispatchers,
+    private val appPrefs: AppPrefs,
     private val networkStatus: NetworkStatus,
     private val resourceProvider: ResourceProvider,
     private val orderDetailRepository: OrderDetailRepository
@@ -135,6 +138,17 @@ class OrderDetailViewModel @AssistedInject constructor(
 
     fun onRefundShippingLabelClick(shippingLabelId: Long) {
         order?.let { triggerEvent(RefundShippingLabel(remoteOrderId = it.remoteId, shippingLabelId = shippingLabelId)) }
+    }
+
+    fun onAddShipmentTrackingClicked() {
+        order?.let {
+            triggerEvent(
+                AddOrderShipmentTracking(
+                orderIdentifier = it.identifier,
+                orderTrackingProvider = appPrefs.getSelectedShipmentTrackingProviderName(),
+                isCustomProvider = appPrefs.getIsSelectedShipmentTrackingProviderCustom()
+            ))
+        }
     }
 
     fun onShippingLabelRefunded() { launch { loadOrderShippingLabels() } }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -172,6 +172,8 @@ class OrderDetailViewModel @AssistedInject constructor(
                     triggerEvent(ShowSnackbar(string.order_shipment_tracking_error))
                     shipmentTrackings.remove(shipmentTracking)
                     _shipmentTrackings.value = shipmentTrackings
+                } else {
+                    _shipmentTrackings.value = orderDetailRepository.getOrderShipmentTrackings(orderIdSet.id)
                 }
             }
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShipmentTrackingListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShipmentTrackingListAdapter.kt
@@ -2,16 +2,20 @@ package com.woocommerce.android.ui.orders.details.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.DiffUtil.Callback
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.R
 import com.woocommerce.android.model.OrderShipmentTracking
+import com.woocommerce.android.ui.orders.OrderShipmentTrackingHelper
 import com.woocommerce.android.ui.orders.details.adapter.OrderDetailShipmentTrackingListAdapter.OrderDetailShipmentTrackingViewHolder
 import com.woocommerce.android.util.DateUtils
 import kotlinx.android.synthetic.main.order_detail_shipment_tracking_list_item.view.*
 
-class OrderDetailShipmentTrackingListAdapter : RecyclerView.Adapter<OrderDetailShipmentTrackingViewHolder>() {
+class OrderDetailShipmentTrackingListAdapter(
+    private val onDeleteShipmentTrackingClicked: (trackingNumber: String) -> Unit
+) : RecyclerView.Adapter<OrderDetailShipmentTrackingViewHolder>() {
     var shipmentTrackingList: List<OrderShipmentTracking> = ArrayList()
         set(value) {
             val diffResult = DiffUtil.calculateDiff(
@@ -25,7 +29,7 @@ class OrderDetailShipmentTrackingListAdapter : RecyclerView.Adapter<OrderDetailS
         }
 
     override fun onCreateViewHolder(parent: ViewGroup, itemType: Int): OrderDetailShipmentTrackingViewHolder {
-        return OrderDetailShipmentTrackingViewHolder(parent)
+        return OrderDetailShipmentTrackingViewHolder(parent, onDeleteShipmentTrackingClicked)
     }
 
     override fun onBindViewHolder(holder: OrderDetailShipmentTrackingViewHolder, position: Int) {
@@ -35,7 +39,8 @@ class OrderDetailShipmentTrackingListAdapter : RecyclerView.Adapter<OrderDetailS
     override fun getItemCount(): Int = shipmentTrackingList.size
 
     class OrderDetailShipmentTrackingViewHolder(
-        parent: ViewGroup
+        parent: ViewGroup,
+        private val onDeleteShipmentTrackingClicked: (trackingNumber: String) -> Unit
     ) : RecyclerView.ViewHolder(
         LayoutInflater.from(parent.context).inflate(R.layout.order_detail_shipment_tracking_list_item, parent, false)
     ) {
@@ -44,6 +49,18 @@ class OrderDetailShipmentTrackingListAdapter : RecyclerView.Adapter<OrderDetailS
             with(itemView.tracking_number) { text = shipmentTracking.trackingNumber }
             with(itemView.tracking_dateShipped) {
                 text = DateUtils.getLocalizedLongDateString(context, shipmentTracking.dateShipped)
+            }
+            with(itemView.tracking_btnTrack) {
+                isVisible = true
+                setOnClickListener {
+                    OrderShipmentTrackingHelper.showTrackingOrDeleteOptionPopup(
+                        anchor = it,
+                        context = context,
+                        trackingLink = shipmentTracking.trackingLink,
+                        trackingNumber = shipmentTracking.trackingNumber,
+                        onDeleteTrackingClicked = onDeleteShipmentTrackingClicked
+                    )
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShipmentTrackingListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShipmentTrackingListAdapter.kt
@@ -6,9 +6,9 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.DiffUtil.Callback
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.R
-import com.woocommerce.android.extensions.getLongDate
 import com.woocommerce.android.model.OrderShipmentTracking
 import com.woocommerce.android.ui.orders.details.adapter.OrderDetailShipmentTrackingListAdapter.OrderDetailShipmentTrackingViewHolder
+import com.woocommerce.android.util.DateUtils
 import kotlinx.android.synthetic.main.order_detail_shipment_tracking_list_item.view.*
 
 class OrderDetailShipmentTrackingListAdapter : RecyclerView.Adapter<OrderDetailShipmentTrackingViewHolder>() {
@@ -42,7 +42,9 @@ class OrderDetailShipmentTrackingListAdapter : RecyclerView.Adapter<OrderDetailS
         fun bind(shipmentTracking: OrderShipmentTracking) {
             with(itemView.tracking_type) { text = shipmentTracking.trackingProvider }
             with(itemView.tracking_number) { text = shipmentTracking.trackingNumber }
-            with(itemView.tracking_dateShipped) { text = shipmentTracking.dateShipped.getLongDate(context) }
+            with(itemView.tracking_dateShipped) {
+                text = DateUtils.getLocalizedLongDateString(context, shipmentTracking.dateShipped)
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShippingLabelsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShippingLabelsAdapter.kt
@@ -16,10 +16,9 @@ import com.woocommerce.android.extensions.expand
 import com.woocommerce.android.extensions.formatToMMMddYYYYhhmm
 import com.woocommerce.android.model.ShippingLabel
 import com.woocommerce.android.tools.ProductImageMap
+import com.woocommerce.android.ui.orders.OrderShipmentTrackingHelper
 import com.woocommerce.android.ui.orders.details.adapter.OrderDetailShippingLabelsAdapter.ShippingLabelsViewHolder
-import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.widgets.AlignedDividerDecoration
-import com.woocommerce.android.widgets.AppRatingDialog
 import kotlinx.android.synthetic.main.order_detail_shipping_label_list_item.view.*
 import java.math.BigDecimal
 
@@ -109,7 +108,7 @@ class OrderDetailShippingLabelsAdapter(
                             formatCurrencyForDisplay(shippingLabel.rate),
                             shippingLabel.refund.refundDate?.formatToMMMddYYYYhhmm() ?: ""
                         ))
-                    showTrackingLinkButton(false)
+                    showTrackingItemButton(false)
                 } else {
                     setShippingLabelTitle(context.getString(
                         R.string.order_shipment_tracking_number_label
@@ -120,11 +119,15 @@ class OrderDetailShippingLabelsAdapter(
                     }
 
                     // display tracking link if available
-                    showTrackingLinkButton(true)
-                    setTrackingLinkClickListener {
-                        ChromeCustomTabUtils.launchUrl(context, shippingLabel.trackingLink)
-                        AppRatingDialog.incrementInteractions()
-                    }
+                    if (shippingLabel.trackingNumber.isNotEmpty()) {
+                        showTrackingItemButton(true)
+                        setTrackingItemClickListener {
+                            OrderShipmentTrackingHelper.showTrackingOrDeleteOptionPopup(
+                                getTrackingItemButton(), context, shippingLabel.trackingLink,
+                                shippingLabel.trackingNumber
+                            )
+                        }
+                    } else showTrackingItemButton(false)
                 }
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailShipmentTrackingListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailShipmentTrackingListView.kt
@@ -21,10 +21,13 @@ class OrderDetailShipmentTrackingListView @JvmOverloads constructor(
         View.inflate(context, R.layout.order_detail_shipment_tracking_list, this)
     }
 
-    fun updateShipmentTrackingList(shipmentTrackings: List<OrderShipmentTracking>) {
+    fun updateShipmentTrackingList(
+        shipmentTrackings: List<OrderShipmentTracking>,
+        onDeleteShipmentTrackingClicked: (trackingNumber: String) -> Unit
+    ) {
         val shipmentTrackingAdapter =
             shipmentTrack_items.adapter as? OrderDetailShipmentTrackingListAdapter
-                ?: OrderDetailShipmentTrackingListAdapter()
+                ?: OrderDetailShipmentTrackingListAdapter(onDeleteShipmentTrackingClicked)
 
         shipmentTrack_items.apply {
             setHasFixedSize(true)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailShipmentTrackingListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailShipmentTrackingListView.kt
@@ -35,7 +35,11 @@ class OrderDetailShipmentTrackingListView @JvmOverloads constructor(
         shipmentTrackingAdapter.shipmentTrackingList = shipmentTrackings
     }
 
-    fun showAddTrackingButton(show: Boolean) {
+    fun showAddTrackingButton(
+        show: Boolean,
+        onTap: () -> Unit
+    ) {
         shipmentTrack_btnAddTracking.isVisible = show
+        shipmentTrack_btnAddTracking.setOnClickListener { onTap() }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelItemView.kt
@@ -55,11 +55,13 @@ class ShippingLabelItemView @JvmOverloads constructor(
         shippingLabelValue.text = value
     }
 
-    fun showTrackingLinkButton(show: Boolean) {
+    fun showTrackingItemButton(show: Boolean) {
         shippingLabelItem_btnTrack.isVisible = show
     }
 
-    fun setTrackingLinkClickListener(clickListener: (() -> Unit)) {
+    fun setTrackingItemClickListener(clickListener: (() -> Unit)) {
         shippingLabelItem_btnTrack.setOnClickListener { clickListener.invoke() }
     }
+
+    fun getTrackingItemButton(): View = shippingLabelItem_btnTrack
 }

--- a/WooCommerce/src/main/res/layout/view_shipping_label_item.xml
+++ b/WooCommerce/src/main/res/layout/view_shipping_label_item.xml
@@ -55,13 +55,10 @@
     <ImageButton
         android:id="@+id/shippingLabelItem_btnTrack"
         style="@style/Woo.ImageButton.More"
-        android:contentDescription="@string/orderdetail_shipping_label_tracking_info"
+        android:contentDescription="@string/order_detail_shipment_tracking_button_contentdesc"
         android:scaleType="centerInside"
-        android:src="@drawable/ic_gridicons_external"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        android:visibility="gone"
-        tools:visibility="gone"/>
+        app:layout_constraintTop_toTopOf="parent"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/menu/menu_order_detail_shipment_tracking_actions.xml
+++ b/WooCommerce/src/main/res/menu/menu_order_detail_shipment_tracking_actions.xml
@@ -11,6 +11,7 @@
         android:title="@string/orderdetail_track_shipment"/>
 
     <item
+        android:visible="false"
         android:id="@+id/menu_delete_shipment"
         android:title="@string/orderdetail_delete_tracking"/>
 


### PR DESCRIPTION
This PR takes care of the 12/13 step of the Order Detail refactoring #2844 .

#### Changes
- Adds the option to add a new shipment tracking.
- Adds the option to delete a new shipment tracking.

#### Notes
- I have split this massive change into multiple small PRs in order to make reviews easier. 
- This PR is to be merged into a feature branch.
- **This PR is in draft till this [Step 11 PR](https://github.com/woocommerce/woocommerce-android/pull/2876) can be merged.**

#### Testing
- Ensure that you have the shipment tracking plugin enabled on your store.
- Click on an order from the Orders tab.
  - Click on the Add tracking button in the Shipment Trackings section.
  - Add a new order shipment tracking and verify that the new tracking is added successfully to the Order detail screen.
- Click on the ellipsis icon of a shipping label item of an order.
  - Click on the **Copy tracking number** button and verify that the tracking number is copied to clipboard.
  - Click on the **Track shipment* button and verify that you are redirected to the tracking website.
  - Click on the **Delete shipment* button and verify that the shipment is removed from the list and an UNOD SnackBar is displayed. Clicking on undo should add the shipment back to the list. Once the SnackBar is dismissed, the shipment should be deleted from the local db.
- Click on an Order from the Orders TAB that has some shipping labels associated with the order. **To create shipping labels, please follow the instructions provided in the Shipping Labels Master Thread - p91TBi-2om**
  - Click on the ellipsis icon beside the shipping label tracking number. 
  - Click on the **Copy tracking number** button and verify that the tracking number is copied to clipboard.
  - Click on the **Track shipment* button and verify that you are redirected to the tracking website. 

#### Screenshots
##### Add shipment Tracking
<img src="https://user-images.githubusercontent.com/22608780/93733719-2e8ff600-fbf4-11ea-8e9b-1b68df9b93fa.gif" width="300"/>. 

##### Delete shipment tracking
<img src="https://user-images.githubusercontent.com/22608780/93733727-36e83100-fbf4-11ea-8ad0-a3c7a9260c2e.gif" width="300"/>. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.