### PR TITLE
Description change-saving fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/AztecEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/AztecEditorFragment.kt
@@ -197,12 +197,7 @@ class AztecEditorFragment : BaseFragment(), IAztecToolbarClickListener, BackPres
     }
 
     private fun editorHasChanges(): Boolean {
-        val hasChanges = if (isHtmlEditorEnabled) {
-            aztec.sourceEditor?.hasChanges()
-        } else {
-            aztec.visualEditor.hasChanges()
-        }
-        return hasChanges != NO_CHANGES
+        return aztec.sourceEditor?.hasChanges() != NO_CHANGES || aztec.visualEditor.hasChanges() != NO_CHANGES
     }
 
     private fun navigateBackWithResult(hasChanges: Boolean) {


### PR DESCRIPTION
Fixes #3418.

**To test:**
1. Open a product without any short description
2. Tap on Add more details -> Short description
3. Type something
4. Switch to HTML mode
5. Tap on Done button
6. Notice the Short description property is added