### PR TITLE
Issue/2905 draft product option

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -31,16 +31,7 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
+          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
         </value>
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
@@ -106,6 +106,7 @@ abstract class BaseProductFragment : BaseFragment(), BackPressListener {
      * Descendants should call this when edits are made so we can show/hide the done/publish button
      */
     protected fun changesMade() {
+        requireActivity().invalidateOptionsMenu()
         showUpdateMenuItem(hasChanges())
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -308,7 +308,11 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         val message: Int
         when (viewModel.isAddFlow) {
             true -> {
-                title = R.string.product_publish_dialog_title
+                title = if (viewModel.isDraftProduct()) {
+                    R.string.product_publish_draft_dialog_title
+                } else {
+                    R.string.product_publish_dialog_title
+                }
                 message = R.string.product_publish_dialog_message
             }
             else -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -216,7 +216,6 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         }
 
         requireActivity().invalidateOptionsMenu()
-        updateOptionsMenuDescription(product.remoteId)
     }
 
     private fun updateProductNameFromDetails(product: Product): String {
@@ -236,11 +235,6 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         menu.clear()
         inflater.inflate(R.menu.menu_product_detail_fragment, menu)
-
-        when (viewModel.isAddFlow) {
-            true -> setupProductAddOptionsMenu(menu)
-            else -> Unit
-        }
         super.onCreateOptionsMenu(menu, inflater)
     }
 
@@ -249,26 +243,15 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
 
         // visibility of these menu items depends on whether we're in the add product flow
         menu.findItem(R.id.menu_view_product).isVisible = viewModel.isProductPublished && !viewModel.isAddFlow
+        menu.findItem(R.id.menu_share).isVisible = !viewModel.isAddFlow
         menu.findItem(R.id.menu_save_as_draft).isVisible = viewModel.isAddFlow &&
             viewModel.hasChanges() &&
             FeatureFlag.PRODUCT_RELEASE_M4.isEnabled()
-        menu.findItem(R.id.menu_share).isVisible = !viewModel.isAddFlow
-    }
 
-    private fun setupProductAddOptionsMenu(menu: Menu) {
         doneOrUpdateMenuItem?.let {
-            it.title = getString(publishTitleId)
-            it.isVisible = true
+            it.title = if (viewModel.isAddFlow) getString(publishTitleId) else getString(updateTitleId)
+            it.isVisible = viewModel.hasChanges()
         }
-    }
-
-    private fun updateOptionsMenuDescription(remoteId: Long) {
-        val doneButtonTitle =
-            when (viewModel.isAddFlow) {
-                true -> getString(publishTitleId)
-                else -> getString(updateTitleId)
-            }
-        doneOrUpdateMenuItem?.title = doneButtonTitle
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -18,7 +18,6 @@ import com.woocommerce.android.R.string
 import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_ADD_IMAGE_TAPPED
 import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.hide
@@ -39,6 +38,7 @@ import com.woocommerce.android.ui.products.ProductShippingViewModel.ShippingData
 import com.woocommerce.android.ui.products.adapters.ProductPropertyCardsAdapter
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
 import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.Optional
 import com.woocommerce.android.widgets.CustomProgressDialog
 import com.woocommerce.android.widgets.SkeletonView
@@ -249,7 +249,9 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
 
         // visibility of these menu items depends on whether we're in the add product flow
         menu.findItem(R.id.menu_view_product).isVisible = viewModel.isProductPublished && !viewModel.isAddFlow
-        menu.findItem(R.id.menu_save_as_draft).isVisible = viewModel.isAddFlow && viewModel.hasChanges()
+        menu.findItem(R.id.menu_save_as_draft).isVisible = viewModel.isAddFlow &&
+            viewModel.hasChanges() &&
+            FeatureFlag.PRODUCT_RELEASE_M4.isEnabled()
         menu.findItem(R.id.menu_share).isVisible = !viewModel.isAddFlow
     }
 
