### PR TITLE
Add M4 beta switch

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -163,7 +163,7 @@ class MainSettingsFragment : androidx.fragment.app.Fragment(), MainSettingsContr
             findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_betaFeaturesFragment)
         }
 
-        option_beta_features.optionValue = getString(R.string.settings_enable_product_teaser_title)
+        option_beta_features.optionValue = getString(R.string.settings_enable_product_adding_teaser_title)
 
         option_privacy.setOnClickListener {
             AnalyticsTracker.track(SETTINGS_PRIVACY_SETTINGS_BUTTON_TAPPED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -424,10 +424,10 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener, ProductS
 
     private fun showProductWIPNoticeCard(show: Boolean) {
         if (show && feedbackState != DISMISSED) {
-            val wipCardMessageId = R.string.product_wip_message_m3
+            val wipCardMessageId = R.string.product_wip_message_m4
             products_wip_card.visibility = View.VISIBLE
             products_wip_card.initView(
-                getString(R.string.product_wip_title),
+                getString(R.string.product_adding_wip_title),
                 getString(wipCardMessageId),
                 onGiveFeedbackClick = ::onGiveFeedbackClicked,
                 onDismissClick = ::onDismissProductWIPNoticeCardClicked

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.util
 
 import android.content.Context
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig
 
 /**
@@ -12,7 +13,7 @@ enum class FeatureFlag {
     DB_DOWNGRADE;
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
-            PRODUCT_RELEASE_M4 -> BuildConfig.DEBUG || isTesting()
+            PRODUCT_RELEASE_M4 -> AppPrefs.isProductsFeatureEnabled() || isTesting()
             PRODUCT_RELEASE_M5 -> BuildConfig.DEBUG || isTesting()
             DB_DOWNGRADE -> {
                 BuildConfig.DEBUG || context != null && PackageUtils.isBetaBuild(context)

--- a/WooCommerce/src/main/res/layout/feature_wip_notice.xml
+++ b/WooCommerce/src/main/res/layout/feature_wip_notice.xml
@@ -20,7 +20,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:textOff="@string/product_wip_title"
-            tools:textOn="@string/product_wip_title" />
+            tools:textOn="@string/product_adding_wip_title" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/feature_wip_morePanel"
@@ -46,7 +46,7 @@
                 app:layout_constraintHorizontal_bias="0.5"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
-                tools:text="@string/product_wip_message_m2" />
+                tools:text="@string/product_wip_message_m4" />
 
             <!-- PRIMARY button -->
             <com.google.android.material.button.MaterialButton

--- a/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
@@ -10,8 +10,8 @@
         android:id="@+id/switchProductsUI"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:toggleOptionDesc="@string/settings_enable_product_teaser_message"
-        app:toggleOptionTitle="@string/settings_enable_product_teaser_title"
+        app:toggleOptionDesc="@string/settings_enable_product_adding_teaser_message"
+        app:toggleOptionTitle="@string/settings_enable_product_adding_teaser_title"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"/>

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -135,7 +135,6 @@
         android:id="@+id/option_beta_features"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:visibility="gone"
         app:optionTitle="@string/beta_features" />
 
     <!--

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -739,7 +739,7 @@
     <string name="settings_send_stats">Collect information</string>
     <string name="settings_enable_v4_stats_title">Improved stats</string>
     <string name="settings_enable_product_adding_teaser_title">Creating products</string>
-    <string name="settings_enable_product_adding_teaser_message">Test out the new product creation (simple, grouped and external products) as we get ready to launch</string>
+    <string name="settings_enable_product_adding_teaser_message">Test out the new product creation as we get ready to launch</string>
     <string name="settings_enable_product_teaser_title">Product editing</string>
     <string name="settings_enable_product_teaser_message">Test out the new product editing functionality as we get ready to launch</string>
     <string name="settings_send_stats_detail">Share information with our analytics tool about your use of services while logged in to your WordPress account</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -571,7 +571,7 @@
     <string name="product_limited_editing_title">Limited editing available</string>
     <string name="product_limited_editing_message">We\'ve added editing functionality to simple products. Keep an eye out for more options soon!</string>
     <string name="product_adding_wip_title">Create products from the app!</string>
-    <string name="product_wip_message_m4">It\'s now possible to create simple, grouped and external products on the go from the Woo app. Not ready yet? Save them as draft!</string>
+    <string name="product_wip_message_m4">It\'s now possible to create simple, grouped and external products on the go from the Woo app. You can enable it by turning on the beta feature in the app settings. Not ready yet? Save them as a draft!</string>
     <string name="product_wip_title">New editing options available</string>
     <string name="product_wip_message_m2">We\'ve added more editing functionalities to products! You can now update images, see previews and share your products.</string>
     <string name="product_wip_message_m3">You can now edit grouped, external and variable products, change product type and update categories and tags.</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -570,6 +570,8 @@
     <string name="product_list_sorting_list_item">Selected sorting option</string>
     <string name="product_limited_editing_title">Limited editing available</string>
     <string name="product_limited_editing_message">We\'ve added editing functionality to simple products. Keep an eye out for more options soon!</string>
+    <string name="product_adding_wip_title">Create products from the app!</string>
+    <string name="product_wip_message_m4">It\'s now possible to create simple, grouped and external products on the go from the Woo app. Not ready yet? Save them as draft!</string>
     <string name="product_wip_title">New editing options available</string>
     <string name="product_wip_message_m2">We\'ve added more editing functionalities to products! You can now update images, see previews and share your products.</string>
     <string name="product_wip_message_m3">You can now edit grouped, external and variable products, change product type and update categories and tags.</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -571,7 +571,7 @@
     <string name="product_limited_editing_title">Limited editing available</string>
     <string name="product_limited_editing_message">We\'ve added editing functionality to simple products. Keep an eye out for more options soon!</string>
     <string name="product_adding_wip_title">Create products from the app!</string>
-    <string name="product_wip_message_m4">It\'s now possible to create simple, grouped and external products on the go from the Woo app. You can enable it by turning on the beta feature in the app settings. Not ready yet? Save them as a draft!</string>
+    <string name="product_wip_message_m4">It\'s now possible to create new products on the go from the Woo app. You can enable it by turning on the beta feature in the app settings. Not ready yet? Save them as a draft!</string>
     <string name="product_wip_title">New editing options available</string>
     <string name="product_wip_message_m2">We\'ve added more editing functionalities to products! You can now update images, see previews and share your products.</string>
     <string name="product_wip_message_m3">You can now edit grouped, external and variable products, change product type and update categories and tags.</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -736,6 +736,8 @@
     <string name="settings_confirm_logout">Are you sure you want to logout from the account %s?</string>
     <string name="settings_send_stats">Collect information</string>
     <string name="settings_enable_v4_stats_title">Improved stats</string>
+    <string name="settings_enable_product_adding_teaser_title">Creating products</string>
+    <string name="settings_enable_product_adding_teaser_message">Test out the new product creation (simple, grouped and external products) as we get ready to launch</string>
     <string name="settings_enable_product_teaser_title">Product editing</string>
     <string name="settings_enable_product_teaser_message">Test out the new product editing functionality as we get ready to launch</string>
     <string name="settings_send_stats_detail">Share information with our analytics tool about your use of services while logged in to your WordPress account</string>


### PR DESCRIPTION
Fixes #3029.

| Products | Settings |
|-|-|
| ![Screenshot_1602862475](https://user-images.githubusercontent.com/1522856/96278637-05396e80-0fd6-11eb-8dab-f22b35aa4d44.png) | ![Screenshot_1602862470](https://user-images.githubusercontent.com/1522856/96278644-07033200-0fd6-11eb-8e70-24b7b7f6951d.png) |


**To test:**
1. Go To Products
2. Verify that a banner is visible at the top
3. Check the banner title & message and make sure they match the design (#3029)
4. Verify that the Add product FAB isn't visible
5. Go to App settings
6. Verify the `Beta features (Creating products)` option is visible
7. Tap on it
8. Verify that the Creating products switch is visible and disabled
9. Enable the switch
10. Go back to Products
11. Verify the Add product FAB is visible now