### PR TITLE
Rename the installDeps gradle task to configureApply

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,9 +161,9 @@ task applyCredentials(type:Exec, dependsOn:checkBundle) {
     }
 }
 
-tasks.register("installDeps") {
+tasks.register("configureApply") {
     group = 'Onboarding'
-    description = 'Install dependencies for production builds'
+    description = 'Install dependencies for debug and production builds'
     dependsOn applyCredentials
     doLast {
         println("Done")


### PR DESCRIPTION
This PR renames the `installDeps` gradle task to `configureApply` to make it match the setup in our other repos. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
