### PR TITLE
Issue/2949 product detail trashed badge

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductStatus.kt
@@ -13,7 +13,8 @@ enum class ProductStatus(@StringRes val stringResource: Int = 0, val value: Stri
     PUBLISH(R.string.product_status_published, CoreProductStatus.PUBLISH.value),
     DRAFT(R.string.product_status_draft, CoreProductStatus.DRAFT.value),
     PENDING(R.string.product_status_pending, CoreProductStatus.PENDING.value),
-    PRIVATE(R.string.product_status_private, CoreProductStatus.PRIVATE.value);
+    PRIVATE(R.string.product_status_private, CoreProductStatus.PRIVATE.value),
+    TRASH(R.string.product_status_trashed, CoreProductStatus.TRASH.value);
 
     /**
      * Returns a localized string used when displaying the status in the UI. The "long" parameter
@@ -26,6 +27,7 @@ enum class ProductStatus(@StringRes val stringResource: Int = 0, val value: Stri
             DRAFT -> R.string.product_status_draft
             PENDING -> R.string.product_status_pending
             PRIVATE -> if (long) R.string.product_status_privately_published else R.string.product_status_private
+            TRASH -> R.string.product_status_trashed
         }
         return context.getString(resId)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductStatusFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductStatusFragment.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.ui.products.ProductStatus.DRAFT
 import com.woocommerce.android.ui.products.ProductStatus.PENDING
 import com.woocommerce.android.ui.products.ProductStatus.PRIVATE
 import com.woocommerce.android.ui.products.ProductStatus.PUBLISH
+import com.woocommerce.android.ui.products.ProductStatus.TRASH
 import kotlinx.android.synthetic.main.fragment_product_status.*
 
 /**
@@ -47,6 +48,7 @@ class ProductStatusFragment : BaseProductSettingsFragment(), OnClickListener {
         btnPublishedPrivately.setOnClickListener(this)
         btnDraft.setOnClickListener(this)
         btnPending.setOnClickListener(this)
+        btnTrashed.setOnClickListener(this)
 
         selectedStatus?.let { status ->
             getButtonForStatus(status)?.isChecked = true
@@ -74,6 +76,7 @@ class ProductStatusFragment : BaseProductSettingsFragment(), OnClickListener {
             btnPublishedPrivately.isChecked = it == btnPublishedPrivately
             btnDraft.isChecked = it == btnDraft
             btnPending.isChecked = it == btnPending
+            btnTrashed.isChecked = it == btnTrashed
             selectedStatus = getStatusForButtonId(it.id)
 
             changesMade()
@@ -103,6 +106,7 @@ class ProductStatusFragment : BaseProductSettingsFragment(), OnClickListener {
             DRAFT -> btnDraft
             PENDING -> btnPending
             PRIVATE -> btnPublishedPrivately
+            TRASH -> btnTrashed
             else -> null
         }
     }
@@ -113,6 +117,7 @@ class ProductStatusFragment : BaseProductSettingsFragment(), OnClickListener {
             R.id.btnDraft -> DRAFT.toString()
             R.id.btnPending -> PENDING.toString()
             R.id.btnPrivate -> PRIVATE.toString()
+            R.id.btnTrashed -> TRASH.toString()
             else -> null
         }
     }

--- a/WooCommerce/src/main/res/layout/fragment_product_status.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_status.xml
@@ -44,4 +44,12 @@
 
     <View style="@style/Woo.Divider" />
 
+    <CheckedTextView
+        android:id="@+id/btnTrashed"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/product_status_trashed" />
+
+    <View style="@style/Woo.Divider" />
+
 </LinearLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -932,6 +932,7 @@
     <string name="product_status_private">Private</string>
     <string name="product_status_pending">Pending review</string>
     <string name="product_status_draft">Draft</string>
+    <string name="product_status_trashed">Trashed</string>
 
     <!-- Product type -->
     <string name="product_type_simple">Simple</string>

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.6.22'
+    fluxCVersion = 'de24ea503a1850414cabe7c5a7c73ed05f606520'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'de24ea503a1850414cabe7c5a7c73ed05f606520'
+    fluxCVersion = '2662558347acb06681a748ea6bf06bb04e16e8bc'
     daggerVersion = '2.25.2'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Closes #2949 - adds a 'Trashed" badge to products that are in the trash. This is a draft because [this FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1708) needs to be merged first.

To test:

* Go to the product list in the app
* On the web, send one of the products displayed in the app to the trash
* Open that in product detail in the app
* After the product is retrieved from the backend, verify that a "Trashed" badge is displayed


![trashed](https://user-images.githubusercontent.com/3903757/94954023-76493400-04b6-11eb-905a-7d1f392dae2e.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
