### PR TITLE
Fix variation names

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariation.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.extensions.isEquivalentTo
 import com.woocommerce.android.extensions.isNotSet
 import com.woocommerce.android.extensions.isSet
 import com.woocommerce.android.extensions.roundError
+import com.woocommerce.android.model.ProductVariation.Option
 import com.woocommerce.android.ui.products.ProductBackorderStatus
 import com.woocommerce.android.ui.products.ProductStatus
 import com.woocommerce.android.ui.products.ProductStatus.PRIVATE
@@ -17,7 +18,6 @@ import com.woocommerce.android.ui.products.ProductStatus.PUBLISH
 import com.woocommerce.android.ui.products.ProductStockStatus
 import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.fluxc.model.WCProductVariationModel
-import org.wordpress.android.fluxc.model.WCProductVariationModel.ProductVariantOption
 import org.wordpress.android.util.DateTimeUtils
 import java.math.BigDecimal
 import java.util.Date
@@ -36,7 +36,7 @@ data class ProductVariation(
     val stockStatus: ProductStockStatus,
     val backorderStatus: ProductBackorderStatus,
     val stockQuantity: Int,
-    val optionName: String,
+    val options: List<Option>,
     var priceWithCurrency: String? = null,
     val isPurchasable: Boolean,
     val isVirtual: Boolean,
@@ -74,7 +74,7 @@ data class ProductVariation(
                 stockQuantity == variation.stockQuantity &&
                 stockStatus == variation.stockStatus &&
                 backorderStatus == variation.backorderStatus &&
-                optionName.fastStripHtml() == variation.optionName.fastStripHtml() &&
+                options == variation.options &&
                 isPurchasable == variation.isPurchasable &&
                 isVirtual == variation.isVirtual &&
                 isDownloadable == variation.isDownloadable &&
@@ -139,6 +139,19 @@ data class ProductVariation(
             it.height = if (height == 0f) "" else height.formatToString()
         }
     }
+
+    fun getName(parentProduct: Product? = null): String {
+        return parentProduct?.attributes?.joinToString(" - ") { attribute ->
+            val option = options.firstOrNull { it.attributeName == attribute.name }
+            option?.optionChoice ?: "Any ${attribute.name}"
+        } ?: options.joinToString(" - ") { o -> o.optionChoice }
+    }
+
+    @Parcelize
+    data class Option(
+        val attributeName: String,
+        val optionChoice: String
+    ) : Parcelable
 }
 
 fun WCProductVariationModel.toAppModel(): ProductVariation {
@@ -162,7 +175,9 @@ fun WCProductVariationModel.toAppModel(): ProductVariation {
         ProductStockStatus.fromString(this.stockStatus),
         ProductBackorderStatus.fromString(this.backorders),
         this.stockQuantity,
-        getAttributeOptionName(this.getProductVariantOptions()),
+        this.getProductVariantOptions()
+            .filter { it.option != null && it.option != null }
+            .map { Option(it.name!!, it.option!!) },
         isPurchasable = this.purchasable,
         isDownloadable = this.downloadable,
         isVirtual = this.virtual,
@@ -176,21 +191,4 @@ fun WCProductVariationModel.toAppModel(): ProductVariation {
         height = this.height.toFloatOrNull() ?: 0f,
         weight = this.weight.toFloatOrNull() ?: 0f
     )
-}
-
-/**
- * Given a list of [ProductVariantOption]
- * returns the product variation combination name in the format {option1} - {option2}
- */
-private fun getAttributeOptionName(variationOptions: List<ProductVariantOption>): String {
-    var optionName = ""
-    for (variationOption in variationOptions) {
-        if (!variationOption.option.isNullOrEmpty()) {
-            if (optionName.isNotEmpty()) {
-                optionName += " - "
-            }
-            optionName += "${variationOption.option}"
-        }
-    }
-    return optionName
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariation.kt
@@ -176,7 +176,7 @@ fun WCProductVariationModel.toAppModel(): ProductVariation {
         ProductBackorderStatus.fromString(this.backorders),
         this.stockQuantity,
         this.getProductVariantOptions()
-            .filter { it.option != null && it.option != null }
+            .filter { it.name != null && it.option != null }
             .map { Option(it.name!!, it.option!!) },
         isPurchasable = this.purchasable,
         isDownloadable = this.downloadable,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
@@ -89,7 +89,7 @@ class VariationDetailCardBuilder(
     private fun ProductVariation.title(): ProductProperty {
         return Editable(
             string.product_detail_title_hint,
-            parentProduct?.name ?: optionName,
+            parentProduct?.name ?: getName(parentProduct),
             isReadOnly = true
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
@@ -18,7 +18,6 @@ import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_VARIATION_UPDATE_BUTTON_TAPPED
-import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.show
@@ -179,12 +178,7 @@ class VariationDetailFragment : BaseFragment(), BackPressListener, NavigationRes
         viewModel.variationViewStateData.observe(viewLifecycleOwner) { old, new ->
             new.variation.takeIfNotEqualTo(old?.variation) { showVariationDetails(it) }
             new.parentProduct.takeIfNotEqualTo(old?.parentProduct) { product ->
-                if (variationName.isEmpty()) {
-                    variationName = product?.attributes?.joinToString(
-                        separator = " - ",
-                        transform = { "Any ${it.name}" }
-                    ) ?: ""
-                }
+                variationName = new.variation.getName(product)
             }
             new.uploadingImageUri?.takeIfNotEqualTo(old?.uploadingImageUri) {
                 if (it.value != null) {
@@ -227,11 +221,6 @@ class VariationDetailFragment : BaseFragment(), BackPressListener, NavigationRes
     }
 
     private fun showVariationDetails(variation: ProductVariation) {
-        val optionName = variation.optionName.fastStripHtml()
-        if (optionName.isNotBlank()) {
-            variationName = variation.optionName.fastStripHtml()
-        }
-
         if (variation.image == null && !viewModel.isUploadingImages(variation.remoteVariationId)) {
             imageGallery.hide()
             addImageContainer.show()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.media.ProductImagesService.Companion.OnProductIma
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.Product.Image
 import com.woocommerce.android.model.ProductVariation
+import com.woocommerce.android.model.ProductVariation.Option
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.products.ParameterRepository
@@ -167,7 +168,7 @@ class VariationDetailViewModel @AssistedInject constructor(
         stockStatus: ProductStockStatus? = null,
         backorderStatus: ProductBackorderStatus? = null,
         stockQuantity: Int? = null,
-        optionName: String? = null,
+        options: List<Option>? = null,
         isPurchasable: Boolean? = null,
         isVirtual: Boolean? = null,
         isDownloadable: Boolean? = null,
@@ -194,7 +195,7 @@ class VariationDetailViewModel @AssistedInject constructor(
             stockStatus = stockStatus ?: viewState.variation.stockStatus,
             backorderStatus = backorderStatus ?: viewState.variation.backorderStatus,
             stockQuantity = stockQuantity ?: viewState.variation.stockQuantity,
-            optionName = optionName ?: viewState.variation.optionName,
+            options = options ?: viewState.variation.options,
             isPurchasable = isPurchasable ?: viewState.variation.isPurchasable,
             isVirtual = isVirtual ?: viewState.variation.isVirtual,
             isDownloadable = isDownloadable ?: viewState.variation.isDownloadable,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListAdapter.kt
@@ -57,11 +57,7 @@ class VariationListAdapter(
     override fun onBindViewHolder(holder: VariationViewHolder, position: Int) {
         val variation = variationList[position]
 
-        holder.txtVariationOptionName.text = if (variation.optionName.isBlank()) {
-            parentProduct?.attributes?.joinToString(separator = " - ", transform = { "Any ${it.name}" }) ?: ""
-        } else {
-            variation.optionName
-        }
+        holder.txtVariationOptionName.text = variation.getName(parentProduct)
 
         val stockStatus = variation.getStockStatusText()
         val bullet = context.getString(R.string.product_bullet)


### PR DESCRIPTION
Fixes #3146. This PR adds "Any _[attribute name]_" to the variation name for any open attribute of the variation.

**To test:**
1. Create variations with some or no options selected
2. Go to Products -> Variable product -> Variations
3. Verify the attribute choices are reflected in the variation names
4. Select an individual variation
5. Verify the attribute choices are reflected in the variation name in the toolbar

![image](https://user-images.githubusercontent.com/1522856/98583594-e6708400-22c4-11eb-89f0-65e71bb0dd5e.png)

![image](https://user-images.githubusercontent.com/1522856/98583562-dbb5ef00-22c4-11eb-9295-0e55e5e4bd52.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
