### PR TITLE
Issue/3195 collapsing toolbar child fragments

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -12,6 +12,7 @@ import android.view.ViewGroup
 import android.view.WindowManager
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavController
@@ -54,6 +55,7 @@ import com.woocommerce.android.ui.sitepicker.SitePickerActivity
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
 import com.woocommerce.android.widgets.AppRatingDialog
+import com.woocommerce.android.widgets.DisableableAppBarLayoutBehavior
 import com.woocommerce.android.widgets.WCPromoDialog
 import com.woocommerce.android.widgets.WCPromoDialog.PromoButton
 import com.woocommerce.android.widgets.WCPromoTooltip
@@ -479,6 +481,12 @@ class MainActivity : AppUpgradeActivity(),
             toolbar.title = title
         }
         collapsing_toolbar.isTitleEnabled = enable
+
+        (app_bar_layout.layoutParams as CoordinatorLayout.LayoutParams).behavior = if (enable) {
+            AppBarLayout.Behavior()
+        } else {
+            DisableableAppBarLayoutBehavior()
+        }
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -55,7 +55,7 @@ import com.woocommerce.android.ui.sitepicker.SitePickerActivity
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
 import com.woocommerce.android.widgets.AppRatingDialog
-import com.woocommerce.android.widgets.DisableableAppBarLayoutBehavior
+import com.woocommerce.android.widgets.DisabledAppBarLayoutBehavior
 import com.woocommerce.android.widgets.WCPromoDialog
 import com.woocommerce.android.widgets.WCPromoDialog.PromoButton
 import com.woocommerce.android.widgets.WCPromoTooltip
@@ -482,20 +482,12 @@ class MainActivity : AppUpgradeActivity(),
         }
         collapsing_toolbar.isTitleEnabled = enable
 
-        // prevent child fragments from nested scroll
         val params = (app_bar_layout.layoutParams as CoordinatorLayout.LayoutParams)
         params.behavior = if (enable) {
             AppBarLayout.Behavior()
         } else {
-            DisableableAppBarLayoutBehavior()
+            DisabledAppBarLayoutBehavior()
         }
-
-        // prevent the toolbar from being dragged in child fragments
-        (params.behavior as AppBarLayout.Behavior).setDragCallback(object : AppBarLayout.Behavior.DragCallback() {
-            override fun canDrag(appBarLayout: AppBarLayout): Boolean {
-                return enable
-            }
-        })
     }
 
     /**
@@ -507,7 +499,6 @@ class MainActivity : AppUpgradeActivity(),
      * @param isAtRoot The value that tells if root fragment is in the current destination
      * @param destination The object for the next navigation destination
      */
-
     private fun isAtTopLevelNavigation(isAtRoot: Boolean, destination: NavDestination): Boolean {
         val isDialogDestination = destination.navigatorName == DIALOG_NAVIGATOR_NAME
         val activeChild = getHostChildFragment()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -482,11 +482,20 @@ class MainActivity : AppUpgradeActivity(),
         }
         collapsing_toolbar.isTitleEnabled = enable
 
