### PR TITLE
Fix the download limit crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsSettingsFragment.kt
@@ -69,7 +69,7 @@ class ProductDownloadsSettingsFragment : BaseProductFragment(R.layout.fragment_p
     }
 
     private fun initFromProductDraft() {
-        fun Number.formatLimitAndExpiry(): String = if (this == -1) "" else this.toString()
+        fun Number.formatLimitAndExpiry(): String = if (this.toLong() == -1L) "" else this.toString()
         val product = requireNotNull(viewModel.getProduct().productDraft)
         binding.productDownloadLimit.setText(product.downloadLimit.formatLimitAndExpiry())
         binding.productDownloadExpiry.setText(product.downloadExpiry.formatLimitAndExpiry())


### PR DESCRIPTION
Fixes #3434. The original implementation tried to compare a `Long` to `-1`, which is always false, resulting in the invalid value being set in the TextView.

**To test:**
1. Go to Products -> Select a product without downloadable files
2. Tap on Add more details
3. Select Downloadable files
4. Add any file
5. Tap on Done
6. Tap on Downloadable files
7. Tap on the Download Settings in the menu
8. Notice the Download limit field is empty