### PR TITLE
[Shipping Labels]: remove the bottom divider of the last product

### DIFF
--- a/WooCommerce/src/main/res/layout/order_detail_shipping_label_list_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_shipping_label_list_item.xml
@@ -51,10 +51,6 @@
             tools:listitem="@layout/order_detail_product_list_item"
             tools:targetApi="lollipop" />
 
-        <View
-            style="@style/Woo.Divider.TitleAligned"
-            android:layout_marginTop="@dimen/minor_50" />
-
         <!-- Print shipping label -->
         <com.google.android.material.button.MaterialButton
             android:id="@+id/shippingLabelList_printBtn"


### PR DESCRIPTION
Fixes #3143 

Removes the divider below the products list in the shipping labels details:

- **Multiple products**: 
<img width="480" alt="Screen Shot 2020-11-26 at 14 39 37" src="https://user-images.githubusercontent.com/1657201/100357883-92201080-2ff5-11eb-92d4-a9d890d0a1e6.png">

- **Single product**:
<img width="480" alt="Screen Shot 2020-11-26 at 14 40 13" src="https://user-images.githubusercontent.com/1657201/100357886-93e9d400-2ff5-11eb-9c39-61ba5aa1a42b.png">

**Testing**:
- Single product:
1. Create an order of a single product with a shipping label.
2. Check on the app that the bottom divider has been removed.

- Multiple products:
1. Create an order with multiple products, then create a shipping label.
2. Check on the app that there dividers between the products, but the divider bellow the last item has been removed.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
