### PR TITLE
Possible fix for a drag shadow crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ ext {
     coroutinesVersion = '1.3.6'
     archComponentsVersion = '2.2.0'
     assertjVersion = '3.11.1'
-    aztecVersion = 'v1.3.40'
+    aztecVersion = 'v1.3.45'
     flipperVersion = '0.52.0'
     stateMachineVersion = '0.2.0'
 }


### PR DESCRIPTION
Fixes #2780.

The same crash has been fixed in Aztec (wordpress-mobile/AztecEditor-Android#924), which is likely the root cause for this exception in WCAndroid.

There isn't a way to test the fix directly since it's hard to reproduce the crash. A simple smoke test of the editor will suffice and we'll monitor for future crashes.