### PR TITLE
Merge hotfix/5.6.1 to trunk (include FluxC's 1.6.27.1's own hotfix)

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -48,9 +48,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "5.6"
+            versionName "5.6.1"
         }
-        versionCode 179
+        versionCode 181
 
         minSdkVersion 21
         targetSdkVersion 30

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.6.27'
+    fluxCVersion = '1.6.27.1'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
We failed to merge the FluxC 1.6.26.1 hotfix into develop back in the day which means that 1.6.26.1 hotfix was never included in 1.6.27.

We since [released FluxC 1.6.27.1](https://github.com/wordpress-mobile/WordPress-FluxC-Android/releases/tag/1.6.27.1) which adds the FluxC 1.6.26.1 hotfix on top of FluxC 1.6.27, I've then done a WC 5.6.1 hotfix to include that FluxC new hotfix in it.

---

This PR merges that WC `hotfix/5.6.1` back into `trunk` to bring everything back in sync.