### PR TITLE
Issue/3298 order detail crash fix take2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -303,10 +303,12 @@ class OrderDetailRepository @Inject constructor(
     fun onOrderChanged(event: OnOrderChanged) {
         when (event.causeOfChange) {
             WCOrderAction.FETCH_SINGLE_ORDER -> {
-                if (event.isError) {
-                    continuationFetchOrder?.resume(false)
-                } else {
-                    continuationFetchOrder?.resume(true)
+                if (continuationFetchOrder?.isActive == true) {
+                    if (event.isError) {
+                        continuationFetchOrder?.resume(false)
+                    } else {
+                        continuationFetchOrder?.resume(true)
+                    }
                 }
             }
             WCOrderAction.FETCH_ORDER_NOTES -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaPickerRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaPickerRepository.kt
@@ -90,11 +90,13 @@ class WPMediaPickerRepository @Inject constructor(
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onMediaListFetched(event: OnMediaListFetched) {
         loadContinuation?.let {
-            if (event.isError) {
-                it.resume(false)
-            } else {
-                canLoadMoreMedia = event.canLoadMore
-                it.resume(true)
+            if (it.isActive) {
+                if (event.isError) {
+                    it.resume(false)
+                } else {
+                    canLoadMoreMedia = event.canLoadMore
+                    it.resume(true)
+                }
             }
         }
     }


### PR DESCRIPTION
Possible fix for #3298. I was unable to reproduce the crash, but the idea is to fix this crash by checking whether the continuation is still active before resuming it. If it's not active, it means it has already been resumed and completed.


The crash happens in the order detail screen when fetching an order and also when choosing media from the media picker. This PR changes the logic in both places.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
