### PR TITLE
Update FluxC to fix a DB migration crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.6.27.2'
+    fluxCVersion = '1.6.27.1'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
This PR updates FluxC bringing it back to version `1.6.27.1`. Because of how the hotfixes have been generated, `1.6.27.1` has more new changes than `1.6.27.2`. These new changes added some database migrations (db version on `1.6.27.1` is `128`, while on `1.6.27.2` is `124`) and since `1.6.27.1` was actually released to some users, we need to keep them on the latest version to avoid crashes. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
