### PR TITLE
Issue/2889 trash product tests

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -219,7 +219,7 @@ class ProductDetailViewModel @AssistedInject constructor(
      * Called when the Trash menu item is clicked in Product detail screen
      */
     fun onTrashButtonClicked() {
-        if (!viewState.isConfirmingTrash) {
+        if (checkConnection() && !viewState.isConfirmingTrash) {
             triggerEvent(
                 ShowDiscardDialog(
                     positiveBtnAction = DialogInterface.OnClickListener { _, _ ->
@@ -234,7 +234,7 @@ class ProductDetailViewModel @AssistedInject constructor(
                     messageId = string.product_confirm_trash,
                     positiveButtonId = string.product_trash_yes,
                     negativeButtonId = string.cancel
-                    )
+                )
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -176,10 +176,11 @@ class ProductDetailViewModel @AssistedInject constructor(
         get() = isAddFlowEntryPoint && viewState.productDraft?.remoteId == DEFAULT_ADD_NEW_PRODUCT_ID
 
     /**
-     * Returns boolean value of [navArgs.isTrashEnabled] to determine if the detail fragment should enable trash menu
+     * Returns boolean value of [navArgs.isTrashEnabled] to determine if the detail fragment should enable
+     * trash menu. Always returns false when we're in the add flow.
      */
     val isTrashEnabled: Boolean
-        get() = navArgs.isTrashEnabled && !isAddFlow && FeatureFlag.PRODUCT_RELEASE_M5.isEnabled()
+        get() = !isAddFlow && navArgs.isTrashEnabled && FeatureFlag.PRODUCT_RELEASE_M5.isEnabled()
 
     init {
         start()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -41,6 +41,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 
@@ -457,9 +458,9 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Do not enable trashing a product during add product flow`() {
-        whenever(viewModel.isAddFlow).thenReturn(true)
+    fun `Do not enable trashing a product when in add product flow`() {
         viewModel.start()
+        doReturn(true).whenever(viewModel).isAddFlow
         assertThat(viewModel.isTrashEnabled).isFalse()
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -38,6 +38,7 @@ import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.ui.products.tags.ProductTagsRepository
 import com.woocommerce.android.util.CoroutineTestRule
 import com.woocommerce.android.util.ProductUtils
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Rule
@@ -438,5 +439,22 @@ class ProductDetailViewModelTest : BaseUnitTest() {
             assertThat(sortedByNameAndParent[9].category).isEqualTo(productCategories[5])
             assertThat(sortedByNameAndParent[10].category).isEqualTo(productCategories[4])
         }
+    }
+
+    @Test
+    fun `Displays the trash confirmation dialog correctly`() {
+        doReturn(product).whenever(productRepository).getProduct(any())
+
+        viewModel.start()
+        viewModel.onTrashButtonClicked()
+
+        var trashDialogShown = false
+        viewModel.event.observeForever {
+            if (it is ShowDiscardDialog && it.messageId == R.string.product_confirm_trash) {
+                trashDialogShown = true
+            }
+        }
+
+        assertThat(trashDialogShown).isTrue()
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -464,7 +464,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Display offline message and don't show trash confirmation when not connected`() {
+    fun `Display offline message and don't show trash confirmation dialog when not connected`() {
         doReturn(false).whenever(networkStatus).isConnected()
 
         var snackbar: ShowSnackbar? = null

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -19,29 +19,29 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductDetailViewState
 import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
 import com.woocommerce.android.ui.products.models.ProductProperty.ComplexProperty
-import com.woocommerce.android.ui.products.models.ProductPropertyCard
-import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.viewmodel.BaseUnitTest
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
-import com.woocommerce.android.viewmodel.ResourceProvider
-import com.woocommerce.android.viewmodel.SavedStateWithArgs
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
-import org.junit.Test
-import org.wordpress.android.fluxc.store.WooCommerceStore
 import com.woocommerce.android.ui.products.models.ProductProperty.Editable
 import com.woocommerce.android.ui.products.models.ProductProperty.PropertyGroup
 import com.woocommerce.android.ui.products.models.ProductProperty.RatingBar
+import com.woocommerce.android.ui.products.models.ProductPropertyCard
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.PRIMARY
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.SECONDARY
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.ui.products.tags.ProductTagsRepository
 import com.woocommerce.android.util.CoroutineTestRule
+import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.ProductUtils
+import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.ResourceProvider
+import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Rule
+import org.junit.Test
+import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 
 @ExperimentalCoroutinesApi
@@ -443,8 +443,6 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Displays the trash confirmation dialog correctly`() {
-        doReturn(product).whenever(productRepository).getProduct(any())
-
         viewModel.start()
         viewModel.onTrashButtonClicked()
 
@@ -456,5 +454,12 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         }
 
         assertThat(trashDialogShown).isTrue()
+    }
+
+    @Test
+    fun `Do not enable trash menu item during add product flow`() {
+        whenever(viewModel.isAddFlow).thenReturn(true)
+        viewModel.start()
+        assertThat(viewModel.isTrashEnabled).isFalse()
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -41,7 +41,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.products
 
 import androidx.lifecycle.MutableLiveData
-import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
@@ -18,8 +17,10 @@ import com.woocommerce.android.ui.products.ProductListViewModel.ViewState
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.woocommerce.android.viewmodel.test
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -139,6 +140,7 @@ class ProductListViewModelTest : BaseUnitTest() {
         assertThat(isAddProductButtonVisible).containsExactly(true, false, true)
     }
 
+
     @Test
     fun `Shows offline message when trashing a product without a connection`() {
         doReturn(false).whenever(networkStatus).isConnected()
@@ -152,5 +154,22 @@ class ProductListViewModelTest : BaseUnitTest() {
 
         viewModel.trashProduct(any())
         assertThat(snackbar).isEqualTo(ShowSnackbar(R.string.offline_error))
+    }
+
+    @Test
+    fun `Shows error message when trashing a product fails`() {
+        runBlocking {
+            doReturn(false).whenever(productRepository).trashProduct(any())
+        }
+
+        createViewModel()
+
+        var snackbar: ShowSnackbar? = null
+        viewModel.event.observeForever {
+            if (it is ShowSnackbar) snackbar = it
+        }
+
+        viewModel.trashProduct(any())
+        assertThat(snackbar).isEqualTo(ShowSnackbar(R.string.product_trash_error))
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
@@ -140,7 +140,6 @@ class ProductListViewModelTest : BaseUnitTest() {
         assertThat(isAddProductButtonVisible).containsExactly(true, false, true)
     }
 
-
     @Test
     fun `Shows offline message when trashing a product without a connection`() {
         doReturn(false).whenever(networkStatus).isConnected()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
@@ -140,7 +140,9 @@ class ProductListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Shows undo trash snackbar correctly`() {
+    fun `Shows offline message when trashing a product without a connection`() {
+        doReturn(false).whenever(networkStatus).isConnected()
+
         createViewModel()
 
         var snackbar: ShowSnackbar? = null
@@ -149,6 +151,6 @@ class ProductListViewModelTest : BaseUnitTest() {
         }
 
         viewModel.trashProduct(any())
-        assertThat(snackbar).isEqualTo(ShowSnackbar(R.string.product_trash_undo_snackbar_message))
+        assertThat(snackbar).isEqualTo(ShowSnackbar(R.string.offline_error))
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
@@ -138,4 +138,17 @@ class ProductListViewModelTest : BaseUnitTest() {
         // then
         assertThat(isAddProductButtonVisible).containsExactly(true, false, true)
     }
+
+    @Test
+    fun `Shows undo trash snackbar correctly`() {
+        createViewModel()
+
+        var snackbar: ShowSnackbar? = null
+        viewModel.event.observeForever {
+            if (it is ShowSnackbar) snackbar = it
+        }
+
+        viewModel.trashProduct(any())
+        assertThat(snackbar).isEqualTo(ShowSnackbar(R.string.product_trash_undo_snackbar_message))
+    }
 }


### PR DESCRIPTION
As part of #2889, this PR adds the following tests for the delete product feature:

**ProductDetailViewModelTest**

- `Displays the trash confirmation dialog correctly`
- `Do not enable trashing a product during add product flow`
- `Display offline message and don't show trash confirmation dialog when not connected`

**ProductListViewModelTest**

- `Shows offline message when trashing a product without a connection`
- `Shows error message when trashing a product fails`

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
