### PR TITLE
Hide the shipment tracking if the order has only virtual products

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -484,17 +484,17 @@ class OrderDetailViewModel @AssistedInject constructor(
     }
 
     private suspend fun loadShipmentTracking(viewState: ViewState): ViewState {
-        val newViewState: ViewState
-        when (orderDetailRepository.fetchOrderShipmentTrackingList(orderIdSet.id, orderIdSet.remoteOrderId)) {
+        if (hasVirtualProductsOnly()) return viewState.copy(isShipmentTrackingAvailable = false)
+
+        return when (orderDetailRepository.fetchOrderShipmentTrackingList(orderIdSet.id, orderIdSet.remoteOrderId)) {
             RequestResult.SUCCESS -> {
                 _shipmentTrackings.value = orderDetailRepository.getOrderShipmentTrackings(orderIdSet.id)
-                newViewState = viewState.copy(isShipmentTrackingAvailable = true)
+                viewState.copy(isShipmentTrackingAvailable = true)
             }
             else -> {
-                newViewState = viewState.copy(isShipmentTrackingAvailable = false)
+                viewState.copy(isShipmentTrackingAvailable = false)
             }
         }
-        return newViewState
     }
 
     private suspend fun loadOrderShippingLabels(viewState: ViewState): ViewState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -193,7 +193,8 @@ class OrderDetailViewModel @AssistedInject constructor(
     fun hasVirtualProductsOnly(): Boolean {
         return if (order.items.isNotEmpty()) {
             val remoteProductIds = order.items.map { it.productId }
-            orderDetailRepository.getProductsByRemoteIds(remoteProductIds).all { it.virtual }
+            val products = orderDetailRepository.getProductsByRemoteIds(remoteProductIds)
+            products.isNotEmpty() && products.all { it.virtual }
         } else false
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -228,8 +228,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
             doReturn(testOrderNotes).whenever(repository).getOrderNotes(any())
-            doReturn(RequestResult.SUCCESS).whenever(repository).fetchOrderShipmentTrackingList(any(), any())
-            doReturn(testOrderShipmentTrackings).whenever(repository).getOrderShipmentTrackings(any())
             doReturn(emptyList<ShippingLabel>()).whenever(repository).getOrderShippingLabels(any())
             doReturn(emptyList<ShippingLabel>()).whenever(repository).fetchOrderShippingLabels(any())
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -145,6 +145,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         doReturn(emptyList<ShippingLabel>()).whenever(repository).getOrderShippingLabels(any())
         doReturn(emptyList<ShippingLabel>()).whenever(repository).fetchOrderShippingLabels(any())
 
+        doReturn(mixedProducts).whenever(repository).getProductsByRemoteIds(any())
+
         var orderData: ViewState? = null
         viewModel.orderDetailViewStateData.observeForever { _, new -> orderData = new }
 
@@ -623,6 +625,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                 dateShipped = "132434323",
                 isCustomProvider = true
             )
+
+            doReturn(mixedProducts).whenever(repository).getProductsByRemoteIds(any())
 
             doReturn(order).whenever(repository).getOrder(any())
             doReturn(order).whenever(repository).fetchOrder(any())


### PR DESCRIPTION
Fixes #3255 

The change is to make sure that the shipment tracking section is hidden if the order has only virtual products.

**Testing**
1. Create an order that has only virtual products.
2. Open the order details.
3. Confirm that the shipment tracking section is not displayed.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
