### PR TITLE
Product details: Enable variable products

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductAddTypeBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductAddTypeBottomSheetBuilder.kt
@@ -23,7 +23,7 @@ class ProductAddTypeBottomSheetBuilder : ProductTypeBottomSheetBuilder {
                 titleResource = string.product_add_type_variable,
                 descResource = string.product_add_type_variable_desc,
                 iconResource = drawable.ic_gridicons_types,
-                isEnabled = false
+                isEnabled = true
             ),
             ProductTypesBottomSheetUiItem(
                 type = GROUPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -554,7 +554,7 @@ class ProductDetailCardBuilder(
     }
 
     // show product variations only if product type is variable and if there are variations for the product
-    private fun Product.variations(): ProductProperty? {
+    private fun Product.variations(): ProductProperty {
         return if (this.numVariations > 0) {
             val properties = mutableMapOf<String, String>()
             for (attribute in this.attributes) {
@@ -573,7 +573,16 @@ class ProductDetailCardBuilder(
                 )
             }
         } else {
-            null
+            ComplexProperty(
+                R.string.product_variations,
+                resources.getString(R.string.product_detail_no_variations),
+                R.drawable.ic_gridicons_types
+            ) {
+                viewModel.onEditProductCardClicked(
+                    ViewProductVariations(this.remoteId),
+                    Stat.PRODUCT_DETAIL_VIEW_PRODUCT_VARIANTS_TAPPED
+                )
+            }
         }
     }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -569,7 +569,7 @@
     <string name="product_wip_message_m2">We\'ve added more editing functionalities to products! You can now update images, see previews and share your products.</string>
     <string name="product_wip_message_m3">You can now edit grouped, external and variable products, change product type and update categories and tags.</string>
     <string name="product_bullet" translatable="false"> \u2022 </string>
-    <string name="product_variant_list_empty">Add options like size and color from web. These will show up as options on the product page of your site</string>
+    <string name="product_variant_list_empty">Adding options like size and color is currently available only on the web. These will show up as options on the product page of your site.</string>
     <string name="product_description_hint">Start writing…</string>
     <string name="product_edit_description">Edit description</string>
     <string name="product_description">Description</string>
@@ -585,6 +585,7 @@
     <string name="product_detail_editable_text_hint">Enter text</string>
     <string name="product_detail_product_type_hint">%1$s product</string>
     <string name="product_detail_add_more">Add more details</string>
+    <string name="product_detail_no_variations">This product has no variations yet</string>
     <string name="product_inventory_quantity">Quantity</string>
     <string name="product_inventory_quantity_summary">How many items are in stock</string>
     <string name="product_inventory_update_sku_error">SKU already in use by another product</string>


### PR DESCRIPTION
Fixes #2979 and #2789. This PR enables the variable product in the add product bottom sheet.

Note: Adding variations is not available yet and is planned for M5.

| Product detail | Empty variation list |
|-|-|
| ![image](https://user-images.githubusercontent.com/1522856/95497047-04835580-09a2-11eb-9323-00379fe49598.png) | ![image](https://user-images.githubusercontent.com/1522856/95497064-0cdb9080-09a2-11eb-97d6-ff27974c3279.png) |
| ![image](https://user-images.githubusercontent.com/1522856/95497166-32689a00-09a2-11eb-9808-f91b99050795.png) | ![image](https://user-images.githubusercontent.com/1522856/95497202-3d232f00-09a2-11eb-8887-4f357e4cf00a.png) |

**To test:**

1. Go to Products
2. Tap on Add product FAB
3. Notice that Variable product option is enabled
4. Tap on the Variable product
5. Notice that the product type is set as Variable product
6. Notice there is message saying there are no variations yet
7. Fill out other properties and publish the product
8. After saving's done, tap on the back button and notice that the product now appears in the product list
9. Open the product again and verify all the data is present