### PR TITLE
Order details crash fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -33,6 +33,7 @@ import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
+import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.model.order.toIdSet
 import org.wordpress.android.fluxc.store.WCOrderStore
@@ -264,8 +265,13 @@ class OrderDetailRepository @Inject constructor(
     suspend fun fetchProductsByRemoteIds(remoteIds: List<Long>) =
         productStore.fetchProductListSynced(selectedSite.get(), remoteIds)?.map { it.toAppModel() } ?: emptyList()
 
-    fun getProductsByRemoteIds(remoteIds: List<Long>) =
-        productStore.getProductsByRemoteIds(selectedSite.get(), remoteIds)
+    fun getProductsByRemoteIds(remoteIds: List<Long>): List<WCProductModel> {
+        return if (remoteIds.isNotEmpty()) {
+            productStore.getProductsByRemoteIds(selectedSite.get(), remoteIds)
+        } else {
+            emptyList()
+        }
+    }
 
     fun getOrderRefunds(remoteOrderId: Long) = refundStore
         .getAllRefunds(selectedSite.get(), remoteOrderId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -75,8 +75,11 @@ class OrderDetailViewModel @AssistedInject constructor(
     private val orderIdSet: OrderIdSet
         get() = navArgs.orderId.toIdSet()
 
-    final lateinit var order: Order
-        private set
+    final var order: Order
+        get() = requireNotNull(viewState.order)
+        set(value) {
+            viewState = viewState.copy(order = value)
+        }
 
     // Keep track of the deleted shipment tracking number in case
     // the request to server fails, we need to display an error message
@@ -340,7 +343,6 @@ class OrderDetailViewModel @AssistedInject constructor(
             launch {
                 if (orderDetailRepository.updateOrderStatus(orderIdSet.id, orderIdSet.remoteOrderId, newStatus)) {
                     order = order.copy(status = CoreOrderStatus.fromValue(newStatus) ?: order.status)
-                    viewState = viewState.copy(order = order)
                 } else {
                     onOrderStatusChangeReverted()
                     triggerEvent(ShowSnackbar(string.order_error_update_general))

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -292,7 +292,7 @@
     <string name="order_fulfill_mark_complete">Mark Order Complete</string>
     <string name="order_fulfill_marked_complete">Order Marked Complete</string>
     <string name="order_status_changed_to">Order status changed to %s</string>
-    <string name="order_error_fetch_notes_generic">Error fetching error notes</string>
+    <string name="order_error_fetch_notes_generic">Error fetching notes</string>
     <string name="order_error_update_general">Error changing order</string>
     <string name="order_error_fetch_generic">Error fetching order</string>
     <string name="order_shipment_tracking">Tracking</string>


### PR DESCRIPTION
Fixes #3338 and #3332.

**To test:**
1. Manually create an empty order without any products
2. Enable _Do not keep activities_
3. Open the order in the app
4. Put the app in the background and open it again
5. Notice the app doesn't crash
6. Notice that no order notes error is displayed