### PR TITLE
Hotfix: Use correct fragment tag during login

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -580,12 +580,12 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
         if (siteAddress != null) {
             val loginEmailFragment = getLoginEmailFragment(
                 useAltLayout = false) ?: LoginEmailFragment.newInstance(siteAddress, true)
-            slideInFragment(loginEmailFragment as Fragment, true, LoginEmailFragment.TAG_ALT_LAYOUT)
+            slideInFragment(loginEmailFragment as Fragment, true, LoginEmailFragment.TAG)
         } else {
             val loginEmailFragment = getLoginEmailFragment(
                 useAltLayout = true) ?: LoginEmailFragment.newInstance(false, false, true, true)
             slideInFragment(
-                loginEmailFragment as Fragment, true, LoginEmailFragment.TAG)
+                loginEmailFragment as Fragment, true, LoginEmailFragment.TAG_ALT_LAYOUT)
         }
     }
 


### PR DESCRIPTION
Fixes #3005 using the correct fragment tag when calling `LoginEmailFragment` from WPcom login flow. 

### To Test
1. Click **Enter your store address**
2. Enter store address click **Continue** The email screen will display - verify the option to login with site creds is visible. 
3. Click back till you return to the Login Prologue view. 
4. Click **Continue with WordPress.com**
5. Verify email screen doesn't have site creds option.
6. Click back to return to Login Prologue.
7. Click **Enter your store address**
8. Enter store address click **Continue** -- the app should not crash.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
