### PR TITLE
Hotfix/2890 link styles

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -45,7 +45,7 @@
         </activity>
 
         <activity android:name=".ui.login.LoginActivity"
-                  android:theme="@style/Theme.LoginFlow"
+                  android:theme="@style/LoginTheme"
                   android:windowSoftInputMode="adjustResize">
         </activity>
 

--- a/WooCommerce/src/main/res/values/styles_login.xml
+++ b/WooCommerce/src/main/res/values/styles_login.xml
@@ -3,12 +3,25 @@
     <!--
         Overloads of Login Themes
      -->
-    <style name="LoginTheme" parent="Theme.LoginFlow"/>
+    <style name="LoginTheme" parent="Theme.LoginFlow">
+        <!-- Colors -->
+        <item name="colorPrimary">@color/color_primary</item>
+        <item name="colorPrimarySurface">@color/color_primary_surface</item>
+        <item name="colorPrimaryVariant">@color/color_primary_variant</item>
+        <item name="colorSecondary">@color/color_secondary</item>
+        <item name="colorSecondaryVariant">@color/color_secondary_variant</item>
 
-    <style name="LoginTheme.TextLabel" parent="TextAppearance.Woo.Subtitle1"/>
+        <item name="colorSurface">@color/color_surface</item>
+        <item name="colorError">@color/color_error</item>
 
-    <style name="LoginTheme.Button.Primary" parent="Woo.Button.Colored"/>
+        <item name="colorOnPrimary">@color/color_on_primary</item>
+        <item name="colorOnPrimarySurface">@color/color_on_primary_surface</item>
+        <item name="colorOnBackground">@color/color_on_background</item>
+        <item name="colorOnSurface">@color/color_on_surface</item>
+        <item name="colorOnError">@color/color_on_error</item>
 
-    <style name="LoginTheme.Button.Secondary" parent="Woo.Button.Secondary"/>
-
+        <item name="colorAccent">@color/color_primary</item>
+        <item name="colorControlNormal">@color/color_primary</item>
+        <item name="android:colorControlActivated">@color/color_primary</item>
+    </style>
 </resources>

--- a/WooCommerce/src/main/res/values/styles_login.xml
+++ b/WooCommerce/src/main/res/values/styles_login.xml
@@ -23,6 +23,9 @@
         <item name="colorAccent">@color/color_primary</item>
         <item name="colorControlNormal">@color/color_primary</item>
         <item name="android:colorControlActivated">@color/color_primary</item>
+
+        <item name="alertDialogTheme">@style/Theme.Woo.Dialog</item>
+        <item name="materialAlertDialogTheme">@style/Theme.Woo.Dialog</item>
     </style>
 
     <style name="Widget.LoginFlow.Button.Tertiary" parent="Widget.MaterialComponents.Button.TextButton">

--- a/WooCommerce/src/main/res/values/styles_login.xml
+++ b/WooCommerce/src/main/res/values/styles_login.xml
@@ -24,4 +24,10 @@
         <item name="colorControlNormal">@color/color_primary</item>
         <item name="android:colorControlActivated">@color/color_primary</item>
     </style>
+
+    <style name="Widget.LoginFlow.Button.Tertiary" parent="Widget.MaterialComponents.Button.TextButton">
+        <item name="android:textAppearance">?attr/textAppearanceBody2</item>
+        <item name="textColor">@color/color_secondary</item>
+        <item name="android:textColor">@color/color_secondary</item>
+    </style>
 </resources>


### PR DESCRIPTION
Closes #2890 and #2901 by implementing Woo-specific color and dialog style definitions. 

Before | After 
-- | --
![before](https://user-images.githubusercontent.com/5810477/94074668-c09c2800-fdc7-11ea-8c3b-c11b4014391b.png)|![Screenshot_1600882879](https://user-images.githubusercontent.com/5810477/94074683-c5f97280-fdc7-11ea-872e-46f1e7f93a45.png)
![93900006-d38dfa00-fcec-11ea-9720-354a0a7348f2](https://user-images.githubusercontent.com/5810477/94074765-ef1a0300-fdc7-11ea-8062-cfcb0b6109f6.png)|![Screenshot_1600898660](https://user-images.githubusercontent.com/5810477/94074779-f4774d80-fdc7-11ea-9b2b-4cd82662b437.png)
![94009306-2e325f00-fd9c-11ea-93f9-75fc042c6c3f](https://user-images.githubusercontent.com/5810477/94074793-fb9e5b80-fdc7-11ea-911e-4698cf9abc13.jpg)|![Screenshot_1600898590](https://user-images.githubusercontent.com/5810477/94074804-035e0000-fdc8-11ea-820c-2f7afacbc519.png)




Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
