### PR TITLE
Merge hotfix/5.6.1 AND hotfix/5.6.2 into develop

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -48,9 +48,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "5.6.1"
+            versionName "5.6.2"
         }
-        versionCode 181
+        versionCode 182
 
         minSdkVersion 21
         targetSdkVersion 30

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -48,9 +48,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "5.6"
+            versionName "5.6.1"
         }
-        versionCode 179
+        versionCode 181
 
         minSdkVersion 21
         targetSdkVersion 30

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.6.27'
+    fluxCVersion = '1.6.27.1'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.6.27.1'
+    fluxCVersion = '1.6.27.2'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
We failed to merge the FluxC 1.6.26.1 hotfix into develop back in the day which means that 1.6.26.1 hotfix was never included in 1.6.27.

We since [released FluxC 1.6.27.1](https://github.com/wordpress-mobile/WordPress-FluxC-Android/releases/tag/1.6.27.1) which adds the FluxC 1.6.26.1 hotfix on top of FluxC 1.6.27, then released WC 5.6.1 hotfix to include that FluxC new hotfix.

But we later realized that FluxC 1.6.26.1 was incorrect and included more than it should have. So we ended up releasing another fix FluxC 1.6.26.2 superseding 1.6.26.1. But WC 5.6.1 was already live in PlayStore by the time we had time to reject it. So we ended up having to do a 5.6.2 already.

---

This PR merges both WC hotfix/5.6.1 and hotfix/5.6.2 back into develop – fixing a conflict using an intermediate branch – to bring everything back in sync.

In practice, its diff keeps the `versionName` of `5.7-rc-1` from `develop` – so that the next beta correctly bumps to 5.7-rc-2 later – but gets the `versionCode 182` from the hotfix 5.6.2 branch to ensure it has the latest build number to increment from for the next build up.