### PR TITLE
issue/2975-remove-product-review-list-ripple

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
@@ -27,7 +27,7 @@ import kotlinx.android.synthetic.main.fragment_reviews_list.*
 import kotlinx.android.synthetic.main.fragment_reviews_list.view.*
 import javax.inject.Inject
 
-class ProductReviewsFragment : BaseFragment(), ReviewListAdapter.OnReviewClickListener {
+class ProductReviewsFragment : BaseFragment() {
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     @Inject lateinit var viewModelFactory: ViewModelFactory
@@ -56,7 +56,7 @@ class ProductReviewsFragment : BaseFragment(), ReviewListAdapter.OnReviewClickLi
         super.onActivityCreated(savedInstanceState)
 
         val activity = requireActivity()
-        reviewsAdapter = ReviewListAdapter(activity, this)
+        reviewsAdapter = ReviewListAdapter(activity, null)
 
         reviewsList.apply {
             layoutManager = LinearLayoutManager(context)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListAdapter.kt
@@ -25,7 +25,7 @@ import kotlinx.android.synthetic.main.order_list_header.view.*
 
 class ReviewListAdapter(
     private val context: Context,
-    private val clickListener: OnReviewClickListener
+    private val clickListener: OnReviewClickListener?
 ) : SectionedRecyclerViewAdapter() {
     private val reviewList = mutableListOf<ProductReview>()
 
@@ -367,8 +367,10 @@ class ReviewListAdapter(
                 itemHolder.divider.visibility = View.INVISIBLE
             }
 
-            itemHolder.itemView.setOnClickListener {
-                clickListener.onReviewClick(review)
+            clickListener?.let { listener ->
+                itemHolder.itemView.setOnClickListener {
+                    listener.onReviewClick(review)
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #2975 - The product review list doesn't enable tapping an item to open the review detail, but the item still shows a ripple as though it's supposed to be tappable. This simple PR removes the ripple.

Note that this is just a quick fix. There's an ongoing discussion about how to best handle this. Ideally we'd show review detail, but the problem is the review detail has moderation tools, and the actual moderation is handled by the review list - there's no similar logic in the _product_ review list.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
