### PR TITLE
issue/2374-parse-products-json-exception-fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.7.1'
+    fluxCVersion = 'd1928676a053ab6dfd0e38ecdec7700e155b9a65'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'd1928676a053ab6dfd0e38ecdec7700e155b9a65'
+    fluxCVersion = '37dc1ad929e97ff2fb901a4461d6df43453a6212'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Fixes #2374 by making sure to handle different API responses when fetching products. This PR just updates the FluxC hash. The actual PR with the fix is in this [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1850).

### To test
- Click on the products tab and verify that fetching products is working as expected.
- I was not able to reproduce the issue the issue with my own test stores but SSP'ing into the merchant's store using this [crash logs](https://sentry.io/organizations/a8c/issues/1910048982/events/17dfea0ced5a4f478d436fcb37a030e0/events/?project=1459556&statsPeriod=14d) would help in reproducing the issue. 

~**This PR is in draft till this [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1850) can be reviewed and merged.**~

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
