### PR TITLE
issue/update-gradle-for-AS4.1

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -11,7 +11,7 @@
       <entry name="!?*.kt" />
       <entry name="!?*.clj" />
     </wildcardResourcePatterns>
-    <bytecodeTargetLevel>
+    <bytecodeTargetLevel target="1.8">
       <module name="fluxc-annotations" target="1.7" />
       <module name="fluxc-processor" target="1.7" />
     </bytecodeTargetLevel>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.automattic.android:fetchstyle:1.1'
         classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlinVersion"


### PR DESCRIPTION
Closes #3013 - this PR updates Gradle to v4.0.2, for compatibility with Android Studio 4.1.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
