### PR TITLE
Issue/2987 password product visibility

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -289,8 +289,7 @@ class ProductDetailViewModel @AssistedInject constructor(
 
     fun hasChanges(): Boolean {
         return viewState.storedProduct?.let { product ->
-            viewState.productDraft?.isSameProduct(product) == false ||
-                viewState.draftPassword != viewState.storedPassword
+            viewState.productDraft?.isSameProduct(product) == false || viewState.isPasswordChanged
         } ?: false
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -289,7 +289,8 @@ class ProductDetailViewModel @AssistedInject constructor(
 
     fun hasChanges(): Boolean {
         return viewState.storedProduct?.let { product ->
-            viewState.productDraft?.isSameProduct(product) == false
+            viewState.productDraft?.isSameProduct(product) == false ||
+                viewState.draftPassword != viewState.storedPassword
         } ?: false
     }
 


### PR DESCRIPTION
Fixes #2987 by checking if the product's password has been changed in the viewModel's `hasChanges()` function.

To Test:

- Open product detail for a product that's not password protected
- Go to the product's settings, change the visibility to Password Protected and enter a password
- Tap Done until you return to product detail
- Verify that the Update button is showing.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
