### PR TITLE
UL: Site picker style tweaks

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -51,7 +51,7 @@
 
         <activity
             android:name=".ui.sitepicker.SitePickerActivity"
-            android:theme="@style/Theme.Woo.DayNight"/>
+            android:theme="@style/LoginTheme"/>
 
         <activity android:name=".ui.login.MagicLinkInterceptActivity">
             <intent-filter>


### PR DESCRIPTION
Closes #3123 by fixing the remaining style issues on the Site Picker activity. **NOTE: The font and button differences can be ignored, [they are fixed in this PR](https://github.com/woocommerce/woocommerce-android/pull/3237) that is still pending review**

The only real visible change here is the bottom system navigation bar now matches the rest of the login process by being white.

Before | After
-- | --
![Screenshot_1607375611](https://user-images.githubusercontent.com/5810477/101407617-223d4000-38a9-11eb-9297-29ee591200a8.png)|![Screenshot_1607376218](https://user-images.githubusercontent.com/5810477/101407633-25d0c700-38a9-11eb-8995-a8177ecd7fd4.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
