### PR TITLE
Issue/2975 review detail from product review list

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -775,7 +775,7 @@ class MainActivity : AppUpgradeActivity(),
                         }
                     }
                 }
-                PRODUCT_REVIEW -> showReviewDetail(note.getCommentId(), true)
+                PRODUCT_REVIEW -> showReviewDetail(note.getCommentId(), launchedFromNotification = true)
                 else -> { /* do nothing */
                 }
             }
@@ -797,7 +797,12 @@ class MainActivity : AppUpgradeActivity(),
         navController.navigateSafely(action)
     }
 
-    override fun showReviewDetail(remoteReviewId: Long, launchedFromNotification: Boolean, tempStatus: String?) {
+    override fun showReviewDetail(
+        remoteReviewId: Long,
+        launchedFromNotification: Boolean,
+        tempStatus: String?,
+        enableModeration: Boolean
+    ) {
         showBottomNav()
         bottomNavView.currentPosition = REVIEWS
 
@@ -807,7 +812,8 @@ class MainActivity : AppUpgradeActivity(),
         val action = ReviewDetailFragmentDirections.actionGlobalReviewDetailFragment(
             remoteReviewId,
             tempStatus,
-            launchedFromNotification
+            launchedFromNotification,
+            enableModeration
         )
         navController.navigateSafely(action)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -807,11 +807,12 @@ class MainActivity : AppUpgradeActivity(),
         enableModeration: Boolean,
         tempStatus: String?
     ) {
-        showBottomNav()
-        bottomNavView.currentPosition = REVIEWS
-
-        val navPos = REVIEWS.position
-        bottom_nav.active(navPos)
+        // make sure the review tab is active if the user came here from a notification
+        if (launchedFromNotification) {
+            showBottomNav()
+            bottomNavView.currentPosition = REVIEWS
+            bottom_nav.active(REVIEWS.position)
+        }
 
         val action = ReviewDetailFragmentDirections.actionGlobalReviewDetailFragment(
             remoteReviewId,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -775,7 +775,11 @@ class MainActivity : AppUpgradeActivity(),
                         }
                     }
                 }
-                PRODUCT_REVIEW -> showReviewDetail(note.getCommentId(), launchedFromNotification = true)
+                PRODUCT_REVIEW -> showReviewDetail(
+                    note.getCommentId(),
+                    launchedFromNotification = true,
+                    enableModeration = true
+                )
                 else -> { /* do nothing */
                 }
             }
