### PR TITLE
Disable product type pre-selection

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -44,7 +44,6 @@ import com.woocommerce.android.ui.products.ProductFilterListViewModel.Companion.
 import com.woocommerce.android.ui.products.ProductListAdapter.OnProductClickListener
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ScrollToTop
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowAddProductBottomSheet
-import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.StartAddProductFlow
 import com.woocommerce.android.ui.products.ProductSortAndFiltersCard.ProductSortAndFilterListener
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -330,7 +330,6 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener, ProductS
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is ScrollToTop -> scrollToTop()
                 is ShowAddProductBottomSheet -> showAddProductBottomSheet()
-                is StartAddProductFlow -> startAddProductFlow()
                 else -> event.isHandled = false
             }
         })
@@ -469,12 +468,6 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener, ProductS
     }
 
     private fun showAddProductBottomSheet() = (activity as? MainNavigationRouter)?.showProductAddBottomSheet()
-
-    private fun startAddProductFlow() {
-        disableSearchListeners()
-        showOptionsMenu(false)
-        (activity as? MainNavigationRouter)?.showAddProduct()
-    }
 
     override fun onRequestLoadMore() {
         viewModel.onLoadMoreRequested()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -15,7 +15,6 @@ import com.woocommerce.android.model.Product
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ScrollToTop
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowAddProductBottomSheet
-import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.StartAddProductFlow
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.LiveDataDelegate
@@ -133,12 +132,7 @@ class ProductListViewModel @AssistedInject constructor(
     }
 
     fun onAddProductButtonClicked() {
-        val shouldShowProductBottomSheet = prefs.getSelectedProductType().isEmpty()
-        if (shouldShowProductBottomSheet) {
-            triggerEvent(ShowAddProductBottomSheet)
-        } else {
-            triggerEvent(StartAddProductFlow)
-        }
+        triggerEvent(ShowAddProductBottomSheet)
     }
 
     fun onSearchOpened() {
@@ -365,7 +359,6 @@ class ProductListViewModel @AssistedInject constructor(
     sealed class ProductListEvent : Event() {
         object ScrollToTop : ProductListEvent()
         object ShowAddProductBottomSheet : ProductListEvent()
-        object StartAddProductFlow : ProductListEvent()
     }
 
     @AssistedInject.Factory


### PR DESCRIPTION
This PR removes the product type preference pre-selection after a product type is selected the first time and always displays the bottom sheet after the Add product button is tapped.