### PR TITLE
issue/2990-hide-product-detail-progress-dialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -81,7 +81,6 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
     }
 
     override fun onDestroyView() {
-        // hide the skeleton view if fragment is destroyed
         skeletonView.hide()
         super.onDestroyView()
     }
@@ -89,6 +88,11 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
     override fun onResume() {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        progressDialog?.dismiss()
     }
 
     override fun onStop() {
@@ -380,6 +384,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
         layoutManager?.let {
             outState.putParcelable(LIST_STATE_KEY, it.onSaveInstanceState())
         }


### PR DESCRIPTION
Fixes #2990 - previously the update progress dialog wasn't being dismissed when the fragment was paused, causing it to continue to appear after the device is rotated and the product is updated.

To test:

- Make a change in product detail
- Tap Update and then immediately rotate your device
- Verify that the progress dialog is still showing and disappears after the product is updated

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
