### PR TITLE
Issue/3133 add linked product picker

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
@@ -44,7 +44,7 @@ class GroupedProductListFragment : BaseFragment(), BackPressListener {
 
     private var doneMenuItem: MenuItem? = null
 
-    override fun getFragmentTitle() = resources.getString(viewModel.getGroupedProductListType().titleId)
+    override fun getFragmentTitle() = resources.getString(viewModel.groupedProductListType.titleId)
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -137,7 +137,13 @@ class GroupedProductListFragment : BaseFragment(), BackPressListener {
     }
 
     private fun setupResultHandlers() {
-        handleResult<List<Long>>(ProductSelectionListFragment.KEY_SELECTED_PRODUCT_IDS_RESULT) {
+        handleResult<List<Long>>(GroupedProductListType.UPSELLS.resultKey) {
+            viewModel.onProductsAdded(it)
+        }
+        handleResult<List<Long>>(GroupedProductListType.CROSS_SELLS.resultKey) {
+            viewModel.onProductsAdded(it)
+        }
+        handleResult<List<Long>>(GroupedProductListType.GROUPED.resultKey) {
             viewModel.onProductsAdded(it)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListType.kt
@@ -3,8 +3,8 @@ package com.woocommerce.android.ui.products
 import androidx.annotation.StringRes
 import com.woocommerce.android.R
 
-enum class GroupedProductListType(@StringRes val titleId: Int) {
-    GROUPED(R.string.grouped_products),
-    UPSELLS(R.string.upsells_label),
-    CROSS_SELLS(R.string.cross_sells_label);
+enum class GroupedProductListType(@StringRes val titleId: Int, val resultKey: String) {
+    GROUPED(R.string.grouped_products, "grouped"),
+    UPSELLS(R.string.upsells_label, "upsells"),
+    CROSS_SELLS(R.string.cross_sells_label, "cross-sells");
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListType.kt
@@ -4,7 +4,7 @@ import androidx.annotation.StringRes
 import com.woocommerce.android.R
 
 enum class GroupedProductListType(@StringRes val titleId: Int, val resultKey: String) {
-    GROUPED(R.string.grouped_products, "grouped"),
-    UPSELLS(R.string.upsells_label, "upsells"),
-    CROSS_SELLS(R.string.cross_sells_label, "cross-sells");
+    GROUPED(R.string.grouped_products, "key_grouped"),
+    UPSELLS(R.string.upsells_label, "key_upsells"),
+    CROSS_SELLS(R.string.cross_sells_label, "key_cross-sells");
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModel.kt
@@ -13,9 +13,6 @@ import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.di.ViewModelAssistedFactory
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.tools.NetworkStatus
-import com.woocommerce.android.ui.products.GroupedProductListType.CROSS_SELLS
-import com.woocommerce.android.ui.products.GroupedProductListType.GROUPED
-import com.woocommerce.android.ui.products.GroupedProductListType.UPSELLS
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductSelectionList
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.LiveDataDelegate
@@ -35,12 +32,6 @@ class GroupedProductListViewModel @AssistedInject constructor(
     private val networkStatus: NetworkStatus,
     private val groupedProductListRepository: GroupedProductListRepository
 ) : ScopedViewModel(savedState, dispatchers) {
-    companion object {
-        const val KEY_GROUPED_PRODUCT_IDS_RESULT = "key_grouped_product_ids_result"
-        const val KEY_UPSELL_PRODUCT_IDS_RESULT = "key_upsell_product_ids_result"
-        const val KEY_CROSS_SELL_PRODUCT_IDS_RESULT = "key_cross_sell_product_ids_result"
-    }
-
     private val navArgs: GroupedProductListFragmentArgs by savedState.navArgs()
 
     private val originalProductIds =
@@ -60,6 +51,9 @@ class GroupedProductListViewModel @AssistedInject constructor(
     private val selectedProductIds
         get() = productListViewState.selectedProductIds
 
+    val groupedProductListType
+        get() = navArgs.groupedProductListType
+
     val hasChanges: Boolean
         get() = selectedProductIds != originalProductIds
 
@@ -74,15 +68,7 @@ class GroupedProductListViewModel @AssistedInject constructor(
         }
     }
 
-    fun getGroupedProductListType() = navArgs.groupedProductListType
-
-    fun getKeyForGroupedProductListType(): String {
-        return when (getGroupedProductListType()) {
-            UPSELLS -> KEY_UPSELL_PRODUCT_IDS_RESULT
-            CROSS_SELLS -> KEY_CROSS_SELL_PRODUCT_IDS_RESULT
-            GROUPED -> KEY_GROUPED_PRODUCT_IDS_RESULT
-        }
-    }
+    fun getKeyForGroupedProductListType() = groupedProductListType.resultKey
 
     fun onProductsAdded(selectedProductIds: List<Long>) {
         // ignore already added products

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/LinkedProductsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/LinkedProductsFragment.kt
@@ -69,13 +69,13 @@ class LinkedProductsFragment : BaseProductFragment() {
             }
         })
 
-        handleResult<List<Long>>(GroupedProductListViewModel.KEY_UPSELL_PRODUCT_IDS_RESULT) {
+        handleResult<List<Long>>(UPSELLS.resultKey) {
             viewModel.updateProductDraft(upsellProductIds = it)
             changesMade()
             updateProductView()
         }
 
-        handleResult<List<Long>>(GroupedProductListViewModel.KEY_CROSS_SELL_PRODUCT_IDS_RESULT) {
+        handleResult<List<Long>>(CROSS_SELLS.resultKey) {
             viewModel.updateProductDraft(crossSellProductIds = it)
             changesMade()
             updateProductView()
@@ -130,7 +130,7 @@ class LinkedProductsFragment : BaseProductFragment() {
         } else {
             GroupedProductListFragmentDirections.actionGlobalGroupedProductListFragment(
                 viewModel.getRemoteProductId(),
-                productIds?.joinToString(",") ?: "",
+                productIds.joinToString(","),
                 groupedProductType
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/LinkedProductsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/LinkedProductsFragment.kt
@@ -122,11 +122,18 @@ class LinkedProductsFragment : BaseProductFragment() {
             else -> viewModel.getProduct().productDraft?.crossSellProductIds
         }
 
-        val action = GroupedProductListFragmentDirections.actionGlobalGroupedProductListFragment(
-            viewModel.getRemoteProductId(),
-            productIds?.joinToString(",") ?: "",
-            groupedProductType
-        )
+        // go straight to the "add products" screen if the list is empty, otherwise show the grouped
+        // products screen
+        val action = if (productIds.isNullOrEmpty()) {
+            ProductDetailFragmentDirections
+                .actionGlobalProductSelectionListFragment(viewModel.getRemoteProductId(), groupedProductType)
+        } else {
+            GroupedProductListFragmentDirections.actionGlobalGroupedProductListFragment(
+                viewModel.getRemoteProductId(),
+                productIds?.joinToString(",") ?: "",
+                groupedProductType
+            )
+        }
         findNavController().navigateSafely(action)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -127,7 +127,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageClickListener
             viewModel.updateProductDraft(type = it.value)
             changesMade()
         }
-        handleResult<List<Long>>(GroupedProductListViewModel.KEY_GROUPED_PRODUCT_IDS_RESULT) {
+        handleResult<List<Long>>(GroupedProductListType.GROUPED.resultKey) {
             viewModel.updateProductDraft(groupedProductIds = it)
             changesMade()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListFragment.kt
@@ -41,10 +41,6 @@ class ProductSelectionListFragment : BaseFragment(),
     OnActionModeEventListener,
     OnQueryTextListener,
     OnActionExpandListener {
-    companion object {
-        const val KEY_SELECTED_PRODUCT_IDS_RESULT = "key_selected_product_ids_result"
-    }
-
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     @Inject lateinit var viewModelFactory: ViewModelFactory
@@ -213,7 +209,9 @@ class ProductSelectionListFragment : BaseFragment(),
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is ExitWithResult<*> -> {
-                    navigateBackWithResult(KEY_SELECTED_PRODUCT_IDS_RESULT, event.data as? List<*>)
+                    val key = viewModel.groupedProductListType.resultKey
+                    val productIds = (event.data as? List<Long>) ?: emptyList()
+                    navigateBackWithResult(key, productIds)
                 }
                 else -> event.isHandled = false
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModel.kt
@@ -55,6 +55,9 @@ class ProductSelectionListViewModel @AssistedInject constructor(
     private val isSearching
         get() = productSelectionListViewState.isSearchActive == true
 
+    val groupedProductListType
+        get() = navArgs.groupedProductListType
+
     val searchQuery
     get() = productSelectionListViewState.searchQuery
 


### PR DESCRIPTION
Closes #3126 - changes the linked products screen so that when "Add products" is tapped, the user is taken directly to the product selector (bypassing the grouped products screen). To test:

- Go to product detail for a linked product
- Tap "Link products"
- Verify that when there are no cross-sells or upsells, tapping "Add products" goes to the product selector
- Verify that when there _are_ cross-sells or upsells, tapping "Edit products" goes to the grouped products screen

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
