### PR TITLE
Unfied login: Use 'store' instead of 'site' consistently throughout the login process

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -807,10 +807,10 @@
     <string name="login_already_logged_in_wpcom">Already logged in to WordPress.com</string>
     <string name="login_username_at">\@%s</string>
     <string name="enter_site_address_share_intent">Enter the address of your WordPress site you\'d like to share the content to.</string>
-    <string name="login_site_address">Site address</string>
+    <string name="login_site_address">Store address</string>
     <string name="login_site_address_help">Need help finding your site address?</string>
-    <string name="login_site_address_help_title">What\'s my site address?</string>
-    <string name="login_site_address_help_content">Your site address appears in the bar at the top of the screen when you visit your site in Chrome.</string>
+    <string name="login_site_address_help_title">What\'s my store address?</string>
+    <string name="login_site_address_help_content">Your store address appears in the bar at the top of the screen when you visit your site in Chrome.</string>
     <string name="login_site_address_more_help">Need more help?</string>
     <string name="login_checking_site_address">Checking site address</string>
     <string name="login_error_while_adding_site">Error while adding site. Error code: %s</string>
@@ -1303,7 +1303,7 @@
     <string name="connect_more">Connect another site</string>
     <string name="connect_site">Connect a site</string>
     <string name="login_done">Done</string>
-    <string name="login_find_your_site_adress">Find your site address</string>
+    <string name="login_find_your_site_adress">Find your store address</string>
     <string name="login_find_your_connected_email">Find your connected email</string>
     <string name="continue_google_button_suffix">Continue with Google</string>
     <string name="continue_site_credentials">Continue with store credentials</string>


### PR DESCRIPTION
Closes #2894 by replacing references to "site" with "store" so the verbiage is consistent. 

Before | After
-- | --
![Screenshot_1600982004](https://user-images.githubusercontent.com/5810477/94201411-f4d81d00-fe89-11ea-886d-c9c7be3fdaaf.png)|![Screenshot_1600982116](https://user-images.githubusercontent.com/5810477/94201423-f6a1e080-fe89-11ea-9513-b7110c23fb4e.png)
![Screenshot_1600982015](https://user-images.githubusercontent.com/5810477/94201436-fd305800-fe89-11ea-985f-2d0a3dec2f6e.png)|![Screenshot_1600982159](https://user-images.githubusercontent.com/5810477/94201443-ff92b200-fe89-11ea-8fbd-36dc976ff0f1.png)



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
