### PR TITLE
Removed previous design for shipping and purchase details

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -36,11 +36,8 @@ import com.woocommerce.android.ui.products.models.ProductProperty.ComplexPropert
 import com.woocommerce.android.ui.products.models.ProductProperty.Editable
 import com.woocommerce.android.ui.products.models.ProductProperty.PropertyGroup
 import com.woocommerce.android.ui.products.models.ProductProperty.RatingBar
-import com.woocommerce.android.ui.products.models.ProductProperty.ReadMore
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
-import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.PRICING
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.PRIMARY
-import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.PURCHASE_DETAILS
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.SECONDARY
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.util.CurrencyFormatter
@@ -72,8 +69,6 @@ class ProductDetailCardBuilder(
             EXTERNAL -> cards.addIfNotEmpty(getExternalProductCard(product))
             OTHER -> cards.addIfNotEmpty(getOtherProductCard(product))
         }
-
-        cards.addIfNotEmpty(getPurchaseDetailsCard(product))
 
         return cards
     }
@@ -172,53 +167,6 @@ class ProductDetailCardBuilder(
                 product.productType()
             ).filterNotEmpty()
         )
-    }
-
-    /**
-     * Existing product detail card UI which that will be replaced by the new design once
-     * Product Release 1 changes are completed.
-     */
-    private fun getPricingAndInventoryCard(product: Product): ProductPropertyCard {
-        // if we have pricing info this card is "Pricing and inventory" otherwise it's just "Inventory"
-        val hasPricingInfo = product.regularPrice != null || product.salePrice != null
-        val cardTitle = if (hasPricingInfo) {
-            resources.getString(R.string.product_pricing_and_inventory)
-        } else {
-            resources.getString(R.string.product_inventory)
-        }
-
-        return ProductPropertyCard(
-            PRICING,
-            cardTitle,
-            listOf(
-                product.variations(),
-                product.readOnlyPrice(),
-                product.readOnlyInventory()
-            ).filterNotEmpty()
-        )
-    }
-
-    private fun getPurchaseDetailsCard(product: Product): ProductPropertyCard {
-        return ProductPropertyCard(
-            PURCHASE_DETAILS,
-            resources.getString(R.string.product_purchase_details),
-            listOf(
-                product.readOnlyShipping(),
-                product.purchaseNote()
-            ).filterNotEmpty()
-        )
-    }
-
-    // if add/edit products is enabled, purchase note appears in product settings
-    private fun Product.purchaseNote(): ProductProperty? {
-        return if (this.purchaseNote.isNotBlank() && !isSimple(this)) {
-            ReadMore(
-                R.string.product_purchase_note,
-                this.purchaseNote
-            )
-        } else {
-            null
-        }
     }
 
     private fun Product.downloads(): ProductProperty? {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/models/ProductPropertyCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/models/ProductPropertyCard.kt
@@ -3,8 +3,6 @@ package com.woocommerce.android.ui.products.models
 data class ProductPropertyCard(val type: Type, val caption: String = "", val properties: List<ProductProperty>) {
     enum class Type {
         PRIMARY,
-        SECONDARY,
-        PRICING,
-        PURCHASE_DETAILS
+        SECONDARY
     }
 }


### PR DESCRIPTION
Fixes #3174. This PR removes the previous shipping and purchase details section from the app since the purchase details have been moved to Product Settings screen.

### To test
- Open the Products tab.
- Add or edit a variable product.
- Ensure the product has some shipping details (go to "Add more details" > "Shipping" to add them if needed).
- Notice the shipping details appear only once in the screen and the `Purchase details` section is no longer displayed.

### Screenshots
(LEFT: Before. RIGHT: After)
<img src="https://user-images.githubusercontent.com/8658164/99546023-e734a480-29ad-11eb-9d4a-c4f755b16260.png" width="300px">. <img src="https://user-images.githubusercontent.com/22608780/104987125-eadeb900-5a3a-11eb-892d-36add1f225a0.png" width="300px">

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
