### PR TITLE
Shipping class initial loading fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassAdapter.kt
@@ -49,8 +49,9 @@ class ProductShippingClassAdapter(
     }
 
     fun update(newItems: List<ShippingClass>, selectedItemId: Long = -1) {
-        val diffResult = DiffUtil.calculateDiff(ShippingClassDiffCallback(items, newItems))
-        items = mutableListOf(noShippingClass, *newItems.toTypedArray())
+        val newItemsPlusNone = mutableListOf(noShippingClass, *newItems.toTypedArray())
+        val diffResult = DiffUtil.calculateDiff(ShippingClassDiffCallback(items, newItemsPlusNone))
+        items = newItemsPlusNone
         selectedShippingClassId = selectedItemId
         diffResult.dispatchUpdatesTo(this)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassAdapter.kt
@@ -3,6 +3,8 @@ package com.woocommerce.android.ui.products
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.DiffUtil.Callback
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.ProductShippingClassItemBinding
@@ -15,53 +17,18 @@ import com.woocommerce.android.ui.products.ProductShippingClassAdapter.ViewHolde
  */
 class ProductShippingClassAdapter(
     context: Context,
-    private val listener: ShippingClassAdapterListener,
-    private var shippingClassSlug: String?
+    private val onItemClicked: (ShippingClass) -> Unit = { },
+    private val onLoadMoreRequested: () -> Unit = { }
 ) : RecyclerView.Adapter<ViewHolder>() {
-    companion object {
-        private const val VT_NO_SHIPPING_CLASS = 0
-        private const val VT_SHIPPING_CLASS = 1
-    }
+    private var items = mutableListOf<ShippingClass>()
+    private val noShippingClass = ShippingClass(
+        name = context.getString(R.string.product_no_shipping_class),
+        slug = "",
+        remoteShippingClassId = 0
+    )
+    private var selectedShippingClassId: Long = -1
 
-    interface ShippingClassAdapterListener {
-        fun onShippingClassClicked(shippingClass: ShippingClass)
-        fun onRequestLoadMore()
-    }
-
-    var shippingClassList: List<ShippingClass> = ArrayList()
-        set(value) {
-            if (!isSameList(value)) {
-                field = value
-                notifyDataSetChanged()
-            }
-        }
-
-    private val inflater: LayoutInflater = LayoutInflater.from(context)
-    private val noShippingClassText: String = context.getString(R.string.product_no_shipping_class)
-
-    init {
-        setHasStableIds(true)
-    }
-
-    override fun getItemId(position: Int): Long {
-        return if (getItemViewType(position) == VT_NO_SHIPPING_CLASS) {
-            -1
-        } else {
-            return getShippingClassAtPosition(position)!!.remoteShippingClassId
-        }
-    }
-
-    override fun getItemViewType(position: Int): Int {
-        return if (position == 0) {
-            VT_NO_SHIPPING_CLASS
-        } else {
-            VT_SHIPPING_CLASS
-        }
-    }
-
-    override fun getItemCount(): Int {
-        return shippingClassList.size + 1
-    }
+    override fun getItemCount() = items.size
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         return ViewHolder(
@@ -77,39 +44,15 @@ class ProductShippingClassAdapter(
         holder.bind(position)
 
         if (position > 0 && position == itemCount - 1) {
-            listener.onRequestLoadMore()
+            onLoadMoreRequested()
         }
     }
 
-    private fun isSameList(classes: List<ShippingClass>): Boolean {
-        if (classes.size != shippingClassList.size) {
-            return false
-        }
-
-        classes.forEach {
-            if (!containsShippingClass(it)) {
-                return false
-            }
-        }
-
-        return true
-    }
-
-    private fun containsShippingClass(shippingClass: ShippingClass): Boolean {
-        shippingClassList.forEach {
-            if (it.remoteShippingClassId == shippingClass.remoteShippingClassId) {
-                return true
-            }
-        }
-        return false
-    }
-
-    private fun getShippingClassAtPosition(position: Int): ShippingClass {
-        return if (getItemViewType(position) == VT_NO_SHIPPING_CLASS) {
-            ShippingClass(slug = "", remoteShippingClassId = 0)
-        } else {
-            shippingClassList[position - 1]
-        }
+    fun update(newItems: List<ShippingClass>, selectedItemId: Long = -1) {
+        val diffResult = DiffUtil.calculateDiff(ShippingClassDiffCallback(items, newItems))
+        items = mutableListOf(noShippingClass, *newItems.toTypedArray())
+        selectedShippingClassId = selectedItemId
+        diffResult.dispatchUpdatesTo(this)
     }
 
     inner class ViewHolder(val viewBinding: ProductShippingClassItemBinding) :
@@ -118,24 +61,33 @@ class ProductShippingClassAdapter(
             itemView.setOnClickListener {
                 val position = adapterPosition
                 if (position > -1) {
-                    getShippingClassAtPosition(position).let {
-                        shippingClassSlug = it.slug
-                        listener.onShippingClassClicked(it)
-                    }
+                    onItemClicked(items[position])
                 }
             }
         }
 
         fun bind(position: Int) {
-            if (getItemViewType(position) == VT_NO_SHIPPING_CLASS) {
-                viewBinding.text.text = noShippingClassText
-                viewBinding.text.isChecked = shippingClassSlug.isNullOrEmpty()
-            } else {
-                getShippingClassAtPosition(position)?.let {
-                    viewBinding.text.text = it.name
-                    viewBinding.text.isChecked = it.slug == shippingClassSlug
-                }
-            }
+            viewBinding.text.text = items[position].name
+            viewBinding.text.isChecked = items[position].remoteShippingClassId == selectedShippingClassId
+        }
+    }
+
+    inner class ShippingClassDiffCallback(
+        private val oldList: List<ShippingClass>,
+        private val newList: List<ShippingClass>
+    ) : Callback() {
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            return oldList[oldItemPosition].remoteShippingClassId == newList[newItemPosition].remoteShippingClassId
+        }
+
+        override fun getOldListSize(): Int = oldList.size
+
+        override fun getNewListSize(): Int = newList.size
+
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            val old = oldList[oldItemPosition]
+            val new = newList[newItemPosition]
+            return old == new
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassAdapter.kt
@@ -1,12 +1,10 @@
 package com.woocommerce.android.ui.products
 
-import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.DiffUtil.Callback
 import androidx.recyclerview.widget.RecyclerView
-import com.woocommerce.android.R
 import com.woocommerce.android.databinding.ProductShippingClassItemBinding
 import com.woocommerce.android.model.ShippingClass
 import com.woocommerce.android.ui.products.ProductShippingClassAdapter.ViewHolder
@@ -16,16 +14,10 @@ import com.woocommerce.android.ui.products.ProductShippingClassAdapter.ViewHolde
  * be "No shipping class" so the user can choose to clear this value.
  */
 class ProductShippingClassAdapter(
-    context: Context,
     private val onItemClicked: (ShippingClass) -> Unit = { },
     private val onLoadMoreRequested: () -> Unit = { }
 ) : RecyclerView.Adapter<ViewHolder>() {
-    private var items = mutableListOf<ShippingClass>()
-    private val noShippingClass = ShippingClass(
-        name = context.getString(R.string.product_no_shipping_class),
-        slug = "",
-        remoteShippingClassId = 0
-    )
+    private var items = listOf<ShippingClass>()
     private var selectedShippingClassId: Long = -1
 
     override fun getItemCount() = items.size
@@ -49,10 +41,9 @@ class ProductShippingClassAdapter(
     }
 
     fun update(newItems: List<ShippingClass>, selectedItemId: Long = -1) {
-        val newItemsPlusNone = mutableListOf(noShippingClass, *newItems.toTypedArray())
-        val diffResult = DiffUtil.calculateDiff(ShippingClassDiffCallback(items, newItemsPlusNone))
-        items = newItemsPlusNone
         selectedShippingClassId = selectedItemId
+        val diffResult = DiffUtil.calculateDiff(ShippingClassDiffCallback(items, newItems))
+        items = newItems
         diffResult.dispatchUpdatesTo(this)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassFragment.kt
@@ -16,7 +16,6 @@ import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.ShippingClass
 import com.woocommerce.android.ui.base.BaseFragment
-import com.woocommerce.android.ui.products.ProductShippingClassAdapter.ShippingClassAdapterListener
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import javax.inject.Inject
@@ -24,8 +23,7 @@ import javax.inject.Inject
 /**
  * Dialog which displays a list of product shipping classes
  */
-class ProductShippingClassFragment : BaseFragment(R.layout.fragment_product_shipping_class_list),
-    ShippingClassAdapterListener {
+class ProductShippingClassFragment : BaseFragment(R.layout.fragment_product_shipping_class_list) {
     companion object {
         const val TAG = "ProductShippingClassFragment"
         const val SELECTED_SHIPPING_CLASS_RESULT = "selected-shipping-class"
@@ -49,8 +47,8 @@ class ProductShippingClassFragment : BaseFragment(R.layout.fragment_product_ship
 
         shippingClassAdapter = ProductShippingClassAdapter(
             requireActivity(),
-            this,
-            navArgs.productShippingClassSlug
+            this::onShippingClassClicked,
+            this::onLoadMoreRequested
         )
 
         with(binding.recycler) {
@@ -78,15 +76,15 @@ class ProductShippingClassFragment : BaseFragment(R.layout.fragment_product_ship
     }
 
     private fun setupObservers() {
-        viewModel.productShippingClassViewStateData.observe(viewLifecycleOwner) { old, new ->
+        viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
             new.isLoadingProgressShown.takeIfNotEqualTo(old?.isLoadingProgressShown) {
                 showLoadingProgress(new.isLoadingProgressShown)
             }
             new.isLoadingMoreProgressShown.takeIfNotEqualTo(old?.isLoadingMoreProgressShown) {
                 showLoadingMoreProgress(new.isLoadingMoreProgressShown)
             }
-            new.shippingClassList.takeIfNotEqualTo(old?.shippingClassList) {
-                shippingClassAdapter?.shippingClassList = it!!
+            new.shippingClassList?.takeIfNotEqualTo(old?.shippingClassList) {
+                shippingClassAdapter?.update(it, navArgs.productShippingClassId)
             }
         }
 
@@ -100,11 +98,11 @@ class ProductShippingClassFragment : BaseFragment(R.layout.fragment_product_ship
 
     override fun getFragmentTitle() = getString(R.string.product_shipping_class)
 
-    override fun onShippingClassClicked(shippingClass: ShippingClass) {
+    private fun onShippingClassClicked(shippingClass: ShippingClass) {
         viewModel.onShippingClassClicked(shippingClass)
     }
 
-    override fun onRequestLoadMore() {
+    private fun onLoadMoreRequested() {
         viewModel.loadShippingClasses(loadMore = true)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassFragment.kt
@@ -46,7 +46,6 @@ class ProductShippingClassFragment : BaseFragment(R.layout.fragment_product_ship
         setupObservers()
 
         shippingClassAdapter = ProductShippingClassAdapter(
-            requireActivity(),
             this::onShippingClassClicked,
             this::onLoadMoreRequested
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassViewModel.kt
@@ -25,8 +25,8 @@ class ProductShippingClassViewModel @AssistedInject constructor(
     private var shippingClassLoadJob: Job? = null
 
     // view state for the shipping class screen
-    final val productShippingClassViewStateData = LiveDataDelegate(savedState, ProductShippingClassViewState())
-    private var productShippingClassViewState by productShippingClassViewStateData
+    final val viewStateData = LiveDataDelegate(savedState, ViewState())
+    private var viewState by viewStateData
 
     /**
      * Load & fetch the shipping classes for the current site, optionally performing a "load more" to
@@ -41,22 +41,22 @@ class ProductShippingClassViewModel @AssistedInject constructor(
         waitForExistingShippingClassFetch()
 
         shippingClassLoadJob = launch {
-            productShippingClassViewState = if (loadMore) {
-                productShippingClassViewState.copy(isLoadingMoreProgressShown = true)
+            viewState = if (loadMore) {
+                viewState.copy(isLoadingMoreProgressShown = true)
             } else {
                 // get cached shipping classes and only show loading progress the list is empty, otherwise show
                 // them right away
                 val cachedShippingClasses = productRepository.getProductShippingClassesForSite()
                 if (cachedShippingClasses.isEmpty()) {
-                    productShippingClassViewState.copy(isLoadingProgressShown = true)
+                    viewState.copy(isLoadingProgressShown = true)
                 } else {
-                    productShippingClassViewState.copy(shippingClassList = cachedShippingClasses)
+                    viewState.copy(shippingClassList = cachedShippingClasses)
                 }
             }
 
             // fetch shipping classes from the backend
             val shippingClasses = productRepository.fetchShippingClassesForSite(loadMore)
-            productShippingClassViewState = productShippingClassViewState.copy(
+            viewState = viewState.copy(
                     isLoadingProgressShown = false,
                     isLoadingMoreProgressShown = false,
                     shippingClassList = shippingClasses
@@ -88,7 +88,7 @@ class ProductShippingClassViewModel @AssistedInject constructor(
     }
 
     @Parcelize
-    data class ProductShippingClassViewState(
+    data class ViewState(
         val isLoadingProgressShown: Boolean = false,
         val isLoadingMoreProgressShown: Boolean = false,
         val shippingClassList: List<ShippingClass>? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingFragment.kt
@@ -144,7 +144,7 @@ class ProductShippingFragment : BaseProductEditorFragment(R.layout.fragment_prod
     private fun showShippingClassFragment() {
         val action = ProductShippingFragmentDirections
                 .actionProductShippingFragmentToProductShippingClassFragment(
-                    productShippingClassSlug = viewModel.shippingData.shippingClassSlug ?: ""
+                    productShippingClassId = viewModel.shippingData.shippingClassId ?: -1
                 )
         findNavController().navigateSafely(action)
     }

--- a/WooCommerce/src/main/res/navigation/nav_graph_products.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_products.xml
@@ -178,9 +178,8 @@
         android:name="com.woocommerce.android.ui.products.ProductShippingClassFragment"
         android:label="ProductShippingClassFragment">
         <argument
-            android:name="productShippingClassSlug"
-            android:defaultValue='""'
-            app:argType="string" />
+            android:name="productShippingClassId"
+            app:argType="long" />
     </fragment>
     <fragment
         android:id="@+id/productPricingFragment"


### PR DESCRIPTION
Fixes #3458 and refactors the shipping class adapter.

**To test:**

1. Clear the app data & login to a store with multiple shipping classes available
2. Go to Products
3. Open a product that has a shipping class selected
4. Tap on the Shipping -> Shipping class
5. Notice that 2 options are displayed initially "No shipping class" and the selected one
6. Notice the remaining options are loaded automatically right after