### PR TITLE
Unified Login: Login Epilogue tracks events

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/UnifiedLoginTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/UnifiedLoginTracker.kt
@@ -23,7 +23,8 @@ class UnifiedLoginTracker
             value?.let { flow -> AppPrefs.setUnifiedLoginLastFlow(flow.value) }
             field = value
         }
-    private var currentStep: Step? = null
+    var currentStep: Step? = null
+        private set
 
     @JvmOverloads
     fun track(
@@ -139,7 +140,8 @@ class UnifiedLoginTracker
         LOGIN_STORE_CREDS("login_store_creds"),
         LOGIN_SITE_ADDRESS("login_site_address"),
         SIGNUP("signup"),
-        GOOGLE_SIGNUP("google_signup")
+        GOOGLE_SIGNUP("google_signup"),
+        EPILOGUE("epilogue")
     }
 
     enum class Step(val value: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/UnifiedLoginTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/UnifiedLoginTracker.kt
@@ -154,7 +154,18 @@ class UnifiedLoginTracker
         USERNAME_PASSWORD("username_password"),
         SUCCESS("success"),
         HELP("help"),
-        SHOW_EMAIL_HINTS("SHOW_EMAIL_HINTS")
+        SHOW_EMAIL_HINTS("show_email_hints"),
+        WRONG_WP_ACCOUNT("wrong_wordpress_account"),
+        NO_WOO_STORES("no_woo_stores"),
+        SITE_LIST("site_list"),
+        JETPACK_NOT_CONNECTED("jetpack_not_connected"),
+        NOT_WOO_STORE("not_woo_store");
+
+        companion object {
+            private val valueMap = Step.values().associateBy(Step::value)
+
+            fun fromValue(value: String) = valueMap[value]
+        }
     }
 
     enum class Click(val value: String) {
@@ -176,7 +187,8 @@ class UnifiedLoginTracker
         LOGIN_WITH_SITE_CREDS("login_with_site_creds"),
         VIEW_CONNECTED_STORES("view_connected_stores"),
         TRY_ANOTHER_ACCOUNT("try_another_account"),
-        HELP_FINDING_CONNECTED_EMAIL("help_finding_connected_email")
+        HELP_FINDING_CONNECTED_EMAIL("help_finding_connected_email"),
+        REFRESH_APP("refresh_app")
     }
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -322,12 +322,19 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         }
 
         if (calledFromLogin) {
+            unifiedLoginTracker.track(step = Step.SITE_LIST)
+
             // Show the 'try another account' button in case the user
             // doesn't see the store they want to log into.
             with(button_secondary) {
                 visibility = View.VISIBLE
                 text = getString(R.string.login_try_another_account)
-                setOnClickListener { presenter.logout() }
+                setOnClickListener {
+                    presenter.logout()
+                    if (calledFromLogin) {
+                        unifiedLoginTracker.trackClick(Click.TRY_ANOTHER_ACCOUNT)
+                    }
+                }
             }
         } else {
             // Called from settings. Hide the button.
@@ -368,6 +375,10 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             isEnabled = true
             setOnClickListener {
                 presenter.getSiteBySiteId(siteAdapter.selectedSiteId)?.let { site -> siteSelected(site) }
+
+                if (calledFromLogin) {
+                    unifiedLoginTracker.trackClick(Click.SUBMIT)
+                }
             }
         }
     }
@@ -461,6 +472,10 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             return
         }
 
+        if (calledFromLogin) {
+            unifiedLoginTracker.track(step = Step.NO_WOO_STORES)
+        }
+
         showUserInfo(centered = true)
         site_picker_root.visibility = View.VISIBLE
         site_list_container.visibility = View.GONE
@@ -469,7 +484,13 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         with(button_primary) {
             text = getString(R.string.login_try_another_account)
             isEnabled = true
-            setOnClickListener { presenter.logout() }
+            setOnClickListener {
+                presenter.logout()
+
+                if (calledFromLogin) {
+                    unifiedLoginTracker.trackClick(Click.TRY_ANOTHER_ACCOUNT)
+                }
+            }
         }
 
         with(button_secondary) {
@@ -552,6 +573,10 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
                 Stat.SITE_PICKER_AUTO_LOGIN_ERROR_NOT_CONNECTED_TO_USER,
                 mapOf(AnalyticsTracker.KEY_URL to url, AnalyticsTracker.KEY_HAS_CONNECTED_STORES to hasConnectedStores))
 
