### PR TITLE
issue/3253-order-detail-missing-header-5.6

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -467,6 +467,16 @@ class OrderListFragment : TopLevelFragment(),
             AnalyticsTracker.KEY_STATUS to orderStatus)
         )
 
+        // if a search is active, we need to collapse the search view so order detail can show it's title and then
+        // remember the user was searching (since both searchQuery and isSearching will be reset)
+        if (isSearching) {
+            val savedSearch = searchQuery
+            clearSearchResults()
+            updateActivityTitle()
+            searchQuery = savedSearch
+            isSearching = true
+        }
+
         showOptionsMenu(false)
         (activity as? MainNavigationRouter)?.showOrderDetail(selectedSite.get().id, localOrderId, remoteOrderId)
     }


### PR DESCRIPTION
Fixes #3253 - Ensures the search view is collapsed when entering order detail so it's title won't be hidden. This targets `release/5.6`.

To test:

- Search the order list
- Tap a search result
- Note that the order detail title appears correctly

**Note:** When testing this you may notice the search query isn't restored when returning to the order list. This is an unrelated bug which apparently has existed for a while. I filed #3262 for this.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