@@ -271,6 +273,11 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
+            R.id.menu_save_as_draft -> {
+                viewModel.onSaveAsDraftButtonClicked()
+                true
+            }
+
             R.id.menu_share -> {
                 viewModel.onShareButtonClicked()
                 true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -215,6 +215,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
             )
         }
 
+        requireActivity().invalidateOptionsMenu()
         updateOptionsMenuDescription(product.remoteId)
     }
 
@@ -236,17 +237,20 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         menu.clear()
         inflater.inflate(R.menu.menu_product_detail_fragment, menu)
 
-        // display View Product on Store menu button only if the Product status is published,
-        // otherwise the page is redirected to a 404
-        menu.findItem(R.id.menu_view_product).isVisible = viewModel.isProductPublished && !viewModel.isAddFlow
-        menu.findItem(R.id.menu_share).isVisible = !viewModel.isAddFlow
-        menu.findItem(R.id.menu_product_settings).isVisible = true
-
         when (viewModel.isAddFlow) {
             true -> setupProductAddOptionsMenu(menu)
             else -> Unit
         }
         super.onCreateOptionsMenu(menu, inflater)
+    }
+
+    override fun onPrepareOptionsMenu(menu: Menu) {
+        super.onPrepareOptionsMenu(menu)
+
+        // visibility of these menu items depends on whether we're in the add product flow
+        menu.findItem(R.id.menu_view_product).isVisible = viewModel.isProductPublished && !viewModel.isAddFlow
+        menu.findItem(R.id.menu_save_as_draft).isVisible = viewModel.isAddFlow && viewModel.hasChanges()
+        menu.findItem(R.id.menu_share).isVisible = !viewModel.isAddFlow
     }
 
     private fun setupProductAddOptionsMenu(menu: Menu) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -14,7 +14,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.LayoutManager
 import com.woocommerce.android.R
-import com.woocommerce.android.R.string
 import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
@@ -24,7 +23,6 @@ import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.Product
-import com.woocommerce.android.model.Product.Image
 import com.woocommerce.android.ui.aztec.AztecEditorFragment
 import com.woocommerce.android.ui.aztec.AztecEditorFragment.Companion.ARG_AZTEC_EDITOR_TEXT
 import com.woocommerce.android.ui.main.MainActivity.NavigationResult
@@ -148,7 +146,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
             )
             changesMade()
         }
