### PR TITLE
Fix MainActivity build failure

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -391,7 +391,7 @@ class MainActivity : AppUpgradeActivity(),
 
         val showCrossIcon: Boolean
         if (isTopLevelNavigation) {
-            app_bar_layout.elevation = 0f
+            binding.appBarLayout.elevation = 0f
             showCrossIcon = false
         } else {
             binding.appBarLayout.elevation = resources.getDimensionPixelSize(R.dimen.appbar_elevation).toFloat()


### PR DESCRIPTION
This tiny PR fixes the build failure that is happening in `develop` after the changes from [this PR](github.com/woocommerce/woocommerce-android/pull/3282).

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
