### PR TITLE
Order details loading refactor

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,6 +13,7 @@
 ----
 * [****] We've updated the UI to a crisper, cleaner design [https://github.com/woocommerce/woocommerce-android/pull/3136]
 * Fixed an issue with unexpected shipment tracking UI in order details
+* Fixed an issue with caching and loading of order details
 
 5.5
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ViewExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ViewExt.kt
@@ -7,6 +7,7 @@ import android.view.animation.Animation
 import android.view.animation.Transformation
 import android.widget.LinearLayout.LayoutParams
 import android.view.View.MeasureSpec
+import androidx.core.view.isVisible
 
 fun View.show() {
     this.visibility = View.VISIBLE
@@ -17,52 +18,58 @@ fun View.hide() {
 }
 
 fun View.expand() {
-    this.visibility = View.VISIBLE
-    this.measure(MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
-            MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED))
-    val targetHeight = this.measuredHeight
-    val view = this
+    if (!this.isVisible) {
+        this.visibility = View.VISIBLE
+        this.measure(
+            MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+            MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED)
+        )
+        val targetHeight = this.measuredHeight
+        val view = this
 
-    this.layoutParams.height = 1
-    val a = object : Animation() {
-        override fun applyTransformation(interpolatedTime: Float, t: Transformation) {
-            view.layoutParams.height = if (interpolatedTime == 1f)
-                LayoutParams.WRAP_CONTENT
-            else
-                (targetHeight * interpolatedTime).toInt()
-            view.requestLayout()
-        }
-
-        override fun willChangeBounds(): Boolean {
-            return true
-        }
-    }
-
-    a.duration = 300
-    this.startAnimation(a)
-}
-
-fun View.collapse() {
-    val initialHeight = this.measuredHeight
-    val view = this
-
-    val a = object : Animation() {
-        override fun applyTransformation(interpolatedTime: Float, t: Transformation) {
-            if (interpolatedTime == 1f) {
-                view.visibility = View.GONE
-            } else {
-                view.layoutParams.height = initialHeight - (initialHeight * interpolatedTime).toInt()
+        this.layoutParams.height = 1
+        val a = object : Animation() {
+            override fun applyTransformation(interpolatedTime: Float, t: Transformation) {
+                view.layoutParams.height = if (interpolatedTime == 1f)
+                    LayoutParams.WRAP_CONTENT
+                else
+                    (targetHeight * interpolatedTime).toInt()
                 view.requestLayout()
+            }
+
+            override fun willChangeBounds(): Boolean {
+                return true
             }
         }
 
-        override fun willChangeBounds(): Boolean {
-            return true
-        }
+        a.duration = 300
+        this.startAnimation(a)
     }
+}
 
-    a.duration = 300
-    this.startAnimation(a)
+fun View.collapse() {
+    if (this.isVisible) {
+        val initialHeight = this.measuredHeight
+        val view = this
+
+        val a = object : Animation() {
+            override fun applyTransformation(interpolatedTime: Float, t: Transformation) {
+                if (interpolatedTime == 1f) {
+                    view.visibility = View.GONE
+                } else {
+                    view.layoutParams.height = initialHeight - (initialHeight * interpolatedTime).toInt()
+                    view.requestLayout()
+                }
+            }
+
+            override fun willChangeBounds(): Boolean {
+                return true
+            }
+        }
+
+        a.duration = 300
+        this.startAnimation(a)
+    }
 }
 
 fun View.expandHitArea(horizontal: Int, vertical: Int) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -151,9 +151,6 @@ class OrderDetailFragment : BaseFragment(), NavigationResult, OrderProductAction
             }
             new.toolbarTitle?.takeIfNotEqualTo(old?.toolbarTitle) { screenTitle = it }
             new.isOrderDetailSkeletonShown?.takeIfNotEqualTo(old?.isOrderDetailSkeletonShown) { showSkeleton(it) }
-            new.isOrderNotesSkeletonShown?.takeIfNotEqualTo(old?.isOrderNotesSkeletonShown) {
-                showOrderNotesSkeleton(it)
-            }
             new.isShipmentTrackingAvailable?.takeIfNotEqualTo(old?.isShipmentTrackingAvailable) {
                 showAddShipmentTracking(it)
             }
@@ -243,10 +240,6 @@ class OrderDetailFragment : BaseFragment(), NavigationResult, OrderProductAction
             true -> skeletonView.show(orderDetail_container, R.layout.skeleton_order_detail, delayed = true)
             false -> skeletonView.hide()
         }
