### PR TITLE
issue/3442-fab-on-my-store-5.8 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -320,7 +320,7 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
             }
             new.isAddProductButtonVisible?.takeIfNotEqualTo(old?.isAddProductButtonVisible) { isVisible ->
                 showAddProductButton(
-                    show = isVisible &&
+                    show = isVisible && isActive &&
                         (requireActivity() as? MainNavigationRouter)?.isAtNavigationRoot() == true
                 )
             }


### PR DESCRIPTION
Fixes #3442 by only showing the "Add Product" FAB when the product list fragment is active. To  test:

- Go to the product list
- Go back to My Store
- Tap the settings icon
- Change the Appearance
- Go back to My Store again
- Verify that the FAB doesn't appear

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
