### PR TITLE
Issue/3232 use fragment layout constructor

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BaseFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BaseFragment.kt
@@ -20,13 +20,8 @@ import javax.inject.Inject
 open class BaseFragment : Fragment, BaseFragmentView, HasAndroidInjector {
     @Inject internal lateinit var androidInjector: DispatchingAndroidInjector<Any>
 
-    constructor() {
-        Fragment()
-    }
-
-    constructor(@LayoutRes layoutId: Int) {
-        Fragment(layoutId)
-    }
+    constructor() : super()
+    constructor(@LayoutRes layoutId: Int) : super(layoutId)
 
     companion object {
         private const val KEY_TITLE = "title"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BaseFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BaseFragment.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.base
 import android.content.Context
 import android.os.Bundle
 import android.view.View
+import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
 import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
@@ -23,7 +24,7 @@ open class BaseFragment : Fragment, BaseFragmentView, HasAndroidInjector {
         Fragment()
     }
 
-    constructor(layoutId: Int) {
+    constructor(@LayoutRes layoutId: Int) {
         Fragment(layoutId)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BaseFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BaseFragment.kt
@@ -16,8 +16,16 @@ import javax.inject.Inject
  * All top level fragments and child fragments should extend this class to provide a consistent method
  * of setting the activity title
  */
-abstract class BaseFragment : Fragment(), BaseFragmentView, HasAndroidInjector {
+open class BaseFragment : Fragment, BaseFragmentView, HasAndroidInjector {
     @Inject internal lateinit var androidInjector: DispatchingAndroidInjector<Any>
+
+    constructor() {
+        Fragment()
+    }
+
+    constructor(layoutId: Int) {
+        Fragment(layoutId)
+    }
 
     companion object {
         private const val KEY_TITLE = "title"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.base
 
+import androidx.annotation.LayoutRes
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainNavigationRouter
 
@@ -11,7 +12,7 @@ abstract class TopLevelFragment : BaseFragment, TopLevelFragmentView {
         BaseFragment()
     }
 
-    constructor(layoutId: Int) {
+    constructor(@LayoutRes layoutId: Int) {
         BaseFragment(layoutId)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -8,13 +8,8 @@ import com.woocommerce.android.ui.main.MainNavigationRouter
  * The main fragments hosted by the bottom bar should extend this class
  */
 abstract class TopLevelFragment : BaseFragment, TopLevelFragmentView {
-    constructor() {
-        BaseFragment()
-    }
-
-    constructor(@LayoutRes layoutId: Int) {
-        BaseFragment(layoutId)
-    }
+    constructor() : super()
+    constructor(@LayoutRes layoutId: Int) : super(layoutId)
 
     /**
      * The extending class may use this variable to defer a part of its

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -6,7 +6,15 @@ import com.woocommerce.android.ui.main.MainNavigationRouter
 /**
  * The main fragments hosted by the bottom bar should extend this class
  */
-abstract class TopLevelFragment : BaseFragment(), TopLevelFragmentView {
+abstract class TopLevelFragment : BaseFragment, TopLevelFragmentView {
+    constructor() {
+        BaseFragment()
+    }
+
+    constructor(layoutId: Int) {
+        BaseFragment(layoutId)
+    }
+
     /**
      * The extending class may use this variable to defer a part of its
      * normal initialization until manually requested.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -2,9 +2,7 @@ package com.woocommerce.android.ui.mystore
 
 import android.content.Context
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams
 import androidx.core.view.children
 import com.google.android.material.appbar.AppBarLayout
@@ -41,7 +39,7 @@ import org.wordpress.android.util.NetworkUtils
 import java.util.Calendar
 import javax.inject.Inject
 
-class MyStoreFragment : TopLevelFragment(),
+class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store),
     MyStoreContract.View,
     MyStoreStatsListener {
     companion object {
@@ -98,12 +96,11 @@ class MyStoreFragment : TopLevelFragment(),
         super.onAttach(context)
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        _binding = FragmentMyStoreBinding.inflate(inflater, container, false)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        _binding = FragmentMyStoreBinding.bind(view)
+
         binding.myStoreRefreshLayout.setOnRefreshListener {
             // Track the user gesture
             AnalyticsTracker.track(Stat.DASHBOARD_PULLED_TO_REFRESH)
@@ -112,11 +109,6 @@ class MyStoreFragment : TopLevelFragment(),
             binding.myStoreRefreshLayout.isRefreshing = false
             refreshMyStoreStats(forced = true)
         }
-        return binding.root
-    }
-
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
 
         savedInstanceState?.let { bundle ->
             isRefreshPending = bundle.getBoolean(STATE_KEY_REFRESH_PENDING, false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
@@ -5,14 +5,13 @@ import android.text.format.DateUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
-import androidx.annotation.LayoutRes
 import androidx.paging.PagedListAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.R
+import com.woocommerce.android.databinding.OrderListHeaderBinding
 import com.woocommerce.android.databinding.OrderListItemBinding
 import com.woocommerce.android.model.TimeGroup
 import com.woocommerce.android.model.toOrderStatus
@@ -48,21 +47,31 @@ class OrderListAdapter(
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+
         return when (viewType) {
             VIEW_TYPE_ORDER_ITEM -> {
                 OrderItemUIViewHolder(
                     OrderListItemBinding.inflate(
-                        LayoutInflater.from(parent.getContext()),
-                        parent, false
+                        inflater,
+                        parent,
+                        false
                     )
                 )
             }
             VIEW_TYPE_LOADING -> {
-                val view = LayoutInflater.from(parent.context)
-                        .inflate(R.layout.skeleton_order_list_item_auto, parent, false)
+                val view = inflater.inflate(R.layout.skeleton_order_list_item_auto, parent, false)
                 LoadingViewHolder(view)
             }
-            VIEW_TYPE_SECTION_HEADER -> SectionHeaderViewHolder(R.layout.order_list_header, parent)
+            VIEW_TYPE_SECTION_HEADER -> {
+                SectionHeaderViewHolder(
+                    OrderListHeaderBinding.inflate(
+                        inflater,
+                        parent,
+                        false
+                    )
+                )
+            }
             else -> {
                 // Fail fast if a new view type is added so we can handle it
                 throw IllegalStateException("The view type '$viewType' needs to be handled")
@@ -126,7 +135,10 @@ class OrderListAdapter(
             viewBinding.orderDate.text = getFormattedOrderDate(ctx, orderItemUI.dateCreated)
             viewBinding.orderNum.text = "#${orderItemUI.orderNumber}"
             viewBinding.orderName.text = orderItemUI.orderName
-            viewBinding.orderTotal.text = currencyFormatter.formatCurrency(orderItemUI.orderTotal, orderItemUI.currencyCode)
+            viewBinding.orderTotal.text = currencyFormatter.formatCurrency(
+                orderItemUI.orderTotal,
+                orderItemUI.currencyCode
+            )
             viewBinding.divider.visibility = if (orderItemUI.isLastItemInSection) View.GONE else View.VISIBLE
 
             // clear existing tags and add new ones
@@ -165,13 +177,10 @@ class OrderListAdapter(
 
     private class LoadingViewHolder(view: View) : RecyclerView.ViewHolder(view)
 
-    private class SectionHeaderViewHolder(
-        @LayoutRes layout: Int,
-        parentView: ViewGroup
-    ) : RecyclerView.ViewHolder(LayoutInflater.from(parentView.context).inflate(layout, parentView, false)) {
-        private val titleView: TextView = itemView.findViewById(R.id.orderListHeader)
+    private class SectionHeaderViewHolder(val viewBinding: OrderListHeaderBinding) :
+        RecyclerView.ViewHolder(viewBinding.getRoot()) {
         fun onBind(header: SectionHeader) {
-            titleView.setText(TimeGroup.valueOf(header.title.name).labelRes)
+            viewBinding.orderListHeader.setText(TimeGroup.valueOf(header.title.name).labelRes)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -118,6 +118,9 @@ class OrderListFragment : TopLevelFragment(),
         TabLayout(requireContext(), null, R.attr.tabStyle)
     }
 
+    private val appBarLayout
+        get() = activity?.findViewById<View>(R.id.app_bar_layout) as? AppBarLayout
+
     private val emptyView
         get() = binding.orderListView.emptyView
 
@@ -769,7 +772,7 @@ class OrderListFragment : TopLevelFragment(),
     // endregion
 
     private fun addTabLayoutToAppBar(tabLayout: TabLayout) {
-        (activity?.findViewById<View>(R.id.app_bar_layout) as? AppBarLayout)?.let { appBar ->
+        (appBarLayout)?.let { appBar ->
             if (isActive && !appBar.children.contains(tabLayout)) {
                 appBar.addView(tabLayout)
             }
@@ -777,7 +780,7 @@ class OrderListFragment : TopLevelFragment(),
     }
 
     private fun removeTabLayoutFromAppBar(tabLayout: TabLayout) {
-        (activity?.findViewById<View>(R.id.app_bar_layout) as? AppBarLayout)?.removeView(tabLayout)
+        appBarLayout?.removeView(tabLayout)
     }
 
     override fun isScrolledToTop() = binding.orderListView.getCurrentPosition() == 0

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -188,7 +188,7 @@ class OrderListFragment : TopLevelFragment(),
 
     override fun onResume() {
         super.onResume()
-        addTabLayoutToAppBar(tabLayout)
+        addTabLayoutToAppBar()
         AnalyticsTracker.trackViewShown(this)
     }
 
@@ -284,19 +284,19 @@ class OrderListFragment : TopLevelFragment(),
 
         if (isActive) {
             showOptionsMenu(true)
-            addTabLayoutToAppBar(tabLayout)
+            addTabLayoutToAppBar()
 
             if (isSearching) {
                 clearSearchResults()
             }
         } else {
-            removeTabLayoutFromAppBar(tabLayout)
+            removeTabLayoutFromAppBar()
         }
     }
 
     override fun onReturnedFromChildFragment() {
         showOptionsMenu(true)
-        addTabLayoutToAppBar(tabLayout)
+        addTabLayoutToAppBar()
 
         if (isOrderStatusFilterEnabled()) {
             viewModel.reloadListFromCache()
@@ -306,7 +306,7 @@ class OrderListFragment : TopLevelFragment(),
     }
 
     override fun onChildFragmentOpened() {
-        removeTabLayoutFromAppBar(tabLayout)
+        removeTabLayoutFromAppBar()
     }
 
     /**
@@ -576,9 +576,9 @@ class OrderListFragment : TopLevelFragment(),
 
     override fun onMenuItemActionExpand(item: MenuItem?): Boolean {
         clearOrderListData()
-        showTabs(false)
         isSearching = true
         checkOrientation()
+        removeTabLayoutFromAppBar()
         expandMainToolbar(false, animate = true)
         return true
     }
@@ -595,6 +595,7 @@ class OrderListFragment : TopLevelFragment(),
         }
         loadListForActiveTab()
         restoreMainToolbar()
+        addTabLayoutToAppBar()
         return true
     }
 
@@ -672,7 +673,6 @@ class OrderListFragment : TopLevelFragment(),
         searchMenuItem?.setOnActionExpandListener(null)
         searchView?.setOnQueryTextListener(null)
         hideOrderStatusListView()
-        showTabs(true)
         (activity as? MainActivity)?.showBottomNav()
 
         if (isFilterEnabled) closeFilteredList()
@@ -771,16 +771,16 @@ class OrderListFragment : TopLevelFragment(),
     }
     // endregion
 
-    private fun addTabLayoutToAppBar(tabLayout: TabLayout) {
-        (appBarLayout)?.let { appBar ->
+    private fun addTabLayoutToAppBar() {
+        (activity?.findViewById<View>(R.id.app_bar_layout) as? AppBarLayout)?.let { appBar ->
             if (isActive && !appBar.children.contains(tabLayout)) {
                 appBar.addView(tabLayout)
             }
         }
     }
 
-    private fun removeTabLayoutFromAppBar(tabLayout: TabLayout) {
-        appBarLayout?.removeView(tabLayout)
+    private fun removeTabLayoutFromAppBar() {
+        (activity?.findViewById<View>(R.id.app_bar_layout) as? AppBarLayout)?.removeView(tabLayout)
     }
 
     override fun isScrolledToTop() = binding.orderListView.getCurrentPosition() == 0

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -5,11 +5,13 @@ import android.graphics.Color
 import android.os.Bundle
 import android.os.Handler
 import android.os.Parcelable
+import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.MenuItem.OnActionExpandListener
 import android.view.View
+import android.view.ViewGroup
 import android.widget.EditText
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.SearchView.OnQueryTextListener

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -41,9 +41,6 @@ import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import dagger.android.support.AndroidSupportInjection
-import kotlinx.android.synthetic.main.fragment_order_list.view.*
-import kotlinx.android.synthetic.main.order_list_view.*
-import kotlinx.android.synthetic.main.order_list_view.view.*
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus.PROCESSING
 import org.wordpress.android.util.DisplayUtils
@@ -121,6 +118,9 @@ class OrderListFragment : TopLevelFragment(),
         TabLayout(requireContext(), null, R.attr.tabStyle)
     }
 
+    private val emptyView
+        get() = binding.orderListView.emptyView
+
     override fun onAttach(context: Context) {
         AndroidSupportInjection.inject(this)
         super.onAttach(context)
@@ -166,7 +166,7 @@ class OrderListFragment : TopLevelFragment(),
         _binding = FragmentOrderListBinding.inflate(inflater, container, false)
         binding.orderRefreshLayout.apply {
             // Set the scrolling view in the custom SwipeRefreshLayout
-            scrollUpChild = order_list_view.ordersList
+            scrollUpChild = binding.orderListView.ordersList
             setOnRefreshListener {
                 AnalyticsTracker.track(Stat.ORDERS_LIST_PULLED_TO_REFRESH)
                 refreshOrders()
@@ -415,23 +415,24 @@ class OrderListFragment : TopLevelFragment(),
             it?.let { emptyViewType ->
                 when (emptyViewType) {
                     EmptyViewType.SEARCH_RESULTS -> {
-                        empty_view.show(emptyViewType, searchQueryOrFilter = searchQuery)
+                        binding.orderStatusListView
+                        emptyView.show(emptyViewType, searchQueryOrFilter = searchQuery)
                     }
                     EmptyViewType.ORDER_LIST -> {
-                        empty_view.show(emptyViewType) {
+                        emptyView.show(emptyViewType) {
                             ChromeCustomTabUtils.launchUrl(requireActivity(), AppUrls.URL_LEARN_MORE_ORDERS)
                         }
                     }
                     EmptyViewType.ORDER_LIST_FILTERED -> {
-                        empty_view.show(emptyViewType, searchQueryOrFilter = viewModel.orderStatusFilter)
+                        emptyView.show(emptyViewType, searchQueryOrFilter = viewModel.orderStatusFilter)
                     }
                     EmptyViewType.NETWORK_OFFLINE, EmptyViewType.NETWORK_ERROR -> {
-                        empty_view.show(emptyViewType) {
+                        emptyView.show(emptyViewType) {
                             refreshOrders()
                         }
                     }
                     else -> {
-                        empty_view.show(emptyViewType)
+                        emptyView.show(emptyViewType)
                     }
                 }
             } ?: hideEmptyView()
@@ -439,7 +440,7 @@ class OrderListFragment : TopLevelFragment(),
     }
 
     private fun hideEmptyView() {
-        empty_view?.hide()
+        emptyView.hide()
     }
 
     private fun updatePagedListData(pagedListData: PagedList<OrderListItemUIType>?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -5,13 +5,11 @@ import android.graphics.Color
 import android.os.Bundle
 import android.os.Handler
 import android.os.Parcelable
-import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.MenuItem.OnActionExpandListener
 import android.view.View
-import android.view.ViewGroup
 import android.widget.EditText
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.SearchView.OnQueryTextListener

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -26,6 +26,7 @@ import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.databinding.FragmentOrderListBinding
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -40,7 +41,6 @@ import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import dagger.android.support.AndroidSupportInjection
-import kotlinx.android.synthetic.main.fragment_order_list.*
 import kotlinx.android.synthetic.main.fragment_order_list.view.*
 import kotlinx.android.synthetic.main.order_list_view.*
 import kotlinx.android.synthetic.main.order_list_view.view.*
@@ -102,6 +102,9 @@ class OrderListFragment : TopLevelFragment(),
     private var searchView: SearchView? = null
     private val searchHandler = Handler()
 
+    private var _binding: FragmentOrderListBinding? = null
+    private val binding get() = _binding!!
+
     // Alias for interacting with [viewModel.searchQuery] so the value is always identical
     // to the real value on the UI side.
     private var searchQuery: String
@@ -160,25 +163,23 @@ class OrderListFragment : TopLevelFragment(),
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val view = inflater.inflate(R.layout.fragment_order_list, container, false)
-        with(view) {
-            orderRefreshLayout?.apply {
-                // Set the scrolling view in the custom SwipeRefreshLayout
-                scrollUpChild = order_list_view.ordersList
-                setOnRefreshListener {
-                    AnalyticsTracker.track(Stat.ORDERS_LIST_PULLED_TO_REFRESH)
-                    refreshOrders()
-                }
+        _binding = FragmentOrderListBinding.inflate(inflater, container, false)
+        binding.orderRefreshLayout.apply {
+            // Set the scrolling view in the custom SwipeRefreshLayout
+            scrollUpChild = order_list_view.ordersList
+            setOnRefreshListener {
+                AnalyticsTracker.track(Stat.ORDERS_LIST_PULLED_TO_REFRESH)
+                refreshOrders()
             }
         }
-        return view
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        order_list_view.init(currencyFormatter = currencyFormatter, orderListListener = this)
-        order_status_list_view.init(listener = this)
+        binding.orderListView.init(currencyFormatter = currencyFormatter, orderListListener = this)
+        binding.orderStatusListView.init(listener = this)
         initializeViewModel()
     }
 
@@ -212,7 +213,7 @@ class OrderListFragment : TopLevelFragment(),
                 }
 
         listState?.let {
-            order_list_view.onFragmentRestoreInstanceState(it)
+            binding.orderListView.onFragmentRestoreInstanceState(it)
             listState = null
         }
 
@@ -229,7 +230,7 @@ class OrderListFragment : TopLevelFragment(),
                     // store the selected tab in SharedPrefs and clear the adapter data,
                     // then load orders with the calculated filter.
                     AppPrefs.setSelectedOrderListTab(tab.position)
-                    order_list_view.clearAdapterData()
+                    binding.orderListView.clearAdapterData()
                     loadListForActiveTab()
                 }
             }
@@ -237,7 +238,7 @@ class OrderListFragment : TopLevelFragment(),
             override fun onTabUnselected(tab: TabLayout.Tab) {}
 
             override fun onTabReselected(tab: TabLayout.Tab) {
-                order_list_view.scrollToTop()
+                binding.orderListView.scrollToTop()
             }
         })
 
@@ -254,7 +255,7 @@ class OrderListFragment : TopLevelFragment(),
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
-        outState.putParcelable(STATE_KEY_LIST, order_list_view.onFragmentSavedInstanceState())
+        outState.putParcelable(STATE_KEY_LIST, binding.orderListView.onFragmentSavedInstanceState())
         outState.putString(STATE_KEY_ACTIVE_FILTER, orderStatusFilter)
         outState.putBoolean(STATE_KEY_IS_SEARCHING, isSearching)
         outState.putBoolean(STATE_KEY_IS_FILTER_ENABLED, isFilterEnabled)
@@ -269,6 +270,7 @@ class OrderListFragment : TopLevelFragment(),
         orderListMenu = null
         searchMenuItem = null
         super.onDestroyView()
+        _binding = null
     }
 
     /**
@@ -350,7 +352,7 @@ class OrderListFragment : TopLevelFragment(),
 
     override fun refreshFragmentState() {
         if (isActive) {
-            order_list_view?.clearAdapterData()
+            binding.orderListView.clearAdapterData()
             refreshOrders() // reload the active list from scratch
         } else {
             // refresh order status options in the background even when order list is hidden
@@ -361,7 +363,7 @@ class OrderListFragment : TopLevelFragment(),
     }
 
     override fun scrollToTop() {
-        order_list_view.scrollToTop()
+        binding.orderListView.scrollToTop()
     }
 
     private fun initializeViewModel() {
@@ -370,26 +372,26 @@ class OrderListFragment : TopLevelFragment(),
         // populate views with any existing viewModel data
         viewModel.orderStatusOptions.value?.let { options ->
             // So the order status can be matched to the appropriate label
-            order_list_view.setOrderStatusOptions(options)
+            binding.orderListView.setOrderStatusOptions(options)
 
             updateOrderStatusList(options)
         }
 
         // setup observers
         viewModel.isFetchingFirstPage.observe(viewLifecycleOwner, Observer {
-            orderRefreshLayout?.isRefreshing = it == true
+            binding.orderRefreshLayout.isRefreshing = it == true
         })
 
         viewModel.isLoadingMore.observe(viewLifecycleOwner, Observer {
             it?.let { isLoadingMore ->
-                order_list_view.setLoadingMoreIndicator(active = isLoadingMore)
+                binding.orderListView.setLoadingMoreIndicator(active = isLoadingMore)
             }
         })
 
         viewModel.orderStatusOptions.observe(viewLifecycleOwner, Observer {
             it?.let { options ->
                 // So the order status can be matched to the appropriate label
-                order_list_view.setOrderStatusOptions(options)
+                binding.orderListView.setOrderStatusOptions(options)
 
                 updateOrderStatusList(options)
             }
@@ -403,7 +405,7 @@ class OrderListFragment : TopLevelFragment(),
             when (event) {
                 is ShowErrorSnack -> {
                     uiMessageResolver.showSnack(event.messageRes)
-                    orderRefreshLayout?.isRefreshing = false
+                    binding.orderRefreshLayout.isRefreshing = false
                 }
                 else -> event.isHandled = false
             }
@@ -441,7 +443,7 @@ class OrderListFragment : TopLevelFragment(),
     }
 
     private fun updatePagedListData(pagedListData: PagedList<OrderListItemUIType>?) {
-        order_list_view?.submitPagedList(pagedListData)
+        binding.orderListView.submitPagedList(pagedListData)
 
         if (pagedListData?.size != 0 && isSearching) {
             WPActivityUtils.hideKeyboard(activity)
@@ -472,8 +474,8 @@ class OrderListFragment : TopLevelFragment(),
     }
 
     private fun updateOrderStatusList(orderStatusList: Map<String, WCOrderStatusModel>) {
-        order_list_view_root.visibility = View.VISIBLE
-        order_status_list_view.updateOrderStatusListView(orderStatusList.values.toList())
+        binding.orderListRoot.visibility = View.VISIBLE
+        binding.orderStatusListView.updateOrderStatusListView(orderStatusList.values.toList())
     }
 
     override fun onOrderStatusSelected(orderStatus: String?) {
@@ -487,7 +489,7 @@ class OrderListFragment : TopLevelFragment(),
             displayFilteredList()
 
             // Load the filtered list
-            order_list_view.clearAdapterData()
+            binding.orderListView.clearAdapterData()
             viewModel.submitSearchOrFilter(statusFilter = orderStatus)
 
             updateActivityTitle()
@@ -662,7 +664,7 @@ class OrderListFragment : TopLevelFragment(),
 
     private fun disableSearchListeners() {
         orderListMenu?.findItem(R.id.menu_settings)?.isVisible = true
-        order_list_view_root.visibility = View.VISIBLE
+        binding.orderListRoot.visibility = View.VISIBLE
         searchMenuItem?.setOnActionExpandListener(null)
         searchView?.setOnQueryTextListener(null)
         hideOrderStatusListView()
@@ -736,15 +738,15 @@ class OrderListFragment : TopLevelFragment(),
     }
 
     private fun displayOrderStatusListView() {
-        order_status_list_view.visibility = View.VISIBLE
-        order_list_view.visibility = View.GONE
-        orderRefreshLayout.isEnabled = false
+        binding.orderStatusListView.visibility = View.VISIBLE
+        binding.orderListView.visibility = View.GONE
+        binding.orderRefreshLayout.isEnabled = false
     }
 
     private fun hideOrderStatusListView() {
-        order_status_list_view.visibility = View.GONE
-        order_list_view.visibility = View.VISIBLE
-        orderRefreshLayout.isEnabled = true
+        binding.orderStatusListView.visibility = View.GONE
+        binding.orderListView.visibility = View.VISIBLE
+        binding.orderRefreshLayout.isEnabled = true
     }
 
     private fun checkOrientation() {
@@ -760,7 +762,7 @@ class OrderListFragment : TopLevelFragment(),
      */
     private fun clearOrderListData() {
         if (!isFilterEnabled) {
-            order_list_view.clearAdapterData()
+            binding.orderListView.clearAdapterData()
         }
     }
     // endregion
@@ -777,5 +779,5 @@ class OrderListFragment : TopLevelFragment(),
         (activity?.findViewById<View>(R.id.app_bar_layout) as? AppBarLayout)?.removeView(tabLayout)
     }
 
-    override fun isScrolledToTop() = order_list_view.getCurrentPosition() == 0
+    override fun isScrolledToTop() = binding.orderListView.getCurrentPosition() == 0
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListView.kt
@@ -24,6 +24,12 @@ class OrderListView @JvmOverloads constructor(
     private lateinit var ordersAdapter: OrderListAdapter
     private lateinit var listener: OrderListListener
 
+    val emptyView
+        get() = binding.emptyView
+
+    val ordersList
+        get() = binding.ordersList
+
     fun init(
         currencyFormatter: CurrencyFormatter,
         orderListListener: OrderListListener
@@ -82,7 +88,8 @@ class OrderListView @JvmOverloads constructor(
         binding.ordersList.smoothScrollToPosition(0)
     }
 
-    fun getCurrentPosition() = (binding.ordersList.layoutManager as? LinearLayoutManager)?.findFirstVisibleItemPosition() ?: 0
+    fun getCurrentPosition() =
+        (binding.ordersList.layoutManager as? LinearLayoutManager)?.findFirstVisibleItemPosition() ?: 0
 
     /**
      * save the order list on configuration change

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListView.kt
@@ -3,14 +3,13 @@ package com.woocommerce.android.ui.orders.list
 import android.content.Context
 import android.os.Parcelable
 import android.util.AttributeSet
-import android.view.View
+import android.view.LayoutInflater
 import android.widget.LinearLayout
 import androidx.core.view.isVisible
 import androidx.paging.PagedList
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.woocommerce.android.R
+import com.woocommerce.android.databinding.OrderListViewBinding
 import com.woocommerce.android.util.CurrencyFormatter
-import kotlinx.android.synthetic.main.order_list_view.view.*
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 
 private const val MAX_INDEX_FOR_VISIBLE_ITEM_TO_KEEP_SCROLL_POSITION = 2
@@ -20,9 +19,7 @@ class OrderListView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : LinearLayout(ctx, attrs, defStyleAttr) {
-    init {
-        View.inflate(context, R.layout.order_list_view, this)
-    }
+    private val binding = OrderListViewBinding.inflate(LayoutInflater.from(ctx), this)
 
     private lateinit var ordersAdapter: OrderListAdapter
     private lateinit var listener: OrderListListener
@@ -34,7 +31,7 @@ class OrderListView @JvmOverloads constructor(
         this.listener = orderListListener
         this.ordersAdapter = OrderListAdapter(orderListListener, currencyFormatter)
 
-        ordersList.apply {
+        binding.ordersList.apply {
             layoutManager = LinearLayoutManager(context)
             itemAnimator = androidx.recyclerview.widget.DefaultItemAnimator()
             setHasFixedSize(true)
@@ -63,7 +60,7 @@ class OrderListView @JvmOverloads constructor(
         ordersAdapter.submitList(list)
 
         post {
-            (ordersList?.layoutManager as? LinearLayoutManager)?.let { layoutManager ->
+            (binding.ordersList.layoutManager as? LinearLayoutManager)?.let { layoutManager ->
                 if (layoutManager.findFirstVisibleItemPosition() < MAX_INDEX_FOR_VISIBLE_ITEM_TO_KEEP_SCROLL_POSITION) {
                     layoutManager.onRestoreInstanceState(recyclerViewState)
                 }
@@ -82,59 +79,24 @@ class OrderListView @JvmOverloads constructor(
      * scroll to the top of the order list
      */
     fun scrollToTop() {
-        ordersList.smoothScrollToPosition(0)
+        binding.ordersList.smoothScrollToPosition(0)
     }
 
-    fun getCurrentPosition() = (ordersList?.layoutManager as? LinearLayoutManager)?.findFirstVisibleItemPosition() ?: 0
+    fun getCurrentPosition() = (binding.ordersList.layoutManager as? LinearLayoutManager)?.findFirstVisibleItemPosition() ?: 0
 
     /**
      * save the order list on configuration change
      */
-    fun onFragmentSavedInstanceState() = ordersList.layoutManager?.onSaveInstanceState()
+    fun onFragmentSavedInstanceState() = binding.ordersList.layoutManager?.onSaveInstanceState()
 
     /**
      * restore the order list on configuration change
      */
     fun onFragmentRestoreInstanceState(listState: Parcelable) {
-        ordersList.layoutManager?.onRestoreInstanceState(listState)
+        binding.ordersList.layoutManager?.onRestoreInstanceState(listState)
     }
 
     fun setLoadingMoreIndicator(active: Boolean) {
-        load_more_progressbar.isVisible = active
+        binding.loadMoreProgressbar.isVisible = active
     }
-
-    // TODO remove this commented-out code before merging feature branch
-    /*fun updateEmptyViewForState(state: OrderListEmptyUiState, fmtArgs: String? = null) {
-        when (state) {
-            is DataShown -> { hideEmptyView() }
-            is EmptyList -> { showEmptyView(state.title, fmtArgs, state.imgResId) }
-            is Loading -> { showEmptyView(state.title) }
-            is ErrorWithRetry -> {
-                showEmptyView(
-                        state.title,
-                        imgResId = state.imgResId,
-                        buttonText = state.buttonText,
-                        onButtonClick = state.onButtonClick()
-                )
-            }
-        }
-    }
-
-    private fun showEmptyView(
-        title: UiString? = null,
-        fmtArgs: String? = null,
-        @DrawableRes imgResId: Int? = null,
-        buttonText: UiString? = null,
-        onButtonClick: (() -> Unit)? = null
-    ) {
-        empty_view?.let { emptyView ->
-            UiHelpers.setTextOrHide(emptyView.title, title, fmtArgs)
-            UiHelpers.setImageOrHide(emptyView.image, imgResId)
-            UiHelpers.setTextOrHide(emptyView.button, buttonText)
-            emptyView.button.setOnClickListener { onButtonClick?.invoke() }
-            if (emptyView.visibility == View.GONE) {
-                WooAnimUtils.fadeIn(emptyView, Duration.MEDIUM)
-            }
-        }
-    }*/
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteFragment.kt
@@ -2,12 +2,10 @@ package com.woocommerce.android.ui.orders.notes
 
 import android.content.DialogInterface
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
@@ -27,7 +25,9 @@ import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.util.ActivityUtils
 import javax.inject.Inject
 
-class AddOrderNoteFragment : BaseFragment(), AddOrderNoteContract.View, BackPressListener {
+class AddOrderNoteFragment : BaseFragment(R.layout.fragment_add_order_note),
+    AddOrderNoteContract.View,
+    BackPressListener {
     companion object {
         const val TAG = "AddOrderNoteFragment"
         private const val FIELD_NOTE_TEXT = "note_text"
@@ -56,13 +56,10 @@ class AddOrderNoteFragment : BaseFragment(), AddOrderNoteContract.View, BackPres
         retainInstance = true
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        _binding = FragmentAddOrderNoteBinding.inflate(inflater, container, false)
-        return binding.root
-    }
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+        _binding = FragmentAddOrderNoteBinding.bind(view)
 
         orderId = navArgs.orderId
         orderNumber = navArgs.orderNumber

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteFragment.kt
@@ -118,6 +118,7 @@ class AddOrderNoteFragment : BaseFragment(R.layout.fragment_add_order_note),
     override fun onDestroyView() {
         presenter.dropView()
         super.onDestroyView()
+        _binding = null
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AboutFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AboutFragment.kt
@@ -2,9 +2,7 @@ package com.woocommerce.android.ui.prefs
 
 import android.content.Context
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.woocommerce.android.AppUrls

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AboutFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AboutFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.R
@@ -15,7 +16,7 @@ import com.woocommerce.android.util.ChromeCustomTabUtils
 import org.wordpress.android.util.DisplayUtils
 import java.util.Calendar
 
-class AboutFragment : androidx.fragment.app.Fragment() {
+class AboutFragment : Fragment(R.layout.fragment_about) {
     companion object {
         const val TAG = "about"
     }
@@ -28,8 +29,10 @@ class AboutFragment : androidx.fragment.app.Fragment() {
         return binding.root
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        _binding = FragmentAboutBinding.bind(view)
 
         val isLandscape = DisplayUtils.isLandscape(activity)
         binding.aboutImage.visibility = if (isLandscape) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AboutFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AboutFragment.kt
@@ -21,18 +21,10 @@ class AboutFragment : Fragment(R.layout.fragment_about) {
         const val TAG = "about"
     }
 
-    private var _binding: FragmentAboutBinding? = null
-    private val binding get() = _binding!!
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        _binding = FragmentAboutBinding.inflate(inflater, container, false)
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        _binding = FragmentAboutBinding.bind(view)
+        val binding = FragmentAboutBinding.bind(view)
 
         val isLandscape = DisplayUtils.isLandscape(activity)
         binding.aboutImage.visibility = if (isLandscape) {
@@ -86,10 +78,5 @@ class AboutFragment : Fragment(R.layout.fragment_about) {
     override fun onStop() {
         super.onStop()
         ChromeCustomTabUtils.disconnect(activity as Context)
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
@@ -1,9 +1,7 @@
 package com.woocommerce.android.ui.prefs
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
@@ -13,7 +11,7 @@ import com.woocommerce.android.databinding.FragmentSettingsBetaBinding
 import com.woocommerce.android.ui.prefs.MainSettingsFragment.AppSettingsListener
 import com.woocommerce.android.util.AnalyticsUtils
 
-class BetaFeaturesFragment : Fragment() {
+class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
     companion object {
         const val TAG = "beta-features"
     }
@@ -23,13 +21,11 @@ class BetaFeaturesFragment : Fragment() {
     private var _binding: FragmentSettingsBetaBinding? = null
     private val binding get() = _binding!!
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        _binding = FragmentSettingsBetaBinding.inflate(inflater, container, false)
-        return binding.root
-    }
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+        _binding = FragmentSettingsBetaBinding.bind(view)
+
         if (activity is AppSettingsListener) {
             settingsListener = activity as AppSettingsListener
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
@@ -18,13 +18,10 @@ class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
 
     private lateinit var settingsListener: AppSettingsListener
 
-    private var _binding: FragmentSettingsBetaBinding? = null
-    private val binding get() = _binding!!
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        _binding = FragmentSettingsBetaBinding.bind(view)
+        val binding = FragmentSettingsBetaBinding.bind(view)
 
         if (activity is AppSettingsListener) {
             settingsListener = activity as AppSettingsListener
@@ -47,10 +44,5 @@ class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
         AnalyticsTracker.trackViewShown(this)
 
         activity?.setTitle(R.string.beta_features)
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/LicensesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/LicensesFragment.kt
@@ -1,9 +1,7 @@
 package com.woocommerce.android.ui.prefs
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.woocommerce.android.R

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/LicensesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/LicensesFragment.kt
@@ -5,26 +5,22 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentLicensesBinding
 import com.woocommerce.android.util.StringUtils
 
-class LicensesFragment : androidx.fragment.app.Fragment() {
+class LicensesFragment : Fragment(R.layout.fragment_licenses) {
     companion object {
         const val TAG = "licenses"
     }
 
-    private var _binding: FragmentLicensesBinding? = null
-    private val binding get() = _binding!!
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        _binding = FragmentLicensesBinding.inflate(inflater, container, false)
-        return binding.root
-    }
+        val binding = FragmentLicensesBinding.bind(view)
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
         context?.let {
             val prompt = StringUtils.getRawFileUrl(it, R.raw.licenses)
             binding.webView.loadData(prompt, "text/html", "utf-8")
@@ -39,10 +35,5 @@ class LicensesFragment : androidx.fragment.app.Fragment() {
             it.title = getString(R.string.settings_licenses)
             (it as AppCompatActivity).supportActionBar?.setHomeAsUpIndicator(R.drawable.ic_gridicons_cross_24dp)
         }
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -84,10 +84,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         } else {
             throw ClassCastException(context.toString() + " must implement AppSettingsListener")
         }
-    }
-
-    override fun onViewStateRestored(savedInstanceState: Bundle?) {
-        super.onViewStateRestored(savedInstanceState)
 
         updateStoreViews()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -8,9 +8,7 @@ import android.os.Bundle
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.method.LinkMovementMethod
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -12,6 +12,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.woocommerce.android.AppPrefs
@@ -47,7 +48,7 @@ import com.woocommerce.android.widgets.WooClickableSpan
 import dagger.android.support.AndroidSupportInjection
 import javax.inject.Inject
 
-class MainSettingsFragment : androidx.fragment.app.Fragment(), MainSettingsContract.View {
+class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSettingsContract.View {
     companion object {
         const val TAG = "main-settings"
         private const val SETTING_NOTIFS_ORDERS = "notifications_orders"
@@ -73,13 +74,10 @@ class MainSettingsFragment : androidx.fragment.app.Fragment(), MainSettingsContr
         super.onAttach(context)
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        _binding = FragmentSettingsMainBinding.inflate(inflater, container, false)
-        return binding.root
-    }
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+        _binding = FragmentSettingsMainBinding.bind(view)
 
         if (activity is AppSettingsListener) {
             settingsListener = activity as AppSettingsListener

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsFragment.kt
@@ -2,9 +2,8 @@ package com.woocommerce.android.ui.prefs
 
 import android.content.Context
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
+import androidx.fragment.app.Fragment
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -19,29 +18,24 @@ import com.woocommerce.android.util.ChromeCustomTabUtils
 import dagger.android.support.AndroidSupportInjection
 import javax.inject.Inject
 
-class PrivacySettingsFragment : androidx.fragment.app.Fragment(), PrivacySettingsContract.View {
+class PrivacySettingsFragment : Fragment(R.layout.fragment_settings_privacy), PrivacySettingsContract.View {
     companion object {
         const val TAG = "privacy-settings"
     }
 
     @Inject lateinit var presenter: PrivacySettingsContract.Presenter
 
-    private var _binding: FragmentSettingsPrivacyBinding? = null
-    private val binding get() = _binding!!
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        _binding = FragmentSettingsPrivacyBinding.inflate(inflater, container, false)
-        return binding.root
-    }
-
     override fun onAttach(context: Context) {
         AndroidSupportInjection.inject(this)
         super.onAttach(context)
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
         presenter.takeView(this)
+
+        val binding = FragmentSettingsPrivacyBinding.bind(view)
 
         binding.switchSendStats.isChecked = presenter.getSendUsageStats()
         binding.switchSendStats.setOnCheckedChangeListener { _, isChecked ->
@@ -77,7 +71,6 @@ class PrivacySettingsFragment : androidx.fragment.app.Fragment(), PrivacySetting
     override fun onDestroyView() {
         presenter.dropView()
         super.onDestroyView()
-        _binding = null
     }
 
     override fun onResume() {


### PR DESCRIPTION
This PR changes all the fragments that have been converted to `ViewBinding` to use the layout ID constructor, as recommended by @hichamboushaba on Slack.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
