### PR TITLE
Unified login bugfix: error message and scroll

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -790,7 +790,7 @@
     
     
     <string name="requesting_otp">Requesting a verification code via SMS.</string>
-    <string name="email_not_registered_wpcom">Hmm, we can\'t find a WordPress.com account connected to this email address. Try the link below to log in using your site address.</string>
+    <string name="email_not_registered_wpcom">Hmm, we can\'t find a WordPress.com account connected to this email address.</string>
     <string name="password_incorrect">It looks like this password is incorrect. Please double check your information and try again.</string>
     
     

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_screen.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_screen.xml
@@ -1,129 +1,138 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:fillViewport="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/label"
-        style="@style/Widget.LoginFlow.TextView.Label"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/margin_extra_large"
-        android:layout_marginStart="@dimen/margin_extra_large"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        tools:text="@string/enter_email_wordpress_com" />
+        android:layout_height="wrap_content">
 
-    <org.wordpress.android.login.widgets.WPLoginInputRow
-        android:id="@+id/login_email_row"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/margin_extra_large"
-        android:layout_marginStart="@dimen/margin_extra_large"
-        android:layout_marginTop="@dimen/margin_extra_large"
-        android:hint="@string/email_address"
-        android:imeOptions="actionNext"
-        android:importantForAutofill="noExcludeDescendants"
-        android:inputType="textEmailAddress"
-        app:layout_constraintTop_toBottomOf="@+id/label"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        tools:ignore="UnusedAttribute" />
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/continue_tos"
-        style="@style/Widget.LoginFlow.Button.Tertiary.Small"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/margin_extra_large"
-        android:layout_marginStart="@dimen/margin_extra_large"
-        android:text="@string/continue_terms_of_service_text"
-        app:layout_constraintTop_toBottomOf="@+id/login_email_row"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        tools:visibility="gone"/>
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/login_continue_button"
-        style="@style/Widget.LoginFlow.Button.Primary"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/margin_extra_large"
-        android:layout_marginStart="@dimen/margin_extra_large"
-        android:text="@string/login_continue"
-        app:layout_goneMarginTop="@dimen/margin_extra_large"
-        app:layout_constraintTop_toBottomOf="@+id/continue_tos"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
-
-    <Space
-        android:id="@+id/spacer"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        app:layout_constraintTop_toBottomOf="@+id/login_continue_button"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
-
-    <FrameLayout
-        android:id="@+id/orLayout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/margin_small_medium"
-        app:layout_constraintBottom_toTopOf="@+id/continue_with_google"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
-
-        <View
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/label"
+            style="@style/Widget.LoginFlow.TextView.Label"
             android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_gravity="center_vertical"
-            android:alpha="0.12"
-            android:background="?attr/colorOnSurface" />
-
-        <TextView
-            style="@style/Widget.LoginFlow.TextView.DividerText"
-            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:paddingStart="@dimen/margin_small"
-            android:paddingEnd="@dimen/margin_small"
-            android:text="@string/login_or" />
+            android:layout_marginEnd="@dimen/margin_extra_large"
+            android:layout_marginStart="@dimen/margin_extra_large"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            tools:text="@string/enter_email_wordpress_com" />
 
