### PR TITLE
Unified Login: Fix secondary help button alignment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginJetpackRequiredFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginJetpackRequiredFragment.kt
@@ -89,7 +89,7 @@ class LoginJetpackRequiredFragment : Fragment() {
             }
         }
 
-        btn_what_is_jetpack.setOnClickListener {
+        btn_secondary_action.setOnClickListener {
             AnalyticsTracker.track(Stat.LOGIN_JETPACK_REQUIRED_WHAT_IS_JETPACK_LINK_TAPPED)
             jetpackLoginListener?.showWhatIsJetpackDialog()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -55,7 +55,7 @@ import kotlinx.android.synthetic.main.activity_site_picker.*
 import kotlinx.android.synthetic.main.fragment_login_jetpack_required.*
 import kotlinx.android.synthetic.main.view_login_epilogue_button_bar.*
 import kotlinx.android.synthetic.main.view_login_no_stores.*
-import kotlinx.android.synthetic.main.view_login_no_stores.btn_what_is_jetpack
+import kotlinx.android.synthetic.main.view_login_no_stores.btn_secondary_action
 import kotlinx.android.synthetic.main.view_login_user_info.*
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.login.LoginMode
@@ -364,7 +364,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         }
 
         no_stores_view.visibility = View.GONE
-        btn_what_is_jetpack.visibility = View.GONE
+        btn_secondary_action.visibility = View.GONE
         site_list_container.visibility = View.VISIBLE
         button_email_help.visibility = View.GONE
 
@@ -492,7 +492,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         site_list_container.visibility = View.GONE
         no_stores_view.visibility = View.VISIBLE
 
-        with(btn_what_is_jetpack) {
+        with(btn_secondary_action) {
             setOnClickListener {
                 AnalyticsTracker.track(Stat.LOGIN_JETPACK_REQUIRED_WHAT_IS_JETPACK_LINK_TAPPED)
                 LoginWhatIsJetpackDialogFragment().show(supportFragmentManager, LoginWhatIsJetpackDialogFragment.TAG)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -366,7 +366,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         no_stores_view.visibility = View.GONE
         btn_secondary_action.visibility = View.GONE
         site_list_container.visibility = View.VISIBLE
-        button_email_help.visibility = View.GONE
+        btn_secondary_action.visibility = View.GONE
 
         site_list_label.text = when {
             wcSites.size == 1 -> getString(R.string.login_connected_store)
@@ -493,6 +493,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         no_stores_view.visibility = View.VISIBLE
 
         with(btn_secondary_action) {
+            text = getString(R.string.login_jetpack_what_is)
             setOnClickListener {
                 AnalyticsTracker.track(Stat.LOGIN_JETPACK_REQUIRED_WHAT_IS_JETPACK_LINK_TAPPED)
                 LoginWhatIsJetpackDialogFragment().show(supportFragmentManager, LoginWhatIsJetpackDialogFragment.TAG)
@@ -605,16 +606,19 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         showUserInfo(centered = true)
         site_picker_root.visibility = View.VISIBLE
         no_stores_view.visibility = View.VISIBLE
-        button_email_help.visibility = View.VISIBLE
         site_list_container.visibility = View.GONE
 
         no_stores_view.text = getString(R.string.login_not_connected_to_account, url)
 
-        button_email_help.setOnClickListener {
-            AnalyticsTracker.track(Stat.SITE_PICKER_HELP_FINDING_CONNECTED_EMAIL_LINK_TAPPED)
-            unifiedLoginTracker.trackClick(Click.HELP_FINDING_CONNECTED_EMAIL)
+        with(btn_secondary_action) {
+            text = getString(R.string.login_need_help_finding_email)
+            setOnClickListener {
+                AnalyticsTracker.track(Stat.SITE_PICKER_HELP_FINDING_CONNECTED_EMAIL_LINK_TAPPED)
+                unifiedLoginTracker.trackClick(Click.HELP_FINDING_CONNECTED_EMAIL)
 
-            LoginEmailHelpDialogFragment().show(supportFragmentManager, LoginEmailHelpDialogFragment.TAG)
+                LoginEmailHelpDialogFragment().show(supportFragmentManager, LoginEmailHelpDialogFragment.TAG)
+            }
+            visibility = View.VISIBLE
         }
 
         with(button_primary) {
@@ -659,7 +663,6 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         showUserInfo(centered = true)
         site_picker_root.visibility = View.VISIBLE
         no_stores_view.visibility = View.VISIBLE
-        button_email_help.visibility = View.GONE
         site_list_container.visibility = View.GONE
 
         with(no_stores_view) {
@@ -691,6 +694,15 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
 
             setText(spannable, TextView.BufferType.SPANNABLE)
             movementMethod = LinkMovementMethod.getInstance()
+        }
+
+        with(btn_secondary_action) {
+            text = getString(R.string.login_jetpack_what_is)
+            setOnClickListener {
+                AnalyticsTracker.track(Stat.LOGIN_JETPACK_REQUIRED_WHAT_IS_JETPACK_LINK_TAPPED)
+                LoginWhatIsJetpackDialogFragment().show(supportFragmentManager, LoginWhatIsJetpackDialogFragment.TAG)
+            }
+            visibility = View.VISIBLE
         }
 
         with(button_primary) {
@@ -741,6 +753,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         site_picker_root.visibility = View.VISIBLE
         no_stores_view.visibility = View.VISIBLE
         site_list_container.visibility = View.GONE
+        btn_secondary_action.visibility = View.GONE
 
         with(no_stores_view) {
             // Build and configure the error message and make part of the message

--- a/WooCommerce/src/main/res/layout-land/fragment_login_jetpack_required.xml
+++ b/WooCommerce/src/main/res/layout-land/fragment_login_jetpack_required.xml
@@ -40,7 +40,7 @@
                 app:layout_constraintVertical_bias="0.50" />
 
             <com.google.android.material.button.MaterialButton
-                android:id="@+id/btn_what_is_jetpack"
+                android:id="@+id/btn_secondary_action"
                 style="@style/Woo.Button"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/layout-land/view_login_no_stores.xml
+++ b/WooCommerce/src/main/res/layout-land/view_login_no_stores.xml
@@ -30,13 +30,14 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_secondary_action"
-        style="@style/Woo.Button"
+        style="@style/Woo.Button.Secondary"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/major_100"
-        android:layout_marginStart="@dimen/major_300"
-        android:layout_marginEnd="@dimen/major_300"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginEnd="@dimen/major_100"
         android:text="@string/login_jetpack_what_is"
         android:textAllCaps="false"
+        android:textAlignment="center"
         android:visibility="gone" />
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout-land/view_login_no_stores.xml
+++ b/WooCommerce/src/main/res/layout-land/view_login_no_stores.xml
@@ -29,7 +29,7 @@
         tools:visibility="visible"/>
 
     <com.google.android.material.button.MaterialButton
-        android:id="@+id/btn_what_is_jetpack"
+        android:id="@+id/btn_secondary_action"
         style="@style/Woo.Button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/layout/activity_site_picker.xml
+++ b/WooCommerce/src/main/res/layout/activity_site_picker.xml
@@ -88,24 +88,6 @@
             <include
                 layout="@layout/view_login_no_stores"/>
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/button_email_help"
-                style="@style/Woo.Button.Secondary"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/major_150"
-                android:layout_marginTop="@dimen/major_100"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:textAllCaps="false"
-                android:text="@string/login_need_help_finding_email"
-                android:visibility="gone"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/no_stores_view"
-                app:layout_constraintVertical_bias="1.0"
-                tools:visibility="gone"/>
-
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.core.widget.NestedScrollView>
 

--- a/WooCommerce/src/main/res/layout/fragment_login_jetpack_required.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_jetpack_required.xml
@@ -51,7 +51,7 @@
                 app:layout_constraintVertical_bias="0.48000002" />
 
             <com.google.android.material.button.MaterialButton
-                android:id="@+id/btn_what_is_jetpack"
+                android:id="@+id/btn_secondary_action"
                 style="@style/Woo.Button"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/layout/view_login_no_stores.xml
+++ b/WooCommerce/src/main/res/layout/view_login_no_stores.xml
@@ -31,12 +31,12 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_secondary_action"
-        style="@style/Woo.Button"
+        style="@style/Woo.Button.Secondary"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/major_100"
-        android:layout_marginStart="@dimen/major_300"
-        android:layout_marginEnd="@dimen/major_300"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginEnd="@dimen/major_100"
         android:text="@string/login_jetpack_what_is"
         android:textAllCaps="false"
         android:visibility="visible" />

--- a/WooCommerce/src/main/res/layout/view_login_no_stores.xml
+++ b/WooCommerce/src/main/res/layout/view_login_no_stores.xml
@@ -30,7 +30,7 @@
         tools:visibility="visible"/>
 
     <com.google.android.material.button.MaterialButton
-        android:id="@+id/btn_what_is_jetpack"
+        android:id="@+id/btn_secondary_action"
         style="@style/Woo.Button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -39,5 +39,5 @@
         android:layout_marginEnd="@dimen/major_300"
         android:text="@string/login_jetpack_what_is"
         android:textAllCaps="false"
-        android:visibility="gone" />
+        android:visibility="visible" />
 </LinearLayout>


### PR DESCRIPTION
Fixes #3342 by removing the extra "email help" button and consolidating both the "email help" and "what is jetpack" help buttons into `btn_secondary_action` and updating where needed. 

Before | After 
-- | --
![before](https://user-images.githubusercontent.com/5810477/102664363-994bc180-4150-11eb-8ede-080fa30ef7b9.jpg)|![after](https://user-images.githubusercontent.com/5810477/102664954-e3817280-4151-11eb-911f-0175c4da31d9.jpg)


### To Test
1. Install the app
2. Tap **Enter your store address**
3. Enter a WordPress.com site, tap **Continue**
4. Enter the email of a WordPress.com account that **is not** connected to the site entered in the last step. Tap **Continue**
5. Enter password, tap **ContInue**
6. On the "not connected" error screen, tap **Need help finding the connected email?** link and verify email help dialog is displayed.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
