### PR TITLE
Issue/3232 viewbinding feedback

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
@@ -1,9 +1,7 @@
 package com.woocommerce.android.ui.feedback
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
@@ -14,14 +12,14 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBA
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_GENERAL_CONTEXT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_PRODUCT_M3_CONTEXT
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SURVEY_SCREEN
+import com.woocommerce.android.databinding.FragmentFeedbackCompletedBinding
 import com.woocommerce.android.extensions.configureStringClick
 import com.woocommerce.android.extensions.startHelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin.FEEDBACK_SURVEY
 import com.woocommerce.android.ui.feedback.SurveyType.MAIN
 import com.woocommerce.android.widgets.WooClickableSpan
-import kotlinx.android.synthetic.main.fragment_feedback_completed.*
 
-class FeedbackCompletedFragment : androidx.fragment.app.Fragment() {
+class FeedbackCompletedFragment : androidx.fragment.app.Fragment(R.layout.fragment_feedback_completed) {
     companion object {
         const val TAG = "survey_completed"
     }
@@ -33,9 +31,19 @@ class FeedbackCompletedFragment : androidx.fragment.app.Fragment() {
         }
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         setHasOptionsMenu(true)
-        return inflater.inflate(R.layout.fragment_feedback_completed, container, false)
+
+        val binding = FragmentFeedbackCompletedBinding.bind(view)
+        val contactUsText = getString(R.string.feedback_completed_contact_us)
+        getString(R.string.feedback_completed_description, contactUsText)
+            .configureStringClick(
+                clickableContent = contactUsText,
+                clickAction = WooClickableSpan { activity?.startHelpActivity(FEEDBACK_SURVEY) },
+                textField = binding.completionHelpGuide
+            )
+        binding.btnBackToStore.setOnClickListener { activity?.onBackPressed() }
     }
 
     override fun onResume() {
@@ -50,15 +58,6 @@ class FeedbackCompletedFragment : androidx.fragment.app.Fragment() {
                 ?.supportActionBar
                 ?.setHomeAsUpIndicator(R.drawable.ic_gridicons_cross_24dp)
         }
-
-        val contactUsText = getString(R.string.feedback_completed_contact_us)
-        getString(R.string.feedback_completed_description, contactUsText)
-            .configureStringClick(
-                clickableContent = contactUsText,
-                clickAction = WooClickableSpan { activity?.startHelpActivity(FEEDBACK_SURVEY) },
-                textField = completion_help_guide
-            )
-        btn_back_to_store.setOnClickListener { activity?.onBackPressed() }
     }
 
     override fun onStop() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackRequestCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackRequestCard.kt
@@ -2,25 +2,22 @@ package com.woocommerce.android.ui.feedback
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.View
-import com.woocommerce.android.R
+import android.view.LayoutInflater
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_FEEDBACK_ACTION
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_LIKED
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_NOT_LIKED
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_SHOWN
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.APP_FEEDBACK_PROMPT
+import com.woocommerce.android.databinding.FeedbackRequestCardBinding
 import com.woocommerce.android.widgets.WCElevatedConstraintLayout
-import kotlinx.android.synthetic.main.feedback_request_card.view.*
 
 class FeedbackRequestCard @JvmOverloads constructor(
     ctx: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : WCElevatedConstraintLayout(ctx, attrs, defStyleAttr) {
-    init {
-        View.inflate(context, R.layout.feedback_request_card, this)
-    }
+    private val binding = FeedbackRequestCardBinding.inflate(LayoutInflater.from(ctx))
 
     /**
      * Sets the click listeners for the buttons on this card
@@ -34,7 +31,7 @@ class FeedbackRequestCard @JvmOverloads constructor(
             mapOf(KEY_FEEDBACK_ACTION to VALUE_FEEDBACK_SHOWN)
         )
 
-        btn_feedbackReq_negative.setOnClickListener {
+        binding.btnFeedbackReqNegative.setOnClickListener {
             AnalyticsTracker.track(
                 APP_FEEDBACK_PROMPT,
                 mapOf(KEY_FEEDBACK_ACTION to VALUE_FEEDBACK_NOT_LIKED)
@@ -42,7 +39,7 @@ class FeedbackRequestCard @JvmOverloads constructor(
             negativeButtonAction()
         }
 
-        btn_feedbackReq_positive.setOnClickListener {
+        binding.btnFeedbackReqPositive.setOnClickListener {
             AnalyticsTracker.track(
                 APP_FEEDBACK_PROMPT,
                 mapOf(KEY_FEEDBACK_ACTION to VALUE_FEEDBACK_LIKED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
@@ -2,9 +2,7 @@ package com.woocommerce.android.ui.feedback
 
 import android.annotation.SuppressLint
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.webkit.WebResourceRequest
 import android.webkit.WebSettings
 import android.webkit.WebView
@@ -21,12 +19,12 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBA
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_OPENED
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_PRODUCT_M3_CONTEXT
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SURVEY_SCREEN
+import com.woocommerce.android.databinding.FragmentFeedbackSurveyBinding
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.feedback.SurveyType.MAIN
 import com.woocommerce.android.widgets.CustomProgressDialog
-import kotlinx.android.synthetic.main.fragment_licenses.*
 
-class FeedbackSurveyFragment : androidx.fragment.app.Fragment() {
+class FeedbackSurveyFragment : androidx.fragment.app.Fragment(R.layout.fragment_feedback_survey) {
     companion object {
         const val TAG = "feedback_survey"
         private const val QUERY_PARAMETER_MESSAGE = "msg"
@@ -42,17 +40,24 @@ class FeedbackSurveyFragment : androidx.fragment.app.Fragment() {
         else VALUE_FEEDBACK_PRODUCT_M3_CONTEXT
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        setHasOptionsMenu(true)
-        return inflater.inflate(R.layout.fragment_feedback_survey, container, false)
-    }
+    private var _binding: FragmentFeedbackSurveyBinding? = null
+    private val binding get() = _binding!!
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setHasOptionsMenu(true)
+
+        _binding = FragmentFeedbackSurveyBinding.bind(view)
+
         configureWebView()
         savedInstanceState?.let {
-            webView.restoreState(it)
-        } ?: webView.loadUrl(arguments.surveyType.url)
+            binding.webView.restoreState(it)
+        } ?: binding.webView.loadUrl(arguments.surveyType.url)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onResume() {
@@ -82,13 +87,13 @@ class FeedbackSurveyFragment : androidx.fragment.app.Fragment() {
     override fun onViewStateRestored(savedInstanceState: Bundle?) {
         super.onViewStateRestored(savedInstanceState)
         savedInstanceState?.let {
-            webView.restoreState(it)
+            binding.webView.restoreState(it)
         }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        webView.saveState(outState)
+        binding.webView.saveState(outState)
     }
 
     override fun onDestroy() {
@@ -113,7 +118,7 @@ class FeedbackSurveyFragment : androidx.fragment.app.Fragment() {
     }
 
     @SuppressLint("SetJavaScriptEnabled")
-    private fun configureWebView() = webView.apply {
+    private fun configureWebView() = binding.webView.apply {
         showProgressDialog()
         settings.apply {
             javaScriptEnabled = true


### PR DESCRIPTION
Converts the user feedback section to view binding. To test:

* Change [userFeedbackIsDue](https://github.com/woocommerce/woocommerce-android/blob/9e3ee2b151a19d3f2ddf9979147ebaa17fbffee4/WooCommerce/src/main/kotlin/com/woocommerce/android/FeedbackPrefs.kt#L31) to simply return `true`
* Go to the Products tab
* Expand "New features available" and tap "Give Feedback"
* Ensure the entire feedback flow works

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
