### PR TITLE
Hotfix: The inventory data

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -89,13 +89,13 @@ class ProductDetailCardBuilder(
             type = SECONDARY,
             properties = listOf(
                 product.price(),
-                product.productType(),
                 product.productReviews(),
                 product.inventory(SIMPLE),
                 product.shipping(),
                 product.categories(),
                 product.tags(),
-                product.shortDescription()
+                product.shortDescription(),
+                product.productType()
             ).filterNotEmpty()
         )
     }
@@ -105,12 +105,12 @@ class ProductDetailCardBuilder(
             type = SECONDARY,
             properties = listOf(
                 product.groupedProducts(),
-                product.productType(),
                 product.productReviews(),
                 product.inventory(GROUPED),
                 product.categories(),
                 product.tags(),
-                product.shortDescription()
+                product.shortDescription(),
+                product.productType()
             ).filterNotEmpty()
         )
     }
@@ -120,13 +120,13 @@ class ProductDetailCardBuilder(
             type = SECONDARY,
             properties = listOf(
                 product.price(),
-                product.productType(),
                 product.productReviews(),
                 product.externalLink(),
                 product.inventory(EXTERNAL),
                 product.categories(),
                 product.tags(),
-                product.shortDescription()
+                product.shortDescription(),
+                product.productType()
             ).filterNotEmpty()
         )
     }
