### PR TITLE
Remove SKU from the list of products in order detail screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
@@ -40,13 +40,6 @@ class OrderDetailProductItemView @JvmOverloads constructor(
         val maxLinesInName = if (expanded) Int.MAX_VALUE else 2
         productInfo_name.maxLines = maxLinesInName
 
-        if (item.sku.isEmpty()) {
-            productInfo_sku.visibility = View.GONE
-        } else {
-            productInfo_sku.visibility = View.VISIBLE
-            productInfo_sku.text = context.getString(R.string.orderdetail_product_lineitem_sku_value, item.sku)
-        }
-
         val productPrice = formatCurrencyForDisplay(item.price)
         val attributes = item.attributesList.takeIf { it.isNotEmpty() }?.let { "$it \u25CF " } ?: StringUtils.EMPTY
 

--- a/WooCommerce/src/main/res/layout/order_detail_product_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_product_item.xml
@@ -46,6 +46,7 @@
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        android:layout_marginTop="@dimen/major_100"
         tools:text="$30.00" />
 
     <com.google.android.material.textview.MaterialTextView

--- a/WooCommerce/src/main/res/layout/order_detail_product_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_product_item.xml
@@ -40,17 +40,6 @@
         tools:text="Candle" />
 
     <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/productInfo_sku"
-        style="@style/Woo.ListItem.Body"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@+id/productInfo_name"
-        app:layout_constraintEnd_toStartOf="@+id/productInfo_total"
-        app:layout_constraintStart_toEndOf="@+id/productInfo_iconFrame"
-        tools:text="T3124"
-        tools:visibility="visible" />
-
-    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/productInfo_total"
         style="@style/Woo.ListItem.Title"
         android:layout_width="wrap_content"
@@ -66,7 +55,7 @@
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toStartOf="@+id/productInfo_total"
         app:layout_constraintStart_toEndOf="@+id/productInfo_iconFrame"
-        app:layout_constraintTop_toBottomOf="@+id/productInfo_sku"
+        app:layout_constraintTop_toBottomOf="@+id/productInfo_name"
         tools:text="Red, Medium • $15.00 x 2" />
 
     <com.google.android.material.textview.MaterialTextView


### PR DESCRIPTION
Fixes #3061 

Removes the SKU from the list of products in the order detail screen to align with the new design:

<img width="615" alt="Screen Shot 2020-12-01 at 12 25 00" src="https://user-images.githubusercontent.com/1657201/100734886-a3d82e00-33d0-11eb-8632-757991384f90.png">


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
