### PR TITLE
Support removing an image from a product variation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * [*] Added support for passwordless logins [https://github.com/woocommerce/woocommerce-android/pull/3268]
 * [*] Fixed a bug where variable products was not displayed when shipping labels were purchased for an order. [https://github.com/woocommerce/woocommerce-android/pull/3283]
 * [**] Fixed an issue where the app could not open the email client on Android 11 during the magic link login process. [https://github.com/woocommerce/woocommerce-android/pull/3291]
+* [***] Now it's possible to remove an image from a Product Variation if the WC version 4.7+. [https://github.com/woocommerce/woocommerce-android/pull/3312]
 
 5.6
 ----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
@@ -53,7 +53,7 @@ class ProductImagesViewModel @AssistedInject constructor(
         ViewState(
             isDoneButtonVisible = false,
             uploadingImageUris = ProductImagesService.getUploadingImageUris(navArgs.remoteId),
-            isImageDeletingAllowed = isMultiSelectionAllowed,
+            isImageDeletingAllowed = true,
             images = navArgs.images.toList(),
             isWarningVisible = !isMultiSelectionAllowed,
             isDragDropDescriptionVisible = isMultiSelectionAllowed

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
@@ -166,12 +166,8 @@ class VariationDetailFragment : BaseFragment(), BackPressListener, NavigationRes
             )
         }
         handleResult<List<Image>>(BaseProductEditorFragment.KEY_IMAGES_DIALOG_RESULT) {
-            val updatedImage = if (it.isEmpty()) {
-                // Image was deleted. Create a placeholder image with ID 0
-                Image(0, "", "", Date())
-            } else {
-                it.first()
-            }
+            // If empty, the image was deleted. Create a placeholder image with ID 0
+            val updatedImage = it.firstOrNull() ?: Image(0, "", "", Date())
 
             viewModel.onVariationChanged(
                 image = updatedImage

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
@@ -48,6 +48,7 @@ import kotlinx.android.synthetic.main.fragment_variation_detail.app_bar_layout
 import kotlinx.android.synthetic.main.fragment_variation_detail.cardsRecyclerView
 import kotlinx.android.synthetic.main.fragment_variation_detail.imageGallery
 import org.wordpress.android.util.ActivityUtils
+import java.util.Date
 import javax.inject.Inject
 
 class VariationDetailFragment : BaseFragment(), BackPressListener, NavigationResult, OnGalleryImageInteractionListener {
@@ -165,11 +166,16 @@ class VariationDetailFragment : BaseFragment(), BackPressListener, NavigationRes
             )
         }
         handleResult<List<Image>>(BaseProductEditorFragment.KEY_IMAGES_DIALOG_RESULT) {
-            if (it.isNotEmpty()) {
-                viewModel.onVariationChanged(
-                    image = it.first()
-                )
+            val updatedImage = if (it.isEmpty()) {
+                // Image was deleted. Create a placeholder image with ID 0
+                Image(0, "", "", Date())
+            } else {
+                it.first()
             }
+
+            viewModel.onVariationChanged(
+                image = updatedImage
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailRepository.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.fluxc.model.WCProductVariationModel
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.OnVariationChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnVariationUpdated
+import org.wordpress.android.fluxc.store.WCProductStore.ProductErrorType
 import javax.inject.Inject
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
@@ -43,6 +44,8 @@ class VariationDetailRepository @Inject constructor(
 
     private var remoteProductId: Long = 0L
     private var remoteVariationId: Long = 0L
+
+    var lastUpdateVariationErrorType: ProductErrorType? = null
 
     init {
         dispatcher.register(this)
@@ -135,6 +138,7 @@ class VariationDetailRepository @Inject constructor(
                         AnalyticsTracker.KEY_ERROR_CONTEXT to this::class.java.simpleName,
                         AnalyticsTracker.KEY_ERROR_TYPE to event.error?.type?.toString(),
                         AnalyticsTracker.KEY_ERROR_DESC to event.error?.message))
+                lastUpdateVariationErrorType = event.error?.type
                 continuationUpdateVariation?.resume(false)
             } else {
                 AnalyticsTracker.track(PRODUCT_VARIATION_UPDATE_SUCCESS)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.store.WCProductStore.ProductErrorType
 import java.math.BigDecimal
 import java.util.Date
 
@@ -226,7 +227,14 @@ class VariationDetailViewModel @AssistedInject constructor(
                 loadVariation(variation.remoteProductId, variation.remoteVariationId)
                 triggerEvent(ShowSnackbar(string.variation_detail_update_product_success))
             } else {
-                triggerEvent(ShowSnackbar(string.variation_detail_update_variation_error))
+                if (
+                    variation.image?.id == 0L &&
+                    variationRepository.lastUpdateVariationErrorType == ProductErrorType.INVALID_VARIATION_IMAGE_ID
+                ) {
+                    triggerEvent(ShowSnackbar(string.variation_detail_update_variation_image_error))
+                } else {
+                    triggerEvent(ShowSnackbar(string.variation_detail_update_variation_error))
+                }
             }
         } else {
             triggerEvent(ShowSnackbar(string.offline_error))

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -716,6 +716,7 @@
     -->
     <string name="variation_detail_fetch_variation_error">Error fetching variation</string>
     <string name="variation_detail_update_variation_error">Error updating variation</string>
+    <string name="variation_detail_update_variation_image_error">Sorry, image removal on product variations is supported in WooCommerce 4.7 or greater.</string>
     <string name="variation_detail_update_product_success">Variation updated</string>
     <string name="variation_detail_price_warning">Variations without price won\'t be shown in your store</string>
     <string name="variation_detail_price_warning_title">Some variations do not have prices</string>

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '34af8f283ced6dc7c1aa5ed352953606b4194bb2'
+    fluxCVersion = 'bbc573267580ca7d60096d3b36e310a0a17f56f0'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Cloes #3066 by adding logic that allows the image to be delete from a product variation. We originally disabled this functionality in Product Variations since there was[ a bug in Woo versions 4.6 and under.](https://github.com/woocommerce/woocommerce/issues/27116). This bug has been [fixed as of Woo v4.7.](https://github.com/woocommerce/woocommerce/pull/27299). 

[**NOTE: This FluxC PR must be merged before this PR**](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1799)

This PR adds the following: 
- Enables the "delete" button on the product image viewer for product variations
- Adds special handling for the new `woocommerce_variation_invalid_image_id` to display a descriptive error message (like iOS): "Sorry, image removal on product variations is supported in WooCommerce 4.7 or greater". 

Caveats:
- Once the variation image is deleted successfully, the variation will display whatever the parent product image is. This is a limit of the API at the moment. 

<img src="https://user-images.githubusercontent.com/5810477/101817425-5f474380-3af0-11eb-9fa0-bc9895fe76eb.png" width="320"/>


## Testing
For testing purposes, I suggest installing on your testing website the plugin [WooCommerce Beta Tester](https://wordpress.org/plugins/woocommerce-beta-tester/) that allow you to switch easily between different versions of WooCommerce.

#### Case 1
1. Configure your website using WooCommerce <=4.6.
2. Run the app, and open a Product Variation with an image.
3. Open that image, and remove it, then update the product variation -> You should get an alert that suggests you to update your website to WooCommerce 4.7 or greater.

#### Case 2
1. Configure your website using WooCommerce 4.7 or greater.
2. Run the app, and open a Product Variation with an image.
3. Open that image, and remove it, then update the product variation -> the image should be removed correctly, with no errors. **Note**: if the parent product has an image, the product variation image will be set to the one used by the parent product. This is due to another bug (?), [discussed here](https://a8c.slack.com/archives/CGPNUU63E/p1605526543184500).

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
