### PR TITLE
Fix crash on Wordpress media library when multiselection is disabled

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
@@ -222,7 +222,7 @@ class WPMediaGalleryView @JvmOverloads constructor(
                 for (image in images) {
                     selectedIds.add(image.id)
                 }
-            } else {
+            } else if (images.isNotEmpty()) {
                 selectedIds.add(images.first().id)
             }
             notifyDataSetChanged()


### PR DESCRIPTION
Fixes #3256 

This fixes a crash that was occurring in the WordPress media library after leaving an image preview and multiselection is disabled. Targets release/5.6.

**To test:**

1. Open a variable product.
2. Go to the variations list.
3. Tap on one of the variations to edit it.
4. Tap on the image, and then tap on "Replace photo", and select WordPress media library.
5. Long tap an image to preview, then tap the back button.
6. Make sure that the app doesn't crash.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
