### PR TITLE
Shipping labels/add product ids

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 5.7
 -----
 * [*] Show fees in the payment details of orders [https://github.com/woocommerce/woocommerce-android/pull/3228]
+* [*] Fixed a bug where variable products was not displayed when shipping labels were purchased for an order. [https://github.com/woocommerce/woocommerce-android/pull/3283]
 
 5.6
 ----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabel.kt
@@ -93,7 +93,7 @@ fun WCShippingLabelModel.WCShippingLabelRefundModel.toAppModel(): ShippingLabel.
  */
 fun List<ShippingLabel>.loadProducts(products: List<Order.Item>): List<ShippingLabel> {
     return this.map { shippingLabel ->
-        if (shippingLabel.productIds.isEmpty()) {
+        if (shippingLabel.productIds.isNullOrEmpty()) {
             shippingLabel.copy(
                 products = products.filter { it.name in shippingLabel.productNames }
             )

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'c00483eba00bace075a280aaa6cd31d1cea41cf6'
+    fluxCVersion = '34af8f283ced6dc7c1aa5ed352953606b4194bb2'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '4891dbd3d7f69cba50e8dc0296d80924cd1650d3'
+    fluxCVersion = '572607290d72c8213c339e092a93524dd9b16d26'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '572607290d72c8213c339e092a93524dd9b16d26'
+    fluxCVersion = 'c00483eba00bace075a280aaa6cd31d1cea41cf6'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
This PR adds the option to use the `product_ids` field in the `ShippingLabel` model. This is needed in order to fetch the product details associated with the shipping label. The logic is to fetch products based on the `product_ids` field, if it's available. If it's not available, we fallback to using the `product_names` field.

~Note: This PR is in draft till this [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1795) can be reviewed and merged.~

### Screenshots
(LEFT: Before the changes in this PR.   RIGHT: After the changes in this PR)
<img src="https://user-images.githubusercontent.com/22608780/101275688-8c80b280-37cd-11eb-9d79-4b64f591f823.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/101275689-8e4a7600-37cd-11eb-92d4-94a93c775e21.png" width="300"/>

#### To test
- Create an order from your test site with atleast 2 variable products.
  - Create/purchase 2 separate shipping labels for the products in the order. To create shipping labels, follow the instructions from `p91TBi-3xD`.
  - Open the app and verify that the products and the shipping labels are displayed correctly for the order.
- The product_ids field is not available by default in all the API responses. For shipping labels created before the 1.24.1 version was released, the product_ids field will not be available. Since I had a few shipping labels created before then, I was able to test this scenario. Please reach out to me to get access to my test site. You can use `Order #1427` to test this particular scenario.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
