### PR TITLE
Fix the tags change detection bug

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -590,7 +590,7 @@ class ProductDetailViewModel @AssistedInject constructor(
 
         val isProductUpdated = when (event) {
             is ExitProductDetail -> isProductDetailUpdated
-            is ExitProductTags -> isProductDetailUpdated || !_addedProductTags.isEmpty()
+            is ExitProductTags -> isProductDetailUpdated && isProductSubDetailUpdated || !_addedProductTags.isEmpty()
             else -> isProductDetailUpdated && isProductSubDetailUpdated
         }
         if (isProductUpdated && event.shouldShowDiscardDialog) {


### PR DESCRIPTION
Fixes #3387.

**To test:**

1. Click on a product from the Products tab.
2. Click on the product type section and change the product type.
3. Click on the Tags section.
4. Click on the back icon and notice that a discard dialog is **not** displayed when there have been no changes made to the screen.