### PR TITLE
Show different banner based on M4 flag switch state

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -424,11 +424,15 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener, ProductS
 
     private fun showProductWIPNoticeCard(show: Boolean) {
         if (show && feedbackState != DISMISSED) {
-            val wipCardMessageId = R.string.product_wip_message_m4
+            val (wipCardTitleId, wipCardMessageId) = if (FeatureFlag.PRODUCT_RELEASE_M4.isEnabled(requireContext()))
+                R.string.product_adding_wip_title to R.string.product_wip_message_m4
+            else
+                R.string.product_wip_title to R.string.product_wip_message_m3
+
             products_wip_card.visibility = View.VISIBLE
             products_wip_card.initView(
-                getString(R.string.product_adding_wip_title),
-                getString(wipCardMessageId),
+                title = getString(wipCardTitleId),
+                message = getString(wipCardMessageId),
                 onGiveFeedbackClick = ::onGiveFeedbackClicked,
                 onDismissClick = ::onDismissProductWIPNoticeCardClicked
             )

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -572,7 +572,7 @@
     <string name="product_limited_editing_title">Limited editing available</string>
     <string name="product_limited_editing_message">We\'ve added editing functionality to simple products. Keep an eye out for more options soon!</string>
     <string name="product_adding_wip_title">Create products from the app!</string>
-    <string name="product_wip_message_m4">It\'s now possible to create new simple, linked and grouped products on the go from the Woo app. You can enable it by turning on the beta feature in the app settings. Not ready yet? Save them as a draft!</string>
+    <string name="product_wip_message_m4">It\'s now possible to create new simple, external and grouped products on the go from the Woo app. You can enable it by turning on the beta feature in the app settings. Not ready yet? Save them as a draft!</string>
     <string name="product_wip_title">New editing options available</string>
     <string name="product_wip_message_m2">We\'ve added more editing functionalities to products! You can now update images, see previews and share your products.</string>
     <string name="product_wip_message_m3">You can now edit grouped, external and variable products, change product type and update categories and tags.</string>
@@ -760,7 +760,7 @@
     <string name="settings_send_stats">Collect information</string>
     <string name="settings_enable_v4_stats_title">Improved stats</string>
     <string name="settings_enable_product_adding_teaser_title">Creating products</string>
-    <string name="settings_enable_product_adding_teaser_message">Test out the new simple, linked and grouped product creation as we get ready to launch</string>
+    <string name="settings_enable_product_adding_teaser_message">Test out the new simple, external and grouped product creation as we get ready to launch</string>
     <string name="settings_enable_product_teaser_title">Product editing</string>
     <string name="settings_enable_product_teaser_message">Test out the new product editing functionality as we get ready to launch</string>
     <string name="settings_send_stats_detail">Share information with our analytics tool about your use of services while logged in to your WordPress account</string>


### PR DESCRIPTION
Depending on whether the beta switch is turned on, we should show a different banner in Product list:

- ON: "**Create products from the app!**: It\'s now possible to create new simple, linked and grouped products..."
- OFF: "**New editing options available**: You can now edit grouped, external and variable products..."