### PR TITLE
Add ADD_ORDER_TRACKING analytics

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_TRACKING_ADD
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.di.ViewModelAssistedFactory
 import com.woocommerce.android.extensions.whenNotNullNorEmpty
@@ -178,6 +179,13 @@ class OrderDetailViewModel @AssistedInject constructor(
 
             triggerEvent(ShowSnackbar(string.order_shipment_tracking_added))
             launch {
+                AnalyticsTracker.track(
+                    ORDER_TRACKING_ADD,
+                    mapOf(AnalyticsTracker.KEY_ID to order?.remoteId,
+                        AnalyticsTracker.KEY_STATUS to order?.status,
+                        AnalyticsTracker.KEY_CARRIER to shipmentTracking.trackingProvider)
+                )
+
                 val addedShipmentTracking = orderDetailRepository.addOrderShipmentTracking(
                     orderIdSet.id,
                     orderIdSet.remoteOrderId,


### PR DESCRIPTION
Fixes #3181.

**To test:**
1. Go to Orders -> Order detail
2. Add a shipment tracking
3. Fill out the details and tap Done
4. Verify the `ORDER_TRACKING_ADD` track event is triggered

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
