### PR TITLE
Fixed crash when there were no products for an order

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -116,8 +116,10 @@ class OrderDetailViewModel @AssistedInject constructor(
 
     fun hasVirtualProductsOnly(): Boolean {
         return orderDetailViewState.order?.items?.let { lineItems ->
-            val remoteProductIds = lineItems.map { it.productId }
-            orderDetailRepository.getProductsByRemoteIds(remoteProductIds).any { it.virtual }
+            if (lineItems.isNotEmpty()) {
+                val remoteProductIds = lineItems.map { it.productId }
+                orderDetailRepository.getProductsByRemoteIds(remoteProductIds).any { it.virtual }
+            } else false
         } ?: false
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -171,6 +171,24 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `hasVirtualProductsOnly returns false if there are no products for the order`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            val order = order.copy(items = emptyList())
+            doReturn(order).whenever(repository).getOrder(any())
+
+            doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
+            doReturn(testOrderNotes).whenever(repository).getOrderNotes(any())
+            doReturn(RequestResult.SUCCESS).whenever(repository).fetchOrderShipmentTrackingList(any(), any())
+            doReturn(testOrderShipmentTrackings).whenever(repository).getOrderShipmentTrackings(any())
+            doReturn(emptyList<ShippingLabel>()).whenever(repository).getOrderShippingLabels(any())
+            doReturn(emptyList<ShippingLabel>()).whenever(repository).fetchOrderShippingLabels(any())
+
+
+            viewModel.start()
+            assertThat(viewModel.hasVirtualProductsOnly()).isEqualTo(false)
+        }
+
+    @Test
     fun `Do not display product list when all products are refunded`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             doReturn(order).whenever(repository).getOrder(any())

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -183,7 +183,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(emptyList<ShippingLabel>()).whenever(repository).getOrderShippingLabels(any())
             doReturn(emptyList<ShippingLabel>()).whenever(repository).fetchOrderShippingLabels(any())
 
-
             viewModel.start()
             assertThat(viewModel.hasVirtualProductsOnly()).isEqualTo(false)
         }


### PR DESCRIPTION
Fixes #3063 by adding a check for the `LineItems` in an order. This crash seems to be happening for manually created orders that does not have any products associated with it. h/t to @astralbodies for providing the stack trace for the crash during beta testing.

### To test
- Manually create an order for your test site from `wp-admin`.
- Open the order in the app.
- Notice the app does not crash.
- Add fee to the order from `wp-admin`. This can be done by clicking on `Add products` -> `Add fee`.
- Open the order in the app after refreshing the order list.  
- Notice the app does not crash.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
