### PR TITLE
Hotfix: Fix Login with Google flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -585,12 +585,12 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
         if (siteAddress != null) {
             val loginEmailFragment = getLoginEmailFragment(
                 useAltLayout = false) ?: LoginEmailFragment.newInstance(siteAddress, true)
-            slideInFragment(loginEmailFragment as Fragment, true, LoginEmailFragment.TAG)
+            slideInFragment(loginEmailFragment as Fragment, true, LoginEmailFragment.TAG_ALT_LAYOUT)
         } else {
             val loginEmailFragment = getLoginEmailFragment(
                 useAltLayout = true) ?: LoginEmailFragment.newInstance(false, false, true, true)
             slideInFragment(
-                loginEmailFragment as Fragment, true, LoginEmailFragment.TAG_ALT_LAYOUT)
+                loginEmailFragment as Fragment, true, LoginEmailFragment.TAG)
         }
     }
 


### PR DESCRIPTION
Closes #2880 by swapping the fragment tags. There are two different layouts for `LoginEmailFragment`:
- One that has a button to allow the user to login with site credentials (tag: `TAG_ALT_LAYOUT`)
- One that has a button to allow for signing in with Google (tag: `TAG`). 

The issue was that the tags were swapped when creating the instance of `LoginEmailFragment` so that when the method `onGoogleLoginFinished` was called we'd attempt to connect to the wrong fragment to call `finishLogin()`. 
```
override fun onGoogleLoginFinished() {
    (supportFragmentManager.findFragmentByTag(LoginEmailFragment.TAG) as? LoginEmailFragment)?.finishLogin()
}
```

If the user hadn't visited the site address flow then that fragment wouldn't exist and `finishLogin()` wouldn't be called. The fix was to use the correct tag to match the layout when creating the `LoginEmailFragment` instance. Tested and now fixed:

<img src="https://user-images.githubusercontent.com/5810477/93805957-7293f280-fc16-11ea-8c08-79fe379d1654.gif" width="320"/>


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
