### PR TITLE
Issue/2981 button styles

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 5.7
 -----
+* [*] Minor style tweaks to the login screens
  
 5.6
 ----

--- a/WooCommerce/src/main/res/values/dimens_base.xml
+++ b/WooCommerce/src/main/res/values/dimens_base.xml
@@ -62,6 +62,9 @@ so that's the baseline as defined in `major_100`.
     <dimen name="line_spacing_extra_50">2sp</dimen>
     <dimen name="line_spacing_extra_100">4sp</dimen>
 
+    <!-- Button heights -->
+    <dimen name="button_height_major_100">36sp</dimen>
+
     <!-- Smaller image sizes (ex. icons) -->
     <dimen name="image_minor_50">24dp</dimen>
     <dimen name="image_minor_60">26dp</dimen>

--- a/WooCommerce/src/main/res/values/styles_login.xml
+++ b/WooCommerce/src/main/res/values/styles_login.xml
@@ -69,6 +69,8 @@
     <style name="Widget.LoginFlow.Button.Primary" parent="Widget.MaterialComponents.Button.UnelevatedButton">
         <item name="materialThemeOverlay">@style/ThemeOverlay.LoginFlow.Button.Secondary</item>
         <item name="android:textAppearance">?attr/textAppearanceButton</item>
+        <item name="backgroundTint">@color/button_colored_bg_selector</item>
+        <item name="android:textColor">@color/color_on_primary_high</item>
         <item name="android:height">@dimen/button_height_major_100</item>
         <item name="android:textAllCaps">false</item>
     </style>

--- a/WooCommerce/src/main/res/values/styles_login.xml
+++ b/WooCommerce/src/main/res/values/styles_login.xml
@@ -66,6 +66,18 @@
     </style>
 
     <!-- Buttons -->
+    <style name="Widget.LoginFlow.Button.Primary" parent="Widget.MaterialComponents.Button.UnelevatedButton">
+        <item name="materialThemeOverlay">@style/ThemeOverlay.LoginFlow.Button.Secondary</item>
+        <item name="android:textAppearance">?attr/textAppearanceSubtitle2</item>
+        <item name="android:height">@dimen/button_height_major_100</item>
+    </style>
+
+    <style name="Widget.LoginFlow.Button.Secondary" parent="Widget.MaterialComponents.Button.OutlinedButton">
+        <item name="materialThemeOverlay">@style/ThemeOverlay.LoginFlow.Button.OnSurface</item>
+        <item name="android:textAppearance">?attr/textAppearanceSubtitle2</item>
+        <item name="android:height">@dimen/button_height_major_100</item>
+    </style>
+
     <style name="Widget.LoginFlow.Button.Tertiary" parent="Widget.MaterialComponents.Button.TextButton">
         <item name="android:textAppearance">?attr/textAppearanceBody2</item>
         <item name="textColor">@color/color_secondary</item>

--- a/WooCommerce/src/main/res/values/styles_login.xml
+++ b/WooCommerce/src/main/res/values/styles_login.xml
@@ -27,6 +27,22 @@
         <item name="alertDialogTheme">@style/Theme.Woo.Dialog</item>
         <item name="materialAlertDialogTheme">@style/Theme.Woo.Dialog</item>
 
+        <!-- Typography -->
+        <item name="textAppearanceHeadline1">@style/TextAppearance.Woo.Headline1</item>
+        <item name="textAppearanceHeadline2">@style/TextAppearance.Woo.Headline2</item>
+        <item name="textAppearanceHeadline3">@style/TextAppearance.Woo.Headline3</item>
+        <item name="textAppearanceHeadline4">@style/TextAppearance.Woo.Headline4</item>
+        <item name="textAppearanceHeadline5">@style/TextAppearance.Woo.Headline5</item>
+        <item name="textAppearanceHeadline6">@style/TextAppearance.Woo.Headline6</item>
+        <item name="textAppearanceSubtitle1">@style/TextAppearance.Woo.Subtitle1</item>
+        <item name="textAppearanceSubtitle2">@style/TextAppearance.Woo.Subtitle2</item>
+        <item name="textAppearanceBody1">@style/TextAppearance.Woo.Body1</item>
+        <item name="textAppearanceBody2">@style/TextAppearance.Woo.Body2</item>
+        <item name="textAppearanceButton">@style/TextAppearance.Woo.Button</item>
+        <item name="textAppearanceCaption">@style/TextAppearance.Woo.Caption</item>
+        <item name="textAppearanceOverline">@style/TextAppearance.Woo.Overline</item>
+        <item name="textAppearanceBadge">@style/TextAppearance.Woo.Badge</item>
+
         <!-- Custom Widgets -->
         <item name="tagViewStyle">@style/Woo.Tag</item>
         <item name="flowLayoutStyle">@style/Woo.FlowLayout</item>
