### PR TITLE
issue/2908-add-category-crash-fix

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 5.9
 -----
+* [*] Fixed a rare crash when adding a new product category that includes symbols. [https://github.com/woocommerce/woocommerce-android/pull/3415]
  
 5.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.databinding.FragmentAddProductCategoryBinding
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.extensions.setHtmlText
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -93,7 +94,7 @@ class AddProductCategoryFragment : BaseFragment(R.layout.fragment_add_product_ca
         }
 
         with(binding.productCategoryParent) {
-            viewModel.getSelectedParentCategoryName()?.let { post { setText(it) } }
+            viewModel.getSelectedParentCategoryName()?.let { post { setHtmlText(it) } }
             setClickListener {
                 val action = AddProductCategoryFragmentDirections
                     .actionAddProductCategoryFragmentToParentCategoryListFragment(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.products.categories
 
 import android.content.DialogInterface
 import android.os.Parcelable
+import android.text.TextUtils
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.squareup.inject.assisted.Assisted
@@ -82,7 +83,7 @@ class AddProductCategoryViewModel @AssistedInject constructor(
         addProductCategoryViewState = addProductCategoryViewState.copy(displayProgressDialog = true)
         launch {
             if (networkStatus.isConnected()) {
-                val categoryNameTrimmed = categoryName.trim()
+                val categoryNameTrimmed = TextUtils.htmlEncode(categoryName.trim())
                 val requestResult = productCategoriesRepository.addProductCategory(categoryNameTrimmed, parentId)
                 // hide progress dialog
                 addProductCategoryViewState = addProductCategoryViewState.copy(displayProgressDialog = false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ParentCategoryListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ParentCategoryListAdapter.kt
@@ -6,6 +6,7 @@ import android.view.ViewGroup
 import androidx.constraintlayout.widget.ConstraintLayout.LayoutParams
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.databinding.ParentCategoryListItemBinding
+import com.woocommerce.android.extensions.setHtmlText
 import com.woocommerce.android.ui.products.OnLoadMoreListener
 import com.woocommerce.android.ui.products.categories.ParentCategoryListAdapter.ParentCategoryListViewHolder
 
@@ -90,7 +91,7 @@ class ParentCategoryListAdapter(
 
         fun bind(parentCategory: ProductCategoryItemUiModel) {
             viewBinder.parentCategoryName.apply {
-                text = parentCategory.category.name
+                setHtmlText(parentCategory.category.name)
 
                 val newLayoutParams = viewBinder.parentCategoryName.layoutParams as LayoutParams
                 newLayoutParams.marginStart = parentCategory.margin

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ProductCategoriesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ProductCategoriesAdapter.kt
@@ -8,9 +8,9 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.ProductCategoryListItemBinding
+import com.woocommerce.android.extensions.setHtmlText
 import com.woocommerce.android.ui.products.OnLoadMoreListener
 import com.woocommerce.android.ui.products.categories.ProductCategoriesAdapter.ProductCategoryViewHolder
-import org.wordpress.android.util.HtmlUtils
 
 class ProductCategoriesAdapter(
     private val context: Context,
@@ -71,11 +71,11 @@ class ProductCategoriesAdapter(
         RecyclerView.ViewHolder(viewBinder.root) {
         fun bind(productCategory: ProductCategoryItemUiModel) {
             viewBinder.categoryName.apply {
-                text = if (productCategory.category.name.isEmpty()) {
+                setHtmlText(if (productCategory.category.name.isEmpty()) {
                     context.getString(R.string.untitled)
                 } else {
-                    HtmlUtils.fastStripHtml(productCategory.category.name)
-                }
+                    productCategory.category.name
+                })
 
                 val newLayoutParams = layoutParams as LayoutParams
                 newLayoutParams.marginStart = productCategory.margin

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedSpinnerView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedSpinnerView.kt
@@ -9,6 +9,7 @@ import android.view.View
 import androidx.annotation.AttrRes
 import com.google.android.material.textfield.TextInputLayout
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.setHtmlText
 import kotlinx.android.synthetic.main.view_material_outlined_spinner.view.*
 
 /**
@@ -47,6 +48,10 @@ class WCMaterialOutlinedSpinnerView @JvmOverloads constructor(
 
     fun setText(selectedText: String) {
         spinner_edit_text.setText(selectedText)
+    }
+
+    fun setHtmlText(selectedText: String) {
+        spinner_edit_text.setHtmlText(selectedText)
     }
 
     fun getText() = spinner_edit_text.text.toString()


### PR DESCRIPTION
Fixes #2908 by adding logic to encode html entities before adding a new category. This is because the API response returns all html entitles encoded but the app does not so when we fetch the newly added category from the local db, we face a crash because the app tries to fetch a category by "&" but the local db stores the category name as "&amp;" because this is response from the API.

#### To test
- Click on the categories section of a product.
- Click on `Add Category`.
- Enter a category name that includes "&".
- Click on the `Done` button.
- The app should no longer crash.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