+        if (calledFromLogin) {
+            unifiedLoginTracker.track(step = Step.WRONG_WP_ACCOUNT)
+        }
+
         showUserInfo(centered = true)
         site_picker_root.visibility = View.VISIBLE
         no_stores_view.visibility = View.VISIBLE
@@ -562,6 +587,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
 
         button_email_help.setOnClickListener {
             AnalyticsTracker.track(Stat.SITE_PICKER_HELP_FINDING_CONNECTED_EMAIL_LINK_TAPPED)
+            unifiedLoginTracker.trackClick(Click.HELP_FINDING_CONNECTED_EMAIL)
 
             LoginEmailHelpDialogFragment().show(supportFragmentManager, LoginEmailHelpDialogFragment.TAG)
         }
@@ -600,6 +626,10 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         AnalyticsTracker.track(
                 Stat.SITE_PICKER_AUTO_LOGIN_ERROR_NOT_CONNECTED_JETPACK,
                 mapOf(AnalyticsTracker.KEY_URL to url))
+
+        if (calledFromLogin) {
+            unifiedLoginTracker.track(step = Step.JETPACK_NOT_CONNECTED)
+        }
 
         showUserInfo(centered = true)
         site_picker_root.visibility = View.VISIBLE
@@ -678,6 +708,10 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
                 mapOf(AnalyticsTracker.KEY_URL to site.url,
                         AnalyticsTracker.KEY_HAS_CONNECTED_STORES to hasConnectedStores))
 
+        if (calledFromLogin) {
+            unifiedLoginTracker.track(step = Step.NOT_WOO_STORE)
+        }
+
         showUserInfo(centered = true)
         site_picker_root.visibility = View.VISIBLE
         no_stores_view.visibility = View.VISIBLE
