### PR TITLE
Set equal margins in Product Images grid

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/ItemDecorators.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/ItemDecorators.kt
@@ -1,0 +1,30 @@
+package com.woocommerce.android.widgets
+
+import android.graphics.Rect
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.ItemDecoration
+import androidx.recyclerview.widget.RecyclerView.State
+
+class GridItemDecoration(
+    private val spanCount: Int,
+    private val spacing: Int
+) : ItemDecoration() {
+    override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: State) {
+        val position = parent.getChildAdapterPosition(view)
+        val column = position % spanCount
+        outRect.left = spacing - column * spacing / spanCount
+        outRect.right = (column + 1) * spacing / spanCount
+        if (position < spanCount) {
+            outRect.top = spacing
+        }
+        outRect.bottom = spacing
+    }
+}
+
+class HorizontalItemDecoration(private val spacing: Int) : ItemDecoration() {
+    override fun getItemOffsets(outRect: Rect, itemPosition: Int, parent: RecyclerView) {
+        outRect.left = spacing
+        outRect.right = spacing
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -17,6 +17,7 @@ import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import com.bumptech.glide.request.RequestOptions
 import com.woocommerce.android.R
+import com.woocommerce.android.R.dimen
 import com.woocommerce.android.di.GlideApp
 import com.woocommerce.android.di.GlideRequest
 import com.woocommerce.android.model.Product
@@ -39,6 +40,7 @@ class WCProductImageGalleryView @JvmOverloads constructor(
         private const val VIEW_TYPE_ADD_IMAGE = 2
         private const val NUM_COLUMNS = 2
         private const val ADD_IMAGE_ITEM_ID = Long.MAX_VALUE
+        private const val NUM_GRID_MARGINS = 3
     }
 
     interface OnGalleryImageClickListener {
@@ -109,10 +111,23 @@ class WCProductImageGalleryView @JvmOverloads constructor(
         imageSize = if (isGridView) {
             val screenWidth = DisplayUtils.getDisplayPixelWidth(context)
             val margin = context.resources.getDimensionPixelSize(R.dimen.margin_extra_large)
-            (screenWidth / 2) - (margin * 2)
+            (screenWidth - margin * NUM_GRID_MARGINS) / 2
         } else {
             context.resources.getDimensionPixelSize(R.dimen.image_major_120)
         }
+
+        addItemDecoration(
+                if (isGridView) {
+                    GridItemDecoration(
+                            spanCount = NUM_COLUMNS,
+                            spacing = resources.getDimensionPixelSize(dimen.margin_extra_large)
+                    )
+                } else {
+                    HorizontalItemDecoration(
+                            spacing = resources.getDimensionPixelSize(dimen.minor_100)
+                    )
+                }
+        )
     }
 
     fun showProductImages(images: List<Product.Image>, listener: OnGalleryImageClickListener) {
@@ -324,15 +339,6 @@ class WCProductImageGalleryView @JvmOverloads constructor(
 
             addImageContainer.layoutParams.height = imageSize
             addImageContainer.layoutParams.width = imageSize
-
-            // add space between items in grid view
-            if (isGridView) {
-                val margin = context.resources.getDimensionPixelSize(R.dimen.margin_medium)
-                with(productImageView.layoutParams as MarginLayoutParams) {
-                    this.topMargin = margin
-                    this.bottomMargin = margin
-                }
-            }
 
             itemView.setOnClickListener {
                 if (adapterPosition > NO_POSITION) {

--- a/WooCommerce/src/main/res/layout/image_gallery_item.xml
+++ b/WooCommerce/src/main/res/layout/image_gallery_item.xml
@@ -9,8 +9,6 @@
         android:layout_width="wrap_content"
         android:layout_height="@dimen/image_major_150"
         android:layout_gravity="center"
-        android:layout_marginStart="@dimen/minor_100"
-        android:layout_marginEnd="@dimen/minor_100"
         android:adjustViewBounds="true"
         android:contentDescription="@string/product_image_content_description"
         tools:layout_width="@dimen/image_major_150"


### PR DESCRIPTION
References: #3166 

**Description**
This PR sets even margins between items in the `Product Images` grid.

**Testing instructions**
1. Run the current `develop` version
2. Navigate to `Product Images`
3. Make sure there are at least 2 images
4. See uneven grid
5. Checkout this PR
6. Navigate to `Product Images`
7. See even grid

**Images**
| Before | After |
| ------ | ----- |
| ![device-2020-11-16-002326](https://user-images.githubusercontent.com/5845095/99199827-27bfd280-27a2-11eb-899a-dc9ebfae15a3.png) | ![device-2020-11-16-002429](https://user-images.githubusercontent.com/5845095/99199853-48882800-27a2-11eb-89ec-3342df587d46.png) |
| ![device-2020-11-16-002253](https://user-images.githubusercontent.com/5845095/99199860-55a51700-27a2-11eb-9eb9-c2d6319d873f.png) | ![device-2020-11-16-002134](https://user-images.githubusercontent.com/5845095/99199864-62296f80-27a2-11eb-8a4e-c3fd77c729af.png) |


Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
