### PR TITLE
Fix issue with unable to open email from app on Android 11

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 5.7
 -----
 * [*] Show fees in the payment details of orders [https://github.com/woocommerce/woocommerce-android/pull/3228]
+* [**] Fixed an issue where the app could not open the email client on Android 11 during the magic link login process. [https://github.com/woocommerce/woocommerce-android/pull/3291]
 
 5.6
 ----

--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -12,10 +12,14 @@
     <!-- Dangerous permissions, access must be requested at runtime -->
     <uses-permission android:name="android.permission.CAMERA" />
 
-    <!-- Required for Android 11 to allow camera access -->
     <queries>
+        <!-- Required for Android 11 to allow camera access -->
         <intent>
             <action android:name="android.media.action.IMAGE_CAPTURE" />
+        </intent>
+        <!-- Required for Android 11 and allows for querying for installed apps -->
+        <intent>
+            <action android:name="android.intent.action.MAIN"/>
         </intent>
     </queries>
 


### PR DESCRIPTION
Fixes #3175. Android 11 changed the way apps can query and interact with other apps. This fix allows us to query for email apps during the Magic Link login process. Here's a screenshot of the original error: 

<img src="https://user-images.githubusercontent.com/5810477/101403056-a5a76300-38a2-11eb-907d-8e19ec8aa142.png" width="320"/>


## To Test
Use a device running API 30 (Android 11)
1. Do a fresh install of the app and open it to begin the login process.
2. Click "Login with WordPress.com"
3. Enter your email address and click Continue
4. Complete login using magic link and verify clicking "open email" opens the email client successfully. 




Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