@@ -694,6 +728,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             spannable.setSpan(
                     WooClickableSpan {
                         AnalyticsTracker.track(Stat.SITE_PICKER_NOT_WOO_STORE_REFRESH_APP_LINK_TAPPED)
+                        unifiedLoginTracker.trackClick(Click.REFRESH_APP)
 
                         progressDialog?.takeIf { !it.isShowing }?.dismiss()
                         progressDialog = ProgressDialog.show(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -35,6 +35,7 @@ import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.LoginEmailHelpDialogFragment
 import com.woocommerce.android.ui.login.UnifiedLoginTracker
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Click
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Flow
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Source
 import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step
 import com.woocommerce.android.ui.main.MainActivity
@@ -64,6 +65,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         private const val KEY_CLICKED_SITE_ID = "clicked_site_id"
         private const val KEY_UNIFIED_TRACKER_SOURCE = "KEY_UNIFIED_TRACKER_SOURCE"
         private const val KEY_UNIFIED_TRACKER_FLOW = "KEY_UNIFIED_TRACKER_FLOW"
+        private const val KEY_UNIFIED_TRACKER_STEP = "KEY_UNIFIED_TRACKER_STEP"
 
         fun showSitePickerFromLogin(context: Context) {
             val intent = Intent(context, SitePickerActivity::class.java)
@@ -174,12 +176,15 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             if (calledFromLogin) {
                 unifiedLoginTracker.setSource(bundle.getString(KEY_UNIFIED_TRACKER_SOURCE, Source.DEFAULT.value))
                 unifiedLoginTracker.setFlow(bundle.getString(KEY_UNIFIED_TRACKER_FLOW))
+                bundle.getString(KEY_UNIFIED_TRACKER_STEP)?.let { stepString ->
+                    Step.fromValue(stepString)?.let { unifiedLoginTracker.setStep(it) }
+                }
             }
         } ?: run {
             // Set unified login tracker source and flow
             if (calledFromLogin) {
                 AppPrefs.getUnifiedLoginLastSource()?.let { unifiedLoginTracker.setSource(it) }
-                AppPrefs.getUnifiedLoginLastFlow()?.let { unifiedLoginTracker.setFlow(it) }
+                unifiedLoginTracker.track(Flow.EPILOGUE, Step.START)
             }
 
             // Signin M1: If using a url to login, we skip showing the store list
@@ -224,6 +229,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
                 outState.putString(KEY_UNIFIED_TRACKER_FLOW, it)
             }
             outState.putString(KEY_UNIFIED_TRACKER_FLOW, unifiedLoginTracker.getSource().value)
+            outState.putString(KEY_UNIFIED_TRACKER_STEP, unifiedLoginTracker.currentStep?.value)
         }
 
         loginSiteUrl?.let { outState.putString(KEY_LOGIN_SITE_URL, it) }


### PR DESCRIPTION
This PR closes #2911 which was a crash caused by missing tracks events, but it goes a step further and installs a logical stream of track events for the following views possible in the login epilogue screen:

Site List | Not Woo Store | No Woo Stores | Wrong WP Account
-- | -- | -- | --
![Screenshot_1601060961](https://user-images.githubusercontent.com/5810477/94307369-a6d32000-ff42-11ea-9b1f-e75f94faf752.png)|![Screenshot_1601061058](https://user-images.githubusercontent.com/5810477/94307381-ab97d400-ff42-11ea-9408-59e16043b4f4.png)|![Screenshot_1601061033](https://user-images.githubusercontent.com/5810477/94307388-af2b5b00-ff42-11ea-9e2d-14a53d8131d5.png)|![Screenshot_1601060956](https://user-images.githubusercontent.com/5810477/94307402-b6526900-ff42-11ea-8801-d10c24757760.png)

The track stream for the login epilogue screen will always start with this event:
```
Tracked: unified_login_step, Properties: {"source":"default","flow":"epilogue","step":"start"}
```
Then a different event will be logged for each screen the user is presented. Below is a walkthrough of common scenarios and the resulting tracks events stream. This can be used as a guide for testing. Note these are all non-failure type scenarios as failure track events are tracked separately.

### Site List

1. Click **Continue with WordPress.com**
2. Login with a WPcom account that has WooCommerce stores connected.
3. The store list picker screen is displayed. Select a store and click **Done**

```
Tracked: unified_login_step, Properties: {"source":"default","flow":"epilogue","step":"start"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"epilogue","step":"site_list"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"epilogue","step":"site_list","click":"submit"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"epilogue","step":"success"}
```

### Not Woo Store/View Connected Stores

1. Click **Enter store address**
2. Enter a site that has jetpack connected but WooCommerce is NOT installed, click **Continue**
3. Enter email and password to continue the login process. 
4. The “Not a WooCommerce site” error screen is displayed. 
5. Click **View Connected stores** (if there are stores available for the current login)
6. Choose a store and click **Done**

```
Tracked: unified_login_step, Properties: {"source":"default","flow":"epilogue","step":"start"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"epilogue","step":"not_woo_store"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"epilogue","step":"not_woo_store","click":"view_connected_stores"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"epilogue","step":"site_list"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"epilogue","step":"site_list","click":"submit"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"epilogue","step":"success"}
```

### Wrong WP Account/Help

1. Click **Enter store address**
2. Enter a site that does not belong to the WPcom user you will be logging in with.
3. Enter email and password to continue the login process. 
4. The “Wrong WP Account” error screen is displayed. 
5. Click **Help** in the top right corner.
6. Click **Back** to return to the error screen.
7. Click **Log in with another account**.  Login process is restarted at the Prologue screen.

```
Tracked: unified_login_step, Properties: {"source":"default","flow":"epilogue","step":"start"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"epilogue","step":"wrong_wordpress_account"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"epilogue","step":"wrong_wordpress_account","click":"show_help"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"epilogue","step":"wrong_wordpress_account","click":"try_another_account"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"prologue","step":"prologue"}

```


### No Woo Stores Connected

1. Click **Continue with WordPress.com**
2. Login with a WPcom account that has **NO** WooCommerce stores connected.
3. The “No WooCommerce stores connected to this account” error screen is displayed.
4. Click **Log in with another account** button. Login process is restarted at the Prologue screen.

```
Tracked: unified_login_step, Properties: {"source":"default","flow":"epilogue","step":"start"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"epilogue","step":"site_list"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"epilogue","step":"no_woo_stores"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"epilogue","step":"no_woo_stores","click":"try_another_account"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"prologue","step":"prologue"}
```


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