-    </FrameLayout>
+        <org.wordpress.android.login.widgets.WPLoginInputRow
+            android:id="@+id/login_email_row"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/margin_extra_large"
+            android:layout_marginStart="@dimen/margin_extra_large"
+            android:layout_marginTop="@dimen/margin_extra_large"
+            android:hint="@string/email_address"
+            android:imeOptions="actionNext"
+            android:importantForAutofill="noExcludeDescendants"
+            android:inputType="textEmailAddress"
+            app:layout_constraintTop_toBottomOf="@+id/label"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            tools:ignore="UnusedAttribute" />
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/continue_with_google"
-        style="@style/Widget.LoginFlow.Button.Secondary"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/margin_extra_large"
-        android:layout_marginEnd="@dimen/margin_extra_large"
-        android:text="@string/continue_google_button_suffix"
-        android:visibility="visible"
-        app:icon="@drawable/ic_google_60dp"
-        app:iconGravity="textStart"
-        app:iconPadding="@dimen/margin_small_medium"
-        app:iconSize="14dp"
-        app:iconTint="@null"
-        app:layout_constraintBottom_toTopOf="@+id/continue_with_google_tos"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/continue_tos"
+            style="@style/Widget.LoginFlow.Button.Tertiary.Small"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/margin_extra_large"
+            android:layout_marginStart="@dimen/margin_extra_large"
+            android:text="@string/continue_terms_of_service_text"
+            app:layout_constraintTop_toBottomOf="@+id/login_email_row"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            tools:visibility="gone"/>
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/continue_with_google_tos"
-        style="@style/Widget.LoginFlow.Button.Tertiary.Small"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/margin_extra_large"
-        android:layout_marginEnd="@dimen/margin_extra_large"
-        android:text="@string/continue_with_google_terms_of_service_text"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/login_continue_button"
+            style="@style/Widget.LoginFlow.Button.Primary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/margin_extra_large"
+            android:layout_marginStart="@dimen/margin_extra_large"
+            android:text="@string/login_continue"
+            app:layout_goneMarginTop="@dimen/margin_extra_large"
+            app:layout_constraintTop_toBottomOf="@+id/continue_tos"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"/>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <Space
+            android:id="@+id/spacer"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            app:layout_constraintTop_toBottomOf="@+id/login_continue_button"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"/>
+
+        <FrameLayout
+            android:id="@+id/orLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_small_medium"
+            app:layout_constraintTop_toBottomOf="@+id/spacer"
+            app:layout_constraintBottom_toTopOf="@+id/continue_with_google"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintVertical_bias="1.0">
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_gravity="center_vertical"
+                android:alpha="0.12"
+                android:background="?attr/colorOnSurface" />
+
+            <TextView
+                style="@style/Widget.LoginFlow.TextView.DividerText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:paddingStart="@dimen/margin_small"
+                android:paddingEnd="@dimen/margin_small"
+                android:text="@string/login_or" />
+
+        </FrameLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/continue_with_google"
+            style="@style/Widget.LoginFlow.Button.Secondary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_extra_large"
+            android:layout_marginEnd="@dimen/margin_extra_large"
+            android:text="@string/continue_google_button_suffix"
+            android:visibility="visible"
+            app:icon="@drawable/ic_google_60dp"
+            app:iconGravity="textStart"
+            app:iconPadding="@dimen/margin_small_medium"
+            app:iconSize="14dp"
+            app:iconTint="@null"
+            app:layout_constraintBottom_toTopOf="@+id/continue_with_google_tos"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"/>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/continue_with_google_tos"
+            style="@style/Widget.LoginFlow.Button.Tertiary.Small"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_extra_large"
+            android:layout_marginEnd="@dimen/margin_extra_large"
+            android:text="@string/continue_with_google_terms_of_service_text"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</ScrollView>


### PR DESCRIPTION
Fixes #2902 by doing the following:
- Removing the "Try the link below to log in using your site address." portion of the error string displayed to the user when they try to log into WordPress.com with an email address that does not exist. **Note that this fix is temporary and is strictly to remove any confusion.** [There is another ticket for Unified Login M2 to add a new screen for this error that will be much clearer](https://github.com/woocommerce/woocommerce-android/issues/2815).
- Nested the email login screen in a `ScrollView` so it will display properly on smaller or lower density screens. 

Before | After
-- | --
![Screenshot_1600976623](https://user-images.githubusercontent.com/5810477/94193526-76c24900-fe7e-11ea-9962-dfba46db0414.png)|![Screenshot_1600976592](https://user-images.githubusercontent.com/5810477/94193538-7924a300-fe7e-11ea-9e94-1745e302fab9.png)
![Screenshot_1600976740](https://user-images.githubusercontent.com/5810477/94193580-8477ce80-fe7e-11ea-8305-669f4d6afcd6.png)|![Screenshot_1600977041](https://user-images.githubusercontent.com/5810477/94193586-86da2880-fe7e-11ea-94cb-89b192a180ae.png)



<img src="https://user-images.githubusercontent.com/5810477/94193607-8b064600-fe7e-11ea-8327-489b0589fdc8.gif" width="320"/>

## To Test

1. Start logged out.
2. Select "Continue with WordPress.com."
3. Enter an email address that doesn't match a WordPress.com account and select "Continue."
4. Notice the new error message with changes.
5. Tap in the email address field and notice the buttons no longer overlap at the bottom of the screen.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
