### PR TITLE
Testing: Update MockingInterceptor requests for okhttp3 v4.X

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/helpers/MockingInterceptor.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/helpers/MockingInterceptor.kt
@@ -13,8 +13,8 @@ class MockingInterceptor : Interceptor {
         val request = chain.request()
 
         // Redirect all WordPress.com REST API requests to local mock server
-        if (request.url().host() == "public-api.wordpress.com") {
-            val newUrl = request.url().newBuilder()
+        if (request.url.host == "public-api.wordpress.com") {
+            val newUrl = request.url.newBuilder()
                 .scheme("http")
                 .host("localhost")
                 .port(TestBase.wireMockPort)


### PR DESCRIPTION
### Changes

After merging https://github.com/woocommerce/woocommerce-android/pull/2933, @AliSoftware noticed test failures on `develop` like this:

```
> Task :WooCommerce:compileVanillaDebugAndroidTestKotlin FAILED
e: /home/circleci/project/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/helpers/MockingInterceptor.kt: (16, 21): Using 'url(): HttpUrl' is an error. moved to val
e: /home/circleci/project/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/helpers/MockingInterceptor.kt: (16, 27): Using 'host(): String' is an error. moved to val
e: /home/circleci/project/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/helpers/MockingInterceptor.kt: (17, 34): Using 'url(): HttpUrl' is an error. moved to val
```

It looks like the reason for the failures was a dependency update to okhttp3 v4.x that wasn't included in that previous branch. This PR updates those requests to access the properties `url` and `host` instead of using the functions `url()` and `host()` from previous version of okhttp3.

### Testing

Confirm all checks pass on this PR, in particular the `Ensure Screenshots Tests Build` job.

### Release

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
