### PR TITLE
Merge hotfix/5.6.2 into trunk

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -48,9 +48,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "5.6.1"
+            versionName "5.6.2"
         }
-        versionCode 181
+        versionCode 182
 
         minSdkVersion 21
         targetSdkVersion 30

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -48,9 +48,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "5.6"
+            versionName "5.6.1"
         }
-        versionCode 179
+        versionCode 181
 
         minSdkVersion 21
         targetSdkVersion 30

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.6.27'
+    fluxCVersion = '1.6.27.1'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.6.27.1'
+    fluxCVersion = '1.6.27.2'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
FluxC 1.6.27.1 (that 5.6.1 was using) was a bad batch and was done incorrectly. FluxC 1.6.27.2 should fix it and make things right again.

WC 5.6.1 was already released to the PlayStore when we realized it, so 5.6.2 is a new hotfix with the correct FluxC 1.6.27.2.