### PR TITLE
issue/3087-media-gallery-view-crash-fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaPickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaPickerFragment.kt
@@ -132,7 +132,7 @@ class WPMediaPickerFragment : BaseFragment(), WPMediaGalleryListener, BackPressL
      * If any images are selected set the title to the selection count, otherwise use default title
      */
     override fun getFragmentTitle(): String {
-        val count = wpMediaGallery.getSelectedCount()
+        val count = wpMediaGallery?.getSelectedCount()
         return if (count == 0) {
             getString(R.string.wpmedia_picker_title)
         } else {


### PR DESCRIPTION
Fixes #3087 by checking if `wpMediaGallery` is null before attempting to fetch the selected image count. If it is null, then the default text would be displayed which would be `WordPress media library`.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
