### PR TITLE
Fix dialog result-handling

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 5.7
 -----
+* [*] Fixed a bug where a selection made in a dialog was ignored (for example the shipping labels reprint paper size)
 * [*] Minor style tweaks to the login screens
 * [*] Show fees in the payment details of orders [https://github.com/woocommerce/woocommerce-android/pull/3228]
 * [*] Added support for passwordless logins [https://github.com/woocommerce/woocommerce-android/pull/3268]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -3,6 +3,9 @@ package com.woocommerce.android.extensions
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.base.TopLevelFragment
+import com.woocommerce.android.ui.products.ProductDetailFragment
 
 /**
  * A helper function that sets the submitted key-value pair in the Fragment's SavedStateHandle. The value can be
@@ -49,4 +52,36 @@ fun <T> Fragment.handleResult(key: String, entryId: Int? = null, handler: (T) ->
             }
         )
     }
+}
+
+/**
+ * A helper function that subscribes a supplied handler function to the Fragment's SavedStateHandle LiveData associated
+ * with the supplied key. This method *must* be used for handling results from dialogs because the entry ID is required.
+ *
+ * @param [key] A unique string that is the same as the one used in [navigateBackWithResult]
+ * @param [entryId] A mandatory ID to identify the correct back stack entry. It's required when calling [handleResult]
+ *  from TopLevelFragment or Dialog (otherwise the result will get lost upon configuration change)
+ * @param [handler] A result handler
+ *
+ * Note: The handler is called only if the value wasn't handled before (i.e. the data is fresh). Once the observer is
+ * called, the boolean value is updated. This puts a limit on the number of observers for a particular key-result pair
+ * to 1.
+ */
+fun <T> Fragment.handleDialogResult(key: String, entryId: Int, handler: (T) -> Unit) {
+    handleResult(key, entryId, handler)
+}
+
+/**
+ * A helper function that subscribes a supplied handler function to the [TopLevelFragment]'s SavedStateHandle LiveData
+ * associated with the supplied key. The `rootFragment` entry ID must be used to deliver the result.
+ *
+ * @param [key] A unique string that is the same as the one used in [navigateBackWithResult]
+ * @param [handler] A result handler
+ *
+ * Note: The handler is called only if the value wasn't handled before (i.e. the data is fresh). Once the observer is
+ * called, the boolean value is updated. This puts a limit on the number of observers for a particular key-result pair
+ * to 1.
+ */
+fun <T> TopLevelFragment.handleResult(key: String, handler: (T) -> Unit) {
+    (this as Fragment).handleResult(key, entryId = R.id.rootFragment, handler = handler)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -39,11 +39,13 @@ fun <T> Fragment.handleResult(key: String, entryId: Int? = null, handler: (T) ->
     }
 
     entry?.savedStateHandle?.let { saveState ->
-        saveState.getLiveData<T>(key).observe(
+        saveState.getLiveData<T?>(key).observe(
             this.viewLifecycleOwner,
             Observer {
-                saveState.remove<T>(key)
-                handler(it)
+                it?.let {
+                    handler(it)
+                    saveState.set(key, null)
+                }
             }
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.TopLevelFragment
-import com.woocommerce.android.ui.products.ProductDetailFragment
 
 /**
  * A helper function that sets the submitted key-value pair in the Fragment's SavedStateHandle. The value can be

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -38,7 +38,7 @@ fun <T> Fragment.handleResult(key: String, entryId: Int? = null, handler: (T) ->
         findNavController().currentBackStackEntry
     }
 
-    findNavController().currentBackStackEntry?.savedStateHandle?.let { saveState ->
+    entry?.savedStateHandle?.let { saveState ->
         saveState.getLiveData<T>(key).observe(
             this.viewLifecycleOwner,
             Observer {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.FEATURE_FEEDBACK_BANNER
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_DETAIL_PRODUCT_TAPPED
+import com.woocommerce.android.extensions.handleDialogResult
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateSafely
@@ -191,7 +192,7 @@ class OrderDetailFragment : BaseFragment(), NavigationResult, OrderProductAction
     }
 
     private fun setupResultHandlers(viewModel: OrderDetailViewModel) {
-        handleResult<String>(OrderStatusSelectorDialog.KEY_ORDER_STATUS_RESULT) {
+        handleDialogResult<String>(OrderStatusSelectorDialog.KEY_ORDER_STATUS_RESULT, R.id.orderDetailFragment) {
             viewModel.onOrderStatusChanged(it)
         }
         handleResult<OrderNote>(AddOrderNoteFragment.KEY_ADD_NOTE_RESULT) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelFragment.kt
@@ -11,6 +11,7 @@ import androidx.core.content.FileProvider
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.handleDialogResult
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
@@ -80,7 +81,7 @@ class PrintShippingLabelFragment : BaseFragment() {
     }
 
     private fun setupResultHandlers(viewModel: PrintShippingLabelViewModel) {
-        handleResult<ShippingLabelPaperSize>(
+        handleDialogResult<ShippingLabelPaperSize>(
             ShippingLabelPaperSizeSelectorDialog.KEY_PAPER_SIZE_RESULT,
             R.id.printShippingLabelFragment
         ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelFragment.kt
@@ -12,7 +12,6 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.handleDialogResult
-import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -344,7 +344,7 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
     }
 
     private fun setupResultHandlers() {
-        handleResult<Bundle>(ProductDetailFragment.KEY_PRODUCT_DETAIL_RESULT, R.id.rootFragment) { bundle ->
+        handleResult<Bundle>(ProductDetailFragment.KEY_PRODUCT_DETAIL_RESULT) { bundle ->
             if (bundle.getBoolean(ProductDetailFragment.KEY_PRODUCT_DETAIL_DID_TRASH)) {
                 // User chose to trash from product detail, but we do the actual trashing here
                 // so we can show a snackbar enabling the user to undo the trashing.


### PR DESCRIPTION
Addresses #3314. This PR fixes 2 issues:

1. The `entryId` was being ignored, which means the dialog result was being returned to the wrong fragment.
2. The `LiveData` was being removed (to prevent the result from being returned multiple times, for example after config. change), but this meant the result was observed only once. If a dialog was opened again, the result wouldn't be delivered.

I could reproduce the bugs reliably with the Reprint paper size dialog:

**To test**
1. Select a store that supports shipping labels
2. Go to Orders and select an order with an existing shipping label
3. Tap on the Reprint shipping label button
4. Tap on the Paper size spinner
5. Change the size
6. **Notice the value changed in the spinner**
8. Tap on the spinner again
9. Change the value
10. **Notice the value is updated**

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
