### PR TITLE
Beta Fix: Fix broken "reset password" link on site creds login screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -383,7 +383,7 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
         AppPrefs.setLoginSiteAddress(siteAddressClean)
 
         if (hasJetpack) {
-            showEmailLoginScreen(siteAddressClean)
+            showEmailLoginScreen(inputSiteAddress)
         } else {
             // hide the keyboard
             org.wordpress.android.util.ActivityUtils.hideKeyboard(this)

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -934,7 +934,8 @@
     <string name="signup_with_email_button">Sign Up with Email</string>
     <string name="signup_with_google_button">Sign Up with Google</string>
     <string name="signup_with_google_progress">Signing up with Google…</string>
-    
+
+    <string name="enter_email_for_site">Log in with WordPress.com to connect to &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="enter_wordpress_site">The website at this address is not a WordPress site. For us to connect to it, the site must have WordPress installed.</string>
     <string name="login_need_help_finding_connected_email">Need help finding the email you connected with?</string>
     <string name="send_verification_email">Send verification email</string>
@@ -1463,5 +1464,4 @@
     <string name="product_downloadable_files_name_invalid">Please enter a valid name</string>
     <string name="product_downloadable_files_download_settings">Download Settings</string>
     <string name="enter_email_wordpress_com">Log in to WordPress.com using an email address to manage all your WordPress sites.</string>
-    <string name="enter_email_for_site">Log in with WordPress.com to connect to %1$s</string>
 </resources>

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -201,8 +201,9 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
                 break;
             case WOO_LOGIN_MODE:
                 if (mOptionalSiteCredsLayout) {
+                    String siteAddressClean = mLoginSiteUrl.replaceFirst("^(http[s]?://)", "");
                     label.setText(Html.fromHtml(
-                            getString(R.string.enter_email_for_site, mLoginSiteUrl)));
+                            getString(R.string.enter_email_for_site, siteAddressClean)));
                 } else {
                     label.setText(getString(R.string.enter_email_wordpress_com));
                 }


### PR DESCRIPTION
Fixes #3349 The issue was stripping the protocol from the URL for the label but then using that same URL for routing to the reset password view. Logic has been updated to strip the protocol for display only when needed for display.

### To Test
1. Freshly install the app
2. Tap **Enter your store address**
3. Enter a store address and tap **Continue**
4. On the login email screen, verify the store address doesn't contain any protocol information like "http://" or "https://"). 
5. Tap **Continue with store credentials**
6. Tap **Reset your password** - verify a webview opens to the reset password page. 

cc: @AliSoftware for a beta release

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
