### PR TITLE
Override the Zendesk empty tickets view to fix dark mode

### DIFF
--- a/WooCommerce/src/main/res/layout/zs_activity_request_list_scene_empty.xml
+++ b/WooCommerce/src/main/res/layout/zs_activity_request_list_scene_empty.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    This class overrides the Zendesk version to fix an issue where the empty message
+    text is the wrong color in dark mode.
+-->
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/request_list_swipe_refresh_layout_empty"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:orientation="vertical">
+
+        <androidx.legacy.widget.Space
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+
+        <include layout="@layout/zs_activity_request_list_empty_logo" />
+
+        <TextView
+            android:id="@+id/request_list_description_empty"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="64dp"
+            android:layout_marginLeft="64dp"
+            android:layout_marginEnd="64dp"
+            android:layout_marginRight="64dp"
+            android:gravity="center"
+            android:text="@string/request_list_empty_text"
+            android:textSize="16sp"
+            android:textColor="@color/woo_gray_40"/>
+
+        <Button
+            android:id="@+id/request_list_empty_start_conversation"
+            style="@style/ZendeskRequestListButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:paddingLeft="16dp"
+            android:paddingTop="10dp"
+            android:paddingRight="16dp"
+            android:paddingBottom="10dp"
+            android:text="@string/request_list_empty_start_conversation" />
+
+        <androidx.legacy.widget.Space
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+
+        <ImageView
+            android:id="@+id/request_list_zendesk_logo_empty"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|center_horizontal"
+            android:layout_marginBottom="24dp"
+            android:contentDescription="@string/zs_general_referrer_logo_label_accessibility"
+            android:padding="8dp"
+            app:srcCompat="@drawable/zs_zendesk_product_logo" />
+
+    </LinearLayout>
+
+</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>


### PR DESCRIPTION
Closes #2384 by overriding the Zendesk layout. The empty message text was the wrong color in dark mode - the only thing Zendesk didn't hard-code style-wise so when dark mode is enabled it would actually do what it was supposed to do and go to lighter text, but unfortunately nothing else in the views are switched to dark mode so this made the text invisible. 

Before | After 
-- | --
![my-tickets-dark-before](https://user-images.githubusercontent.com/5810477/101702048-2191de80-3a4e-11eb-8768-98e4fa0a8da2.jpg)|![my-tickets-dark-after](https://user-images.githubusercontent.com/5810477/101702050-22c30b80-3a4e-11eb-97bc-207f34b7c981.jpg)

### To Test
Verify the view in light and dark mode. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
