### PR TITLE
issue/3431-product-selector-done-button-5.8

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListFragment.kt
@@ -296,7 +296,7 @@ class ProductSelectionListFragment : BaseFragment(R.layout.fragment_product_list
 
         override fun onCreateActionMode(mode: ActionMode, menu: Menu): Boolean {
             // display done menu button & disable PTR action
-            mode.menuInflater.inflate(R.menu.menu_done, menu)
+            mode.menuInflater.inflate(R.menu.menu_action_mode_check, menu)
             onActionModeEventListener.onActionModeCreated()
             return true
         }

--- a/WooCommerce/src/main/res/drawable/ic_menu_action_mode_check.xml
+++ b/WooCommerce/src/main/res/drawable/ic_menu_action_mode_check.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@color/color_on_primary_surface"
+      android:pathData="M9,19.414l-6.707,-6.707 1.414,-1.414L9,16.586 20.293,5.293l1.414,1.414"/>
+</vector>

--- a/WooCommerce/src/main/res/menu/menu_action_mode_check.xml
+++ b/WooCommerce/src/main/res/menu/menu_action_mode_check.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/menu_done"
+        android:title="@string/done"
+        android:icon="@drawable/ic_menu_action_mode_check"
+        app:showAsAction="always"/>
+</menu>


### PR DESCRIPTION
Fixes #3431 - To test:

- Go to product detail
- Add linked products
- Verify the Done button (now a checkmark) is light in both light mode and dark mode

Note that I changed the Done button into a checkmark, which is a familiar pattern in action mode. Note also that I made a new checkmark drawable for this to ensure the check icon is colored correctly regardless of SDK version (`iconTint` isn't available < SDK 26).

![light](https://user-images.githubusercontent.com/3903757/104651076-26693400-5685-11eb-8a60-5e001a4f102d.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
