### PR TITLE
Added missing flag when adding shipment tracking for an order

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderShipmentTrackingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderShipmentTrackingFragment.kt
@@ -211,6 +211,7 @@ class AddOrderShipmentTrackingFragment : BaseFragment(), AddOrderShipmentTrackin
                     trackingNumber = trackingNumText,
                     dateShipped = getDateShippedText(),
                     trackingProvider = providerText,
+                    isCustomProvider = isCustomProvider,
                     trackingLink = if (isCustomProvider) { customProviderTrackingUrl } else ""
                 )
 


### PR DESCRIPTION
This tiny PR fixes #3074 by adding the missing `isCustomProvider` flag when adding shipment tracking for an order.

#### To test
- Click on an order from the Orders tab.
- Go to Tracking section and select "Add Tracking".
- Choose custom courier and fill in all fields. Make sure you enter a courier name.
- Click on `Add` and notice that the courier name is displayed correctly.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
