### PR TITLE
Toplevel navigation POC

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ActivityExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ActivityExt.kt
@@ -27,24 +27,6 @@ fun FragmentActivity.navigateBackWithResult(requestCode: Int, result: Bundle, @I
 }
 
 /**
- * Used for passing back some result from a fragment using the Navigation component
- * to one of the top level activities.
- *
- * It reuses the logic from the above method but uses the getActiveTopLevelFragment()
- * from [MainActivity] to get the current active fragment
- */
-fun MainActivity.navigateBackWithResult(requestCode: Int, result: Bundle, @IdRes navHostId: Int, @IdRes dest: Int) {
-    val childFragmentManager = supportFragmentManager.findFragmentById(navHostId)?.childFragmentManager
-    var backStackListener: FragmentManager.OnBackStackChangedListener by Delegates.notNull()
-    backStackListener = FragmentManager.OnBackStackChangedListener {
-        (getActiveTopLevelFragment() as? NavigationResult)?.onNavigationResult(requestCode, result)
-        childFragmentManager?.removeOnBackStackChangedListener(backStackListener)
-    }
-    childFragmentManager?.addOnBackStackChangedListener(backStackListener)
-    findNavController(navHostId).popBackStack(dest, false)
-}
-
-/**
  * Used for starting the HelpActivity in a wrapped way whenever a troubleshooting URL click happens
  */
 fun FragmentActivity.startHelpActivity(origin: Origin) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -70,17 +70,3 @@ fun <T> Fragment.handleDialogResult(key: String, entryId: Int, handler: (T) -> U
     handleResult(key, entryId, handler)
 }
 
-///**
-// * A helper function that subscribes a supplied handler function to the [TopLevelFragment]'s SavedStateHandle LiveData
-// * associated with the supplied key. The `rootFragment` entry ID must be used to deliver the result.
-// *
-// * @param [key] A unique string that is the same as the one used in [navigateBackWithResult]
-// * @param [handler] A result handler
-// *
-// * Note: The handler is called only if the value wasn't handled before (i.e. the data is fresh). Once the observer is
-// * called, the boolean value is updated. This puts a limit on the number of observers for a particular key-result pair
-// * to 1.
-// */
-//fun <T> TopLevelFragment.handleResult(key: String, handler: (T) -> Unit) {
-//    (this as Fragment).handleResult(key, entryId = R.id.rootFragment, handler = handler)
-//}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -70,17 +70,17 @@ fun <T> Fragment.handleDialogResult(key: String, entryId: Int, handler: (T) -> U
     handleResult(key, entryId, handler)
 }
 
-/**
- * A helper function that subscribes a supplied handler function to the [TopLevelFragment]'s SavedStateHandle LiveData
- * associated with the supplied key. The `rootFragment` entry ID must be used to deliver the result.
- *
- * @param [key] A unique string that is the same as the one used in [navigateBackWithResult]
- * @param [handler] A result handler
- *
- * Note: The handler is called only if the value wasn't handled before (i.e. the data is fresh). Once the observer is
- * called, the boolean value is updated. This puts a limit on the number of observers for a particular key-result pair
- * to 1.
- */
-fun <T> TopLevelFragment.handleResult(key: String, handler: (T) -> Unit) {
-    (this as Fragment).handleResult(key, entryId = R.id.rootFragment, handler = handler)
-}
+///**
+// * A helper function that subscribes a supplied handler function to the [TopLevelFragment]'s SavedStateHandle LiveData
+// * associated with the supplied key. The `rootFragment` entry ID must be used to deliver the result.
+// *
+// * @param [key] A unique string that is the same as the one used in [navigateBackWithResult]
+// * @param [handler] A result handler
+// *
+// * Note: The handler is called only if the value wasn't handled before (i.e. the data is fresh). Once the observer is
+// * called, the boolean value is updated. This puts a limit on the number of observers for a particular key-result pair
+// * to 1.
+// */
+//fun <T> TopLevelFragment.handleResult(key: String, handler: (T) -> Unit) {
+//    (this as Fragment).handleResult(key, entryId = R.id.rootFragment, handler = handler)
+//}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/navigation/KeepStateNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/navigation/KeepStateNavigator.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.navigation
 
 import android.content.Context
 import android.os.Bundle
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.navigation.NavDestination
 import androidx.navigation.NavOptions
