### PR TITLE
Hide the product list and shipment tracking section if shipping labels are available

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -414,15 +414,21 @@ class OrderDetailViewModel @AssistedInject constructor(
     private fun loadOrderShippingLabels() {
         order?.let { order ->
             orderDetailRepository.getOrderShippingLabels(orderIdSet.remoteOrderId)
-                .whenNotNullNorEmpty { _shippingLabels.value = it.loadProducts(order.items) }
+                .whenNotNullNorEmpty {
+                    _shippingLabels.value = it.loadProducts(order.items)
+                    hideShipmentTrackingAndProductsCard()
+                }
 
             launch {
                 _shippingLabels.value = orderDetailRepository
                     .fetchOrderShippingLabels(orderIdSet.remoteOrderId)
                     .loadProducts(order.items)
+                hideShipmentTrackingAndProductsCard()
             }
         }
+    }
 
+    private fun hideShipmentTrackingAndProductsCard() {
         // hide the shipment tracking section and the product list section if
         // shipping labels are available for the order
         _shippingLabels.value?.whenNotNullNorEmpty {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -420,22 +420,24 @@ class OrderDetailViewModel @AssistedInject constructor(
                 }
 
             launch {
-                _shippingLabels.value = orderDetailRepository
+                orderDetailRepository
                     .fetchOrderShippingLabels(orderIdSet.remoteOrderId)
                     .loadProducts(order.items)
-                hideShipmentTrackingAndProductsCard()
+                    .whenNotNullNorEmpty {
+                        _shippingLabels.value = it
+
+                        // hide the shipment tracking section and the product list section if
+                        // shipping labels are available for the order
+                        hideShipmentTrackingAndProductsCard()
+                    }
             }
         }
     }
 
     private fun hideShipmentTrackingAndProductsCard() {
-        // hide the shipment tracking section and the product list section if
-        // shipping labels are available for the order
-        _shippingLabels.value?.whenNotNullNorEmpty {
-            _productList.value = emptyList()
-            _shipmentTrackings.value = emptyList()
-            orderDetailViewState = orderDetailViewState.copy(isShipmentTrackingAvailable = false)
-        }
+        _productList.value = emptyList()
+        _shipmentTrackings.value = emptyList()
+        orderDetailViewState = orderDetailViewState.copy(isShipmentTrackingAvailable = false)
     }
 
     @Parcelize


### PR DESCRIPTION
Fixes #3051 by adding the logic to display products card and shipment tracking card only if shipping labels are not available.

#### To test
- Clear the storage cache of the app and login again.
- Click on an order with shipping labels available.
- Notice that once the shipping labels are fetched and displayed, the products and shipment trackings card is no longer visible.
- Go back to the Orders screen.
- Switch on aeroplane mode.
- Click on the same order again from step 2.
- Notice the shipping labels are displayed and the products and shipment trackings section is no longer displayed.

**This might be a bit confusing to the user so I thought it made more sense to release this as part of the beta fix.** 

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
