### PR TITLE
issue/3322-scroll-to-top-expand-toolbar

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -703,6 +703,7 @@ class MainActivity : AppUpgradeActivity(),
         // if we're at the root scroll the active fragment to the top, otherwise clear the nav backstack
         if (isAtNavigationRoot()) {
             getActiveTopLevelFragment()?.scrollToTop()
+            expandToolbar(expand = true, animate = true)
         } else {
             navigateToRoot()
         }


### PR DESCRIPTION
Fixes #3322 - to test:

- Scroll down each of the top level fragments
- Tap the nav bar button for each fragment
- Ensure the view scrolls to the top and the main toolbar expands

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
