### PR TITLE
issue/enable-m5-for-all

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
@@ -5,8 +5,8 @@ import com.woocommerce.android.R
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.model.Product
-import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewLinkedProducts
 import com.woocommerce.android.ui.products.ProductNavigationTarget.AddProductDownloadableFile
+import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewLinkedProducts
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductCategories
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductShipping
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductShortDescriptionEditor
@@ -17,7 +17,6 @@ import com.woocommerce.android.ui.products.ProductType.GROUPED
 import com.woocommerce.android.ui.products.ProductType.OTHER
 import com.woocommerce.android.ui.products.ProductType.SIMPLE
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.ResourceProvider
 
 class ProductDetailBottomSheetBuilder(
@@ -149,7 +148,7 @@ class ProductDetailBottomSheetBuilder(
     }
 
     private fun Product.getLinkedProducts(): ProductDetailBottomSheetUiItem? {
-        return if (!hasLinkedProducts() && FeatureFlag.PRODUCT_RELEASE_M5.isEnabled()) {
+        return if (!hasLinkedProducts()) {
             ProductDetailBottomSheetUiItem(
                 ProductDetailBottomSheetType.LINKED_PRODUCTS,
                 ViewLinkedProducts(remoteId),
@@ -161,7 +160,7 @@ class ProductDetailBottomSheetBuilder(
     }
 
     private fun Product.getDownloadableFiles(): ProductDetailBottomSheetUiItem? {
-        if (!FeatureFlag.PRODUCT_RELEASE_M5.isEnabled() || (isDownloadable && downloads.isNotEmpty())) return null
+        if (isDownloadable && downloads.isNotEmpty()) return null
         return ProductDetailBottomSheetUiItem(
             ProductDetailBottomSheetType.PRODUCT_DOWNLOADS,
             AddProductDownloadableFile

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -580,9 +580,7 @@ class ProductDetailCardBuilder(
     }
 
     private fun Product.linkedProducts(): ProductProperty? {
-        if (!hasLinkedProducts()) {
-            return null
-        }
+        if (!hasLinkedProducts()) return null
 
         val upsellDesc = StringUtils.getPluralString(
             resources,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -44,7 +44,6 @@ import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.PURCH
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.SECONDARY
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.PriceUtils
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -205,7 +204,7 @@ class ProductDetailCardBuilder(
             resources.getString(R.string.product_purchase_details),
             listOf(
                 product.readOnlyShipping(),
-                if (FeatureFlag.PRODUCT_RELEASE_M5.isEnabled()) null else product.downloadsLegacy(),
+                null,
                 product.purchaseNote()
             ).filterNotEmpty()
         )
@@ -224,7 +223,7 @@ class ProductDetailCardBuilder(
     }
 
     private fun Product.downloads(): ProductProperty? {
-        if (!FeatureFlag.PRODUCT_RELEASE_M5.isEnabled() || !this.isDownloadable || this.downloads.isEmpty()) return null
+        if (!this.isDownloadable || this.downloads.isEmpty()) return null
         return ComplexProperty(
             title = R.string.product_downloadable_files,
             value = StringUtils.getQuantityString(
@@ -581,7 +580,7 @@ class ProductDetailCardBuilder(
     }
 
     private fun Product.linkedProducts(): ProductProperty? {
-        if (!hasLinkedProducts() || !FeatureFlag.PRODUCT_RELEASE_M5.isEnabled()) {
+        if (!hasLinkedProducts()) {
             return null
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -204,7 +204,6 @@ class ProductDetailCardBuilder(
             resources.getString(R.string.product_purchase_details),
             listOf(
                 product.readOnlyShipping(),
-                null,
                 product.purchaseNote()
             ).filterNotEmpty()
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -73,7 +73,6 @@ import com.woocommerce.android.ui.products.settings.ProductVisibility
 import com.woocommerce.android.ui.products.tags.ProductTagsRepository
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.Optional
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.LiveDataDelegate
@@ -199,7 +198,7 @@ class ProductDetailViewModel @AssistedInject constructor(
      * trash menu. Always returns false when we're in the add flow.
      */
     val isTrashEnabled: Boolean
-        get() = !isAddFlow && navArgs.isTrashEnabled && FeatureFlag.PRODUCT_RELEASE_M5.isEnabled()
+        get() = !isAddFlow && navArgs.isTrashEnabled
 
     init {
         start()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSettingsFragment.kt
@@ -25,15 +25,14 @@ import com.woocommerce.android.ui.products.BaseProductFragment
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitSettings
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductPurchaseNoteEditor
 import com.woocommerce.android.ui.products.ProductStatus
-import com.woocommerce.android.ui.products.ProductType.SIMPLE
 import com.woocommerce.android.ui.products.ProductType
+import com.woocommerce.android.ui.products.ProductType.SIMPLE
 import com.woocommerce.android.ui.products.settings.ProductCatalogVisibilityFragment.Companion.ARG_CATALOG_VISIBILITY
 import com.woocommerce.android.ui.products.settings.ProductCatalogVisibilityFragment.Companion.ARG_IS_FEATURED
 import com.woocommerce.android.ui.products.settings.ProductSlugFragment.Companion.ARG_SLUG
 import com.woocommerce.android.ui.products.settings.ProductStatusFragment.Companion.ARG_SELECTED_STATUS
 import com.woocommerce.android.ui.products.settings.ProductVisibilityFragment.Companion.ARG_PASSWORD
 import com.woocommerce.android.ui.products.settings.ProductVisibilityFragment.Companion.ARG_VISIBILITY
-import com.woocommerce.android.util.FeatureFlag
 import kotlinx.android.synthetic.main.fragment_product_settings.*
 
 class ProductSettingsFragment : BaseProductFragment(), NavigationResult {
@@ -87,7 +86,7 @@ class ProductSettingsFragment : BaseProductFragment(), NavigationResult {
             activity?.invalidateOptionsMenu()
         }
 
-        if (FeatureFlag.PRODUCT_RELEASE_M5.isEnabled() && viewModel.getProduct().storedProduct?.productType == SIMPLE) {
+        if (viewModel.getProduct().storedProduct?.productType == SIMPLE) {
             productIsDownloadable.visibility = View.VISIBLE
             productIsDownloadableDivider.visibility = View.VISIBLE
             productIsDownloadable.setOnCheckedChangeListener { checkbox, isChecked ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -7,12 +7,10 @@ import com.woocommerce.android.BuildConfig
  * "Feature flags" are used to hide in-progress features from release versions
  */
 enum class FeatureFlag {
-    PRODUCT_RELEASE_M5,
     SHIPPING_LABELS_M2,
     DB_DOWNGRADE;
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
-            PRODUCT_RELEASE_M5 -> BuildConfig.DEBUG || isTesting()
             SHIPPING_LABELS_M2 -> BuildConfig.DEBUG || isTesting()
             DB_DOWNGRADE -> {
                 BuildConfig.DEBUG || context != null && PackageUtils.isBetaBuild(context)


### PR DESCRIPTION
As we discussed on Slack, this PR removes the M5 feature flag so the following are enabled for all users:

- Product downloads
- Linked products
- Product deletion (trash)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
