### PR TITLE
issue/3435-download-settings-5.8

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -370,7 +370,6 @@ class ProductDetailViewModel @AssistedInject constructor(
     }
 
     fun onDownloadsSettingsClicked() {
-        discardEditChanges()
         triggerEvent(ViewProductDownloadsSettings)
     }
 


### PR DESCRIPTION
Fixes #3435 - The problem was that we were discarding changes when download settings was tapped.

- Go to Products and tap on a product that has a downloadable file (add one if needed).
- Tap on the "Downloadable files" detail.
- Tap the overflow menu > Download Settings.
- Make changes to "Download limit" and "Download expiration".
- Tap "Done" at top right.
- Tap the overflow menu > Download Settings again.
- Observe that the changes from step 4 are showing

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
