### PR TITLE
issue/2992-feedback-dismiss

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -413,7 +413,7 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener, ProductS
     }
 
     private fun showProductWIPNoticeCard(show: Boolean) {
-        if (show && feedbackState == UNANSWERED) {
+        if (show && feedbackState != DISMISSED) {
             val wipCardMessageId = R.string.product_wip_message_m3
             products_wip_card.visibility = View.VISIBLE
             products_wip_card.initView(


### PR DESCRIPTION
Fixes #2992 - this tiny PR changes the feedback card on the product list so it's only hidden once the user taps Dismiss.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
