### PR TITLE
make viewModelFactory injection lazy in ProductFilterListFragment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
@@ -30,6 +30,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.AlignedDividerDecoration
+import dagger.Lazy
 import javax.inject.Inject
 
 class ProductFilterListFragment : BaseFragment(R.layout.fragment_product_filter_list),
@@ -39,10 +40,10 @@ class ProductFilterListFragment : BaseFragment(R.layout.fragment_product_filter_
         const val TAG = "ProductFilterListFragment"
     }
 
-    @Inject lateinit var viewModelFactory: ViewModelFactory
+    @Inject lateinit var viewModelFactory: Lazy<ViewModelFactory>
     private val viewModel: ProductFilterListViewModel by navGraphViewModels(
             R.id.nav_graph_product_filters
-    ) { viewModelFactory }
+    ) { viewModelFactory.get() }
 
     private lateinit var productFilterListAdapter: ProductFilterListAdapter
 


### PR DESCRIPTION
Fixes #3081 by making `viewModelFactory` in `ProductFilterListFragment` lazy. 

I haven't been able to reproduce this issue but the cause of the crash could be that the dagger injection in `BaseFragment` is on the `onAttach` method and `SavedStateRegistryOwner` needed for `viewModelFactory` of `BaseFragment` depended on `findNavController` which is not available before onCreate. This PR makes the injection of viewModelFactory lazy, so we won't try to access findNavController before onCreate. 

This fix worked previously in #3081 for `AddCategoryFragment` and `ProductFilterOptionFragment` so I just extended the same logic to `ProductFilterListFragment`.

### To test
- Click on the Products tab.
- Verify that the product filter option works as expected.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
