### PR TITLE
Add example format in RELEASE-NOTES

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,5 @@
+*** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+
 5.4
 -----
 * You can now add and edit linked products


### PR DESCRIPTION
Same as https://github.com/woocommerce/woocommerce-ios/pull/3057, this adds an example at the top to help internal and external contributors remember what the format is. 

Ref p91TBi-3Ah-p2

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **LOL YES** 🤣 
