### PR TITLE
Stop the menu crash on Product details and add logs to identify the cause

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -11,9 +11,9 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.isVisible
 import androidx.annotation.StringRes
 import androidx.core.view.forEach
+import androidx.core.view.isVisible
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -47,14 +47,12 @@ import com.woocommerce.android.ui.wpmediapicker.WPMediaPickerFragment
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.CrashUtils
 import com.woocommerce.android.util.Optional
-import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.widgets.CustomProgressDialog
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageInteractionListener
 import kotlinx.android.synthetic.main.fragment_product_detail.*
 import org.wordpress.android.util.ActivityUtils
-import java.lang.StringBuilder
 
 class ProductDetailFragment : BaseProductFragment(), OnGalleryImageInteractionListener, NavigationResult {
     companion object {
@@ -288,15 +286,15 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageInteractionLi
     override fun onPrepareOptionsMenu(menu: Menu) {
         super.onPrepareOptionsMenu(menu)
 
-        fun Menu.printItems() : String = buildString {
+        fun Menu.printItems(): String = buildString {
             this@printItems.forEach {
                 append("${resources.getResourceName(it.itemId)}\n")
             }
         }
 
-        if(menu.findItem(R.id.menu_view_product) == null) {
+        if (menu.findItem(R.id.menu_view_product) == null) {
             val message = """menu.findItem(R.id.menu_view_product) is null
-                |User is ${if(viewModel.isAddFlow) "creating a product" else "modifying a product"}
+                |User is ${if (viewModel.isAddFlow) "creating a product" else "modifying a product"}
                 |menu elements:
                 |${menu.printItems()}
             """.trimMargin()
@@ -310,7 +308,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageInteractionLi
 
         // change the font color of the trash menu item to red, and only show it if it should be enabled
         with(menu.findItem(R.id.menu_trash_product)) {
-            if(this == null) return@with
+            if (this == null) return@with
             val title = SpannableString(this.title)
             title.setSpan(ForegroundColorSpan(Color.RED), 0, title.length, 0)
             this.setTitle(title)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -13,6 +13,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.annotation.StringRes
+import androidx.core.view.forEach
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -44,13 +45,16 @@ import com.woocommerce.android.ui.products.adapters.ProductPropertyCardsAdapter
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
 import com.woocommerce.android.ui.wpmediapicker.WPMediaPickerFragment
 import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.CrashUtils
 import com.woocommerce.android.util.Optional
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.widgets.CustomProgressDialog
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageInteractionListener
 import kotlinx.android.synthetic.main.fragment_product_detail.*
 import org.wordpress.android.util.ActivityUtils
+import java.lang.StringBuilder
 
 class ProductDetailFragment : BaseProductFragment(), OnGalleryImageInteractionListener, NavigationResult {
     companion object {
@@ -284,20 +288,36 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageInteractionLi
     override fun onPrepareOptionsMenu(menu: Menu) {
         super.onPrepareOptionsMenu(menu)
 
+        fun Menu.printItems() : String = buildString {
+            this@printItems.forEach {
+                append("${resources.getResourceName(it.itemId)}\n")
+            }
+        }
+
+        if(menu.findItem(R.id.menu_view_product) == null) {
+            val message = """menu.findItem(R.id.menu_view_product) is null
+                |User is ${if(viewModel.isAddFlow) "creating a product" else "modifying a product"}
+                |menu elements:
+                |${menu.printItems()}
+            """.trimMargin()
+            CrashUtils.logException(NullPointerException(message))
+        }
+
         // visibility of these menu items depends on whether we're in the add product flow
-        menu.findItem(R.id.menu_view_product).isVisible = viewModel.isProductPublished && !viewModel.isAddFlow
-        menu.findItem(R.id.menu_share).isVisible = !viewModel.isAddFlow
-        menu.findItem(R.id.menu_product_settings).isVisible = true
+        menu.findItem(R.id.menu_view_product)?.isVisible = viewModel.isProductPublished && !viewModel.isAddFlow
+        menu.findItem(R.id.menu_share)?.isVisible = !viewModel.isAddFlow
+        menu.findItem(R.id.menu_product_settings)?.isVisible = true
 
         // change the font color of the trash menu item to red, and only show it if it should be enabled
         with(menu.findItem(R.id.menu_trash_product)) {
+            if(this == null) return@with
             val title = SpannableString(this.title)
             title.setSpan(ForegroundColorSpan(Color.RED), 0, title.length, 0)
             this.setTitle(title)
             this.isVisible = viewModel.isTrashEnabled
         }
 
-        menu.findItem(R.id.menu_save_as_draft).isVisible = viewModel.isAddFlow && viewModel.hasChanges()
+        menu.findItem(R.id.menu_save_as_draft)?.isVisible = viewModel.isAddFlow && viewModel.hasChanges()
 
         doneOrUpdateMenuItem?.let {
             it.title = if (viewModel.isAddFlow) getString(publishTitleId) else getString(updateTitleId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -292,6 +292,10 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageInteractionLi
             }
         }
 
+        // Some users are experiencing a crash because the entry R.id.menu_view_product is missing from the menu
+        // see: https://github.com/woocommerce/woocommerce-android/issues/3241
+        // If this happens, we will send the below report, and we avoid the crash using the null checks below
+        // TODO: remove the null checks once the root cause is identified is fixed
         if (menu.findItem(R.id.menu_view_product) == null) {
             val message = """menu.findItem(R.id.menu_view_product) is null
                 |User is ${if (viewModel.isAddFlow) "creating a product" else "modifying a product"}


### PR DESCRIPTION
This PR is related to the issue #3241, the goal is to stop the crash, and add some logs to have more context about what's causing it in the first place.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
