### PR TITLE
issue/3416-drag-images-crash-fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
@@ -294,8 +294,10 @@ class ProductImagesViewModel @AssistedInject constructor(
     }
 
     fun onGalleryImageMoved(from: Int, to: Int) {
-        val reorderedImages = images.swap(from, to)
-        viewState = viewState.copy(images = reorderedImages)
+        if (from < images.size && to < images.size) {
+            val reorderedImages = images.swap(from, to)
+            viewState = viewState.copy(images = reorderedImages)
+        }
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
@@ -294,7 +294,8 @@ class ProductImagesViewModel @AssistedInject constructor(
     }
 
     fun onGalleryImageMoved(from: Int, to: Int) {
-        if (from < images.size && to < images.size) {
+        val canSwap = from >= 0 && from < images.size && to >= 0 && to < images.size
+        if (canSwap) {
             val reorderedImages = images.swap(from, to)
             viewState = viewState.copy(images = reorderedImages)
         }


### PR DESCRIPTION
Fixes #3416 by adding logic to check the image size before reordering images. I have not been able to reproduce this issue and to be honest, I'm not really sure if this is the best approach to fix this crash. I figured the worst thing that would happen here with this fix is that the images would not be reordered and that would be a better experience to the user compared to facing a crash when updating images.

But if anyone can think of a better way to solve this, I'm all 👂 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