-        (app_bar_layout.layoutParams as CoordinatorLayout.LayoutParams).behavior = if (enable) {
+        // prevent child fragments from nested scroll
+        val params = (app_bar_layout.layoutParams as CoordinatorLayout.LayoutParams)
+        params.behavior = if (enable) {
             AppBarLayout.Behavior()
         } else {
             DisableableAppBarLayoutBehavior()
         }
+
+        // prevent the toolbar from being dragged in child fragments
+        (params.behavior as AppBarLayout.Behavior).setDragCallback(object : AppBarLayout.Behavior.DragCallback() {
+            override fun canDrag(appBarLayout: AppBarLayout): Boolean {
+                return enable
+            }
+        })
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -125,6 +125,9 @@ class MainActivity : AppUpgradeActivity(),
     private var isToolbarExpanded = true
     private var restoreToolbarHeight = 0
 
+    private val toolbarEnabledBehavior = AppBarLayout.Behavior()
+    private val toolbarDisabledBehavior = DisabledAppBarLayoutBehavior()
+
     private lateinit var bottomNavView: MainBottomNavigationView
     private lateinit var navController: NavController
 
@@ -484,9 +487,9 @@ class MainActivity : AppUpgradeActivity(),
 
         val params = (app_bar_layout.layoutParams as CoordinatorLayout.LayoutParams)
         params.behavior = if (enable) {
-            AppBarLayout.Behavior()
+            toolbarEnabledBehavior
         } else {
-            DisabledAppBarLayoutBehavior()
+            toolbarDisabledBehavior
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/DisableableAppBarLayoutBehavior.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/DisableableAppBarLayoutBehavior.kt
@@ -1,0 +1,26 @@
+package com.woocommerce.android.widgets
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import com.google.android.material.appbar.AppBarLayout
+
+/**
+ * Custom layout behavior which disables collapsing toolbar
+ */
+class DisableableAppBarLayoutBehavior : AppBarLayout.Behavior {
+    constructor() : super() {}
+    constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs) {}
+
+    override fun onStartNestedScroll(
+        parent: CoordinatorLayout,
+        child: AppBarLayout,
+        directTargetChild: View,
+        target: View,
+        nestedScrollAxes: Int,
+        type: Int
+    ): Boolean {
+        return false
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/DisabledAppBarLayoutBehavior.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/DisabledAppBarLayoutBehavior.kt
@@ -9,7 +9,7 @@ import com.google.android.material.appbar.AppBarLayout
  */
 class DisabledAppBarLayoutBehavior() : AppBarLayout.Behavior() {
     /**
-     * Prevent the toolbar from being dragged in child fragments
+     * Prevent the toolbar from being dragged
      */
     init {
         setDragCallback(object : AppBarLayout.Behavior.DragCallback() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/DisabledAppBarLayoutBehavior.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/DisabledAppBarLayoutBehavior.kt
@@ -7,12 +7,21 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 import com.google.android.material.appbar.AppBarLayout
 
 /**
- * Custom layout behavior which disables collapsing toolbar
+ * Custom layout behavior which prevents collapsing toolbar from being expanded
  */
-class DisableableAppBarLayoutBehavior : AppBarLayout.Behavior {
+class DisabledAppBarLayoutBehavior : AppBarLayout.Behavior {
+    init {
+        // prevent the toolbar from being dragged in child fragments
+        setDragCallback(object : AppBarLayout.Behavior.DragCallback() {
+            override fun canDrag(appBarLayout: AppBarLayout): Boolean {
+                return false
+            }
+        })
+    }
     constructor() : super() {}
     constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs) {}
 
+    // prevent nested scroll
     override fun onStartNestedScroll(
         parent: CoordinatorLayout,
         child: AppBarLayout,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/DisabledAppBarLayoutBehavior.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/DisabledAppBarLayoutBehavior.kt
@@ -1,7 +1,5 @@
 package com.woocommerce.android.widgets
 
-import android.content.Context
-import android.util.AttributeSet
 import android.view.View
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import com.google.android.material.appbar.AppBarLayout
@@ -9,19 +7,21 @@ import com.google.android.material.appbar.AppBarLayout
 /**
  * Custom layout behavior which prevents collapsing toolbar from being expanded
  */
-class DisabledAppBarLayoutBehavior : AppBarLayout.Behavior {
+class DisabledAppBarLayoutBehavior() : AppBarLayout.Behavior() {
+    /**
+     * Prevent the toolbar from being dragged in child fragments
+     */
     init {
-        // prevent the toolbar from being dragged in child fragments
         setDragCallback(object : AppBarLayout.Behavior.DragCallback() {
             override fun canDrag(appBarLayout: AppBarLayout): Boolean {
                 return false
             }
         })
     }
-    constructor() : super() {}
-    constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs) {}
 
-    // prevent nested scroll
+    /**
+     * Prevent nested scroll
+     */
     override fun onStartNestedScroll(
         parent: CoordinatorLayout,
         child: AppBarLayout,

--- a/WooCommerce/src/main/res/layout/activity_main.xml
+++ b/WooCommerce/src/main/res/layout/activity_main.xml
@@ -18,9 +18,9 @@
 
         <com.google.android.material.appbar.AppBarLayout
             android:id="@+id/app_bar_layout"
-            android:elevation="@dimen/appbar_elevation"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:elevation="@dimen/appbar_elevation">
 
             <com.google.android.material.appbar.CollapsingToolbarLayout
                 android:id="@+id/collapsing_toolbar"
@@ -29,8 +29,7 @@
                 android:layout_height="@dimen/expanded_toolbar_height"
                 app:titleEnabled="true">
 
-                <include
-                    layout="@layout/view_toolbar" />
+                <include layout="@layout/view_toolbar" />
             </com.google.android.material.appbar.CollapsingToolbarLayout>
         </com.google.android.material.appbar.AppBarLayout>
 


### PR DESCRIPTION
Closes #3195 - in #3136 we changed the toolbar design throughout the app, but a bug was introduced which could leave an empty area at the top of child fragments if a PTR was performed. This PR addresses this with a custom AppBar behavior which prevents the toolbar from being expanded.

To test:

* Open a child fragment (ex: order detail)
* Perform a PTR and note that the empty area does not appear
* Drag down on the toolbar and note that the empty area does not appear
* Return to the top level fragment (order list, in this case) and note that the toolbar correctly collapses & expands

![before](https://user-images.githubusercontent.com/3903757/100144575-f9f32180-2e64-11eb-9486-3e21db18dc31.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
