### PR TITLE
issue/3081-filter-option-crash-fix

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 5.4
 -----
- 
+* [*] Fixed a rare crash happening when adding new product category and selecting product filter options. [https://github.com/woocommerce/woocommerce-android/pull/3098]
 
 5.3
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
@@ -25,13 +25,14 @@ import com.woocommerce.android.ui.products.ProductFilterListViewModel.FilterList
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.AlignedDividerDecoration
 import kotlinx.android.synthetic.main.fragment_product_filter_option_list.*
+import dagger.Lazy
 import javax.inject.Inject
 
 class ProductFilterOptionListFragment : BaseFragment(), OnProductFilterOptionClickListener {
-    @Inject lateinit var viewModelFactory: ViewModelFactory
+    @Inject lateinit var viewModelFactory: Lazy<ViewModelFactory>
     private val viewModel: ProductFilterListViewModel by navGraphViewModels(
             R.id.nav_graph_product_filters
-    ) { viewModelFactory }
+    ) { viewModelFactory.get() }
 
     private val arguments: ProductFilterOptionListFragmentArgs by navArgs()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
@@ -30,6 +30,7 @@ import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.CustomProgressDialog
 import kotlinx.android.synthetic.main.fragment_add_product_category.*
 import org.wordpress.android.util.ActivityUtils
+import dagger.Lazy
 import javax.inject.Inject
 
 class AddProductCategoryFragment : BaseFragment(), BackPressListener {
@@ -42,10 +43,10 @@ class AddProductCategoryFragment : BaseFragment(), BackPressListener {
     private var progressDialog: CustomProgressDialog? = null
 
     @Inject lateinit var uiMessageResolver: UIMessageResolver
-    @Inject lateinit var viewModelFactory: ViewModelFactory
+    @Inject lateinit var viewModelFactory: Lazy<ViewModelFactory>
 
     private val viewModel: AddProductCategoryViewModel
-        by navGraphViewModels(R.id.nav_graph_add_product_category) { viewModelFactory }
+        by navGraphViewModels(R.id.nav_graph_add_product_category) { viewModelFactory.get() }
 
     override fun onCreateView(
         inflater: LayoutInflater,


### PR DESCRIPTION
Fixes #3081 by making `viewModelFactory` in `ProductFilterOptionFragment`  and `AddProductCategoryFragment` lazy. 

The cause of the crash could be that the dagger injection in `BaseFragment` is on the `onAttach` method and `SavedStateRegistryOwner` needed for `viewModelFactory` of `BaseFragment` depended on `findNavController` which is not available before onCreate. This PR makes the injection of viewModelFactory lazy, so we won't try to access findNavController before onCreate.

**I noticed this crash happen in two places, based on the logs from Sentry.**

### To test
- Click on a Product from the Products tab.
  - Click on the `categories` section. 
  - Click on `Add Category`.
  - Verify that a new category is added to the product successfully.
- Verify that the product filter option works correctly.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
