### PR TITLE
Added fees section to refund by items screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -179,8 +179,10 @@ class IssueRefundViewModel @AssistedInject constructor(
                     subtotal = formatCurrency(BigDecimal.ZERO),
                     taxes = formatCurrency(BigDecimal.ZERO),
                     shippingSubtotal = formatCurrency(order.shippingTotal),
+                    feesTotal = formatCurrency(order.feesTotal),
                     formattedProductsRefund = formatCurrency(BigDecimal.ZERO),
                     isShippingRefundVisible = order.shippingTotal > BigDecimal.ZERO,
+                    isFeesVisible = order.feesTotal > BigDecimal.ZERO,
                     isShippingNoticeVisible = true,
                     isNextButtonEnabled = false
             )
@@ -595,8 +597,10 @@ class IssueRefundViewModel @AssistedInject constructor(
         val shippingRefund: BigDecimal = BigDecimal.ZERO,
         val formattedShippingRefund: String? = null,
         val shippingSubtotal: String? = null,
+        val feesTotal: String? = null,
         val shippingTaxes: String? = null,
         val isShippingRefundVisible: Boolean? = null,
+        val isFeesVisible: Boolean? = null,
         val isShippingNoticeVisible: Boolean? = null,
         val selectedItemsHeader: String? = null,
         val selectButtonTitle: String? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByItemsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByItemsFragment.kt
@@ -115,6 +115,9 @@ class RefundByItemsFragment : BaseFragment() {
             new.shippingSubtotal?.takeIfNotEqualTo(old?.shippingSubtotal) {
                 issueRefund_shippingTotal.text = it
             }
+            new.feesTotal?.takeIfNotEqualTo(old?.feesTotal) {
+                issueRefund_feesTotal.text = it
+            }
             new.taxes?.takeIfNotEqualTo(old?.taxes) {
                 issueRefund_taxesTotal.text = it
             }
@@ -139,6 +142,13 @@ class RefundByItemsFragment : BaseFragment() {
                     issueRefund_shippingRefundNotice.show()
                 } else {
                     issueRefund_shippingRefundNotice.hide()
+                }
+            }
+            new.isFeesVisible?.takeIfNotEqualTo(old?.isFeesVisible) { isVisible ->
+                if (isVisible) {
+                    issueRefund_feesGroup.show()
+                } else {
+                    issueRefund_feesGroup.hide()
                 }
             }
             // TODO: Temporarily disabled, this will be used in a future release - do not remove

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByItemsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByItemsFragment.kt
@@ -80,20 +80,6 @@ class RefundByItemsFragment : BaseFragment() {
 //        issueRefund_productsTotal.setOnClickListener {
 //            viewModel.onProductRefundAmountTapped()
 //        }
-
-        val linkText = getString(R.string.order_refunds_store_admin_link_text)
-        val noticeText = getString(R.string.order_refunds_shipping_refund_notice, linkText)
-        val spannable = SpannableString(noticeText)
-        val span = WooClickableSpan { viewModel.onOpenStoreAdminLinkClicked() }
-        span.useCustomStyle = false
-        spannable.setSpan(
-                span,
-                (noticeText.length - linkText.length),
-                noticeText.length,
-                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
-
-        issueRefund_shippingRefundNotice.setText(spannable, TextView.BufferType.SPANNABLE)
-        issueRefund_shippingRefundNotice.movementMethod = LinkMovementMethod.getInstance()
     }
 
     private fun setupObservers() {
@@ -147,8 +133,10 @@ class RefundByItemsFragment : BaseFragment() {
             new.isFeesVisible?.takeIfNotEqualTo(old?.isFeesVisible) { isVisible ->
                 if (isVisible) {
                     issueRefund_feesGroup.show()
+                    updateRefundNoticeView(getString(R.string.order_refunds_shipping_refund_notice_fees))
                 } else {
                     issueRefund_feesGroup.hide()
+                    updateRefundNoticeView(getString(R.string.order_refunds_shipping_refund_notice))
                 }
             }
             // TODO: Temporarily disabled, this will be used in a future release - do not remove
@@ -193,5 +181,21 @@ class RefundByItemsFragment : BaseFragment() {
                 else -> event.isHandled = false
             }
         })
+    }
+
+    private fun updateRefundNoticeView(refundNoticeText: String) {
+        val linkText = getString(R.string.order_refunds_store_admin_link_text)
+        val noticeText = String.format(refundNoticeText, linkText)
+        val spannable = SpannableString(noticeText)
+        val span = WooClickableSpan { viewModel.onOpenStoreAdminLinkClicked() }
+        span.useCustomStyle = false
+        spannable.setSpan(
+            span,
+            (noticeText.length - linkText.length),
+            noticeText.length,
+            Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+
+        issueRefund_shippingRefundNotice.setText(spannable, TextView.BufferType.SPANNABLE)
+        issueRefund_shippingRefundNotice.movementMethod = LinkMovementMethod.getInstance()
     }
 }

--- a/WooCommerce/src/main/res/layout/refund_by_items_products.xml
+++ b/WooCommerce/src/main/res/layout/refund_by_items_products.xml
@@ -69,6 +69,26 @@
         tools:text="$1.00" />
 
     <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/issueRefund_lblFees"
+        style="@style/Woo.Card.Body.High"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/minor_50"
+        android:text="@string/orderdetail_payment_fees"
+        app:layout_constraintEnd_toStartOf="@+id/issueRefund_feesTotal"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/issueRefund_shippingTotal" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/issueRefund_feesTotal"
+        style="@style/Woo.Card.Body.High"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/issueRefund_lblFees"
+        tools:text="$5.00" />
+
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/issueRefund_lblTaxes"
         style="@style/Woo.Card.Body.High"
         android:layout_width="0dp"
@@ -77,7 +97,7 @@
         android:text="@string/taxes"
         app:layout_constraintEnd_toStartOf="@+id/issueRefund_taxesTotal"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/issueRefund_shippingTotal" />
+        app:layout_constraintTop_toBottomOf="@id/issueRefund_feesTotal" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/issueRefund_taxesTotal"
@@ -152,6 +172,13 @@
         android:layout_height="wrap_content"
         android:visibility="gone"
         app:constraint_referenced_ids="issueRefund_shippingTotal,issueRefund_lblShipping" />
+
+    <androidx.constraintlayout.widget.Group
+        android:id="@+id/issueRefund_feesGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:constraint_referenced_ids="issueRefund_feesTotal,issueRefund_lblFees" />
 
     <!--     TODO: Temporarily disabled, this will be used in a future release - do not remove -->
     <!--        <com.google.android.material.button.MaterialButton-->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -401,6 +401,7 @@
     </plurals>
     <string name="order_refunds_refund_info_title">Refunded products</string>
     <string name="order_refunds_shipping_refund_notice">You can refund shipping and tax amounts %s</string>
+    <string name="order_refunds_shipping_refund_notice_fees">You can refund fees, shipping and tax amounts %s</string>
     <string name="order_refunds_store_admin_link_text">in your store admin</string>
     <!--
         Add Order Note


### PR DESCRIPTION
Fixes #3392 by adding the option to display fees section in the Issue refund screen. This section will only be displayed if fees is applicable for an order.

#### Screenshot
<img src="https://user-images.githubusercontent.com/22608780/103726701-97fb0f80-4fff-11eb-8f44-204d0f4c95ea.png" width="300"/>

#### Testing
- Create an order.
- Add some fees in `wp-admin`.
- Open the order in the app and confirm the fees are displayed in the payment section.
- Issue a refund for the order and notice the fees are displayed on the refund screen.

@rachelmcr, I have added you as a reviewer since you caught the bug in the first place. I also targeted `develop` instead of the release branch because we are already in `5.7-rc-5` and I didn't think this warranted another beta release. But let me know if you feel otherwise :D  

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
