### PR TITLE
Show empty view if product list empty

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -184,7 +184,13 @@ class ProductListViewModel @AssistedInject constructor(
         val excludedProductIds: List<Long>? = excludeProductId?.let { id ->
             ArrayList<Long>().also { it.add(id) }
         }
-        _productList.value = productRepository.getProductList(productFilterOptions, excludedProductIds)
+        val products = productRepository.getProductList(productFilterOptions, excludedProductIds)
+        _productList.value = products
+
+        viewState = viewState.copy(
+            isEmptyViewVisible = products.isEmpty(),
+            displaySortAndFilterCard = products.isNotEmpty()
+        )
     }
 
     final fun loadProducts(loadMore: Boolean = false, scrollToTop: Boolean = false) {


### PR DESCRIPTION
Fixes #3386.

**To test**

1. Login to a store with only 1 product.
2. Click on the Products tab and click on the product.
3. Trash this product.
4. Notice the empty view is displayed and the sort & filter card is hidden