### PR TITLE
Variation details: Remove shipping class

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
@@ -189,7 +189,7 @@ class VariationDetailCardBuilder(
             val shippingGroup = if (hasShippingInfo) {
                 mapOf(
                     Pair(resources.getString(string.product_weight), weightWithUnits),
-                    Pair(resources.getString(string.product_dimensions), sizeWithUnits),
+                    Pair(resources.getString(string.product_dimensions), sizeWithUnits)
                 )
             } else {
                 mapOf(Pair("", resources.getString(string.product_shipping_empty)))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
@@ -190,10 +190,6 @@ class VariationDetailCardBuilder(
                 mapOf(
                     Pair(resources.getString(string.product_weight), weightWithUnits),
                     Pair(resources.getString(string.product_dimensions), sizeWithUnits),
-                    Pair(
-                        resources.getString(string.product_shipping_class),
-                        viewModel.getShippingClassByRemoteShippingClassId(this.shippingClassId)
-                    )
                 )
             } else {
                 mapOf(Pair("", resources.getString(string.product_shipping_empty)))


### PR DESCRIPTION
Because [editing shipping class is not yet supported](https://github.com/woocommerce/woocommerce-android/issues/2782) for variations, the shipping class should not be shown in variation details.

![image](https://user-images.githubusercontent.com/1522856/95563279-7d73c300-0a1d-11eb-9f8e-bcb60103bc2c.png)
