### PR TITLE
Fix the overlap between orders list and other fragments when rotating the device

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -474,7 +474,7 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
     }
 
     private fun updateOrderStatusList(orderStatusList: Map<String, WCOrderStatusModel>) {
-        binding.orderListRoot.visibility = View.VISIBLE
+        binding.orderListViewRoot.visibility = View.VISIBLE
         binding.orderStatusListView.updateOrderStatusListView(orderStatusList.values.toList())
     }
 
@@ -665,7 +665,7 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
 
     private fun disableSearchListeners() {
         orderListMenu?.findItem(R.id.menu_settings)?.isVisible = true
-        binding.orderListRoot.visibility = View.VISIBLE
+        binding.orderListViewRoot.visibility = View.VISIBLE
         searchMenuItem?.setOnActionExpandListener(null)
         searchView?.setOnQueryTextListener(null)
         hideOrderStatusListView()

--- a/WooCommerce/src/main/res/layout/fragment_order_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_list.xml
@@ -3,7 +3,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/order_list_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"


### PR DESCRIPTION
Fixes #3356, after converting the OrderListFragment to viewbinding, we were updating the visibility of the root view, instead of the listview parent, as they had quite similar ids `order_list_view_root` vs `order_list_root`, and this caused the fragment to appear on top of other fragments.

### Testing

1. Launch the app.
2. Open the Orders tab and wait for the order list to load.
3. Open the My store tab.
4. Rotate your device between landscape and portrait. and confirm that the orders list doesn't appear.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
