### PR TITLE
Issue/3232 view binding sitepicker take2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginNoJetpackFragment.kt
@@ -148,7 +148,7 @@ class LoginNoJetpackFragment : Fragment() {
                     .into(image_avatar)
         }
 
-        with(no_stores_view) {
+        with(no_stores_view_text) {
             visibility = View.VISIBLE
             text = getString(R.string.login_no_jetpack, siteAddress)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -54,7 +54,6 @@ import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
 import kotlinx.android.synthetic.main.activity_site_picker.*
 import kotlinx.android.synthetic.main.fragment_login_jetpack_required.*
-import kotlinx.android.synthetic.main.view_login_epilogue_button_bar.*
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.login.LoginMode
 import javax.inject.Inject
@@ -321,13 +320,13 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
                 hasConnectedStores = true
 
                 // Make "show connected stores" visible to the user
-                button_secondary.visibility = View.VISIBLE
-                button_secondary.text = getString(R.string.login_view_connected_stores)
+                binding.loginEpilogueButtonBar.buttonSecondary.visibility = View.VISIBLE
+                binding.loginEpilogueButtonBar.buttonSecondary.text = getString(R.string.login_view_connected_stores)
             } else {
                 hasConnectedStores = false
 
                 // Hide "show connected stores"
-                button_secondary.visibility = View.GONE
+                binding.loginEpilogueButtonBar.buttonSecondary.visibility = View.GONE
             }
 
             loginSiteUrl?.let { processLoginSite(it) }
@@ -339,7 +338,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
 
             // Show the 'try another account' button in case the user
             // doesn't see the store they want to log into.
-            with(button_secondary) {
+            with(binding.loginEpilogueButtonBar.buttonSecondary) {
                 visibility = View.VISIBLE
                 text = getString(R.string.login_try_another_account)
                 setOnClickListener {
@@ -351,7 +350,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             }
         } else {
             // Called from settings. Hide the button.
-            button_secondary.isVisible = false
+            binding.loginEpilogueButtonBar.buttonSecondary.isVisible = false
         }
 
         AnalyticsTracker.track(
@@ -384,7 +383,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             selectedSite.getIfExists()?.siteId ?: wcSites[0].siteId
         }
 
-        with(button_primary) {
+        with(binding.loginEpilogueButtonBar.buttonPrimary) {
             text = getString(R.string.done)
             isEnabled = true
             setOnClickListener {
@@ -399,7 +398,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
 
     override fun onSiteClick(siteId: Long) {
         clickedSiteId = siteId
-        button_primary.isEnabled = true
+        binding.loginEpilogueButtonBar.buttonPrimary.isEnabled = true
     }
 
     override fun siteSelected(site: SiteModel, isAutoLogin: Boolean) {
@@ -463,7 +462,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
 
         // re-select the previous site, if there was one
         siteAdapter.selectedSiteId = currentSite?.siteId ?: 0L
-        button_primary.isEnabled = siteAdapter.selectedSiteId != 0L
+        binding.loginEpilogueButtonBar.buttonPrimary.isEnabled = siteAdapter.selectedSiteId != 0L
 
         WooUpgradeRequiredDialog().show(supportFragmentManager)
     }
@@ -504,7 +503,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             visibility = View.VISIBLE
         }
 
-        with(button_primary) {
+        with(binding.loginEpilogueButtonBar.buttonPrimary) {
             text = getString(R.string.login_jetpack_view_instructions_alt)
             isEnabled = true
             setOnClickListener {
@@ -513,7 +512,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             }
         }
 
-        with(button_secondary) {
+        with(binding.loginEpilogueButtonBar.buttonSecondary) {
             visibility = View.VISIBLE
             text = getString(R.string.login_try_another_account)
             isEnabled = true
@@ -624,7 +623,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             visibility = View.VISIBLE
         }
 
-        with(button_primary) {
+        with(binding.loginEpilogueButtonBar.buttonPrimary) {
             text = getString(R.string.login_try_another_account)
             setOnClickListener {
                 AnalyticsTracker.track(Stat.SITE_PICKER_TRY_ANOTHER_ACCOUNT_BUTTON_TAPPED)
@@ -635,7 +634,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             }
         }
 
-        with(button_secondary) {
+        with(binding.loginEpilogueButtonBar.buttonSecondary) {
             visibility = if (hasConnectedStores) {
                 text = getString(R.string.login_view_connected_stores)
 
@@ -708,7 +707,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             visibility = View.VISIBLE
         }
 
-        with(button_primary) {
+        with(binding.loginEpilogueButtonBar.buttonPrimary) {
             text = getString(R.string.login_try_another_store)
             setOnClickListener {
                 AnalyticsTracker.track(Stat.SITE_PICKER_TRY_ANOTHER_STORE_BUTTON_TAPPED)
@@ -719,7 +718,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             }
         }
 
-        with(button_secondary) {
+        with(binding.loginEpilogueButtonBar.buttonSecondary) {
             visibility = if (hasConnectedStores) {
                 text = getString(R.string.login_view_connected_stores)
 
@@ -786,7 +785,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             movementMethod = LinkMovementMethod.getInstance()
         }
 
-        with(button_primary) {
+        with(binding.loginEpilogueButtonBar.buttonPrimary) {
             text = getString(R.string.login_try_another_account)
 
             setOnClickListener {
@@ -798,7 +797,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             }
         }
 
-        with(button_secondary) {
+        with(binding.loginEpilogueButtonBar.buttonSecondary) {
             visibility = if (hasConnectedStores) {
                 text = getString(R.string.login_view_connected_stores)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -52,8 +52,6 @@ import dagger.android.AndroidInjection
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
-import kotlinx.android.synthetic.main.activity_site_picker.*
-import kotlinx.android.synthetic.main.fragment_login_jetpack_required.*
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.login.LoginMode
 import javax.inject.Inject
@@ -131,36 +129,36 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
                 ?: intent.getBooleanExtra(KEY_CALLED_FROM_LOGIN, false)
 
         if (calledFromLogin) {
-            toolbar.visibility = View.GONE
-            button_help.setOnClickListener {
+            binding.toolbar.toolbar.visibility = View.GONE
+            binding.buttonHelp.setOnClickListener {
                 startActivity(HelpActivity.createIntent(this, Origin.LOGIN_EPILOGUE, null))
                 AnalyticsTracker.track(Stat.SITE_PICKER_HELP_BUTTON_TAPPED)
                 if (calledFromLogin) {
                     unifiedLoginTracker.trackClick(Click.SHOW_HELP)
                 }
             }
-            site_list_container.elevation = resources.getDimension(R.dimen.plane_01)
+            binding.siteListContainer.elevation = resources.getDimension(R.dimen.plane_01)
         } else {
             // Opened from settings to change active store.
             overridePendingTransition(R.anim.activity_slide_in_from_right, R.anim.activity_slide_out_to_left)
 
-            toolbar.visibility = View.VISIBLE
-            setSupportActionBar(toolbar as Toolbar)
+            binding.toolbar.toolbar.visibility = View.VISIBLE
+            setSupportActionBar(binding.toolbar.toolbar as Toolbar)
             supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
             title = getString(R.string.site_picker_title)
-            button_help.visibility = View.GONE
-            site_list_label.visibility = View.GONE
-            site_list_container.elevation = 0f
-            (site_list_container.layoutParams as MarginLayoutParams).topMargin = 0
-            (site_list_container.layoutParams as MarginLayoutParams).bottomMargin = 0
+            binding.buttonHelp.visibility = View.GONE
+            binding.siteListLabel.visibility = View.GONE
+            binding.siteListContainer.elevation = 0f
+            (binding.siteListContainer.layoutParams as MarginLayoutParams).topMargin = 0
+            (binding.siteListContainer.layoutParams as MarginLayoutParams).bottomMargin = 0
         }
 
         presenter.takeView(this)
 
-        sites_recycler.layoutManager = androidx.recyclerview.widget.LinearLayoutManager(this)
+        binding.sitesRecycler.layoutManager = androidx.recyclerview.widget.LinearLayoutManager(this)
         siteAdapter = SitePickerAdapter(this, this)
-        sites_recycler.adapter = siteAdapter
+        binding.sitesRecycler.adapter = siteAdapter
 
         loadUserInfo()
 
@@ -358,7 +356,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
                 mapOf(AnalyticsTracker.KEY_NUMBER_OF_STORES to presenter.getWooCommerceSites().size)
         )
 
-        site_picker_root.visibility = View.VISIBLE
+        binding.sitePickerRoot.visibility = View.VISIBLE
 
         if (wcSites.isEmpty()) {
             showNoStoresView()
@@ -366,11 +364,11 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         }
 
         binding.noStoresView.noStoresViewText.visibility = View.GONE
-        btn_secondary_action.visibility = View.GONE
-        site_list_container.visibility = View.VISIBLE
-        btn_secondary_action.visibility = View.GONE
+        binding.noStoresView.btnSecondaryAction.visibility = View.GONE
+        binding.siteListContainer.visibility = View.VISIBLE
+        binding.noStoresView.btnSecondaryAction.visibility = View.GONE
 
-        site_list_label.text = when {
+        binding.siteListLabel.text = when {
             wcSites.size == 1 -> getString(R.string.login_connected_store)
             calledFromLogin -> getString(R.string.login_pick_store)
             else -> getString(R.string.site_picker_title)
@@ -474,7 +472,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
 
         val siteName = if (!TextUtils.isEmpty(site.name)) site.name else getString(R.string.untitled)
         Snackbar.make(
-                site_picker_root as ViewGroup,
+                binding.sitePickerRoot as ViewGroup,
                 getString(R.string.login_verifying_site_error, siteName),
                 BaseTransientBottomBar.LENGTH_LONG
         ).show()
@@ -490,11 +488,11 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         }
 
         showUserInfo(centered = true)
-        site_picker_root.visibility = View.VISIBLE
-        site_list_container.visibility = View.GONE
+        binding.sitePickerRoot.visibility = View.VISIBLE
+        binding.siteListContainer.visibility = View.GONE
         binding.noStoresView.noStoresViewText.visibility = View.VISIBLE
 
-        with(btn_secondary_action) {
+        with(binding.noStoresView.btnSecondaryAction) {
             text = getString(R.string.login_jetpack_what_is)
             setOnClickListener {
                 AnalyticsTracker.track(Stat.LOGIN_JETPACK_REQUIRED_WHAT_IS_JETPACK_LINK_TAPPED)
@@ -532,7 +530,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         }
 
         when (show) {
-            true -> skeletonView.show(sites_recycler, R.layout.skeleton_site_picker, delayed = true)
+            true -> skeletonView.show(binding.sitesRecycler, R.layout.skeleton_site_picker, delayed = true)
             false -> skeletonView.hide()
         }
     }
@@ -606,13 +604,13 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         }
 
         showUserInfo(centered = true)
-        site_picker_root.visibility = View.VISIBLE
+        binding.sitePickerRoot.visibility = View.VISIBLE
         binding.noStoresView.noStoresViewText.visibility = View.VISIBLE
-        site_list_container.visibility = View.GONE
+        binding.siteListContainer.visibility = View.GONE
 
         binding.noStoresView.noStoresViewText.text = getString(R.string.login_not_connected_to_account, url)
 
-        with(btn_secondary_action) {
+        with(binding.noStoresView.btnSecondaryAction) {
             text = getString(R.string.login_need_help_finding_email)
             setOnClickListener {
                 AnalyticsTracker.track(Stat.SITE_PICKER_HELP_FINDING_CONNECTED_EMAIL_LINK_TAPPED)
@@ -663,9 +661,9 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         }
 
         showUserInfo(centered = true)
-        site_picker_root.visibility = View.VISIBLE
+        binding.sitePickerRoot.visibility = View.VISIBLE
         binding.noStoresView.noStoresViewText.visibility = View.VISIBLE
-        site_list_container.visibility = View.GONE
+        binding.siteListContainer.visibility = View.GONE
 
         with(binding.noStoresView.noStoresViewText) {
             val refreshAppText = getString(R.string.login_refresh_app_continue)
@@ -698,7 +696,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             movementMethod = LinkMovementMethod.getInstance()
         }
 
-        with(btn_secondary_action) {
+        with(binding.noStoresView.btnSecondaryAction) {
             text = getString(R.string.login_jetpack_what_is)
             setOnClickListener {
                 AnalyticsTracker.track(Stat.LOGIN_JETPACK_REQUIRED_WHAT_IS_JETPACK_LINK_TAPPED)
@@ -752,10 +750,10 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         }
 
         showUserInfo(centered = true)
-        site_picker_root.visibility = View.VISIBLE
-        no_stores_view.visibility = View.VISIBLE
-        site_list_container.visibility = View.GONE
-        btn_secondary_action.visibility = View.GONE
+        binding.sitePickerRoot.visibility = View.VISIBLE
+        binding.noStoresView.noStoresView.visibility = View.VISIBLE
+        binding.siteListContainer.visibility = View.GONE
+        binding.noStoresView.btnSecondaryAction.visibility = View.GONE
 
         with(binding.noStoresView.noStoresViewText) {
             // Build and configure the error message and make part of the message

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -288,16 +288,16 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
      */
     private fun showUserInfo(centered: Boolean) {
         if (calledFromLogin) {
-            binding.loginUserInfo.userInfoGroup.visibility = View.VISIBLE
+            binding.loginUserInfo.loginUserInfo.visibility = View.VISIBLE
             if (centered) {
-                binding.loginUserInfo.userInfoGroup.gravity = Gravity.CENTER
+                binding.loginUserInfo.loginUserInfo.gravity = Gravity.CENTER
                 with(binding.loginUserInfo.imageAvatar) {
                     layoutParams.height = resources.getDimensionPixelSize(R.dimen.image_major_64)
                     layoutParams.width = resources.getDimensionPixelSize(R.dimen.image_major_64)
                     requestLayout()
                 }
             } else {
-                binding.loginUserInfo.userInfoGroup.gravity = Gravity.START
+                binding.loginUserInfo.loginUserInfo.gravity = Gravity.START
                 with(binding.loginUserInfo.imageAvatar) {
                     layoutParams.height = resources.getDimensionPixelSize(R.dimen.image_major_72)
                     layoutParams.width = resources.getDimensionPixelSize(R.dimen.image_major_72)
@@ -305,7 +305,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
                 }
             }
         } else {
-            binding.loginUserInfo.userInfoGroup.visibility = View.GONE
+            binding.loginUserInfo.loginUserInfo.visibility = View.GONE
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.databinding.ActivitySitePickerBinding
 import com.woocommerce.android.di.GlideApp
 import com.woocommerce.android.push.FCMRegistrationIntentService
 import com.woocommerce.android.support.HelpActivity
@@ -54,8 +55,6 @@ import dagger.android.HasAndroidInjector
 import kotlinx.android.synthetic.main.activity_site_picker.*
 import kotlinx.android.synthetic.main.fragment_login_jetpack_required.*
 import kotlinx.android.synthetic.main.view_login_epilogue_button_bar.*
-import kotlinx.android.synthetic.main.view_login_no_stores.*
-import kotlinx.android.synthetic.main.view_login_no_stores.btn_secondary_action
 import kotlinx.android.synthetic.main.view_login_user_info.*
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.login.LoginMode
@@ -116,12 +115,17 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
      */
     private var hasConnectedStores: Boolean = false
 
+    private var _binding: ActivitySitePickerBinding? = null
+    private val binding get() = _binding!!
+
     override fun androidInjector(): AndroidInjector<Any> = androidInjector
 
     override fun onCreate(savedInstanceState: Bundle?) {
         AndroidInjection.inject(this)
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_site_picker)
+
+        _binding = ActivitySitePickerBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
         currentSite = selectedSite.getIfExists()
 
@@ -363,7 +367,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             return
         }
 
-        no_stores_view.visibility = View.GONE
+        binding.noStoresView.noStoresViewText.visibility = View.GONE
         btn_secondary_action.visibility = View.GONE
         site_list_container.visibility = View.VISIBLE
         btn_secondary_action.visibility = View.GONE
@@ -490,7 +494,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         showUserInfo(centered = true)
         site_picker_root.visibility = View.VISIBLE
         site_list_container.visibility = View.GONE
-        no_stores_view.visibility = View.VISIBLE
+        binding.noStoresView.noStoresViewText.visibility = View.VISIBLE
 
         with(btn_secondary_action) {
             text = getString(R.string.login_jetpack_what_is)
@@ -605,10 +609,10 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
 
         showUserInfo(centered = true)
         site_picker_root.visibility = View.VISIBLE
-        no_stores_view.visibility = View.VISIBLE
+        binding.noStoresView.noStoresViewText.visibility = View.VISIBLE
         site_list_container.visibility = View.GONE
 
-        no_stores_view.text = getString(R.string.login_not_connected_to_account, url)
+        binding.noStoresView.noStoresViewText.text = getString(R.string.login_not_connected_to_account, url)
 
         with(btn_secondary_action) {
             text = getString(R.string.login_need_help_finding_email)
@@ -662,10 +666,10 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
 
         showUserInfo(centered = true)
         site_picker_root.visibility = View.VISIBLE
-        no_stores_view.visibility = View.VISIBLE
+        binding.noStoresView.noStoresViewText.visibility = View.VISIBLE
         site_list_container.visibility = View.GONE
 
-        with(no_stores_view) {
+        with(binding.noStoresView.noStoresViewText) {
             val refreshAppText = getString(R.string.login_refresh_app_continue)
             val notConnectedText = getString(
                     R.string.login_not_connected_jetpack,
@@ -755,7 +759,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
         site_list_container.visibility = View.GONE
         btn_secondary_action.visibility = View.GONE
 
-        with(no_stores_view) {
+        with(binding.noStoresView.noStoresViewText) {
             // Build and configure the error message and make part of the message
             // clickable. When clicked, we'll fetch a fresh copy of the active site from the API.
             val siteName = site.name.takeIf { !it.isNullOrEmpty() } ?: site.url

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -55,7 +55,6 @@ import dagger.android.HasAndroidInjector
 import kotlinx.android.synthetic.main.activity_site_picker.*
 import kotlinx.android.synthetic.main.fragment_login_jetpack_required.*
 import kotlinx.android.synthetic.main.view_login_epilogue_button_bar.*
-import kotlinx.android.synthetic.main.view_login_user_info.*
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.login.LoginMode
 import javax.inject.Inject
@@ -268,11 +267,11 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
      * Load the user info view with user information and gravatar.
      */
     private fun loadUserInfo() {
-        text_displayname.text = presenter.getUserDisplayName()
+        binding.loginUserInfo.textDisplayname.text = presenter.getUserDisplayName()
 
         presenter.getUserName()?.let { userName ->
             if (userName.isNotEmpty()) {
-                text_username.text = String.format(getString(R.string.at_username), userName)
+                binding.loginUserInfo.textUsername.text = String.format(getString(R.string.at_username), userName)
             }
         }
 
@@ -280,7 +279,7 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             .load(presenter.getUserAvatarUrl())
             .placeholder(R.drawable.img_gravatar_placeholder)
             .circleCrop()
-            .into(image_avatar)
+            .into(binding.loginUserInfo.imageAvatar)
     }
 
     /**
@@ -292,24 +291,24 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
      */
     private fun showUserInfo(centered: Boolean) {
         if (calledFromLogin) {
-            user_info_group.visibility = View.VISIBLE
+            binding.loginUserInfo.userInfoGroup.visibility = View.VISIBLE
             if (centered) {
-                user_info_group.gravity = Gravity.CENTER
-                with(image_avatar) {
+                binding.loginUserInfo.userInfoGroup.gravity = Gravity.CENTER
+                with(binding.loginUserInfo.imageAvatar) {
                     layoutParams.height = resources.getDimensionPixelSize(R.dimen.image_major_64)
                     layoutParams.width = resources.getDimensionPixelSize(R.dimen.image_major_64)
                     requestLayout()
                 }
             } else {
-                user_info_group.gravity = Gravity.START
-                with(image_avatar) {
+                binding.loginUserInfo.userInfoGroup.gravity = Gravity.START
+                with(binding.loginUserInfo.imageAvatar) {
                     layoutParams.height = resources.getDimensionPixelSize(R.dimen.image_major_72)
                     layoutParams.width = resources.getDimensionPixelSize(R.dimen.image_major_72)
                     requestLayout()
                 }
             }
         } else {
-            user_info_group.visibility = View.GONE
+            binding.loginUserInfo.userInfoGroup.visibility = View.GONE
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerAdapter.kt
@@ -3,16 +3,13 @@ package com.woocommerce.android.ui.sitepicker
 import android.content.Context
 import android.text.TextUtils
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import android.widget.RadioButton
-import android.widget.TextView
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.R
+import com.woocommerce.android.databinding.SitePickerItemBinding
 import com.woocommerce.android.ui.sitepicker.SitePickerAdapter.SiteViewHolder
 import com.woocommerce.android.util.StringUtils
-import kotlinx.android.synthetic.main.site_picker_item.view.*
 import org.wordpress.android.fluxc.model.SiteModel
 
 class SitePickerAdapter(private val context: Context, private val listener: OnSiteClickListener) :
@@ -49,25 +46,18 @@ class SitePickerAdapter(private val context: Context, private val listener: OnSi
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SiteViewHolder {
-        return SiteViewHolder(LayoutInflater.from(context).inflate(R.layout.site_picker_item, parent, false))
+        return SiteViewHolder(
+            SitePickerItemBinding.inflate(
+                LayoutInflater.from(context),
+                parent,
+                false
+            )
+        )
     }
 
     override fun onBindViewHolder(holder: SiteViewHolder, position: Int) {
         val site = siteList[position]
-        holder.radio.isVisible = siteList.size > 1
-        holder.radio.isChecked = site.siteId == selectedSiteId
-        holder.txtSiteName.text = if (!TextUtils.isEmpty(site.name)) site.name else context.getString(R.string.untitled)
-        holder.txtSiteDomain.text = StringUtils.getSiteDomainAndPath(site)
-        if (itemCount > 1) {
-            holder.itemView.setOnClickListener {
-                if (selectedSiteId != site.siteId) {
-                    listener.onSiteClick(site.siteId)
-                    selectedSiteId = site.siteId
-                }
-            }
-        } else {
-            holder.itemView.setOnClickListener(null)
-        }
+        holder.bind(site)
     }
 
     /**
@@ -99,13 +89,26 @@ class SitePickerAdapter(private val context: Context, private val listener: OnSi
         return false
     }
 
-    class SiteViewHolder(view: View) : RecyclerView.ViewHolder(view) {
-        val radio: RadioButton = view.radio
-        val txtSiteName: TextView = view.text_site_name
-        val txtSiteDomain: TextView = view.text_site_domain
-
+    inner class SiteViewHolder(val viewBinding: SitePickerItemBinding) : RecyclerView.ViewHolder(viewBinding.root) {
         init {
-            radio.isClickable = false
+            viewBinding.radio.isClickable = false
+        }
+
+        fun bind(site: SiteModel) {
+            viewBinding.radio.isVisible = siteList.size > 1
+            viewBinding.radio.isChecked = site.siteId == selectedSiteId
+            viewBinding.textSiteName.text = if (!TextUtils.isEmpty(site.name)) site.name else context.getString(R.string.untitled)
+            viewBinding.textSiteDomain.text = StringUtils.getSiteDomainAndPath(site)
+            if (itemCount > 1) {
+                viewBinding.root.setOnClickListener {
+                    if (selectedSiteId != site.siteId) {
+                        listener.onSiteClick(site.siteId)
+                        selectedSiteId = site.siteId
+                    }
+                }
+            } else {
+                viewBinding.root.setOnClickListener(null)
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerAdapter.kt
@@ -97,7 +97,8 @@ class SitePickerAdapter(private val context: Context, private val listener: OnSi
         fun bind(site: SiteModel) {
             viewBinding.radio.isVisible = siteList.size > 1
             viewBinding.radio.isChecked = site.siteId == selectedSiteId
-            viewBinding.textSiteName.text = if (!TextUtils.isEmpty(site.name)) site.name else context.getString(R.string.untitled)
+            viewBinding.textSiteName.text =
+                if (!TextUtils.isEmpty(site.name)) site.name else context.getString(R.string.untitled)
             viewBinding.textSiteDomain.text = StringUtils.getSiteDomainAndPath(site)
             if (itemCount > 1) {
                 viewBinding.root.setOnClickListener {

--- a/WooCommerce/src/main/res/layout-land/view_login_epilogue_button_bar.xml
+++ b/WooCommerce/src/main/res/layout-land/view_login_epilogue_button_bar.xml
@@ -2,8 +2,7 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/frame_bottom"
+    android:id="@+id/login_epilogue_button_bar"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:clipToPadding="false"

--- a/WooCommerce/src/main/res/layout-land/view_login_no_stores.xml
+++ b/WooCommerce/src/main/res/layout-land/view_login_no_stores.xml
@@ -2,14 +2,13 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/no_stores_view"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@+id/user_info_group"
+    app:layout_constraintTop_toBottomOf="@+id/login_user_info"
     app:layout_constraintVertical_bias="0.0" >
 
     <com.google.android.material.textview.MaterialTextView
@@ -25,9 +24,7 @@
         android:drawablePadding="@dimen/major_100"
         android:lineSpacingExtra="@dimen/line_spacing_extra_50"
         android:text="@string/login_no_stores"
-        android:textStyle="bold"
-        android:visibility="gone"
-        tools:visibility="visible"/>
+        android:textStyle="bold" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_secondary_action"
@@ -39,6 +36,5 @@
         android:layout_marginEnd="@dimen/major_100"
         android:text="@string/login_jetpack_what_is"
         android:textAllCaps="false"
-        android:textAlignment="center"
-        android:visibility="gone" />
+        android:textAlignment="center" />
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout-land/view_login_no_stores.xml
+++ b/WooCommerce/src/main/res/layout-land/view_login_no_stores.xml
@@ -3,6 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/no_stores_view"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
@@ -13,7 +14,7 @@
 
     <com.google.android.material.textview.MaterialTextView
         style="@style/Woo.TextView.Subtitle1"
-        android:id="@+id/no_stores_view"
+        android:id="@+id/no_stores_view_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/major_100"

--- a/WooCommerce/src/main/res/layout/activity_site_picker.xml
+++ b/WooCommerce/src/main/res/layout/activity_site_picker.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/site_picker_root"
-    android:background="@color/color_surface"
-    android:layout_height="match_parent"
     android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/color_surface"
     android:orientation="vertical"
     android:visibility="visible">
 
@@ -16,8 +15,8 @@
         android:layout_height="wrap_content">
 
         <include
-            layout="@layout/view_toolbar"
-            android:id="@+id/toolbar"/>
+            android:id="@+id/toolbar"
+            layout="@layout/view_toolbar" />
     </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.core.widget.NestedScrollView
@@ -36,17 +35,17 @@
                 android:layout_width="48dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/minor_50"
-                android:src="@drawable/ic_help_24dp"
                 android:contentDescription="@string/help"
+                android:src="@drawable/ic_help_24dp"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent"/>
+                app:layout_constraintTop_toTopOf="parent" />
 
             <LinearLayout
                 android:id="@+id/site_list_container"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/major_100"
                 android:layout_marginTop="@dimen/major_75"
+                android:layout_marginBottom="@dimen/major_100"
                 android:orientation="vertical"
                 android:visibility="visible"
                 app:layout_constraintBottom_toBottomOf="parent"
@@ -58,38 +57,42 @@
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/site_list_label"
-                    android:textAppearance="@style/TextAppearance.Woo.Subtitle2"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_margin="@dimen/major_100"
                     android:text="@string/login_pick_store"
-                    android:textAllCaps="true"/>
+                    android:textAllCaps="true"
+                    android:textAppearance="@style/TextAppearance.Woo.Subtitle2" />
 
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/sites_recycler"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:nestedScrollingEnabled="false"
-                    tools:listitem="@layout/site_picker_item"
-                    tools:itemCount="3"/>
+                    tools:itemCount="3"
+                    tools:listitem="@layout/site_picker_item" />
             </LinearLayout>
 
             <include
+                android:id="@+id/login_user_info"
                 layout="@layout/view_login_user_info"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/major_200"
                 android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_200"
                 android:layout_marginEnd="@dimen/major_100"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
             <include
-                layout="@layout/view_login_no_stores"/>
+                android:id="@+id/no_stores_view"
+                layout="@layout/view_login_no_stores" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.core.widget.NestedScrollView>
 
-    <include layout="@layout/view_login_epilogue_button_bar"/>
+    <include
+        android:id="@+id/login_epilogue_button_bar"
+        layout="@layout/view_login_epilogue_button_bar" />
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout/activity_site_picker.xml
+++ b/WooCommerce/src/main/res/layout/activity_site_picker.xml
@@ -6,8 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/color_surface"
-    android:orientation="vertical"
-    android:visibility="visible">
+    android:orientation="vertical">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar_layout"
@@ -47,13 +46,11 @@
                 android:layout_marginTop="@dimen/major_75"
                 android:layout_marginBottom="@dimen/major_100"
                 android:orientation="vertical"
-                android:visibility="visible"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/login_user_info"
-                app:layout_constraintVertical_bias="0.0"
-                tools:visibility="gone">
+                app:layout_constraintVertical_bias="0.0">
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/site_list_label"

--- a/WooCommerce/src/main/res/layout/activity_site_picker.xml
+++ b/WooCommerce/src/main/res/layout/activity_site_picker.xml
@@ -51,7 +51,7 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/user_info_group"
+                app:layout_constraintTop_toBottomOf="@+id/login_user_info"
                 app:layout_constraintVertical_bias="0.0"
                 tools:visibility="gone">
 

--- a/WooCommerce/src/main/res/layout/view_login_epilogue_button_bar.xml
+++ b/WooCommerce/src/main/res/layout/view_login_epilogue_button_bar.xml
@@ -2,8 +2,7 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/frame_bottom"
+    android:id="@+id/login_epilogue_button_bar"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:clipToPadding="false"

--- a/WooCommerce/src/main/res/layout/view_login_no_stores.xml
+++ b/WooCommerce/src/main/res/layout/view_login_no_stores.xml
@@ -3,6 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/no_stores_view"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
@@ -13,7 +14,7 @@
 
     <com.google.android.material.textview.MaterialTextView
         style="@style/Woo.TextView.Subtitle1"
-        android:id="@+id/no_stores_view"
+        android:id="@+id/no_stores_view_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/major_100"

--- a/WooCommerce/src/main/res/layout/view_login_no_stores.xml
+++ b/WooCommerce/src/main/res/layout/view_login_no_stores.xml
@@ -2,14 +2,13 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/no_stores_view"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@+id/user_info_group"
+    app:layout_constraintTop_toBottomOf="@+id/login_user_info"
     app:layout_constraintVertical_bias="0.0">
 
     <com.google.android.material.textview.MaterialTextView
@@ -26,9 +25,7 @@
         android:gravity="center_horizontal"
         android:lineSpacingExtra="@dimen/line_spacing_extra_50"
         android:text="@string/login_no_stores"
-        android:textStyle="bold"
-        android:visibility="gone"
-        tools:visibility="visible"/>
+        android:textStyle="bold" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_secondary_action"
@@ -39,6 +36,5 @@
         android:layout_marginStart="@dimen/major_100"
         android:layout_marginEnd="@dimen/major_100"
         android:text="@string/login_jetpack_what_is"
-        android:textAllCaps="false"
-        android:visibility="visible" />
+        android:textAllCaps="false" />
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout/view_login_user_info.xml
+++ b/WooCommerce/src/main/res/layout/view_login_user_info.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/user_info_group"
+    android:id="@+id/login_user_info"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"


### PR DESCRIPTION
Converts the site picker to view binding. To test:

* Login to a site without Jetpack and verify the "Jetpack required" screen appears correctly
* Login to a Jetpack site that has no stores and verify the "No stores" screen appear correctly
* Login to a Jetpack site with stores and verify it all works correctly
* Go to settings and verify the site picker works correctly when changing stores

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
