### PR TITLE
Issue/3069 shipping labels text changes

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -318,7 +318,7 @@
         Print shipping labels
     -->
     <string name="shipping_label_print_error_message">If there was a printing error when you purchased the label, you can print it again.</string>
-    <string name="shipping_label_print_disclaimer">If you already used the label in a package, printing and using it again is a violation of our terms of services.</string>
+    <string name="shipping_label_print_disclaimer">If you already used the label on a package, printing and using it again is a violation of our terms of service.</string>
     <string name="shipping_label_paper_size">Paper size</string>
     <string name="shipping_label_paper_size_options_title">Choose paper size</string>
     <string name="shipping_label_print_button">Print shipping label</string>
@@ -328,17 +328,17 @@
     <string name="shipping_label_paper_size_legal">Legal (8.5 x 14 in)</string>
     <string name="shipping_label_paper_size_letter">Letter (8.5 x 11 in)</string>
     <string name="shipping_label_paper_size_label">Label (4 x 6 in)</string>
-    <string name="print_shipping_label_info_title">Print with your phone</string>
+    <string name="print_shipping_label_info_title">Print with your device</string>
     <string name="print_shipping_label_format_options_title">Label format options</string>
     <string name="print_shipping_label_info_step_count_1" translatable="false">1</string>
     <string name="print_shipping_label_info_step_count_2" translatable="false">2</string>
     <string name="print_shipping_label_info_step_count_3" translatable="false">3</string>
     <string name="print_shipping_label_info_step_count_4" translatable="false">4</string>
     <string name="print_shipping_label_info_step_count_5" translatable="false">5</string>
-    <string name="print_shipping_label_info_step_1">Make sure your printer and your phone are connected to the <b>same wifi networks</b></string>
+    <string name="print_shipping_label_info_step_1">Make sure your printer and your device are connected to the <b>same WiFi networks</b></string>
     <string name="print_shipping_label_info_step_2">After selecting <b>\"Print shipping label\"</b>, you may have to select and add a printer if you haven\'t printed from this device before.</string>
-    <string name="print_shipping_label_info_step_3">You can select your phone\'s <b>default print service</b> or install your <b>printer\'s brand app</b> (this should appear as a recommended option)</string>
-    <string name="print_shipping_label_info_step_4">You might have to <b>configure wifi printing directly on the printer itself.</b> Make sure the printer firmware is updated and see your printer documentation for instructions.</string>
+    <string name="print_shipping_label_info_step_3">You can select your device\'s <b>default print service</b> or install your <b>printer\'s brand app</b> (this should appear as a recommended option)</string>
+    <string name="print_shipping_label_info_step_4">You might have to <b>configure WiFi printing directly on the printer itself.</b> Make sure the printer firmware is updated and see your printer documentation for instructions.</string>
     <string name="print_shipping_label_info_step_5">If you are still experiencing issues printing from your device, you can <b>save your label as PDF</b> and send it by email to print it from another device.</string>
 
     <!--


### PR DESCRIPTION
This tiny PR fixes #3069 by updating some text in the shipping label info screen. 

- Changes wifi to WiFi (there are two).
- Changes the title of the Shipping Label info screen from “Print with your phone” to “Print with your device” as they might be using a tablet.
- Changes terms of services to service (drop the pluralization on services).
- Changes label `on` a package (instead of `in`).

#### To test
- Click on `Reprint shipping label` button.
- Notice the text changes (`terms of services` is changed to `terms of service`.
- Click on `Don't know how to print from your phone?`. 
- Notice the text changes. i.e. Toolbar title is changed to `Print from your device`. wifi is change to `WiFi`.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
