### PR TITLE
Remove Products M3 feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 5.2
 -----
-* Product editing is now out of beta is available for all users
+* Product editing is now out of beta and is available for all users
  
 5.1
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 5.2
 -----
+* Product editing is now out of beta is available for all users
  
 5.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
@@ -93,7 +93,7 @@ class ProductDetailBottomSheetBuilder(
     }
 
     private fun Product.getCategories(): ProductDetailBottomSheetUiItem? {
-        return if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled() && !hasCategories) {
+        return if (!hasCategories) {
             ProductDetailBottomSheetUiItem(
                 ProductDetailBottomSheetType.PRODUCT_CATEGORIES,
                 ViewProductCategories(remoteId),
@@ -105,7 +105,7 @@ class ProductDetailBottomSheetBuilder(
     }
 
     private fun Product.getTags(): ProductDetailBottomSheetUiItem? {
-        return if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled() && !hasTags) {
+        return if (!hasTags) {
             ProductDetailBottomSheetUiItem(
                 ProductDetailBottomSheetType.PRODUCT_TAGS,
                 ViewProductTags(remoteId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.ui.products.ProductType.EXTERNAL
 import com.woocommerce.android.ui.products.ProductType.GROUPED
 import com.woocommerce.android.ui.products.ProductType.SIMPLE
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.ResourceProvider
 
 class ProductDetailBottomSheetBuilder(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -41,7 +41,6 @@ import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.PURCH
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.SECONDARY
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.PriceUtils
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.ResourceProvider

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -63,19 +63,11 @@ class ProductDetailCardBuilder(
         val cards = mutableListOf<ProductPropertyCard>()
         cards.addIfNotEmpty(getPrimaryCard(product))
 
-        if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled()) {
-            when (product.type) {
-                SIMPLE -> cards.addIfNotEmpty(getSimpleProductCard(product))
-                VARIABLE -> cards.addIfNotEmpty(getVariableProductCard(product))
-                GROUPED -> cards.addIfNotEmpty(getGroupedProductCard(product))
-                EXTERNAL -> cards.addIfNotEmpty(getExternalProductCard(product))
-            }
-        } else {
-            if (isSimple(product)) {
-                cards.addIfNotEmpty(getSimpleProductCard(product))
-            } else {
-                cards.addIfNotEmpty(getPricingAndInventoryCard(product))
-            }
+        when (product.type) {
+            SIMPLE -> cards.addIfNotEmpty(getSimpleProductCard(product))
+            VARIABLE -> cards.addIfNotEmpty(getVariableProductCard(product))
+            GROUPED -> cards.addIfNotEmpty(getGroupedProductCard(product))
+            EXTERNAL -> cards.addIfNotEmpty(getExternalProductCard(product))
         }
 
         cards.addIfNotEmpty(getPurchaseDetailsCard(product))
@@ -248,38 +240,32 @@ class ProductDetailCardBuilder(
 
     // show stock properties as a group if stock management is enabled, otherwise show sku separately
     private fun Product.readOnlyInventory(): ProductProperty {
-        return when {
-            this.isStockManaged -> {
-                val group = mapOf(
-                    Pair(resources.getString(R.string.product_stock_status),
-                        ProductStockStatus.stockStatusToDisplayString(resources, this.stockStatus)
-                    ),
-                    Pair(resources.getString(R.string.product_backorders),
-                        ProductBackorderStatus.backordersToDisplayString(resources, this.backorderStatus)
-                    ),
-                    Pair(resources.getString(R.string.product_stock_quantity),
-                        StringUtils.formatCount(this.stockQuantity)
-                    ),
-                    Pair(resources.getString(R.string.product_sku), this.sku)
-                )
-                PropertyGroup(
-                    R.string.product_inventory,
-                    group
-                )
-            }
-            FeatureFlag.PRODUCT_RELEASE_M3.isEnabled() -> {
-                ComplexProperty(
-                    R.string.product_sku,
-                    this.sku,
-                    R.drawable.ic_gridicons_list_checkmark
-                )
-            }
-            else -> {
-                ComplexProperty(
-                    R.string.product_sku,
-                    this.sku
-                )
-            }
+        return if (this.isStockManaged) {
+            val group = mapOf(
+                Pair(
+                    resources.getString(R.string.product_stock_status),
+                    ProductStockStatus.stockStatusToDisplayString(resources, this.stockStatus)
+                ),
+                Pair(
+                    resources.getString(R.string.product_backorders),
+                    ProductBackorderStatus.backordersToDisplayString(resources, this.backorderStatus)
+                ),
+                Pair(
+                    resources.getString(R.string.product_stock_quantity),
+                    StringUtils.formatCount(this.stockQuantity)
+                ),
+                Pair(resources.getString(R.string.product_sku), this.sku)
+            )
+            PropertyGroup(
+                R.string.product_inventory,
+                group
+            )
+        } else {
+            ComplexProperty(
+                R.string.product_sku,
+                this.sku,
+                R.drawable.ic_gridicons_list_checkmark
+            )
         }
     }
 
@@ -472,29 +458,25 @@ class ProductDetailCardBuilder(
         }
     }
 
-    private fun Product.productType(): ProductProperty? {
-        return if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled()) {
-            val productType = resources.getString(this.getProductTypeFormattedForDisplay())
-            val onClickHandler = {
-                viewModel.onEditProductCardClicked(
-                    ViewProductTypes(false),
-                    Stat.PRODUCT_DETAIL_VIEW_PRODUCT_TYPE_TAPPED
-                )
-            }
-
-            ComplexProperty(
-                R.string.product_type,
-                resources.getString(R.string.product_detail_product_type_hint, productType),
-                R.drawable.ic_gridicons_product,
-                onClick = if (remoteId != 0L) onClickHandler else null
+    private fun Product.productType(): ProductProperty {
+        val productType = resources.getString(this.getProductTypeFormattedForDisplay())
+        val onClickHandler = {
+            viewModel.onEditProductCardClicked(
+                ViewProductTypes(false),
+                Stat.PRODUCT_DETAIL_VIEW_PRODUCT_TYPE_TAPPED
             )
-        } else {
-            null
         }
+
+        return ComplexProperty(
+            R.string.product_type,
+            resources.getString(R.string.product_detail_product_type_hint, productType),
+            R.drawable.ic_gridicons_product,
+            onClick = if (remoteId != 0L) onClickHandler else null
+        )
     }
 
     private fun Product.productReviews(): ProductProperty? {
-        return if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled() && this.reviewsAllowed) {
+        return if (this.reviewsAllowed) {
             val ratingCount = this.ratingCount
             RatingBar(
                 R.string.product_reviews,
@@ -512,51 +494,44 @@ class ProductDetailCardBuilder(
         }
     }
 
-    private fun Product.groupedProducts(): ProductProperty? {
+    private fun Product.groupedProducts(): ProductProperty {
         val groupedProductsSize = this.groupedProductIds.size
         val showTitle = groupedProductsSize > 0
-        return if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled()) {
-            val groupedProductsDesc = if (showTitle) {
-                StringUtils.getQuantityString(
-                    resourceProvider = resources,
-                    quantity = groupedProductsSize,
-                    default = R.string.grouped_products_count,
-                    one = R.string.grouped_products_single
-                )
-            } else {
-                resources.getString(R.string.grouped_product_empty)
-            }
 
-            ComplexProperty(
-                R.string.grouped_products,
-                groupedProductsDesc,
-                R.drawable.ic_widgets,
-                showTitle = showTitle
-            ) {
-                viewModel.onEditProductCardClicked(
-                    ViewGroupedProducts(this.remoteId, this.groupedProductIds.joinToString(",")),
-                    Stat.PRODUCT_DETAIL_VIEW_GROUPED_PRODUCTS_TAPPED
-                )
-            }
+        val groupedProductsDesc = if (showTitle) {
+            StringUtils.getQuantityString(
+                resourceProvider = resources,
+                quantity = groupedProductsSize,
+                default = R.string.grouped_products_count,
+                one = R.string.grouped_products_single
+            )
         } else {
-            null
+            resources.getString(R.string.grouped_product_empty)
+        }
+
+        return ComplexProperty(
+            R.string.grouped_products,
+            groupedProductsDesc,
+            R.drawable.ic_widgets,
+            showTitle = showTitle
+        ) {
+            viewModel.onEditProductCardClicked(
+                ViewGroupedProducts(this.remoteId, this.groupedProductIds.joinToString(",")),
+                Stat.PRODUCT_DETAIL_VIEW_GROUPED_PRODUCTS_TAPPED
+            )
         }
     }
 
     private fun Product.title(): ProductProperty {
         val name = this.name.fastStripHtml()
-        return if (isSimple(this) || FeatureFlag.PRODUCT_RELEASE_M3.isEnabled()) {
-            Editable(
-                R.string.product_detail_title_hint,
-                name,
-                onTextChanged = viewModel::onProductTitleChanged
-            )
-        } else {
-            ComplexProperty(R.string.product_name, name)
-        }
+        return Editable(
+            R.string.product_detail_title_hint,
+            name,
+            onTextChanged = viewModel::onProductTitleChanged
+        )
     }
 
-    private fun Product.description(): ProductProperty? {
+    private fun Product.description(): ProductProperty {
         val productDescription = this.description
         val showTitle = productDescription.isNotEmpty()
         val description = if (productDescription.isEmpty()) {
@@ -565,27 +540,17 @@ class ProductDetailCardBuilder(
             productDescription
         }
 
-        return when {
-            isSimple(this) || FeatureFlag.PRODUCT_RELEASE_M3.isEnabled() -> {
-                ComplexProperty(
-                    R.string.product_description,
-                    description,
-                    showTitle = showTitle
-                ) {
-                    viewModel.onEditProductCardClicked(
-                        ViewProductDescriptionEditor(
-                            productDescription, resources.getString(R.string.product_description)
-                        ),
-                        PRODUCT_DETAIL_VIEW_PRODUCT_DESCRIPTION_TAPPED
-                    )
-                }
-            }
-            productDescription.isNotEmpty() -> {
-                ComplexProperty(R.string.product_description, description)
-            }
-            else -> {
-                null
-            }
+        return ComplexProperty(
+            R.string.product_description,
+            description,
+            showTitle = showTitle
+        ) {
+            viewModel.onEditProductCardClicked(
+                ViewProductDescriptionEditor(
+                    productDescription, resources.getString(R.string.product_description)
+                ),
+                PRODUCT_DETAIL_VIEW_PRODUCT_DESCRIPTION_TAPPED
+            )
         }
     }
 
@@ -614,7 +579,7 @@ class ProductDetailCardBuilder(
     }
 
     private fun Product.categories(): ProductProperty? {
-        return if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled() && hasCategories) {
+        return if (hasCategories) {
             val categories = categories.joinToString(transform = { it.name })
 
             ComplexProperty(
@@ -634,7 +599,7 @@ class ProductDetailCardBuilder(
     }
 
     private fun Product.tags(): ProductProperty? {
-        return if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled() && hasTags) {
+        return if (hasTags) {
             val tags = this.tags.joinToString(transform = { it.name })
 
             ComplexProperty(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -555,13 +555,12 @@ class ProductDetailViewModel @AssistedInject constructor(
     }
 
     fun fetchBottomSheetList() {
-        val featureFlagCondition = FeatureFlag.PRODUCT_RELEASE_M3.isEnabled() || viewState.productDraft?.type == SIMPLE
         viewState.productDraft?.let {
             launch(dispatchers.computation) {
                 val detailList = productDetailBottomSheetBuilder.buildBottomSheetList(it)
                 withContext(dispatchers.main) {
                     _productDetailBottomSheetList.value = detailList
-                    viewState = viewState.copy(showBottomSheetButton = detailList.isNotEmpty() && featureFlagCondition)
+                    viewState = viewState.copy(showBottomSheetButton = detailList.isNotEmpty())
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -51,7 +51,6 @@ import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductSe
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductSlug
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductStatus
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductVisibility
-import com.woocommerce.android.ui.products.ProductType.SIMPLE
 import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
 import com.woocommerce.android.ui.products.categories.ProductCategoryItemUiModel
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
@@ -61,7 +60,6 @@ import com.woocommerce.android.ui.products.settings.ProductVisibility
 import com.woocommerce.android.ui.products.tags.ProductTagsRepository
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.Optional
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.LiveDataDelegate

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -357,9 +357,7 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener, ProductS
 
     private fun showProductWIPNoticeCard(show: Boolean) {
         if (show && feedbackState == UNANSWERED) {
-            val wipCardMessageId = if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled()) {
-                R.string.product_wip_message_m3
-            } else R.string.product_wip_message_m2
+            val wipCardMessageId = R.string.product_wip_message_m3
             products_wip_card.visibility = View.VISIBLE
             products_wip_card.initView(
                 getString(R.string.product_wip_title),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductsWIPNoticeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductsWIPNoticeCard.kt
@@ -10,9 +10,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_FEEDBACK
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_FEEDBACK_CONTEXT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_PRODUCT_M3_FEEDBACK
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.FEATURE_FEEDBACK_BANNER
-import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.PRODUCTS_M2
 import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.PRODUCTS_M3
-import com.woocommerce.android.util.FeatureFlag.PRODUCT_RELEASE_M3
 import com.woocommerce.android.util.WooAnimUtils
 import kotlinx.android.synthetic.main.products_wip_notice.view.*
 
@@ -26,9 +24,7 @@ class ProductsWIPNoticeCard @JvmOverloads constructor(
     }
 
     val wipFeatureType
-        get() =
-            if (PRODUCT_RELEASE_M3.isEnabled()) PRODUCTS_M3
-            else PRODUCTS_M2
+        get() = PRODUCTS_M3
 
     private var isExpanded: Boolean
         set(value) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSettingsFragment.kt
@@ -30,7 +30,6 @@ import com.woocommerce.android.ui.products.settings.ProductSlugFragment.Companio
 import com.woocommerce.android.ui.products.settings.ProductStatusFragment.Companion.ARG_SELECTED_STATUS
 import com.woocommerce.android.ui.products.settings.ProductVisibilityFragment.Companion.ARG_PASSWORD
 import com.woocommerce.android.ui.products.settings.ProductVisibilityFragment.Companion.ARG_VISIBILITY
-import com.woocommerce.android.util.FeatureFlag
 import kotlinx.android.synthetic.main.fragment_product_settings.*
 
 class ProductSettingsFragment : BaseProductFragment(), NavigationResult {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSettingsFragment.kt
@@ -65,7 +65,7 @@ class ProductSettingsFragment : BaseProductFragment(), NavigationResult {
         }
 
         val isSimple = viewModel.getProduct().productDraft?.type == ProductType.SIMPLE
-        if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled() && isSimple) {
+        if (isSimple) {
             productIsVirtual.visibility = View.VISIBLE
             productIsVirtual.setOnCheckedChangeListener { _, isChecked ->
                 AnalyticsTracker.track(Stat.PRODUCT_SETTINGS_VIRTUAL_TOGGLED)
@@ -76,17 +76,12 @@ class ProductSettingsFragment : BaseProductFragment(), NavigationResult {
             productIsVirtual.visibility = View.GONE
         }
 
-        if (FeatureFlag.PRODUCT_RELEASE_M3.isEnabled()) {
-            productReviewsAllowed.visibility = View.VISIBLE
-            productReviewsAllowedDivider.visibility = View.VISIBLE
-            productReviewsAllowed.setOnCheckedChangeListener { _, isChecked ->
-                AnalyticsTracker.track(Stat.PRODUCT_SETTINGS_REVIEWS_TOGGLED)
-                viewModel.updateProductDraft(reviewsAllowed = isChecked)
-                activity?.invalidateOptionsMenu()
-            }
-        } else {
-            productReviewsAllowed.visibility = View.GONE
-            productReviewsAllowedDivider.visibility = View.GONE
+        productReviewsAllowed.visibility = View.VISIBLE
+        productReviewsAllowedDivider.visibility = View.VISIBLE
+        productReviewsAllowed.setOnCheckedChangeListener { _, isChecked ->
+            AnalyticsTracker.track(Stat.PRODUCT_SETTINGS_REVIEWS_TOGGLED)
+            viewModel.updateProductDraft(reviewsAllowed = isChecked)
+            activity?.invalidateOptionsMenu()
         }
 
         productPurchaseNote.setOnClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
@@ -35,7 +35,6 @@ import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.
 import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.ViewPricing
 import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.ViewShipping
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.FeatureFlag.PRODUCT_RELEASE_M3
 import com.woocommerce.android.util.PriceUtils
 import com.woocommerce.android.viewmodel.ResourceProvider
 import org.wordpress.android.util.FormatUtils
@@ -103,7 +102,11 @@ class VariationDetailCardBuilder(
             variationDescription
         }
 
-        val onClick = {
+        return ComplexProperty(
+            string.product_description,
+            description,
+            showTitle = variationDescription.isNotEmpty()
+        ) {
             viewModel.onEditVariationCardClicked(
                 ViewDescriptionEditor(
                     variationDescription, resources.getString(string.product_description)
@@ -111,13 +114,6 @@ class VariationDetailCardBuilder(
                 Stat.PRODUCT_VARIATION_VIEW_VARIATION_DESCRIPTION_TAPPED
             )
         }
-
-        return ComplexProperty(
-            string.product_description,
-            description,
-            showTitle = variationDescription.isNotEmpty(),
-            onClick = if (PRODUCT_RELEASE_M3.isEnabled()) onClick else null
-        )
     }
 
     private fun ProductVariation.visibility(): ProductProperty {
@@ -131,12 +127,8 @@ class VariationDetailCardBuilder(
             visibilityIcon = drawable.ic_gridicons_not_visible
         }
 
-        return if (PRODUCT_RELEASE_M3.isEnabled()) {
-            Switch(visibility, isVisible, visibilityIcon) {
-                viewModel.onVariationVisibilitySwitchChanged(it)
-            }
-        } else {
-            Switch(visibility, isVisible, visibilityIcon)
+        return Switch(visibility, isVisible, visibilityIcon) {
+            viewModel.onVariationVisibilitySwitchChanged(it)
         }
     }
 
@@ -150,7 +142,7 @@ class VariationDetailCardBuilder(
 
     // If we have pricing info, show price & sales price as a group,
     // otherwise provide option to add pricing info for the variation
-    private fun ProductVariation.price(): ProductProperty? {
+    private fun ProductVariation.price(): ProductProperty {
         val pricingGroup = PriceUtils.getPriceGroup(
             parameters,
             resources,
@@ -162,34 +154,28 @@ class VariationDetailCardBuilder(
             saleEndDateGmt
         )
 
-        return if (regularPrice.isSet() || PRODUCT_RELEASE_M3.isEnabled()) {
-            val onClick = {
-                viewModel.onEditVariationCardClicked(
-                    ViewPricing(
-                        PricingData(
-                            isSaleScheduled = isSaleScheduled,
-                            saleStartDate = saleStartDateGmt,
-                            saleEndDate = saleEndDateGmt,
-                            regularPrice = regularPrice,
-                            salePrice = salePrice
-                        )
-                    ),
-                    PRODUCT_VARIATION_VIEW_PRICE_SETTINGS_TAPPED
-                )
-            }
+        val isWarningVisible = regularPrice.isNotSet() && this.isVisible
 
-            val isWarningVisible = regularPrice.isNotSet() && this.isVisible
-            PropertyGroup(
-                string.product_price,
-                pricingGroup,
-                drawable.ic_gridicons_money,
-                showTitle = regularPrice.isSet(),
-                isHighlighted = isWarningVisible,
-                isDividerVisible = !isWarningVisible,
-                onClick = if (PRODUCT_RELEASE_M3.isEnabled()) onClick else null
+        return PropertyGroup(
+            string.product_price,
+            pricingGroup,
+            drawable.ic_gridicons_money,
+            showTitle = regularPrice.isSet(),
+            isHighlighted = isWarningVisible,
+            isDividerVisible = !isWarningVisible
+        ) {
+            viewModel.onEditVariationCardClicked(
+                ViewPricing(
+                    PricingData(
+                        isSaleScheduled = isSaleScheduled,
+                        saleStartDate = saleStartDateGmt,
+                        saleEndDate = saleEndDateGmt,
+                        regularPrice = regularPrice,
+                        salePrice = salePrice
+                    )
+                ),
+                PRODUCT_VARIATION_VIEW_PRICE_SETTINGS_TAPPED
             )
-        } else {
-            null
         }
     }
 
@@ -213,7 +199,12 @@ class VariationDetailCardBuilder(
                 mapOf(Pair("", resources.getString(string.product_shipping_empty)))
             }
 
-            val onClick = {
+            PropertyGroup(
+                string.product_shipping,
+                shippingGroup,
+                drawable.ic_gridicons_shipping,
+                hasShippingInfo
+            ) {
                 viewModel.onEditVariationCardClicked(
                     ViewShipping(
                         ShippingData(
@@ -228,14 +219,6 @@ class VariationDetailCardBuilder(
                     PRODUCT_VARIATION_VIEW_SHIPPING_SETTINGS_TAPPED
                 )
             }
-
-            PropertyGroup(
-                string.product_shipping,
-                shippingGroup,
-                drawable.ic_gridicons_shipping,
-                hasShippingInfo,
-                onClick = if (PRODUCT_RELEASE_M3.isEnabled()) onClick else null
-            )
         } else {
             null
         }
@@ -266,7 +249,11 @@ class VariationDetailCardBuilder(
             )
         }
 
-        val onClick = {
+        return PropertyGroup(
+            R.string.product_inventory,
+            inventoryGroup,
+            R.drawable.ic_gridicons_list_checkmark,
+            true) {
             viewModel.onEditVariationCardClicked(
                 ViewInventory(
                     InventoryData(
@@ -281,13 +268,5 @@ class VariationDetailCardBuilder(
                 PRODUCT_VARIATION_VIEW_INVENTORY_SETTINGS_TAPPED
             )
         }
-
-        return PropertyGroup(
-            R.string.product_inventory,
-            inventoryGroup,
-            R.drawable.ic_gridicons_list_checkmark,
-            true,
-            onClick = if (PRODUCT_RELEASE_M3.isEnabled()) onClick else null
-        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.util
 
 import android.content.Context
-import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig
 
 /**
@@ -17,7 +16,7 @@ enum class FeatureFlag {
             // setting screen. i.e. check AppPrefs.isProductsFeatureEnabled() method
             // Also, turn on the feature during testing
             SHIPPING_LABELS_M1 -> BuildConfig.DEBUG || isTesting()
-            PRODUCT_RELEASE_M4 -> BuildConfig.DEBUG && AppPrefs.isProductsFeatureEnabled() || isTesting()
+            PRODUCT_RELEASE_M4 -> BuildConfig.DEBUG || isTesting()
             DB_DOWNGRADE -> {
                 BuildConfig.DEBUG || context != null && PackageUtils.isBetaBuild(context)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -8,7 +8,6 @@ import com.woocommerce.android.BuildConfig
  * "Feature flags" are used to hide in-progress features from release versions
  */
 enum class FeatureFlag {
-    PRODUCT_RELEASE_M3,
     PRODUCT_RELEASE_M4,
     SHIPPING_LABELS_M1,
     DB_DOWNGRADE;
@@ -19,7 +18,6 @@ enum class FeatureFlag {
             // Also, turn on the feature during testing
             SHIPPING_LABELS_M1 -> BuildConfig.DEBUG || isTesting()
             PRODUCT_RELEASE_M4 -> BuildConfig.DEBUG && AppPrefs.isProductsFeatureEnabled() || isTesting()
-            PRODUCT_RELEASE_M3 -> isTesting() || AppPrefs.isProductsFeatureEnabled()
             DB_DOWNGRADE -> {
                 BuildConfig.DEBUG || context != null && PackageUtils.isBetaBuild(context)
             }

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -113,6 +113,7 @@
         android:id="@+id/option_beta_features"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:visibility="gone"
         app:optionTitle="@string/beta_features"/>
 
     <!--


### PR DESCRIPTION
Fixes #2846. This PR removes all M3 product feature flag checks and hides the Beta section from the settings (product editing was the only feature there). I've kept the code since it'll be reused once M4 goes beta.

Any feature flag condition with a logical AND should be kept (without the flag), others should be gone.

**To test:** Just smoke test products, make sure things look OK.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
