### PR TITLE
Issue/3296 Fix issue of menu disappearing after device rotation in order child fragments

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -139,7 +139,6 @@ class OrderListFragment : TopLevelFragment(),
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        menu.clear()
         inflater.inflate(R.menu.menu_order_list_fragment, menu)
 
         orderListMenu = menu


### PR DESCRIPTION
Fixes #3296 and #3241 

Currently when trying to add an order note or shipment tracking, if the user rotates their device, the menu item "add" disappears, and they can't restore until leaving the screen and coming back.
For explanation on the cause please check p1607510188013600-slack-C6H8C3G23?thread_ts=1607448083.487900&cid=C6H8C3G23

This solution just removes the line https://github.com/woocommerce/woocommerce-android/blob/1893713106a1fe3b111134714b5524f08fc9b495/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt#L142 as I didn't notice any issue without it.
We can also check `isChildFragmentShowing()` before clearing and inflating the menu if there is an impact using the above solution.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.