### PR TITLE
Remove References to "master"

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -9,7 +9,7 @@
   <component name="GitSharedSettings">
     <option name="FORCE_PUSH_PROHIBITED_PATTERNS">
       <list>
-        <option value="master, develop" />
+        <option value="trunk, develop" />
       </list>
     </option>
   </component>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/LiveDataUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/LiveDataUtils.kt
@@ -13,7 +13,7 @@ import java.util.concurrent.TimeoutException
  * `InstantTaskExecutorRule` or a similar mechanism to execute tasks synchronously.
  *
  * credit:
- * https://github.com/android/architecture-components-samples/blob/master/LiveDataSample/app/src/test/java/com/android/example/livedatabuilder/util/LiveDataTestUtil.kt
+ * https://github.com/android/architecture-components-samples/blob/main/LiveDataSample/app/src/test/java/com/android/example/livedatabuilder/util/LiveDataTestUtil.kt
  */
 fun <T> LiveData<T>.getOrAwaitValue(
     time: Long = 2,
@@ -47,7 +47,7 @@ fun <T> LiveData<T>.getOrAwaitValue(
  * Observes a [LiveData] until the `block` is done executing.
  *
  * credit:
- * https://github.com/android/architecture-components-samples/blob/master/LiveDataSample/app/src/test/java/com/android/example/livedatabuilder/util/LiveDataTestUtil.kt
+ * https://github.com/android/architecture-components-samples/blob/main/LiveDataSample/app/src/test/java/com/android/example/livedatabuilder/util/LiveDataTestUtil.kt
  */
 fun <T> LiveData<T>.observeForTesting(block: () -> Unit) {
     val observer = Observer<T> { }

--- a/tools/team-props/git-hooks/pre-commit
+++ b/tools/team-props/git-hooks/pre-commit
@@ -7,7 +7,7 @@
 
 BRANCH=`git rev-parse --abbrev-ref HEAD`
 
-if [[ "$BRANCH" == "master" || "$BRANCH" == "develop" ]]; then
+if [[ "$BRANCH" == "trunk" || "$BRANCH" == "develop" ]]; then
   echo "You are on branch $BRANCH. Are you sure you want to commit to this branch?"
   echo "If so, commit with -n to bypass this pre-commit hook."
   exit 1

--- a/tools/team-props/git-hooks/pre-commit
+++ b/tools/team-props/git-hooks/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Stops accidental commits to master and develop. Pulled from: https://gist.github.com/stefansundin/9059706
+# Stops accidental commits to trunk and develop. Pulled from: https://gist.github.com/stefansundin/9059706
 # Install:
 # cd path/to/git/repo
 # curl -fL -o .git/hooks/pre-commit https://gist.githubusercontent.com/stefansundin/9059706/raw/pre-commit


### PR DESCRIPTION
Ref paaHJt-15h-p2

This removes all the references to "master" that I could remove. 

Only these are left:

https://github.com/woocommerce/woocommerce-android/blob/f65a1cbb1da4bfb402ec3ab5dee2ba631f37190e/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ChromeCustomTabUtils.kt#L117-L118

https://github.com/woocommerce/woocommerce-android/blob/bd643aeb96eb0f85744abc5a09bff32cd7273224/.circleci/config.yml#L126

It doesn't look like there are alternatives for them at the moment.

## Testing

I believe the build passing should be enough. You can also test the `pre-commit` hook by:

1. Building with this branch. 
2. Close Android Studio.
2. In terminal, `git checkout trunk`.
3. `touch TOUCH`
4. `git add TOUCH`
5. `git commit -m "Testing"`

You should see an error and the commit will be aborted. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

