### PR TITLE
CONTRIBUTING.md: Add information about our PR merge policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,14 @@ The core team monitors and reviews all pull requests. Depending on the changes, 
 
 We do our best to respond quickly to all pull requests. If you don't get a response from us after a week, feel free to reach out to us via Slack.
 
+Note: If you are part of the org and have the permissions on the repo, don't forget to assign yourself to the PR, and add the appropriate GitHub label and Milestone for the PR
+
+### PR merge policy
+
+* PRs require one reviewer to approve the PR before it can be merged to the base branch
+* We keep the PR git history when merging (merge via "merge commit")
+* The reviewer who approved the PR will merge it right after approval (without waiting for the PR author) if all checks are green.
+
 ### Development Practices
 
 <!--TODO-->


### PR DESCRIPTION
Similar to https://github.com/wordpress-mobile/WordPress-Android/pull/13243, add a mention in our contributing guidelines about the merge policy we use for this repo.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
