### PR TITLE
Issue/2615 fetch media crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesUtils.kt
@@ -108,6 +108,9 @@ object ProductImagesUtils {
         } catch (e: IllegalStateException) {
             WooLog.e(T.MEDIA, "Can't download the image at: $mediaUri", e)
             null
+        } catch (e: SecurityException) {
+            WooLog.e(T.MEDIA, "Can't download the image at: $mediaUri", e)
+            null
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesUtils.kt
@@ -104,7 +104,7 @@ object ProductImagesUtils {
         }
 
         return try {
-            MediaUtils.downloadExternalMedia(context, mediaUri)
+            MediaUtils.downloadExternalMedia(context.applicationContext, mediaUri)
         } catch (e: IllegalStateException) {
             WooLog.e(T.MEDIA, "Can't download the image at: $mediaUri", e)
             null


### PR DESCRIPTION
This PR is another attempt to fix - or, at least, alleviate - #2615. The first part of this fix is:

- Catch the `SecurityException` in `ProductImageUtils.fetchMedia()` and return null
- The null media will cause `ProductImageService` to call `handleFailure()`
- `handleFailure()` fires an event that's caught by the product detail view model, which can show the upload error snackbar

That's not really a fix but a bandaid to stop the crash. The second part is to use the application context when calling `MediaUtils.downloadExternalMedia()`. This is a result of a conversation with @planarvoid that suggested the crash was caused by a context switch.

If this PR ends up not helping, the next step is to make a copy of the chosen image(s) as recommended in [this SO comment](https://stackoverflow.com/a/31274622/1673548).

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