@@ -800,8 +804,8 @@ class MainActivity : AppUpgradeActivity(),
     override fun showReviewDetail(
         remoteReviewId: Long,
         launchedFromNotification: Boolean,
-        tempStatus: String?,
-        enableModeration: Boolean
+        enableModeration: Boolean,
+        tempStatus: String?
     ) {
         showBottomNav()
         bottomNavView.currentPosition = REVIEWS

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
@@ -13,7 +13,12 @@ interface MainNavigationRouter {
         markComplete: Boolean = false
     )
     fun showAddProduct()
-    fun showReviewDetail(remoteReviewId: Long, launchedFromNotification: Boolean, tempStatus: String? = null, enableModeration: Boolean = true)
+    fun showReviewDetail(
+        remoteReviewId: Long,
+        launchedFromNotification: Boolean,
+        tempStatus: String? = null,
+        enableModeration: Boolean = true
+    )
     fun showProductFilters(stockStatus: String?, productType: String?, productStatus: String?)
     fun showFeedbackSurvey()
     fun showProductAddBottomSheet()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
@@ -16,8 +16,8 @@ interface MainNavigationRouter {
     fun showReviewDetail(
         remoteReviewId: Long,
         launchedFromNotification: Boolean,
-        tempStatus: String? = null,
-        enableModeration: Boolean = true
+        enableModeration: Boolean,
+        tempStatus: String? = null
     )
     fun showProductFilters(stockStatus: String?, productType: String?, productStatus: String?)
     fun showFeedbackSurvey()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
@@ -13,7 +13,7 @@ interface MainNavigationRouter {
         markComplete: Boolean = false
     )
     fun showAddProduct()
-    fun showReviewDetail(remoteReviewId: Long, launchedFromNotification: Boolean, tempStatus: String? = null)
+    fun showReviewDetail(remoteReviewId: Long, launchedFromNotification: Boolean, tempStatus: String? = null, enableModeration: Boolean = true)
     fun showProductFilters(stockStatus: String?, productType: String?, productStatus: String?)
     fun showFeedbackSurvey()
     fun showProductAddBottomSheet()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.ProductReview
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.ui.reviews.ReviewListAdapter
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -27,7 +28,7 @@ import kotlinx.android.synthetic.main.fragment_reviews_list.*
 import kotlinx.android.synthetic.main.fragment_reviews_list.view.*
 import javax.inject.Inject
 
-class ProductReviewsFragment : BaseFragment() {
+class ProductReviewsFragment : BaseFragment(), ReviewListAdapter.OnReviewClickListener {
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     @Inject lateinit var viewModelFactory: ViewModelFactory
@@ -56,7 +57,7 @@ class ProductReviewsFragment : BaseFragment() {
         super.onActivityCreated(savedInstanceState)
 
         val activity = requireActivity()
-        reviewsAdapter = ReviewListAdapter(activity, null)
+        reviewsAdapter = ReviewListAdapter(activity, this)
 
         reviewsList.apply {
             layoutManager = LinearLayoutManager(context)
@@ -137,5 +138,13 @@ class ProductReviewsFragment : BaseFragment() {
     override fun onDestroyView() {
         skeletonView.hide()
         super.onDestroyView()
+    }
+
+    override fun onReviewClick(review: ProductReview) {
+        (activity as? MainNavigationRouter)?.showReviewDetail(
+            review.remoteId,
+            launchedFromNotification = false,
+            enableModeration = false
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
@@ -206,30 +206,37 @@ class ReviewDetailFragment : BaseFragment() {
     }
 
     private fun configureModerationButtons(status: ProductReviewStatus) {
-        review_approve.setOnCheckedChangeListener(null)
+        val visibility = if (navArgs.enableModeration) View.VISIBLE else View.GONE
+        review_approve.visibility = visibility
+        review_spam.visibility = visibility
+        review_trash.visibility = visibility
 
-        // Use the status override if present,else new status
-        when (val newStatus = navArgs.tempStatus?.let { ProductReviewStatus.fromString(it) } ?: status) {
-            APPROVED -> review_approve.isChecked = true
-            HOLD -> review_approve.isChecked = false
-            else -> WooLog.w(REVIEWS, "Unable to process Review with a status of $newStatus")
-        }
+        if (navArgs.enableModeration) {
+            review_approve.setOnCheckedChangeListener(null)
 
-        // Configure the moderate button
-        review_approve.setOnCheckedChangeListener(moderateListener)
+            // Use the status override if present,else new status
+            when (val newStatus = navArgs.tempStatus?.let { ProductReviewStatus.fromString(it) } ?: status) {
+                APPROVED -> review_approve.isChecked = true
+                HOLD -> review_approve.isChecked = false
+                else -> WooLog.w(REVIEWS, "Unable to process Review with a status of $newStatus")
+            }
 
-        // Configure the spam button
-        review_spam.setOnClickListener {
-            AnalyticsTracker.track(Stat.REVIEW_DETAIL_SPAM_BUTTON_TAPPED)
+            // Configure the moderate button
+            review_approve.setOnCheckedChangeListener(moderateListener)
 
-            processReviewModeration(SPAM)
-        }
+            // Configure the spam button
+            review_spam.setOnClickListener {
+                AnalyticsTracker.track(Stat.REVIEW_DETAIL_SPAM_BUTTON_TAPPED)
 
-        // Configure the trash button
-        review_trash.setOnClickListener {
-            AnalyticsTracker.track(Stat.REVIEW_DETAIL_TRASH_BUTTON_TAPPED)
+                processReviewModeration(SPAM)
+            }
 
-            processReviewModeration(TRASH)
+            // Configure the trash button
+            review_trash.setOnClickListener {
+                AnalyticsTracker.track(Stat.REVIEW_DETAIL_TRASH_BUTTON_TAPPED)
+
+                processReviewModeration(TRASH)
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListAdapter.kt
@@ -5,7 +5,6 @@ import android.view.View
 import android.widget.ImageView
 import android.widget.RatingBar
 import android.widget.TextView
-import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.woocommerce.android.R
@@ -25,7 +24,7 @@ import kotlinx.android.synthetic.main.order_list_header.view.*
 
 class ReviewListAdapter(
     private val context: Context,
-    private val clickListener: OnReviewClickListener?
+    private val clickListener: OnReviewClickListener
 ) : SectionedRecyclerViewAdapter() {
     private val reviewList = mutableListOf<ProductReview>()
 
@@ -367,10 +366,8 @@ class ReviewListAdapter(
                 itemHolder.divider.visibility = View.INVISIBLE
             }
 
-            clickListener?.let { listener ->
-                itemHolder.itemView.setOnClickListener {
-                    listener.onReviewClick(review)
-                }
+            itemHolder.itemView.setOnClickListener {
+                clickListener.onReviewClick(review)
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -292,6 +292,7 @@ class ReviewListFragment : TopLevelFragment(), ItemDecorationListener, ReviewLis
         (activity as? MainNavigationRouter)?.showReviewDetail(
                 review.remoteId,
                 launchedFromNotification = false,
+                enableModeration = true,
                 tempStatus = pendingModerationNewStatus
         )
     }

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -262,6 +262,9 @@
         <argument
             android:name="launchedFromNotification"
             app:argType="boolean" />
+        <argument
+            android:name="enableModeration"
+            app:argType="boolean" />
     </fragment>
     <action
         android:id="@+id/action_global_reviewDetailFragment"


### PR DESCRIPTION
Closes #2975 (again) - this PR enables showing review detail from the product review list, with the moderation buttons hidden.

![product-review](https://user-images.githubusercontent.com/3903757/95604796-13135080-0a26-11eb-8c5d-a9bb5af83a9c.gif)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
