### PR TITLE
Clear the fragmentManager backstack when navigating to a TopLevelFragment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/navigation/KeepStateNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/navigation/KeepStateNavigator.kt
@@ -50,6 +50,10 @@ class KeepStateNavigator(
             transaction.detach(it)
         }
 
+        while (manager.backStackEntryCount >= 1) {
+            manager.popBackStackImmediate()
+        }
+
         var fragment = manager.findFragmentByTag(tag)
         if (fragment == null) {
             val className = destination.className


### PR DESCRIPTION
Fixes #3484, the cause of the issue is that when we find that the `navController`'s current destination is one of the 4 toplevel fragments, we assume that it's being shown (isAtNavigationRoot()), but due to an issue with the custom navigator, we can have a state, where we showing a child fragment, and the navController thinks that the current destination is `orders` or `products`, and then `scrollToTop` throws the NullPointerException.

This happens if the user clicked on a button that navigates to a child fragment, and then clicked on the bottom nav item when the bottom navigation view is sliding to the bottom, this gives the following state (notice that the bottom nav view is visible):

<img src="https://user-images.githubusercontent.com/1657201/105989633-b05fc680-60a1-11eb-99a1-c2e8789a330d.png" width=360/> <img src="https://user-images.githubusercontent.com/1657201/105989638-b2c22080-60a1-11eb-8963-90afe37581ec.png" width=360/>

The fix is: making sure that we clear the fragmentManager backstack when navigating to a top-level fragment.

#### Testing
1. Click on orders tab.
2. Click on one of the orders, then before the bottom nav view is hidden, click on the orders tab.
3. Make sure that the order list screen is shown, and the app doesn't crash.

Repeat the above for products.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
