### PR TITLE
Login: Fix backstack when jumping back to the Prologue screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -112,7 +112,7 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
         val fragment = LoginPrologueFragment.newInstance()
         supportFragmentManager.beginTransaction()
             .replace(R.id.fragment_container, fragment, LoginPrologueFragment.TAG)
-            .addToBackStack(null)
+            .addToBackStack(LoginPrologueFragment.TAG)
             .commitAllowingStateLoss()
     }
 
@@ -206,7 +206,8 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
         // Clear logged in url from AppPrefs
         AppPrefs.removeLoginSiteAddress()
 
-        showPrologueFragment()
+        // Pop all the fragments from the backstack until we get to the Prologue fragment
+        supportFragmentManager.popBackStack(LoginPrologueFragment.TAG, 0)
     }
 
     override fun onPrimaryButtonClicked() {


### PR DESCRIPTION
I noticed while testing changes in another PR that clicking "Log in with another" account from an error screen during the login process would correctly jump back to the Prologue screen, but he backstack was remaining intact. Clicking back would cycle back to the error screen. When on the prologue, clicking back should close/minimize the app. This PR fixes this by properly clearing the backstack.

Before | After
-- | --
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/5810477/102408442-9370a780-3fbb-11eb-864e-3e8050ee420b.gif)|![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/5810477/102408446-94a1d480-3fbb-11eb-8cb7-12881adb993c.gif)

### To Test
1. Start the login process
2. Tap **Enter store address**
3. Enter the address **testnojetpack.mystagingwebsite.com**, tap **Continue**
4. On the "Jetpack required" screen, tap **Log in with another account** - the Welcome/Prologue screen appears. 
5. Tap **back** on the device. The app should minimize/close.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
