### PR TITLE
Create a custom navigator to handle top level fragments navigation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ActivityExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ActivityExt.kt
@@ -7,7 +7,6 @@ import androidx.fragment.app.FragmentManager
 import androidx.navigation.findNavController
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
-import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainActivity.NavigationResult
 import kotlin.properties.Delegates
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ActivityExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ActivityExt.kt
@@ -27,24 +27,6 @@ fun FragmentActivity.navigateBackWithResult(requestCode: Int, result: Bundle, @I
 }
 
 /**
- * Used for passing back some result from a fragment using the Navigation component
- * to one of the top level activities.
- *
- * It reuses the logic from the above method but uses the getActiveTopLevelFragment()
- * from [MainActivity] to get the current active fragment
- */
-fun MainActivity.navigateBackWithResult(requestCode: Int, result: Bundle, @IdRes navHostId: Int, @IdRes dest: Int) {
-    val childFragmentManager = supportFragmentManager.findFragmentById(navHostId)?.childFragmentManager
-    var backStackListener: FragmentManager.OnBackStackChangedListener by Delegates.notNull()
-    backStackListener = FragmentManager.OnBackStackChangedListener {
-        (getActiveTopLevelFragment() as? NavigationResult)?.onNavigationResult(requestCode, result)
-        childFragmentManager?.removeOnBackStackChangedListener(backStackListener)
-    }
-    childFragmentManager?.addOnBackStackChangedListener(backStackListener)
-    findNavController(navHostId).popBackStack(dest, false)
-}
-
-/**
  * Used for starting the HelpActivity in a wrapped way whenever a troubleshooting URL click happens
  */
 fun FragmentActivity.startHelpActivity(origin: Origin) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -3,8 +3,6 @@ package com.woocommerce.android.extensions
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
-import com.woocommerce.android.R
-import com.woocommerce.android.ui.base.TopLevelFragment
 
 /**
  * A helper function that sets the submitted key-value pair in the Fragment's SavedStateHandle. The value can be

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -103,37 +103,6 @@ fun <T> Fragment.handleDialogNotice(key: String, entryId: Int, handler: (T) -> U
 }
 
 /**
- * A helper function that subscribes a supplied handler function to the [TopLevelFragment]'s SavedStateHandle LiveData
- * associated with the supplied key. The `rootFragment` entry ID must be used to deliver the result.
- *
- * @param [key] A unique string that is the same as the one used in [navigateBackWithResult]
- * @param [handler] A result handler
- *
- * Note: The handler is called only if the value wasn't handled before (i.e. the data is fresh). Once the observer is
- * called, the value is nulled and the handler won't be called. This puts a limit on the number of observers for
- * a particular key-result pair to 1.
- */
-fun <T> TopLevelFragment.handleResult(key: String, handler: (T) -> Unit) {
-    (this as Fragment).handleResult(key, entryId = R.id.rootFragment, handler = handler)
-}
-
-/**
- * A helper function that subscribes a supplied noice handler function to the [TopLevelFragment]'s SavedStateHandle
- * LiveData associated with the supplied key. Its purpose is to handle a notice without any value.
- * The `rootFragment` entry ID must be used to deliver the result.
- *
- * @param [key] A unique string that is the same as the one used in [navigateBackWithNotice]
- * @param [handler] A result handler
- *
- * Note: The handler is called only if the value wasn't handled before (i.e. the data is fresh). Once the observer is
- * called, the value is nulled and the handler won't be called. This puts a limit on the number of observers for
- * a particular key-result pair to 1.
- */
-fun TopLevelFragment.handleNotice(key: String, handler: () -> Unit) {
-    (this as Fragment).handleNotice(key, entryId = R.id.rootFragment, handler = handler)
-}
-
-/**
  * A helper function that subscribes a supplied handler function to the Fragment's SavedStateHandle LiveData associated
  * with the supplied key. Its purpose is to handle a notice without any value.
  *

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/navigation/KeepStateNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/navigation/KeepStateNavigator.kt
@@ -1,0 +1,72 @@
+package com.woocommerce.android.navigation
+
+import android.content.Context
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.navigation.NavDestination
+import androidx.navigation.NavOptions
+import androidx.navigation.Navigator
+import androidx.navigation.fragment.FragmentNavigator
+import com.woocommerce.android.ui.base.TopLevelFragment
+import java.util.ArrayDeque
+
+/**
+ * A custom navigator that keeps the state of toplevel navigation fragments when navigating to other tabs.
+ * Based on the solution described here: https://github.com/STAR-ZERO/navigation-keep-fragment-sample
+ */
+@Navigator.Name("fragment")
+class KeepStateNavigator(
+    private val context: Context,
+    private val manager: FragmentManager, // Should pass childFragmentManager.
+    private val containerId: Int
+) : FragmentNavigator(context, manager, containerId) {
+    private var backStack: ArrayDeque<Int>
+
+    private var lastTopLevelFragment: Fragment? = null
+
+    init {
+        val field = FragmentNavigator::class.java.getDeclaredField("mBackStack")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        backStack = field.get(this) as ArrayDeque<Int>
+    }
+
+    override fun navigate(
+        destination: Destination,
+        args: Bundle?,
+        navOptions: NavOptions?,
+        navigatorExtras: Navigator.Extras?
+    ): NavDestination? {
+        val cls = Class.forName(destination.className)
+        if (!TopLevelFragment::class.java.isAssignableFrom(cls)) {
+            return super.navigate(destination, args, navOptions, navigatorExtras)
+        }
+
+        val tag = destination.id.toString()
+        val transaction = manager.beginTransaction()
+
+        (lastTopLevelFragment ?: manager.primaryNavigationFragment)?.let {
+            transaction.detach(it)
+        }
+
+        var fragment = manager.findFragmentByTag(tag)
+        if (fragment == null) {
+            val className = destination.className
+            fragment = manager.fragmentFactory.instantiate(context.classLoader, className)
+            transaction.add(containerId, fragment, tag)
+        } else {
+            transaction.attach(fragment)
+        }
+        lastTopLevelFragment = fragment
+
+        backStack.clear()
+        backStack.add(destination.id)
+
+        transaction.setPrimaryNavigationFragment(fragment)
+        transaction.setReorderingAllowed(true)
+        transaction.commit()
+
+        return destination
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragmentRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragmentRouter.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.base
 
 interface TopLevelFragmentRouter {
-    fun showOrderList(orderStatusFilter: String? = null)
     fun showNotificationDetail(remoteNoteId: Long)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/BottomNavigationPosition.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/BottomNavigationPosition.kt
@@ -1,11 +1,6 @@
 package com.woocommerce.android.ui.main
 
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.base.TopLevelFragment
-import com.woocommerce.android.ui.mystore.MyStoreFragment
-import com.woocommerce.android.ui.products.ProductListFragment
-import com.woocommerce.android.ui.reviews.ReviewListFragment
-import com.woocommerce.android.ui.orders.list.OrderListFragment
 
 enum class BottomNavigationPosition(val position: Int, val id: Int) {
     MY_STORE(0, R.id.dashboard),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/BottomNavigationPosition.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/BottomNavigationPosition.kt
@@ -22,16 +22,4 @@ fun findNavigationPositionById(id: Int): BottomNavigationPosition = when (id) {
     else -> BottomNavigationPosition.MY_STORE
 }
 
-fun BottomNavigationPosition.getTag(): String = when (this) {
-    BottomNavigationPosition.MY_STORE -> MyStoreFragment.TAG
-    BottomNavigationPosition.ORDERS -> OrderListFragment.TAG
-    BottomNavigationPosition.PRODUCTS -> ProductListFragment.TAG
-    BottomNavigationPosition.REVIEWS -> ReviewListFragment.TAG
-}
-
-fun BottomNavigationPosition.createFragment(): TopLevelFragment = when (this) {
-    BottomNavigationPosition.MY_STORE -> MyStoreFragment.newInstance()
-    BottomNavigationPosition.ORDERS -> OrderListFragment.newInstance()
-    BottomNavigationPosition.PRODUCTS -> ProductListFragment.newInstance()
-    BottomNavigationPosition.REVIEWS -> ReviewListFragment.newInstance()
-}
+fun BottomNavigationPosition.getTag(): String = id.toString()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -89,7 +89,6 @@ class MainActivity : AppUpgradeActivity(),
 
         private const val KEY_BOTTOM_NAV_POSITION = "key-bottom-nav-position"
         private const val KEY_UNFILLED_ORDER_COUNT = "unfilled-order-count"
-        private const val KEY_IS_TOOLBAR_EXPANDED = "is-toolbar-expanded"
 
         private const val DIALOG_NAVIGATOR_NAME = "dialog"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -15,6 +15,8 @@ import androidx.appcompat.widget.Toolbar
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.fragment.NavHostFragment
@@ -122,7 +124,6 @@ class MainActivity : AppUpgradeActivity(),
     private var previousDestinationId: Int? = null
     private var unfilledOrderCount: Int = 0
     private var isMainThemeApplied = false
-    private var isToolbarExpanded = true
     private var restoreToolbarHeight = 0
 
     private val toolbarEnabledBehavior = AppBarLayout.Behavior()
@@ -135,6 +136,28 @@ class MainActivity : AppUpgradeActivity(),
 
     // TODO: Using deprecated ProgressDialog temporarily - a proper post-login experience will replace this
     private var progressDialog: ProgressDialog? = null
+
+    private val fragmentLifecycleObserver: FragmentLifecycleCallbacks = object : FragmentLifecycleCallbacks() {
+        override fun onFragmentViewCreated(fm: FragmentManager, f: Fragment, v: View, savedInstanceState: Bundle?) {
+            val currentDestination = navController.currentDestination!!
+            val isFullScreenFragment = currentDestination.id == R.id.productImageViewerFragment ||
+                currentDestination.id == R.id.wpMediaViewerFragment
+
+            if (!isFullScreenFragment) {
+                // re-expand the AppBar when returning to top level fragment, collapse it when entering a child fragment
+                if (f is TopLevelFragment) {
+                    f.view?.post {
+                        expandToolbar(expand = f.isScrolledToTop(), animate = false)
+                    }
+                } else {
+                    expandToolbar(expand = false, animate = false)
+                }
+
+                // collapsible toolbar should only be able to expand for top-level fragments
+                enableToolbarExpansion(f is TopLevelFragment)
+            }
+        }
+    }
 
     /**
      * Manually set the theme here so the splash screen will be visible while this activity
@@ -175,6 +198,7 @@ class MainActivity : AppUpgradeActivity(),
             setGraph(R.navigation.nav_graph_main)
             addOnDestinationChangedListener(this@MainActivity)
         }
+        navHostFragment.childFragmentManager.registerFragmentLifecycleCallbacks(fragmentLifecycleObserver, false)
 
         binding.bottomNav.init(navController, this)
 
@@ -212,13 +236,6 @@ class MainActivity : AppUpgradeActivity(),
         if (!BuildConfig.DEBUG) {
             checkForAppUpdates()
         }
-
-        // detect when the collapsible toolbar if fully expanded
-        binding.appBarLayout.addOnOffsetChangedListener(AppBarLayout.OnOffsetChangedListener { _, verticalOffset ->
-            if (isAtNavigationRoot()) {
-                isToolbarExpanded = (verticalOffset == 0)
-            }
-        })
 
         // see overridden onChildViewAdded() and onChildViewRemoved() below
         binding.appBarLayout.setOnHierarchyChangeListener(this)
@@ -262,7 +279,6 @@ class MainActivity : AppUpgradeActivity(),
     override fun onSaveInstanceState(outState: Bundle) {
         outState.putInt(KEY_BOTTOM_NAV_POSITION, binding.bottomNav.currentPosition.id)
         outState.putInt(KEY_UNFILLED_ORDER_COUNT, unfilledOrderCount)
-        outState.putBoolean(KEY_IS_TOOLBAR_EXPANDED, isToolbarExpanded)
         super.onSaveInstanceState(outState)
     }
 
@@ -275,8 +291,6 @@ class MainActivity : AppUpgradeActivity(),
             if (count > 0) {
                 showOrderBadge(count)
             }
-
-            isToolbarExpanded = it.getBoolean(KEY_IS_TOOLBAR_EXPANDED)
         }
     }
 
@@ -448,18 +462,6 @@ class MainActivity : AppUpgradeActivity(),
             } else {
                 it.onChildFragmentOpened()
             }
-        }
-
-        if (!isFullScreenFragment) {
-            // re-expand the AppBar when returning to top level fragment, collapse it when entering a child fragment
-            if (isAtRoot) {
-                expandToolbar(expand = isToolbarExpanded, animate = false)
-            } else {
-                expandToolbar(expand = false, animate = false)
-            }
-
-            // collapsible toolbar should only be able to expand for top-level fragments
-            enableToolbarExpansion(isAtRoot)
         }
 
         previousDestinationId = destination.id
@@ -649,10 +651,6 @@ class MainActivity : AppUpgradeActivity(),
             NotificationHandler.removeAllReviewNotifsFromSystemBar(this)
         } else if (navPos == ORDERS) {
             NotificationHandler.removeAllOrderNotifsFromSystemBar(this)
-        }
-
-        getActiveTopLevelFragment()?.let {
-            expandToolbar(it.isScrolledToTop(), animate = false)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -145,6 +145,7 @@ class MainActivity : AppUpgradeActivity(),
             if (!isFullScreenFragment) {
                 // re-expand the AppBar when returning to top level fragment, collapse it when entering a child fragment
                 if (f is TopLevelFragment) {
+                    // We need to post this to the view handler to make sure isScrolledToTop returns the correct value
                     f.view?.post {
                         expandToolbar(expand = f.isScrolledToTop(), animate = false)
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -339,9 +339,10 @@ class MainActivity : AppUpgradeActivity(),
     /**
      * Returns the current top level fragment (ie: the one showing in the bottom nav)
      */
-    internal fun getActiveTopLevelFragment(): TopLevelFragment? {
+    private fun getActiveTopLevelFragment(): TopLevelFragment? {
         val tag = binding.bottomNav.currentPosition.getTag()
-        return supportFragmentManager.findFragmentByTag(tag) as? TopLevelFragment
+        val navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment_main) as NavHostFragment
+        return navHostFragment.childFragmentManager.findFragmentByTag(tag) as? TopLevelFragment
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -330,10 +330,10 @@ class MainActivity : AppUpgradeActivity(),
     override fun isAtNavigationRoot(): Boolean {
         return if (::navController.isInitialized) {
             val currentDestinationId = navController.currentDestination?.id
-            currentDestinationId == R.id.dashboard
-                || currentDestinationId == R.id.orders
-                || currentDestinationId == R.id.products
-                || currentDestinationId == R.id.reviews
+            currentDestinationId == R.id.dashboard ||
+                currentDestinationId == R.id.orders ||
+                currentDestinationId == R.id.products ||
+                currentDestinationId == R.id.reviews
         } else {
             true
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -376,13 +376,6 @@ class MainActivity : AppUpgradeActivity(),
             return
         }
 
-        // show/hide the top level fragment container if this is a dialog destination from root or, just root itself
-        if (isTopLevelNavigation) {
-            binding.container.visibility = View.VISIBLE
-        } else {
-            binding.container.visibility = View.INVISIBLE
-        }
-
         val showCrossIcon: Boolean
         if (isTopLevelNavigation) {
             binding.appBarLayout.elevation = 0f
@@ -496,7 +489,6 @@ class MainActivity : AppUpgradeActivity(),
 
     /**
      * Returns a Boolean value in order to set the behaviour from a root navigation type in terms of:
-     * .container visibility
      * .menu items visibility
      * .top nav bar titles
      *

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -254,7 +254,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store),
         super.onSaveInstanceState(outState)
         outState.putBoolean(STATE_KEY_REFRESH_PENDING, isRefreshPending)
         outState.putInt(STATE_KEY_TAB_POSITION, tabStatsPosition)
-         outState.putBoolean(STATE_KEY_IS_EMPTY_VIEW_SHOWING, isEmptyViewVisible)
+        outState.putBoolean(STATE_KEY_IS_EMPTY_VIEW_SHOWING, isEmptyViewVisible)
     }
 
     override fun showStats(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -116,7 +116,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store),
         super.onViewCreated(view, savedInstanceState)
         setHasOptionsMenu(true)
 
-        _tabLayout = TabLayout(requireContext(), null, R.attr.tabStyle)
+        _tabLayout = TabLayout(requireContext(), null, R.attr.scrollableTabStyle)
         addTabLayoutToAppBar()
 
         _binding = FragmentMyStoreBinding.bind(view)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -773,5 +773,5 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
         (activity?.findViewById<View>(R.id.app_bar_layout) as? AppBarLayout)?.removeView(tabLayout)
     }
 
-    override fun isScrolledToTop() = binding.orderListView.getCurrentPosition() == 0
+    override fun isScrolledToTop() = binding.orderListView.ordersList.computeVerticalScrollOffset() == 0
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
@@ -19,7 +19,6 @@ import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
-import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.ProductFilterListAdapter.OnProductFilterClickListener
 import com.woocommerce.android.ui.products.ProductFilterListViewModel.Companion.ARG_PRODUCT_FILTER_STATUS
@@ -81,11 +80,11 @@ class ProductFilterListFragment : BaseFragment(R.layout.fragment_product_filter_
             bundle.putString(ARG_PRODUCT_FILTER_STOCK_STATUS, viewModel.getFilterByStockStatus())
             bundle.putString(ARG_PRODUCT_FILTER_STATUS, viewModel.getFilterByProductStatus())
             bundle.putString(ARG_PRODUCT_FILTER_TYPE_STATUS, viewModel.getFilterByProductType())
-            (requireActivity() as? MainActivity)?.navigateBackWithResult(
+            requireActivity().navigateBackWithResult(
                     RequestCodes.PRODUCT_LIST_FILTERS,
                     bundle,
                     R.id.nav_host_fragment_main,
-                    R.id.rootFragment
+                    R.id.products
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
@@ -15,7 +15,6 @@ import com.woocommerce.android.databinding.FragmentProductFilterOptionListBindin
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
-import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.products.ProductFilterListViewModel.Companion.ARG_PRODUCT_FILTER_STATUS
 import com.woocommerce.android.ui.products.ProductFilterListViewModel.Companion.ARG_PRODUCT_FILTER_STOCK_STATUS
 import com.woocommerce.android.ui.products.ProductFilterListViewModel.Companion.ARG_PRODUCT_FILTER_TYPE_STATUS
@@ -70,11 +69,11 @@ class ProductFilterOptionListFragment : BaseFragment(R.layout.fragment_product_f
             bundle.putString(ARG_PRODUCT_FILTER_STOCK_STATUS, viewModel.getFilterByStockStatus())
             bundle.putString(ARG_PRODUCT_FILTER_STATUS, viewModel.getFilterByProductStatus())
             bundle.putString(ARG_PRODUCT_FILTER_TYPE_STATUS, viewModel.getFilterByProductType())
-            (requireActivity() as? MainActivity)?.navigateBackWithResult(
+            requireActivity().navigateBackWithResult(
                     RequestCodes.PRODUCT_LIST_FILTERS,
                     bundle,
                     R.id.nav_host_fragment_main,
-                    R.id.rootFragment
+                    R.id.products
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -122,6 +122,7 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
         skeletonView.hide()
         disableSearchListeners()
         searchView = null
+        showAddProductButton(false)
         super.onDestroyView()
         _binding = null
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.products
 
 import android.content.Context
 import android.os.Bundle
-import android.os.Parcelable
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
@@ -65,7 +64,6 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
     NavigationResult {
     companion object {
         val TAG: String = ProductListFragment::class.java.simpleName
-        const val KEY_LIST_STATE = "list-state"
         fun newInstance() = ProductListFragment()
     }
 
@@ -73,7 +71,6 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     private lateinit var productAdapter: ProductListAdapter
-    private var listState: Parcelable? = null
 
     private val viewModel: ProductListViewModel by viewModels { viewModelFactory }
 
@@ -99,8 +96,6 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
         setupResultHandlers()
         setHasOptionsMenu(true)
 
-        listState = savedInstanceState?.getParcelable(KEY_LIST_STATE)
-
         productAdapter = ProductListAdapter(this, this)
         binding.productsRecycler.layoutManager = LinearLayoutManager(requireActivity())
         binding.productsRecycler.adapter = productAdapter
@@ -121,11 +116,6 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
     override fun onAttach(context: Context) {
         AndroidSupportInjection.inject(this)
         super.onAttach(context)
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        outState.putParcelable(KEY_LIST_STATE, binding.productsRecycler.layoutManager?.onSaveInstanceState())
-        super.onSaveInstanceState(outState)
     }
 
     override fun onDestroyView() {
@@ -416,10 +406,6 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
 
     private fun showProductList(products: List<Product>) {
         productAdapter.setProductList(products)
-        listState?.let {
-            binding.productsRecycler.layoutManager?.onRestoreInstanceState(it)
-            listState = null
-        }
 
         showProductWIPNoticeCard(true)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.reviews
 
 import android.content.Context
 import android.os.Bundle
-import android.os.Parcelable
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
@@ -47,7 +46,6 @@ class ReviewListFragment : TopLevelFragment(R.layout.fragment_reviews_list),
     ReviewListAdapter.OnReviewClickListener {
     companion object {
         const val TAG = "ReviewListFragment"
-        const val KEY_LIST_STATE = "list-state"
         const val KEY_NEW_DATA_AVAILABLE = "new-data-available"
 
         fun newInstance() = ReviewListFragment()
@@ -65,7 +63,6 @@ class ReviewListFragment : TopLevelFragment(R.layout.fragment_reviews_list),
     private var menuMarkAllRead: MenuItem? = null
 
     private var newDataAvailable = false // New reviews are available in cache
-    private var listState: Parcelable? = null // Save the state of the recycler view
 
     private var pendingModerationRequest: ProductReviewModerationRequest? = null
     private var pendingModerationRemoteReviewId: Long? = null
@@ -79,7 +76,6 @@ class ReviewListFragment : TopLevelFragment(R.layout.fragment_reviews_list),
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
         savedInstanceState?.let { bundle ->
-            listState = bundle.getParcelable(KEY_LIST_STATE)
             newDataAvailable = bundle.getBoolean(KEY_NEW_DATA_AVAILABLE, false)
         }
     }
@@ -186,9 +182,6 @@ class ReviewListFragment : TopLevelFragment(R.layout.fragment_reviews_list),
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
-        val listState = binding.reviewsList.layoutManager?.onSaveInstanceState()
-        outState.putParcelable(KEY_LIST_STATE, listState)
-
         outState.putBoolean(KEY_NEW_DATA_AVAILABLE, newDataAvailable)
         super.onSaveInstanceState(outState)
     }
@@ -254,10 +247,6 @@ class ReviewListFragment : TopLevelFragment(R.layout.fragment_reviews_list),
     private fun showReviewList(reviews: List<ProductReview>) {
         if (isActive) {
             reviewsAdapter.setReviews(reviews)
-            listState?.let {
-                binding.reviewsList.layoutManager?.onRestoreInstanceState(listState)
-                listState = null
-            }
             showEmptyView(reviews.isEmpty())
         } else {
             newDataAvailable = true

--- a/WooCommerce/src/main/res/layout/activity_main.xml
+++ b/WooCommerce/src/main/res/layout/activity_main.xml
@@ -38,12 +38,6 @@
             android:layout_height="match_parent"
             app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-            <!-- container for top level fragments -->
-            <FrameLayout
-                android:id="@+id/container"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent" />
-
             <!-- container for child fragments in the nav graph -->
             <androidx.fragment.app.FragmentContainerView
                 android:id="@+id/nav_host_fragment_main"

--- a/WooCommerce/src/main/res/layout/activity_main.xml
+++ b/WooCommerce/src/main/res/layout/activity_main.xml
@@ -51,7 +51,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 app:defaultNavHost="true"
-                app:navGraph="@navigation/nav_graph_main"
                 tools:layout="@layout/fragment_my_store" />
         </FrameLayout>
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -3,11 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph_main"
-    app:startDestination="@id/rootFragment">
-    <fragment
-        android:id="@+id/rootFragment"
-        android:name="com.woocommerce.android.ui.main.RootFragment"
-        tools:layout="@layout/fragment_root" />
+    app:startDestination="@id/dashboard">
 
     <fragment
         android:id="@+id/feedbackSurveyFragment"
@@ -429,4 +425,24 @@
             app:nullable="true"
             android:defaultValue="@null" />
     </dialog>
+    <fragment
+        android:id="@+id/dashboard"
+        android:name="com.woocommerce.android.ui.mystore.MyStoreFragment"
+        android:label="fragment_my_store"
+        tools:layout="@layout/fragment_my_store" />
+    <fragment
+        android:id="@+id/orders"
+        android:name="com.woocommerce.android.ui.orders.list.OrderListFragment"
+        android:label="fragment_order_list"
+        tools:layout="@layout/fragment_order_list" />
+    <fragment
+        android:id="@+id/products"
+        android:name="com.woocommerce.android.ui.products.ProductListFragment"
+        android:label="fragment_product_list"
+        tools:layout="@layout/fragment_product_list" />
+    <fragment
+        android:id="@+id/reviews"
+        android:name="com.woocommerce.android.ui.reviews.ReviewListFragment"
+        android:label="fragment_reviews_list"
+        tools:layout="@layout/fragment_reviews_list" />
 </navigation>


### PR DESCRIPTION
First part of #3411, the changes included are:

1. Create a custom navigator that handles navigation of toplevel fragments, while keeping their state.
2. Add the top level fragments to the navgraph.
3. Update MainActivity and MainBottomNavigationView to use the new navigator.
4. Update logic of different top level fragments to avoid accessing the views in `onSaveInstanceState`, the views are available currently only between `onCreateView` and `onDestroyView`, and as fragments are detached, `onSaveInstanceState` may be called before `onDestroyView`.
5. Update handling of toolbar expansion after navigation events: 439b68c46029c79495f095d07145ae42ddbc8849

A known issue: the bottom navigation bar may appear in some child fragments, this will be handled in the next PR.

Testing:
Test app's navigation, and confirm that it's working as expected.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
