### PR TITLE
Update RELEASE NOTES for Products M5 Release

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,9 +2,7 @@
 
 5.8
 -----
-* [*] Milestone 5: Product downloadable files feature is now available. [https://github.com/woocommerce/woocommerce-android/pull/2750]
-* [*] Milestone 5: Added ability to manage linked products. [https://github.com/woocommerce/woocommerce-android/pull/3056]
-* [*] Milestone 5: Added product deletion. [https://github.com/woocommerce/woocommerce-android/pull/2935]
+* [**] Products: Now you can add/edit downloadable files, manage linked products and delete products. [https://github.com/woocommerce/woocommerce-android/pull/3056]
 * [*] Fixed a bug where the moderation buttons in the product review detail would be partially hidden for some locales [https://github.com/woocommerce/woocommerce-android/pull/3382]
  
 5.7

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,9 @@
 
 5.8
 -----
+* [*] Milestone 5: Product downloadable files feature is now available. [https://github.com/woocommerce/woocommerce-android/pull/2750]
+* [*] Milestone 5: Added ability to manage linked products. [https://github.com/woocommerce/woocommerce-android/pull/3056]
+* [*] Milestone 5: Added product deletion. [https://github.com/woocommerce/woocommerce-android/pull/2935]
 * [*] Fixed a bug where the moderation buttons in the product review detail would be partially hidden for some locales [https://github.com/woocommerce/woocommerce-android/pull/3382]
  
 5.7


### PR DESCRIPTION
We opened these features in https://github.com/woocommerce/woocommerce-android/pull/3370. This just updates the release notes for Editorial. 

## Testing

Please review the `RELEASE-NOTES.txt`. 🙂 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. YES.

