### PR TITLE
Changed search cursor color so it's visible

### DIFF
--- a/WooCommerce/src/main/res/drawable/searchview_cursor.xml
+++ b/WooCommerce/src/main/res/drawable/searchview_cursor.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <size android:width="2dp" />
-    <solid android:color="@color/color_on_primary_surface_medium" />
+    <solid android:color="@color/color_on_background" />
 </shape>


### PR DESCRIPTION
Fixes #3275 - Prior to this PR the search view cursor color made the cursor invisible. This PR fixes this for both light & dark modes.

![before](https://user-images.githubusercontent.com/3903757/101060225-2d1c6b80-355d-11eb-862a-4e630624f0b9.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
