### PR TITLE
Redirect to the previous screen after survey completion

### DIFF
--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -24,7 +24,7 @@
             app:exitAnim="@anim/activity_slide_out_to_left"
             app:popEnterAnim="@anim/activity_slide_in_from_left"
             app:popExitAnim="@anim/activity_slide_out_to_right"
-            app:popUpTo="@id/rootFragment"
+            app:popUpTo="@id/feedbackSurveyFragment"
             app:popUpToInclusive="true" />
     </fragment>
     <action


### PR DESCRIPTION
Fixes #3141 

Currently after finishing a survey, we always pop to the My Store tab, with the changes of this PR, we will only pop to the previous screen:
- **Products:**
![products](https://user-images.githubusercontent.com/1657201/100348235-ef609580-2fe6-11eb-9b06-2db3bfaf6a4d.gif)
- **Shipping Labels**
![shipping_labels](https://user-images.githubusercontent.com/1657201/100348344-14ed9f00-2fe7-11eb-9658-e5e22c3c2cc6.gif)

I didn't change the behavior from settings, as IMO it makes more sense (popping back to the MainActivity after finishing the survey):

![settings](https://user-images.githubusercontent.com/1657201/100349140-42871800-2fe8-11eb-9b5d-c2cedb5d5f70.gif)

WDYT @anitaa1990 @ThomazFB about the last point?


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
