### PR TITLE
Unified login: Login discovery error view (style + tracks events)

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginDiscoveryErrorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginDiscoveryErrorFragment.kt
@@ -16,8 +16,12 @@ import com.woocommerce.android.R
 import com.woocommerce.android.R.layout
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Click
+import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step
+import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_login_discovery_error.*
 import org.wordpress.android.login.LoginListener
+import javax.inject.Inject
 
 class LoginDiscoveryErrorFragment : Fragment() {
     companion object {
@@ -52,6 +56,7 @@ class LoginDiscoveryErrorFragment : Fragment() {
 
     private var loginListener: LoginListener? = null
     private var jetpackLoginListener: LoginNoJetpackListener? = null
+    @Inject internal lateinit var unifiedLoginTracker: UnifiedLoginTracker
 
     private var errorMessage: Int? = null
 
@@ -100,6 +105,7 @@ class LoginDiscoveryErrorFragment : Fragment() {
         with(discovery_wordpress_option_view) {
             setOnClickListener {
                 AnalyticsTracker.track(Stat.LOGIN_DISCOVERY_ERROR_SIGN_IN_WORDPRESS_BUTTON_TAPPED)
+                unifiedLoginTracker.trackClick(Click.CONTINUE_WITH_WORDPRESS_COM)
                 jetpackLoginListener?.showEmailLoginScreen(siteAddress)
             }
         }
@@ -107,6 +113,7 @@ class LoginDiscoveryErrorFragment : Fragment() {
         with(discovery_troubleshoot_option_view) {
             setOnClickListener {
                 AnalyticsTracker.track(Stat.LOGIN_DISCOVERY_ERROR_TROUBLESHOOT_BUTTON_TAPPED)
+                unifiedLoginTracker.trackClick(Click.HELP_TROUBLESHOOTING_TIPS)
                 jetpackLoginListener?.showJetpackTroubleshootingTips()
             }
         }
@@ -114,6 +121,7 @@ class LoginDiscoveryErrorFragment : Fragment() {
         with(discovery_try_option_view) {
             setOnClickListener {
                 AnalyticsTracker.track(Stat.LOGIN_DISCOVERY_ERROR_TRY_AGAIN_TAPPED)
+                unifiedLoginTracker.trackClick(Click.TRY_AGAIN)
                 jetpackLoginListener?.showUsernamePasswordScreen(
                         siteAddress, siteXmlRpcAddress, mInputUsername, mInputPassword
                 )
@@ -137,6 +145,7 @@ class LoginDiscoveryErrorFragment : Fragment() {
     }
 
     override fun onAttach(context: Context) {
+        AndroidSupportInjection.inject(this)
         super.onAttach(context)
 
         // this will throw if parent activity doesn't implement the login listener interface
@@ -154,5 +163,6 @@ class LoginDiscoveryErrorFragment : Fragment() {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
         AnalyticsTracker.track(Stat.LOGIN_DISCOVERY_ERROR_SCREEN_VIEWED)
+        unifiedLoginTracker.track(step = Step.CONNECTION_ERROR)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/UnifiedLoginTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/UnifiedLoginTracker.kt
@@ -152,7 +152,8 @@ class UnifiedLoginTracker
         USERNAME_PASSWORD("username_password"),
         SUCCESS("success"),
         HELP("help"),
-        SHOW_EMAIL_HINTS("SHOW_EMAIL_HINTS")
+        SHOW_EMAIL_HINTS("SHOW_EMAIL_HINTS"),
+        CONNECTION_ERROR("connection_error")
     }
 
     enum class Click(val value: String) {
@@ -174,7 +175,9 @@ class UnifiedLoginTracker
         LOGIN_WITH_SITE_CREDS("login_with_site_creds"),
         VIEW_CONNECTED_STORES("view_connected_stores"),
         TRY_ANOTHER_ACCOUNT("try_another_account"),
-        HELP_FINDING_CONNECTED_EMAIL("help_finding_connected_email")
+        HELP_FINDING_CONNECTED_EMAIL("help_finding_connected_email"),
+        HELP_TROUBLESHOOTING_TIPS("help_troubleshooting_tips"),
+        TRY_AGAIN("try_again")
     }
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WooLoginFragmentModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WooLoginFragmentModule.kt
@@ -20,4 +20,8 @@ internal abstract class WooLoginFragmentModule {
     @FragmentScope
     @ContributesAndroidInjector
     internal abstract fun loginEmailHelpDialogFragment(): LoginEmailHelpDialogFragment
+
+    @FragmentScope
+    @ContributesAndroidInjector
+    internal abstract fun loginDiscoveryErrorFragment(): LoginDiscoveryErrorFragment
 }

--- a/WooCommerce/src/main/res/layout/fragment_login_discovery_error.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_discovery_error.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:background="@color/default_window_background"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -36,10 +37,9 @@
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/discovery_error_message"
+                style="@style/Woo.TextView.Body1"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_200"
-                android:layout_marginEnd="@dimen/major_200"
                 android:textAppearance="?attr/textAppearanceBody1"
                 android:lineSpacingExtra="@dimen/line_spacing_extra_50"
                 android:textAlignment="center"
@@ -52,10 +52,9 @@
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/discovery_error_tip_message"
+                style="@style/Woo.TextView.Body1"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_200"
-                android:layout_marginEnd="@dimen/major_200"
                 android:textAppearance="?attr/textAppearanceBody1"
                 android:lineSpacingExtra="@dimen/line_spacing_extra_50"
                 android:text="@string/login_discovery_error_options"

--- a/WooCommerce/src/main/res/values/styles_login.xml
+++ b/WooCommerce/src/main/res/values/styles_login.xml
@@ -26,6 +26,20 @@
 
         <item name="alertDialogTheme">@style/Theme.Woo.Dialog</item>
         <item name="materialAlertDialogTheme">@style/Theme.Woo.Dialog</item>
+
+        <!-- Custom Widgets -->
+        <item name="tagViewStyle">@style/Woo.Tag</item>
+        <item name="flowLayoutStyle">@style/Woo.FlowLayout</item>
+        <item name="settingsToggleOptionStyle">@style/Widget.Woo.Settings.OptionToggle</item>
+        <item name="settingsOptionValueStyle">@style/Widget.Woo.Settings.OptionValue</item>
+        <item name="settingsCategoryHeaderStyle">@style/Widget.Woo.Settings.CategoryHeader</item>
+        <item name="settingsButtonStyle">@style/Widget.Woo.Settings.Button</item>
+        <item name="wcToggleOutlinedButtonStyle">@style/Widget.Woo.WCToggleOutlinedButton</item>
+        <item name="wcToggleOutlinedSelectorButtonStyle">@style/Widget.Woo.WCToggleOutlinedSelectorButton</item>
+        <item name="wcMaterialOutlinedSpinnerViewStyle">@style/Widget.Woo.WCMaterialOutlinedSpinnerView</item>
+        <item name="wcMaterialOutlinedCurrencyEditTextViewStyle">@style/Widget.Woo.WCMaterialOutlinedCurrencyEditTextView</item>
+        <item name="wcMaterialOutlinedEditTextViewStyle">@style/Widget.Woo.WCMaterialOutlinedEditTextView</item>
+        <item name="wcSingleOptionTextViewStyle">@style/Widget.Woo.WCSingleOptionTextView</item>
     </style>
 
     <style name="Widget.LoginFlow.Button.Tertiary" parent="Widget.MaterialComponents.Button.TextButton">


### PR DESCRIPTION
Fixes #2913 by adding basic styling to the login discovery error screen. Note, the style is just temporary until we get an official design (if needed). Also added track events for the main view:

```
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_store_creds","step":"username_password","click":"submit"}
Tracked: unified_login_failure, Properties: {"source":"default","flow":"login_store_creds","step":"username_password","failure":"XMLRPC_BLOCKED - https:\/\/testwooshop.mystagingwebsite.com"}
Tracked: unified_login_step, Properties: {"source":"default","flow":"login_store_creds","step":"connection_error"}
```

As well as click events for all three buttons:

```
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_store_creds","step":"connection_error","click":"continue_with_wordpress_com"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_store_creds","step":"connection_error","click":"help_troubleshooting_tips"}
Tracked: unified_login_interaction, Properties: {"source":"default","flow":"login_store_creds","step":"connection_error","click":"try_again"}
```

Before | After (Light) | After (Dark)
-- | -- | --
![Screenshot_1601063404](https://user-images.githubusercontent.com/5810477/94311619-907c9280-ff49-11ea-8e1b-f3d5e6cc010c.png)|![Screenshot_1601063727](https://user-images.githubusercontent.com/5810477/94311625-93778300-ff49-11ea-8ed9-45fb0cd3ee83.png)|![Screenshot_1601063747](https://user-images.githubusercontent.com/5810477/94311630-95414680-ff49-11ea-8739-9a6abb815540.png)

### To Test
1. Start with a Jetpack-connected site.
2. Open the app (start logged out).
3. Select "Enter your store address."
4. Enter your store address and select "Continue."
5. On the email screen, select "Continue with store credentials."
6. Before entering your store credentials, go to the web and block XML-RPC on the site (e.g. by activating the [Disable XML-RPC](https://wordpress.org/plugins/disable-xml-rpc/) plugin).
7. In the app, enter your store credentials. The Discovery error screen is displayed.
8. Verify style and track events above.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
