### PR TITLE
Only show the FAB when a top level fragment is showing

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -319,7 +319,10 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
                 binding.productsSortFilterCard.setSortingTitle(getString(it))
             }
             new.isAddProductButtonVisible?.takeIfNotEqualTo(old?.isAddProductButtonVisible) { isVisible ->
-                showAddProductButton(show = isVisible)
+                showAddProductButton(
+                    show = isVisible &&
+                        (requireActivity() as? MainNavigationRouter)?.isAtNavigationRoot() == true
+                )
             }
         }
 


### PR DESCRIPTION
Fixes #3359 - This PR fixes the bug by only showing the FAB when we're at the navigation root. To test:

- Go to the product list and ensure the FAB is showing
- Go to product detail and ensure the FAB is not showing
- Rotate the device
- Ensure product detail is still not showing the FAB
- Return to the product list
- Ensure the FAB is showing again 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
