### PR TITLE
Add M4 tracking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -267,6 +267,8 @@ class AnalyticsTracker private constructor(private val context: Context) {
         PRODUCT_LIST_VIEW_FILTER_OPTIONS_TAPPED,
         PRODUCT_LIST_VIEW_SORTING_OPTIONS_TAPPED,
         PRODUCT_LIST_SORTING_OPTION_SELECTED,
+        PRODUCT_LIST_ADD_PRODUCT_BUTTON_TAPPED,
+        ADD_PRODUCT_PRODUCT_TYPE_SELECTED,
 
         // -- Product detail
         PRODUCT_DETAIL_LOADED,
@@ -294,6 +296,10 @@ class AnalyticsTracker private constructor(private val context: Context) {
         PRODUCT_TAG_SETTINGS_DONE_BUTTON_TAPPED,
         PRODUCT_DETAIL_UPDATE_SUCCESS,
         PRODUCT_DETAIL_UPDATE_ERROR,
+        ADD_PRODUCT_PUBLISH_TAPPED,
+        ADD_PRODUCT_SAVE_AS_DRAFT_TAPPED,
+        ADD_PRODUCT_SUCCESS,
+        ADD_PRODUCT_FAILED,
 
         // -- Product Categories
         PRODUCT_CATEGORIES_LOADED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -13,6 +13,10 @@ import com.woocommerce.android.R
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ADD_PRODUCT_FAILED
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ADD_PRODUCT_PUBLISH_TAPPED
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ADD_PRODUCT_SAVE_AS_DRAFT_TAPPED
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ADD_PRODUCT_SUCCESS
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_IMAGE_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_SHARE_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_UPDATE_BUTTON_TAPPED
@@ -84,6 +88,7 @@ import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.store.WCProductStore.ProductErrorType
 import java.math.BigDecimal
 import java.util.Date
+import java.util.Locale
 
 @OpenClassOnDebug
 class ProductDetailViewModel @AssistedInject constructor(
@@ -336,7 +341,6 @@ class ProductDetailViewModel @AssistedInject constructor(
      * Called when the "Save as draft" button is clicked in Product detail screen
      */
     fun onSaveAsDraftButtonClicked() {
-        // TODO analytics
         updateProductDraft(productStatus = DRAFT)
         startPublishProduct()
     }
@@ -351,14 +355,28 @@ class ProductDetailViewModel @AssistedInject constructor(
 
     private fun startPublishProduct(exitWhenDone: Boolean = false) {
         viewState.productDraft?.let {
+            trackPublishing(it)
+
             viewState = viewState.copy(isProgressDialogShown = true)
             launch {
                 val isSuccess = addProduct(it)
-                if (isSuccess && exitWhenDone) {
-                    triggerEvent(ExitProduct)
+                if (isSuccess) {
+                    AnalyticsTracker.track(ADD_PRODUCT_SUCCESS)
+
+                    if (exitWhenDone) {
+                        triggerEvent(ExitProduct)
+                    }
+                } else {
+                    AnalyticsTracker.track(ADD_PRODUCT_FAILED)
                 }
             }
         }
+    }
+
+    private fun trackPublishing(it: Product) {
+        val properties = mapOf("product_type" to it.productType.value.toLowerCase(Locale.ROOT))
+        val statId = if (it.status == DRAFT) ADD_PRODUCT_SAVE_AS_DRAFT_TAPPED else ADD_PRODUCT_PUBLISH_TAPPED
+        AnalyticsTracker.track(statId, properties)
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -144,6 +144,7 @@ class ProductListViewModel @AssistedInject constructor(
     }
 
     fun onAddProductButtonClicked() {
+        AnalyticsTracker.track(Stat.PRODUCT_LIST_ADD_PRODUCT_BUTTON_TAPPED)
         triggerEvent(ShowAddProductBottomSheet)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
@@ -10,6 +10,8 @@ import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.di.ViewModelAssistedFactory
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductAdd
@@ -19,6 +21,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDiscardDialog
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import kotlinx.android.parcel.Parcelize
+import java.util.Locale.ROOT
 
 @OpenClassOnDebug
 class ProductTypesBottomSheetViewModel @AssistedInject constructor(
@@ -37,6 +40,9 @@ class ProductTypesBottomSheetViewModel @AssistedInject constructor(
 
     fun onProductTypeSelected(productTypeUiItem: ProductTypesBottomSheetUiItem) {
         if (navArgs.isAddProduct) {
+            val properties = mapOf("product_type" to productTypeUiItem.type.value.toLowerCase(ROOT))
+            AnalyticsTracker.track(Stat.ADD_PRODUCT_PRODUCT_TYPE_SELECTED, properties)
+
             saveUserSelection(productTypeUiItem.type)
             triggerEvent(ViewProductAdd)
             triggerEvent(ExitWithResult(productTypeUiItem.type))


### PR DESCRIPTION
Fixes #3038. 

## Testing

### Publish product
- Go to the Products tab
- Tap on “+” FAB —> should see `🔵 Tracked product_list_add_product_button_tapped` in the console
- Tap a product type in the bottom sheet —> should see `🔵 Tracked add_product_product_type_selected` with a property `”product_type”: (selectedProductType)` in the console
- Enter some product details
- Tap “Publish” in the navigation bar —> should see `🔵 Tracked add_product_publish_tapped` with a property `”product_type”: (selectedProductType)` in the console. After the product is added remotely, should see `🔵 Tracked add_product_success` in the console

### Save as draft from discard changes action sheet
- Go back to the Products tab
- Tap on “+” FAB, and select a product type
- Enter some product details
- Tap on the back button to leave the product screen --> should see a discard changes action sheet
- Tap “Save as Draft” —> should see `🔵 Tracked add_product_save_as_draft_tapped` with a property `”product_type”: (selectedProductType)` in the console. After the product is added remotely, should see `🔵 Tracked add_product_success` in the console

### Save as draft from the more menu
- Go back to the Products tab
- Tap on “+” FAB, and select a product type
- Enter some product details
- Tap “…” in the toolbar
- Tap “Save as draft” —> should see `🔵 Tracked add_product_save_as_draft_tapped` with a property `”product_type”: (selectedProductType)` in the console. After the product is added remotely, should see `🔵 Tracked add_product_success` in the console

### Failed to add a product
- Turn off internet connection (offline mode)
- Go back to the Products tab
- Tap on “+” FAB, and select a product type
- Enter some product details
- Tap “Publish” in the navigation bar —> should see `🔵 Tracked add_product_publish_tapped` with a property `”product_type”: (selectedProductType)` followed by `🔵 Tracked add_product_failed` 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
