### PR TITLE
Show the confirm discard dialog when exiting product tags after adding new tags

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -588,6 +588,7 @@ class ProductDetailViewModel @AssistedInject constructor(
 
         val isProductUpdated = when (event) {
             is ExitProductDetail -> isProductDetailUpdated
+            is ExitProductTags -> isProductDetailUpdated || !_addedProductTags.isEmpty()
             else -> isProductDetailUpdated && isProductSubDetailUpdated
         }
         if (isProductUpdated && event.shouldShowDiscardDialog) {
@@ -636,7 +637,7 @@ class ProductDetailViewModel @AssistedInject constructor(
             return false
         } else {
             if (event is ExitProductTags) {
-                clearProductTagFilter()
+                clearProductTagsState()
             }
             return true
         }
@@ -800,6 +801,7 @@ class ProductDetailViewModel @AssistedInject constructor(
      */
     private fun discardEditChanges() {
         viewState = viewState.copy(productDraft = viewState.productBeforeEnteringFragment)
+        _addedProductTags.clearList()
 
         // updates the UPDATE menu button in the product detail screen i.e. the UPDATE menu button
         // will only be displayed if there are changes made to the Product model.
@@ -1390,11 +1392,11 @@ class ProductDetailViewModel @AssistedInject constructor(
     }
 
     /**
-     * Called when user exits the product tag fragment to clear the stored filter (otherwise it
-     * will be retained when the user returns to the tag fragment)
+     * Called when user exits the product tag fragment to clear the stored filter and the done button state
+     * (otherwise it will be retained when the user returns to the tag fragment)
      */
-    fun clearProductTagFilter() {
-        productTagsViewState = productTagsViewState.copy(currentFilter = "")
+    fun clearProductTagsState() {
+        productTagsViewState = productTagsViewState.copy(currentFilter = "", shouldDisplayDoneMenuButton = false)
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsFragment.kt
@@ -171,7 +171,7 @@ class ProductTagsFragment : BaseProductFragment(), OnLoadMoreListener, OnProduct
         viewModel.event.observe(viewLifecycleOwner, Observer { event ->
             when (event) {
                 is ExitProductTags -> {
-                    viewModel.clearProductTagFilter()
+                    viewModel.clearProductTagsState()
                     findNavController().navigateUp()
                 }
                 else -> event.isHandled = false


### PR DESCRIPTION
Fixes #3095 

Currently when exiting the product tags screen after adding new tags (tags that don't exist in the server), the confirm discard dialog is not shown.
This PR fixes this.

**Testing**:
- Go to product detail and choose to add tags
- Type a tag that doesn't already exist
- Hit enter to add it as a chip
- Press the back button
- Check that the "Confirm discard" dialog appears


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
