### PR TITLE
Update Slack Channel in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,4 +46,4 @@ Have a look at the [Coding Style Guide](https://github.com/woocommerce/woocommer
 
 ## Getting in Touch
 
-If you have questions or just want to say hi, join the [WooCommerce Slack](https://woocommerce.com/community-slack/) and drop a message on the `#mobile` channel.
+If you have questions or just want to say hi, join the [WooCommerce Slack](https://woocommerce.com/community-slack/) and drop a message on the `#mobile-apps` channel.


### PR DESCRIPTION
I just replaced the Slack channel mentioned in `CONTRIBUTING.md`. It is apparently `#mobile-apps` and not `#mobile`. Someone asked a question in that `#mobile-apps` channel and they weren't sure if it was the right place. 

<img src="https://user-images.githubusercontent.com/198826/96196771-824ce100-0f0d-11eb-8ca3-7ae288e2204c.png" width="300">

## Testing

Please review the changes below. 🙂 