### PR TITLE
Issue/2967 non core product type

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -33,7 +33,7 @@ data class Product(
     val description: String,
     val shortDescription: String,
     val slug: String,
-    val type: ProductType,
+    val type: String,
     val status: ProductStatus?,
     val catalogVisibility: ProductCatalogVisibility?,
     val isFeatured: Boolean,
@@ -150,6 +150,7 @@ data class Product(
                 length > 0 || width > 0 || height > 0 ||
                 shippingClass.isNotEmpty()
         }
+    val productType = ProductType.fromString(type)
 
     /**
      * Verifies if there are any changes made to the external link settings
@@ -288,7 +289,7 @@ data class Product(
 
     @StringRes
     fun getProductTypeFormattedForDisplay(): Int {
-        return when (this.type) {
+        return when (this.productType) {
             ProductType.SIMPLE -> {
                 if (this.isVirtual) R.string.product_type_virtual
                 else R.string.product_type_physical
@@ -379,7 +380,7 @@ fun Product.toDataModel(storedProductModel: WCProductModel?): WCProductModel {
         it.menuOrder = menuOrder
         it.categories = categoriesToJson()
         it.tags = tagsToJson()
-        it.type = type.value
+        it.type = type
         it.groupedProductIds = groupedProductIds.joinToString(
             separator = ",",
             prefix = "[",
@@ -394,7 +395,7 @@ fun WCProductModel.toAppModel(): Product {
         name = this.name,
         description = this.description,
         shortDescription = this.shortDescription,
-        type = ProductType.fromString(this.type),
+        type = this.type,
         status = ProductStatus.fromString(this.status),
         catalogVisibility = ProductCatalogVisibility.fromString(this.catalogVisibility),
         isFeatured = this.featured,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -1,10 +1,8 @@
 package com.woocommerce.android.model
 
 import android.os.Parcelable
-import androidx.annotation.StringRes
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
-import com.woocommerce.android.R
 import com.woocommerce.android.extensions.areSameImagesAs
 import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.formatDateToISO8601Format
@@ -150,8 +148,7 @@ data class Product(
                 length > 0 || width > 0 || height > 0 ||
                 shippingClass.isNotEmpty()
         }
-    val productType: ProductType
-        get() = ProductType.fromString(type)
+    val productType get() = ProductType.fromString(type)
 
     /**
      * Verifies if there are any changes made to the external link settings

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -150,7 +150,8 @@ data class Product(
                 length > 0 || width > 0 || height > 0 ||
                 shippingClass.isNotEmpty()
         }
-    val productType = ProductType.fromString(type)
+    val productType: ProductType
+        get() = ProductType.fromString(type)
 
     /**
      * Verifies if there are any changes made to the external link settings
@@ -285,19 +286,6 @@ data class Product(
                 groupedProductIds = updatedProduct.groupedProductIds
             )
         } ?: this.copy()
-    }
-
-    @StringRes
-    fun getProductTypeFormattedForDisplay(): Int {
-        return when (this.productType) {
-            ProductType.SIMPLE -> {
-                if (this.isVirtual) R.string.product_type_virtual
-                else R.string.product_type_physical
-            }
-            ProductType.VARIABLE -> R.string.product_type_variable
-            ProductType.GROUPED -> R.string.product_type_grouped
-            ProductType.EXTERNAL -> R.string.product_type_external
-        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductTa
 import com.woocommerce.android.ui.products.ProductShippingViewModel.ShippingData
 import com.woocommerce.android.ui.products.ProductType.EXTERNAL
 import com.woocommerce.android.ui.products.ProductType.GROUPED
+import com.woocommerce.android.ui.products.ProductType.OTHER
 import com.woocommerce.android.ui.products.ProductType.SIMPLE
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -66,6 +67,9 @@ class ProductDetailBottomSheetBuilder(
                     product.getTags(),
                     product.getShortDescription()
                 )
+            }
+            OTHER -> {
+                emptyList()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
@@ -35,7 +35,7 @@ class ProductDetailBottomSheetBuilder(
     )
 
     fun buildBottomSheetList(product: Product): List<ProductDetailBottomSheetUiItem> {
-        return when (product.type) {
+        return when (product.productType) {
             SIMPLE -> {
                 listOfNotNull(
                     product.getShipping(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
@@ -69,7 +69,11 @@ class ProductDetailBottomSheetBuilder(
                 )
             }
             OTHER -> {
-                emptyList()
+                listOfNotNull(
+                    product.getCategories(),
+                    product.getTags(),
+                    product.getShortDescription()
+                )
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -64,10 +64,11 @@ class ProductDetailCardBuilder(
         cards.addIfNotEmpty(getPrimaryCard(product))
 
         when (product.productType) {
+            SIMPLE -> cards.addIfNotEmpty(getSimpleProductCard(product))
             VARIABLE -> cards.addIfNotEmpty(getVariableProductCard(product))
             GROUPED -> cards.addIfNotEmpty(getGroupedProductCard(product))
             EXTERNAL -> cards.addIfNotEmpty(getExternalProductCard(product))
-            else -> cards.addIfNotEmpty(getSimpleProductCard(product))
+            OTHER -> cards.addIfNotEmpty(getOtherProductCard(product))
         }
 
         cards.addIfNotEmpty(getPurchaseDetailsCard(product))
@@ -140,6 +141,23 @@ class ProductDetailCardBuilder(
                 product.productReviews(),
                 product.inventory(VARIABLE),
                 product.shipping(),
+                product.categories(),
+                product.tags(),
+                product.shortDescription(),
+                product.productType()
+            ).filterNotEmpty()
+        )
+    }
+
+    /**
+     * Used for product types the app doesn't support yet (ex: subscriptions), uses a subset
+     * of properties since we can't be sure pricing, shipping, etc., are applicable
+     */
+    private fun getOtherProductCard(product: Product): ProductPropertyCard {
+        return ProductPropertyCard(
+            type = SECONDARY,
+            properties = listOf(
+                product.productReviews(),
                 product.categories(),
                 product.tags(),
                 product.shortDescription(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -477,8 +477,8 @@ class ProductDetailCardBuilder(
         }
     }
 
-    private fun Product.productType(): ProductProperty {
-        val productType = when (this.productType) {
+    private fun Product.productTypeDisplayName(): String {
+        return when (productType) {
             SIMPLE -> {
                 if (this.isVirtual) resources.getString(R.string.product_type_virtual)
                 else resources.getString(R.string.product_type_physical)
@@ -488,7 +488,9 @@ class ProductDetailCardBuilder(
             EXTERNAL -> resources.getString(R.string.product_type_external)
             OTHER -> this.type.capitalize() // show the actual product type string for unsupported products
         }
+    }
 
+    private fun Product.productType(): ProductProperty {
         val onClickHandler = {
             viewModel.onEditProductCardClicked(
                 ViewProductTypes(false),
@@ -498,9 +500,9 @@ class ProductDetailCardBuilder(
 
         return ComplexProperty(
             R.string.product_type,
-            resources.getString(R.string.product_detail_product_type_hint, productType),
+            resources.getString(R.string.product_detail_product_type_hint, productTypeDisplayName()),
             R.drawable.ic_gridicons_product,
-            onClick = if (remoteId != 0L) onClickHandler else null
+            onClick = if (remoteId != 0L && productType != OTHER) onClickHandler else null
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -9,8 +9,8 @@ import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.filterNotEmpty
 import com.woocommerce.android.extensions.isSet
 import com.woocommerce.android.model.Product
-import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewGroupedProducts
 import com.woocommerce.android.ui.products.ProductInventoryViewModel.InventoryData
+import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewGroupedProducts
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductCategories
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductDescriptionEditor
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductExternalLink
@@ -26,6 +26,7 @@ import com.woocommerce.android.ui.products.ProductPricingViewModel.PricingData
 import com.woocommerce.android.ui.products.ProductShippingViewModel.ShippingData
 import com.woocommerce.android.ui.products.ProductType.EXTERNAL
 import com.woocommerce.android.ui.products.ProductType.GROUPED
+import com.woocommerce.android.ui.products.ProductType.OTHER
 import com.woocommerce.android.ui.products.ProductType.SIMPLE
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
 import com.woocommerce.android.ui.products.models.ProductProperty
@@ -63,10 +64,10 @@ class ProductDetailCardBuilder(
         cards.addIfNotEmpty(getPrimaryCard(product))
 
         when (product.productType) {
-            SIMPLE -> cards.addIfNotEmpty(getSimpleProductCard(product))
             VARIABLE -> cards.addIfNotEmpty(getVariableProductCard(product))
             GROUPED -> cards.addIfNotEmpty(getGroupedProductCard(product))
             EXTERNAL -> cards.addIfNotEmpty(getExternalProductCard(product))
+            else -> cards.addIfNotEmpty(getSimpleProductCard(product))
         }
 
         cards.addIfNotEmpty(getPurchaseDetailsCard(product))
@@ -459,7 +460,17 @@ class ProductDetailCardBuilder(
     }
 
     private fun Product.productType(): ProductProperty {
-        val productType = resources.getString(this.getProductTypeFormattedForDisplay())
+        val productType = when (this.productType) {
+            SIMPLE -> {
+                if (this.isVirtual) resources.getString(R.string.product_type_virtual)
+                else resources.getString(R.string.product_type_physical)
+            }
+            VARIABLE -> resources.getString(R.string.product_type_variable)
+            GROUPED -> resources.getString(R.string.product_type_grouped)
+            EXTERNAL -> resources.getString(R.string.product_type_external)
+            OTHER -> this.type.capitalize() // show the actual product type string for unsupported products
+        }
+
         val onClickHandler = {
             viewModel.onEditProductCardClicked(
                 ViewProductTypes(false),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -52,7 +52,7 @@ class ProductDetailCardBuilder(
     private val currencyFormatter: CurrencyFormatter,
     private val parameters: SiteParameters
 ) {
-    private fun isSimple(product: Product) = product.type == SIMPLE
+    private fun isSimple(product: Product) = product.productType == SIMPLE
 
     private lateinit var originalSku: String
 
@@ -62,7 +62,7 @@ class ProductDetailCardBuilder(
         val cards = mutableListOf<ProductPropertyCard>()
         cards.addIfNotEmpty(getPrimaryCard(product))
 
-        when (product.type) {
+        when (product.productType) {
             SIMPLE -> cards.addIfNotEmpty(getSimpleProductCard(product))
             VARIABLE -> cards.addIfNotEmpty(getVariableProductCard(product))
             GROUPED -> cards.addIfNotEmpty(getGroupedProductCard(product))
@@ -399,7 +399,7 @@ class ProductDetailCardBuilder(
 
     // enable editing external product link
     private fun Product.externalLink(): ProductProperty? {
-        return if (this.type == EXTERNAL) {
+        return if (this.productType == EXTERNAL) {
             val hasExternalLink = this.externalUrl.isNotEmpty()
             val externalGroup = if (hasExternalLink) {
                 mapOf(Pair("", this.externalUrl))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -124,7 +124,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
 
     private fun setupResultHandlers(viewModel: ProductDetailViewModel) {
         handleResult<ProductType>(ProductTypesBottomSheetFragment.KEY_PRODUCT_TYPE_RESULT) {
-            viewModel.updateProductDraft(type = it)
+            viewModel.updateProductDraft(type = it.value)
             changesMade()
         }
         handleResult<List<Long>>(GroupedProductListFragment.KEY_GROUPED_PRODUCT_IDS_RESULT) {
@@ -234,7 +234,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
         productDetail_addMoreContainer.setOnClickListener {
             // TODO: add tracking events here
             viewModel.onEditProductCardClicked(
-                ViewProductDetailBottomSheet(product.type)
+                ViewProductDetailBottomSheet(product.productType)
             )
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -550,7 +550,7 @@ class ProductDetailViewModel @AssistedInject constructor(
         menuOrder: Int? = null,
         categories: List<ProductCategory>? = null,
         tags: List<ProductTag>? = null,
-        type: ProductType? = null,
+        type: String? = null,
         groupedProductIds: List<Long>? = null
     ) {
         viewState.productDraft?.let { product ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -198,8 +198,8 @@ class ProductDetailViewModel @AssistedInject constructor(
     private fun startAddNewProduct() {
         val preferredSavedType = prefs.getSelectedProductType()
         val defaultProductType = ProductType.fromString(preferredSavedType)
-        val defaultProduct = ProductHelper.getDefaultNewProduct(type = defaultProductType)
-        viewState = viewState.copy(productDraft = ProductHelper.getDefaultNewProduct(type = defaultProductType))
+        val defaultProduct = ProductHelper.getDefaultNewProduct(productType = defaultProductType)
+        viewState = viewState.copy(productDraft = ProductHelper.getDefaultNewProduct(productType = defaultProductType))
         updateProductState(defaultProduct)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductHelper.kt
@@ -39,7 +39,7 @@ object ProductHelper {
             name = "",
             description = "",
             shortDescription = "",
-            type = type,
+            type = type.value,
             status = PUBLISH,
             catalogVisibility = VISIBLE,
             isFeatured = false,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductHelper.kt
@@ -33,13 +33,13 @@ object ProductHelper {
      * Default Product for initial state of Product Add flow
      * */
 
-    fun getDefaultNewProduct(type: ProductType): Product {
+    fun getDefaultNewProduct(productType: ProductType): Product {
         return Product(
             remoteId = 0L,
             name = "",
             description = "",
             shortDescription = "",
-            type = type.value,
+            type = productType.value,
             status = PUBLISH,
             catalogVisibility = VISIBLE,
             isFeatured = false,
@@ -49,7 +49,7 @@ object ProductHelper {
             firstImageUrl = null,
             totalSales = 0,
             reviewsAllowed = false,
-            isVirtual = type == VARIABLE,
+            isVirtual = productType == VARIABLE,
             ratingCount = 0,
             averageRating = 0f,
             permalink = "",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
@@ -117,7 +117,7 @@ class ProductItemViewHolder(parent: ViewGroup) : RecyclerView.ViewHolder(
 
         val stock = when (product.stockStatus) {
             InStock -> {
-                if (product.type == VARIABLE) {
+                if (product.productType == VARIABLE) {
                     if (product.numVariations > 0) {
                         context.getString(
                             R.string.product_stock_status_instock_with_variations,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductType.kt
@@ -9,7 +9,8 @@ enum class ProductType(@StringRes val stringResource: Int = 0, val value: String
     SIMPLE(R.string.product_type_simple, CoreProductType.SIMPLE.value),
     GROUPED(R.string.product_type_grouped, CoreProductType.GROUPED.value),
     EXTERNAL(R.string.product_type_external, CoreProductType.EXTERNAL.value),
-    VARIABLE(R.string.product_type_variable, CoreProductType.VARIABLE.value);
+    VARIABLE(R.string.product_type_variable, CoreProductType.VARIABLE.value),
+    OTHER;
 
     companion object {
         fun fromString(type: String): ProductType {
@@ -17,7 +18,8 @@ enum class ProductType(@StringRes val stringResource: Int = 0, val value: String
                 "grouped" -> GROUPED
                 "external" -> EXTERNAL
                 "variable" -> VARIABLE
-                else -> SIMPLE
+                "simple" -> SIMPLE
+                else -> OTHER
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSettingsFragment.kt
@@ -63,7 +63,7 @@ class ProductSettingsFragment : BaseProductFragment(), NavigationResult {
             viewModel.onSettingsMenuOrderButtonClicked()
         }
 
-        val isSimple = viewModel.getProduct().productDraft?.type == ProductType.SIMPLE
+        val isSimple = viewModel.getProduct().productDraft?.productType == ProductType.SIMPLE
         if (isSimple) {
             productIsVirtual.visibility = View.VISIBLE
             productIsVirtual.setOnCheckedChangeListener { _, isChecked ->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -12,6 +12,8 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
+import com.woocommerce.android.R.drawable
+import com.woocommerce.android.R.string
 import com.woocommerce.android.media.ProductImagesServiceWrapper
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
@@ -21,6 +23,7 @@ import com.woocommerce.android.ui.products.ProductStatus.DRAFT
 import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
 import com.woocommerce.android.ui.products.models.ProductProperty.ComplexProperty
 import com.woocommerce.android.ui.products.models.ProductProperty.Editable
+import com.woocommerce.android.ui.products.models.ProductProperty.PropertyGroup
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.PRIMARY
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.SECONDARY
@@ -78,7 +81,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
     }
 
     private val prefs: AppPrefs = mock {
-        on(it.getSelectedProductType()).then { "" }
+        on(it.getSelectedProductType()).then { "simple" }
     }
 
     private val productUtils = ProductUtils()
@@ -105,25 +108,23 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
         ProductPropertyCard(
             type = SECONDARY,
             properties = listOf(
-                // TODO ideally we want to include price & inventory to test simple products but this causes
-                // the "Displays the product detail properties correctly" test to fail
-                /*PropertyGroup(
+                PropertyGroup(
                     R.string.product_price,
                     defaultPricingGroup,
                     R.drawable.ic_gridicons_money,
                     showTitle = false
                 ),
                 PropertyGroup(
-                    R.string.product_inventory,
+                    string.product_inventory,
                     mapOf(
                         Pair(
-                            resources.getString(R.string.product_stock_status),
-                            resources.getString(R.string.product_stock_status_instock)
+                            resources.getString(string.product_stock_status),
+                            resources.getString(string.product_stock_status_instock)
                         )
                     ),
-                    R.drawable.ic_gridicons_list_checkmark,
+                    drawable.ic_gridicons_list_checkmark,
                     true
-                ),*/
+                ),
                 ComplexProperty(
                     R.string.product_type,
                     resources.getString(R.string.product_detail_product_type_hint),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -21,7 +21,6 @@ import com.woocommerce.android.ui.products.ProductStatus.DRAFT
 import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
 import com.woocommerce.android.ui.products.models.ProductProperty.ComplexProperty
 import com.woocommerce.android.ui.products.models.ProductProperty.Editable
-import com.woocommerce.android.ui.products.models.ProductProperty.PropertyGroup
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.PRIMARY
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.SECONDARY
@@ -106,7 +105,9 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
         ProductPropertyCard(
             type = SECONDARY,
             properties = listOf(
-                PropertyGroup(
+                // TODO ideally we want to include price & inventory to test simple products but this causes
+                // the "Displays the product detail properties correctly" test to fail
+                /*PropertyGroup(
                     R.string.product_price,
                     defaultPricingGroup,
                     R.drawable.ic_gridicons_money,
@@ -122,7 +123,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                     ),
                     R.drawable.ic_gridicons_list_checkmark,
                     true
-                ),
+                ),*/
                 ComplexProperty(
                     R.string.product_type,
                     resources.getString(R.string.product_detail_product_type_hint),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -15,6 +15,7 @@ object ProductTestUtils {
             localSiteId = 1
             remoteProductId = productId
             status = "publish"
+            type = "simple"
             stockStatus = "instock"
             price = "20.00"
             salePrice = "10.00"


### PR DESCRIPTION
Fixes #2967 and closes #2778 - prior to this PR, non-core product types (such as "subscription") showed in product detail as simple products. This PR addresses this by storing the raw product type as a string so we can show the actual product type. It also adds `ProductType.OTHER` so we can treat these non-core product types separately. Since we don't know whether these product types have things like shipping or inventory, we only show a subset of the product properties (as per our Slack discussion).

![image](https://user-images.githubusercontent.com/3903757/96162997-4acb3e00-0ee7-11eb-8c07-2f0fd2170f66.png)

To test, add a non-core product (subscription, booking, etc.) on the web and verify the product detail in the mobile app:

- Shows the correct product type
- Shows the product type as read only
- Does not show pricing, shipping, or inventory

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
