### PR TITLE
Fix typo in shipping label refund request screen

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -308,7 +308,7 @@
     <!--
         Shipping label Refunds
     -->
-    <string name="shipping_label_refund_message">You can request a refund for a shipping label that has not been used to ship a package. It will take a least 14 days to process.</string>
+    <string name="shipping_label_refund_message">You can request a refund for a shipping label that has not been used to ship a package. It will take at least 14 days to process.</string>
     <string name="shipping_label_refund_purchase_date_title">Purchase date</string>
     <string name="shipping_label_refund_amount_title">Amount eligible for refund</string>
     <string name="shipping_label_refund_button">Refund label (-%1$s)</string>


### PR DESCRIPTION
## Changes 

This PR just updated the copy on the shipping label refund request screen 😄 

## Testing

- Go to the orders tab
- Tap on an order with at least one shipping label that hasn't been refunded
- Tap on the "..." icon on the shipping label package that hasn't been refunded, then tap "Request a refund" --> note that the instruction text at the top shows the updated copy (`a least` -> `at least`)

## Example screenshots

before | after
-- | --
![Screenshot_1605057561](https://user-images.githubusercontent.com/1945542/98754485-cabec800-2401-11eb-9028-b57a7c814e72.png) | ![Screenshot_1605058233](https://user-images.githubusercontent.com/1945542/98754489-cdb9b880-2401-11eb-9a30-54c19cae1582.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