@@ -42,6 +58,14 @@
         <item name="wcSingleOptionTextViewStyle">@style/Widget.Woo.WCSingleOptionTextView</item>
     </style>
 
+    <!-- TextViews -->
+
+    <style name="Widget.LoginFlow.TextView.Label" parent="Widget.MaterialComponents.TextView">
+        <item name="android:textAppearance">?attr/textAppearanceBody2</item>
+        <item name="android:textColor">@color/color_on_surface_high</item>
+    </style>
+
+    <!-- Buttons -->
     <style name="Widget.LoginFlow.Button.Tertiary" parent="Widget.MaterialComponents.Button.TextButton">
         <item name="android:textAppearance">?attr/textAppearanceBody2</item>
         <item name="textColor">@color/color_secondary</item>

--- a/WooCommerce/src/main/res/values/styles_login.xml
+++ b/WooCommerce/src/main/res/values/styles_login.xml
@@ -68,14 +68,16 @@
     <!-- Buttons -->
     <style name="Widget.LoginFlow.Button.Primary" parent="Widget.MaterialComponents.Button.UnelevatedButton">
         <item name="materialThemeOverlay">@style/ThemeOverlay.LoginFlow.Button.Secondary</item>
-        <item name="android:textAppearance">?attr/textAppearanceSubtitle2</item>
+        <item name="android:textAppearance">?attr/textAppearanceButton</item>
         <item name="android:height">@dimen/button_height_major_100</item>
+        <item name="android:textAllCaps">false</item>
     </style>
 
     <style name="Widget.LoginFlow.Button.Secondary" parent="Widget.MaterialComponents.Button.OutlinedButton">
         <item name="materialThemeOverlay">@style/ThemeOverlay.LoginFlow.Button.OnSurface</item>
-        <item name="android:textAppearance">?attr/textAppearanceSubtitle2</item>
+        <item name="android:textAppearance">?attr/textAppearanceButton</item>
         <item name="android:height">@dimen/button_height_major_100</item>
+        <item name="android:textAllCaps">false</item>
     </style>
 
     <style name="Widget.LoginFlow.Button.Tertiary" parent="Widget.MaterialComponents.Button.TextButton">

--- a/WooCommerce/src/main/res/values/type.xml
+++ b/WooCommerce/src/main/res/values/type.xml
@@ -91,6 +91,7 @@
         <item name="android:textColor">@color/color_on_surface</item>
         <item name="android:textStyle">normal</item>
         <item name="lineHeight">@dimen/line_height_minor_80</item>
+        <item name="android:letterSpacing">0.01</item>
     </style>
 
     <style name="TextAppearance.Woo.Caption" parent="TextAppearance.MaterialComponents.Caption">


### PR DESCRIPTION
Fixes #2981, #2980   and #3185 by implementing the following:
- Added text style overrides for all text to match the rest of the app - now using Roboto throughout! 🥳 (this updated the heading font as well)
- Removed the default letter spacing that comes with using `roboto-medium`
- Updated disabled background and text color for the primary button. 
- Set the height of the primary and secondary buttons to 36dp. 

Before | After Light | After Dark
-- | -- | --
![before-welcome](https://user-images.githubusercontent.com/5810477/100686804-1273a800-334d-11eb-914b-1cfb86ecffd8.png)|![after-welcome](https://user-images.githubusercontent.com/5810477/100686809-143d6b80-334d-11eb-8a09-d21bd670ef2d.png)|![after-welcome-dark](https://user-images.githubusercontent.com/5810477/100686816-16072f00-334d-11eb-8b9a-53fa2175fc28.png)
![before-email-disabled](https://user-images.githubusercontent.com/5810477/100686832-1f909700-334d-11eb-8ce1-6ce9c3b84c75.png)|![after-email-disabled](https://user-images.githubusercontent.com/5810477/100686894-3e8f2900-334d-11eb-8117-b719844bef3c.png)|![after-email-disabled-dark](https://user-images.githubusercontent.com/5810477/100686902-3fc05600-334d-11eb-9485-2b97bc35f365.png)
![before-email](https://user-images.githubusercontent.com/5810477/100686937-52d32600-334d-11eb-8362-ff0b4bad21ff.png)|![after-email](https://user-images.githubusercontent.com/5810477/100687232-e573c500-334d-11eb-9b1a-b1650dbd66aa.png)|![after-email-dark](https://user-images.githubusercontent.com/5810477/100687237-e73d8880-334d-11eb-8a80-ea00493b522a.png)

@Garance91540 I verified primary buttons are using Pink 50. 


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
