### PR TITLE
Pinpoint OpenJDK version to 11 in the CircleCI Release build task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
           command: |
             /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
             eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
-            brew install openjdk
+            brew install openjdk@11
             brew install bundletool
             echo "export PATH='/home/linuxbrew/.linuxbrew/Cellar/bundletool/1.2.0/bin:$PATH'" >> $BASH_ENV
             rm WooCommerce/release.jks


### PR DESCRIPTION
This PR fixes an issue where we didn't pinpoint the openJDK version installed by brew on CircleCI. This PR pinpoints it to OpenJDK@11.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
