### PR TITLE
Display shipment tracking even if the list is empty

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -44,7 +44,8 @@ object AppPrefs {
         SELECTED_APP_THEME,
         SELECTED_PRODUCT_TYPE,
         UNIFIED_LOGIN_LAST_ACTIVE_SOURCE,
-        UNIFIED_LOGIN_LAST_ACTIVE_FLOW
+        UNIFIED_LOGIN_LAST_ACTIVE_FLOW,
+        TRACKING_EXTENSION_AVAILABLE
     }
 
     /**
@@ -324,6 +325,14 @@ object AppPrefs {
 
     fun setUnifiedLoginLastFlow(flow: String) {
         setString(DeletablePrefKey.UNIFIED_LOGIN_LAST_ACTIVE_FLOW, flow)
+    }
+
+    fun isTrackingExtensionAvailable(): Boolean {
+        return getBoolean(DeletablePrefKey.TRACKING_EXTENSION_AVAILABLE, false)
+    }
+
+    fun setTrackingExtensionAvailable(isAvailable: Boolean) {
+        setBoolean(DeletablePrefKey.TRACKING_EXTENSION_AVAILABLE, isAvailable)
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/PrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/PrefsWrapper.kt
@@ -1,0 +1,11 @@
+package com.woocommerce.android
+
+import javax.inject.Inject
+
+class PrefsWrapper @Inject constructor(private val prefs: AppPrefs) {
+    var isTrackingExtensionAvailable: Boolean
+        get() = prefs.isTrackingExtensionAvailable()
+        set(value) {
+            prefs.setTrackingExtensionAvailable(value)
+        }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -437,7 +437,7 @@ class OrderDetailViewModel @AssistedInject constructor(
 
     private fun loadShipmentTracking(shippingLabels: ListInfo<ShippingLabel>): ListInfo<OrderShipmentTracking> {
         val trackingList = orderDetailRepository.getOrderShipmentTrackings(orderIdSet.id)
-        return if (shippingLabels.isVisible || hasVirtualProductsOnly() || trackingList.isEmpty()) {
+        return if (shippingLabels.isVisible || hasVirtualProductsOnly()) {
             ListInfo(isVisible = false)
         } else {
             ListInfo(list = trackingList)
@@ -482,12 +482,6 @@ class OrderDetailViewModel @AssistedInject constructor(
 
         if (shippingLabels.isVisible) {
             _shippingLabels.value = shippingLabels.list
-
-            viewState = viewState.copy(
-                isShipmentTrackingAvailable = false,
-                isProductListVisible = _productList.value?.isNotEmpty(),
-                areShippingLabelsVisible = shippingLabels.isVisible
-            )
         }
 
         if (orderProducts.isVisible) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -22,6 +22,7 @@ import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.model.OrderNote
 import com.woocommerce.android.model.OrderShipmentTracking
 import com.woocommerce.android.model.Refund
+import com.woocommerce.android.model.RequestResult.SUCCESS
 import com.woocommerce.android.model.ShippingLabel
 import com.woocommerce.android.model.WooPlugin
 import com.woocommerce.android.model.getNonRefundedProducts
@@ -85,6 +86,7 @@ class OrderDetailViewModel @AssistedInject constructor(
     // the request to server fails, we need to display an error message
     // and add the deleted tracking number back to the list
     private var deletedOrderShipmentTrackingSet = mutableSetOf<String>()
+    private var isShipmentTrackingAvailable = false
 
     final val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
@@ -437,7 +439,7 @@ class OrderDetailViewModel @AssistedInject constructor(
 
     private fun loadShipmentTracking(shippingLabels: ListInfo<ShippingLabel>): ListInfo<OrderShipmentTracking> {
         val trackingList = orderDetailRepository.getOrderShipmentTrackings(orderIdSet.id)
-        return if (shippingLabels.isVisible || hasVirtualProductsOnly()) {
+        return if (isShipmentTrackingAvailable && shippingLabels.isVisible || hasVirtualProductsOnly()) {
             ListInfo(isVisible = false)
         } else {
             ListInfo(list = trackingList)
@@ -449,7 +451,8 @@ class OrderDetailViewModel @AssistedInject constructor(
     }
 
     private fun fetchShipmentTrackingAsync() = async {
-        orderDetailRepository.fetchOrderShipmentTrackingList(orderIdSet.id, orderIdSet.remoteOrderId)
+        val result = orderDetailRepository.fetchOrderShipmentTrackingList(orderIdSet.id, orderIdSet.remoteOrderId)
+        isShipmentTrackingAvailable = result == SUCCESS
     }
 
     private fun fetchOrderShippingLabelsAsync() = async {


### PR DESCRIPTION
Fixes #3350. The shipment tracking card is displayed when:

- order has either no products or at least on physical product
- order doesn't have shipping labels