### PR TITLE
Issue/2848 product variations scroll

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
@@ -170,15 +170,20 @@ class VariationListFragment : BaseFragment(),
     }
 
     private fun showVariations(variations: List<ProductVariation>, parentProduct: Product?) {
-        val adapter = (variationList.adapter ?: VariationListAdapter(
-            requireContext(),
-            GlideApp.with(this),
-            this,
-            parentProduct,
-            viewModel::onItemClick
-        )) as VariationListAdapter
+        val adapter: VariationListAdapter
+        if (variationList.adapter == null) {
+            adapter = VariationListAdapter(
+                requireContext(),
+                GlideApp.with(this),
+                this,
+                parentProduct,
+                viewModel::onItemClick
+            )
+            variationList.adapter = adapter
+        } else {
+            adapter = variationList.adapter as VariationListAdapter
+        }
 
-        variationList.adapter = adapter
         adapter.setVariationList(variations)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'ea9de1ad23838ba5b2d3675cc0b5889ba32f3bf1'
+    fluxCVersion = '4cb14aba724cda04b854a9d2efc4462a53480b9b'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Fixes #2848
Prerequisite [WordPress-FluxC-Android #1786](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1786)

This change makes sure that the adapter is not set every time a new set of product variations are fetched from the database. The current situation was actually created by design since the ordering of product variations on the api's side and on the database' side was different. As such pagination could not work.

Both, this PR and [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1786) together, solve this problem. The FluxC change aligns the ordering of product variations on both, the api and database, by 'date'. This, along with this PR's change, makes it possible for pagination to work as expected.

⚠️ Please note that the ordering of product variations now changes, from 'menu' to 'date', which change the product's logic for that screen. However, this change was communicated already with the team and everyone agreed on it.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
