### PR TITLE
Remove the add variable product option

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 
 5.3
 -----
-* In Settings > Beta features, a Products switch is now available for turning Products M4 features on and off (default off). Products M4 features: add a simple/grouped/external/variable product with actions to publish or save as draft.
+* In Settings > Beta features, a Products switch is now available for turning Products M4 features on and off (default off). Products M4 features: add a simple/grouped/external product with actions to publish or save as draft.
 * Application settings have been moved to a gear icon on the Dashboard
 * You can now view product review details directly from product detail screen
 * Product detail screen now includes the number of ratings for that product

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductAddTypeBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductAddTypeBottomSheetBuilder.kt
@@ -23,7 +23,7 @@ class ProductAddTypeBottomSheetBuilder : ProductTypeBottomSheetBuilder {
                 titleResource = string.product_add_type_variable,
                 descResource = string.product_add_type_variable_desc,
                 iconResource = drawable.ic_gridicons_types,
-                isEnabled = true
+                isEnabled = false
             ),
             ProductTypesBottomSheetUiItem(
                 type = GROUPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
@@ -35,7 +35,7 @@ class ProductTypesBottomSheetViewModel @AssistedInject constructor(
     val productTypesBottomSheetList: LiveData<List<ProductTypesBottomSheetUiItem>> = _productTypesBottomSheetList
 
     fun loadProductTypes(builder: ProductTypeBottomSheetBuilder) {
-        _productTypesBottomSheetList.value = builder.buildBottomSheetList()
+        _productTypesBottomSheetList.value = builder.buildBottomSheetList().filter { it.isEnabled }
     }
 
     fun onProductTypeSelected(productTypeUiItem: ProductTypesBottomSheetUiItem) {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -571,7 +571,7 @@
     <string name="product_limited_editing_title">Limited editing available</string>
     <string name="product_limited_editing_message">We\'ve added editing functionality to simple products. Keep an eye out for more options soon!</string>
     <string name="product_adding_wip_title">Create products from the app!</string>
-    <string name="product_wip_message_m4">It\'s now possible to create new products on the go from the Woo app. You can enable it by turning on the beta feature in the app settings. Not ready yet? Save them as a draft!</string>
+    <string name="product_wip_message_m4">It\'s now possible to create new simple, linked and grouped products on the go from the Woo app. You can enable it by turning on the beta feature in the app settings. Not ready yet? Save them as a draft!</string>
     <string name="product_wip_title">New editing options available</string>
     <string name="product_wip_message_m2">We\'ve added more editing functionalities to products! You can now update images, see previews and share your products.</string>
     <string name="product_wip_message_m3">You can now edit grouped, external and variable products, change product type and update categories and tags.</string>
@@ -739,7 +739,7 @@
     <string name="settings_send_stats">Collect information</string>
     <string name="settings_enable_v4_stats_title">Improved stats</string>
     <string name="settings_enable_product_adding_teaser_title">Creating products</string>
-    <string name="settings_enable_product_adding_teaser_message">Test out the new product creation as we get ready to launch</string>
+    <string name="settings_enable_product_adding_teaser_message">Test out the new simple, linked and grouped product creation as we get ready to launch</string>
     <string name="settings_enable_product_teaser_title">Product editing</string>
     <string name="settings_enable_product_teaser_message">Test out the new product editing functionality as we get ready to launch</string>
     <string name="settings_send_stats_detail">Share information with our analytics tool about your use of services while logged in to your WordPress account</string>


### PR DESCRIPTION
Fixes #3068.

This PR removes the variable product from the add-product bottom sheet and updates the messages.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
