### PR TITLE
Unified login: Track event login step fixes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginAnalyticsTracker.kt
@@ -293,8 +293,7 @@ class LoginAnalyticsTracker(
     }
 
     override fun emailFormScreenResumed() {
-        // Not needed as this should already be set and saved in saveInstanceState.
-        // This screen can be accessed from multiple flows.
+        unifiedLoginTracker.setStep(Step.ENTER_EMAIL_ADDRESS)
     }
 
     override fun trackEmailSignupConfirmationViewed() {
@@ -307,5 +306,13 @@ class LoginAnalyticsTracker(
 
     override fun trackCreateAccountClick() {
         TODO("Not yet implemented")
+    }
+
+    override fun emailPasswordFormScreenResumed() {
+        unifiedLoginTracker.setStep(Step.START)
+    }
+
+    override fun siteAddressFormScreenResumed() {
+        unifiedLoginTracker.setStep(Step.START)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginAnalyticsTracker.kt
@@ -315,4 +315,16 @@ class LoginAnalyticsTracker(
     override fun siteAddressFormScreenResumed() {
         unifiedLoginTracker.setStep(Step.START)
     }
+
+    override fun magicLinkRequestScreenResumed() {
+        unifiedLoginTracker.setStep(Step.START)
+    }
+
+    override fun magicLinkSentScreenResumed() {
+        unifiedLoginTracker.setStep(Step.MAGIC_LINK_REQUESTED)
+    }
+
+    override fun usernamePasswordScreenResumed() {
+        unifiedLoginTracker.setStep(Step.USERNAME_PASSWORD)
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/UnifiedLoginTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/UnifiedLoginTracker.kt
@@ -108,6 +108,10 @@ class UnifiedLoginTracker
         currentFlow = Flow.values().find { it.value == value }
     }
 
+    fun setStep(step: Step) {
+        currentStep = step
+    }
+
     fun setFlowAndStep(flow: Flow, step: Step) {
         currentFlow = flow
         currentStep = step

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.kt
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.kt
@@ -68,6 +68,8 @@ interface LoginAnalyticsListener {
     fun trackEmailSignupConfirmationViewed()
     fun trackSocialSignupConfirmationViewed()
     fun trackCreateAccountClick()
+    fun emailPasswordFormScreenResumed()
+    fun siteAddressFormScreenResumed()
 
     enum class CreatedAccountSource {
         EMAIL,

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.kt
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.kt
@@ -70,6 +70,9 @@ interface LoginAnalyticsListener {
     fun trackCreateAccountClick()
     fun emailPasswordFormScreenResumed()
     fun siteAddressFormScreenResumed()
+    fun magicLinkRequestScreenResumed()
+    fun magicLinkSentScreenResumed()
+    fun usernamePasswordScreenResumed()
 
     enum class CreatedAccountSource {
         EMAIL,

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
@@ -109,6 +109,7 @@ public class LoginEmailPasswordFragment extends LoginBaseFormFragment<LoginListe
     @Override
     public void onResume() {
         super.onResume();
+        mAnalyticsListener.emailPasswordFormScreenResumed();
         updatePrimaryButtonEnabledStatus();
 
         // connect to the Service. We'll receive updates via EventBus.

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkRequestFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkRequestFragment.java
@@ -202,6 +202,11 @@ public class LoginMagicLinkRequestFragment extends Fragment {
         getActivity().setTitle(R.string.magic_link_login_title);
     }
 
+    @Override public void onResume() {
+        super.onResume();
+        mAnalyticsListener.magicLinkRequestScreenResumed();
+    }
+
     @Override
     public void onDetach() {
         super.onDetach();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkSentFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkSentFragment.java
@@ -125,6 +125,11 @@ public class LoginMagicLinkSentFragment extends Fragment {
         }
     }
 
+    @Override public void onResume() {
+        super.onResume();
+        mAnalyticsListener.magicLinkSentScreenResumed();
+    }
+
     @Override
     public void onDetach() {
         super.onDetach();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -166,6 +166,12 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
         });
     }
 
+    @Override public void onResume() {
+        super.onResume();
+
+        mAnalyticsListener.siteAddressFormScreenResumed();
+    }
+
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -279,6 +279,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseDiscoveryFragment im
 
     @Override public void onResume() {
         super.onResume();
+        mAnalyticsListener.usernamePasswordScreenResumed();
         updatePrimaryButtonEnabledStatus();
     }
 
@@ -695,3 +696,4 @@ public class LoginUsernamePasswordFragment extends LoginBaseDiscoveryFragment im
         finishLogin();
     }
 }
+


### PR DESCRIPTION
This PR fixes an issue where previously if the user clicked on the "Help" icon on any of the login views (not the epilogue screen - that will be a different PR), the `Step` would continue to be set to `help` erroneously even after the user returned to the regular login screen. For example:

On the site address screen the unified event string would normally look like then when you click **Continue**:
```
{"source":"default","flow":"login_site_address","step":"start","click":"submit"}
```

But, if you click "help" while on this screen, then click back to return to the site address screen and then click **Continue**, the event looks like this:
```
{"source":"default","flow":"login_site_address","step":"help","click":"submit"}
```

To fix this I've added some additional login listeners for setting the appropriate step when that view resumes:
- `emailPasswordFormScreenResumed()`
- `siteAddressFormScreenResumed()`
- `magicLinkRequestScreenResumed()`
- `fun magicLinkSentScreenResumed()`
- `usernamePasswordScreenResumed()`

This cleans up the track event flow and makes it more accurate. Below are snippets from various scenarios. Notice how the **Help** button is clicked between screens to ensure the `Step` is accurately reset when resumed. 

### Login by Site Address
```
Tracked: unified_login_step, Properties: {"source":"default","flow":"prologue","step":"prologue"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"prologue","step":"prologue","click":"login_with_site_address"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_site_address","step":"start"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_site_address","step":"start","click":"show_help"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_site_address","step":"help"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_site_address","step":"start","click":"submit"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_site_address","step":"enter_email_address"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_site_address","step":"enter_email_address","click":"show_help"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_site_address","step":"help"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_site_address","step":"enter_email_address","click":"submit"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_magic_link","step":"start"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_magic_link","step":"start","click":"login_with_password"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_password","step":"start"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_password","step":"start","click":"show_help"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_password","step":"help"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_password","step":"start","click":"submit"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_password","step":"success"}
```

### Site Credentials Screen
```
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_site_address","step":"enter_email_address","click":"login_with_site_creds"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_store_creds","step":"username_password"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_store_creds","step":"username_password","click":"show_help"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_store_creds","step":"help"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_store_creds","step":"username_password","click":"submit"}
```

### Login with WordPress.com

```
Tracked: unified_login_step, Properties: {"source":"default","flow":"wordpress_com","step":"enter_email_address"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"wordpress_com","step":"enter_email_address","click":"show_help"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"wordpress_com","step":"help"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"wordpress_com","step":"enter_email_address","click":"submit"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_magic_link","step":"start"}
```

### To Test
Verify clicking the toolbar **help** button and then clicking back sends the correct track event on the following screens:

**Site Address Login Flow**
- Site address screen
- email screen
- site credentials screen
- magic link screens (requested and sent)

**WordPress.com
- email screen
- magic link screens

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
