### PR TITLE
issue/update-build-tools-30

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -40,7 +40,7 @@ androidExtensions {
 
 android {
     compileSdkVersion 30
-    buildToolsVersion '29.0.2'
+    buildToolsVersion '30.0.0'
 
     defaultConfig {
         applicationId "com.woocommerce.android"


### PR DESCRIPTION
I could've sworn I did this as part of #2852 but apparently not! This simple PR updates `buildToolsVersion` to match `compileSdkVersion`.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
