### PR TITLE
Make survey loading dialog dismissal capable of allowing state loss

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.feedback
 import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebResourceRequest
@@ -92,12 +91,6 @@ class FeedbackSurveyFragment : androidx.fragment.app.Fragment() {
         webView.saveState(outState)
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        when (item.itemId) {
-        }
-        return super.onOptionsItemSelected(item)
-    }
-
     override fun onDestroy() {
         if (surveyCompleted.not()) {
             AnalyticsTracker.track(
@@ -129,8 +122,12 @@ class FeedbackSurveyFragment : androidx.fragment.app.Fragment() {
         webViewClient = surveyWebViewClient
     }
 
+    /**
+     * We use this dismissAllowingStateLoss for dialog dismissal to avoid any kind of commit operation
+     * from the [FragmentManager] after the `onSaveInstanceState` is called
+     */
     private fun hideProgressDialog() {
-        progressDialog?.dismiss()
+        progressDialog?.dismissAllowingStateLoss()
         progressDialog = null
     }
 


### PR DESCRIPTION
Summary
==========
Fixes issue #2884 reported on Sentry. The issue is caused by an app crash when the user leaves the app meanwhile the Survey WebView is still loading. The root cause of it is that when the WebView is finished with the survey loading we call the `dismiss` from the loading dialog after the Fragment entered an Instance state recovery, causing an illegal operation, to avoid that we just call a safer method to dismiss the Dialog called `dismissAllowingStateLoss`.

Steps to Reproduce
==========
1. Go to the App Settings
2. Click on the `Send feedback` option
3. When the Survey loading dialog appears, quickly press the home button
4. Open the logcat and verify if an exception is thrown with the description `IllegalStateException: Can not perform this action after onSaveInstanceState`

![ezgif-3-25a1a1980700](https://user-images.githubusercontent.com/5920403/93839758-5323b680-fc64-11ea-9d24-3dc7b1bbb900.gif)

How to Test the fix
==========
1. Go to the App Settings
2. Click on the `Send feedback` option
3. When the Survey loading dialog appears, quickly press the home button
4. No exception should appear on the logcat, reopen the app and verify if the app continues in the Survey screen

Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
