### PR TITLE
Trigger Tracks Event When a Product is Deleted

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -295,6 +295,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         ADD_PRODUCT_SUCCESS,
         ADD_PRODUCT_FAILED,
         PRODUCT_IMAGE_UPLOAD_FAILED,
+        PRODUCT_DETAIL_PRODUCT_DELETED,
 
         // -- Product Categories
         PRODUCT_CATEGORIES_LOADED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ADD_PRODUCT_PUBLI
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ADD_PRODUCT_SAVE_AS_DRAFT_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ADD_PRODUCT_SUCCESS
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_IMAGE_TAPPED
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_PRODUCT_DELETED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_SHARE_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_UPDATE_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_VIEW_EXTERNAL_TAPPED
@@ -242,6 +243,7 @@ class ProductDetailViewModel @AssistedInject constructor(
             triggerEvent(
                 ShowDialog(
                     positiveBtnAction = DialogInterface.OnClickListener { _, _ ->
+                        AnalyticsTracker.track(PRODUCT_DETAIL_PRODUCT_DELETED)
                         viewState = viewState.copy(isConfirmingTrash = false)
                         viewState.productDraft?.let { product ->
                             triggerEvent(ExitWithResult(product.remoteId))


### PR DESCRIPTION
Closes #3364 

This triggers the Tracks event `product_detail_product_deleted` when a product is deleted. This is the same as iOS (https://github.com/woocommerce/woocommerce-ios/pull/3401). 

## Testing

1. Navigate to a product. 
2. Tap on Option Menu → Trash product. 
3. Confirm that the Tracks event is triggered and you can see this in the console:

   ```
    I/WooCommerce-UTILS: 🔵 Tracked: product_detail_product_deleted, Properties:
    ```

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

