### PR TITLE
issue/3134-photo-view-update

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -182,7 +182,7 @@ dependencies {
 
     implementation 'com.facebook.shimmer:shimmer:0.4.0'
     implementation 'com.github.vihtarb:tooltip:0.2.0'
-    implementation 'com.github.chrisbanes:PhotoView:2.0.0'
+    implementation 'com.github.chrisbanes:PhotoView:2.3.0'
 
     // Dagger
     implementation "com.google.dagger:dagger:$daggerVersion"


### PR DESCRIPTION
Closes #3134 - this simple PR updates the `PhotoView` library to the latest version. To test, verify that pinch & zoom are working in the fullscreen product image viewer.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
