### PR TITLE
Use Log In instead of Get Started for Woo

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -573,10 +573,13 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
 
     @Override
     protected void buildToolbar(Toolbar toolbar, ActionBar actionBar) {
+        if (mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE) {
+            actionBar.setTitle(R.string.log_in);
+            return;
+        }
+
         if (mShouldUseNewLayout) {
             actionBar.setTitle(R.string.get_started);
-        } else if (mOptionalSiteCredsLayout) {
-            actionBar.setTitle(R.string.log_in);
         } else {
             super.buildToolbar(toolbar, actionBar);
         }


### PR DESCRIPTION
Fixes #3118 by updating the header on the Email page of the WordPress.com login flow to use "Log In" instead of "Get Started". 

Before | After 
-- | --
![before](https://user-images.githubusercontent.com/5810477/100688542-9b401300-3350-11eb-919a-173276159558.png)|![after](https://user-images.githubusercontent.com/5810477/100688547-9d09d680-3350-11eb-8d25-a2aa1312b455.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
