### PR TITLE
issue/3088-missing-argument-selectedImage 

### DIFF
--- a/WooCommerce/src/main/res/navigation/nav_graph_image_gallery.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_image_gallery.xml
@@ -18,6 +18,7 @@
             app:argType="com.woocommerce.android.model.Product$Image[]" />
         <argument
             android:name="selectedImage"
+            android:defaultValue="@null"
             app:argType="com.woocommerce.android.model.Product$Image"
             app:nullable="true" />
         <argument


### PR DESCRIPTION
Fixes #3088 by providing a default value for `selectedImage` in the `ProductImagesFragment`'s navArgs.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
