### PR TITLE
Issue/3034 order product list images

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -46,7 +46,6 @@ import com.woocommerce.android.ui.orders.AddOrderShipmentTrackingFragment
 import com.woocommerce.android.ui.orders.OrderNavigationTarget
 import com.woocommerce.android.ui.orders.OrderNavigator
 import com.woocommerce.android.ui.orders.OrderProductActionListener
-import com.woocommerce.android.ui.orders.details.OrderDetailRepository.OnProductImageChanged
 import com.woocommerce.android.ui.orders.details.adapter.OrderDetailShippingLabelsAdapter.OnShippingLabelClickListener
 import com.woocommerce.android.ui.orders.notes.AddOrderNoteFragment
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRefundFragment
@@ -57,9 +56,6 @@ import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.SkeletonView
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_order_detail.*
-import org.greenrobot.eventbus.EventBus
-import org.greenrobot.eventbus.Subscribe
-import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import javax.inject.Inject
 
@@ -95,12 +91,10 @@ class OrderDetailFragment : BaseFragment(), NavigationResult, OrderProductAction
     override fun onResume() {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
-        EventBus.getDefault().register(this)
     }
 
     override fun onStop() {
         undoSnackbar?.dismiss()
-        EventBus.getDefault().unregister(this)
         super.onStop()
     }
 
@@ -146,6 +140,7 @@ class OrderDetailFragment : BaseFragment(), NavigationResult, OrderProductAction
             new.isRefreshing?.takeIfNotEqualTo(old?.isRefreshing) {
                 orderRefreshLayout.isRefreshing = it
             }
+            new.refreshedProductId?.takeIfNotEqualTo(old?.refreshedProductId) { refreshProduct(it) }
         }
 
         viewModel.orderNotes.observe(viewLifecycleOwner, Observer {
@@ -224,6 +219,10 @@ class OrderDetailFragment : BaseFragment(), NavigationResult, OrderProductAction
 
     private fun showOrderNotesSkeleton(show: Boolean) {
         orderDetail_noteList.showSkeleton(show)
+    }
+
+    private fun refreshProduct(remoteProductId: Long) {
+        orderDetail_productList.notifyProductChanged(remoteProductId)
     }
 
     private fun showOrderNotes(orderNotes: List<OrderNote>) {
@@ -369,11 +368,5 @@ class OrderDetailFragment : BaseFragment(), NavigationResult, OrderProductAction
             it.addCallback(dismissCallback)
             it.show()
         }
-    }
-
-    @SuppressWarnings("unused")
-    @Subscribe(threadMode = MAIN)
-    fun onProductImageChanged(event: OnProductImageChanged) {
-        orderDetail_productList.notifyProductChanged(event.remoteProductId)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -46,6 +46,7 @@ import com.woocommerce.android.ui.orders.AddOrderShipmentTrackingFragment
 import com.woocommerce.android.ui.orders.OrderNavigationTarget
 import com.woocommerce.android.ui.orders.OrderNavigator
 import com.woocommerce.android.ui.orders.OrderProductActionListener
+import com.woocommerce.android.ui.orders.details.OrderDetailRepository.OnProductImageChanged
 import com.woocommerce.android.ui.orders.details.adapter.OrderDetailShippingLabelsAdapter.OnShippingLabelClickListener
 import com.woocommerce.android.ui.orders.notes.AddOrderNoteFragment
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRefundFragment
@@ -56,6 +57,9 @@ import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.SkeletonView
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_order_detail.*
+import org.greenrobot.eventbus.EventBus
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import javax.inject.Inject
 
@@ -91,10 +95,12 @@ class OrderDetailFragment : BaseFragment(), NavigationResult, OrderProductAction
     override fun onResume() {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
+        EventBus.getDefault().register(this)
     }
 
     override fun onStop() {
         undoSnackbar?.dismiss()
+        EventBus.getDefault().unregister(this)
         super.onStop()
     }
 
@@ -363,5 +369,11 @@ class OrderDetailFragment : BaseFragment(), NavigationResult, OrderProductAction
             it.addCallback(dismissCallback)
             it.show()
         }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = MAIN)
+    fun onProductImageChanged(event: OnProductImageChanged) {
+        orderDetail_productList.notifyProductChanged(event.remoteProductId)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -26,6 +26,7 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCOrderAction
+import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
@@ -42,6 +43,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType
 import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderStatusPayload
 import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
 import org.wordpress.android.fluxc.store.WCRefundStore
 import org.wordpress.android.fluxc.store.WCShippingLabelStore
 import javax.inject.Inject
@@ -363,6 +365,17 @@ class OrderDetailRepository @Inject constructor(
                 continuationDeleteShipmentTracking = null
             }
             else -> { }
+        }
+    }
+
+    /**
+     * This will be triggered if we fetched a product via ProduictImageMap so we could get its image
+     */
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = MAIN)
+    fun onProductChanged(event: OnProductChanged) {
+        if (event.causeOfChange == FETCH_SINGLE_PRODUCT && !event.isError) {
+            // TODO orderDetail_productList.notifyProductChanged(event.remoteProductId)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.fluxc.Dispatcher
@@ -368,14 +369,17 @@ class OrderDetailRepository @Inject constructor(
         }
     }
 
+    class OnProductImageChanged(val remoteProductId: Long)
+
     /**
-     * This will be triggered if we fetched a product via ProduictImageMap so we could get its image
+     * This will be triggered if we fetched a product via ProduictImageMap so we could get its image.
+     * Here we fire an event that tells the fragment to update that product in the order product list.
      */
     @SuppressWarnings("unused")
     @Subscribe(threadMode = MAIN)
     fun onProductChanged(event: OnProductChanged) {
         if (event.causeOfChange == FETCH_SINGLE_PRODUCT && !event.isError) {
-            // TODO orderDetail_productList.notifyProductChanged(event.remoteProductId)
+            EventBus.getDefault().post(OnProductImageChanged(event.remoteProductId))
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailProductListAdapter.kt
@@ -39,4 +39,12 @@ class OrderDetailProductListAdapter(
     }
 
     override fun getItemCount() = orderItems.size
+
+    fun notifyProductChanged(productId: Long) {
+        for (position in 0 until orderItems.size) {
+            if (orderItems[position].productId == productId) {
+                notifyItemChanged(position)
+            }
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailProductListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailProductListView.kt
@@ -66,6 +66,12 @@ class OrderDetailProductListView @JvmOverloads constructor(
         }
     }
 
+    fun notifyProductChanged(remoteProductId: Long) {
+        with(productList_products.adapter as OrderDetailProductListAdapter) {
+            this.notifyProductChanged(remoteProductId)
+        }
+    }
+
     fun showOrderFulfillOption(
         show: Boolean,
         onOrderFulfillTapped: () -> Unit


### PR DESCRIPTION
Fixes #3034 - In the issue, the first time you go to order detail none of the product images would appear. The problem was due to not capturing `onProductChanged` when a product is fetched, so there was no way the order product list would know the product has been fetched and we can now show the image.

To test:

- Clear the app's storage cache
- Go to the order list
- Tap an order with a product
- Verify that the product image appears after a few seconds

**Note:** I'm not thrilled with this solution - especially relying on an `EventBus` - and I'm open to suggestions. The problem is that `onProductChanged` needs to be captured by the `OrderDetailRepository` and then the repository had to have a way to tell the fragment the product image is now available. If there's a better way to do this, I'd love to hear it!

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
