### PR TITLE
Betafix: Add back the orderRefreshLayout PTR handling.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -161,6 +161,14 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
         _binding = FragmentOrderListBinding.bind(view)
         binding.orderListView.init(currencyFormatter = currencyFormatter, orderListListener = this)
         binding.orderStatusListView.init(listener = this)
+        binding.orderRefreshLayout?.apply {
+            // Set the scrolling view in the custom refresh SwipeRefreshLayout
+            scrollUpChild = binding.orderListView.ordersList
+            setOnRefreshListener {
+                AnalyticsTracker.track(Stat.ORDERS_LIST_PULLED_TO_REFRESH)
+                refreshOrders()
+            }
+        }
 
         initializeViewModel()
         initializeTabs()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -161,7 +161,7 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
         _binding = FragmentOrderListBinding.bind(view)
         binding.orderListView.init(currencyFormatter = currencyFormatter, orderListListener = this)
         binding.orderStatusListView.init(listener = this)
-        binding.orderRefreshLayout?.apply {
+        binding.orderRefreshLayout.apply {
             // Set the scrolling view in the custom refresh SwipeRefreshLayout
             scrollUpChild = binding.orderListView.ordersList
             setOnRefreshListener {


### PR DESCRIPTION
Fixes #3335. Adds back the `scrollUpChild` and `setOnRefreshListener` logic for the `orderRefreshLayout`. This logic was accidentally removed in this PR. **This PR merges into the current beta 5.7.**

cc: @AliSoftware -- will require a new beta cut



### To Test
- Scroll down the orders list a few pages and then scroll back to the top. Verify successful. 
- Open Flipper. Initiate a PTR on the orders list. Verify request is sent over the network. Verify the "refreshing" animation disappears when complete. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