@@ -135,14 +135,14 @@ class ProductDetailCardBuilder(
         return ProductPropertyCard(
             type = SECONDARY,
             properties = listOf(
-                product.productType(),
-                product.productReviews(),
                 product.variations(),
+                product.productReviews(),
                 product.inventory(VARIABLE),
                 product.shipping(),
                 product.categories(),
                 product.tags(),
-                product.shortDescription()
+                product.shortDescription(),
+                product.productType()
             ).filterNotEmpty()
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -322,7 +322,8 @@ class ProductDetailCardBuilder(
 
         if (productType == SIMPLE || productType == VARIABLE) {
             if (this.isStockManaged) {
-                inventory[resources.getString(R.string.product_stock_quantity)] = FormatUtils.formatInt(this.stockQuantity)
+                inventory[resources.getString(R.string.product_stock_quantity)] =
+                    FormatUtils.formatInt(this.stockQuantity)
                 inventory[resources.getString(R.string.product_backorders)] =
                     ProductBackorderStatus.backordersToDisplayString(resources, this.backorderStatus)
             } else if (productType == SIMPLE) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -91,7 +91,7 @@ class ProductDetailCardBuilder(
                 product.price(),
                 product.productType(),
                 product.productReviews(),
-                product.inventory(),
+                product.inventory(SIMPLE),
                 product.shipping(),
                 product.categories(),
                 product.tags(),
@@ -107,7 +107,7 @@ class ProductDetailCardBuilder(
                 product.groupedProducts(),
                 product.productType(),
                 product.productReviews(),
-                product.inventory(),
+                product.inventory(GROUPED),
                 product.categories(),
                 product.tags(),
                 product.shortDescription()
@@ -123,7 +123,7 @@ class ProductDetailCardBuilder(
                 product.productType(),
                 product.productReviews(),
                 product.externalLink(),
-                product.inventory(),
+                product.inventory(EXTERNAL),
                 product.categories(),
                 product.tags(),
                 product.shortDescription()
@@ -138,7 +138,7 @@ class ProductDetailCardBuilder(
                 product.productType(),
                 product.productReviews(),
                 product.variations(),
-                product.inventory(),
+                product.inventory(VARIABLE),
                 product.shipping(),
                 product.categories(),
                 product.tags(),
@@ -313,32 +313,31 @@ class ProductDetailCardBuilder(
 
     // show stock properties as a group if stock management is enabled and if the product type is [SIMPLE],
     // otherwise show sku separately
-    private fun Product.inventory(): ProductProperty {
-        val inventoryGroup = when {
-            ProductType.isGroupedOrExternalProduct(this.type) ->
-                mapOf(
-                    Pair(resources.getString(R.string.product_sku), this.sku)
-                )
-            this.isStockManaged -> mapOf(
-                Pair(resources.getString(R.string.product_backorders),
-                    ProductBackorderStatus.backordersToDisplayString(resources, this.backorderStatus)),
-                Pair(resources.getString(R.string.product_stock_quantity),
-                    FormatUtils.formatInt(this.stockQuantity)),
-                Pair(resources.getString(R.string.product_sku), this.sku)
-            )
-            this.sku.isNotEmpty() -> mapOf(
-                Pair(resources.getString(R.string.product_sku), this.sku),
-                Pair(resources.getString(R.string.product_stock_status),
-                    ProductStockStatus.stockStatusToDisplayString(resources, this.stockStatus))
-            )
-            else -> mapOf(
-                Pair("", ProductStockStatus.stockStatusToDisplayString(resources, this.stockStatus))
-            )
+    private fun Product.inventory(productType: ProductType): ProductProperty {
+        val inventory = mutableMapOf<String, String>()
+
+        if (this.sku.isNotEmpty()) {
+            inventory[resources.getString(R.string.product_sku)] = this.sku
+        }
+
+        if (productType == SIMPLE || productType == VARIABLE) {
+            if (this.isStockManaged) {
+                inventory[resources.getString(R.string.product_stock_quantity)] = FormatUtils.formatInt(this.stockQuantity)
+                inventory[resources.getString(R.string.product_backorders)] =
+                    ProductBackorderStatus.backordersToDisplayString(resources, this.backorderStatus)
+            } else if (productType == SIMPLE) {
+                inventory[resources.getString(R.string.product_stock_status)] =
+                    ProductStockStatus.stockStatusToDisplayString(resources, this.stockStatus)
+            }
+        }
+
+        if (inventory.isEmpty()) {
+            inventory[""] = resources.getString(R.string.product_inventory_empty)
         }
 
         return PropertyGroup(
             R.string.product_inventory,
-            inventoryGroup,
+            inventory,
             R.drawable.ic_gridicons_list_checkmark,
             true
         ) {
@@ -352,7 +351,8 @@ class ProductDetailCardBuilder(
                         backorderStatus = this.backorderStatus,
                         isSoldIndividually = this.isSoldIndividually
                     ),
-                    originalSku
+                    originalSku,
+                    productType
                 ),
                 PRODUCT_DETAIL_VIEW_INVENTORY_SETTINGS_TAPPED
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
@@ -10,9 +10,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.extensions.collapse
 import com.woocommerce.android.extensions.expand
-import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateBackWithResult
-import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.dialog.CustomDiscardDialog
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModel.kt
@@ -9,6 +9,9 @@ import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.di.ViewModelAssistedFactory
+import com.woocommerce.android.ui.products.ProductType.EXTERNAL
+import com.woocommerce.android.ui.products.ProductType.GROUPED
+import com.woocommerce.android.ui.products.ProductType.VARIABLE
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -30,13 +33,16 @@ class ProductInventoryViewModel @AssistedInject constructor(
         private const val SEARCH_TYPING_DELAY_MS = 500L
     }
     private val navArgs: ProductInventoryFragmentArgs by savedState.navArgs()
+    private val isProduct = navArgs.requestCode == RequestCodes.PRODUCT_DETAIL_INVENTORY
 
     val viewStateData = LiveDataDelegate(
         savedState,
         ViewState(
             inventoryData = navArgs.inventoryData,
             isDoneButtonVisible = false,
-            isIndividualSaleSwitchVisible = navArgs.requestCode == RequestCodes.PRODUCT_DETAIL_INVENTORY
+            isIndividualSaleSwitchVisible = isProduct,
+            isStockManagementVisible = !isProduct || navArgs.productType != EXTERNAL && navArgs.productType != GROUPED,
+            isStockStatusVisible = !isProduct || navArgs.productType != VARIABLE
         )
     )
     private var viewState by viewStateData
@@ -154,6 +160,8 @@ class ProductInventoryViewModel @AssistedInject constructor(
         val isDoneButtonVisible: Boolean? = null,
         val skuErrorMessage: Int? = null,
         val isIndividualSaleSwitchVisible: Boolean? = null,
+        val isStockStatusVisible: Boolean? = null,
+        val isStockManagementVisible: Boolean? = null,
         val isDoneButtonDisabled: Boolean = false
     ) : Parcelable {
         val isDoneButtonEnabled: Boolean

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
@@ -17,7 +17,11 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 sealed class ProductNavigationTarget : Event() {
     data class ShareProduct(val url: String, val title: String) : ProductNavigationTarget()
     data class ViewProductVariations(val remoteId: Long) : ProductNavigationTarget()
-    data class ViewProductInventory(val inventoryData: InventoryData, val sku: String) : ProductNavigationTarget()
+    data class ViewProductInventory(
+        val inventoryData: InventoryData,
+        val sku: String,
+        val productType: ProductType
+    ) : ProductNavigationTarget()
     data class ViewProductPricing(val pricingData: PricingData) : ProductNavigationTarget()
     data class ViewProductShipping(val shippingData: ShippingData) : ProductNavigationTarget()
     data class ViewProductExternalLink(val remoteId: Long) : ProductNavigationTarget()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -105,7 +105,8 @@ class ProductNavigator @Inject constructor() {
                         .actionProductDetailFragmentToProductInventoryFragment(
                             RequestCodes.PRODUCT_DETAIL_INVENTORY,
                             target.inventoryData,
-                            target.sku
+                            target.sku,
+                            target.productType
                         )
                 fragment.findNavController().navigateSafely(action)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyView.kt
@@ -10,6 +10,7 @@ import android.widget.TextView
 import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import com.woocommerce.android.R
 import com.woocommerce.android.util.WooLog
@@ -43,7 +44,7 @@ class WCProductPropertyView @JvmOverloads constructor(
 
         if (propertyIcon != null) {
             propertyGroupIcon?.isVisible = true
-            propertyGroupIcon?.setImageDrawable(context.getDrawable(propertyIcon))
+            propertyGroupIcon?.setImageDrawable(ContextCompat.getDrawable(context, propertyIcon))
         } else {
             propertyGroupIcon?.isVisible = false
         }

--- a/WooCommerce/src/main/res/layout/fragment_product_inventory.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_inventory.xml
@@ -105,6 +105,13 @@
                 app:barrierDirection="bottom"
                 app:constraint_referenced_ids="manageStock_morePanel,edit_product_stock_status" />
 
+            <androidx.constraintlayout.widget.Group
+                android:id="@+id/stockManagementPanel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="visible"
+                app:constraint_referenced_ids="manageStock_barrier,manageStock_morePanel,manageStock_switch,edit_product_stock_status,manageStock_switch,soldIndividually_switch" />
+
             <!-- Product Sold Individually switch -->
             <com.google.android.material.switchmaterial.SwitchMaterial
                 android:id="@+id/soldIndividually_switch"

--- a/WooCommerce/src/main/res/navigation/nav_graph_products.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_products.xml
@@ -123,6 +123,10 @@
         <argument
             android:name="sku"
             app:argType="string" />
+        <argument
+            android:name="productType"
+            app:argType="com.woocommerce.android.ui.products.ProductType"
+            android:defaultValue="SIMPLE" />
     </fragment>
     <fragment
         android:id="@+id/productShippingFragment"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -129,12 +129,6 @@ class ProductDetailViewModelTest : BaseUnitTest() {
                     ),
                     R.drawable.ic_gridicons_money
                 ),
-                ComplexProperty(
-                    R.string.product_type,
-                    resources.getString(R.string.product_detail_product_type_hint),
-                    R.drawable.ic_gridicons_product,
-                    true
-                ),
                 RatingBar(
                     R.string.product_reviews,
                     resources.getString(R.string.product_reviews_count, product.ratingCount),
@@ -180,6 +174,12 @@ class ProductDetailViewModelTest : BaseUnitTest() {
                     R.string.product_short_description,
                     product.shortDescription,
                     R.drawable.ic_gridicons_align_left
+                ),
+                ComplexProperty(
+                    R.string.product_type,
+                    resources.getString(R.string.product_detail_product_type_hint),
+                    R.drawable.ic_gridicons_product,
+                    true
                 )
             )
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -144,7 +144,10 @@ class ProductDetailViewModelTest : BaseUnitTest() {
                 PropertyGroup(
                     R.string.product_inventory,
                     mapOf(
-                        Pair("", resources.getString(R.string.product_stock_status_instock))
+                        Pair(
+                            resources.getString(R.string.product_stock_status),
+                            resources.getString(R.string.product_stock_status_instock)
+                        )
                     ),
                     R.drawable.ic_gridicons_list_checkmark,
                     true

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -121,7 +121,10 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                 PropertyGroup(
                     R.string.product_inventory,
                     mapOf(
-                        Pair("", resources.getString(R.string.product_stock_status_instock))
+                        Pair(
+                            resources.getString(R.string.product_stock_status),
+                            resources.getString(R.string.product_stock_status_instock)
+                        )
                     ),
                     R.drawable.ic_gridicons_list_checkmark,
                     true

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -112,12 +112,6 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                     R.drawable.ic_gridicons_money,
                     showTitle = false
                 ),
-                ComplexProperty(
-                    R.string.product_type,
-                    resources.getString(R.string.product_detail_product_type_hint),
-                    R.drawable.ic_gridicons_product,
-                    true
-                ),
                 PropertyGroup(
                     R.string.product_inventory,
                     mapOf(
@@ -127,6 +121,12 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                         )
                     ),
                     R.drawable.ic_gridicons_list_checkmark,
+                    true
+                ),
+                ComplexProperty(
+                    R.string.product_type,
+                    resources.getString(R.string.product_detail_product_type_hint),
+                    R.drawable.ic_gridicons_product,
                     true
                 )
             )


### PR DESCRIPTION
Fixes #2999. The inventory property and inventory screen was not showing/hiding the correct fields for different product types and this PR fixes that.

**To test:**
Inventory screen should show the following:
- Simple products: Everything should be visible (SKU, stock management switch, stock status, stock quantity, backorder status, limit to one switch)
- Variable products: Like Simple but Stock status is hidden
- External products: Only SKU shown
- Grouped products: Only SKU shown

Inventory property in Product details should should also not show any value that's not editable for a particular product type. So stock status for variable products, for example.