### PR TITLE
issue/3276-extra-space-below-search-5.6

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -25,20 +25,18 @@ abstract class TopLevelFragment : BaseFragment(), TopLevelFragmentView {
     abstract fun isScrolledToTop(): Boolean
 
     /**
-     * Called when the fragment shows a search view so the toolbar size is shrunk
-     * to a non-expanded size
+     * Called when the fragment shows or hides a search view so we can properly disable the collapsing
+     * toolbar when a search is active
      */
-    fun expandMainToolbar(expand: Boolean, animate: Boolean) {
-        (activity as? MainActivity)?.expandToolbar(expand, animate)
-    }
-
-    /**
-     * Called when the fragment hides a search view so the toolbar can be re-expanded
-     * if scrolled to the top
-     */
-    fun restoreMainToolbar() {
-        if (isScrolledToTop()) {
-            expandMainToolbar(true, true)
+    fun onSearchViewActiveChanged(isActive: Boolean) {
+        (activity as? MainActivity)?.let {
+            if (isActive) {
+                it.enableToolbarExpansion(false)
+                it.expandToolbar(false, false)
+            } else {
+                it.enableToolbarExpansion(true)
+                it.expandToolbar(true, true)
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -480,7 +480,7 @@ class MainActivity : AppUpgradeActivity(),
         app_bar_layout.setExpanded(expand, animate)
     }
 
-    private fun enableToolbarExpansion(enable: Boolean) {
+    fun enableToolbarExpansion(enable: Boolean) {
         if (!enable) {
             toolbar.title = title
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -583,7 +583,7 @@ class OrderListFragment : TopLevelFragment(),
         showTabs(false)
         isSearching = true
         checkOrientation()
-        expandMainToolbar(false, animate = true)
+        onSearchViewActiveChanged(isActive = true)
         return true
     }
 
@@ -598,7 +598,7 @@ class OrderListFragment : TopLevelFragment(),
             searchMenuItem?.isVisible = true
         }
         loadListForActiveTab()
-        restoreMainToolbar()
+        onSearchViewActiveChanged(isActive = false)
         return true
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -280,14 +280,14 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener, ProductS
 
     override fun onMenuItemActionExpand(item: MenuItem?): Boolean {
         viewModel.onSearchOpened()
-        expandMainToolbar(false, animate = true)
+        onSearchViewActiveChanged(isActive = true)
         return true
     }
 
     override fun onMenuItemActionCollapse(item: MenuItem?): Boolean {
         viewModel.onSearchClosed()
         closeSearchView()
-        restoreMainToolbar()
+        onSearchViewActiveChanged(isActive = false)
         return true
     }
 


### PR DESCRIPTION
Fixes #3276 - This PR, which targets `release/5.6`, disables the collapsing toolbar while an order search or product search is active. Without this it's possible to expand the toolbar during a search, which shows a large empty space below the `searchView` (see screenshot below).

To test:

- Perform an order search
- Verify that you can't expand the toolbar
- Do the same for a product search

![101039549-c8b8d680-3573-11eb-885d-ecdbff39a2c3](https://user-images.githubusercontent.com/3903757/101068276-80df8280-3566-11eb-93d5-0620a441967a.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
