### PR TITLE
Use the correct color when displaying the selected filter in orders screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.orders.list
 
 import android.content.Context
-import android.graphics.Color
 import android.os.Bundle
 import android.os.Handler
 import android.view.Menu
@@ -40,6 +39,7 @@ import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import dagger.android.support.AndroidSupportInjection
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus.PROCESSING
+import org.wordpress.android.login.util.getColorFromAttribute
 import org.wordpress.android.util.DisplayUtils
 import java.util.Locale
 import javax.inject.Inject
@@ -661,7 +661,7 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
             })
 
         searchView?.findViewById<EditText>(R.id.search_src_text)?.also {
-            it.setHintTextColor(Color.WHITE)
+            it.setHintTextColor(requireContext().getColorFromAttribute(R.attr.colorOnSurface))
             it.isEnabled = false
         }
         (activity as? MainActivity)?.showBottomNav()
@@ -677,6 +677,7 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
         if (isFilterEnabled) {
             isFilterEnabled = false
             searchView?.findViewById<EditText>(R.id.search_src_text)?.also {
+                it.setHintTextColor(requireContext().getColorFromAttribute(android.R.attr.textColorHint))
                 it.isEnabled = true
             }
             searchView?.queryHint = getString(R.string.orderlist_search_hint)


### PR DESCRIPTION
Fixes #3252, we use the hint text to display the selected filter in the orders screen, and we were setting its color always to white. With this fix, we will set it to the `colorOnSurface` attribute, and restore the default color when we close the filtered screen.

#### Testing
Repeat the following steps for both light and dark theme:
1. Go to Orders
2. Select the search icon
3. Select a filter on the search screen
4. Confirm the selected filter is displayed

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
