### PR TITLE
Issue/3232 viewbinding order notes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteFragment.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ADD_ORDER_NOTE_ADD_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ADD_ORDER_NOTE_EMAIL_NOTE_TO_CUSTOMER_TOGGLED
+import com.woocommerce.android.databinding.FragmentAddOrderNoteBinding
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.model.OrderNote
 import com.woocommerce.android.ui.base.BaseFragment
@@ -22,7 +23,6 @@ import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.notes.AddOrderNoteContract.Presenter
 import com.woocommerce.android.util.AnalyticsUtils
-import kotlinx.android.synthetic.main.fragment_add_order_note.*
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.util.ActivityUtils
 import javax.inject.Inject
@@ -45,6 +45,9 @@ class AddOrderNoteFragment : BaseFragment(), AddOrderNoteContract.View, BackPres
     private var isConfirmingDiscard = false
     private var shouldShowDiscardDialog = true
 
+    private var _binding: FragmentAddOrderNoteBinding? = null
+    private val binding get() = _binding!!
+
     private val navArgs: AddOrderNoteFragmentArgs by navArgs()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -54,7 +57,8 @@ class AddOrderNoteFragment : BaseFragment(), AddOrderNoteContract.View, BackPres
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.fragment_add_order_note, container, false)
+        _binding = FragmentAddOrderNoteBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
@@ -64,12 +68,12 @@ class AddOrderNoteFragment : BaseFragment(), AddOrderNoteContract.View, BackPres
         orderNumber = navArgs.orderNumber
 
         savedInstanceState?.let { state ->
-            addNote_switch.isChecked = state.getBoolean(FIELD_IS_CUSTOMER_NOTE)
+            binding.addNoteSwitch.isChecked = state.getBoolean(FIELD_IS_CUSTOMER_NOTE)
             if (state.getBoolean(FIELD_IS_CONFIRMING_DISCARD)) {
                 confirmDiscard()
             }
             state.getString(FIELD_NOTE_TEXT)?.let {
-                addNote_editor.setText(it)
+                binding.addNoteEditor.setText(it)
             }
         }
 
