### PR TITLE
Issue/3144 display shipping info

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/IProduct.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/IProduct.kt
@@ -15,7 +15,8 @@ interface IProduct {
      */
     fun getWeightWithUnits(weightUnit: String?): String {
         return if (weight > 0) {
-            "${weight.formatToString()}${weightUnit ?: ""}"
+            val unit = weightUnit ?: EMPTY
+            "${weight.formatToString()}$unit"
         } else ""
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/IProduct.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/IProduct.kt
@@ -28,36 +28,20 @@ interface IProduct {
      * Eg: 12 x 15 x 13 in
      */
     fun getSizeWithUnits(dimensionUnit: String?): String {
-        val hasLength = length > 0
-        val hasWidth = width > 0
-        val hasHeight = height > 0
         val unit = dimensionUnit ?: EMPTY
-        val size = if (hasLength && hasWidth && hasHeight) {
-            length.formatToString() +
-                X + width.formatToString() +
-                X + height.formatToString() +
+        val dimensions = arrayOf(length, width, height).filter { it > 0 }
+        val size = when (dimensions.size) {
+            NO_DIMENSIONS -> EMPTY
+            ONE_DIMENSIONAL -> dimensions[0].formatToString() + unit
+            TWO_DIMENSIONAL -> dimensions[0].formatToString() +
+                X + dimensions[1].formatToString() +
                 SPACE + unit
-        } else if (hasLength && hasWidth) {
-            length.formatToString() +
-                X + width.formatToString() +
+            THREE_DIMENSIONAL -> dimensions[0].formatToString() +
+                X + dimensions[1].formatToString() +
+                X + dimensions[2].formatToString() +
                 SPACE + unit
-        } else if (hasLength && hasHeight) {
-            length.formatToString() +
-                X + height.formatToString() +
-                SPACE + unit
-        } else if (hasWidth && hasHeight) {
-            width.formatToString() +
-                X + height.formatToString() +
-                SPACE + unit
-        } else if (hasLength) {
-            length.formatToString() + unit
-        } else if (hasWidth) {
-            width.formatToString() + unit
-        } else if (hasHeight) {
-            height.formatToString() + unit
-        } else {
-            EMPTY
-        }
+            else -> UnsupportedOperationException("More than three dimensions!")
+        } as String
         return size.trim()
     }
 
@@ -65,5 +49,10 @@ interface IProduct {
         private const val EMPTY = ""
         private const val SPACE = " "
         private const val X = " x "
+
+        private const val NO_DIMENSIONS = 0
+        private const val ONE_DIMENSIONAL = 1
+        private const val TWO_DIMENSIONAL = 2
+        private const val THREE_DIMENSIONAL = 3
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/IProduct.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/IProduct.kt
@@ -33,8 +33,18 @@ interface IProduct {
             "${length.formatToString()} " +
                 "x ${width.formatToString()} " +
                 "x ${height.formatToString()} $unit"
+        } else if (hasLength && hasWidth) {
+            "${length.formatToString()} x ${width.formatToString()} $unit"
+        } else if (hasLength && hasHeight) {
+            "${length.formatToString()} x ${height.formatToString()} $unit"
         } else if (hasWidth && hasHeight) {
             "${width.formatToString()} x ${height.formatToString()} $unit"
+        } else if (hasLength) {
+            "${length.formatToString()}$unit"
+        } else if (hasWidth) {
+            "${width.formatToString()}$unit"
+        } else if (hasHeight) {
+            "${height.formatToString()}$unit"
         } else {
             ""
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/IProduct.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/IProduct.kt
@@ -29,7 +29,7 @@ interface IProduct {
         val hasWidth = width > 0
         val hasHeight = height > 0
         val unit = dimensionUnit ?: ""
-        return if (hasLength && hasWidth && hasHeight) {
+        val size = if (hasLength && hasWidth && hasHeight) {
             "${length.formatToString()} " +
                 "x ${width.formatToString()} " +
                 "x ${height.formatToString()} $unit"
@@ -37,6 +37,7 @@ interface IProduct {
             "${width.formatToString()} x ${height.formatToString()} $unit"
         } else {
             ""
-        }.trim()
+        }
+        return size.trim()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/IProduct.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/IProduct.kt
@@ -28,26 +28,39 @@ interface IProduct {
         val hasLength = length > 0
         val hasWidth = width > 0
         val hasHeight = height > 0
-        val unit = dimensionUnit ?: ""
+        val unit = dimensionUnit ?: EMPTY
         val size = if (hasLength && hasWidth && hasHeight) {
-            "${length.formatToString()} " +
-                "x ${width.formatToString()} " +
-                "x ${height.formatToString()} $unit"
+            length.formatToString() +
+                X + width.formatToString() +
+                X + height.formatToString() +
+                SPACE + unit
         } else if (hasLength && hasWidth) {
-            "${length.formatToString()} x ${width.formatToString()} $unit"
+            length.formatToString() +
+                X + width.formatToString() +
+                SPACE + unit
         } else if (hasLength && hasHeight) {
-            "${length.formatToString()} x ${height.formatToString()} $unit"
+            length.formatToString() +
+                X + height.formatToString() +
+                SPACE + unit
         } else if (hasWidth && hasHeight) {
-            "${width.formatToString()} x ${height.formatToString()} $unit"
+            width.formatToString() +
+                X + height.formatToString() +
+                SPACE + unit
         } else if (hasLength) {
-            "${length.formatToString()}$unit"
+            length.formatToString() + unit
         } else if (hasWidth) {
-            "${width.formatToString()}$unit"
+            width.formatToString() + unit
         } else if (hasHeight) {
-            "${height.formatToString()}$unit"
+            height.formatToString() + unit
         } else {
-            ""
+            EMPTY
         }
         return size.trim()
+    }
+
+    companion object {
+        private const val EMPTY = ""
+        private const val SPACE = " "
+        private const val X = " x "
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/IProduct.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/IProduct.kt
@@ -40,8 +40,8 @@ interface IProduct {
                 X + dimensions[1].formatToString() +
                 X + dimensions[2].formatToString() +
                 SPACE + unit
-            else -> UnsupportedOperationException("More than three dimensions!")
-        } as String
+            else -> throw UnsupportedOperationException("More than three dimensions!")
+        }
         return size.trim()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/IProduct.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/IProduct.kt
@@ -16,8 +16,10 @@ interface IProduct {
     fun getWeightWithUnits(weightUnit: String?): String {
         return if (weight > 0) {
             val unit = weightUnit ?: EMPTY
-            "${weight.formatToString()}$unit"
-        } else ""
+            weight.formatToString() + unit
+        } else {
+            EMPTY
+        }
     }
 
     /**

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/IProductTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/IProductTest.kt
@@ -1,0 +1,146 @@
+package com.woocommerce.android.model
+
+import com.woocommerce.android.extensions.formatToString
+import com.woocommerce.android.ui.products.ProductHelper
+import com.woocommerce.android.ui.products.ProductType
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class IProductTest {
+    private val product = ProductHelper.getDefaultNewProduct(ProductType.SIMPLE)
+
+    /* WEIGHT */
+
+    @Test
+    fun `given negative weight, when getting weight, then return empty`() {
+        val product = product.copy(weight = -1f)
+
+        val result = product.getWeightWithUnits(null)
+
+        assertEquals(EMPTY, result)
+    }
+
+    @Test
+    fun `given zero weight, when getting weight, then return empty`() {
+        val product = product.copy(weight = 0f)
+
+        val result = product.getWeightWithUnits(null)
+
+        assertEquals(EMPTY, result)
+    }
+
+    @Test
+    fun `given weight without unit, when getting weight, then return weight without unit`() {
+        val weight = 1f
+        val product = product.copy(weight = weight)
+
+        val result = product.getWeightWithUnits(null)
+
+        val expected = weight.formatToString()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `given weight with unit, when getting weight, then return weight with unit`() {
+        val weight = 1f
+        val product = product.copy(weight = weight)
+
+        val result = product.getWeightWithUnits(WEIGHT_UNIT)
+
+        val expected = weight.formatToString() + WEIGHT_UNIT
+        assertEquals(expected, result)
+    }
+
+    /* SIZE */
+
+    @Test
+    fun `given negative dimens, when getting size, then return empty`() {
+        val length = -1f
+        val width = -2f
+        val height = -3f
+        val product = product.copy(length = length, width = width, height = height)
+
+        val result = product.getSizeWithUnits(null)
+
+        assertEquals(EMPTY, result)
+    }
+
+    @Test
+    fun `given no dimens, when getting size, then return empty`() {
+        val length = 0f
+        val width = 0f
+        val height = 0f
+        val product = product.copy(length = length, width = width, height = height)
+
+        val result = product.getSizeWithUnits(null)
+
+        assertEquals(EMPTY, result)
+    }
+
+    @Test
+    fun `given dimens without unit, when getting size, then return dimensions without unit`() {
+        val length = 1f
+        val width = 2f
+        val height = 3f
+        val product = product.copy(length = length, width = width, height = height)
+
+        val result = product.getSizeWithUnits(null)
+
+        val expected = length.formatToString() +
+            X + width.formatToString() +
+            X + height.formatToString() +
+            SPACE
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `given dimens with unit, when getting size, then return dimensions with unit`() {
+        val length = 1f
+        val width = 2f
+        val height = 3f
+        val product = product.copy(length = length, width = width, height = height)
+
+        val result = product.getSizeWithUnits(DIMENSION_UNIT)
+
+        val expected = length.formatToString() +
+            X + width.formatToString() +
+            X + height.formatToString() +
+            SPACE + DIMENSION_UNIT
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `given width and height without unit, when getting size, then return width and height without unit`() {
+        val width = 2f
+        val height = 3f
+        val product = product.copy(length = 0f, width = width, height = height)
+
+        val result = product.getSizeWithUnits(null)
+
+        val expected = width.formatToString() +
+            X + height.formatToString()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `given width and height with unit, when getting size, then return width and height with unit`() {
+        val width = 2f
+        val height = 3f
+        val product = product.copy(length = 0f, width = width, height = height)
+
+        val result = product.getSizeWithUnits(DIMENSION_UNIT)
+
+        val expected = width.formatToString() +
+            X + height.formatToString() +
+            SPACE + DIMENSION_UNIT
+        assertEquals(expected, result)
+    }
+
+    companion object {
+        private const val EMPTY = ""
+        private const val SPACE = " "
+        private const val X = " x "
+        private const val WEIGHT_UNIT = "kg"
+        private const val DIMENSION_UNIT = "cm"
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/IProductTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/IProductTest.kt
@@ -88,8 +88,7 @@ class IProductTest {
 
         val expected = length.formatToString() +
             X + width.formatToString() +
-            X + height.formatToString() +
-            SPACE
+            X + height.formatToString()
         assertEquals(expected, result)
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/IProductTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/IProductTest.kt
@@ -109,6 +109,60 @@ class IProductTest {
     }
 
     @Test
+    fun `given length and width without unit, when getting size, then return length and width without unit`() {
+        val length = 1f
+        val width = 2f
+        val product = product.copy(length = length, width = width, height = 0f)
+
+        val result = product.getSizeWithUnits(null)
+
+        val expected = length.formatToString() +
+            X + width.formatToString()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `given length and width with unit, when getting size, then return length and width with unit`() {
+        val length = 1f
+        val width = 2f
+        val product = product.copy(length = length, width = width, height = 0f)
+
+        val result = product.getSizeWithUnits(DIMENSION_UNIT)
+
+        val expected = length.formatToString() +
+            X + width.formatToString() +
+            SPACE + DIMENSION_UNIT
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `given length and height without unit, when getting size, then return length and height without unit`() {
+        val length = 1f
+        val height = 3f
+        val product = product.copy(length = length, width = 0f, height = height)
+
+        val result = product.getSizeWithUnits(null)
+
+        val expected = length.formatToString() +
+            X + height.formatToString()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `given length and height with unit, when getting size, then return length and height with unit`() {
+        val length = 1f
+        val height = 3f
+        val product = product.copy(length = length, width = 0f, height = height)
+
+        val result = product.getSizeWithUnits(DIMENSION_UNIT)
+
+        val expected = length.formatToString() +
+            X + height.formatToString() +
+            SPACE + DIMENSION_UNIT
+        assertEquals(expected, result)
+    }
+
+    @Test
     fun `given width and height without unit, when getting size, then return width and height without unit`() {
         val width = 2f
         val height = 3f
@@ -132,6 +186,72 @@ class IProductTest {
         val expected = width.formatToString() +
             X + height.formatToString() +
             SPACE + DIMENSION_UNIT
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `given length without unit, when getting size, then return length without unit`() {
+        val length = 1f
+        val product = product.copy(length = length, width = 0f, height = 0f)
+
+        val result = product.getSizeWithUnits(null)
+
+        val expected = length.formatToString()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `given length with unit, when getting size, then return length with unit`() {
+        val length = 1f
+        val product = product.copy(length = length, width = 0f, height = 0f)
+
+        val result = product.getSizeWithUnits(DIMENSION_UNIT)
+
+        val expected = length.formatToString() + DIMENSION_UNIT
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `given width without unit, when getting size, then return width without unit`() {
+        val width = 2f
+        val product = product.copy(length = 0f, width = width, height = 0f)
+
+        val result = product.getSizeWithUnits(null)
+
+        val expected = width.formatToString()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `given width with unit, when getting size, then return width with unit`() {
+        val width = 2f
+        val product = product.copy(length = 0f, width = width, height = 0f)
+
+        val result = product.getSizeWithUnits(DIMENSION_UNIT)
+
+        val expected = width.formatToString() + DIMENSION_UNIT
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `given height without unit, when getting size, then return height without unit`() {
+        val height = 3f
+        val product = product.copy(length = 0f, width = 0f, height = height)
+
+        val result = product.getSizeWithUnits(null)
+
+        val expected = height.formatToString()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `given height with unit, when getting size, then return height with unit`() {
+        val height = 3f
+        val product = product.copy(length = 0f, width = 0f, height = height)
+
+        val result = product.getSizeWithUnits(DIMENSION_UNIT)
+
+        val expected = height.formatToString() + DIMENSION_UNIT
         assertEquals(expected, result)
     }
 


### PR DESCRIPTION
Fixes #3144 

This PR mainly fixed the issue where some dimension related shipping information where missing within the product details screen. As part of this PR the below was done:
1) A new test suite was added, the `IProductTest.kt` test class. This test suite is now solely responsible for testing how the weight and size functions are constructing the end string result.
1) The new test suite structure is based on the `given/when/then` pattern. But, if that pattern should not be used or another pattern is already agreed within the team, please let me know and I will rename the test to the currently agreed pattern.
1) The new tests, as well as the missing functionality, where added using TDD.
1) In addition, further refactorings on the main interface occurred, the `IProduct.kt` interface. These refactoring was mainly done for readability, static code analysis and consistency purposes. However, the last commit adds a refactoring that reduces the cyclomatic complexity of the size function itself, which is also the main production related change. This change is fully covered by test, as such, functional wise nothing changes.

This idea of improving the size function like that came to me after going through the iOS solution, so **KUDOS** to the team (and more specifically to @jaclync).

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
