### PR TITLE
Enable grouped product adding

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductAddTypeBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductAddTypeBottomSheetBuilder.kt
@@ -30,7 +30,7 @@ class ProductAddTypeBottomSheetBuilder : ProductTypeBottomSheetBuilder {
                 titleResource = string.product_add_type_grouped,
                 descResource = string.product_add_type_grouped_desc,
                 iconResource = drawable.ic_widgets,
-                isEnabled = false
+                isEnabled = true
             ),
             ProductTypesBottomSheetUiItem(
                 type = EXTERNAL,


### PR DESCRIPTION
Fixes #2960. This PR enables the grouped product in the add product bottom sheet.

**To test:**
1. Go to Products
2. Tap on Add product FAB
3. Notice that Grouped product option is enabled
4. Tap on the Grouped product
5. Notice that the product type is set as Grouped product
6. Fill out the properties and publish the product
7. After saving's done, tap on the back button and notice that the product now appears in the product list
8. Open the product again and verify all the data is present