### PR TITLE
issue/release-notes-remove-linked-products-5.4 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,6 @@
  
 5.4
 -----
-* You can now add and edit linked products
 * Selected product variation information now fully displayed in order details
 * Fixed a rare crash happening when adding new product category and selecting product filter options. [https://github.com/woocommerce/woocommerce-android/pull/3098]
 


### PR DESCRIPTION
This PR removes the mention of linked products in the release notes. Linked products are part of M5 and aren't available to users yet.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
