### PR TITLE
issue/3154-login-site-address-crash-fix

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -224,7 +224,10 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
 
     @Override
     public void afterTextChanged(Editable s) {
-        mLoginSiteAddressValidator.setAddress(EditTextUtils.getText(mSiteAddressInput.getEditText()));
+        if (mSiteAddressInput != null) {
+            mLoginSiteAddressValidator
+                    .setAddress(EditTextUtils.getText(mSiteAddressInput.getEditText()));
+        }
     }
 
     @Override
@@ -233,7 +236,9 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
 
     @Override
     public void onTextChanged(CharSequence s, int start, int before, int count) {
-        mSiteAddressInput.setError(null);
+        if (mSiteAddressInput != null) {
+            mSiteAddressInput.setError(null);
+        }
     }
 
     private void showError(int messageId) {


### PR DESCRIPTION
Fixes #3154 by adding a null check when user enters a site address during login. I haven't been able to reproduce the issue but it looks like we set the `mSiteAddressInput=null` when the fragment is destroyed. So if the `onTextChanged` is called before the `mSiteAddressInput` could be initialised again, this crash could potentially happen.

Given that we needn't update the `mSiteAddressInput` field after the fragment is destroyed, it seemed enough to do just a null check here to ensure that this crash doesn't happen again. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
