### PR TITLE
Issue/3186 bold store address

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -358,7 +358,7 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
         AppPrefs.setLoginSiteAddress(siteAddressClean)
 
         if (hasJetpack) {
-            showEmailLoginScreen(inputSiteAddress)
+            showEmailLoginScreen(siteAddressClean)
         } else {
             // hide the keyboard
             org.wordpress.android.util.ActivityUtils.hideKeyboard(this)

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -918,8 +918,7 @@
     <string name="signup_with_email_button">Sign Up with Email</string>
     <string name="signup_with_google_button">Sign Up with Google</string>
     <string name="signup_with_google_progress">Signing up with Google…</string>
-
-    <string name="enter_email_for_site">Log in with WordPress.com to connect to %1$s</string>
+    <string name="enter_email_for_site">Log in with WordPress.com to connect to &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="enter_wordpress_site">The website at this address is not a WordPress site. For us to connect to it, the site must have WordPress installed.</string>
     <string name="login_need_help_finding_connected_email">Need help finding the email you connected with?</string>
     <string name="send_verification_email">Send verification email</string>

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -193,14 +193,16 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
                 if (!mShouldUseNewLayout) {
                     label.setText(R.string.enter_email_wordpress_com);
                 } else if (!TextUtils.isEmpty(mLoginSiteUrl)) {
-                    label.setText(getString(R.string.enter_email_for_site, mLoginSiteUrl));
+                    label.setText(Html.fromHtml(
+                            getString(R.string.enter_email_for_site, mLoginSiteUrl)));
                 } else {
                     label.setText(R.string.enter_email_to_continue_wordpress_com);
                 }
                 break;
             case WOO_LOGIN_MODE:
                 if (mOptionalSiteCredsLayout) {
-                    label.setText(getString(R.string.enter_email_for_site, mLoginSiteUrl));
+                    label.setText(Html.fromHtml(
+                            getString(R.string.enter_email_for_site, mLoginSiteUrl)));
                 } else {
                     label.setText(getString(R.string.enter_email_wordpress_com));
                 }


### PR DESCRIPTION
Fixes #3186 by doing the following:
- Strips the protocol from the store address for a cleaner look that better matches the designs.  
- Bolds the store address

Before | After 
-- | --
![before](https://user-images.githubusercontent.com/5810477/100681305-64aecc00-3341-11eb-80a8-6d0dd0308c73.png)|![after](https://user-images.githubusercontent.com/5810477/100681307-66788f80-3341-11eb-82aa-9bb53ddef687.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
