### PR TITLE
Add crowdsignal survey URL rule

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -26,4 +26,5 @@ object AppUrls {
     const val CROWDSIGNAL_PRODUCT_SURVEY = "https://automattic.survey.fm/woo-app-feature-feedback-products"
     const val CROWDSIGNAL_SHIPPING_LABELS_SURVEY =
         "https://automattic.survey.fm/woo-app-feature-feedback-shipping-labels"
+    const val CROWDSIGNAL_PLATFORM_TAG = "woo-mobile-platform=android"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -26,5 +26,4 @@ object AppUrls {
     const val CROWDSIGNAL_PRODUCT_SURVEY = "https://automattic.survey.fm/woo-app-feature-feedback-products"
     const val CROWDSIGNAL_SHIPPING_LABELS_SURVEY =
         "https://automattic.survey.fm/woo-app-feature-feedback-shipping-labels"
-    const val CROWDSIGNAL_PLATFORM_TAG = "woo-mobile-platform=android"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -631,7 +631,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_FEEDBACK_DISMISSED = "dismissed"
         const val VALUE_FEEDBACK_GIVEN = "gave_feedback"
         const val VALUE_PRODUCT_M3_FEEDBACK = "products_m3"
-        const val VALUE_SHIPPING_LABELS_M3_FEEDBACK = "shipping_labels_m3"
+        const val VALUE_SHIPPING_LABELS_M1_FEEDBACK = "shipping_labels_m1"
 
         const val IMAGE_SOURCE_CAMERA = "camera"
         const val IMAGE_SOURCE_DEVICE = "device"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
@@ -11,9 +11,11 @@ enum class SurveyType(private val untaggedUrl: String, private val milestone: In
         get() = "$untaggedUrl?$platformTag$milestoneTag"
 
     private val milestoneTag
-        get() = milestone?.let {
-            "&milestone=$it"
-        } ?: ""
+            get() = when(this) {
+                PRODUCT -> "&product_milestone=$milestone"
+                SHIPPING_LABELS -> "&shipping_label_milestone=$milestone"
+                else -> ""
+            }
 
     private val platformTag = "woo-mobile-platform=android"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
@@ -11,11 +11,11 @@ enum class SurveyType(private val untaggedUrl: String, private val milestone: In
         get() = "$untaggedUrl?$platformTag$milestoneTag"
 
     private val milestoneTag
-            get() = when(this) {
-                PRODUCT -> "&product_milestone=$milestone"
-                SHIPPING_LABELS -> "&shipping_label_milestone=$milestone"
-                else -> ""
-            }
+        get() = when (this) {
+            PRODUCT -> "&product_milestone=$milestone"
+            SHIPPING_LABELS -> "&shipping_label_milestone=$milestone"
+            else -> ""
+        }
 
     private val platformTag = "woo-mobile-platform=android"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
@@ -12,7 +12,7 @@ enum class SurveyType(private val untaggedUrl: String, private val milestone: In
 
     private val milestoneTag
         get() = when (this) {
-            PRODUCT -> "&product_milestone=$milestone"
+            PRODUCT -> "&product-milestone=$milestone"
             SHIPPING_LABELS -> "&shipping_label_milestone=$milestone"
             else -> ""
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
@@ -1,9 +1,13 @@
 package com.woocommerce.android.ui.feedback
 
 import com.woocommerce.android.AppUrls
+import com.woocommerce.android.AppUrls.CROWDSIGNAL_PLATFORM_TAG
 
-enum class SurveyType(val url: String) {
+enum class SurveyType(private val untagedUrl: String) {
     PRODUCT(AppUrls.CROWDSIGNAL_PRODUCT_SURVEY),
     SHIPPING_LABELS(AppUrls.CROWDSIGNAL_SHIPPING_LABELS_SURVEY),
-    MAIN(AppUrls.CROWDSIGNAL_MAIN_SURVEY)
+    MAIN(AppUrls.CROWDSIGNAL_MAIN_SURVEY);
+
+    val url
+        get() = "$untagedUrl?$CROWDSIGNAL_PLATFORM_TAG"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
@@ -3,11 +3,16 @@ package com.woocommerce.android.ui.feedback
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.AppUrls.CROWDSIGNAL_PLATFORM_TAG
 
-enum class SurveyType(private val untagedUrl: String) {
-    PRODUCT(AppUrls.CROWDSIGNAL_PRODUCT_SURVEY),
-    SHIPPING_LABELS(AppUrls.CROWDSIGNAL_SHIPPING_LABELS_SURVEY),
+enum class SurveyType(private val untagedUrl: String, private val milestone: Int? = null) {
+    PRODUCT(AppUrls.CROWDSIGNAL_PRODUCT_SURVEY, 4),
+    SHIPPING_LABELS(AppUrls.CROWDSIGNAL_SHIPPING_LABELS_SURVEY, 1),
     MAIN(AppUrls.CROWDSIGNAL_MAIN_SURVEY);
 
     val url
-        get() = "$untagedUrl?$CROWDSIGNAL_PLATFORM_TAG"
+        get() = "$untagedUrl?$CROWDSIGNAL_PLATFORM_TAG$milestoneTag"
+
+    private val milestoneTag
+        get() = milestone?.let {
+            "&milestone=$it"
+        } ?: ""
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
@@ -1,18 +1,19 @@
 package com.woocommerce.android.ui.feedback
 
 import com.woocommerce.android.AppUrls
-import com.woocommerce.android.AppUrls.CROWDSIGNAL_PLATFORM_TAG
 
-enum class SurveyType(private val untagedUrl: String, private val milestone: Int? = null) {
+enum class SurveyType(private val untaggedUrl: String, private val milestone: Int? = null) {
     PRODUCT(AppUrls.CROWDSIGNAL_PRODUCT_SURVEY, 4),
     SHIPPING_LABELS(AppUrls.CROWDSIGNAL_SHIPPING_LABELS_SURVEY, 1),
     MAIN(AppUrls.CROWDSIGNAL_MAIN_SURVEY);
 
     val url
-        get() = "$untagedUrl?$CROWDSIGNAL_PLATFORM_TAG$milestoneTag"
+        get() = "$untaggedUrl?$platformTag$milestoneTag"
 
     private val milestoneTag
         get() = milestone?.let {
             "&milestone=$it"
         } ?: ""
+
+    private val platformTag = "woo-mobile-platform=android"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -327,7 +327,7 @@ class OrderDetailFragment : BaseFragment(), NavigationResult, OrderProductAction
     private fun onGiveFeedbackClicked() {
         AnalyticsTracker.track(
             FEATURE_FEEDBACK_BANNER, mapOf(
-            AnalyticsTracker.KEY_FEEDBACK_CONTEXT to AnalyticsTracker.VALUE_SHIPPING_LABELS_M3_FEEDBACK,
+            AnalyticsTracker.KEY_FEEDBACK_CONTEXT to AnalyticsTracker.VALUE_SHIPPING_LABELS_M1_FEEDBACK,
             AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_GIVEN
         ))
         registerFeedbackSetting(GIVEN)
@@ -339,7 +339,7 @@ class OrderDetailFragment : BaseFragment(), NavigationResult, OrderProductAction
     private fun onDismissProductWIPNoticeCardClicked() {
         AnalyticsTracker.track(
             FEATURE_FEEDBACK_BANNER, mapOf(
-            AnalyticsTracker.KEY_FEEDBACK_CONTEXT to AnalyticsTracker.VALUE_SHIPPING_LABELS_M3_FEEDBACK,
+            AnalyticsTracker.KEY_FEEDBACK_CONTEXT to AnalyticsTracker.VALUE_SHIPPING_LABELS_M1_FEEDBACK,
             AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_DISMISSED
         ))
         registerFeedbackSetting(DISMISSED)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/feedback/SurveyTypeTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/feedback/SurveyTypeTest.kt
@@ -16,12 +16,12 @@ class SurveyTypeTest {
 
     @Test
     fun `Product SurveyType url should include a milestone tag`() {
-        assertThat(PRODUCT.url.contains(Regex("milestone=\\d(?!\\S)"))).isTrue()
+        assertThat(PRODUCT.url.contains(Regex("product-milestone=\\d(?!\\S)"))).isTrue()
     }
 
     @Test
     fun `ShippingLabels SurveyType url should include a milestone tag`() {
-        assertThat(SHIPPING_LABELS.url.contains(Regex("milestone=\\d(?!\\S)"))).isTrue()
+        assertThat(SHIPPING_LABELS.url.contains(Regex("shipping_label_milestone=\\d(?!\\S)"))).isTrue()
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/feedback/SurveyTypeTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/feedback/SurveyTypeTest.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.ui.feedback
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class SurveyTypeTest {
+    @Test
+    fun `SurveyType url should include platform tag for any URL`() {
+        SurveyType.values().forEach {
+            assertThat(it.url.contains("woo-mobile-platform=android")).isTrue()
+        }
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/feedback/SurveyTypeTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/feedback/SurveyTypeTest.kt
@@ -1,5 +1,8 @@
 package com.woocommerce.android.ui.feedback
 
+import com.woocommerce.android.ui.feedback.SurveyType.MAIN
+import com.woocommerce.android.ui.feedback.SurveyType.PRODUCT
+import com.woocommerce.android.ui.feedback.SurveyType.SHIPPING_LABELS
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -9,5 +12,20 @@ class SurveyTypeTest {
         SurveyType.values().forEach {
             assertThat(it.url.contains("woo-mobile-platform=android")).isTrue()
         }
+    }
+
+    @Test
+    fun `Product SurveyType url should include a milestone tag`() {
+        assertThat(PRODUCT.url.contains(Regex("milestone=\\d(?!\\S)"))).isTrue()
+    }
+
+    @Test
+    fun `ShippingLabels SurveyType url should include a milestone tag`() {
+        assertThat(SHIPPING_LABELS.url.contains(Regex("milestone=\\d(?!\\S)"))).isTrue()
+    }
+
+    @Test
+    fun `Main SurveyType url should NOT include a milestone tag`() {
+        assertThat(MAIN.url.contains(Regex("milestone=\\d(?!\\S)"))).isFalse()
     }
 }


### PR DESCRIPTION
Summary
==========
Fixes issue #3045. Our survey implementation code as it is right now is not submitting in any way a clear platform identification to achieve an easy identification of the user inputs on our surveys.

How to Test
==========
⚠️ There are no visual changes to test the survey with the new URL, but I've added a unit test for the `SurveyType` class to enforce that we're not leaving the URL platform information untagged.

1. Go to the My Store section
2. Click on the Settings icon on the upper right corner of the toolbar
3. Once the settings view is presented, click on the `Send feedback` option
4. Wait for the survey loading and make sure everything is working the same way as before
5. Complete the Survey Form
6. Go to the CrowdSignal dashboard with a valid A8C account and go to the respective Survey overview page you just answered
7. Click at the far right corner of the Overview page and click on export button to download the Survey report, you can export in both CSV or Excel, it's up to your choice.
8. Go to the right end of the report file and verify if the custom tags are presented according to the Survey you just answered

Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
