### PR TITLE
Empty date crash fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabel.kt
@@ -47,7 +47,7 @@ fun WCShippingLabelModel.toAppModel(): ShippingLabel {
         carrierId,
         serviceName,
         status,
-        Date(dateCreated.toLong()),
+        dateCreated.toLongOrNull()?.let { Date(it) },
         packageName,
         rate.toBigDecimal(),
         refundableAmount.toBigDecimal(),


### PR DESCRIPTION
Fixes #3299. 

I'm not sure how a shipping label is created without a date but this change will take care of it (the model property was already nullable).