### PR TITLE
Issue/572 sqlite blob too big exception

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'af50831bc526ee06454a4599faf56d59b5a83307'
+    fluxCVersion = 'ea9de1ad23838ba5b2d3675cc0b5889ba32f3bf1'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.6.26'
+    fluxCVersion = 'af50831bc526ee06454a4599faf56d59b5a83307'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Partially fixes #572 - this PR simply updates the FluxC hash to include [this fix](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1777), which should cut down on the `SQLiteBlobTooBigExceptions` we've been seeing.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
