### PR TITLE
Search in product detail fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -285,9 +285,7 @@ class ProductListViewModel @AssistedInject constructor(
             isLoading = true,
             canLoadMore = productRepository.canLoadMoreProducts,
             isEmptyViewVisible = _productList.value?.isEmpty() == true,
-            displaySortAndFilterCard = (
-                productFilterOptions.isNotEmpty() || _productList.value?.isNotEmpty() == true
-                )
+            displaySortAndFilterCard = productFilterOptions.isNotEmpty() || _productList.value?.isNotEmpty() == true
         )
 
         viewState = viewState.copy(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
-import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
@@ -43,8 +42,7 @@ class ProductListViewModel @AssistedInject constructor(
     @Assisted savedState: SavedStateWithArgs,
     dispatchers: CoroutineDispatchers,
     private val productRepository: ProductListRepository,
-    private val networkStatus: NetworkStatus,
-    private val prefs: AppPrefs
+    private val networkStatus: NetworkStatus
 ) : ScopedViewModel(savedState, dispatchers) {
     companion object {
         private const val SEARCH_TYPING_DELAY_MS = 500L

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -144,7 +144,7 @@ class ProductListViewModel @AssistedInject constructor(
     fun onAddProductButtonClicked() {
         launch {
             cancelSearch()
-            
+
             AnalyticsTracker.track(Stat.PRODUCT_LIST_ADD_PRODUCT_BUTTON_TAPPED)
             triggerEvent(ShowAddProductBottomSheet)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -142,8 +142,18 @@ class ProductListViewModel @AssistedInject constructor(
     }
 
     fun onAddProductButtonClicked() {
-        AnalyticsTracker.track(Stat.PRODUCT_LIST_ADD_PRODUCT_BUTTON_TAPPED)
-        triggerEvent(ShowAddProductBottomSheet)
+        launch {
+            cancelSearch()
+            
+            AnalyticsTracker.track(Stat.PRODUCT_LIST_ADD_PRODUCT_BUTTON_TAPPED)
+            triggerEvent(ShowAddProductBottomSheet)
+        }
+    }
+
+    private suspend fun cancelSearch() {
+        searchJob?.cancelAndJoin()
+        viewState = viewState.copy(query = null, isSearchActive = false, isEmptyViewVisible = false)
+        _productList.value = productRepository.getProductList()
     }
 
     fun onSearchOpened() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -372,12 +372,12 @@ class ProductListViewModel @AssistedInject constructor(
     sealed class ProductListEvent : Event() {
         object ScrollToTop : ProductListEvent()
         object ShowAddProductBottomSheet : ProductListEvent()
-        object ShowProductSortingBottomSheet : Event()
+        object ShowProductSortingBottomSheet : ProductListEvent()
         data class ShowProductFilterScreen(
             val stockStatusFilter: String?,
             val productTypeFilter: String?,
             val productStatusFilter: String?
-        ) : Event()
+        ) : ProductListEvent()
     }
 
     @AssistedInject.Factory

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
@@ -8,7 +8,6 @@ import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.Product
@@ -33,7 +32,6 @@ class ProductListViewModelTest : BaseUnitTest() {
     private val networkStatus: NetworkStatus = mock()
     private val productRepository: ProductListRepository = mock()
     private val savedState: SavedStateWithArgs = mock()
-    private val prefs: AppPrefs = mock()
 
     private val coroutineDispatchers = CoroutineDispatchers(
         Dispatchers.Unconfined,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
@@ -56,8 +56,7 @@ class ProductListViewModelTest : BaseUnitTest() {
                         savedState,
                         coroutineDispatchers,
                         productRepository,
-                        networkStatus,
-                        prefs
+                        networkStatus
                 )
         )
     }


### PR DESCRIPTION
Fixes: #3244.

**To test:**

1. Go to Products
2. Tap on the Search icon
3. Tap on the Add product FAB
4. Notice the search is canceled