### PR TITLE
Fix crash of Product Images

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 5.9
 -----
 * [*] Fixed a rare crash when adding a new product category that includes symbols. [https://github.com/woocommerce/woocommerce-android/pull/3415]
+* [*] Fixed a crash in the product images gallery when re-ordering photos by drag and drop. [https://github.com/woocommerce/woocommerce-android/pull/3465]
  
 5.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/DraggableItemTouchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/DraggableItemTouchHelper.kt
@@ -37,4 +37,11 @@ class DraggableItemTouchHelper(
                 }
             }
         }
-)
+) {
+    var isAttached: Boolean = false
+
+    override fun attachToRecyclerView(recyclerView: RecyclerView?) {
+        super.attachToRecyclerView(recyclerView)
+        isAttached = recyclerView != null
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsFragment.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.ui.products.ProductDetailViewModel
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitProductDownloads
 import com.woocommerce.android.ui.wpmediapicker.WPMediaPickerFragment
 import com.woocommerce.android.widgets.CustomProgressDialog
+import com.woocommerce.android.widgets.DraggableItemTouchHelper
 
 class ProductDownloadsFragment : BaseProductFragment(R.layout.fragment_product_downloads_list) {
     private val itemTouchHelper by lazy {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/DraggableItemTouchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/DraggableItemTouchHelper.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.products.downloads
+package com.woocommerce.android.widgets
 
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -30,7 +30,6 @@ import com.woocommerce.android.R.dimen
 import com.woocommerce.android.di.GlideApp
 import com.woocommerce.android.di.GlideRequest
 import com.woocommerce.android.model.Product
-import com.woocommerce.android.ui.products.downloads.DraggableItemTouchHelper
 import kotlinx.android.synthetic.main.image_gallery_item.view.*
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.PhotonUtils

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -402,7 +402,7 @@ class WCProductImageGalleryView @JvmOverloads constructor(
 
         @SuppressLint("ClickableViewAccessibility")
         private val dragOnTouchListener = OnTouchListener { _, event ->
-            if (event.action == MotionEvent.ACTION_DOWN) {
+            if (event.action == MotionEvent.ACTION_DOWN && draggableItemTouchHelper.isAttached) {
                 draggableItemTouchHelper.startDrag(this@ImageViewHolder)
             }
             return@OnTouchListener false


### PR DESCRIPTION
Fixes #3374, currently when there are any changes to the product images, we update the state of the ItemTouchHelper to enable/disable dragging, which causes the NPE.

The fix here is by adding a `isAttached` property to the `DraggableItemTouchHelper`, which allows checking if it's attached to a recyclerView or not, and checking this property before starting the dragging.

I also moved the `DraggableItemTouchHelper` to the `widgets` package, as it's used in multiple places now.

To confirm the fix:
1. Open a product that has multiple images.
2. Open the images gallery.
3. Long click on one of the images to start dragging.
4. Delete all images except one.
5. Click on the last image.
6. Confirm the app doesn't crash.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
