### PR TITLE
issue/3057-product-list-crash-fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -58,7 +58,7 @@ data class Product(
     val shippingClassId: Long,
     val isDownloadable: Boolean,
     val downloads: List<ProductFile>,
-    val downloadLimit: Int,
+    val downloadLimit: Long,
     val downloadExpiry: Int,
     val purchaseNote: String,
     val numVariations: Int,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -359,7 +359,7 @@ class ProductDetailViewModel @AssistedInject constructor(
         }
     }
 
-    fun onDownloadLimitChanged(value: Int) {
+    fun onDownloadLimitChanged(value: Long) {
         viewState.productDraft?.let {
             updateProductDraft(
                 downloadLimit = value
@@ -701,7 +701,7 @@ class ProductDetailViewModel @AssistedInject constructor(
         upsellProductIds: List<Long>? = null,
         crossSellProductIds: List<Long>? = null,
         downloads: List<ProductFile>? = null,
-        downloadLimit: Int? = null,
+        downloadLimit: Long? = null,
         downloadExpiry: Int? = null,
         isDownloadable: Boolean? = null
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsSettingsFragment.kt
@@ -62,7 +62,7 @@ class ProductDownloadsSettingsFragment : BaseProductFragment() {
     }
 
     private fun initFromProductDraft() {
-        fun Int.formatLimitAndExpiry(): String = if (this == -1) "" else this.toString()
+        fun Number.formatLimitAndExpiry(): String = if (this == -1) "" else this.toString()
         val product = requireNotNull(viewModel.getProduct().productDraft)
         product_download_limit.setText(product.downloadLimit.formatLimitAndExpiry())
         product_download_expiry.setText(product.downloadExpiry.formatLimitAndExpiry())
@@ -75,7 +75,7 @@ class ProductDownloadsSettingsFragment : BaseProductFragment() {
             changesMade()
         }
         product_download_limit.setOnTextChangedListener {
-            val value = if (it.isNullOrEmpty()) -1 else it.toString().toInt()
+            val value = if (it.isNullOrEmpty()) -1 else it.toString().toLong()
             viewModel.onDownloadLimitChanged(value)
             changesMade()
         }

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'ea9de1ad23838ba5b2d3675cc0b5889ba32f3bf1'
+    fluxCVersion = 'c9000e2251e355121e10d5c3116d2ef7fc8d7cef'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'c9000e2251e355121e10d5c3116d2ef7fc8d7cef'
+    fluxCVersion = 'd8e829b204598a3a8eff61bce9fd90d088bb914a'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Fixes #3057. This PR just updates the FluxC hash that includes the actual fix [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1784). 

### To test
- From `wp-admin`, update the download_limit field of a product to `123123124124`.
- Open the app and click on the Products tab and verify that it is displayed correctly.
- Click on the product with the `download_limit` and verify that you are able to view the product details correctly and update it without any issues.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
