### PR TITLE
Issue/3127 hide already selected products

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModel.kt
@@ -99,7 +99,11 @@ class GroupedProductListViewModel @AssistedInject constructor(
 
     fun onAddProductButtonClicked() {
         AnalyticsTracker.track(Stat.GROUPED_PRODUCT_LINKED_PRODUCTS_ADD_TAPPED)
-        triggerEvent(ViewProductSelectionList(navArgs.remoteProductId, navArgs.groupedProductListType))
+        triggerEvent(ViewProductSelectionList(
+            navArgs.remoteProductId,
+            navArgs.groupedProductListType,
+            excludedProductIds = selectedProductIds)
+        )
     }
 
     fun onDoneButtonClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListRepository.kt
@@ -165,7 +165,7 @@ class ProductListRepository @Inject constructor(
         productFilterOptions: Map<ProductFilterOption, String> = emptyMap(),
         excludedProductIds: List<Long>? = null
     ): List<Product> {
-        // TODO: a FluxC fix needs to be made so we don't have to pass null here
+        // we need to pass null because FluxC crashes when an empty list is passed
         val excludedIds = if (excludedProductIds?.isNotEmpty() == true) {
             excludedProductIds
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListRepository.kt
@@ -165,12 +165,18 @@ class ProductListRepository @Inject constructor(
         productFilterOptions: Map<ProductFilterOption, String> = emptyMap(),
         excludedProductIds: List<Long>? = null
     ): List<Product> {
+        // TODO: a FluxC fix needs to be made so we don't have to pass null here
+        val excludedIds = if (excludedProductIds?.isNotEmpty() == true) {
+            excludedProductIds
+        } else {
+            null
+        }
         return if (selectedSite.exists()) {
             val wcProducts = productStore.getProductsByFilterOptions(
                     selectedSite.get(),
                     filterOptions = productFilterOptions,
                     sortType = productSortingChoice,
-                    excludedProductIds = excludedProductIds
+                    excludedProductIds = excludedIds
             )
             wcProducts.map { it.toAppModel() }
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListRepository.kt
@@ -165,12 +165,7 @@ class ProductListRepository @Inject constructor(
         productFilterOptions: Map<ProductFilterOption, String> = emptyMap(),
         excludedProductIds: List<Long>? = null
     ): List<Product> {
-        // we need to pass null because FluxC crashes when an empty list is passed
-        val excludedIds = if (excludedProductIds?.isNotEmpty() == true) {
-            excludedProductIds
-        } else {
-            null
-        }
+        val excludedIds = excludedProductIds?.takeIf { it.isNotEmpty() }
         return if (selectedSite.exists()) {
             val wcProducts = productStore.getProductsByFilterOptions(
                     selectedSite.get(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
@@ -62,6 +62,7 @@ sealed class ProductNavigationTarget : Event() {
     data class ViewLinkedProducts(val remoteId: Long) : ProductNavigationTarget()
     data class ViewProductSelectionList(
         val remoteId: Long,
-        val groupedProductType: GroupedProductListType
+        val groupedProductType: GroupedProductListType,
+        val excludedProductIds: List<Long>
     ) : ProductNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -233,7 +233,10 @@ class ProductNavigator @Inject constructor() {
 
             is ViewProductSelectionList -> {
                 val action = ProductDetailFragmentDirections
-                    .actionGlobalProductSelectionListFragment(target.remoteId, target.groupedProductType)
+                    .actionGlobalProductSelectionListFragment(
+                        target.remoteId,
+                        target.groupedProductType,
+                        target.excludedProductIds.joinToString(","))
                 fragment.findNavController().navigateSafely(action)
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModel.kt
@@ -10,9 +10,6 @@ import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.di.ViewModelAssistedFactory
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.tools.NetworkStatus
-import com.woocommerce.android.ui.products.GroupedProductListType.CROSS_SELLS
-import com.woocommerce.android.ui.products.GroupedProductListType.GROUPED
-import com.woocommerce.android.ui.products.GroupedProductListType.UPSELLS
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.LiveDataDelegate

--- a/WooCommerce/src/main/res/navigation/nav_graph_products.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_products.xml
@@ -269,6 +269,10 @@
         <argument
             android:name="groupedProductListType"
             app:argType="com.woocommerce.android.ui.products.GroupedProductListType"/>
+        <argument
+            android:name="excludedProductIds"
+            android:defaultValue='""'
+            app:argType="string" />
     </fragment>
     <fragment
         android:id="@+id/linkedProductsFragment"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModelTest.kt
@@ -32,6 +32,9 @@ class ProductSelectionListViewModelTest : BaseUnitTest() {
         private const val PRODUCT_REMOTE_ID = 10L
     }
 
+    private val productList = ProductTestUtils.generateProductList()
+    private val excludedProductIds = listOf(PRODUCT_REMOTE_ID)
+
     private val networkStatus: NetworkStatus = mock()
     private val productRepository: ProductListRepository = mock()
     private val savedState: SavedStateWithArgs = spy(
@@ -40,15 +43,14 @@ class ProductSelectionListViewModelTest : BaseUnitTest() {
             null,
             ProductSelectionListFragmentArgs(
                 remoteProductId = PRODUCT_REMOTE_ID,
-                groupedProductListType = GroupedProductListType.GROUPED
+                groupedProductListType = GroupedProductListType.GROUPED,
+                excludedProductIds = excludedProductIds.joinToString(",")
             )
         )
     )
 
     private val coroutineDispatchers = CoroutineDispatchers(
         Dispatchers.Unconfined, Dispatchers.Unconfined, Dispatchers.Unconfined)
-    private val productList = ProductTestUtils.generateProductList()
-    private val excludedProductIds = listOf(PRODUCT_REMOTE_ID)
 
     private lateinit var viewModel: ProductSelectionListViewModel
 


### PR DESCRIPTION
Fixes #3127 - previously, if you added linked products to a product that didn't have any and then returned to the product selector to add more, the previously selected ones would continue to appear. This PR corrects this by passing a list of excluded product IDs to the selector.

To test:

- Go to product detail for a linked product that has no cross-sells (or no upsells)
- Tap the "Add product" button below the cross-sells
- Add a product or two and click done
- Click "Edit product" below the cross-sells
- Choose to add a product and verify that the previously added products no longer appear

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
