### PR TITLE
Fix for the navigation result handler being called multiple times

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -5,6 +5,29 @@ import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import java.util.concurrent.atomic.AtomicBoolean
 
+/*
+ * A helper function that sets the submitted key-value pair in the Fragment's SavedStateHandle. The value can be
+ * observed as a LiveData using the same key - see the Fragment.handleResult() extension function.
+ *
+ * This mechanism is used to facilitate the request-result communication between 2 separate fragments.
+ *
+ * Note: The value is stored along with a boolean value (true), which signifies that the data is fresh and has not been
+ * observed yet. AtomicBoolean type is used to store the boolean so that the value can be updated once once the data is
+ * handled/observed.
+ */
+fun <T> Fragment.navigateBackWithResult(key: String, result: T) {
+    findNavController().previousBackStackEntry?.savedStateHandle?.set(key, Pair(result, AtomicBoolean(true)))
+    findNavController().navigateUp()
+}
+
+/*
+ * A helper function that subscribes a supplied handler function to the Fragment's SavedStateHandle LiveData associated
+ * with the supplied key.
+ *
+ * Note: The handler is called only if the value wasn't handled before (i.e. the data is fresh). Once the observer is
+ * called, the boolean value is updated. This puts a limit on the number of observers for a particular key-result pair
+ * to 1.
+ */
 fun <T> Fragment.handleResult(key: String, handler: (T) -> Unit) {
     findNavController().currentBackStackEntry?.savedStateHandle?.getLiveData<Pair<T, AtomicBoolean>>(key)?.observe(
         this.viewLifecycleOwner,
@@ -15,9 +38,4 @@ fun <T> Fragment.handleResult(key: String, handler: (T) -> Unit) {
             }
         }
     )
-}
-
-fun <T> Fragment.navigateBackWithResult(key: String, result: T) {
-    findNavController().previousBackStackEntry?.savedStateHandle?.set(key, Pair(result, AtomicBoolean(true)))
-    findNavController().navigateUp()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -3,17 +3,21 @@ package com.woocommerce.android.extensions
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
+import java.util.concurrent.atomic.AtomicBoolean
 
 fun <T> Fragment.handleResult(key: String, handler: (T) -> Unit) {
-    findNavController().currentBackStackEntry?.savedStateHandle?.getLiveData<T>(key)?.observe(
+    findNavController().currentBackStackEntry?.savedStateHandle?.getLiveData<Pair<T, AtomicBoolean>>(key)?.observe(
         this.viewLifecycleOwner,
         Observer {
-            handler(it)
+            val isFresh = it.second.getAndSet(false)
+            if (isFresh) {
+                handler(it.first)
+            }
         }
     )
 }
 
 fun <T> Fragment.navigateBackWithResult(key: String, result: T) {
-    findNavController().previousBackStackEntry?.savedStateHandle?.set(key, result)
+    findNavController().previousBackStackEntry?.savedStateHandle?.set(key, Pair(result, AtomicBoolean(true)))
     findNavController().navigateUp()
 }


### PR DESCRIPTION
This PR fixes #2929 and prevents the navigation result LiveData from calling the observer multiple times by using `AtomicBoolean`.

**To test:**
1. Go to Products -> Product detail -> Tap on image gallery
2. Select WordPress media library and add an image
3. Rotate the screen
4. Notice no new  image was added