### PR TITLE
issue/3309-product-list-options-menu

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -96,6 +96,7 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
         _binding = FragmentProductListBinding.bind(view)
         setupObservers(viewModel)
         setupResultHandlers()
+        setHasOptionsMenu(true)
 
         listState = savedInstanceState?.getParcelable(KEY_LIST_STATE)
 


### PR DESCRIPTION
Fixes #3309 - restored `setHasOptionsMenu(true)` to the product list, which accidentally got removed during the view binding conversion.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
