### PR TITLE
Add inventory and shipping properties to variable products

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -147,6 +147,8 @@ class ProductDetailCardBuilder(
                 product.productType(),
                 product.productReviews(),
                 product.variations(),
+                product.inventory(),
+                product.shipping(),
                 product.categories(),
                 product.tags(),
                 product.shortDescription()


### PR DESCRIPTION
Fixes #2809.

This PR adds back inventory and shipping to the variable product detail in order to match the web & iOS behavior.