### PR TITLE
Beta fix: Use HTML entities in String resource to fix translation issues 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelInfoFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelInfoFragment.kt
@@ -7,10 +7,25 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.util.StringUtils
+import kotlinx.android.synthetic.main.fragment_print_shipping_label_info.view.*
 
 class PrintShippingLabelInfoFragment : Fragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.fragment_print_shipping_label_info, container, false)
+        val view = inflater.inflate(R.layout.fragment_print_shipping_label_info, container, false)
+
+        view.printShippingLabelInfo_step1.text =
+            StringUtils.fromHtml(getString(R.string.print_shipping_label_info_step_1))
+        view.printShippingLabelInfo_step2.text =
+            StringUtils.fromHtml(getString(R.string.print_shipping_label_info_step_2))
+        view.printShippingLabelInfo_step3.text =
+            StringUtils.fromHtml(getString(R.string.print_shipping_label_info_step_3))
+        view.printShippingLabelInfo_step4.text =
+            StringUtils.fromHtml(getString(R.string.print_shipping_label_info_step_4))
+        view.printShippingLabelInfo_step5.text =
+            StringUtils.fromHtml(getString(R.string.print_shipping_label_info_step_5))
+
+        return view
     }
 
     override fun onResume() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import android.content.res.Configuration
 import android.content.res.Resources.NotFoundException
 import android.net.Uri
+import android.os.Build
 import android.text.Html
+import android.text.Spanned
 import android.util.Patterns
 import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
@@ -178,6 +180,17 @@ object StringUtils {
      */
     fun getRawTextFromHtml(htmlStr: String) =
             Html.fromHtml(htmlStr).toString().replace("\n", " ").replace("  ", " ")
+
+    /**
+     * Helper method for using the appropriate `Html.fromHtml()` for the build version.
+     */
+    fun fromHtml(htmlStr: String): Spanned {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            Html.fromHtml(htmlStr, Html.FROM_HTML_MODE_LEGACY)
+        } else {
+            Html.fromHtml(htmlStr)
+        }
+    }
 
     /**
      * Returns a string for the specified locale.

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -336,11 +336,11 @@
     <string name="print_shipping_label_info_step_count_3" translatable="false">3</string>
     <string name="print_shipping_label_info_step_count_4" translatable="false">4</string>
     <string name="print_shipping_label_info_step_count_5" translatable="false">5</string>
-    <string name="print_shipping_label_info_step_1">Make sure your printer and your device are connected to the <b>same WiFi networks</b></string>
-    <string name="print_shipping_label_info_step_2">After selecting <b>\"Print shipping label\"</b>, you may have to select and add a printer if you haven\'t printed from this device before.</string>
-    <string name="print_shipping_label_info_step_3">You can select your device\'s <b>default print service</b> or install your <b>printer\'s brand app</b> (this should appear as a recommended option)</string>
-    <string name="print_shipping_label_info_step_4">You might have to <b>configure WiFi printing directly on the printer itself.</b> Make sure the printer firmware is updated and see your printer documentation for instructions.</string>
-    <string name="print_shipping_label_info_step_5">If you are still experiencing issues printing from your device, you can <b>save your label as PDF</b> and send it by email to print it from another device.</string>
+    <string name="print_shipping_label_info_step_1">Make sure your printer and your device are connected to the &lt;b&gt;same WiFi networks&lt;/b&gt;</string>
+    <string name="print_shipping_label_info_step_2">After selecting &lt;b&gt;\"Print shipping label\"&lt;/b&gt;, you may have to select and add a printer if you haven\'t printed from this device before.</string>
+    <string name="print_shipping_label_info_step_3">You can select your device\'s &lt;b&gt;default print service&lt;/b&gt; or install your &lt;b&gt;printer\'s brand app&lt;/b&gt; (this should appear as a recommended option)</string>
+    <string name="print_shipping_label_info_step_4">You might have to &lt;b&gt;configure WiFi printing directly on the printer itself.&lt;/b&gt; Make sure the printer firmware is updated and see your printer documentation for instructions.</string>
+    <string name="print_shipping_label_info_step_5">If you are still experiencing issues printing from your device, you can &lt;b&gt;save your label as PDF&lt;/b&gt; and send it by email to print it from another device.</string>
 
     <!--
         Refunds


### PR DESCRIPTION
Some strings were being sent to the translators that didn't make sense. It turns out that when a string includes HTML tags for formatting, the tags, along with the text between tags, were being removed before being sent for translation:

<img width="822" alt="Screen Shot 2020-11-11 at 3 57 32 PM" src="https://user-images.githubusercontent.com/5810477/98863609-9f0a0500-2436-11eb-8707-0a61978ca333.png">

The fix was to replace the HTML tags with HTML entities so the text doesn't get dropped. The screen effected was the shipping label help screen. Here is a screenshot of the screen after the changes:

<img src="https://user-images.githubusercontent.com/5810477/98863745-ceb90d00-2436-11eb-95ce-a9e8cf9f2321.png" width="330"/>



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
