### PR TITLE
UL: Add new login tint color for secondary button icon

### DIFF
--- a/WooCommerce/src/main/res/values/colors_login.xml
+++ b/WooCommerce/src/main/res/values/colors_login.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Override colors in the WordPressLoginFlow library in this file.
+-->
+<resources>
+<!--    <color name="login_input_label_static_text_color">@color/color_on_surface_disabled</color>-->
+    <color name="login_secondary_button_icon_tint_color">@color/color_on_surface_disabled</color>
+</resources>

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_optional_site_creds_screen.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_optional_site_creds_screen.xml
@@ -78,7 +78,8 @@
             app:iconGravity="textStart"
             app:iconPadding="@dimen/margin_small_medium"
             app:iconSize="14dp"
-            app:iconTint="@null"
+            app:iconTint="@color/login_secondary_button_icon_tint_color"
+            app:iconTintMode="src_in"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />

--- a/libs/login/WordPressLoginFlow/src/main/res/values/colors.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/colors.xml
@@ -121,6 +121,7 @@
     <color name="login_primary_button_normal_color">@color/blue_medium</color>
     <color name="login_primary_button_text_color">@color/white</color>
     <color name="login_secondary_button_text_color">@color/blue_wordpress</color>
+    <color name="login_secondary_button_icon_tint_color">@color/gray</color>
     <color name="login_google_button_text_color">@color/blue_wordpress</color>
     <color name="login_text_label_text_color">@color/grey_dark</color>
     <color name="login_input_label_static_text_color">@color/grey_text_min</color>


### PR DESCRIPTION
Fixes #2982 by adding a new `login_secondary_button_icon_tint_color` to the WordPressLoginLibrary for tinting the icons of secondary buttons. I set the default to match the default of the icon itself so as to not effect WordPress, and then overrode the icon color in a new `colors_login.xml` and set it to `@color/color_on_surface_disabled`. 

Before | After Light | After Dark
-- | -- | --
![before](https://user-images.githubusercontent.com/5810477/100676283-9e2e0a00-3336-11eb-96d1-17458ac08abb.png)|![after](https://user-images.githubusercontent.com/5810477/100676288-a0906400-3336-11eb-9c39-23f17261caaf.png)|![after-dark](https://user-images.githubusercontent.com/5810477/100676291-a1c19100-3336-11eb-85eb-c6a2f726ecd6.png)



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
