### PR TITLE
Navigation refactoring: top level fragments cleanup

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BaseFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BaseFragment.kt
@@ -57,12 +57,6 @@ open class BaseFragment : Fragment, BaseFragmentView, HasAndroidInjector {
     }
 
     fun updateActivityTitle() {
-        // if this is a top level fragment, skip setting the title when it's not active in the bottom nav
-        (this as? TopLevelFragment)?.let {
-            if (!it.isActive) {
-                return
-            }
-        }
         if (isAdded && !isHidden) {
             activity?.title = getFragmentTitle()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.base
 
 import androidx.annotation.LayoutRes
 import com.woocommerce.android.ui.main.MainActivity
-import com.woocommerce.android.ui.main.MainNavigationRouter
 
 /**
  * The main fragments hosted by the bottom bar should extend this class
@@ -10,21 +9,6 @@ import com.woocommerce.android.ui.main.MainNavigationRouter
 abstract class TopLevelFragment : BaseFragment, TopLevelFragmentView {
     constructor() : super()
     constructor(@LayoutRes layoutId: Int) : super(layoutId)
-
-    /**
-     * The extending class may use this variable to defer a part of its
-     * normal initialization until manually requested.
-     */
-    var deferInit: Boolean = false
-
-    override var isActive: Boolean = false
-        get() {
-            return if (isAdded && !isHidden) {
-                (activity as? MainNavigationRouter)?.isAtNavigationRoot() ?: false
-            } else {
-                false
-            }
-        }
 
     abstract fun isScrolledToTop(): Boolean
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -10,7 +10,7 @@ abstract class TopLevelFragment : BaseFragment, TopLevelFragmentView {
     constructor() : super()
     constructor(@LayoutRes layoutId: Int) : super(layoutId)
 
-    abstract fun isScrolledToTop(): Boolean
+    abstract fun shouldExpandToolbar(): Boolean
 
     /**
      * Called when the fragment shows or hides a search view so we can properly disable the collapsing

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragmentView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragmentView.kt
@@ -9,7 +9,7 @@ interface TopLevelFragmentView : BaseFragmentView {
     /**
      * Refresh this top-level fragment data and reset its state.
      */
-    fun refreshFragmentState()
+    fun refreshFragmentState() { }
 
     /**
      * Scroll to the top of this view

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragmentView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragmentView.kt
@@ -4,30 +4,8 @@ package com.woocommerce.android.ui.base
  * Special interface for top-level fragments hosted by the bottom bar.
  */
 interface TopLevelFragmentView : BaseFragmentView {
-    var isActive: Boolean
-
-    /**
-     * Refresh this top-level fragment data and reset its state.
-     */
-    fun refreshFragmentState() { }
-
     /**
      * Scroll to the top of this view
      */
     fun scrollToTop()
-
-    /**
-     * User returned to this top level fragment from a nav component fragment
-     */
-    fun onReturnedFromChildFragment() {
-
-    }
-
-    /**
-     * A child fragment for the active tab has been opened.
-     */
-    fun onChildFragmentOpened() {
-        // Override this method if the top level fragment needs to perform some
-        // sort of cleanup once a child fragment has been opened.
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragmentView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragmentView.kt
@@ -19,7 +19,9 @@ interface TopLevelFragmentView : BaseFragmentView {
     /**
      * User returned to this top level fragment from a nav component fragment
      */
-    fun onReturnedFromChildFragment()
+    fun onReturnedFromChildFragment() {
+
+    }
 
     /**
      * A child fragment for the active tab has been opened.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -143,7 +143,9 @@ class MainActivity : AppUpgradeActivity(),
             val isFullScreenFragment = currentDestination.id == R.id.productImageViewerFragment ||
                 currentDestination.id == R.id.wpMediaViewerFragment
 
-            if (!isFullScreenFragment) {
+            val isDialogDestination = currentDestination.navigatorName == DIALOG_NAVIGATOR_NAME
+
+            if (!isFullScreenFragment && !isDialogDestination) {
                 // re-expand the AppBar when returning to top level fragment, collapse it when entering a child fragment
                 if (f is TopLevelFragment) {
                     // We need to post this to the view handler to make sure isScrolledToTop returns the correct value

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -456,15 +456,6 @@ class MainActivity : AppUpgradeActivity(),
             hideBottomNav()
         }
 
-        getActiveTopLevelFragment()?.let {
-            if (isTopLevelNavigation) {
-                it.updateActivityTitle()
-                it.onReturnedFromChildFragment()
-            } else {
-                it.onChildFragmentOpened()
-            }
-        }
-
         previousDestinationId = destination.id
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -148,7 +148,7 @@ class MainActivity : AppUpgradeActivity(),
                 if (f is TopLevelFragment) {
                     // We need to post this to the view handler to make sure isScrolledToTop returns the correct value
                     f.view?.post {
-                        expandToolbar(expand = f.isScrolledToTop(), animate = false)
+                        expandToolbar(expand = f.shouldExpandToolbar(), animate = false)
                     }
                 } else {
                     expandToolbar(expand = false, animate = false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -302,11 +302,6 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store),
         binding.statsScrollView.smoothScrollTo(0, 0)
     }
 
-    override fun refreshFragmentState() {
-        MyStorePresenter.resetForceRefresh()
-        refreshMyStoreStats(forced = false)
-    }
-
     override fun refreshMyStoreStats(forced: Boolean) {
         // If this fragment is currently active, force a refresh of data. If not, set
         // a flag to force a refresh when it becomes active

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -67,10 +67,6 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store),
     override var isRefreshPending: Boolean = false // If true, the fragment will refresh its data when it's visible
     private var errorSnackbar: Snackbar? = null
 
-    // If false, the fragment will refresh its data when it's visible on onHiddenChanged
-    // this is to prevent the stats getting refreshed twice when the fragment is loaded when app is closed and opened
-    private var isStatsRefreshed: Boolean = false
-
     private var tabStatsPosition: Int = 0 // Save the current position of stats tab view
     private val activeGranularity: StatsGranularity
         get() {
@@ -180,43 +176,13 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store),
 
         tabLayout.addOnTabSelectedListener(tabSelectedListener)
 
-        if (isActive && !deferInit) {
-            isStatsRefreshed = true
-            refreshMyStoreStats(forced = this.isRefreshPending)
-        }
+        refreshMyStoreStats(forced = this.isRefreshPending)
     }
 
     override fun onResume() {
         super.onResume()
         handleFeedbackRequestCardState()
         AnalyticsTracker.trackViewShown(this)
-    }
-
-    override fun onHiddenChanged(hidden: Boolean) {
-        super.onHiddenChanged(hidden)
-
-        if (!isHidden) {
-            if (!isStatsRefreshed) {
-                // silently refresh if this fragment is no longer hidden
-                refreshMyStoreStats(forced = false)
-            }
-            addTabLayoutToAppBar()
-            showChartSkeleton(true)
-            binding.myStoreRefreshLayout.visibility = View.VISIBLE
-            binding.statsErrorScrollView.visibility = View.GONE
-        } else {
-            isStatsRefreshed = false
-            removeTabLayoutFromAppBar()
-        }
-    }
-
-    override fun onReturnedFromChildFragment() {
-        // If this fragment is now visible and we've deferred loading stats due to it not
-        // being visible - go ahead and load the stats.
-        if (!deferInit) {
-            refreshMyStoreStats(forced = this.isRefreshPending)
-        }
-        addTabLayoutToAppBar()
     }
 
     override fun onStop() {
@@ -344,21 +310,15 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store),
     override fun refreshMyStoreStats(forced: Boolean) {
         // If this fragment is currently active, force a refresh of data. If not, set
         // a flag to force a refresh when it becomes active
-        when {
-            isActive -> {
-                isRefreshPending = false
-                if (forced) {
-                    binding.myStoreStats.clearLabelValues()
-                    binding.myStoreStats.clearChartData()
-                    myStoreDateBar.clearDateRangeValues()
-                }
-                presenter.run {
-                    loadStats(activeGranularity, forced)
-                    coroutineScope.launch { loadTopPerformersStats(activeGranularity, forced) }
-                    fetchHasOrders()
-                }
-            }
-            else -> isRefreshPending = true
+        if (forced) {
+            binding.myStoreStats.clearLabelValues()
+            binding.myStoreStats.clearChartData()
+            myStoreDateBar.clearDateRangeValues()
+        }
+        presenter.run {
+            loadStats(activeGranularity, forced)
+            coroutineScope.launch { loadTopPerformersStats(activeGranularity, forced) }
+            fetchHasOrders()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -436,7 +436,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store),
 
     private fun addTabLayoutToAppBar() {
         appBarLayout
-            ?.takeIf { isActive && !it.children.containsInstanceOf(tabLayout) }
+            ?.takeIf { !it.children.containsInstanceOf(tabLayout) }
             ?.takeIf { AppPrefs.isV4StatsSupported() }
             ?.addView(
                 tabLayout,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -443,5 +443,5 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store),
         appBarLayout?.removeView(tabLayout)
     }
 
-    override fun isScrolledToTop() = binding.statsScrollView.scrollY == 0
+    override fun shouldExpandToolbar() = binding.statsScrollView.scrollY == 0
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -46,7 +46,7 @@ import javax.inject.Inject
 import org.wordpress.android.util.ActivityUtils as WPActivityUtils
 
 class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
-        OrderStatusListView.OrderStatusListListener, OnQueryTextListener, OnActionExpandListener, OrderListListener {
+    OrderStatusListView.OrderStatusListListener, OnQueryTextListener, OnActionExpandListener, OrderListListener {
     companion object {
         const val TAG: String = "OrderListFragment"
         const val STATE_KEY_ACTIVE_FILTER = "active-order-status-filter"
@@ -69,13 +69,17 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
     // Alias for interacting with [viewModel.orderStatusFilter] so the value is always
     // identical to the real value on the UI side.
     private var orderStatusFilter: String
-        private set(value) { viewModel.orderStatusFilter = value }
+        private set(value) {
+            viewModel.orderStatusFilter = value
+        }
         get() = viewModel.orderStatusFilter
 
     // Alias for interacting with [viewModel.isSearching] so the value is always identical
     // to the real value on the UI side.
     private var isSearching: Boolean
-        private set(value) { viewModel.isSearching = value }
+        private set(value) {
+            viewModel.isSearching = value
+        }
         get() = viewModel.isSearching
 
     private var orderListMenu: Menu? = null
@@ -89,7 +93,9 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
     // Alias for interacting with [viewModel.searchQuery] so the value is always identical
     // to the real value on the UI side.
     private var searchQuery: String
-        private set(value) { viewModel.searchQuery = value }
+        private set(value) {
+            viewModel.searchQuery = value
+        }
         get() = viewModel.searchQuery
 
     /**
@@ -395,7 +401,8 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
         AnalyticsTracker.track(
             Stat.ORDER_OPEN, mapOf(
             AnalyticsTracker.KEY_ID to remoteOrderId,
-            AnalyticsTracker.KEY_STATUS to orderStatus)
+            AnalyticsTracker.KEY_STATUS to orderStatus
+        )
         )
 
         // if a search is active, we need to collapse the search view so order detail can show it's title and then
@@ -421,8 +428,9 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
         orderStatusFilter = orderStatus ?: StringUtils.EMPTY
         if (isAdded) {
             AnalyticsTracker.track(
-                    Stat.ORDERS_LIST_FILTER,
-                    mapOf(AnalyticsTracker.KEY_STATUS to orderStatus.orEmpty()))
+                Stat.ORDERS_LIST_FILTER,
+                mapOf(AnalyticsTracker.KEY_STATUS to orderStatus.orEmpty())
+            )
 
             // Display the filtered list view
             displayFilteredList()
@@ -573,8 +581,9 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
      */
     private fun handleNewSearchRequest(query: String) {
         AnalyticsTracker.track(
-                Stat.ORDERS_LIST_FILTER,
-                mapOf(AnalyticsTracker.KEY_SEARCH to query))
+            Stat.ORDERS_LIST_FILTER,
+            mapOf(AnalyticsTracker.KEY_SEARCH to query)
+        )
 
         searchQuery = query
         submitSearchQuery(searchQuery)
@@ -646,10 +655,10 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
         isFilterEnabled = true
         hideOrderStatusListView()
         searchView?.queryHint = getString(R.string.orders)
-                .plus(orderStatusFilter.let { filter ->
-                    val orderStatusLabel = getOrderStatusOptions()[filter]?.label
-                    getString(R.string.orderlist_filtered, orderStatusLabel)
-                })
+            .plus(orderStatusFilter.let { filter ->
+                val orderStatusLabel = getOrderStatusOptions()[filter]?.label
+                getString(R.string.orderlist_filtered, orderStatusLabel)
+            })
 
         searchView?.findViewById<EditText>(R.id.search_src_text)?.also {
             it.setHintTextColor(Color.WHITE)
@@ -718,5 +727,7 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
         (activity?.findViewById<View>(R.id.app_bar_layout) as? AppBarLayout)?.removeView(tabLayout)
     }
 
-    override fun isScrolledToTop() = binding.orderListView.ordersList.computeVerticalScrollOffset() == 0
+    override fun shouldExpandToolbar(): Boolean {
+        return binding.orderListView.ordersList.computeVerticalScrollOffset() == 0 && !isSearching
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -142,10 +142,6 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
         trashProductUndoSnack?.dismiss()
     }
 
-    override fun onChildFragmentOpened() {
-        showAddProductButton(false)
-    }
-
     override fun onNavigationResult(requestCode: Int, result: Bundle) {
         when (requestCode) {
             RequestCodes.PRODUCT_LIST_FILTERS -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -490,5 +490,7 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
             .run { FeedbackPrefs.setFeatureFeedbackSettings(TAG, this) }
     }
 
-    override fun isScrolledToTop() = binding.productsRecycler.computeVerticalScrollOffset() == 0
+    override fun shouldExpandToolbar() :Boolean {
+        return binding.productsRecycler.computeVerticalScrollOffset() == 0 && !viewModel.isSearching()
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -490,7 +490,7 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
             .run { FeedbackPrefs.setFeatureFeedbackSettings(TAG, this) }
     }
 
-    override fun shouldExpandToolbar() :Boolean {
+    override fun shouldExpandToolbar(): Boolean {
         return binding.productsRecycler.computeVerticalScrollOffset() == 0 && !viewModel.isSearching()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -62,8 +62,6 @@ class ReviewListFragment : TopLevelFragment(R.layout.fragment_reviews_list),
     private val skeletonView = SkeletonView()
     private var menuMarkAllRead: MenuItem? = null
 
-    private var newDataAvailable = false // New reviews are available in cache
-
     private var pendingModerationRequest: ProductReviewModerationRequest? = null
     private var pendingModerationRemoteReviewId: Long? = null
     private var pendingModerationNewStatus: String? = null
@@ -75,13 +73,12 @@ class ReviewListFragment : TopLevelFragment(R.layout.fragment_reviews_list),
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
-        savedInstanceState?.let { bundle ->
-            newDataAvailable = bundle.getBoolean(KEY_NEW_DATA_AVAILABLE, false)
-        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        setHasOptionsMenu(true)
 
         _binding = FragmentReviewsListBinding.bind(view)
 
@@ -169,23 +166,6 @@ class ReviewListFragment : TopLevelFragment(R.layout.fragment_reviews_list),
         changeReviewStatusSnackbar?.dismiss()
     }
 
-    override fun onHiddenChanged(hidden: Boolean) {
-        super.onHiddenChanged(hidden)
-
-        // If this fragment is no longer visible dismiss the pending review moderation
-        // s it can be processed immediately, otherwise silently refresh
-        if (hidden) {
-            changeReviewStatusSnackbar?.dismiss()
-        } else {
-            checkForNewDataAvailable()
-        }
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        outState.putBoolean(KEY_NEW_DATA_AVAILABLE, newDataAvailable)
-        super.onSaveInstanceState(outState)
-    }
-
     override fun onDestroyView() {
         skeletonView.hide()
         super.onDestroyView()
@@ -197,8 +177,7 @@ class ReviewListFragment : TopLevelFragment(R.layout.fragment_reviews_list),
             new.isSkeletonShown?.takeIfNotEqualTo(old?.isSkeletonShown) { showSkeleton(it) }
             new.hasUnreadReviews?.takeIfNotEqualTo(old?.hasUnreadReviews) { showMarkAllReadMenuItem(it) }
             new.isRefreshing?.takeIfNotEqualTo(old?.isRefreshing) {
-                if (isActive)
-                    binding.notifsRefreshLayout.isRefreshing = it
+                binding.notifsRefreshLayout.isRefreshing = it
             }
             new.isLoadingMore?.takeIfNotEqualTo(old?.isLoadingMore) { binding.notifsLoadMoreProgress.isVisible = it }
         }
@@ -240,17 +219,14 @@ class ReviewListFragment : TopLevelFragment(R.layout.fragment_reviews_list),
                 context?.let { NotificationHandler.removeAllReviewNotifsFromSystemBar(it) }
             }
             ActionStatus.ERROR -> menuMarkAllRead?.actionView = null
-            else -> {}
+            else -> {
+            }
         }
     }
 
     private fun showReviewList(reviews: List<ProductReview>) {
-        if (isActive) {
-            reviewsAdapter.setReviews(reviews)
-            showEmptyView(reviews.isEmpty())
-        } else {
-            newDataAvailable = true
-        }
+        reviewsAdapter.setReviews(reviews)
+        showEmptyView(reviews.isEmpty())
     }
 
     private fun showSkeleton(show: Boolean) {
@@ -274,29 +250,16 @@ class ReviewListFragment : TopLevelFragment(R.layout.fragment_reviews_list),
     }
 
     private fun showMarkAllReadMenuItem(show: Boolean) {
-        val showMarkAllRead = isActive && show
-        menuMarkAllRead?.let { if (it.isVisible != showMarkAllRead) it.isVisible = showMarkAllRead }
+        menuMarkAllRead?.let { if (it.isVisible != show) it.isVisible = show }
     }
 
     private fun openReviewDetail(review: ProductReview) {
-        showOptionsMenu(false)
         (activity as? MainNavigationRouter)?.showReviewDetail(
-                review.remoteId,
-                launchedFromNotification = false,
-                enableModeration = true,
-                tempStatus = pendingModerationNewStatus
+            review.remoteId,
+            launchedFromNotification = false,
+            enableModeration = true,
+            tempStatus = pendingModerationNewStatus
         )
-    }
-
-    /**
-     * We use this to clear the options menu when navigating to a child destination - otherwise this
-     * fragment's menu will continue to appear when the child is shown
-     */
-    private fun showOptionsMenu(show: Boolean) {
-        setHasOptionsMenu(show)
-        if (show) {
-            activity?.invalidateOptionsMenu()
-        }
     }
 
     private fun handleReviewModerationRequest(request: ProductReviewModerationRequest) {
@@ -307,7 +270,8 @@ class ReviewListFragment : TopLevelFragment(R.layout.fragment_reviews_list),
                 resetPendingModerationVariables()
             }
             ActionStatus.ERROR -> revertPendingModerationState()
-            else -> { /* do nothing */ }
+            else -> { /* do nothing */
+            }
         }
     }
 
@@ -339,15 +303,15 @@ class ReviewListFragment : TopLevelFragment(R.layout.fragment_reviews_list),
             }
 
             changeReviewStatusSnackbar = uiMessageResolver
-                    .getUndoSnack(
-                            R.string.review_moderation_undo,
-                            ProductReviewStatus.getLocalizedLabel(context, newStatus)
-                                    .toLowerCase(Locale.getDefault()),
-                            actionListener = actionListener
-                    ).also {
-                        it.addCallback(callback)
-                        it.show()
-                    }
+                .getUndoSnack(
+                    R.string.review_moderation_undo,
+                    ProductReviewStatus.getLocalizedLabel(context, newStatus)
+                        .toLowerCase(Locale.getDefault()),
+                    actionListener = actionListener
+                ).also {
+                    it.addCallback(callback)
+                    it.show()
+                }
 
             // Manually remove the product review from the list if it's new
             // status will be spam or trash
@@ -387,27 +351,8 @@ class ReviewListFragment : TopLevelFragment(R.layout.fragment_reviews_list),
 
     override fun getFragmentTitle() = getString(R.string.review_notifications)
 
-    override fun refreshFragmentState() {
-        if (isActive) {
-            viewModel.forceRefreshReviews()
-        }
-    }
-
     override fun scrollToTop() {
         binding.reviewsList.smoothScrollToPosition(0)
-    }
-
-    override fun onReturnedFromChildFragment() {
-        checkForNewDataAvailable()
-        showOptionsMenu(true)
-    }
-
-    private fun checkForNewDataAvailable() {
-        if (newDataAvailable && isActive) {
-            viewModel.reloadReviewsFromCache()
-            viewModel.checkForUnreadReviews()
-            newDataAvailable = false
-        }
     }
 
     override fun getItemTypeAtPosition(position: Int) = reviewsAdapter.getItemTypeAtRecyclerPosition(position)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -361,5 +361,5 @@ class ReviewListFragment : TopLevelFragment(R.layout.fragment_reviews_list),
         openReviewDetail(review)
     }
 
-    override fun isScrolledToTop() = binding.reviewsList.computeVerticalScrollOffset() == 0
+    override fun shouldExpandToolbar() = binding.reviewsList.computeVerticalScrollOffset() == 0
 }

--- a/WooCommerce/src/main/res/navigation/nav_graph_products.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_products.xml
@@ -485,4 +485,5 @@
         app:exitAnim="@anim/activity_slide_out_to_left"
         app:popEnterAnim="@anim/activity_slide_in_from_left"
         app:popExitAnim="@anim/activity_slide_out_to_right" />
+    <include app:graph="@navigation/nav_graph_image_gallery" />
 </navigation>


### PR DESCRIPTION
third part of #3411, the goal of this PR is cleaning up the logic of the top level fragments.

As with the new navigation architecture, we will have only one active fragment per time, we can simplify a lot of logic that has to deal with updating the menus and listeners when going to child fragments.

**Testing**
Test navigation, especially going from top level fragments to child fragments (when search enabled and disabled), and confirm everything works as expected.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
