### PR TITLE
Unified Login bugfix: Make site address password screen scrollable

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_optional_site_creds_screen.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_optional_site_creds_screen.xml
@@ -1,78 +1,87 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fillViewport="true"
     android:paddingStart="@dimen/margin_extra_large"
     android:paddingEnd="@dimen/margin_extra_large">
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/label"
-        style="@style/Widget.LoginFlow.TextView.Label"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/margin_extra_large"
-        android:gravity="start"
-        android:textAlignment="viewStart"
-        tools:text="@string/enter_email_wordpress_com"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/login_email_row"/>
+        android:layout_height="wrap_content">
 
-    <org.wordpress.android.login.widgets.WPLoginInputRow
-        android:id="@+id/login_email_row"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="start"
-        android:hint="@string/email_address"
-        android:imeOptions="actionNext"
-        android:importantForAutofill="noExcludeDescendants"
-        android:inputType="textEmailAddress"
-        android:textAlignment="viewStart"
-        tools:ignore="UnusedAttribute"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/label"
-        app:layout_constraintBottom_toTopOf="@+id/login_find_connected_email"/>
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/label"
+            style="@style/Widget.LoginFlow.TextView.Label"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_extra_large"
+            android:gravity="start"
+            android:textAlignment="viewStart"
+            tools:text="@string/enter_email_wordpress_com"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/login_email_row"/>
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/login_find_connected_email"
-        style="@style/Widget.LoginFlow.Button.Tertiary"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:paddingEnd="@dimen/margin_none"
-        android:paddingStart="@dimen/margin_none"
-        android:text="@string/login_find_your_connected_email"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/login_email_row"
-        app:layout_constraintHorizontal_bias="0.0"/>
+        <org.wordpress.android.login.widgets.WPLoginInputRow
+            android:id="@+id/login_email_row"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="start"
+            android:hint="@string/email_address"
+            android:imeOptions="actionNext"
+            android:importantForAutofill="noExcludeDescendants"
+            android:inputType="textEmailAddress"
+            android:textAlignment="viewStart"
+            tools:ignore="UnusedAttribute"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/label"
+            app:layout_constraintBottom_toTopOf="@+id/login_find_connected_email"/>
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/login_continue_button"
-        style="@style/Widget.LoginFlow.Button.Primary"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/login_continue"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/login_site_creds"/>
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/login_find_connected_email"
+            style="@style/Widget.LoginFlow.Button.Tertiary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingEnd="@dimen/margin_none"
+            android:paddingStart="@dimen/margin_none"
+            android:text="@string/login_find_your_connected_email"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/login_email_row"
+            app:layout_constraintHorizontal_bias="0.0"/>
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/login_site_creds"
-        style="@style/Widget.LoginFlow.Button.Secondary"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/continue_site_credentials"
-        app:icon="@drawable/ic_globe_grey_24dp"
-        app:iconGravity="textStart"
-        app:iconPadding="@dimen/margin_small_medium"
-        app:iconSize="14dp"
-        app:iconTint="@null"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/login_continue_button"
+            style="@style/Widget.LoginFlow.Button.Primary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/login_continue"
+            app:layout_constraintTop_toBottomOf="@+id/login_find_connected_email"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/login_site_creds"
+            app:layout_constraintVertical_bias="1.0"/>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/login_site_creds"
+            style="@style/Widget.LoginFlow.Button.Secondary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/continue_site_credentials"
+            app:icon="@drawable/ic_globe_grey_24dp"
+            app:iconGravity="textStart"
+            app:iconPadding="@dimen/margin_small_medium"
+            app:iconSize="14dp"
+            app:iconTint="@null"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>


### PR DESCRIPTION
Closes #2897 by nesting the layout in a ScrollView so buttons no longer overlap on smaller screens. 

Before | After
-- | --
![Screenshot_1600981495](https://user-images.githubusercontent.com/5810477/94200445-6dd67500-fe88-11ea-87aa-6de105ba93b0.png)|![Screenshot_1600981390](https://user-images.githubusercontent.com/5810477/94200451-70d16580-fe88-11ea-941c-a3ac099830a3.png)


## To Test
1. First update your devices settings to set **Display Size to Larger** and **Font size to Large** - this will just make it easier to test this issue. 
2. Start logged out of the app.
3. Select "Enter your store address."
4. Enter your store address and select "Continue."
5. On the "Enter email address" screen, try scrolling the view and verify all buttons are now accessible and no longer overlapped.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