-        handleResult<List<Image>>(BaseProductEditorFragment.KEY_IMAGES_DIALOG_RESULT) {
+        handleResult<List<Product.Image>>(BaseProductEditorFragment.KEY_IMAGES_DIALOG_RESULT) {
             viewModel.updateProductDraft(
                 images = it
             )
@@ -220,7 +218,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
 
     private fun updateProductNameFromDetails(product: Product): String {
         return if (viewModel.isAddFlow && product.name.isEmpty()) {
-            getString(string.product_add_tool_bar_title)
+            getString(R.string.product_add_tool_bar_title)
         } else product.name.fastStripHtml()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -758,20 +758,23 @@ class ProductDetailViewModel @AssistedInject constructor(
     }
 
     /**
+     * Returns true if the product draft has a status of DRAFT
+     */
+    fun isDraftProduct() = viewState.productDraft?.status?.let { it == DRAFT } ?: false
+
+    /**
      * Add a new product to the backend only if network is connected.
      * Otherwise, an offline snackbar is displayed.
      */
     private suspend fun addProduct(product: Product) {
         if (networkStatus.isConnected()) {
-            val isDraft = product.status?.let { it == DRAFT } ?: false
-
-            @StringRes val successId = if (isDraft) {
+            @StringRes val successId = if (isDraftProduct()) {
                 string.product_detail_publish_product_draft_success
             } else {
                 string.product_detail_publish_product_success
             }
 
-            @StringRes val failId = if (isDraft) {
+            @StringRes val failId = if (isDraftProduct()) {
                 string.product_detail_publish_product_draft_error
             } else {
                 string.product_detail_publish_product_error

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -53,7 +53,6 @@ import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductSl
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductStatus
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductVisibility
 import com.woocommerce.android.ui.products.ProductStatus.DRAFT
-import com.woocommerce.android.ui.products.ProductType.SIMPLE
 import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
 import com.woocommerce.android.ui.products.categories.ProductCategoryItemUiModel
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
@@ -63,7 +62,6 @@ import com.woocommerce.android.ui.products.settings.ProductVisibility
 import com.woocommerce.android.ui.products.tags.ProductTagsRepository
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.Optional
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.LiveDataDelegate
@@ -566,13 +564,12 @@ class ProductDetailViewModel @AssistedInject constructor(
     }
 
     fun fetchBottomSheetList() {
-        val featureFlagCondition = FeatureFlag.PRODUCT_RELEASE_M3.isEnabled() || viewState.productDraft?.type == SIMPLE
         viewState.productDraft?.let {
             launch(dispatchers.computation) {
                 val detailList = productDetailBottomSheetBuilder.buildBottomSheetList(it)
                 withContext(dispatchers.main) {
                     _productDetailBottomSheetList.value = detailList
-                    viewState = viewState.copy(showBottomSheetButton = detailList.isNotEmpty() && featureFlagCondition)
+                    viewState = viewState.copy(showBottomSheetButton = detailList.isNotEmpty())
                 }
             }
         }

--- a/WooCommerce/src/main/res/menu/menu_product_detail_fragment.xml
+++ b/WooCommerce/src/main/res/menu/menu_product_detail_fragment.xml
@@ -6,30 +6,34 @@
     <item
         android:id="@+id/menu_done"
         android:title="@string/update"
-        app:showAsAction="ifRoom"
         android:visible="false"
-        tools:visible="true"/>
+        app:showAsAction="ifRoom"
+        tools:visible="true" />
+
+    <item
+        android:id="@+id/menu_save_as_draft"
+        android:title="@string/product_detail_safe_as_draft"
+        android:visible="false"
+        app:showAsAction="withText"
+        tools:visible="true" />
 
     <item
         android:id="@+id/menu_share"
-        android:icon="@drawable/ic_share_white_24dp"
         android:title="@string/share"
         app:showAsAction="withText"
-        tools:visible="true"
-        />
+        tools:visible="true" />
 
     <item
         android:id="@+id/menu_view_product"
         android:title="@string/product_view_in_store"
-        app:showAsAction="withText"
         android:visible="false"
-        tools:visible="true"/>
+        app:showAsAction="withText"
+        tools:visible="true" />
 
     <item
         android:id="@+id/menu_product_settings"
         android:title="@string/product_settings"
-        app:showAsAction="withText"
         android:visible="false"
-        tools:visible="true"
-        />
+        app:showAsAction="withText"
+        tools:visible="true" />
 </menu>

--- a/WooCommerce/src/main/res/menu/menu_product_detail_fragment.xml
+++ b/WooCommerce/src/main/res/menu/menu_product_detail_fragment.xml
@@ -1,39 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
         android:id="@+id/menu_done"
         android:title="@string/update"
         android:visible="false"
-        app:showAsAction="ifRoom"
-        tools:visible="true" />
+        app:showAsAction="ifRoom" />
 
     <item
         android:id="@+id/menu_save_as_draft"
         android:title="@string/product_detail_safe_as_draft"
-        android:visible="false"
-        app:showAsAction="withText"
-        tools:visible="true" />
+        app:showAsAction="withText" />
 
     <item
         android:id="@+id/menu_share"
         android:title="@string/share"
-        app:showAsAction="withText"
-        tools:visible="true" />
+        app:showAsAction="withText" />
 
     <item
         android:id="@+id/menu_view_product"
         android:title="@string/product_view_in_store"
-        android:visible="false"
-        app:showAsAction="withText"
-        tools:visible="true" />
+        app:showAsAction="withText" />
 
     <item
         android:id="@+id/menu_product_settings"
         android:title="@string/product_settings"
-        android:visible="false"
-        app:showAsAction="withText"
-        tools:visible="true" />
+        app:showAsAction="withText" />
 </menu>

--- a/WooCommerce/src/main/res/menu/menu_product_detail_fragment.xml
+++ b/WooCommerce/src/main/res/menu/menu_product_detail_fragment.xml
@@ -10,7 +10,7 @@
 
     <item
         android:id="@+id/menu_save_as_draft"
-        android:title="@string/product_detail_safe_as_draft"
+        android:title="@string/product_detail_save_as_draft"
         app:showAsAction="withText" />
 
     <item

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -618,7 +618,7 @@
     <string name="grouped_product_empty">Add products to the group</string>
     <string name="product_selection_count">%d products selected</string>
     <string name="product_selection_count_single">%d product selected</string>
-    <string name="product_detail_safe_as_draft">Save as draft</string>
+    <string name="product_detail_save_as_draft">Save as draft</string>
     <!--
         Product Add more details Bottom sheet
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -549,6 +549,8 @@
     <string name="product_update_dialog_message">Please wait…</string>
     <string name="product_detail_update_product_error">Error updating product</string>
     <string name="product_detail_update_product_success">Product updated</string>
+    <string name="product_detail_update_draft_success">Product draft saved</string>
+    <string name="product_detail_update_draft_error">Error saving product draft</string>
     <string name="product_detail_update_product_password_error">Error updating password</string>
     <string name="product_detail_title_hint">Enter Product Title</string>
     <string name="product_detail_editable_text_hint">Enter text</string>
@@ -969,6 +971,8 @@
     <string name="product_publish_dialog_message">@string/product_update_dialog_message</string>
     <string name="product_detail_publish_product_error">Error publishing product</string>
     <string name="product_detail_publish_product_success">Product published</string>
+    <string name="product_detail_publish_product_draft_error">Error saving product draft</string>
+    <string name="product_detail_publish_product_draft_success">Product draft saved</string>
 
     <!-- In-App Feedback -->
     <string name="feedback_request_title">Enjoying the WooCommerce app?</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -549,8 +549,6 @@
     <string name="product_update_dialog_message">Please wait…</string>
     <string name="product_detail_update_product_error">Error updating product</string>
     <string name="product_detail_update_product_success">Product updated</string>
-    <string name="product_detail_update_draft_success">Product draft saved</string>
-    <string name="product_detail_update_draft_error">Error saving product draft</string>
     <string name="product_detail_update_product_password_error">Error updating password</string>
     <string name="product_detail_title_hint">Enter Product Title</string>
     <string name="product_detail_editable_text_hint">Enter text</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -966,6 +966,7 @@
     <string name="product_add_tool_bar_title">New Product</string>
     <string name="product_add_tool_bar_menu_button_done">PUBLISH</string>
     <string name="product_publish_dialog_title">Publishing product</string>
+    <string name="product_publish_draft_dialog_title">Saving draft</string>
     <string name="product_publish_dialog_message">@string/product_update_dialog_message</string>
     <string name="product_detail_publish_product_error">Error publishing product</string>
     <string name="product_detail_publish_product_success">Product published</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -618,6 +618,7 @@
     <string name="grouped_product_empty">Add products to the group</string>
     <string name="product_selection_count">%d products selected</string>
     <string name="product_selection_count_single">%d product selected</string>
+    <string name="product_detail_safe_as_draft">Save as draft</string>
     <!--
         Product Add more details Bottom sheet
     -->


### PR DESCRIPTION
Closes #2905 - This PR is the first step towards enabling users to save a new product as a draft. To test, click the FAB in the product list to start the add product flow, make a change or two to the product, then select "Save as draft" from the options menu.

I also simplified some of the logic regarding menu item visibility and text, since that was necessary to ensure "Save as draft" only appears in the add flow after changes have been made.

![draft](https://user-images.githubusercontent.com/3903757/94674526-4f3c0800-02e6-11eb-9b02-79b1a00bdd0a.gif)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
