### PR TITLE
Added tracking event when product image upload fails

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -301,6 +301,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         ADD_PRODUCT_SAVE_AS_DRAFT_TAPPED,
         ADD_PRODUCT_SUCCESS,
         ADD_PRODUCT_FAILED,
+        PRODUCT_IMAGE_UPLOAD_FAILED,
 
         // -- Product Categories
         PRODUCT_CATEGORIES_LOADED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -4,6 +4,8 @@ import android.content.Intent
 import android.net.Uri
 import androidx.collection.LongSparseArray
 import androidx.core.app.JobIntentService
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_IMAGE_UPLOAD_FAILED
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.tools.SelectedSite
@@ -214,6 +216,11 @@ class ProductImagesService : JobIntentService() {
                         T.MEDIA,
                         "productImagesService > error uploading media: ${event.error.type}, ${event.error.message}"
                 )
+                AnalyticsTracker.track(
+                    PRODUCT_IMAGE_UPLOAD_FAILED, mapOf(
+                    AnalyticsTracker.KEY_ERROR_CONTEXT to this::class.java.simpleName,
+                    AnalyticsTracker.KEY_ERROR_TYPE to event.error?.type?.toString(),
+                    AnalyticsTracker.KEY_ERROR_DESC to event.error?.message))
                 handleFailure()
             }
             event.canceled -> {


### PR DESCRIPTION
Fixes #3157 by adding a new tracking event on product image upload error.

#### To test
-Go to the Products tab
- Add or edit a product
- Tap on the "+" cell or any image cell in the images header
- Tap "Add Photos"
- Choose a photo or take one with camera, and quickly switch to offline mode --> after a bit, an error alert is shown. Verify that the `PRODUCT_IMAGE_UPLOAD_FAILED` event is displayed in the console.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