@@ -79,21 +83,21 @@ class AddOrderNoteFragment : BaseFragment(), AddOrderNoteContract.View, BackPres
         }
 
         if (presenter.hasBillingEmail(orderId)) {
-            addNote_switch.setOnCheckedChangeListener { _, isChecked ->
+            binding.addNoteSwitch.setOnCheckedChangeListener { _, isChecked ->
                 AnalyticsTracker.track(
                         ADD_ORDER_NOTE_EMAIL_NOTE_TO_CUSTOMER_TOGGLED,
                         mapOf(AnalyticsTracker.KEY_STATE to AnalyticsUtils.getToggleStateLabel(isChecked)))
 
                 val drawableId = if (isChecked) R.drawable.ic_note_public else R.drawable.ic_note_private
-                addNote_icon.setImageDrawable(ContextCompat.getDrawable(requireActivity(), drawableId))
+                binding.addNoteIcon.setImageDrawable(ContextCompat.getDrawable(requireActivity(), drawableId))
             }
         } else {
-            addNote_switch.visibility = View.GONE
+            binding.addNoteSwitch.visibility = View.GONE
         }
 
         if (savedInstanceState == null) {
-            addNote_editor.requestFocus()
-            ActivityUtils.showKeyboard(addNote_editor)
+            binding.addNoteEditor.requestFocus()
+            ActivityUtils.showKeyboard(binding.addNoteEditor)
         }
 
         presenter.takeView(this)
@@ -132,7 +136,7 @@ class AddOrderNoteFragment : BaseFragment(), AddOrderNoteContract.View, BackPres
                 val noteText = getNoteText()
                 if (noteText.isNotEmpty()) {
                     val orderNote = OrderNote(
-                        isCustomerNote = addNote_switch.isChecked,
+                        isCustomerNote = binding.addNoteSwitch.isChecked,
                         note = noteText
                     )
                     shouldShowDiscardDialog = false
@@ -146,12 +150,12 @@ class AddOrderNoteFragment : BaseFragment(), AddOrderNoteContract.View, BackPres
 
     override fun onSaveInstanceState(outState: Bundle) {
         outState.putString(FIELD_NOTE_TEXT, getNoteText())
-        outState.putBoolean(FIELD_IS_CUSTOMER_NOTE, addNote_switch?.isChecked ?: false)
+        outState.putBoolean(FIELD_IS_CUSTOMER_NOTE, binding.addNoteSwitch.isChecked)
         outState.putBoolean(FIELD_IS_CONFIRMING_DISCARD, isConfirmingDiscard)
         super.onSaveInstanceState(outState)
     }
 
-    override fun getNoteText() = addNote_editor?.text?.toString()?.trim() ?: ""
+    override fun getNoteText() = binding.addNoteEditor.text?.toString()?.trim() ?: ""
 
     /**
      * Prevent back press in the main activity if the user entered a note so we can confirm the discard

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/OrderDetailOrderNoteItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/OrderDetailOrderNoteItemView.kt
@@ -36,15 +36,9 @@ class OrderDetailOrderNoteItemView @JvmOverloads constructor(
         binding.orderNoteNote.text = getHtmlText(note.note)
 
         @DrawableRes val drawableId = when {
-            note.isCustomerNote -> {
-                R.drawable.ic_note_public
-            }
-            note.isSystemNote -> {
-                R.drawable.ic_note_system
-            }
-            else -> {
-                R.drawable.ic_note_private
-            }
+            note.isCustomerNote -> R.drawable.ic_note_public
+            note.isSystemNote -> R.drawable.ic_note_system
+            else -> R.drawable.ic_note_private
         }
         binding.orderNoteIcon.setImageDrawable(ContextCompat.getDrawable(context, drawableId))
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/OrderDetailOrderNoteItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/OrderDetailOrderNoteItemView.kt
@@ -8,6 +8,7 @@ import android.text.Spanned
 import android.text.format.DateFormat
 import android.util.AttributeSet
 import android.view.LayoutInflater
+import androidx.annotation.DrawableRes
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import com.woocommerce.android.R
@@ -34,17 +35,18 @@ class OrderDetailOrderNoteItemView @JvmOverloads constructor(
         binding.orderNoteHeader.text = header
         binding.orderNoteNote.text = getHtmlText(note.note)
 
-        when {
+        @DrawableRes val drawableId = when {
             note.isCustomerNote -> {
-                binding.orderNoteIcon.setImageDrawable(ContextCompat.getDrawable(context, R.drawable.ic_note_public))
+                R.drawable.ic_note_public
             }
             note.isSystemNote -> {
-                binding.orderNoteIcon.setImageDrawable(ContextCompat.getDrawable(context, R.drawable.ic_note_system))
+                R.drawable.ic_note_system
             }
             else -> {
-                binding.orderNoteIcon.setImageDrawable(ContextCompat.getDrawable(context, R.drawable.ic_note_private))
+                R.drawable.ic_note_private
             }
         }
+        binding.orderNoteIcon.setImageDrawable(ContextCompat.getDrawable(context, drawableId))
     }
 
     private fun getHtmlText(txt: String): Spanned {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/OrderDetailOrderNoteItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/OrderDetailOrderNoteItemView.kt
@@ -7,21 +7,19 @@ import android.text.Html
 import android.text.Spanned
 import android.text.format.DateFormat
 import android.util.AttributeSet
-import android.view.View
+import android.view.LayoutInflater
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import com.woocommerce.android.R
+import com.woocommerce.android.databinding.OrderDetailNoteItemBinding
 import com.woocommerce.android.model.OrderNote
-import kotlinx.android.synthetic.main.order_detail_note_item.view.*
 
 class OrderDetailOrderNoteItemView @JvmOverloads constructor(
     ctx: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : ConstraintLayout(ctx, attrs, defStyleAttr) {
-    init {
-        View.inflate(context, R.layout.order_detail_note_item, this)
-    }
+    private val binding = OrderDetailNoteItemBinding.inflate(LayoutInflater.from(ctx), this, true)
 
     @SuppressLint("SetTextI18n")
     fun initView(note: OrderNote, showBottomPadding: Boolean) {
@@ -33,18 +31,18 @@ class OrderDetailOrderNoteItemView @JvmOverloads constructor(
         }
         val header = if (note.isSystemNote) "$date ($type)" else "$date - ${note.author} ($type)"
 
-        orderNote_header.text = header
-        orderNote_note.text = getHtmlText(note.note)
+        binding.orderNoteHeader.text = header
+        binding.orderNoteNote.text = getHtmlText(note.note)
 
         when {
             note.isCustomerNote -> {
-                orderNote_icon.setImageDrawable(ContextCompat.getDrawable(context, R.drawable.ic_note_public))
+                binding.orderNoteIcon.setImageDrawable(ContextCompat.getDrawable(context, R.drawable.ic_note_public))
             }
             note.isSystemNote -> {
-                orderNote_icon.setImageDrawable(ContextCompat.getDrawable(context, R.drawable.ic_note_system))
+                binding.orderNoteIcon.setImageDrawable(ContextCompat.getDrawable(context, R.drawable.ic_note_system))
             }
             else -> {
-                orderNote_icon.setImageDrawable(ContextCompat.getDrawable(context, R.drawable.ic_note_private))
+                binding.orderNoteIcon.setImageDrawable(ContextCompat.getDrawable(context, R.drawable.ic_note_private))
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/OrderDetailOrderNoteListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/OrderDetailOrderNoteListView.kt
@@ -3,27 +3,25 @@ package com.woocommerce.android.ui.orders.notes
 import android.content.Context
 import android.text.format.DateFormat
 import android.util.AttributeSet
-import android.view.View
+import android.view.LayoutInflater
 import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.databinding.OrderDetailNoteListBinding
 import com.woocommerce.android.model.OrderNote
 import com.woocommerce.android.ui.orders.notes.OrderNoteListItem.Header
 import com.woocommerce.android.ui.orders.notes.OrderNoteListItem.Note
 import com.woocommerce.android.widgets.SkeletonView
-import kotlinx.android.synthetic.main.order_detail_note_list.view.*
 
 class OrderDetailOrderNoteListView @JvmOverloads constructor(
     ctx: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : MaterialCardView(ctx, attrs, defStyleAttr) {
-    init {
-        View.inflate(context, R.layout.order_detail_note_list, this)
-    }
+    private val binding = OrderDetailNoteListBinding.inflate(LayoutInflater.from(ctx), this)
 
     interface OrderDetailNoteListener {
         fun onRequestAddNote()
@@ -35,13 +33,13 @@ class OrderDetailOrderNoteListView @JvmOverloads constructor(
     fun initView(notes: List<OrderNote>, orderDetailListener: OrderDetailNoteListener) {
         listener = orderDetailListener
 
-        noteList_addNoteContainer.setOnClickListener {
+        binding.noteListAddNoteContainer.setOnClickListener {
             AnalyticsTracker.track(Stat.ORDER_DETAIL_ADD_NOTE_BUTTON_TAPPED)
 
             listener.onRequestAddNote()
         }
 
-        notesList_notes.apply {
+        binding.notesListNotes.apply {
             setHasFixedSize(false)
             layoutManager = LinearLayoutManager(context)
             adapter = OrderNotesAdapter()
@@ -59,7 +57,7 @@ class OrderDetailOrderNoteListView @JvmOverloads constructor(
     }
 
     fun updateView(notes: List<OrderNote>) {
-        val adapter = notesList_notes.adapter as? OrderNotesAdapter ?: OrderNotesAdapter()
+        val adapter = binding.notesListNotes.adapter as? OrderNotesAdapter ?: OrderNotesAdapter()
         enableItemAnimator(adapter.itemCount == 0)
 
         val notesWithHeaders = addHeaders(notes)
@@ -68,13 +66,13 @@ class OrderDetailOrderNoteListView @JvmOverloads constructor(
 
     fun showSkeleton(show: Boolean) {
         if (show) {
-            skeletonView.show(notesList_notes, R.layout.skeleton_order_notes_list, delayed = false)
+            skeletonView.show(binding.notesListNotes, R.layout.skeleton_order_notes_list, delayed = false)
         } else {
             skeletonView.hide()
         }
     }
 
     private fun enableItemAnimator(enable: Boolean) {
-        notesList_notes.itemAnimator = if (enable) DefaultItemAnimator() else null
+        binding.notesListNotes.itemAnimator = if (enable) DefaultItemAnimator() else null
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/OrderNoteViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/OrderNoteViewHolder.kt
@@ -1,29 +1,20 @@
 package com.woocommerce.android.ui.orders.notes
 
-import android.view.LayoutInflater
-import android.view.ViewGroup
-import androidx.annotation.LayoutRes
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.material.textview.MaterialTextView
-import com.woocommerce.android.R
+import androidx.viewbinding.ViewBinding
+import com.woocommerce.android.databinding.OrderDetailNoteListHeaderBinding
+import com.woocommerce.android.databinding.OrderDetailNoteListNoteBinding
 
-abstract class OrderNoteViewHolder(parent: ViewGroup, @LayoutRes layout: Int) : RecyclerView.ViewHolder(
-        LayoutInflater.from(
-                parent.context
-        ).inflate(layout, parent, false)
-)
+abstract class OrderNoteViewHolder(viewBinding: ViewBinding) : RecyclerView.ViewHolder(viewBinding.getRoot())
 
-class HeaderItemViewHolder(parent: ViewGroup) : OrderNoteViewHolder(parent, R.layout.order_detail_note_list_header) {
-    private val header: MaterialTextView = itemView.findViewById(R.id.orderDetail_noteListHeader)
-
+class HeaderItemViewHolder(val viewBinding: OrderDetailNoteListHeaderBinding) : OrderNoteViewHolder(viewBinding) {
     fun bind(item: OrderNoteListItem.Header) {
-        header.text = item.text
+        viewBinding.orderDetailNoteListHeader.text = item.text
     }
 }
 
-class NoteItemViewHolder(parent: ViewGroup) : OrderNoteViewHolder(parent, R.layout.order_detail_note_list_note) {
-    private val noteItem = itemView as OrderDetailOrderNoteItemView
+class NoteItemViewHolder(val viewBinding: OrderDetailNoteListNoteBinding) : OrderNoteViewHolder(viewBinding) {
     fun bind(item: OrderNoteListItem.Note, isLast: Boolean) {
-        noteItem.initView(item.note, isLast)
+        viewBinding.noteItemView.initView(item.note, isLast)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/OrderNotesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/OrderNotesAdapter.kt
@@ -1,8 +1,11 @@
 package com.woocommerce.android.ui.orders.notes
 
+import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView.Adapter
+import com.woocommerce.android.databinding.OrderDetailNoteListHeaderBinding
+import com.woocommerce.android.databinding.OrderDetailNoteListNoteBinding
 import com.woocommerce.android.ui.orders.notes.OrderNoteListItem.Header
 import com.woocommerce.android.ui.orders.notes.OrderNoteListItem.Note
 import com.woocommerce.android.ui.orders.notes.OrderNoteListItem.ViewType
@@ -23,9 +26,26 @@ class OrderNotesAdapter : Adapter<OrderNoteViewHolder>() {
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): OrderNoteViewHolder {
+        val inflater = LayoutInflater.from(parent.getContext())
         return when (viewType) {
-            ViewType.NOTE.id -> NoteItemViewHolder(parent)
-            ViewType.HEADER.id -> HeaderItemViewHolder(parent)
+            ViewType.NOTE.id -> {
+                NoteItemViewHolder(
+                    OrderDetailNoteListNoteBinding.inflate(
+                        inflater,
+                        parent,
+                        false
+                    )
+                )
+            }
+            ViewType.HEADER.id -> {
+                HeaderItemViewHolder(
+                    OrderDetailNoteListHeaderBinding.inflate(
+                        inflater,
+                        parent,
+                        false
+                    )
+                )
+            }
             else -> throw IllegalArgumentException("Unexpected view type in OrderNotesAdapter")
         }
     }

--- a/WooCommerce/src/main/res/layout/order_detail_note_list_note.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_note_list_note.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.woocommerce.android.ui.orders.notes.OrderDetailOrderNoteItemView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/noteItemView"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"/>


### PR DESCRIPTION
This PR converts the order notes part of order detail to `ViewBinding`. To test, simply ensure that order notes are working as expected.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
