### PR TITLE
UL: Hide "what is jetpack" button when displaying list of stores

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -51,7 +51,7 @@
 
         <activity
             android:name=".ui.sitepicker.SitePickerActivity"
-            android:theme="@style/Theme.Woo.DayNight"/>
+            android:theme="@style/LoginTheme"/>
 
         <activity android:name=".ui.login.MagicLinkInterceptActivity">
             <intent-filter>

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -364,6 +364,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         }
 
         no_stores_view.visibility = View.GONE
+        btn_what_is_jetpack.visibility = View.GONE
         site_list_container.visibility = View.VISIBLE
         button_email_help.visibility = View.GONE
 
@@ -491,9 +492,12 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         site_list_container.visibility = View.GONE
         no_stores_view.visibility = View.VISIBLE
 
-        btn_what_is_jetpack.setOnClickListener {
-            AnalyticsTracker.track(Stat.LOGIN_JETPACK_REQUIRED_WHAT_IS_JETPACK_LINK_TAPPED)
-            LoginWhatIsJetpackDialogFragment().show(supportFragmentManager, LoginWhatIsJetpackDialogFragment.TAG)
+        with(btn_what_is_jetpack) {
+            setOnClickListener {
+                AnalyticsTracker.track(Stat.LOGIN_JETPACK_REQUIRED_WHAT_IS_JETPACK_LINK_TAPPED)
+                LoginWhatIsJetpackDialogFragment().show(supportFragmentManager, LoginWhatIsJetpackDialogFragment.TAG)
+            }
+            visibility = View.VISIBLE
         }
 
         with(button_primary) {

--- a/WooCommerce/src/main/res/layout-land/view_login_no_stores.xml
+++ b/WooCommerce/src/main/res/layout-land/view_login_no_stores.xml
@@ -37,5 +37,6 @@
         android:layout_marginStart="@dimen/major_300"
         android:layout_marginEnd="@dimen/major_300"
         android:text="@string/login_jetpack_what_is"
-        android:textAllCaps="false" />
+        android:textAllCaps="false"
+        android:visibility="gone" />
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout/view_login_no_stores.xml
+++ b/WooCommerce/src/main/res/layout/view_login_no_stores.xml
@@ -38,5 +38,6 @@
         android:layout_marginStart="@dimen/major_300"
         android:layout_marginEnd="@dimen/major_300"
         android:text="@string/login_jetpack_what_is"
-        android:textAllCaps="false" />
+        android:textAllCaps="false"
+        android:visibility="gone" />
 </LinearLayout>


### PR DESCRIPTION
Fixes #3292 by hiding the "What is Jetpack" button by default and only displaying it in the "No stores" view (WordPress.com login flow):

Before | After
-- | --
![Screenshot_1607373992](https://user-images.githubusercontent.com/5810477/101406190-1e102300-38a7-11eb-82dd-44e0c7f8d1cc.png)|![Screenshot_1607375611](https://user-images.githubusercontent.com/5810477/101406238-2cf6d580-38a7-11eb-8558-958e5d65719e.png)

## To Test
1. Use the "Login with WordPress.com" flow and log into an account that has Woo stores connected to Jetpack. 
2. Verify the "What is jetpack" button is not visible.

1. Use the "Login with WordPress.com" flow and log into an account that has **no** woo stores connected to Jetpack. 
2. Verify the "What is jetpack" button is visible. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