-    }
-
-    private fun showOrderNotesSkeleton(show: Boolean) {
-        orderDetail_noteList.showSkeleton(show)
     }
 
     private fun refreshProduct(remoteProductId: Long) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -131,7 +131,7 @@ class OrderDetailFragment : BaseFragment(), NavigationResult, OrderProductAction
     }
 
     private fun setupObservers(viewModel: OrderDetailViewModel) {
-        viewModel.orderDetailViewStateData.observe(viewLifecycleOwner) { old, new ->
+        viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
             new.order?.takeIfNotEqualTo(old?.order) { showOrderDetail(it) }
             new.orderStatus?.takeIfNotEqualTo(old?.orderStatus) { showOrderStatus(it) }
             new.isMarkOrderCompleteButtonVisible?.takeIfNotEqualTo(old?.isMarkOrderCompleteButtonVisible) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -458,7 +458,7 @@ class OrderDetailViewModel @AssistedInject constructor(
         orderDetailRepository.getOrderShippingLabels(orderIdSet.remoteOrderId)
             .loadProducts(order.items)
             .whenNotNullNorEmpty {
-               return ListInfo(list = it)
+                return ListInfo(list = it)
             }
         return ListInfo(isVisible = false)
     }
@@ -520,7 +520,6 @@ class OrderDetailViewModel @AssistedInject constructor(
         val toolbarTitle: String? = null,
         val orderStatus: OrderStatus? = null,
         val isOrderDetailSkeletonShown: Boolean? = null,
-        val isOrderNotesSkeletonShown: Boolean? = null,
         val isRefreshing: Boolean? = null,
         val isShipmentTrackingAvailable: Boolean? = null,
         val refreshedProductId: Long? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -127,15 +127,21 @@ class OrderDetailViewModel @AssistedInject constructor(
                 orderInDb?.let {
                     order = orderInDb
                     displayOrderDetails()
+                    fetchAndDisplayOrderDetails()
                 }
             }
         }
     }
 
+    private suspend fun fetchAndDisplayOrderDetails() {
+        fetchOrderNotes()
+        fetchProductAndShippingDetails()
+        displayOrderDetails()
+    }
+
     private fun displayOrderDetails() {
         updateOrderState()
         loadOrderNotes()
-
         displayProductAndShippingDetails()
     }
 
@@ -147,9 +153,7 @@ class OrderDetailViewModel @AssistedInject constructor(
             val fetchedOrder = orderDetailRepository.fetchOrder(navArgs.orderId)
             if (fetchedOrder != null) {
                 order = fetchedOrder
-
-                fetchProductAndShippingDetails()
-                displayOrderDetails()
+                fetchAndDisplayOrderDetails()
             } else {
                 triggerEvent(ShowSnackbar(string.order_error_fetch_generic))
             }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -149,7 +149,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         doReturn(mixedProducts).whenever(repository).getProductsByRemoteIds(any())
 
         var orderData: ViewState? = null
-        viewModel.orderDetailViewStateData.observeForever { _, new -> orderData = new }
+        viewModel.viewStateData.observeForever { _, new -> orderData = new }
 
         // order notes
         val orderNotes = ArrayList<OrderNote>()
@@ -324,7 +324,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             }
 
             var areProductsVisible: Boolean? = null
-            viewModel.orderDetailViewStateData.observeForever { _, new ->
+            viewModel.viewStateData.observeForever { _, new ->
                 areProductsVisible = new.isProductListVisible
             }
 
@@ -357,7 +357,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             }
 
             var areProductsVisible: Boolean? = null
-            viewModel.orderDetailViewStateData.observeForever { _, new ->
+            viewModel.viewStateData.observeForever { _, new ->
                 areProductsVisible = new.isProductListVisible
             }
 
@@ -385,7 +385,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(orderShippingLabels).whenever(repository).getOrderShippingLabels(any())
 
             var orderData: ViewState? = null
-            viewModel.orderDetailViewStateData.observeForever { _, new -> orderData = new }
+            viewModel.viewStateData.observeForever { _, new -> orderData = new }
 
             val shippingLabels = ArrayList<ShippingLabel>()
             viewModel.shippingLabels.observeForever {
@@ -421,7 +421,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(null).whenever(repository).getOrder(any())
 
             val isSkeletonShown = ArrayList<Boolean>()
-            viewModel.orderDetailViewStateData.observeForever { old, new ->
+            viewModel.viewStateData.observeForever { old, new ->
                 new.isOrderDetailSkeletonShown?.takeIfNotEqualTo(old?.isOrderDetailSkeletonShown) {
                     isSkeletonShown.add(it)
                 }
@@ -475,7 +475,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         }
 
         val orderStatusList = ArrayList<OrderStatus>()
-        viewModel.orderDetailViewStateData.observeForever { old, new ->
+        viewModel.viewStateData.observeForever { old, new ->
             new.orderStatus?.takeIfNotEqualTo(old?.orderStatus) { orderStatusList.add(it) }
         }
 
@@ -517,7 +517,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         doReturn(emptyList<ShippingLabel>()).whenever(repository).fetchOrderShippingLabels(any())
 
         var newOrder: Order? = null
-        viewModel.orderDetailViewStateData.observeForever { old, new ->
+        viewModel.viewStateData.observeForever { old, new ->
             new.order?.takeIfNotEqualTo(old?.order) { newOrder = it }
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -153,13 +153,19 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         // order notes
         val orderNotes = ArrayList<OrderNote>()
         viewModel.orderNotes.observeForever {
-            it?.let { orderNotes.addAll(it) }
+            it?.let {
+                orderNotes.clear()
+                orderNotes.addAll(it)
+            }
         }
 
         // order shipment Trackings
         val shipmentTrackings = ArrayList<OrderShipmentTracking>()
         viewModel.shipmentTrackings.observeForever {
-            it?.let { shipmentTrackings.addAll(it) }
+            it?.let {
+                shipmentTrackings.clear()
+                shipmentTrackings.addAll(it)
+            }
         }
 
         // product list should not be empty when shipping labels are not available and products are not refunded

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -82,7 +82,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     private val orderWithParameters = ViewState(
         order = order,
         isRefreshing = false,
-        isOrderNotesSkeletonShown = false,
         isOrderDetailSkeletonShown = false,
         toolbarTitle = resources.getString(string.orderdetail_orderstatus_ordernum, order.number),
         isShipmentTrackingAvailable = true,


### PR DESCRIPTION
This PR fixes a couple of issues: #3318 & #3313. 

The main change is in the way data is loaded and displayed. Before, some UI elements were updated by multiple sources, which resulted in views reshuffling and hiding/showing. Also some of the data wasn't cached and the UI kept changing each time an order was opened. Now all the related data (shipping labels, shipment tracking, products & refunds) is loaded first and based on that data the UI elements are displayed.

**To test:**
1. Go to Orders
2. Tap on an any order detail
3. If the order was opened for the first time, the skeleton is shown, otherwise the details are shown immediately (data is refreshed, so a single update to the UI is expected)
4. After loading is done, the most up-to-date details are displayed
5. Verify the notes are loaded
6. Pull to refresh and notice nothing changes (everything should be fresh)
7. Go back to the list
8. Open the same order again
9. Notice that the cached data is opened and there is no update to the UI
10. Pull to refresh and notice nothing changes (everything should be fresh)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
