### PR TITLE
issue/3344-product-list-crash-fix

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -8,7 +8,6 @@
     tools:context="com.woocommerce.android.ui.products.ProductListFragment">
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:animateLayoutChanges="true"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 


### PR DESCRIPTION
Fixes #3344 by removing `android:animateLayoutChanges="true"` from `fragment_product_list`. There is an open issue [here](https://issuetracker.google.com/issues/148720682) that can cause the `RecyclerView` to crash when its parent switches to another view, if inside a `ConstraintLayout`. 

Since the `android:animateLayoutChanges="true"` was added in [this PR](https://github.com/woocommerce/woocommerce-android/commit/42a70a967b9d9f7004875114bc73c78bdcce170b) to make the filter card hide when scrolling (and this has not yet been fixed), I thought it'd be safe to remove that. 

**Note that this PR is targeted against the `5.6.3` release branch since this crash is affecting more than 160 users.**

cc @loremattei just tagging you here in the PR since this will also be included in the new release. Thank you 🙏 
@nbradbury I'd like to get your thoughts on this fix before merging the PR. Thank you 🙇‍♀️ 


Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
