### PR TITLE
Change Feedback card UI reference to the correct one

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -31,7 +31,6 @@ import kotlinx.android.synthetic.main.fragment_dashboard.empty_stats_view
 import kotlinx.android.synthetic.main.fragment_dashboard.empty_view
 import kotlinx.android.synthetic.main.fragment_dashboard.scroll_view
 import kotlinx.android.synthetic.main.fragment_dashboard.view.*
-import kotlinx.android.synthetic.main.fragment_my_store.*
 import org.wordpress.android.fluxc.model.WCTopEarnerModel
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import java.util.Calendar
@@ -337,7 +336,7 @@ class DashboardFragment : TopLevelFragment(), DashboardContract.View, DashboardS
     private fun handleFeedbackRequestPositiveClick() {
         context?.let {
             // Hide the card and set last feedback date to now
-            store_feedback_request_card.visibility = View.GONE
+            dashboard_feedback_request_card.visibility = View.GONE
             FeedbackPrefs.lastFeedbackDate = Calendar.getInstance().time
 
             // Request a ReviewInfo object from the Google Reviews API. If this fails


### PR DESCRIPTION
Summary
==========
Fixes issue #2966. The `DashboardFragment` was doing direct access to a `MyStoreFragment` View component, causing a nullability issue since the object is non-existent inside the Dashboard context.

How to Test
==========

1. Change your testing site to any version below 4.0 in order to forcefully make the app use the Stats V3 and Dashboard classes
2. Do the three months time jump on the device calendar in order to trigger the Feedback Request Card at the `My Store` section of the app
3. Click on the `I like it` button
4. Verify that the app doesn't crash and the card is dismissed correctly

Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
