### PR TITLE
UL: Store Picker & Store address screen tweaks

### DIFF
--- a/WooCommerce/src/main/res/drawable/ic_help_24dp.xml
+++ b/WooCommerce/src/main/res/drawable/ic_help_24dp.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+
+    <path
+        android:fillColor="@color/color_icon_menu_login"
+        android:pathData="M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103 0.897-2 2-2s2 0.897 2 2-0.897 2-2 2c-0.552 0-1 0.448-1 1v2h2v-1.14c1.722-0.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z" />
+
+</vector>

--- a/WooCommerce/src/main/res/layout/activity_site_picker.xml
+++ b/WooCommerce/src/main/res/layout/activity_site_picker.xml
@@ -59,7 +59,7 @@
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/site_list_label"
-                    android:textAppearance="@style/TextAppearance.Woo.Body2"
+                    android:textAppearance="@style/TextAppearance.Woo.Subtitle2"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_margin="@dimen/major_100"

--- a/WooCommerce/src/main/res/layout/activity_site_picker.xml
+++ b/WooCommerce/src/main/res/layout/activity_site_picker.xml
@@ -31,12 +31,14 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-            <com.google.android.material.button.MaterialButton
+            <ImageButton
                 android:id="@+id/button_help"
                 style="@style/Woo.Button"
-                android:layout_width="wrap_content"
+                android:layout_width="48dp"
                 android:layout_height="wrap_content"
-                android:text="@string/help"
+                android:layout_marginTop="@dimen/minor_50"
+                android:src="@drawable/ic_help_24dp"
+                android:contentDescription="@string/help"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"/>
 
@@ -74,7 +76,13 @@
             </LinearLayout>
 
             <include
-                layout="@layout/view_login_user_info"/>
+                layout="@layout/view_login_user_info"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/major_100"
+                app:layout_constraintEnd_toStartOf="@+id/button_help"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
             <include
                 layout="@layout/view_login_no_stores"/>

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -58,6 +58,11 @@
     <color name="color_icon_menu">@color/woo_white</color>
 
     <!--
+        Toolbar icons for login menus
+    -->
+    <color name="color_icon_menu_login">@color/color_on_surface_high_selector</color>
+
+    <!--
         Custom widget tint
     -->
     <color name="ratings_bar_progress_tint">@color/color_on_surface_high</color>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1394,9 +1394,9 @@
     <string name="signup_confirmation_title">Signup confirmation</string>
     
     <string name="login_site_address">Site address</string>
-    <string name="login_site_address_help_title">What\'s my site address?</string>
-    <string name="login_site_address_help_content">Your site address appears in the bar at the top of the screen when you visit your site in Chrome.</string>
-    <string name="login_find_your_site_adress">Find your site address</string>
+    <string name="login_site_address_help_title">What\'s my store address?</string>
+    <string name="login_site_address_help_content">Your store address appears in the bar at the top of the screen when you visit your store in Chrome.</string>
+    <string name="login_find_your_site_adress">Find your store address</string>
     <string name="enter_email_wordpress_com">Log in to WordPress.com using an email address to manage all your WordPress sites.</string>
     <string name="email_not_registered_wpcom">Hmm, we can\'t find a WordPress.com account connected to this email address.</string>
     <string name="login_magic_links_label">We\'ll email you a link that\'ll log you in instantly, no password needed.</string>


### PR DESCRIPTION
This PR closes #2984 and tweaks the following:
- Store picker screen: Update text styling for "SELECT STORE TO CONNECT"
- Store picker screen: Change the help button to use the icon
- Site address screen: Change any reference of "site" to "store"
- Site address help dialog: Change any reference of "site" to "store"

Before | After
-- | --
![Screenshot_1604004203](https://user-images.githubusercontent.com/5810477/97630383-e5f30600-1a05-11eb-9d1b-0de8e66b9a8f.png)|![Screenshot_1603997656](https://user-images.githubusercontent.com/5810477/97630400-ed1a1400-1a05-11eb-9749-cce0f29767e3.png)
![Screenshot_1604004184](https://user-images.githubusercontent.com/5810477/97630420-f3a88b80-1a05-11eb-9912-359aa9390ac9.png)|![Screenshot_1603998176](https://user-images.githubusercontent.com/5810477/97630431-f905d600-1a05-11eb-8b2b-b162a16c3014.png)
![Screenshot_1604004187](https://user-images.githubusercontent.com/5810477/97630441-002ce400-1a06-11eb-8364-cd1a45b2637a.png)|![Screenshot_1603998184](https://user-images.githubusercontent.com/5810477/97630450-0327d480-1a06-11eb-9064-0f790f0a3542.png)



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
