### PR TITLE
Fix multiple crashes in Product detail

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -16,7 +16,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * handled/observed.
  */
 fun <T> Fragment.navigateBackWithResult(key: String, result: T) {
-    findNavController().previousBackStackEntry?.savedStateHandle?.set(key, Pair(result, AtomicBoolean(true)))
+    findNavController().previousBackStackEntry?.savedStateHandle?.set(key, result)
     findNavController().navigateUp()
 }
 
@@ -29,13 +29,11 @@ fun <T> Fragment.navigateBackWithResult(key: String, result: T) {
  * to 1.
  */
 fun <T> Fragment.handleResult(key: String, handler: (T) -> Unit) {
-    findNavController().currentBackStackEntry?.savedStateHandle?.getLiveData<Pair<T, AtomicBoolean>>(key)?.observe(
+    findNavController().currentBackStackEntry?.savedStateHandle?.getLiveData<T>(key)?.observe(
         this.viewLifecycleOwner,
         Observer {
-            val isFresh = it.second.getAndSet(false)
-            if (isFresh) {
-                handler(it.first)
-            }
+            findNavController().currentBackStackEntry?.savedStateHandle?.remove<T>(key)
+            handler(it)
         }
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -11,9 +11,6 @@ import java.util.concurrent.atomic.AtomicBoolean
  *
  * This mechanism is used to facilitate the request-result communication between 2 separate fragments.
  *
- * Note: The value is stored along with a boolean value (true), which signifies that the data is fresh and has not been
- * observed yet. AtomicBoolean type is used to store the boolean so that the value can be updated once once the data is
- * handled/observed.
  */
 fun <T> Fragment.navigateBackWithResult(key: String, result: T) {
     findNavController().previousBackStackEntry?.savedStateHandle?.set(key, result)
@@ -24,9 +21,9 @@ fun <T> Fragment.navigateBackWithResult(key: String, result: T) {
  * A helper function that subscribes a supplied handler function to the Fragment's SavedStateHandle LiveData associated
  * with the supplied key.
  *
- * Note: The handler is called only if the value wasn't handled before (i.e. the data is fresh). Once the observer is
- * called, the boolean value is updated. This puts a limit on the number of observers for a particular key-result pair
- * to 1.
+ * Note: Once the observer is called, the value is removed from the SavedStateHandle so that the handler isn't called
+ * repeatedly on device rotation. Another reason is that the value does not need to be serialized.
+ * This puts a limit on the number of observers for a particular key-result pair to 1.
  */
 fun <T> Fragment.handleResult(key: String, handler: (T) -> Unit) {
     findNavController().currentBackStackEntry?.savedStateHandle?.getLiveData<T>(key)?.observe(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.extensions
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
-import java.util.concurrent.atomic.AtomicBoolean
 
 /*
  * A helper function that sets the submitted key-value pair in the Fragment's SavedStateHandle. The value can be

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -25,11 +25,13 @@ fun <T> Fragment.navigateBackWithResult(key: String, result: T) {
  * This puts a limit on the number of observers for a particular key-result pair to 1.
  */
 fun <T> Fragment.handleResult(key: String, handler: (T) -> Unit) {
-    findNavController().currentBackStackEntry?.savedStateHandle?.getLiveData<T>(key)?.observe(
-        this.viewLifecycleOwner,
-        Observer {
-            findNavController().currentBackStackEntry?.savedStateHandle?.remove<T>(key)
-            handler(it)
-        }
-    )
+    findNavController().currentBackStackEntry?.savedStateHandle?.let { saveState ->
+        saveState.getLiveData<T>(key).observe(
+            this.viewLifecycleOwner,
+            Observer {
+                saveState.remove<T>(key)
+                handler(it)
+            }
+        )
+    }
 }


### PR DESCRIPTION
Fixes #2963, #2964, and #2965.

The problem was with serialization/deserialization of the `Pair`s that were being saved in the `SavedStateHandle` as a way to return a value to a different fragment. 

It turns out that once a result is handled, there is no need to keep the value so it can simply be removed and it will never need to get serialized. This also solves the repeated handler-calling after screen rotation, so the use of `AtomicBoolean` can be also removed and only the actual result is passed.

**To test:**
- Test the reproduction scenario in each issue above (image gallery, shipping, inventory, pricing, grouped products)
- Test that the fix from #2929 is still fixed