### PR TITLE
Issue/3240 bottom nav overlaps fab

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -453,8 +453,16 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
     private fun showAddProductButton(show: Boolean) {
         val addProductButton = requireActivity().findViewById<FloatingActionButton>(R.id.addProductButton)
 
-        fun showButton() = run { addProductButton.isVisible = true }
-        fun hideButton() = run { addProductButton.isVisible = false }
+        fun showButton() = run {
+            if (!addProductButton.isVisible) {
+                addProductButton.show()
+            }
+        }
+        fun hideButton() = run {
+            if (addProductButton.isVisible) {
+                addProductButton.hide()
+            }
+        }
 
         when (show) {
             true -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -442,13 +442,15 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
     }
 
     private fun showAddProductButton(show: Boolean) {
-        val addProductFab = requireActivity().findViewById<FloatingActionButton>(R.id.addProductButton)
-        fun showButton() = run { addProductFab.isVisible = true }
-        fun hideButton() = run { addProductFab.isVisible = false }
+        val addProductButton = requireActivity().findViewById<FloatingActionButton>(R.id.addProductButton)
+
+        fun showButton() = run { addProductButton.isVisible = true }
+        fun hideButton() = run { addProductButton.isVisible = false }
+
         when (show) {
             true -> {
                 showButton()
-                addProductFab.setOnClickListener {
+                addProductButton.setOnClickListener {
                     viewModel.onAddProductButtonClicked()
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -160,11 +160,16 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
         }
     }
 
+    override fun onChildFragmentOpened() {
+        showAddProductButton(false)
+    }
+
     override fun onReturnedFromChildFragment() {
         showOptionsMenu(true)
 
         if (!viewModel.isSearching()) {
             viewModel.reloadProductsFromDb(excludeProductId = pendingTrashProductId)
+            showAddProductButton(true)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -472,7 +472,10 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
                     viewModel.onAddProductButtonClicked()
                 }
             }
-            else -> hideButton()
+            else -> {
+                hideButton()
+                addProductButton.setOnClickListener(null)
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -451,6 +451,7 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
     }
 
     private fun showAddProductButton(show: Boolean) {
+        // note that the FAB is part of the main activity so it can be direct child of the CoordinatorLayout
         val addProductButton = requireActivity().findViewById<FloatingActionButton>(R.id.addProductButton)
 
         fun showButton() = run {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -151,8 +151,12 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
         if (hidden) {
             disableSearchListeners()
             trashProductUndoSnack?.dismiss()
+            showAddProductButton(false)
         } else {
             enableSearchListeners()
+            if (!viewModel.isSearching()) {
+                showAddProductButton(true)
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -15,6 +15,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.FeedbackPrefs
 import com.woocommerce.android.NavGraphMainDirections
@@ -441,12 +442,13 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
     }
 
     private fun showAddProductButton(show: Boolean) {
-        fun showButton() = run { binding.addProductButton.isVisible = true }
-        fun hideButton() = run { binding.addProductButton.isVisible = false }
+        val addProductFab = requireActivity().findViewById<FloatingActionButton>(R.id.addProductButton)
+        fun showButton() = run { addProductFab.isVisible = true }
+        fun hideButton() = run { addProductFab.isVisible = false }
         when (show) {
             true -> {
                 showButton()
-                binding.addProductButton.setOnClickListener {
+                addProductFab.setOnClickListener {
                     viewModel.onAddProductButtonClicked()
                 }
             }

--- a/WooCommerce/src/main/res/layout/activity_main.xml
+++ b/WooCommerce/src/main/res/layout/activity_main.xml
@@ -60,6 +60,7 @@
             style="@style/Woo.AddButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
             android:layout_margin="@dimen/major_100"
             android:animateLayoutChanges="true"
             android:visibility="gone"

--- a/WooCommerce/src/main/res/layout/activity_main.xml
+++ b/WooCommerce/src/main/res/layout/activity_main.xml
@@ -63,6 +63,7 @@
             android:layout_gravity="bottom|end"
             android:layout_margin="@dimen/major_100"
             android:animateLayoutChanges="true"
+            android:contentDescription="@string/add_products_button"
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/WooCommerce/src/main/res/layout/activity_main.xml
+++ b/WooCommerce/src/main/res/layout/activity_main.xml
@@ -54,6 +54,18 @@
                 app:navGraph="@navigation/nav_graph_main"
                 tools:layout="@layout/fragment_my_store" />
         </FrameLayout>
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/addProductButton"
+            style="@style/Woo.AddButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/major_100"
+            android:animateLayoutChanges="true"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            tools:visibility="visible" />
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
     <com.woocommerce.android.ui.network.OfflineStatusBarView

--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -78,17 +78,5 @@
             app:layout_constraintStart_toStartOf="parent"
             tools:visibility="gone" />
 
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/addProductButton"
-            style="@style/Woo.AddButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/major_100"
-            android:animateLayoutChanges="true"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            tools:visibility="visible" />
-
     </androidx.constraintlayout.widget.ConstraintLayout>
 </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>


### PR DESCRIPTION
Fixes #3240 - the only way I could reliably fix the overlapped FAB was to move it to the main activity, so it's a direct child of the `CoordinatorLayout`. Doing this also fixes another bug, where snackbars would overlap the FAB.

I made two other changes to the FAB in this PR:

- Use `show()` and `hide()` so the FAB animates
- Added missing `android:contentDescription` for accessibility

![fab](https://user-images.githubusercontent.com/3903757/101811854-9d406980-3ae8-11eb-918c-b3203d3c24b3.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
