### PR TITLE
Product Attributes: Use the correct hex for interpunct

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
@@ -41,7 +41,7 @@ class OrderDetailProductItemView @JvmOverloads constructor(
         productInfo_name.maxLines = maxLinesInName
 
         val productPrice = formatCurrencyForDisplay(item.price)
-        val attributes = item.attributesList.takeIf { it.isNotEmpty() }?.let { "$it \u00B7 " } ?: StringUtils.EMPTY
+        val attributes = item.attributesList.takeIf { it.isNotEmpty() }?.let { "$it \u2981 " } ?: StringUtils.EMPTY
 
         productInfo_attributes.text = context.getString(
             R.string.orderdetail_product_lineitem_attributes,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
@@ -41,7 +41,7 @@ class OrderDetailProductItemView @JvmOverloads constructor(
         productInfo_name.maxLines = maxLinesInName
 
         val productPrice = formatCurrencyForDisplay(item.price)
-        val attributes = item.attributesList.takeIf { it.isNotEmpty() }?.let { "$it \u25CF " } ?: StringUtils.EMPTY
+        val attributes = item.attributesList.takeIf { it.isNotEmpty() }?.let { "$it \u00B7 " } ?: StringUtils.EMPTY
 
         productInfo_attributes.text = context.getString(
             R.string.orderdetail_product_lineitem_attributes,


### PR DESCRIPTION
Closes #3145. Updates the hex code for the interpunct used to separate the order product attributes from quanity. 

Before | After
-- | --
![Screenshot_1607977973](https://user-images.githubusercontent.com/5810477/102132638-d860d680-3e21-11eb-92bb-772028769a01.png)|![Screenshot_1607977922](https://user-images.githubusercontent.com/5810477/102132640-da2a9a00-3e21-11eb-8bd6-899f45fd7bca.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
