### PR TITLE
Add back order status change tracking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -259,6 +259,11 @@ class OrderDetailViewModel @AssistedInject constructor(
             else -> resourceProvider.getString(string.order_status_changed_to, newStatus)
         }
 
+        AnalyticsTracker.track(Stat.ORDER_STATUS_CHANGE, mapOf(
+            AnalyticsTracker.KEY_ID to order.remoteId,
+            AnalyticsTracker.KEY_FROM to order.status.value,
+            AnalyticsTracker.KEY_TO to newStatus))
+
         // display undo snackbar
         triggerEvent(ShowUndoSnackbar(
             message = snackMessage,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -541,6 +541,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             if (it is ShowSnackbar) snackbar = it
         }
 
+        viewModel.order = order
         viewModel.start()
         viewModel.onOrderStatusChanged(CoreOrderStatus.PROCESSING.value)
         viewModel.updateOrderStatus(CoreOrderStatus.PROCESSING.value)


### PR DESCRIPTION
`ORDER_STATUS_CHANGE` tracking was accidentally removed during refactoring. This PR adds it back.

**To test:**
1. Go to Orders -> Open any order
2. Tap on the order status and then change it
3. Verify the `ORDER_STATUS_CHANGE` is tracked in the logcat