### PR TITLE
Modified the products wip banner text for M5

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -426,8 +426,8 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
 
     private fun showProductWIPNoticeCard(show: Boolean) {
         if (show && feedbackState != DISMISSED) {
-            val wipCardTitleId = R.string.product_adding_wip_title
-            val wipCardMessageId = R.string.product_wip_message_m4
+            val wipCardTitleId = R.string.product_wip_title_m5
+            val wipCardMessageId = R.string.product_wip_message_m5
 
             binding.productsWipCard.visibility = View.VISIBLE
             binding.productsWipCard.initView(

--- a/WooCommerce/src/main/res/layout/feature_wip_notice.xml
+++ b/WooCommerce/src/main/res/layout/feature_wip_notice.xml
@@ -22,7 +22,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:textOff="@string/product_wip_title"
-            tools:textOn="@string/product_adding_wip_title" />
+            tools:textOn="@string/product_wip_title_m5" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/feature_wip_morePanel"
@@ -48,7 +48,7 @@
                 app:layout_constraintHorizontal_bias="0.5"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
-                tools:text="@string/product_wip_message_m4" />
+                tools:text="@string/product_wip_message_m5" />
 
             <!-- PRIMARY button -->
             <com.google.android.material.button.MaterialButton

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -619,7 +619,9 @@
     <string name="product_limited_editing_message">We\'ve added editing functionality to simple products. Keep an eye out for more options soon!</string>
     <string name="product_adding_wip_title">Create products from the app!</string>
     <string name="product_wip_message_m4">It\'s now possible to create new simple, linked and grouped products on the go from the Woo app. Not ready yet? Save them as a draft!</string>
+    <string name="product_wip_message_m5">You can now add downloadable files to a product and link upsell &amp; cross-sell products. No longer want a product? Trash it!</string>
     <string name="product_wip_title">New editing options available</string>
+    <string name="product_wip_title_m5">New features available!</string>
     <string name="product_wip_message_m2">We\'ve added more editing functionalities to products! You can now update images, see previews and share your products.</string>
     <string name="product_wip_message_m3">You can now edit grouped, external and variable products, change product type and update categories and tags.</string>
     <string name="product_bullet" translatable="false"> \u2022 </string>


### PR DESCRIPTION
Fixes #3444 by modifying the products work in progress banner text for M5.

### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/104919754-c512cf00-59bc-11eb-94de-1167a2b615b8.png" width="300"/>

### To test
Click on the Products TAB and notice the banner title has changed to:
**Title:** New features available!
**Body:** You can now add downloadable files to a product and link upsell & cross-sell products. No longer want a product? Trash it!


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
