### PR TITLE
Fix: Navigation result lost

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -28,8 +28,14 @@ fun <T> Fragment.navigateBackWithResult(key: String, result: T) {
  * called, the boolean value is updated. This puts a limit on the number of observers for a particular key-result pair
  * to 1.
  */
-fun <T> Fragment.handleResult(key: String, handler: (T) -> Unit) {
-    findNavController().currentBackStackEntry?.savedStateHandle?.getLiveData<Pair<T, AtomicBoolean>>(key)?.observe(
+fun <T> Fragment.handleResult(key: String, entryId: Int? = null, handler: (T) -> Unit) {
+    val entry = if (entryId != null) {
+        findNavController().getBackStackEntry(entryId)
+    } else {
+        findNavController().currentBackStackEntry
+    }
+
+    entry?.savedStateHandle?.getLiveData<Pair<T, AtomicBoolean>>(key)?.observe(
         this.viewLifecycleOwner,
         Observer {
             val isFresh = it.second.getAndSet(false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -333,7 +333,7 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener, ProductS
     }
 
     private fun setupResultHandlers() {
-        handleResult<Bundle>(ProductDetailFragment.KEY_PRODUCT_DETAIL_RESULT) { bundle ->
+        handleResult<Bundle>(ProductDetailFragment.KEY_PRODUCT_DETAIL_RESULT, R.id.rootFragment) { bundle ->
             if (bundle.getBoolean(ProductDetailFragment.KEY_PRODUCT_DETAIL_DID_TRASH)) {
                 // User chose to trash from product detail, but we do the actual trashing here
                 // so we can show a snackbar enabling the user to undo the trashing.


### PR DESCRIPTION
This PR fixes a problem when a top fragment never receives a result from a child fragment and there is a configuration change. In this case, a top fragment always has to supply the `R.id.rootFragment` as an ID when calling `handleResult()`.

**To test:**
1. Go To Products -> Product detail
2. Rotate the screen
3. Tap on Trash product from the menu & confirm
4. Notice the product gets removed from the list