### PR TITLE
Fixed renamed icons

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -98,11 +98,11 @@ class ProductImagesFragment : BaseProductEditorFragment(R.layout.fragment_produc
         when (viewModel.viewStateData.liveData.value?.productImagesState) {
             is Dragging -> {
                 inflater.inflate(R.menu.menu_dragging, menu)
-                setHomeIcon(R.drawable.ic_gridicons_cross_white_24dp)
+                setHomeIcon(R.drawable.ic_gridicons_cross_24dp)
             }
             Browsing -> {
                 super.onCreateOptionsMenu(menu, inflater)
-                setHomeIcon(R.drawable.ic_back_white_24dp)
+                setHomeIcon(R.drawable.ic_back_24dp)
             }
         }
     }


### PR DESCRIPTION
This PR is a simple fix for two renamed icons that were not reflected in [this PR](https://github.com/woocommerce/woocommerce-android/pull/3178) that was just merged.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
