### PR TITLE
Issue/2968 update product type fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailTypeBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailTypeBottomSheetBuilder.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.products.ProductType.EXTERNAL
 import com.woocommerce.android.ui.products.ProductType.GROUPED
 import com.woocommerce.android.ui.products.ProductType.SIMPLE
+import com.woocommerce.android.ui.products.ProductType.VARIABLE
 import com.woocommerce.android.ui.products.ProductTypesBottomSheetViewModel.ProductTypesBottomSheetUiItem
 
 class ProductDetailTypeBottomSheetBuilder : ProductTypeBottomSheetBuilder {
@@ -11,16 +12,16 @@ class ProductDetailTypeBottomSheetBuilder : ProductTypeBottomSheetBuilder {
         return listOf(
             ProductTypesBottomSheetUiItem(
                 type = SIMPLE,
-                titleResource = R.string.product_type_physical,
+                titleResource = R.string.product_type_simple,
                 descResource = R.string.product_type_physical_desc,
                 iconResource = R.drawable.ic_gridicons_product,
                 isEnabled = true
             ),
             ProductTypesBottomSheetUiItem(
-                type = SIMPLE,
-                titleResource = R.string.product_type_virtual,
-                descResource = R.string.product_type_virtual_desc,
-                iconResource = R.drawable.ic_gridicons_cloud_outline,
+                type = VARIABLE,
+                titleResource = R.string.product_type_variable,
+                descResource = R.string.product_type_variation_desc,
+                iconResource = R.drawable.ic_gridicons_types,
                 isEnabled = true
             ),
             ProductTypesBottomSheetUiItem(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
@@ -97,7 +97,7 @@ class ProductTypesBottomSheetFragment : BottomSheetDialogFragment(), HasAndroidI
                 )
 
                 is ExitWithResult<*> -> {
-                    (event.data as? ProductTypesBottomSheetUiItem)?.let {
+                    (event.data as? ProductType)?.let {
                         navigateWithSelectedResult(type = it)
                     }
                 }
@@ -121,7 +121,7 @@ class ProductTypesBottomSheetFragment : BottomSheetDialogFragment(), HasAndroidI
         }
     }
 
-    private fun navigateWithSelectedResult(type: ProductTypesBottomSheetUiItem) {
+    private fun navigateWithSelectedResult(type: ProductType) {
         when (navArgs.isAddProduct) {
             true -> dismiss()
             else -> navigateBackWithResult(KEY_PRODUCT_TYPE_RESULT, type)


### PR DESCRIPTION
Fixes #2968 . This PR fixes two issues with product types:
**Issue 1: Unable to update product type after selecting a new product.** Fixed in ccaa208. This was because the `ExitWithResult` data was `ProductType` but we were checking if the data was of `ProductTypesBottomSheetUiItem `. 


**Issue 2:** Based on the designs, Physical and Virtual should be grouped as Simple in the product type selector. I should be able to switch a simple product between physical and virtual using the virtual product option in Product Settings. The fix is to remove the Virtual product option from the product list selector. This was already taken care of in #2791 but the changes seems to have been missed somehow during a merge conflict 🤷 

### To test
- Click on a PHYSICAL product from the Products tab.
- Click on the Product Type section.
  - Notice that the product type selection includes: "Variable", "Grouped" and "External" options only.
  - Change the product type to anything else and verify that a confirmation dialog is displayed.
  - Click on Cancel and notice that the dialog is dismissed.
  - Change the product type to anything else and verify that a confirmation dialog is displayed.
  - Click on Change and notice that the product type is changed in the Product Detail screen.
  - Notice the "UPDATE" menu button is displayed.
  - Click on the "Update" menu button and verify that the product type is updated successfully.
- Follow the above steps for a Variable, Grouped and External products.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
