### PR TITLE
Merge release/5.7 into develop after new beta + Release Notes update

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -48,9 +48,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "5.7-rc-1"
+            versionName "5.7-rc-2"
         }
-        versionCode 180
+        versionCode 181
 
         minSdkVersion 21
         targetSdkVersion 30

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -50,7 +50,7 @@ android {
         } else {
             versionName "5.7-rc-2"
         }
-        versionCode 181
+        versionCode 183
 
         minSdkVersion 21
         targetSdkVersion 30

--- a/WooCommerce/metadata/PlayStoreStrings.pot
+++ b/WooCommerce/metadata/PlayStoreStrings.pot
@@ -11,19 +11,23 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_057"
+msgid ""
+"5.7:\n"
+"- Remove images from product variations!\n"
+"- The app can open the email client on Android 11 during the magic link login process.\n"
+"- Bug fixes: variable products display when shipping labels are purchased; selections made in a dialog are honored.\n"
+"- Fees display on order payment details.\n"
+"- Passwordless logins supported.\n"
+"- Minor style improvements to the login screens.\n"
+msgstr ""
+
 msgctxt "release_note_056"
 msgid ""
 "5.6:\n"
 "You asked, and we listened! You can now create simple, grouped, and external products for your store directly from your favorite Android mobile devices. Turn your ideas into products, even when you’re away from your computer.\n"
 "\n"
 "We’ve also updated our UI to a crisper, cleaner design, and we fixed a bug in order details that will make shipment tracking a breeze.\n"
-msgstr ""
-
-msgctxt "release_note_055"
-msgid ""
-"5.5:\n"
-"You asked, and we listened! Now you can create simple, grouped, and external products directly from your favorite Android mobile devices. Turn ideas into products – even when you’re away from your desktop.\n"
-"Other fixes: We fixed a bug affecting product variation names when the variation option was “open,” and a typo on the shipping label screen.\n"
 msgstr ""
 
 #. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,8 +1,6 @@
-* [*] Fixed a bug where a selection made in a dialog was ignored (for example the shipping labels reprint paper size)
-* [*] Minor style tweaks to the login screens
-* [*] Show fees in the payment details of orders [https://github.com/woocommerce/woocommerce-android/pull/3228]
-* [*] Added support for passwordless logins [https://github.com/woocommerce/woocommerce-android/pull/3268]
-* [*] Fixed a bug where variable products was not displayed when shipping labels were purchased for an order. [https://github.com/woocommerce/woocommerce-android/pull/3283]
-* [**] Fixed an issue where the app could not open the email client on Android 11 during the magic link login process. [https://github.com/woocommerce/woocommerce-android/pull/3291]
-* [***] Now it's possible to remove an image from a Product Variation if the WC version 4.7+. [https://github.com/woocommerce/woocommerce-android/pull/3312]
-
+- Remove images from product variations!
+- The app can open the email client on Android 11 during the magic link login process.
+- Bug fixes: variable products display when shipping labels are purchased; selections made in a dialog are honored.
+- Fees display on order payment details.
+- Passwordless logins supported.
+- Minor style improvements to the login screens.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -33,6 +33,7 @@ import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
+import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.model.order.toIdSet
 import org.wordpress.android.fluxc.store.WCOrderStore
@@ -264,8 +265,13 @@ class OrderDetailRepository @Inject constructor(
     suspend fun fetchProductsByRemoteIds(remoteIds: List<Long>) =
         productStore.fetchProductListSynced(selectedSite.get(), remoteIds)?.map { it.toAppModel() } ?: emptyList()
 
-    fun getProductsByRemoteIds(remoteIds: List<Long>) =
-        productStore.getProductsByRemoteIds(selectedSite.get(), remoteIds)
+    fun getProductsByRemoteIds(remoteIds: List<Long>): List<WCProductModel> {
+        return if (remoteIds.isNotEmpty()) {
+            productStore.getProductsByRemoteIds(selectedSite.get(), remoteIds)
+        } else {
+            emptyList()
+        }
+    }
 
     fun getOrderRefunds(remoteOrderId: Long) = refundStore
         .getAllRefunds(selectedSite.get(), remoteOrderId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -75,8 +75,11 @@ class OrderDetailViewModel @AssistedInject constructor(
     private val orderIdSet: OrderIdSet
         get() = navArgs.orderId.toIdSet()
 
-    final lateinit var order: Order
-        private set
+    final var order: Order
+        get() = requireNotNull(viewState.order)
+        set(value) {
+            viewState = viewState.copy(order = value)
+        }
 
     // Keep track of the deleted shipment tracking number in case
     // the request to server fails, we need to display an error message
@@ -340,7 +343,6 @@ class OrderDetailViewModel @AssistedInject constructor(
             launch {
                 if (orderDetailRepository.updateOrderStatus(orderIdSet.id, orderIdSet.remoteOrderId, newStatus)) {
                     order = order.copy(status = CoreOrderStatus.fromValue(newStatus) ?: order.status)
-                    viewState = viewState.copy(order = order)
                 } else {
                     onOrderStatusChangeReverted()
                     triggerEvent(ShowSnackbar(string.order_error_update_general))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -161,6 +161,14 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
         _binding = FragmentOrderListBinding.bind(view)
         binding.orderListView.init(currencyFormatter = currencyFormatter, orderListListener = this)
         binding.orderStatusListView.init(listener = this)
+        binding.orderRefreshLayout?.apply {
+            // Set the scrolling view in the custom refresh SwipeRefreshLayout
+            scrollUpChild = binding.orderListView.ordersList
+            setOnRefreshListener {
+                AnalyticsTracker.track(Stat.ORDERS_LIST_PULLED_TO_REFRESH)
+                refreshOrders()
+            }
+        }
 
         initializeViewModel()
         initializeTabs()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -161,7 +161,7 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
         _binding = FragmentOrderListBinding.bind(view)
         binding.orderListView.init(currencyFormatter = currencyFormatter, orderListListener = this)
         binding.orderStatusListView.init(listener = this)
-        binding.orderRefreshLayout?.apply {
+        binding.orderRefreshLayout.apply {
             // Set the scrolling view in the custom refresh SwipeRefreshLayout
             scrollUpChild = binding.orderListView.ordersList
             setOnRefreshListener {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -292,7 +292,7 @@
     <string name="order_fulfill_mark_complete">Mark Order Complete</string>
     <string name="order_fulfill_marked_complete">Order Marked Complete</string>
     <string name="order_status_changed_to">Order status changed to %s</string>
-    <string name="order_error_fetch_notes_generic">Error fetching error notes</string>
+    <string name="order_error_fetch_notes_generic">Error fetching notes</string>
     <string name="order_error_update_general">Error changing order</string>
     <string name="order_error_fetch_generic">Error fetching order</string>
     <string name="order_shipment_tracking">Tracking</string>

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.7.0'
+    fluxCVersion = '1.7.1'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
New beta 5.7-rc-2 which contains:

 - Fix #3340 for issue #3338
 - Fix #3337 for issue #3335
 - FluxC 1.7.1 hotfix – which brings back the fix for https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1781 that we failed to merge back to develop after the 1.6.26.1 hotfix

This PR also contains updates to the Release Notes with Editorial review copy.