### PR TITLE
issue/3261-heart-alignment 

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -190,8 +190,10 @@
             android:id="@+id/imageHeart"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
+            android:layout_gravity="center_vertical"
             android:importantForAccessibility="no"
+            android:paddingStart="@dimen/major_100"
+            android:paddingEnd="0dp"
             android:scaleType="center"
             app:srcCompat="@drawable/ic_gridicons_heart_outline" />
 
@@ -200,11 +202,12 @@
             style="@style/Woo.TextView.Caption"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
             android:layout_margin="@dimen/minor_00"
             android:gravity="center_vertical"
-            android:paddingStart="@dimen/major_200"
+            android:paddingStart="@dimen/major_100"
             android:paddingEnd="@dimen/major_100"
             android:text="@string/settings_hiring"
-            tools:text="Made for love by Automattic. We're hiring!" />
+            tools:text="Made with love by Automattic. We're hiring!" />
     </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
Fixes #3261 - Center align the heart icon in settings and ensure there's 16dp padding at its start.

![before](https://user-images.githubusercontent.com/3903757/100933873-f7737600-34bb-11eb-85d0-1adb70e3b8e2.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
