### PR TITLE
Update label on the email screen in the WPcom login email flow

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1411,7 +1411,7 @@
     <string name="login_get_link_by_email">Get a login link by email</string>
     <string name="signup_magic_link_message">We’ve emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com.</string>
     <string name="signup_confirmation_magic_link_message">We’ll email you a signup link to create your new WordPress.com account.</string>
-    <string name="enter_email_wordpress_com">Log in to WordPress.com using an email address to manage all your WordPress sites.</string>
+    <string name="enter_email_wordpress_com">Log in with your WordPress.com account email address to manage your WooCommerce stores.</string>
     <string name="login_site_address_help_title">What\'s my site address?</string>
     <string name="login_site_address_help_content">Your site address appears in the bar at the top of the screen when you visit your site in Chrome.</string>
     <string name="login_find_your_site_adress">Find your site address</string>


### PR DESCRIPTION
Fixes #3119 by updating the label on the email form for the the WordPress.com login flow. 

Before | After 
-- | --
![Screenshot_1606788996](https://user-images.githubusercontent.com/5810477/100689116-d2fb8a80-3351-11eb-8371-d41880b0dacb.png)|![Screenshot_1606789088](https://user-images.githubusercontent.com/5810477/100689119-d68f1180-3351-11eb-8f1c-6b3f61967ce8.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
