### PR TITLE
Unit test improvements

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.util.observeForTesting
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
+import com.woocommerce.android.viewmodel.TestDispatcher
 import com.woocommerce.android.viewmodel.test
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.NETWORK_ERROR
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.NETWORK_OFFLINE
@@ -35,6 +36,7 @@ import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.ORDER_LIST_ALL_
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.ORDER_LIST_LOADING
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.SEARCH_RESULTS
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.InternalCoroutinesApi
 import org.junit.Before
 import org.junit.Test
 import org.wordpress.android.fluxc.Dispatcher
@@ -50,6 +52,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+@InternalCoroutinesApi
 class OrderListViewModelTest : BaseUnitTest() {
     private val selectedSite: SelectedSite = mock()
     private val networkStatus: NetworkStatus = mock()
@@ -58,9 +61,9 @@ class OrderListViewModelTest : BaseUnitTest() {
     private val orderStore: WCOrderStore = mock()
     private val resourceProvider: ResourceProvider = mock()
     private val coroutineDispatchers = CoroutineDispatchers(
-        Dispatchers.Unconfined,
-        Dispatchers.Unconfined,
-        Dispatchers.Unconfined
+        TestDispatcher,
+        TestDispatcher,
+        TestDispatcher
     )
     private val savedStateArgs: SavedStateWithArgs = mock()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -35,7 +35,6 @@ import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.ORDER_LIST
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.ORDER_LIST_ALL_PROCESSED
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.ORDER_LIST_LOADING
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.SEARCH_RESULTS
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -27,10 +27,14 @@ import com.woocommerce.android.util.observeForTesting
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
-import com.woocommerce.android.viewmodel.TEST_DISPATCHER
 import com.woocommerce.android.viewmodel.test
-import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
-import kotlinx.coroutines.InternalCoroutinesApi
+import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.NETWORK_ERROR
+import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.NETWORK_OFFLINE
+import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.ORDER_LIST
+import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.ORDER_LIST_ALL_PROCESSED
+import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.ORDER_LIST_LOADING
+import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.SEARCH_RESULTS
+import kotlinx.coroutines.Dispatchers
 import org.junit.Before
 import org.junit.Test
 import org.wordpress.android.fluxc.Dispatcher
@@ -46,7 +50,6 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-@UseExperimental(InternalCoroutinesApi::class)
 class OrderListViewModelTest : BaseUnitTest() {
     private val selectedSite: SelectedSite = mock()
     private val networkStatus: NetworkStatus = mock()
@@ -55,9 +58,9 @@ class OrderListViewModelTest : BaseUnitTest() {
     private val orderStore: WCOrderStore = mock()
     private val resourceProvider: ResourceProvider = mock()
     private val coroutineDispatchers = CoroutineDispatchers(
-            TEST_DISPATCHER,
-            TEST_DISPATCHER,
-            TEST_DISPATCHER
+        Dispatchers.Unconfined,
+        Dispatchers.Unconfined,
+        Dispatchers.Unconfined
     )
     private val savedStateArgs: SavedStateWithArgs = mock()
 
@@ -251,7 +254,7 @@ class OrderListViewModelTest : BaseUnitTest() {
      * - There are NO orders in the db for the active store
      */
     @Test
-    fun `Display |No orders yet| empty view when no orders for site for ALL tab`() = test {
+    fun `Display 'No orders yet' empty view when no orders for site for ALL tab`() = test {
         viewModel.isSearching = false
         doReturn(true).whenever(repository).hasCachedOrdersForSite()
 
@@ -265,7 +268,7 @@ class OrderListViewModelTest : BaseUnitTest() {
             // Verify
             val emptyView = viewModel.emptyViewType.value
             assertNotNull(emptyView)
-            assertTrue(emptyView == EmptyViewType.ORDER_LIST)
+            assertEquals(emptyView, ORDER_LIST)
         }
     }
 
@@ -283,7 +286,7 @@ class OrderListViewModelTest : BaseUnitTest() {
      * - There are NO orders in the db for the active store
      */
     @Test
-    fun `Display |No orders to process yet| empty view when no orders for site for PROCESSING tab`() = test {
+    fun `Display 'No orders to process yet' empty view when no orders for site for PROCESSING tab`() = test {
         viewModel.isSearching = false
         viewModel.orderStatusFilter = CoreOrderStatus.PROCESSING.value
         doReturn(true).whenever(repository).hasCachedOrdersForSite()
@@ -298,7 +301,7 @@ class OrderListViewModelTest : BaseUnitTest() {
             // Verify
             val emptyView = viewModel.emptyViewType.value
             assertNotNull(emptyView)
-            assertTrue(emptyView == EmptyViewType.ORDER_LIST_ALL_PROCESSED)
+            assertEquals(emptyView, ORDER_LIST_ALL_PROCESSED)
         }
     }
 
@@ -315,7 +318,7 @@ class OrderListViewModelTest : BaseUnitTest() {
      * - There is 1 or more orders in the db for the active store
      */
     @Test
-    fun `Processing Tab displays |All orders processed| empty view if no orders to process`() = test {
+    fun `Processing Tab displays 'All orders processed' empty view if no orders to process`() = test {
         viewModel.isSearching = false
         viewModel.orderStatusFilter = CoreOrderStatus.PROCESSING.value
         doReturn(true).whenever(repository).hasCachedOrdersForSite()
@@ -330,7 +333,7 @@ class OrderListViewModelTest : BaseUnitTest() {
             // Verify
             val emptyView = viewModel.emptyViewType.value
             assertNotNull(emptyView)
-            assertTrue(emptyView == EmptyViewType.ORDER_LIST_ALL_PROCESSED)
+            assertEquals(emptyView, ORDER_LIST_ALL_PROCESSED)
         }
     }
 
@@ -360,7 +363,7 @@ class OrderListViewModelTest : BaseUnitTest() {
             // Verify
             val emptyView = viewModel.emptyViewType.value
             assertNotNull(emptyView)
-            assertTrue(emptyView == EmptyViewType.NETWORK_ERROR)
+            assertEquals(emptyView, NETWORK_ERROR)
         }
     }
 
@@ -391,7 +394,7 @@ class OrderListViewModelTest : BaseUnitTest() {
             // Verify
             val emptyView = viewModel.emptyViewType.value
             assertNotNull(emptyView)
-            assertTrue(emptyView == EmptyViewType.NETWORK_OFFLINE)
+            assertEquals(emptyView, NETWORK_OFFLINE)
         }
     }
 
@@ -419,7 +422,7 @@ class OrderListViewModelTest : BaseUnitTest() {
             // Verify
             val emptyView = viewModel.emptyViewType.value
             assertNotNull(emptyView)
-            assertTrue(emptyView == EmptyViewType.SEARCH_RESULTS)
+            assertEquals(emptyView, SEARCH_RESULTS)
         }
     }
 
@@ -445,7 +448,7 @@ class OrderListViewModelTest : BaseUnitTest() {
             // Verify
             val emptyView = viewModel.emptyViewType.value
             assertNotNull(emptyView)
-            assertTrue(emptyView == EmptyViewType.ORDER_LIST_LOADING)
+            assertEquals(emptyView, ORDER_LIST_LOADING)
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModelTest.kt
@@ -19,30 +19,43 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
+import com.woocommerce.android.viewmodel.TestDispatcher
 import com.woocommerce.android.viewmodel.test
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.delay
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 
+@InternalCoroutinesApi
 class ProductInventoryViewModelTest : BaseUnitTest() {
     private val productDetailRepository: ProductDetailRepository = mock()
 
     private val takenSku = "taken"
 
     private val initialData = InventoryData(
-        "SKU123", false, false, InStock, 10, No
+        "SKU123",
+        isStockManaged = false,
+        isSoldIndividually = false,
+        stockStatus = InStock,
+        stockQuantity = 10,
+        backorderStatus = No
     )
 
     private val expectedData = InventoryData(
-        "SKU321", true, true, OutOfStock, 0, Yes
+        "SKU321",
+        isStockManaged = true,
+        isSoldIndividually = true,
+        stockStatus = OutOfStock,
+        stockQuantity = 0,
+        backorderStatus = Yes
     )
 
     private val coroutineDispatchers = CoroutineDispatchers(
-        Dispatchers.Unconfined,
-        Dispatchers.Unconfined,
-        Dispatchers.Unconfined
+        TestDispatcher,
+        TestDispatcher,
+        TestDispatcher
     )
 
     private lateinit var viewModel: ProductInventoryViewModel
@@ -119,7 +132,6 @@ class ProductInventoryViewModelTest : BaseUnitTest() {
         assertThat(actual?.inventoryData?.sku).isEqualTo(expectedData.sku)
         assertThat(actual?.isDoneButtonVisible).isTrue()
 
-        delay(600)
         assertThat(actual?.isDoneButtonVisible).isTrue()
         assertThat(actual?.isDoneButtonDisabled).isFalse()
         assertThat(actual?.skuErrorMessage).isEqualTo(0)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModelTest.kt
@@ -21,9 +21,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
 import com.woocommerce.android.viewmodel.TestDispatcher
 import com.woocommerce.android.viewmodel.test
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.InternalCoroutinesApi
-import kotlinx.coroutines.delay
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
@@ -32,7 +32,10 @@ class ProductListViewModelTest : BaseUnitTest() {
     private val prefs: AppPrefs = mock()
 
     private val coroutineDispatchers = CoroutineDispatchers(
-            Dispatchers.Unconfined, Dispatchers.Unconfined, Dispatchers.Unconfined)
+        Dispatchers.Unconfined,
+        Dispatchers.Unconfined,
+        Dispatchers.Unconfined
+    )
     private val productList = ProductTestUtils.generateProductList()
     private lateinit var viewModel: ProductListViewModel
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/viewmodel/CoroutinesUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/viewmodel/CoroutinesUtils.kt
@@ -4,8 +4,6 @@ import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Delay
-import kotlinx.coroutines.Dispatchers.Unconfined
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlin.coroutines.CoroutineContext
@@ -16,11 +14,8 @@ fun <T> test(context: CoroutineContext = EmptyCoroutineContext, block: suspend C
     runBlocking(context, block)
 }
 
-@ExperimentalCoroutinesApi val TEST_SCOPE = CoroutineScope(Unconfined)
-@InternalCoroutinesApi val TEST_DISPATCHER: CoroutineDispatcher = TestDispatcher()
-
 @InternalCoroutinesApi
-private class TestDispatcher : CoroutineDispatcher(), Delay {
+object TestDispatcher : CoroutineDispatcher(), Delay {
     @InternalCoroutinesApi
     override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) {
         continuation.resume(Unit)


### PR DESCRIPTION
This is just a minor unit test fix, which removes some warnings but mainly removes the `|` characters from method names. These were used in the `OrderListViewModelTest` and I had to comment it all out because I couldn't run the tests.

I also used a `TestDispatcher` in `ProductInventoryViewModelTest`, which skips the coroutine `delay()` calls.