### PR TITLE
Products/sqliteblobtoobigexception crash fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -263,7 +263,9 @@ class OrderDetailRepository @Inject constructor(
 
     fun hasVirtualProductsOnly(remoteProductIds: List<Long>): Boolean {
         return if (remoteProductIds.isNotEmpty()) {
-            productStore.getVirtualProductCountByRemoteIds(selectedSite.get(), remoteProductIds) == remoteProductIds.size
+            productStore.getVirtualProductCountByRemoteIds(
+                selectedSite.get(), remoteProductIds
+            ) == remoteProductIds.size
         } else false
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -34,7 +34,6 @@ import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
-import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.model.order.toIdSet
 import org.wordpress.android.fluxc.store.WCOrderStore

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -263,7 +263,7 @@ class OrderDetailRepository @Inject constructor(
 
     fun hasVirtualProductsOnly(remoteProductIds: List<Long>): Boolean {
         return if (remoteProductIds.isNotEmpty()) {
-            productStore.hasVirtualProductsOnly(selectedSite.get(), remoteProductIds) == remoteProductIds.size
+            productStore.getVirtualProductCountByRemoteIds(selectedSite.get(), remoteProductIds) == remoteProductIds.size
         } else false
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -262,12 +262,16 @@ class OrderDetailRepository @Inject constructor(
     suspend fun fetchProductsByRemoteIds(remoteIds: List<Long>) =
         productStore.fetchProductListSynced(selectedSite.get(), remoteIds)?.map { it.toAppModel() } ?: emptyList()
 
-    fun getProductsByRemoteIds(remoteIds: List<Long>): List<WCProductModel> {
-        return if (remoteIds.isNotEmpty()) {
-            productStore.getProductsByRemoteIds(selectedSite.get(), remoteIds)
-        } else {
-            emptyList()
-        }
+    fun hasVirtualProductsOnly(remoteProductIds: List<Long>): Boolean {
+        return if (remoteProductIds.isNotEmpty()) {
+            productStore.hasVirtualProductsOnly(selectedSite.get(), remoteProductIds) == remoteProductIds.size
+        } else false
+    }
+
+    fun getProductCountForOrder(remoteProductIds: List<Long>): Int {
+        return if (remoteProductIds.isNotEmpty()) {
+            productStore.getProductCountByRemoteIds(selectedSite.get(), remoteProductIds)
+        } else 0
     }
 
     fun getOrderRefunds(remoteOrderId: Long) = refundStore

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -190,8 +190,7 @@ class OrderDetailViewModel @AssistedInject constructor(
     fun hasVirtualProductsOnly(): Boolean {
         return if (order.items.isNotEmpty()) {
             val remoteProductIds = order.items.map { it.productId }
-            val products = orderDetailRepository.getProductsByRemoteIds(remoteProductIds)
-            products.isNotEmpty() && products.all { it.virtual }
+            orderDetailRepository.hasVirtualProductsOnly(remoteProductIds)
         } else false
     }
 
@@ -430,7 +429,7 @@ class OrderDetailViewModel @AssistedInject constructor(
     // the database might be missing certain products, so we need to fetch the ones we don't have
     private fun fetchOrderProductsAsync() = async {
         val productIds = order.items.map { it.productId }
-        val numLocalProducts = orderDetailRepository.getProductsByRemoteIds(productIds).count()
+        val numLocalProducts = orderDetailRepository.getProductCountForOrder(productIds)
         if (numLocalProducts != order.items.size) {
             orderDetailRepository.fetchProductsByRemoteIds(productIds)
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -147,8 +147,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         doReturn(emptyList<ShippingLabel>()).whenever(repository).getOrderShippingLabels(any())
         doReturn(emptyList<ShippingLabel>()).whenever(repository).fetchOrderShippingLabels(any())
 
-        doReturn(mixedProducts).whenever(repository).getProductsByRemoteIds(any())
-
         var orderData: ViewState? = null
         viewModel.viewStateData.observeForever { _, new -> orderData = new }
 
@@ -228,7 +226,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             val virtualItems = listOf(item.copy(productId = 3), item.copy(productId = 4))
             val virtualOrder = order.copy(items = virtualItems)
 
-            doReturn(virtualProducts).whenever(repository).getProductsByRemoteIds(listOf(3, 4))
+            doReturn(true).whenever(repository).hasVirtualProductsOnly(listOf(3, 4))
             doReturn(virtualOrder).whenever(repository).getOrder(any())
             doReturn(virtualOrder).whenever(repository).fetchOrder(any())
 
@@ -251,7 +249,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             val mixedItems = listOf(item, item.copy(productId = 2))
             val mixedOrder = order.copy(items = mixedItems)
 
-            doReturn(mixedProducts).whenever(repository).getProductsByRemoteIds(listOf(1, 2))
+            doReturn(false).whenever(repository).hasVirtualProductsOnly(listOf(1, 2))
             doReturn(mixedOrder).whenever(repository).getOrder(any())
             doReturn(mixedOrder).whenever(repository).fetchOrder(any())
 
@@ -285,7 +283,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `fetch products if there are some missing`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            val product = mixedProducts.first()
             val item = OrderTestUtils.generateTestOrder().items.first().copy(productId = 1)
             val items = listOf(item, item.copy(productId = 2))
             val ids = items.map { it.productId }
@@ -293,7 +290,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             val order = order.copy(items = items)
             doReturn(order).whenever(repository).getOrder(any())
             doReturn(order).whenever(repository).fetchOrder(any())
-            doReturn(listOf(product)).whenever(repository).getProductsByRemoteIds(ids)
+            doReturn(1).whenever(repository).getProductCountForOrder(ids)
 
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
             doReturn(testOrderNotes).whenever(repository).getOrderNotes(any())

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.7.1'
+    fluxCVersion = '3ec50694515889fb6d30a2c7e86611e55f86b73f'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '3ec50694515889fb6d30a2c7e86611e55f86b73f'
+    fluxCVersion = 'c8793c9f6ef92921195cd6c3967bd941de6b1ec8'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Fixes #3462.  We seem to be getting a few `SqliteBlobTooBigException` crashes when fetching `ProductSqlUtils.getProductsByRemoteIds` method in `WCProductStore`.

There are 2 places in the app where this method is called:
- When trying to find if there are any virtual products for the order.
- When trying to find the total product count available locally for the order. 

Both of these scenarios require only the product count and not the entire product model list. So this PR adds logic to fetch just the product count for an order.

### To test
- Click on an order that does not contain any products and verify that the app does not crash.
- Click on an order that contains only virtual products and verify that only the billing details are displayed.
- Click on an order that contains only physical products and verify that the shipping + billing details are displayed.
- Click on an order that contains both physical and virtual products and verify that the shipping + billing details are displayed.

~**Note that this PR should not be merged until this [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1849) can be reviewed and merged**~

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
