### PR TITLE
Hotfix: bypass site address check for WPcom username login screen

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -634,7 +634,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseDiscoveryFragment im
             return;
         }
 
-        if (mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE) {
+        if (!mIsWpcom && mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE) {
             SiteModel lastAddedXMLRPCSite = SiteUtils.getXMLRPCSiteByUrl(mSiteStore, mInputSiteAddress);
             if (lastAddedXMLRPCSite != null) {
                 // the wp.getOptions endpoint is already called


### PR DESCRIPTION
Closes #2900 by bypassing the site address check if the user was routed to the username/password screen through the WordPress.com login flow. This fix allows a successful WPcom login to finish successfully. The reason this was an issue in the first place is because the previous login flow did not have a dedicated WPcom login path - there was always a site address.

## To Test
pinging @rachelmcr for testing since reproducing this bug is a huge PITA and she's already got test accounts set up for this scenario. 

1. Start logged out.
2. Select "Continue with WordPress.com."
3. Enter the email address for a WordPress.com account that isn't allowed to log in with its email address.
4. Select the "Or type your password" option.
5. Enter your account password and tap "Continue."
6. Notice you're redirected to log in with your username and password.
7. Enter your username and password, and tap "Continue." 
8. A successful login will route you to the store picker screen.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


