### PR TITLE
origin/issue/2998-grouped-product-background

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
@@ -68,6 +68,7 @@ class ProductItemViewHolder(parent: ViewGroup) : RecyclerView.ViewHolder(
             }
             firstImage.isNullOrEmpty() -> {
                 size = imageSize / 2
+                itemView.productImageFrame.setBackgroundColor(ContextCompat.getColor(context, R.color.white))
                 itemView.productImage.setImageResource(R.drawable.ic_product)
             }
             else -> {


### PR DESCRIPTION
Fixes #2998 - this simple PR set the background color to white for products with no images to ensure that they don't continue to have a purple background when de-selected.

To test:

* Open a grouped product
* Tap "Grouped products"
* Tap "Add product"
* Select a product with no images
* Deselect it and verify the purple selection background is no longer showing

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
