### PR TITLE
Update button style to be unelevated and force to use Subtitle2

### DIFF
--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -424,6 +424,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
 
     <!--  Button with only a border and no color fill  -->
     <style name="Woo.Button.Outlined" parent="Widget.MaterialComponents.Button.OutlinedButton">
+        <item name="android:textAppearance">?attr/textAppearanceSubtitle2</item>
         <item name="android:textColor">@color/button_fg_selector</item>
         <item name="android:paddingStart">@dimen/major_100</item>
         <item name="android:paddingEnd">@dimen/major_100</item>
@@ -431,7 +432,8 @@ theme across the entire app. Overridden versions should be added to the styles.x
     </style>
 
     <!--  Button filled with color  -->
-    <style name="Woo.Button.Colored" parent="Widget.MaterialComponents.Button">
+    <style name="Woo.Button.Colored" parent="Widget.MaterialComponents.Button.UnelevatedButton">
+        <item name="android:textAppearance">?attr/textAppearanceSubtitle2</item>
         <item name="android:paddingStart">@dimen/major_100</item>
         <item name="android:paddingEnd">@dimen/major_100</item>
         <item name="backgroundTint">@color/button_colored_bg_selector</item>


### PR DESCRIPTION
Fixes #3122 and partially fixes #3123 by updating the button styles used in the login prologue and epilogue screens. These screens are not actually a part of the login library, they are using the same styles as the rest of the app. I took a look at Figma and it looks like these changes should apply to the rest of the app so I made them directly to the button styles:
- Use Subtitle2 for text
- Use unelevated buttons

Before | After 
-- | --
![prologue-before](https://user-images.githubusercontent.com/5810477/100943888-1a0d8b00-34cc-11eb-91d2-705180a101df.png)|![prologue-after](https://user-images.githubusercontent.com/5810477/100943890-1b3eb800-34cc-11eb-82bb-3ae97ffb8503.png)
![epilogue-before](https://user-images.githubusercontent.com/5810477/100944015-60fb8080-34cc-11eb-9ecb-e148321a4e84.png)|![epilogue-after](https://user-images.githubusercontent.com/5810477/100944020-635dda80-34cc-11eb-9124-2ae39fc68f08.png)



Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
