### PR TITLE
Switch the string validation command to lint

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,7 +9,7 @@ Dotenv.load('~/.wcandroid-env.default')
 ENV[GHHELPER_REPO="woocommerce/woocommerce-android"]
 ENV["PROJECT_NAME"]="WooCommerce"
 ENV["PROJECT_ROOT_FOLDER"]="./"
-ENV["validate_translations"]="buildVanillaRelease"
+ENV["validate_translations"]="lintVanillaRelease"
 
 SUPPORTED_LOCALES = [
   { glotpress: "ar", google_play: "ar",  promo_config: {}},


### PR DESCRIPTION
This PR fixes an issue where the string validation wasn't executed by the `finalize_release` lane because the `gradle` task t be invoked was set to `buildVanillaRelease` which doesn't run the linter. 

This PR switches it to `lintVanillaRelease`.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
