### PR TITLE
Fix ripple for logout button in settings

### DIFF
--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -408,7 +408,6 @@ theme across the entire app. Overridden versions should be added to the styles.x
     <!--  Borderless button (i.e: text button)  -->
     <style name="Woo.Button" parent="Widget.MaterialComponents.Button.TextButton">
         <item name="android:textColor">@color/button_fg_selector</item>
-        <item name="android:background">?attr/selectableItemBackgroundBorderless</item>
         <item name="android:paddingStart">@dimen/major_100</item>
         <item name="android:paddingEnd">@dimen/major_100</item>
     </style>
@@ -641,6 +640,8 @@ theme across the entire app. Overridden versions should be added to the styles.x
     </style>
 
     <style name="Widget.Woo.Settings.Button" parent="Woo.Button">
+        <item name="android:insetTop">0dp</item>
+        <item name="android:insetBottom">0dp</item>
         <item name="android:textAlignment">textStart</item>
         <item name="android:paddingStart">@dimen/margin_app_title_aligned</item>
         <item name="android:paddingEnd">@dimen/major_100</item>


### PR DESCRIPTION
Closes #3233 by fixing the ripple style for the settings button (and the text button style in general):
- Removed the override for the background of button style so proper theme style will be used.
- Set button top and bottom inset to 0 so the ripple fills the button edge to edge

Before | After
-- | --
![button-before](https://user-images.githubusercontent.com/5810477/103300968-37038400-49ce-11eb-9ee9-3d7b9a13c3ea.jpg)|![button-after](https://user-images.githubusercontent.com/5810477/103300970-38cd4780-49ce-11eb-93e1-e296553661d1.jpg)

### Demo: Before

https://user-images.githubusercontent.com/5810477/103300984-45ea3680-49ce-11eb-9d92-8745e6fc51c3.mp4

### Demo: After

https://user-images.githubusercontent.com/5810477/103300993-497dbd80-49ce-11eb-9a11-738486a2c2f8.mp4

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