@@ -19,6 +20,8 @@ class KeepStateNavigator(
 ) : FragmentNavigator(context, manager, containerId) {
 
     private var backStack: ArrayDeque<Int>
+
+    private var lastTopLevelFragment: Fragment? = null
 
     init {
         val field = FragmentNavigator::class.java.getDeclaredField("mBackStack")
@@ -40,9 +43,8 @@ class KeepStateNavigator(
         val tag = destination.id.toString()
         val transaction = manager.beginTransaction()
 
-        val currentFragment = manager.primaryNavigationFragment
-        if (currentFragment != null) {
-            transaction.detach(currentFragment)
+        (lastTopLevelFragment?:manager.primaryNavigationFragment)?.let {
+            transaction.detach(it)
         }
 
         var fragment = manager.findFragmentByTag(tag)
@@ -53,6 +55,7 @@ class KeepStateNavigator(
         } else {
             transaction.attach(fragment)
         }
+        lastTopLevelFragment = fragment
 
         backStack.clear()
         backStack.add(destination.id)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/navigation/KeepStateNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/navigation/KeepStateNavigator.kt
@@ -1,0 +1,54 @@
+package com.woocommerce.android.navigation
+
+import android.content.Context
+import android.os.Bundle
+import androidx.fragment.app.FragmentManager
+import androidx.navigation.NavDestination
+import androidx.navigation.NavOptions
+import androidx.navigation.Navigator
+import androidx.navigation.fragment.FragmentNavigator
+
+@Navigator.Name("keep_state_fragment") // `keep_state_fragment` is used in navigation xml
+class KeepStateNavigator(
+    private val context: Context,
+    private val manager: FragmentManager, // Should pass childFragmentManager.
+    private val containerId: Int
+) : FragmentNavigator(context, manager, containerId) {
+
+    override fun navigate(
+        destination: Destination,
+        args: Bundle?,
+        navOptions: NavOptions?,
+        navigatorExtras: Navigator.Extras?
+    ): NavDestination? {
+        val tag = destination.id.toString()
+        val transaction = manager.beginTransaction()
+
+        var initialNavigate = false
+        val currentFragment = manager.primaryNavigationFragment
+        if (currentFragment != null) {
+            transaction.detach(currentFragment)
+        } else {
+            initialNavigate = true
+        }
+
+        var fragment = manager.findFragmentByTag(tag)
+        if (fragment == null) {
+            val className = destination.className
+            fragment = manager.fragmentFactory.instantiate(context.classLoader, className)
+            transaction.add(containerId, fragment, tag)
+        } else {
+            transaction.attach(fragment)
+        }
+
+        transaction.setPrimaryNavigationFragment(fragment)
+        transaction.setReorderingAllowed(true)
+        transaction.commitNow()
+
+        return if (initialNavigate) {
+            destination
+        } else {
+            null
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -18,13 +18,7 @@ abstract class TopLevelFragment : BaseFragment, TopLevelFragmentView {
     var deferInit: Boolean = false
 
     override var isActive: Boolean = false
-        get() {
-            return if (isAdded && !isHidden) {
-                (activity as? MainNavigationRouter)?.isAtNavigationRoot() ?: false
-            } else {
-                false
-            }
-        }
+        get() = true
 
     abstract fun isScrolledToTop(): Boolean
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/BottomNavigationPosition.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/BottomNavigationPosition.kt
@@ -22,16 +22,4 @@ fun findNavigationPositionById(id: Int): BottomNavigationPosition = when (id) {
     else -> BottomNavigationPosition.MY_STORE
 }
 
-fun BottomNavigationPosition.getTag(): String = when (this) {
-    BottomNavigationPosition.MY_STORE -> MyStoreFragment.TAG
-    BottomNavigationPosition.ORDERS -> OrderListFragment.TAG
-    BottomNavigationPosition.PRODUCTS -> ProductListFragment.TAG
-    BottomNavigationPosition.REVIEWS -> ReviewListFragment.TAG
-}
-
-fun BottomNavigationPosition.createFragment(): TopLevelFragment = when (this) {
-    BottomNavigationPosition.MY_STORE -> MyStoreFragment.newInstance()
-    BottomNavigationPosition.ORDERS -> OrderListFragment.newInstance()
-    BottomNavigationPosition.PRODUCTS -> ProductListFragment.newInstance()
-    BottomNavigationPosition.REVIEWS -> ReviewListFragment.newInstance()
-}
+fun BottomNavigationPosition.getTag(): String = id.toString()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -56,6 +56,7 @@ import com.woocommerce.android.ui.orders.list.OrderListFragment
 import com.woocommerce.android.ui.orders.list.OrderListFragmentDirections
 import com.woocommerce.android.ui.prefs.AppSettingsActivity
 import com.woocommerce.android.ui.reviews.ReviewDetailFragmentDirections
+import com.woocommerce.android.ui.reviews.ReviewListFragmentDirections
 import com.woocommerce.android.ui.sitepicker.SitePickerActivity
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
@@ -801,14 +802,12 @@ class MainActivity : AppUpgradeActivity(),
         enableModeration: Boolean,
         tempStatus: String?
     ) {
-//        // make sure the review tab is active if the user came here from a notification
-//        if (launchedFromNotification) {
-//            showBottomNav()
-//            binding.bottomNav.currentPosition = REVIEWS
-//            binding.bottomNav.active(REVIEWS.position)
-//        }
+        // make sure the review tab is active if the user came here from a notification
+        if (launchedFromNotification) {
+            navController.navigate(R.id.reviews)
+        }
 
-        val action = ReviewDetailFragmentDirections.actionGlobalReviewDetailFragment(
+        val action = ReviewListFragmentDirections.actionReviewsToReviewDetailFragment(
             remoteReviewId,
             tempStatus,
             launchedFromNotification,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
+import androidx.navigation.findNavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupWithNavController
@@ -345,6 +346,14 @@ class MainActivity : AppUpgradeActivity(),
     }
 
     /**
+     * Returns the current top level fragment (ie: the one showing in the bottom nav)
+     */
+    internal fun getActiveTopLevelFragment(): TopLevelFragment? {
+        val tag = binding.bottomNav.currentPosition.getTag()
+        return supportFragmentManager.findFragmentByTag(tag) as? TopLevelFragment
+    }
+
+    /**
      * Returns the fragment currently shown by the navigation component, or null if we're at the root
      */
     private fun getActiveChildFragment(): Fragment? {
@@ -439,15 +448,6 @@ class MainActivity : AppUpgradeActivity(),
         } else {
             hideBottomNav()
         }
-
-//        getActiveTopLevelFragment()?.let {
-//            if (isTopLevelNavigation) {
-//                it.updateActivityTitle()
-//                it.onReturnedFromChildFragment()
-//            } else {
-//                it.onChildFragmentOpened()
-//            }
-//        }
 
         if (!isFullScreenFragment) {
             // re-expand the AppBar when returning to top level fragment, collapse it when entering a child fragment
@@ -651,9 +651,9 @@ class MainActivity : AppUpgradeActivity(),
             NotificationHandler.removeAllOrderNotifsFromSystemBar(this)
         }
 
-//        getActiveTopLevelFragment()?.let {
-//            expandToolbar(it.isScrolledToTop(), animate = false)
-//        }
+        getActiveTopLevelFragment()?.let {
+            expandToolbar(it.isScrolledToTop(), animate = false)
+        }
     }
 
     override fun onNavItemReselected(navPos: BottomNavigationPosition) {
@@ -665,13 +665,13 @@ class MainActivity : AppUpgradeActivity(),
         }
         AnalyticsTracker.track(stat)
 
-//        // if we're at the root scroll the active fragment to the top, otherwise clear the nav backstack
-//        if (isAtNavigationRoot()) {
-//            getActiveTopLevelFragment()?.scrollToTop()
-//            expandToolbar(expand = true, animate = true)
-//        } else {
-//            navigateToRoot()
-//        }
+        // if we're at the root scroll the active fragment to the top, otherwise clear the nav backstack
+        if (isAtNavigationRoot()) {
+            getActiveTopLevelFragment()?.scrollToTop()
+            expandToolbar(expand = true, animate = true)
+        } else {
+            navController.navigate(binding.bottomNav.currentPosition.id)
+        }
     }
     // endregion
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -201,9 +201,6 @@ class MainBottomNavigationView @JvmOverloads constructor(
             .setPopEnterAnim(anim.nav_default_pop_enter_anim)
             .setPopExitAnim(anim.nav_default_pop_exit_anim)
 
-//        if (item.order and Menu.CATEGORY_SECONDARY == 0) {
-//            builder.setPopUpTo(R.id.dashboard, false)
-//        }
         val options: NavOptions = builder.build()
         return try {
             navController.navigate(item.itemId, null, options)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -193,7 +193,6 @@ class MainBottomNavigationView @JvmOverloads constructor(
 
     override fun onNavigationItemSelected(item: MenuItem): Boolean {
         val navPos = findNavigationPositionById(item.itemId)
-        listener.onNavItemSelected(navPos)
         val builder = Builder()
             .setLaunchSingleTop(true)
             .setEnterAnim(anim.nav_default_enter_anim)
@@ -202,12 +201,12 @@ class MainBottomNavigationView @JvmOverloads constructor(
             .setPopExitAnim(anim.nav_default_pop_exit_anim)
 
         val options: NavOptions = builder.build()
-        return try {
+        try {
             navController.navigate(item.itemId, null, options)
-            true
         } catch (e: IllegalArgumentException) {
-            false
+            return false
         }
+        listener.onNavItemSelected(navPos)
         return true
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -11,6 +11,9 @@ import android.view.MenuItem
 import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentManager
+import androidx.navigation.NavController
+import androidx.navigation.Navigation
+import androidx.navigation.ui.setupWithNavController
 import com.google.android.material.badge.BadgeDrawable
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.bottomnavigation.BottomNavigationView.OnNavigationItemReselectedListener
@@ -28,8 +31,6 @@ class MainBottomNavigationView @JvmOverloads constructor(
     attrs: AttributeSet? = null
 ) : BottomNavigationView(context, attrs),
         OnNavigationItemSelectedListener, OnNavigationItemReselectedListener {
-    private lateinit var navAdapter: NavAdapter
-    private lateinit var fragmentManager: FragmentManager
     private lateinit var listener: MainNavigationListener
     private lateinit var ordersBadge: BadgeDrawable
     private lateinit var reviewsBadge: BadgeDrawable
@@ -43,22 +44,18 @@ class MainBottomNavigationView @JvmOverloads constructor(
         fun onNavItemReselected(navPos: BottomNavigationPosition)
     }
 
-    var currentPosition: BottomNavigationPosition
+    val currentPosition: BottomNavigationPosition
         get() = findNavigationPositionById(selectedItemId)
-        set(navPos) = updateCurrentPosition(navPos)
 
-    fun init(fm: FragmentManager, listener: MainNavigationListener) {
-        this.fragmentManager = fm
+    fun init(navController: NavController, listener: MainNavigationListener) {
         this.listener = listener
 
-        navAdapter = NavAdapter()
         addTopDivider()
         createBadges()
 
         assignNavigationListeners(true)
 
-        // Default to the dashboard position
-        active(MY_STORE.position)
+        setupWithNavController(navController)
     }
 
     /**
@@ -148,12 +145,6 @@ class MainBottomNavigationView @JvmOverloads constructor(
         }
     }
 
-    fun getFragment(navPos: BottomNavigationPosition): TopLevelFragment = navAdapter.getFragment(navPos)
-
-    fun updatePositionAndDeferInit(navPos: BottomNavigationPosition) {
-        updateCurrentPosition(navPos, true)
-    }
-
     /**
      * For use when restoring the navigation bar after the host activity
      * state has been restored.
@@ -183,8 +174,6 @@ class MainBottomNavigationView @JvmOverloads constructor(
 
     override fun onNavigationItemSelected(item: MenuItem): Boolean {
         val navPos = findNavigationPositionById(item.itemId)
-        currentPosition = navPos
-
         listener.onNavItemSelected(navPos)
         return true
     }
@@ -194,83 +183,9 @@ class MainBottomNavigationView @JvmOverloads constructor(
         listener.onNavItemReselected(navPos)
     }
 
-    /**
-     * Replaces the fragment in [MY_STORE] based on whether the revenue stats is available
-     */
-    fun replaceStatsFragment() {
-        val fragment = fragmentManager.findFragment(currentPosition)
-        val tag = currentPosition.getTag()
-
-        // replace the fragment
-        fragmentManager.beginTransaction()
-                .replace(R.id.container, fragment, tag)
-                .show(fragment)
-                .commitAllowingStateLoss()
-
-        // update the correct fragment in the navigation adapter
-        navAdapter.replaceFragment(currentPosition, fragment)
-    }
-
-    private fun updateCurrentPosition(navPos: BottomNavigationPosition, deferInit: Boolean = false) {
-        assignNavigationListeners(false)
-        try {
-            selectedItemId = navPos.id
-        } finally {
-            assignNavigationListeners(true)
-        }
-
-        val fragment = navAdapter.getFragment(navPos)
-        fragment.deferInit = deferInit
-
-        // hide previous fragment if it exists
-        val fragmentTransaction = fragmentManager.beginTransaction()
-        previousNavPos?.let {
-            val previousFragment = navAdapter.getFragment(it)
-            fragmentTransaction.hide(previousFragment)
-        }
-
-        // add the fragment if it hasn't been added yet
-        val tag = navPos.getTag()
-        if (fragmentManager.findFragmentByTag(tag) == null) {
-            fragmentTransaction.add(R.id.container, fragment, tag)
-        }
-
-        // show the new fragment
-        fragmentTransaction.show(fragment)
-        fragmentTransaction.commitAllowingStateLoss()
-
-        previousNavPos = navPos
-    }
 
     private fun assignNavigationListeners(assign: Boolean) {
         setOnNavigationItemSelectedListener(if (assign) this else null)
         setOnNavigationItemReselectedListener(if (assign) this else null)
     }
-
-    /**
-     * Extension function for retrieving an existing fragment from the [FragmentManager]
-     * if one exists, if not, create a new instance of the requested fragment.
-     */
-    private fun FragmentManager.findFragment(position: BottomNavigationPosition): TopLevelFragment {
-        return (findFragmentByTag(position.getTag()) ?: position.createFragment()) as TopLevelFragment
-    }
-
-    // region Private Classes
-    private inner class NavAdapter {
-        private val fragments = SparseArray<TopLevelFragment>(BottomNavigationPosition.values().size)
-
-        internal fun getFragment(navPos: BottomNavigationPosition): TopLevelFragment {
-            fragments[navPos.position]?.let {
-                return it
-            }
-
-            val fragment = fragmentManager.findFragment(navPos)
-            fragments.put(navPos.position, fragment)
-            return fragment
-        }
-
-        internal fun replaceFragment(navPos: BottomNavigationPosition, fragment: TopLevelFragment) =
-                fragments.put(navPos.position, fragment)
-    }
-    // endregion
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -256,7 +256,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store),
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         outState.putBoolean(STATE_KEY_REFRESH_PENDING, isRefreshPending)
-        outState.putInt(STATE_KEY_TAB_POSITION, tabLayout.selectedTabPosition)
+        outState.putInt(STATE_KEY_TAB_POSITION, tabStatsPosition)
         outState.putBoolean(STATE_KEY_IS_EMPTY_VIEW_SHOWING, isEmptyViewShowing())
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -480,7 +480,7 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
             isSearching = true
         }
 
-        showOptionsMenu(false)
+        // showOptionsMenu(false)
         (activity as? MainNavigationRouter)?.showOrderDetail(selectedSite.get().id, localOrderId, remoteOrderId)
     }
 
@@ -599,6 +599,7 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
             searchView?.post { searchMenuItem?.expandActionView() }
         } else {
             clearSearchResults()
+            (activity as? MainActivity)?.showBottomNav()
             searchMenuItem?.isVisible = true
         }
         loadListForActiveTab()
@@ -682,7 +683,6 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
         searchMenuItem?.setOnActionExpandListener(null)
         searchView?.setOnQueryTextListener(null)
         hideOrderStatusListView()
-        (activity as? MainActivity)?.showBottomNav()
 
         if (isFilterEnabled) closeFilteredList()
     }
@@ -701,7 +701,6 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
         searchMenuItem?.setOnActionExpandListener(this)
         searchView?.setOnQueryTextListener(this)
         displayOrderStatusListView()
-
         (activity as? MainActivity)?.hideBottomNav()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -252,7 +252,7 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
-        outState.putParcelable(STATE_KEY_LIST, binding.orderListView.onFragmentSavedInstanceState())
+        //outState.putParcelable(STATE_KEY_LIST, binding.orderListView.onFragmentSavedInstanceState())
         outState.putString(STATE_KEY_ACTIVE_FILTER, orderStatusFilter)
         outState.putBoolean(STATE_KEY_IS_SEARCHING, isSearching)
         outState.putBoolean(STATE_KEY_IS_FILTER_ENABLED, isFilterEnabled)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -47,7 +47,7 @@ import javax.inject.Inject
 import org.wordpress.android.util.ActivityUtils as WPActivityUtils
 
 class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
-        OrderStatusListView.OrderStatusListListener, OnQueryTextListener, OnActionExpandListener, OrderListListener {
+    OrderStatusListView.OrderStatusListListener, OnQueryTextListener, OnActionExpandListener, OrderListListener {
     companion object {
         const val TAG: String = "OrderListFragment"
         const val STATE_KEY_LIST = "list-state"
@@ -83,13 +83,17 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
     // Alias for interacting with [viewModel.orderStatusFilter] so the value is always
     // identical to the real value on the UI side.
     private var orderStatusFilter: String
-        private set(value) { viewModel.orderStatusFilter = value }
+        private set(value) {
+            viewModel.orderStatusFilter = value
+        }
         get() = viewModel.orderStatusFilter
 
     // Alias for interacting with [viewModel.isSearching] so the value is always identical
     // to the real value on the UI side.
     private var isSearching: Boolean
-        private set(value) { viewModel.isSearching = value }
+        private set(value) {
+            viewModel.isSearching = value
+        }
         get() = viewModel.isSearching
 
     private var orderListMenu: Menu? = null
@@ -103,7 +107,9 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
     // Alias for interacting with [viewModel.searchQuery] so the value is always identical
     // to the real value on the UI side.
     private var searchQuery: String
-        private set(value) { viewModel.searchQuery = value }
+        private set(value) {
+            viewModel.searchQuery = value
+        }
         get() = viewModel.searchQuery
 
     /**
@@ -112,9 +118,9 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
      */
     private var isFilterEnabled: Boolean = false
 
-    private val tabLayout: TabLayout by lazy {
-        TabLayout(requireContext(), null, R.attr.tabStyle)
-    }
+    private var _tabLayout: TabLayout? = null
+    private val tabLayout
+        get() = _tabLayout!!
 
     private val emptyView
         get() = binding.orderListView.emptyView
@@ -157,6 +163,9 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        _tabLayout = TabLayout(requireContext(), null, R.attr.tabStyle)
+        addTabLayoutToAppBar()
 
         _binding = FragmentOrderListBinding.bind(view)
         binding.orderListView.init(currencyFormatter = currencyFormatter, orderListListener = this)
@@ -239,7 +248,6 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
 
     override fun onResume() {
         super.onResume()
-        addTabLayoutToAppBar()
         AnalyticsTracker.trackViewShown(this)
     }
 
@@ -255,9 +263,11 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
 
     override fun onDestroyView() {
         disableSearchListeners()
+        removeTabLayoutFromAppBar()
         searchView = null
         orderListMenu = null
         searchMenuItem = null
+        _tabLayout = null
         super.onDestroyView()
         _binding = null
     }
@@ -265,24 +275,24 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
     /**
      * Gets called when moving between TopLevelFragments
      */
-    override fun onHiddenChanged(hidden: Boolean) {
-        super.onHiddenChanged(hidden)
-
-        if (isActive) {
-            showOptionsMenu(true)
-            addTabLayoutToAppBar()
-
-            if (isSearching) {
-                clearSearchResults()
-            }
-        } else {
-            removeTabLayoutFromAppBar()
-        }
-    }
+//    override fun onHiddenChanged(hidden: Boolean) {
+//        super.onHiddenChanged(hidden)
+//
+//        if (isActive) {
+//            showOptionsMenu(true)
+//            addTabLayoutToAppBar()
+//
+//            if (isSearching) {
+//                clearSearchResults()
+//            }
+//        } else {
+//            removeTabLayoutFromAppBar()
+//        }
+//    }
 
     override fun onReturnedFromChildFragment() {
         showOptionsMenu(true)
-        addTabLayoutToAppBar()
+        // addTabLayoutToAppBar()
 
         if (isOrderStatusFilterEnabled()) {
             viewModel.reloadListFromCache()
@@ -456,7 +466,8 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
         AnalyticsTracker.track(
             Stat.ORDER_OPEN, mapOf(
             AnalyticsTracker.KEY_ID to remoteOrderId,
-            AnalyticsTracker.KEY_STATUS to orderStatus)
+            AnalyticsTracker.KEY_STATUS to orderStatus
+        )
         )
 
         // if a search is active, we need to collapse the search view so order detail can show it's title and then
@@ -482,8 +493,9 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
         orderStatusFilter = orderStatus ?: StringUtils.EMPTY
         if (isAdded) {
             AnalyticsTracker.track(
-                    Stat.ORDERS_LIST_FILTER,
-                    mapOf(AnalyticsTracker.KEY_STATUS to orderStatus.orEmpty()))
+                Stat.ORDERS_LIST_FILTER,
+                mapOf(AnalyticsTracker.KEY_STATUS to orderStatus.orEmpty())
+            )
 
             // Display the filtered list view
             displayFilteredList()
@@ -633,8 +645,9 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
      */
     private fun handleNewSearchRequest(query: String) {
         AnalyticsTracker.track(
-                Stat.ORDERS_LIST_FILTER,
-                mapOf(AnalyticsTracker.KEY_SEARCH to query))
+            Stat.ORDERS_LIST_FILTER,
+            mapOf(AnalyticsTracker.KEY_SEARCH to query)
+        )
 
         searchQuery = query
         submitSearchQuery(searchQuery)
@@ -707,10 +720,10 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
         isFilterEnabled = true
         hideOrderStatusListView()
         searchView?.queryHint = getString(R.string.orders)
-                .plus(orderStatusFilter.let { filter ->
-                    val orderStatusLabel = getOrderStatusOptions()[filter]?.label
-                    getString(R.string.orderlist_filtered, orderStatusLabel)
-                })
+            .plus(orderStatusFilter.let { filter ->
+                val orderStatusLabel = getOrderStatusOptions()[filter]?.label
+                getString(R.string.orderlist_filtered, orderStatusLabel)
+            })
 
         searchView?.findViewById<EditText>(R.id.search_src_text)?.also {
             it.setHintTextColor(Color.WHITE)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
@@ -81,12 +81,12 @@ class ProductFilterListFragment : BaseFragment(R.layout.fragment_product_filter_
             bundle.putString(ARG_PRODUCT_FILTER_STOCK_STATUS, viewModel.getFilterByStockStatus())
             bundle.putString(ARG_PRODUCT_FILTER_STATUS, viewModel.getFilterByProductStatus())
             bundle.putString(ARG_PRODUCT_FILTER_TYPE_STATUS, viewModel.getFilterByProductType())
-            (requireActivity() as? MainActivity)?.navigateBackWithResult(
-                    RequestCodes.PRODUCT_LIST_FILTERS,
-                    bundle,
-                    R.id.nav_host_fragment_main,
-                    R.id.rootFragment
-            )
+//            (requireActivity() as? MainActivity)?.navigateBackWithResult(
+//                    RequestCodes.PRODUCT_LIST_FILTERS,
+//                    bundle,
+//                    R.id.nav_host_fragment_main,
+//                    R.id.rootFragment
+//            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
@@ -81,12 +81,12 @@ class ProductFilterListFragment : BaseFragment(R.layout.fragment_product_filter_
             bundle.putString(ARG_PRODUCT_FILTER_STOCK_STATUS, viewModel.getFilterByStockStatus())
             bundle.putString(ARG_PRODUCT_FILTER_STATUS, viewModel.getFilterByProductStatus())
             bundle.putString(ARG_PRODUCT_FILTER_TYPE_STATUS, viewModel.getFilterByProductType())
-//            (requireActivity() as? MainActivity)?.navigateBackWithResult(
-//                    RequestCodes.PRODUCT_LIST_FILTERS,
-//                    bundle,
-//                    R.id.nav_host_fragment_main,
-//                    R.id.rootFragment
-//            )
+            requireActivity().navigateBackWithResult(
+                    RequestCodes.PRODUCT_LIST_FILTERS,
+                    bundle,
+                    R.id.nav_host_fragment_main,
+                    R.id.products
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
@@ -70,12 +70,12 @@ class ProductFilterOptionListFragment : BaseFragment(R.layout.fragment_product_f
             bundle.putString(ARG_PRODUCT_FILTER_STOCK_STATUS, viewModel.getFilterByStockStatus())
             bundle.putString(ARG_PRODUCT_FILTER_STATUS, viewModel.getFilterByProductStatus())
             bundle.putString(ARG_PRODUCT_FILTER_TYPE_STATUS, viewModel.getFilterByProductType())
-            (requireActivity() as? MainActivity)?.navigateBackWithResult(
-                    RequestCodes.PRODUCT_LIST_FILTERS,
-                    bundle,
-                    R.id.nav_host_fragment_main,
-                    R.id.rootFragment
-            )
+//            (requireActivity() as? MainActivity)?.navigateBackWithResult(
+//                    RequestCodes.PRODUCT_LIST_FILTERS,
+//                    bundle,
+//                    R.id.nav_host_fragment_main,
+//                    R.id.rootFragment
+//            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
@@ -70,12 +70,12 @@ class ProductFilterOptionListFragment : BaseFragment(R.layout.fragment_product_f
             bundle.putString(ARG_PRODUCT_FILTER_STOCK_STATUS, viewModel.getFilterByStockStatus())
             bundle.putString(ARG_PRODUCT_FILTER_STATUS, viewModel.getFilterByProductStatus())
             bundle.putString(ARG_PRODUCT_FILTER_TYPE_STATUS, viewModel.getFilterByProductType())
-//            (requireActivity() as? MainActivity)?.navigateBackWithResult(
-//                    RequestCodes.PRODUCT_LIST_FILTERS,
-//                    bundle,
-//                    R.id.nav_host_fragment_main,
-//                    R.id.rootFragment
-//            )
+            requireActivity().navigateBackWithResult(
+                    RequestCodes.PRODUCT_LIST_FILTERS,
+                    bundle,
+                    R.id.nav_host_fragment_main,
+                    R.id.products
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -124,7 +124,7 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
-        outState.putParcelable(KEY_LIST_STATE, binding.productsRecycler.layoutManager?.onSaveInstanceState())
+        //outState.putParcelable(KEY_LIST_STATE, binding.productsRecycler.layoutManager?.onSaveInstanceState())
         super.onSaveInstanceState(outState)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -321,7 +321,7 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
             new.isAddProductButtonVisible?.takeIfNotEqualTo(old?.isAddProductButtonVisible) { isVisible ->
                 showAddProductButton(
                     show = isVisible &&
-                        (requireActivity() as? MainNavigationRouter)?.isAtNavigationRoot() == true
+                        findNavController().currentDestination?.id == R.id.products
                 )
             }
         }

--- a/WooCommerce/src/main/res/layout/activity_main.xml
+++ b/WooCommerce/src/main/res/layout/activity_main.xml
@@ -38,12 +38,6 @@
             android:layout_height="match_parent"
             app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-            <!-- container for top level fragments -->
-            <FrameLayout
-                android:id="@+id/container"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent" />
-
             <!-- container for child fragments in the nav graph -->
             <androidx.fragment.app.FragmentContainerView
                 android:id="@+id/nav_host_fragment_main"

--- a/WooCommerce/src/main/res/layout/activity_main.xml
+++ b/WooCommerce/src/main/res/layout/activity_main.xml
@@ -51,7 +51,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 app:defaultNavHost="true"
-                app:navGraph="@navigation/nav_graph_main"
                 tools:layout="@layout/fragment_my_store" />
         </FrameLayout>
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -3,11 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph_main"
-    app:startDestination="@id/rootFragment">
-    <fragment
-        android:id="@+id/rootFragment"
-        android:name="com.woocommerce.android.ui.main.RootFragment"
-        tools:layout="@layout/fragment_root" />
+    app:startDestination="@id/dashboard">
 
     <fragment
         android:id="@+id/feedbackSurveyFragment"
@@ -381,4 +377,24 @@
             android:name="orderIdentifier"
             app:argType="string" />
     </fragment>
+    <keep_state_fragment
+        android:id="@+id/dashboard"
+        android:name="com.woocommerce.android.ui.mystore.MyStoreFragment"
+        android:label="fragment_my_store"
+        tools:layout="@layout/fragment_my_store" />
+    <keep_state_fragment
+        android:id="@+id/orders"
+        android:name="com.woocommerce.android.ui.orders.list.OrderListFragment"
+        android:label="fragment_order_list"
+        tools:layout="@layout/fragment_order_list" />
+    <keep_state_fragment
+        android:id="@+id/products"
+        android:name="com.woocommerce.android.ui.products.ProductListFragment"
+        android:label="fragment_product_list"
+        tools:layout="@layout/fragment_product_list" />
+    <keep_state_fragment
+        android:id="@+id/reviews"
+        android:name="com.woocommerce.android.ui.reviews.ReviewListFragment"
+        android:label="fragment_reviews_list"
+        tools:layout="@layout/fragment_reviews_list" />
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -234,11 +234,6 @@
             android:name="enableModeration"
             app:argType="boolean" />
     </fragment>
-    <action
-        android:id="@+id/action_global_reviewDetailFragment"
-        app:destination="@id/reviewDetailFragment"
-        app:enterAnim="@anim/activity_slide_in_from_right"
-        app:popExitAnim="@anim/activity_slide_out_to_right" />
     <include app:graph="@navigation/nav_graph_refunds" />
     <include app:graph="@navigation/nav_graph_products" />
     <include app:graph="@navigation/nav_graph_product_filters" />
@@ -395,5 +390,9 @@
         android:id="@+id/reviews"
         android:name="com.woocommerce.android.ui.reviews.ReviewListFragment"
         android:label="fragment_reviews_list"
-        tools:layout="@layout/fragment_reviews_list" />
+        tools:layout="@layout/fragment_reviews_list" >
+        <action
+            android:id="@+id/action_reviews_to_reviewDetailFragment"
+            app:destination="@id/reviewDetailFragment" />
+    </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -214,11 +214,6 @@
             app:argType="string"
             app:nullable="true" />
     </action>
-    <action
-        android:id="@+id/action_global_orderDetailFragment"
-        app:destination="@id/orderDetailFragment"
-        app:enterAnim="@anim/activity_slide_in_from_right"
-        app:popExitAnim="@anim/activity_slide_out_to_right" />
     <fragment
         android:id="@+id/reviewDetailFragment"
         android:name="com.woocommerce.android.ui.reviews.ReviewDetailFragment"
@@ -377,22 +372,26 @@
             android:name="orderIdentifier"
             app:argType="string" />
     </fragment>
-    <keep_state_fragment
+    <fragment
         android:id="@+id/dashboard"
         android:name="com.woocommerce.android.ui.mystore.MyStoreFragment"
         android:label="fragment_my_store"
         tools:layout="@layout/fragment_my_store" />
-    <keep_state_fragment
+    <fragment
         android:id="@+id/orders"
         android:name="com.woocommerce.android.ui.orders.list.OrderListFragment"
         android:label="fragment_order_list"
-        tools:layout="@layout/fragment_order_list" />
-    <keep_state_fragment
+        tools:layout="@layout/fragment_order_list" >
+        <action
+            android:id="@+id/action_orders_to_orderDetailFragment"
+            app:destination="@id/orderDetailFragment" />
+    </fragment>
+    <fragment
         android:id="@+id/products"
         android:name="com.woocommerce.android.ui.products.ProductListFragment"
         android:label="fragment_product_list"
         tools:layout="@layout/fragment_product_list" />
-    <keep_state_fragment
+    <fragment
         android:id="@+id/reviews"
         android:name="com.woocommerce.android.ui.reviews.ReviewListFragment"
         android:label="fragment_reviews_list"


### PR DESCRIPTION
This is a POC for how we can handle the top level fragments navigation using the nav component too, it's based on the sample https://github.com/STAR-ZERO/navigation-keep-fragment-sample, but with some additions to allow navigating to child fragments:
1. The new navigator that we use, replaces the default fragment navigator, and handles navigation of `TopLevelFragment`s in a way that saves the state, while delegates the navigation of other fragments to the default `FragmentNavigator`
2. We use a bit of reflection to be able to add our TopLevelFragments to the backstack: https://github.com/woocommerce/woocommerce-android/blob/c39b24e213547d7dc37dbed8fdea9a60f8dd73a9/WooCommerce/src/main/kotlin/com/woocommerce/android/navigation/KeepStateNavigator.kt#L27-L29
3. When navigating to a new tab, we clear the backstack, and add the new tab to it.

By doing the above, the lifecycle of TopLevelFragments becomes simpler:
- The instance is saved during navigation to other tabs.
- They are `active` only when they are visible, and their views gets destroyed when navigating to other tabs.

For the navigation graph, I suggest the following:
1. Cleanup the nav_graph_main by moving the order related destinations to their own subgraph.
2. Use defined destinations instead of global destinations when possible, as it makes the navgraph easier to read, and well encapsulated https://stackoverflow.com/a/56909107/5494024, I did this for the order details as a first step.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
