### PR TITLE
Fix the issue of trashing/spamming reviews opened from push notification

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -13,7 +13,6 @@ import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.AppUrls
@@ -69,6 +68,7 @@ class ReviewListFragment : TopLevelFragment(), ItemDecorationListener, ReviewLis
     private var newDataAvailable = false // New reviews are available in cache
     private var listState: Parcelable? = null // Save the state of the recycler view
 
+    private var pendingModerationRequest: ProductReviewModerationRequest? = null
     private var pendingModerationRemoteReviewId: Long? = null
     private var pendingModerationNewStatus: String? = null
     private var changeReviewStatusSnackbar: Snackbar? = null
@@ -225,11 +225,19 @@ class ReviewListFragment : TopLevelFragment(), ItemDecorationListener, ReviewLis
         })
 
         viewModel.moderateProductReview.observe(viewLifecycleOwner, Observer {
-            it?.let { request -> handleReviewModerationRequest(request) }
+            if (reviewsAdapter.isEmpty()) {
+                pendingModerationRequest = it
+            } else {
+                it?.let { request -> handleReviewModerationRequest(request) }
+            }
         })
 
         viewModel.reviewList.observe(viewLifecycleOwner, Observer {
             showReviewList(it)
+            pendingModerationRequest?.let {
+                handleReviewModerationRequest(it)
+                pendingModerationRequest = null
+            }
         })
     }
 


### PR DESCRIPTION
Fixes #2921 

Currently when we open a review from the push notification, and the app was in background, trashing or spamming it doesn't update the reviews list immediately, the user has to leave the screen or force a refresh before seeing the effect.

This was caused by a race condition between the ViewModel and the Fragment, the list of reviews is fetched by the ViewModel, and the moderation request is passed using EventBus from the child fragment, so when clicking on back on the child fragment, the moderation request is sent to the fragment before the list adapter gets the reviews list, which results in the failure here: https://github.com/woocommerce/woocommerce-android/blob/441c03dbe156cd39971bd8d75f4b8ecfbb1a7204/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListAdapter.kt#L143-L148

The fix I did is checking if the adapter is empty before applying the moderation, and if it's empty, the request will be saved until the reviews list is updated.

**Testing**
- Close or background the app.
- Create a new review on your store.
- Tap the review push notification and notice the review details open.
- Tap the "Trash" or "Spam" button.
- Confirm that the review is hidden from the reviews list.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
