### PR TITLE
issue/3254-product-list-extra-divider-5.6

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -385,6 +385,7 @@ class MainActivity : AppUpgradeActivity(),
 
         val showCrossIcon: Boolean
         if (isTopLevelNavigation) {
+            app_bar_layout.elevation = 0f
             showCrossIcon = false
         } else {
             app_bar_layout.elevation = resources.getDimensionPixelSize(R.dimen.appbar_elevation).toFloat()


### PR DESCRIPTION
Fixes #3254 by removing the appBar elevation when returning to a top level fragment. Note that this targets `release/5.6`.

To test:

- Go to the product list
- Select a filter
- Ensure the shadow doesn't appear below the toolbar when returning to the product list

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
