### PR TITLE
Enforce use of bundle exec in Fastfile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,6 +1,10 @@
 default_platform(:android)
 fastlane_require 'dotenv'
 
+unless FastlaneCore::Helper.bundler?
+  UI.user_error!('Please run fastlane via `bundle exec`')
+end
+
 platform :android do
 ########################################################################
 # Environment


### PR DESCRIPTION
## Description

This adds checks in the `Fastfile` so that it stops you from accidentally run `fastlane` without prefixing them with `bundle exec`.

If you forget to prepend `bundle exec` when invoking `fastlane`, this will now error and stop, telling you to use `bundle exec` – so you run the versions of fastlane specified in the repo's `Gemfile.lock` – instead of continuing to run with the system-wide version – which might not be the same and behave differently than when ran under bundle exec.

## To test:


1️⃣  Run `fastlane lanes`, and check it fails with the following output

<details><summary>Expected fastlane failure when running without <tt>bundle exec</tt></summary>

```
[✔] 🚀 
[17:57:49]: fastlane detected a Gemfile in the current directory
[17:57:49]: However, it seems like you didn't use `bundle exec`
[17:57:49]: To launch fastlane faster, please use
[17:57:49]: 
[17:57:49]: $ bundle exec fastlane lanes
[17:57:49]: 
[17:57:49]: Get started using a Gemfile for fastlane https://docs.fastlane.tools/getting-started/ios/setup/#use-a-gemfile
[17:57:50]: Installing Ruby gem 'fastlane-plugin-wpmreleasetoolkit'...
[17:58:07]: Found gem "fastlane-plugin-release_helper" instead of the required name "fastlane-plugin-wpmreleasetoolkit"
[17:58:07]: Successfully installed 'fastlane-plugin-wpmreleasetoolkit'
[17:58:07]: Error loading plugin 'fastlane-plugin-wpmreleasetoolkit': cannot load such file -- fastlane/plugin/wpmreleasetoolkit
[17:58:07]: It seems like you wanted to load some plugins, however they couldn't be loaded
[17:58:07]: Please follow the troubleshooting guide: https://docs.fastlane.tools/plugins/plugins-troubleshooting/
+-----------------------------------+-----------+------------------+
|                           Used plugins                           |
+-----------------------------------+-----------+------------------+
| Plugin                            | Version   | Action           |
+-----------------------------------+-----------+------------------+
| fastlane-plugin-wpmreleasetoolkit | undefined | No actions found |
+-----------------------------------+-----------+------------------+

[!] No actions were found while loading one or more plugins
    Please use `bundle exec fastlane` with plugins
    More info - https://docs.fastlane.tools/plugins/using-plugins/#run-with-plugins

[17:58:08]: ------------------------------
[17:58:08]: --- Step: default_platform ---
[17:58:08]: ------------------------------

[!] Please run fastlane via `bundle exec`
```
</details>

2️⃣  Run `bundle exec fastlane lanes` (or `be fastlane lanes` if you created an alias for `bundle exec` in your `.zshrc`, which I recommend) and check that it runs without issues and lists the available lanes

