### PR TITLE
Replace Automattic copyright with WooCommerce

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AboutFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AboutFragment.kt
@@ -37,10 +37,6 @@ class AboutFragment : Fragment(R.layout.fragment_about) {
         val copyright = String.format(getString(R.string.about_copyright), Calendar.getInstance().get(Calendar.YEAR))
         binding.aboutCopyright.text = copyright
 
-        binding.aboutUrl.setOnClickListener {
-            ChromeCustomTabUtils.launchUrl(activity as Context, AppUrls.AUTOMATTIC_HOME)
-        }
-
         binding.aboutPrivacy.setOnClickListener {
             ChromeCustomTabUtils.launchUrl(activity as Context, AppUrls.AUTOMATTIC_PRIVACY_POLICY)
         }

--- a/WooCommerce/src/main/res/layout/fragment_about.xml
+++ b/WooCommerce/src/main/res/layout/fragment_about.xml
@@ -75,34 +75,12 @@
         tools:text="Version 3.3-rc2" />
 
     <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/about_publisher"
-        style="@style/Woo.TextView.Caption"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/minor_00"
-        android:gravity="center_vertical"
-        android:text="@string/about_publisher"
-        android:layout_gravity="center"/>
-
-    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/about_copyright"
         style="@style/Woo.TextView.Caption"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/minor_00"
-        android:gravity="center_vertical"
+        android:gravity="center"
         android:layout_gravity="center"
-        tools:text="\@Automattic, Inc"/>
-
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/about_url"
-        style="@style/Woo.TextView.Caption"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/minor_00"
-        android:gravity="center_vertical"
-        android:clickable="true"
-        android:focusable="true"
-        android:text="@string/about_url_text"
-        android:layout_gravity="center"/>
+        tools:text="\@WooCommerce, Inc and WooCommerce Ireland"/>
 </LinearLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -882,11 +882,9 @@
     <string name="logviewer_error_copy_to_clipboard">Error copying to clipboard</string>
     <string name="logviewer_share_error">Unable to share log</string>
     <string name="about_appname">WooCommerce for Android</string>
-    <string name="about_publisher">Publisher: Automattic, Inc</string>
     <string name="about_tos">Terms of Service</string>
-    <string name="about_url_text" translatable="false">automattic.com</string>
     <string name="about_version">Version %s</string>
-    <string name="about_copyright" translatable="false">© %1$d Automattic, Inc</string>
+    <string name="about_copyright" translatable="false">© %1$d WooCommerce, Inc and WooCommerce Ireland</string>
     <!--
         Login Library Imported Strings
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -884,7 +884,7 @@
     <string name="about_appname">WooCommerce for Android</string>
     <string name="about_tos">Terms of Service</string>
     <string name="about_version">Version %s</string>
-    <string name="about_copyright" translatable="false">© %1$d WooCommerce, Inc and WooCommerce Ireland</string>
+    <string name="about_copyright" translatable="false">© %1$d WooCommerce, Inc and WooCommerce Ireland Ltd</string>
     <!--
         Login Library Imported Strings
     -->


### PR DESCRIPTION
Fixes #3473, it replaces the Automattic copyright by WooCommerce, and deletes the `publisher` and `url` lines, to align with iOS platform, for more context: p1611577960000600-slack-CGPNUU63E

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.