### PR TITLE
Fix order detail products

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,9 +1,8 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
-* Fixed an issue with unexpected shipment tracking UI in order details
-
 5.6
 -----
+* Fixed an issue with unexpected shipment tracking UI in order details
  
 5.5
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+* Fixed an issue with unexpected shipment tracking UI in order details
+
 5.5
 -----
  

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -253,6 +253,9 @@ class OrderDetailRepository @Inject constructor(
     fun getOrderNotes(localOrderId: Int) =
         orderStore.getOrderNotesForOrder(localOrderId).map { it.toAppModel() }
 
+    suspend fun fetchProductsByRemoteIds(remoteIds: List<Long>) =
+        productStore.fetchProductListSynced(selectedSite.get(), remoteIds)?.map { it.toAppModel() } ?: emptyList()
+
     fun getProductsByRemoteIds(remoteIds: List<Long>) =
         productStore.getProductsByRemoteIds(selectedSite.get(), remoteIds)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -124,7 +124,7 @@ class OrderDetailViewModel @AssistedInject constructor(
         return orderDetailViewState.order?.items?.let { lineItems ->
             if (lineItems.isNotEmpty()) {
                 val remoteProductIds = lineItems.map { it.productId }
-                orderDetailRepository.getProductsByRemoteIds(remoteProductIds).any { it.virtual }
+                orderDetailRepository.getProductsByRemoteIds(remoteProductIds).all { it.virtual }
             } else false
         } ?: false
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -19,7 +19,6 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.model.OrderNote
 import com.woocommerce.android.model.OrderShipmentTracking
-import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.Refund
 import com.woocommerce.android.model.RequestResult
 import com.woocommerce.android.model.ShippingLabel

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -9,7 +9,7 @@ import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
 
 object ProductTestUtils {
-    fun generateProduct(productId: Long = 1L): Product {
+    fun generateProduct(productId: Long = 1L, isVirtual: Boolean = false): Product {
         return WCProductModel(2).apply {
             dateCreated = "2018-01-05T05:14:30Z"
             localSiteId = 1
@@ -43,6 +43,7 @@ object ProductTestUtils {
             groupedProductIds = "[10,11]"
             ratingCount = 4
             shortDescription = "short desc"
+            virtual = isVirtual
         }.toAppModel()
     }
 


### PR DESCRIPTION
While working on the shipping labels I noticed some unexpected behavior, which gets manifested in shipment tracking and shipping label UI. Eventually, I found the issues:

- The `hasVirtualProductsOnly()` method had the wrong `any()` instead of `all()` call that checks if a product is virtual
- `hasVirtualProductsOnly()` loads products from the database but they might not be all fetched, which can result in false positive => this is now checked and order products are prefetched

I added unit tests to test both cases.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
