### PR TITLE
Merge/hotfix 5.6.3 into release 5.7

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -48,9 +48,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "5.6.2"
+            versionName "5.6.3"
         }
-        versionCode 182
+        versionCode 185
 
         minSdkVersion 21
         targetSdkVersion 30

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -48,9 +48,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "5.6.1"
+            versionName "5.6.2"
         }
-        versionCode 181
+        versionCode 182
 
         minSdkVersion 21
         targetSdkVersion 30

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -48,9 +48,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "5.7-rc-3"
+            versionName "5.7-rc-4"
         }
-        versionCode 184
+        versionCode 186
 
         minSdkVersion 21
         targetSdkVersion 30

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -48,9 +48,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "5.6"
+            versionName "5.6.1"
         }
-        versionCode 179
+        versionCode 181
 
         minSdkVersion 21
         targetSdkVersion 30

--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -8,7 +8,6 @@
     tools:context="com.woocommerce.android.ui.products.ProductListFragment">
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:animateLayoutChanges="true"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.6.27'
+    fluxCVersion = '1.6.27.1'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.6.27.2'
+    fluxCVersion = '1.6.27.1'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.6.27.1'
+    fluxCVersion = '1.6.27.2'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
This PR merges the changes from `hotfix/5.6.3` into `5.7`.
Since FluxC `1.7.1` already contains the FluxC changes, the only actual one here is the change added with https://github.com/woocommerce/woocommerce-android/pull/3365

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
