### PR TITLE
Hide the new downloadable files section if products M5 flag is not enabled

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -224,7 +224,7 @@ class ProductDetailCardBuilder(
     }
 
     private fun Product.downloads(): ProductProperty? {
-        if (!this.isDownloadable || this.downloads.isEmpty()) return null
+        if (!FeatureFlag.PRODUCT_RELEASE_M5.isEnabled() || !this.isDownloadable || this.downloads.isEmpty()) return null
         return ComplexProperty(
             title = R.string.product_downloadable_files,
             value = StringUtils.getQuantityString(


### PR DESCRIPTION
Fixes #3250 

The release app currently shows two sections of downloadable files, the legacy one and the new one.
This PR makes sure that the new downloadable files section is hidden if products M5 flag is not enabled.

It targets release/5.6 branch.

**Testing**
1. Make sure that you use a release build to confirm that the flag is disabled.
2. Navigate to a downloadable product.
3. Make sure that only the legacy downloads section is displayed.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
