### PR TITLE
Unified Login - Fix email help link crash from SitePickerActivity

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WooLoginFragmentModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WooLoginFragmentModule.kt
@@ -17,6 +17,7 @@ internal abstract class WooLoginFragmentModule {
     @ContributesAndroidInjector(modules = [MagicLinkInterceptModule::class])
     internal abstract fun magicLinkInterceptFragment(): MagicLinkInterceptFragment
 
+    @FragmentScope
     @ContributesAndroidInjector
     internal abstract fun loginEmailHelpDialogFragment(): LoginEmailHelpDialogFragment
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -44,6 +44,9 @@ import com.woocommerce.android.util.CrashUtils
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WooClickableSpan
 import dagger.android.AndroidInjection
+import dagger.android.AndroidInjector
+import dagger.android.DispatchingAndroidInjector
+import dagger.android.HasAndroidInjector
 import kotlinx.android.synthetic.main.activity_site_picker.*
 import kotlinx.android.synthetic.main.view_login_epilogue_button_bar.*
 import kotlinx.android.synthetic.main.view_login_no_stores.*
@@ -53,7 +56,7 @@ import org.wordpress.android.login.LoginMode
 import javax.inject.Inject
 
 class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteClickListener,
-        LoginEmailHelpDialogFragment.Listener {
+        LoginEmailHelpDialogFragment.Listener, HasAndroidInjector {
     companion object {
         private const val STATE_KEY_SITE_ID_LIST = "key-supported-site-id-list"
         private const val KEY_CALLED_FROM_LOGIN = "called_from_login"
@@ -75,6 +78,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         }
     }
 
+    @Inject internal lateinit var androidInjector: DispatchingAndroidInjector<Any>
     @Inject lateinit var presenter: SitePickerContract.Presenter
     @Inject lateinit var selectedSite: SelectedSite
     @Inject lateinit var unifiedLoginTracker: UnifiedLoginTracker
@@ -104,6 +108,8 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
      * This controls the "view connected stores" button visibility.
      */
     private var hasConnectedStores: Boolean = false
+
+    override fun androidInjector(): AndroidInjector<Any> = androidInjector
 
     override fun onCreate(savedInstanceState: Bundle?) {
         AndroidInjection.inject(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerModule.kt
@@ -1,8 +1,11 @@
 package com.woocommerce.android.ui.sitepicker
 
 import com.woocommerce.android.di.ActivityScope
+import com.woocommerce.android.di.FragmentScope
+import com.woocommerce.android.ui.login.LoginEmailHelpDialogFragment
 import dagger.Binds
 import dagger.Module
+import dagger.android.ContributesAndroidInjector
 
 @Module
 internal abstract class SitePickerModule {
@@ -10,4 +13,8 @@ internal abstract class SitePickerModule {
     @Binds
     abstract fun provideSitePickerPresenter(sitePickerPresenter: SitePickerPresenter):
             SitePickerContract.Presenter
+
+    @FragmentScope
+    @ContributesAndroidInjector
+    internal abstract fun loginEmailHelpDialogFragment(): LoginEmailHelpDialogFragment
 }


### PR DESCRIPTION
The email help dialog works when accessed on the email screen during login (`LoginActivity`), but would crash when attempting to open from the "Wrong WordPress.com account..." error screen launched from `SitePickerActivity`. This is because the necessary code hadn't been added to the `SitePickerModule` to allow injecting this fragment. So this PR closes #2898 by adding a missing dagger injector for the email help dialog to the site picker activity. 

## To Test
1. Click "login with site address"
2. Enter site address and click "continue"
3. Enter an email address for a WPcom account that does not have access to the site entered in the previous screen. 
4. Finish login and the "Connected to a different WordPress.com" account error screen is displayed.
5. Click "Need help finding connected email address" - the help dialog should show without crashing. 

Wrong WPcom account screen | Connected email help dialog
-- | --
![Screenshot_1600972559](https://user-images.githubusercontent.com/5810477/94191689-e3881400-fe7b-11ea-8e41-bfbf3a048401.png)|![Screenshot_1600976224](https://user-images.githubusercontent.com/5810477/94191697-e6830480-fe7b-11ea-9657-6ab384c12cbc.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
