### PR TITLE
Issue/2036 single product display

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailProductListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailProductListView.kt
@@ -34,10 +34,10 @@ class OrderDetailProductListView @JvmOverloads constructor(
         productClickListener: OrderProductActionListener
     ) {
         productList_lblProduct.text = StringUtils.getQuantityString(
-            context,
-            orderItems.size,
-            R.string.orderdetail_product_multiple,
-            R.string.orderdetail_product
+            context = context,
+            quantity = orderItems.size,
+            default = R.string.orderdetail_product_multiple,
+            one = R.string.orderdetail_product
         )
 
         productList_products.apply {


### PR DESCRIPTION
Fixes #2036 

When a user enters the order details screen that contains a single product, then the product section was displaying `Products` as plural instead of `Product` as singular.

This PR fixes this issue, which was actually a bug in the code due to the misuse of the `getQuantityString(...)` function. Since the `zero` argument is before `one`, when not using named arguments it is easy to misuse it. By explicitly adding named arguments to select `one` instead of the default `zero` parameter for the singular `Product` string the problem is automatically fixed.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
