### PR TITLE
issue/3317-order-list-settings-menu 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -5,6 +5,7 @@ import android.app.ProgressDialog
 import android.content.Intent
 import android.content.res.Resources.Theme
 import android.os.Bundle
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
@@ -290,6 +291,16 @@ class MainActivity : AppUpgradeActivity(),
             binding.bottomNav.currentPosition = MY_STORE
         } else {
             super.onBackPressed()
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            android.R.id.home -> {
+                onBackPressed()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -5,8 +5,6 @@ import android.app.ProgressDialog
 import android.content.Intent
 import android.content.res.Resources.Theme
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
@@ -66,7 +64,6 @@ import dagger.android.AndroidInjection
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
-import kotlinx.android.synthetic.main.activity_main.*
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.login.LoginAnalyticsListener
@@ -231,22 +228,6 @@ class MainActivity : AppUpgradeActivity(),
     override fun showProgressDialog(@StringRes stringId: Int) {
         hideProgressDialog()
         progressDialog = ProgressDialog.show(this, "", getString(stringId), true)
-    }
-
-    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
-        // don't show the options menu unless we're at the root
-        if (isAtNavigationRoot()) {
-            menuInflater.inflate(R.menu.menu_action_bar, menu)
-            return true
-        } else {
-            return false
-        }
-    }
-
-    override fun onPrepareOptionsMenu(menu: Menu?): Boolean {
-        // settings icon only appears on the dashboard
-        menu?.findItem(R.id.menu_settings)?.isVisible = binding.bottomNav.currentPosition == MY_STORE
-        return super.onPrepareOptionsMenu(menu)
     }
 
     override fun onResume() {
@@ -517,23 +498,6 @@ class MainActivity : AppUpgradeActivity(),
         return (isDialogDestination && activeChildIsRoot) || isAtRoot
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            // User clicked the "up" button in the action bar
-            android.R.id.home -> {
-                onBackPressed()
-                true
-            }
-            // User selected the settings menu option
-            R.id.menu_settings -> {
-                showSettingsScreen()
-                AnalyticsTracker.track(Stat.MAIN_MENU_SETTINGS_TAPPED)
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
-        }
-    }
-
     override fun androidInjector(): AndroidInjector<Any> = androidInjector
 
     public override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -584,6 +548,7 @@ class MainActivity : AppUpgradeActivity(),
     }
 
     override fun showSettingsScreen() {
+        AnalyticsTracker.track(Stat.MAIN_MENU_SETTINGS_TAPPED)
         val intent = Intent(this, AppSettingsActivity::class.java)
         startActivityForResult(intent, RequestCodes.SETTINGS)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainContract.kt
@@ -23,7 +23,6 @@ interface MainContract {
         fun showLoginScreen()
         fun showSitePickerScreen()
         fun updateSelectedSite()
-        fun showSettingsScreen()
         fun updateOfflineStatusBar(isConnected: Boolean)
         fun hideBottomNav()
         fun showBottomNav()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
@@ -22,4 +22,5 @@ interface MainNavigationRouter {
     fun showProductFilters(stockStatus: String?, productType: String?, productStatus: String?)
     fun showFeedbackSurvey()
     fun showProductAddBottomSheet()
+    fun showSettingsScreen()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -2,6 +2,9 @@ package com.woocommerce.android.ui.mystore
 
 import android.content.Context
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup.LayoutParams
 import androidx.core.view.children
@@ -98,6 +101,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store),
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setHasOptionsMenu(true)
 
         _binding = FragmentMyStoreBinding.bind(view)
 
@@ -223,6 +227,21 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store),
         presenter.dropView()
         super.onDestroyView()
         _binding = null
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        inflater.inflate(R.menu.menu_action_bar, menu)
+        super.onCreateOptionsMenu(menu, inflater)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.menu_settings -> {
+                (activity as? MainNavigationRouter)?.showSettingsScreen()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {


### PR DESCRIPTION
Fixes #3317 by moving the settings menu from the main activity to the My Store fragment. To test:

- Go to the order list
- Tap the search icon
- Tap the back button
- Verify that the settings icon doesn't appear above the order list

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
