### PR TITLE
Add product/variation inventory ViewModel unit tests

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
@@ -243,7 +243,7 @@ class ProductDetailRepository @Inject constructor(
 
     fun getProduct(remoteProductId: Long): Product? = getCachedWCProductModel(remoteProductId)?.toAppModel()
 
-    fun isProductSkuAvailableLocally(sku: String) = !productStore.geProductExistsBySku(selectedSite.get(), sku)
+    fun isSkuAvailableLocally(sku: String) = !productStore.geProductExistsBySku(selectedSite.get(), sku)
 
     fun getCachedVariationCount(remoteProductId: Long) =
             productStore.getVariationsForProduct(selectedSite.get(), remoteProductId).size

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModel.kt
@@ -35,6 +35,7 @@ class ProductInventoryViewModel @AssistedInject constructor(
         savedState,
         ViewState(
             inventoryData = navArgs.inventoryData,
+            isDoneButtonVisible = false,
             isIndividualSaleSwitchVisible = navArgs.requestCode == RequestCodes.PRODUCT_DETAIL_INVENTORY
         )
     )
@@ -62,9 +63,9 @@ class ProductInventoryViewModel @AssistedInject constructor(
             if (sku == originalSku) {
                 clearSkuError()
             } else {
-                viewState = viewState.copy(explicitlyHideDoneButton = true)
+                viewState = viewState.copy(isDoneButtonDisabled = true)
 
-                if (!productRepository.isProductSkuAvailableLocally(sku)) {
+                if (!productRepository.isSkuAvailableLocally(sku)) {
                     showSkuError()
                 } else {
                     clearSkuError()
@@ -85,7 +86,7 @@ class ProductInventoryViewModel @AssistedInject constructor(
                             showSkuError()
                         }
 
-                        viewState = viewState.copy(explicitlyHideDoneButton = false)
+                        viewState = viewState.copy(isDoneButtonDisabled = false)
                     }
                 }
             }
@@ -153,10 +154,10 @@ class ProductInventoryViewModel @AssistedInject constructor(
         val isDoneButtonVisible: Boolean? = null,
         val skuErrorMessage: Int? = null,
         val isIndividualSaleSwitchVisible: Boolean? = null,
-        val explicitlyHideDoneButton: Boolean = false
+        val isDoneButtonDisabled: Boolean = false
     ) : Parcelable {
         val isDoneButtonEnabled: Boolean
-            get() = !explicitlyHideDoneButton && (skuErrorMessage == 0 || skuErrorMessage == null)
+            get() = !isDoneButtonDisabled && (skuErrorMessage == 0 || skuErrorMessage == null)
     }
 
     @Parcelize

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModelTest.kt
@@ -1,0 +1,226 @@
+package com.woocommerce.android.ui.products
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.viewmodel.SavedStateWithArgs
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.spy
+import com.nhaarman.mockitokotlin2.whenever
+import com.woocommerce.android.R.string
+import com.woocommerce.android.RequestCodes
+import com.woocommerce.android.ui.products.ProductBackorderStatus.No
+import com.woocommerce.android.ui.products.ProductBackorderStatus.Yes
+import com.woocommerce.android.ui.products.ProductInventoryViewModel.InventoryData
+import com.woocommerce.android.ui.products.ProductInventoryViewModel.ViewState
+import com.woocommerce.android.ui.products.ProductStockStatus.InStock
+import com.woocommerce.android.ui.products.ProductStockStatus.OutOfStock
+import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
+import com.woocommerce.android.viewmodel.test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+
+class ProductInventoryViewModelTest : BaseUnitTest() {
+    private val productDetailRepository: ProductDetailRepository = mock()
+
+    private val takenSku = "taken"
+
+    private val initialData = InventoryData(
+        "SKU123", false, false, InStock, 10, No
+    )
+
+    private val expectedData = InventoryData(
+        "SKU321", true, true, OutOfStock, 0, Yes
+    )
+
+    private val coroutineDispatchers = CoroutineDispatchers(
+        Dispatchers.Unconfined,
+        Dispatchers.Unconfined,
+        Dispatchers.Unconfined
+    )
+
+    private lateinit var viewModel: ProductInventoryViewModel
+
+    @Before
+    fun setup() {
+        viewModel = createViewModel(RequestCodes.PRODUCT_DETAIL_INVENTORY)
+    }
+
+    private fun createViewModel(requestCode: Int): ProductInventoryViewModel {
+        val savedState = SavedStateWithArgs(
+            SavedStateHandle(),
+            null,
+            ProductInventoryFragmentArgs(requestCode, initialData, initialData.sku!!)
+        )
+        return spy(
+            ProductInventoryViewModel(
+                savedState,
+                coroutineDispatchers,
+                productDetailRepository
+            )
+        )
+    }
+
+    @Test
+    fun `Test that the initial data is displayed correctly`() = test {
+        var actual: InventoryData? = null
+        viewModel.viewStateData.observeForever { _, new ->
+            actual = new.inventoryData
+        }
+
+        assertThat(actual).isEqualTo(initialData)
+    }
+
+    @Test
+    fun `Test that when data is changed the view state is updated`() = test {
+        var actual: InventoryData? = null
+        viewModel.viewStateData.observeForever { _, new ->
+            actual = new.inventoryData
+        }
+
+        viewModel.onDataChanged(
+            expectedData.sku,
+            expectedData.backorderStatus,
+            expectedData.isSoldIndividually,
+            expectedData.isStockManaged,
+            expectedData.stockQuantity,
+            expectedData.stockStatus
+        )
+
+        assertThat(actual).isEqualTo(expectedData)
+    }
+
+    @Test
+    fun `Test that an error is shown and done button disabled if SKU is already taken`() = test {
+        whenever(productDetailRepository.isSkuAvailableLocally(takenSku)).thenReturn(false)
+        whenever(productDetailRepository.isSkuAvailableRemotely(expectedData.sku!!)).thenReturn(true)
+        whenever(productDetailRepository.isSkuAvailableLocally(expectedData.sku!!)).thenReturn(true)
+
+        var actual: ViewState? = null
+        viewModel.viewStateData.observeForever { _, new ->
+            actual = new
+        }
+
+        viewModel.onSkuChanged(takenSku)
+
+        assertThat(actual?.inventoryData?.sku).isEqualTo(takenSku)
+        assertThat(actual?.isDoneButtonVisible).isTrue()
+        assertThat(actual?.isDoneButtonDisabled).isTrue()
+        assertThat(actual?.skuErrorMessage).isEqualTo(string.product_inventory_update_sku_error)
+
+        viewModel.onSkuChanged(expectedData.sku!!)
+
+        assertThat(actual?.inventoryData?.sku).isEqualTo(expectedData.sku)
+        assertThat(actual?.isDoneButtonVisible).isTrue()
+
+        delay(600)
+        assertThat(actual?.isDoneButtonVisible).isTrue()
+        assertThat(actual?.isDoneButtonDisabled).isFalse()
+        assertThat(actual?.skuErrorMessage).isEqualTo(0)
+    }
+
+    @Test
+    fun `Test that a discard dialog isn't shown if no data changed`() = test {
+        val events = mutableListOf<Event>()
+        viewModel.event.observeForever {
+            events.add(it)
+        }
+
+        assertThat(events).isEmpty()
+
+        viewModel.onExit()
+
+        assertThat(events.singleOrNull { it is Exit }).isNotNull
+        assertThat(events.any { it is ShowDiscardDialog }).isFalse()
+        assertThat(events.any { it is ExitWithResult<*> }).isFalse()
+    }
+
+    @Test
+    fun `Test that a discard dialog is shown if data changed`() = test {
+        val events = mutableListOf<Event>()
+        viewModel.event.observeForever {
+            events.add(it)
+        }
+
+        viewModel.onDataChanged(expectedData.sku)
+
+        viewModel.onExit()
+
+        assertThat(events.singleOrNull { it is ShowDiscardDialog }).isNotNull
+        assertThat(events.any { it is ExitWithResult<*> }).isFalse()
+        assertThat(events.any { it is Exit }).isFalse()
+    }
+
+    @Test
+    fun `Test that a the correct data is returned when Done button clicked`() = test {
+        val events = mutableListOf<Event>()
+        viewModel.event.observeForever {
+            events.add(it)
+        }
+
+        viewModel.onDataChanged(
+            expectedData.sku,
+            expectedData.backorderStatus,
+            expectedData.isSoldIndividually,
+            expectedData.isStockManaged,
+            expectedData.stockQuantity,
+            expectedData.stockStatus
+        )
+
+        viewModel.onDoneButtonClicked()
+
+        assertThat(events.any { it is ShowDiscardDialog }).isFalse()
+        assertThat(events.any { it is Exit }).isFalse()
+
+        @Suppress("UNCHECKED_CAST")
+        val result = events.single { it is ExitWithResult<*> } as ExitWithResult<InventoryData>
+
+        assertThat(result.data).isEqualTo(expectedData)
+    }
+
+    @Test
+    fun `Test that the done button is only shown if data changed`() = test {
+        var viewState: ViewState? = null
+        viewModel.viewStateData.observeForever { _, new ->
+            viewState = new
+        }
+
+        assertThat(viewState?.isDoneButtonVisible).isFalse()
+
+        viewModel.onDataChanged(backorderStatus = expectedData.backorderStatus)
+
+        assertThat(viewState?.isDoneButtonVisible).isTrue()
+
+        viewModel.onDataChanged(backorderStatus = initialData.backorderStatus)
+
+        assertThat(viewState?.isDoneButtonVisible).isFalse()
+    }
+
+    @Test
+    fun `Test that the individual sale switch is visible for products`() = test {
+        var viewState: ViewState? = null
+        viewModel.viewStateData.observeForever { _, new ->
+            viewState = new
+        }
+
+        assertThat(viewState?.isIndividualSaleSwitchVisible).isTrue()
+    }
+
+    @Test
+    fun `Test that the individual sale switch is not visible for variations`() = test {
+        viewModel = createViewModel(RequestCodes.VARIATION_DETAIL_INVENTORY)
+
+        var viewState: ViewState? = null
+        viewModel.viewStateData.observeForever { _, new ->
+            viewState = new
+        }
+
+        assertThat(viewState?.isIndividualSaleSwitchVisible).isFalse()
+    }
+}


### PR DESCRIPTION
This PR adds the missing unit tests for the new `ProductInventoryViewModel`.

**To test:** Run the `ProductInventoryViewModelTest` tests and makes sure all of them pass.