### PR TITLE
Hotfix: Fix google login issue

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -155,12 +155,12 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
      * site address flow. This layout includes an option to sign in with site
      * credentials.
      *
-     * @param useAltLayout If true, use the layout that includes the option to log
+     * @param siteCredsLayout If true, use the layout that includes the option to log
      * in with site credentials.
      */
-    private fun getLoginEmailFragment(useAltLayout: Boolean): LoginEmailFragment? {
-        val fragment = if (useAltLayout) {
-            supportFragmentManager.findFragmentByTag(LoginEmailFragment.TAG_ALT_LAYOUT)
+    private fun getLoginEmailFragment(siteCredsLayout: Boolean): LoginEmailFragment? {
+        val fragment = if (siteCredsLayout) {
+            supportFragmentManager.findFragmentByTag(LoginEmailFragment.TAG_SITE_CREDS_LAYOUT)
         } else {
             supportFragmentManager.findFragmentByTag(LoginEmailFragment.TAG)
         }
@@ -578,14 +578,15 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
 
     override fun showEmailLoginScreen(siteAddress: String?) {
         if (siteAddress != null) {
+            // Show the layout that includes the option to login with site credentials.
             val loginEmailFragment = getLoginEmailFragment(
-                useAltLayout = false) ?: LoginEmailFragment.newInstance(siteAddress, true)
-            slideInFragment(loginEmailFragment as Fragment, true, LoginEmailFragment.TAG)
+                siteCredsLayout = true) ?: LoginEmailFragment.newInstance(siteAddress, true)
+            slideInFragment(loginEmailFragment as Fragment, true, LoginEmailFragment.TAG_SITE_CREDS_LAYOUT)
         } else {
             val loginEmailFragment = getLoginEmailFragment(
-                useAltLayout = true) ?: LoginEmailFragment.newInstance(false, false, true, true)
+                siteCredsLayout = false) ?: LoginEmailFragment.newInstance(false, false, true, true)
             slideInFragment(
-                loginEmailFragment as Fragment, true, LoginEmailFragment.TAG_ALT_LAYOUT)
+                loginEmailFragment as Fragment, true, LoginEmailFragment.TAG)
         }
     }
 

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -83,7 +83,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     private static final String ARG_HIDE_TOS = "ARG_HIDE_TOS";
 
     public static final String TAG = "login_email_fragment_tag";
-    public static final String TAG_ALT_LAYOUT = "login_email_fragment_alternate_layout_tag";
+    public static final String TAG_SITE_CREDS_LAYOUT = "login_email_fragment_site_creds_layout_tag";
     public static final int MAX_EMAIL_LENGTH = 100;
 
     private ArrayList<Integer> mOldSitesIDs = new ArrayList<>();


### PR DESCRIPTION
These changes fix an issue where the `LoginEmailFragment` cannot be found upon successful social login so the app appears to hang when really it just has no way to move forward because the TAG used to recall the fragment from the stack wasn't the same one used in it's creation. This confusion happens because there are two different layouts now for the `LoginEmailFragment`, one that has an option to login with site creds, and one that does not. The Tag names I originally used conflict with the logic used in the fragment itself so to avoid these issues in the future I have renamed the tag for the site credentials layout from `TAG_ALT_LAYOUT` to `TAG_SITE_CREDS_LAYOUT` removing the confusion. 

## To Test
- Verify able to log into the app using Google Login
- Also verify site credentials button appears on emai login screen when logging in with Site Address. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
