### PR TITLE
Allow option to single tap a product for selection

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.products
 
 import android.content.Context
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
@@ -156,5 +157,6 @@ class ProductItemViewHolder(parent: ViewGroup) : RecyclerView.ViewHolder(
         object : ItemDetailsLookup.ItemDetails<Long>() {
             override fun getPosition() = adapterPosition
             override fun getSelectionKey() = itemId
+            override fun inSelectionHotspot(e: MotionEvent) = true
         }
 }


### PR DESCRIPTION
Fixes #2969 by allowing the option to single select a grouped product for selection. This option is disabled by default when using the `recyclerView-selection` library but can be enabled by overriding the `inSelectionHotspot` method and returning `true`.

#### To test
- Click on a grouped product from the product list.
- Click on `Grouped products` section.
- Click on `Add Product`.
- Single tap a product from the list and notice the item is selected as expected.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
