### PR TITLE
Fix ripple effect of "add more details" button in product details

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderTrackingProviderListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderTrackingProviderListAdapter.kt
@@ -171,7 +171,6 @@ class AddOrderTrackingProviderListAdapter(
 
             val isChecked = provider.carrierName == selectedCarrierName
             viewBinding.addShipmentTrackingProviderListItemTick.isVisible = isChecked
-            viewBinding.addShipmentTrackingProviderListItemTick.isChecked = isChecked
 
             viewBinding.root.setOnClickListener {
                 listener.onProviderClick(provider)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -256,7 +256,7 @@ class ProductDetailFragment : BaseProductFragment(R.layout.fragment_product_deta
             }
         }
 
-        binding.productDetailAddMoreContainer.setOnClickListener {
+        binding.productDetailAddMoreButton.setOnClickListener {
             // TODO: add tracking events here
             viewModel.onEditProductCardClicked(
                 ViewProductDetailBottomSheet(product.productType)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListAdapter.kt
@@ -57,7 +57,6 @@ class ProductFilterOptionListAdapter(
         fun bind(filter: FilterListOptionItemUiModel) {
             viewBinding.filterOptionItemName.text = filter.filterOptionItemName
             viewBinding.filterOptionItemTick.isVisible = filter.isSelected
-            viewBinding.filterOptionItemTick.isChecked = filter.isSelected
         }
     }
 }

--- a/WooCommerce/src/main/res/layout-land/fragment_login_jetpack_required.xml
+++ b/WooCommerce/src/main/res/layout-land/fragment_login_jetpack_required.xml
@@ -41,7 +41,7 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btn_secondary_action"
-                style="@style/Woo.Button"
+                style="@style/Woo.Button.TextButton"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/minor_100"

--- a/WooCommerce/src/main/res/layout-land/fragment_login_what_is_jetpack.xml
+++ b/WooCommerce/src/main/res/layout-land/fragment_login_what_is_jetpack.xml
@@ -7,7 +7,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_learn_more"
-        style="@style/Woo.Button"
+        style="@style/Woo.Button.TextButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/minor_100"
@@ -18,7 +18,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_ok"
-        style="@style/Woo.Button"
+        style="@style/Woo.Button.TextButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/minor_100"

--- a/WooCommerce/src/main/res/layout-land/view_login_no_stores.xml
+++ b/WooCommerce/src/main/res/layout-land/view_login_no_stores.xml
@@ -30,7 +30,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_secondary_action"
-        style="@style/Woo.Button.Secondary"
+        style="@style/Woo.Button.TextButton.Secondary"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/major_100"

--- a/WooCommerce/src/main/res/layout/activity_site_picker.xml
+++ b/WooCommerce/src/main/res/layout/activity_site_picker.xml
@@ -32,7 +32,7 @@
 
             <ImageButton
                 android:id="@+id/button_help"
-                style="@style/Woo.Button"
+                style="@style/Woo.Button.TextButton"
                 android:layout_width="48dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/minor_50"

--- a/WooCommerce/src/main/res/layout/dialog_order_tracking_provider_list_item.xml
+++ b/WooCommerce/src/main/res/layout/dialog_order_tracking_provider_list_item.xml
@@ -22,18 +22,17 @@
             app:layout_constraintTop_toTopOf="parent"
             tools:text="Canada Post" />
 
-        <com.google.android.material.radiobutton.MaterialRadioButton
+        <ImageView
             android:id="@+id/addShipmentTrackingProviderListItem_tick"
-            style="@style/Woo.Button.TextButton.Toggle"
-            android:layout_width="@dimen/min_tap_target"
-            android:layout_height="wrap_content"
+            android:layout_width="@dimen/image_minor_60"
+            android:layout_height="@dimen/image_minor_60"
             android:contentDescription="@string/order_shipment_tracking_provider_list_item"
-            android:button="@null"
-            android:drawableEnd="@drawable/ic_done_secondary"
+            android:src="@drawable/ic_done_secondary"
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
+            android:layout_marginEnd="@dimen/major_100"
             tools:visibility="visible"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/dialog_order_tracking_provider_list_item.xml
+++ b/WooCommerce/src/main/res/layout/dialog_order_tracking_provider_list_item.xml
@@ -24,7 +24,7 @@
 
         <com.google.android.material.radiobutton.MaterialRadioButton
             android:id="@+id/addShipmentTrackingProviderListItem_tick"
-            style="@style/Woo.Button.Toggle"
+            style="@style/Woo.Button.TextButton.Toggle"
             android:layout_width="@dimen/min_tap_target"
             android:layout_height="wrap_content"
             android:contentDescription="@string/order_shipment_tracking_provider_list_item"

--- a/WooCommerce/src/main/res/layout/dialog_promo.xml
+++ b/WooCommerce/src/main/res/layout/dialog_promo.xml
@@ -52,7 +52,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/button1"
-        style="@style/Woo.Button"
+        style="@style/Woo.Button.TextButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/major_150"

--- a/WooCommerce/src/main/res/layout/dialog_version_upgrade_required.xml
+++ b/WooCommerce/src/main/res/layout/dialog_version_upgrade_required.xml
@@ -28,7 +28,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/upgrade_instructions"
-        style="@style/Woo.Button"
+        style="@style/Woo.Button.TextButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/minor_100"

--- a/WooCommerce/src/main/res/layout/fragment_info_screen.xml
+++ b/WooCommerce/src/main/res/layout/fragment_info_screen.xml
@@ -52,7 +52,7 @@
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/info_link"
-            style="@style/Woo.Button"
+            style="@style/Woo.Button.TextButton"
             android:layout_width="@dimen/minor_00"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/major_300"

--- a/WooCommerce/src/main/res/layout/fragment_login_jetpack_required.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_jetpack_required.xml
@@ -52,7 +52,7 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btn_secondary_action"
-                style="@style/Woo.Button"
+                style="@style/Woo.Button.TextButton"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/minor_100"

--- a/WooCommerce/src/main/res/layout/fragment_login_no_jetpack.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_no_jetpack.xml
@@ -18,7 +18,7 @@
 
             <Button
                 android:id="@+id/button_help"
-                style="@style/Woo.Button"
+                style="@style/Woo.Button.TextButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/help"

--- a/WooCommerce/src/main/res/layout/fragment_login_no_wpcom_account_found.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_no_wpcom_account_found.xml
@@ -52,7 +52,7 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btn_find_connected_email"
-                style="@style/Woo.Button.Secondary"
+                style="@style/Woo.Button.TextButton.Secondary"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/minor_100"

--- a/WooCommerce/src/main/res/layout/fragment_login_no_wpcom_account_found.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_no_wpcom_account_found.xml
@@ -52,7 +52,7 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btn_find_connected_email"
-                style="@style/Woo.Button.TextButton"
+                style="@style/Woo.Button.Secondary"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/minor_100"

--- a/WooCommerce/src/main/res/layout/fragment_login_what_is_jetpack.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_what_is_jetpack.xml
@@ -8,7 +8,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_learn_more"
-        style="@style/Woo.Button"
+        style="@style/Woo.Button.TextButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/minor_100"
@@ -23,7 +23,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_ok"
-        style="@style/Woo.Button"
+        style="@style/Woo.Button.TextButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/minor_50"

--- a/WooCommerce/src/main/res/layout/fragment_product_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_detail.xml
@@ -160,7 +160,7 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/productDetail_addMoreButton"
-                style="@style/Woo.Button"
+                style="@style/Woo.Button.TextButton"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:gravity="start|center_vertical"

--- a/WooCommerce/src/main/res/layout/fragment_product_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_detail.xml
@@ -138,10 +138,10 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
         android:visibility="gone"
-        tools:visibility="visible"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
+        tools:visibility="visible">
 
         <View
             android:id="@+id/productDetail_addMoreDivider"
@@ -154,31 +154,22 @@
             style="@style/Woo.Card.WithoutPadding"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:background="?attr/selectableItemBackground"
-            android:contentDescription="@string/orderdetail_addnote_contentdesc"
-            android:descendantFocusability="blocksDescendants"
-            android:gravity="center_vertical"
-            android:importantForAccessibility="yes"
-            android:orientation="horizontal"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/productDetail_addMoreDivider">
 
-            <com.google.android.material.textview.MaterialTextView
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/productDetail_addMoreButton"
                 style="@style/Woo.Button"
-                android:drawableStart="@drawable/ic_add"
-                android:gravity="start|center_vertical"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:clickable="false"
-                android:focusable="false"
-                android:importantForAccessibility="no"
-                android:paddingStart="@dimen/major_100"
-                android:paddingEnd="@dimen/major_100"
-                android:drawablePadding="@dimen/major_100"
-                android:text="@string/product_detail_add_more" />
+                android:gravity="start|center_vertical"
+                android:insetTop="0dp"
+                android:insetBottom="0dp"
+                android:text="@string/product_detail_add_more"
+                app:icon="@drawable/ic_add"
+                app:iconPadding="@dimen/major_100" />
         </com.woocommerce.android.widgets.WCElevatedLinearLayout>
-
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/WooCommerce/src/main/res/layout/fragment_product_pricing.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_pricing.xml
@@ -110,7 +110,7 @@
                 <!-- Remove End Date button -->
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/scheduleSale_RemoveEndDateButton"
-                    style="@style/Woo.Button"
+                    style="@style/Woo.Button.TextButton"
                     android:textAllCaps="false"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/layout/fragment_refund_by_items.xml
+++ b/WooCommerce/src/main/res/layout/fragment_refund_by_items.xml
@@ -38,7 +38,7 @@
 
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/issueRefund_selectButton"
-                        style="@style/Woo.Button"
+                        style="@style/Woo.Button.TextButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/order_refunds_items_select_all"

--- a/WooCommerce/src/main/res/layout/fragment_review_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_review_detail.xml
@@ -134,7 +134,7 @@
 
             <ToggleButton
                 android:id="@+id/review_approve"
-                style="@style/Woo.Button.Toggle"
+                style="@style/Woo.Button.TextButton.Toggle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="@dimen/major_100"
@@ -146,7 +146,7 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/review_spam"
-                style="@style/Woo.Button"
+                style="@style/Woo.Button.TextButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="@dimen/margin_extra_large"
@@ -157,7 +157,7 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/review_trash"
-                style="@style/Woo.Button"
+                style="@style/Woo.Button.TextButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="@dimen/major_100"

--- a/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_privacy.xml
@@ -41,7 +41,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonLearnMore"
-        style="@style/Woo.Button"
+        style="@style/Woo.Button.TextButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/major_100"
@@ -77,7 +77,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonPrivacyPolicy"
-        style="@style/Woo.Button"
+        style="@style/Woo.Button.TextButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/major_100"
@@ -112,7 +112,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonTracking"
-        style="@style/Woo.Button"
+        style="@style/Woo.Button.TextButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/major_100"

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -193,7 +193,7 @@
             <!-- Call or message button -->
             <ImageButton
                 android:id="@+id/customerInfo_callOrMessageBtn"
-                style="@style/Woo.Button"
+                style="@style/Woo.Button.TextButton"
                 android:layout_width="@dimen/image_major_50"
                 android:layout_height="@dimen/image_major_50"
                 android:contentDescription="@string/orderdetail_call_or_message_contentdesc"
@@ -230,7 +230,7 @@
             <!-- Email Button -->
             <ImageButton
                 android:id="@+id/customerInfo_emailBtn"
-                style="@style/Woo.Button"
+                style="@style/Woo.Button.TextButton"
                 android:layout_width="@dimen/min_tap_target"
                 android:layout_height="@dimen/min_tap_target"
                 android:clickable="true"
@@ -263,7 +263,7 @@
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/customerInfo_viewMoreButtonTitle"
-                style="@style/Woo.Button"
+                style="@style/Woo.Button.TextButton"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"

--- a/WooCommerce/src/main/res/layout/order_detail_note_list.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_note_list.xml
@@ -53,7 +53,7 @@
                 app:srcCompat="@drawable/ic_add"/>
 
             <com.google.android.material.textview.MaterialTextView
-                style="@style/Woo.Button"
+                style="@style/Woo.Button.TextButton"
                 android:paddingStart="@dimen/minor_00"
                 android:paddingEnd="@dimen/minor_00"
                 android:layout_width="wrap_content"

--- a/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
@@ -350,7 +350,7 @@
             <!-- Refund button -->
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/paymentInfo_issueRefundButton"
-                style="@style/Woo.Button"
+                style="@style/Woo.Button.TextButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="end|center_vertical"

--- a/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_list.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_list.xml
@@ -40,7 +40,7 @@
         <!-- Button: Add Tracking -->
         <com.google.android.material.button.MaterialButton
             android:id="@+id/shipmentTrack_btnAddTracking"
-            style="@style/Woo.Button"
+            style="@style/Woo.Button.TextButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical|end"

--- a/WooCommerce/src/main/res/layout/order_detail_shipping_label_list_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_shipping_label_list_item.xml
@@ -172,7 +172,7 @@
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/shippingLabelItem_viewMoreButtonTitle"
-                style="@style/Woo.Button"
+                style="@style/Woo.Button.TextButton"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"

--- a/WooCommerce/src/main/res/layout/product_filter_option_list_item.xml
+++ b/WooCommerce/src/main/res/layout/product_filter_option_list_item.xml
@@ -23,7 +23,7 @@
 
     <com.google.android.material.radiobutton.MaterialRadioButton
         android:id="@+id/filterOptionItem_tick"
-        style="@style/Woo.Button.Toggle"
+        style="@style/Woo.Button.TextButton.Toggle"
         android:layout_width="@dimen/min_tap_target"
         android:layout_height="wrap_content"
         android:button="@null"

--- a/WooCommerce/src/main/res/layout/product_filter_option_list_item.xml
+++ b/WooCommerce/src/main/res/layout/product_filter_option_list_item.xml
@@ -21,18 +21,18 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:text="Canada Post" />
 
-    <com.google.android.material.radiobutton.MaterialRadioButton
+    <ImageView
         android:id="@+id/filterOptionItem_tick"
-        style="@style/Woo.Button.TextButton.Toggle"
-        android:layout_width="@dimen/min_tap_target"
-        android:layout_height="wrap_content"
+        android:layout_width="@dimen/image_minor_60"
+        android:layout_height="@dimen/image_minor_60"
         android:button="@null"
         android:contentDescription="@string/product_list_filters_list_item"
-        android:drawableEnd="@drawable/ic_done_secondary"
+        android:src="@drawable/ic_done_secondary"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        android:layout_marginEnd="@dimen/major_100"
         tools:visibility="visible" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/product_property_read_more_view_layout.xml
+++ b/WooCommerce/src/main/res/layout/product_property_read_more_view_layout.xml
@@ -38,7 +38,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btnReadMore"
-        style="@style/Woo.Button"
+        style="@style/Woo.Button.TextButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:paddingTop="@dimen/minor_50"

--- a/WooCommerce/src/main/res/layout/refund_by_items_shipping.xml
+++ b/WooCommerce/src/main/res/layout/refund_by_items_shipping.xml
@@ -164,7 +164,7 @@
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/issueRefund_shippingRefundTotalButton"
-            style="@style/Woo.Button"
+            style="@style/Woo.Button.TextButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:paddingEnd="@dimen/major_100"

--- a/WooCommerce/src/main/res/layout/shipping_label_creation_step.xml
+++ b/WooCommerce/src/main/res/layout/shipping_label_creation_step.xml
@@ -42,7 +42,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/editButton"
-        style="@style/Woo.Button.TextButton"
+        style="@style/Woo.Button.Secondary"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/edit"

--- a/WooCommerce/src/main/res/layout/shipping_label_creation_step.xml
+++ b/WooCommerce/src/main/res/layout/shipping_label_creation_step.xml
@@ -42,7 +42,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/editButton"
-        style="@style/Woo.Button.Secondary"
+        style="@style/Woo.Button.TextButton.Secondary"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/edit"

--- a/WooCommerce/src/main/res/layout/view_login_no_stores.xml
+++ b/WooCommerce/src/main/res/layout/view_login_no_stores.xml
@@ -31,7 +31,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_secondary_action"
-        style="@style/Woo.Button.Secondary"
+        style="@style/Woo.Button.TextButton.Secondary"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/major_100"

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -413,10 +413,6 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="iconTint">@color/button_fg_selector</item>
     </style>
 
-    <style name="Woo.Button.TextButton">
-        <item name="android:textAppearance">@style/TextAppearance.Woo.Body1</item>
-    </style>
-
     <!--  Borderless button with smaller text used for inner options  -->
     <style name="Woo.Button.Secondary">
         <item name="android:textAppearance">@style/TextAppearance.Woo.Body1</item>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -410,6 +410,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:textColor">@color/button_fg_selector</item>
         <item name="android:paddingStart">@dimen/major_100</item>
         <item name="android:paddingEnd">@dimen/major_100</item>
+        <item name="iconTint">@color/button_fg_selector</item>
     </style>
 
     <style name="Woo.Button.TextButton">

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -132,7 +132,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:layout_marginBottom">@dimen/minor_00</item>
     </style>
 
-    <style name="Woo.Card.ExpanderButton" parent="Woo.Button">
+    <style name="Woo.Card.ExpanderButton" parent="Woo.Button.TextButton">
         <item name="android:textAppearance">?attr/textAppearanceSubtitle1</item>
         <item name="android:gravity">start|center_vertical</item>
         <item name="android:textColor">@color/color_on_surface_high</item>
@@ -146,7 +146,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:textAllCaps">false</item>
     </style>
 
-    <style name="Woo.Card.Button" parent="Woo.Button">
+    <style name="Woo.Card.Button" parent="Woo.Button.TextButton">
         <item name="android:layout_marginStart">@dimen/major_100</item>
         <item name="android:layout_marginEnd">@dimen/major_100</item>
         <item name="android:layout_marginTop">@dimen/major_100</item>
@@ -406,7 +406,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
         Button Styles
     -->
     <!--  Borderless button (i.e: text button)  -->
-    <style name="Woo.Button" parent="Widget.MaterialComponents.Button.TextButton">
+    <style name="Woo.Button.TextButton" parent="Widget.MaterialComponents.Button.TextButton">
         <item name="android:textColor">@color/button_fg_selector</item>
         <item name="android:paddingStart">@dimen/major_100</item>
         <item name="android:paddingEnd">@dimen/major_100</item>
@@ -414,7 +414,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
     </style>
 
     <!--  Borderless button with smaller text used for inner options  -->
-    <style name="Woo.Button.Secondary">
+    <style name="Woo.Button.TextButton.Secondary">
         <item name="android:textAppearance">@style/TextAppearance.Woo.Body1</item>
     </style>
 
@@ -451,7 +451,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="backgroundTint">@color/button_colored_bg_white_selector</item>
     </style>
 
-    <style name="Woo.Button.Toggle">
+    <style name="Woo.Button.TextButton.Toggle">
         <item name="android:textColor">@color/button_toggle_fg_secondary_selector</item>
         <item name="android:background">@android:color/transparent</item>
     </style>
@@ -636,7 +636,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:paddingBottom">@dimen/minor_00</item>
     </style>
 
-    <style name="Widget.Woo.Settings.Button" parent="Woo.Button">
+    <style name="Widget.Woo.Settings.Button" parent="Woo.Button.TextButton">
         <item name="android:insetTop">0dp</item>
         <item name="android:insetBottom">0dp</item>
         <item name="android:textAlignment">textStart</item>

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -74,7 +74,7 @@
         <item name="tabStyle">@style/Woo.TabLayout</item>
         <item name="scrollableTabStyle">@style/Woo.TabLayout.Scrollable</item>
         <item name="appBarLayoutStyle">@style/Woo.AppBarLayout</item>
-        <item name="borderlessButtonStyle">@style/Woo.Button</item>
+        <item name="borderlessButtonStyle">@style/Woo.Button.TextButton</item>
         <item name="materialCardViewStyle">@style/Woo.Card</item>
         <item name="android:listDivider">@drawable/list_divider</item>
         <item name="ratingBarStyleSmall">@style/Woo.RatingsBar.Small</item>


### PR DESCRIPTION
Fixes #3379.
After merging #3378, the button "add more details" was impacted, as it didn't have any touch feedback.

The PR contains two changes:
1. c3f53f065c1c963199fdbd032c1014ab4891eee9 which fixes the ripple effect of the button.
2. e1d2850697d97286f7a0bbc0f5a934aa80bcdfd6 which removes the style `Woo.Button.TextButton` as it's exactly the same as `Woo.Button.Secondary`

I was also thinking about renaming `Woo.Button` to `Woo.Button.TextButton` as it inherits from `Widget.MaterialComponents.Button.TextButton` to clarify its usage, but wanted your opinion before doing it.

@AmandaRiu I'm assigning you this as you were the last to make changes to those parts 🙂 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
