### PR TITLE
Fix WPProductImageGallery memory leak

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -221,7 +221,7 @@ dependencies {
         // See https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/919
         exclude group: 'com.squareup.okhttp3'
     }
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.0-alpha-3'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.5'
 
     // Dependencies for local unit tests
     testImplementation "junit:junit:4.12"


### PR DESCRIPTION
This PR resolves a memory leak introduced in #3178 and found by @AmandaRiu. 

**Reason of the leak:**
Observing `LiveData` inside `ViewHolder` with `MainActivity` as `lifecycleowner` will prevent `ViewHolder` and the rest of the hierarchy from GC.

**Solution:**
Don't rely on lifecycle to observe/remove observers but rather on RecyclerView's callbacks.

**Ideal solution:**
We could create a separate lifecycle for `ViewHolder`s. Some kind of generic `ViewHolder` could prevent from similar mistakes in the future. The general idea is presented here: https://github.com/Sarquella/LifecycleCells/blob/master/lifecyclecells/src/main/java/dev/sarquella/lifecyclecells/LifecycleViewHolder.kt

## Test/reproduction sequence
1. Go to `products` tab
2. Click on product details
3. Go to image gallery
4. Go back to product details
5. Go back to `products` tab
6. Repeat

After 2 minutes:

### Before (memory usage ~ 421 mb, growing tendency)
![image](https://user-images.githubusercontent.com/5845095/101412443-e8892b00-38e2-11eb-98f6-9b9e35d3e820.png)

### After (memory usage ~300mb, flat tendency)
![image](https://user-images.githubusercontent.com/5845095/101412482-fb036480-38e2-11eb-9626-7c18fa864071.png)


Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
