### PR TITLE
Update FluxC commit hash to pull in the hotfix for empty order product variation keys

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,10 @@
 
 5.5
 -----
+
+5.4.1
+-----
+** Fixed issue in order product variations where an empty variation key would cause a crash [https://github.com/woocommerce/woocommerce-android/pull/3188]
  
 5.4
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.6.26'
+    fluxCVersion = '1.6.26.1'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Fixes the crash in #3183 by updating the FluxC version to include the fix completed in this PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1778

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
