### PR TITLE
issue/3232-viewbinding-main-toolbar

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -187,8 +187,7 @@ class MainActivity : AppUpgradeActivity(),
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        // we have to use findViewById rather than view binding for the toolbar since it's an included layout
-        toolbar = findViewById<Toolbar>(R.id.toolbar)
+        toolbar = binding.toolbar.toolbar
         setSupportActionBar(toolbar)
         toolbar.navigationIcon = null
 

--- a/WooCommerce/src/main/res/layout/activity_main.xml
+++ b/WooCommerce/src/main/res/layout/activity_main.xml
@@ -29,7 +29,9 @@
                 android:layout_height="@dimen/expanded_toolbar_height"
                 app:titleEnabled="true">
 
-                <include layout="@layout/view_toolbar" />
+                <include
+                    android:id="@+id/toolbar"
+                    layout="@layout/view_toolbar" />
             </com.google.android.material.appbar.CollapsingToolbarLayout>
         </com.google.android.material.appbar.AppBarLayout>
 


### PR DESCRIPTION
In #3234 I relied on `findViewById` to reference the toolbar because I didn't think we could use view binding for included views. In [this discussion](https://github.com/woocommerce/woocommerce-android/pull/3234#discussion_r563734508) we discovered that we _can_ access included views to both the `include` tag and the view being included.

So, this small PR updates the main activity to use view binding to access to included toolbar.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
