### PR TITLE
Merge release/5.6 into develop after 3 successive betas + fixing conflicts

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -48,9 +48,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "5.6-rc-4"
+            versionName "5.6-rc-3"
         }
-        versionCode 177
+        versionCode 176
 
         minSdkVersion 21
         targetSdkVersion 30

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -221,7 +221,7 @@ dependencies {
         // See https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/919
         exclude group: 'com.squareup.okhttp3'
     }
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.0-alpha-3'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.5'
 
     // Dependencies for local unit tests
     testImplementation "junit:junit:4.12"

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -48,9 +48,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "5.6-rc-4"
+            versionName "5.6-rc-5"
         }
-        versionCode 177
+        versionCode 178
 
         minSdkVersion 21
         targetSdkVersion 30

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -48,9 +48,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "5.6-rc-2"
+            versionName "5.6-rc-3"
         }
-        versionCode 175
+        versionCode 176
 
         minSdkVersion 21
         targetSdkVersion 30

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -48,9 +48,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "5.6-rc-3"
+            versionName "5.6-rc-4"
         }
-        versionCode 176
+        versionCode 177
 
         minSdkVersion 21
         targetSdkVersion 30

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -25,20 +25,18 @@ abstract class TopLevelFragment : BaseFragment(), TopLevelFragmentView {
     abstract fun isScrolledToTop(): Boolean
 
     /**
-     * Called when the fragment shows a search view so the toolbar size is shrunk
-     * to a non-expanded size
+     * Called when the fragment shows or hides a search view so we can properly disable the collapsing
+     * toolbar when a search is active
      */
-    fun expandMainToolbar(expand: Boolean, animate: Boolean) {
-        (activity as? MainActivity)?.expandToolbar(expand, animate)
-    }
-
-    /**
-     * Called when the fragment hides a search view so the toolbar can be re-expanded
-     * if scrolled to the top
-     */
-    fun restoreMainToolbar() {
-        if (isScrolledToTop()) {
-            expandMainToolbar(true, true)
+    fun onSearchViewActiveChanged(isActive: Boolean) {
+        (activity as? MainActivity)?.let {
+            if (isActive) {
+                it.enableToolbarExpansion(false)
+                it.expandToolbar(false, false)
+            } else {
+                it.enableToolbarExpansion(true)
+                it.expandToolbar(true, true)
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -480,7 +480,7 @@ class MainActivity : AppUpgradeActivity(),
         app_bar_layout.setExpanded(expand, animate)
     }
 
-    private fun enableToolbarExpansion(enable: Boolean) {
+    fun enableToolbarExpansion(enable: Boolean) {
         if (!enable) {
             toolbar.title = title
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -583,7 +583,7 @@ class OrderListFragment : TopLevelFragment(),
         showTabs(false)
         isSearching = true
         checkOrientation()
-        expandMainToolbar(false, animate = true)
+        onSearchViewActiveChanged(isActive = true)
         return true
     }
 
@@ -598,7 +598,7 @@ class OrderListFragment : TopLevelFragment(),
             searchMenuItem?.isVisible = true
         }
         loadListForActiveTab()
-        restoreMainToolbar()
+        onSearchViewActiveChanged(isActive = false)
         return true
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -139,7 +139,6 @@ class OrderListFragment : TopLevelFragment(),
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        menu.clear()
         inflater.inflate(R.menu.menu_order_list_fragment, menu)
 
         orderListMenu = menu

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -568,7 +568,6 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
         isSearching = true
         checkOrientation()
         removeTabLayoutFromAppBar()
-        expandMainToolbar(false, animate = true)
         onSearchViewActiveChanged(isActive = true)
         return true
     }
@@ -584,7 +583,6 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
             searchMenuItem?.isVisible = true
         }
         loadListForActiveTab()
-        restoreMainToolbar()
         addTabLayoutToAppBar()
         onSearchViewActiveChanged(isActive = false)
         return true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -11,9 +11,9 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.isVisible
 import androidx.annotation.StringRes
 import androidx.core.view.forEach
+import androidx.core.view.isVisible
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -47,14 +47,12 @@ import com.woocommerce.android.ui.wpmediapicker.WPMediaPickerFragment
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.CrashUtils
 import com.woocommerce.android.util.Optional
-import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.widgets.CustomProgressDialog
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageInteractionListener
 import kotlinx.android.synthetic.main.fragment_product_detail.*
 import org.wordpress.android.util.ActivityUtils
-import java.lang.StringBuilder
 
 class ProductDetailFragment : BaseProductFragment(), OnGalleryImageInteractionListener, NavigationResult {
     companion object {
@@ -288,15 +286,15 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageInteractionLi
     override fun onPrepareOptionsMenu(menu: Menu) {
         super.onPrepareOptionsMenu(menu)
 
-        fun Menu.printItems() : String = buildString {
+        fun Menu.printItems(): String = buildString {
             this@printItems.forEach {
                 append("${resources.getResourceName(it.itemId)}\n")
             }
         }
 
-        if(menu.findItem(R.id.menu_view_product) == null) {
+        if (menu.findItem(R.id.menu_view_product) == null) {
             val message = """menu.findItem(R.id.menu_view_product) is null
-                |User is ${if(viewModel.isAddFlow) "creating a product" else "modifying a product"}
+                |User is ${if (viewModel.isAddFlow) "creating a product" else "modifying a product"}
                 |menu elements:
                 |${menu.printItems()}
             """.trimMargin()
@@ -310,7 +308,7 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageInteractionLi
 
         // change the font color of the trash menu item to red, and only show it if it should be enabled
         with(menu.findItem(R.id.menu_trash_product)) {
-            if(this == null) return@with
+            if (this == null) return@with
             val title = SpannableString(this.title)
             title.setSpan(ForegroundColorSpan(Color.RED), 0, title.length, 0)
             this.setTitle(title)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -13,6 +13,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.annotation.StringRes
+import androidx.core.view.forEach
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -44,13 +45,16 @@ import com.woocommerce.android.ui.products.adapters.ProductPropertyCardsAdapter
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
 import com.woocommerce.android.ui.wpmediapicker.WPMediaPickerFragment
 import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.CrashUtils
 import com.woocommerce.android.util.Optional
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.widgets.CustomProgressDialog
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageInteractionListener
 import kotlinx.android.synthetic.main.fragment_product_detail.*
 import org.wordpress.android.util.ActivityUtils
+import java.lang.StringBuilder
 
 class ProductDetailFragment : BaseProductFragment(), OnGalleryImageInteractionListener, NavigationResult {
     companion object {
@@ -284,20 +288,36 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageInteractionLi
     override fun onPrepareOptionsMenu(menu: Menu) {
         super.onPrepareOptionsMenu(menu)
 
+        fun Menu.printItems() : String = buildString {
+            this@printItems.forEach {
+                append("${resources.getResourceName(it.itemId)}\n")
+            }
+        }
+
+        if(menu.findItem(R.id.menu_view_product) == null) {
+            val message = """menu.findItem(R.id.menu_view_product) is null
+                |User is ${if(viewModel.isAddFlow) "creating a product" else "modifying a product"}
+                |menu elements:
+                |${menu.printItems()}
+            """.trimMargin()
+            CrashUtils.logException(NullPointerException(message))
+        }
+
         // visibility of these menu items depends on whether we're in the add product flow
-        menu.findItem(R.id.menu_view_product).isVisible = viewModel.isProductPublished && !viewModel.isAddFlow
-        menu.findItem(R.id.menu_share).isVisible = !viewModel.isAddFlow
-        menu.findItem(R.id.menu_product_settings).isVisible = true
+        menu.findItem(R.id.menu_view_product)?.isVisible = viewModel.isProductPublished && !viewModel.isAddFlow
+        menu.findItem(R.id.menu_share)?.isVisible = !viewModel.isAddFlow
+        menu.findItem(R.id.menu_product_settings)?.isVisible = true
 
         // change the font color of the trash menu item to red, and only show it if it should be enabled
         with(menu.findItem(R.id.menu_trash_product)) {
+            if(this == null) return@with
             val title = SpannableString(this.title)
             title.setSpan(ForegroundColorSpan(Color.RED), 0, title.length, 0)
             this.setTitle(title)
             this.isVisible = viewModel.isTrashEnabled
         }
 
-        menu.findItem(R.id.menu_save_as_draft).isVisible = viewModel.isAddFlow && viewModel.hasChanges()
+        menu.findItem(R.id.menu_save_as_draft)?.isVisible = viewModel.isAddFlow && viewModel.hasChanges()
 
         doneOrUpdateMenuItem?.let {
             it.title = if (viewModel.isAddFlow) getString(publishTitleId) else getString(updateTitleId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -292,6 +292,10 @@ class ProductDetailFragment : BaseProductFragment(), OnGalleryImageInteractionLi
             }
         }
 
+        // Some users are experiencing a crash because the entry R.id.menu_view_product is missing from the menu
+        // see: https://github.com/woocommerce/woocommerce-android/issues/3241
+        // If this happens, we will send the below report, and we avoid the crash using the null checks below
+        // TODO: remove the null checks once the root cause is identified is fixed
         if (menu.findItem(R.id.menu_view_product) == null) {
             val message = """menu.findItem(R.id.menu_view_product) is null
                 |User is ${if (viewModel.isAddFlow) "creating a product" else "modifying a product"}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -280,14 +280,14 @@ class ProductListFragment : TopLevelFragment(), OnProductClickListener, ProductS
 
     override fun onMenuItemActionExpand(item: MenuItem?): Boolean {
         viewModel.onSearchOpened()
-        expandMainToolbar(false, animate = true)
+        onSearchViewActiveChanged(isActive = true)
         return true
     }
 
     override fun onMenuItemActionCollapse(item: MenuItem?): Boolean {
         viewModel.onSearchClosed()
         closeSearchView()
-        restoreMainToolbar()
+        onSearchViewActiveChanged(isActive = false)
         return true
     }
 

--- a/WooCommerce/src/main/res/drawable/searchview_cursor.xml
+++ b/WooCommerce/src/main/res/drawable/searchview_cursor.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <size android:width="2dp" />
-    <solid android:color="@color/color_on_primary_surface_medium" />
+    <solid android:color="@color/color_on_background" />
 </shape>


### PR DESCRIPTION
Merge `release/5.6` back to `develop` after:
 - rc-3 (missed a merge back to develop): #3278, #3277, #3280
 - rc-4: #3295
 - rc-5: #3305 – added very soon after rc-4 so now included in this PR as well

Supersedes #3302 to fix the conflict resolution

## Git Graph of branches involved in this PR 🍝 

```
                                  #3278 #3277 #3280 #3295  #3305
                                     ▼     ▼     ▼     ▼      ▼
                                 ○────○     ╲     ╲     ╲      ╲
╔═════════════╗          rc-1   ╱      ╲     ╲     ╲     ╲      ╲
║ release/5.6 ║         ○─●─ ─ ●──○─────○─────○─────●─────●──────● ─ ─ ─ ─ ─ ─ ─ ─ ─ ▶
╚═════════════╝        ╱   ╲  rc-2 ╲               rc-3  rc-4   rc-5
                      ╱     ╲       ╲                       ╲      ╲
                     ╱       ╲       ╲                       ╲      ╲  ┌──────────────────────────────┐
                    ╱ code    ╲       ╲                     ○━◎━━━○━━○ │merge/release-5.6-into-develop│
                   ╱ freeze    ╲       ╲                   ╱  fix      └──────────────────────────────┘
                  ╱             ╲       ╲                 ╱ conflict   ╲ <- This PR
╔═══════╗        ╱               ╲       ╲               ╱
║develop╠───○─○─○────○───○──○──○──○─○─○─○─○───○───○──○──○────────────────◌───────▶
╚═══════╝  ╱                         ╱
          ▲                         ▲
        #3136                     #3274


            ○─ Commit      ●─ Tag      ▼─ PR      ◎─ Conflict fix
```

## Conflict resolution details

Changes in `OrderListFragment.kt` around the conflict come from:
 - #3136 and #3274 in `develop`
 - #3278 in `release/5.6`

The conflict likely happened because we failed to merge the release branch back into develop after `rc-3` (which included #3278), letting `develop` go out of sync with the fixes that landed in `release/5.6`.


```kotlin
    override fun onMenuItemActionExpand(item: MenuItem?): Boolean {
        clearOrderListData()
        isSearching = true
        checkOrientation()
<<<<<<< develop
        removeTabLayoutFromAppBar()
        expandMainToolbar(false, animate = true)
=======
        onSearchViewActiveChanged(isActive = true)
>>>>>>> release/5.6
        return true
    }
    override fun onMenuItemActionCollapse(item: MenuItem?): Boolean {
        if (isFilterEnabled) {
            closeFilteredList()
            enableSearchListeners()
            searchMenuItem?.isVisible = false
            searchView?.post { searchMenuItem?.expandActionView() }
        } else {
            clearSearchResults()
            searchMenuItem?.isVisible = true
        }
        loadListForActiveTab()
<<<<<<< develop
        restoreMainToolbar()
        addTabLayoutToAppBar()
=======
        onSearchViewActiveChanged(isActive = false)
>>>>>>> release/5.6
        return true
    }
```

## Changes added post-conflict-resolution

After resolving the conflict by keeping both sides, we saw that the CI ended up failing the build. @0nko fixed the build by removing the MainToolbar-related lines, in a commit on top of the conflict fix.

After this conflict resolution + merge, we ended up also doing a new `rc-5` beta (to add #3305) while this PR was still open, so I brought in those new changes from `release/5.6` into the `merge/release-5.6-into-develop` branch too so that it includes changes from rc-3, rc-4 but also now rc-5.

I'd love @nbradbury to review this PR and validate the conflict resolution seems correct here, since it happens he was the one who worked on all the PRs that have touched this part of the conflicting code 🙂 