### PR TITLE
issue/3058-order-detail-crash-fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailProductListAdapter.kt
@@ -41,7 +41,7 @@ class OrderDetailProductListAdapter(
     override fun getItemCount() = orderItems.size
 
     fun notifyProductChanged(productId: Long) {
-        for (position in 0 until orderItems.size) {
+        for (position in orderItems.indices) {
             if (orderItems[position].productId == productId) {
                 notifyItemChanged(position)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailProductListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailProductListView.kt
@@ -67,8 +67,8 @@ class OrderDetailProductListView @JvmOverloads constructor(
     }
 
     fun notifyProductChanged(remoteProductId: Long) {
-        with(productList_products.adapter as OrderDetailProductListAdapter) {
-            this.notifyProductChanged(remoteProductId)
+        with(productList_products.adapter as? OrderDetailProductListAdapter) {
+            this?.notifyProductChanged(remoteProductId)
         }
     }
 


### PR DESCRIPTION
Fixes #3058 by adding logic to check if the `OrderDetailProductListAdapter` is initialised before updating it.

#### To test
- Click on an order from the Orders tab.
- Click on a product from the product list.
- Click on the back arrow button.
- Notice the app no longer crashes.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
