### PR TITLE
Issue/3232 viewbinding wpmedia

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaPickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaPickerFragment.kt
@@ -54,7 +54,6 @@ class WPMediaPickerFragment : BaseFragment(R.layout.fragment_wpmedia_picker),
     private var _binding: FragmentWpmediaPickerBinding? = null
     private val binding get() = _binding!!
 
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaPickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaPickerFragment.kt
@@ -2,12 +2,10 @@ package com.woocommerce.android.ui.wpmediapicker
 
 import android.content.DialogInterface
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
@@ -15,6 +13,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.databinding.FragmentWpmediaPickerBinding
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateSafely
@@ -30,10 +29,11 @@ import com.woocommerce.android.ui.wpmediapicker.WPMediaGalleryView.WPMediaGaller
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ViewModelFactory
-import kotlinx.android.synthetic.main.fragment_wpmedia_picker.*
 import javax.inject.Inject
 
-class WPMediaPickerFragment : BaseFragment(), WPMediaGalleryListener, BackPressListener {
+class WPMediaPickerFragment : BaseFragment(R.layout.fragment_wpmedia_picker),
+    WPMediaGalleryListener,
+    BackPressListener {
     companion object {
         private const val KEY_IS_CONFIRMING_DISCARD = "is_confirming_discard"
         const val KEY_WP_IMAGE_PICKER_RESULT = "key_wp_image_picker_result"
@@ -51,9 +51,27 @@ class WPMediaPickerFragment : BaseFragment(), WPMediaGalleryListener, BackPressL
     private var doneOrUpdateMenuItem: MenuItem? = null
     private var isConfirmingDiscard = false
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    private var _binding: FragmentWpmediaPickerBinding? = null
+    private val binding get() = _binding!!
+
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
         setHasOptionsMenu(true)
-        return inflater.inflate(R.layout.fragment_wpmedia_picker, container, false)
+        _binding = FragmentWpmediaPickerBinding.bind(view)
+
+        binding.wpMediaGallery.isMultiSelectionAllowed = navArgs.allowMultiple
+        initializeViewModel()
+
+        if (savedInstanceState?.getBoolean(KEY_IS_CONFIRMING_DISCARD) == true) {
+            confirmDiscard()
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
@@ -67,17 +85,6 @@ class WPMediaPickerFragment : BaseFragment(), WPMediaGalleryListener, BackPressL
         super.onPrepareOptionsMenu(menu)
 
         doneOrUpdateMenuItem?.isVisible = isMultiSelectAllowed
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
-        wpMediaGallery.isMultiSelectionAllowed = navArgs.allowMultiple
-        initializeViewModel()
-
-        if (savedInstanceState?.getBoolean(KEY_IS_CONFIRMING_DISCARD) == true) {
-            confirmDiscard()
-        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -112,12 +119,12 @@ class WPMediaPickerFragment : BaseFragment(), WPMediaGalleryListener, BackPressL
 
     private fun setupObservers() {
         viewModel.mediaList.observe(viewLifecycleOwner, Observer {
-            wpMediaGallery.showImages(it, this, isMultiSelectAllowed)
+            binding.wpMediaGallery.showImages(it, this, isMultiSelectAllowed)
         })
 
         viewModel.viewStateLiveData.observe(viewLifecycleOwner) { old, new ->
-            new.isLoading?.takeIfNotEqualTo(old?.isLoading) { loadingProgress.isVisible = it }
-            new.isLoadingMore?.takeIfNotEqualTo(old?.isLoadingMore) { loadingMoreProgress.isVisible = it }
+            new.isLoading?.takeIfNotEqualTo(old?.isLoading) { binding.loadingProgress.isVisible = it }
+            new.isLoadingMore?.takeIfNotEqualTo(old?.isLoadingMore) { binding.loadingMoreProgress.isVisible = it }
             new.isEmptyViewVisible?.takeIfNotEqualTo(old?.isEmptyViewVisible) { showEmptyView(it) }
             new.isMultiSelectionAllowed?.takeIfNotEqualTo(old?.isEmptyViewVisible) {
                 doneOrUpdateMenuItem?.isVisible = it
@@ -136,7 +143,7 @@ class WPMediaPickerFragment : BaseFragment(), WPMediaGalleryListener, BackPressL
      * If any images are selected set the title to the selection count, otherwise use default title
      */
     override fun getFragmentTitle(): String {
-        val count = wpMediaGallery?.getSelectedCount()
+        val count = binding.wpMediaGallery.getSelectedCount()
         return if (count == 0) {
             getString(R.string.wpmedia_picker_title)
         } else {
@@ -149,8 +156,8 @@ class WPMediaPickerFragment : BaseFragment(), WPMediaGalleryListener, BackPressL
      * simply navigate back
      */
     private fun navigateBackWithResult() {
-        if (wpMediaGallery.getSelectedCount() > 0) {
-            navigateBackWithResult(KEY_WP_IMAGE_PICKER_RESULT, wpMediaGallery.getSelectedImages())
+        if (binding.wpMediaGallery.getSelectedCount() > 0) {
+            navigateBackWithResult(KEY_WP_IMAGE_PICKER_RESULT, binding.wpMediaGallery.getSelectedImages())
         } else {
             findNavController().navigateUp()
         }
@@ -169,7 +176,7 @@ class WPMediaPickerFragment : BaseFragment(), WPMediaGalleryListener, BackPressL
     override fun onSelectionCountChanged() {
         requireActivity().title = getFragmentTitle()
 
-        if (!isMultiSelectAllowed && wpMediaGallery.getSelectedCount() == 1) {
+        if (!isMultiSelectAllowed && binding.wpMediaGallery.getSelectedCount() == 1) {
             navigateBackWithResult()
         }
     }
@@ -183,7 +190,7 @@ class WPMediaPickerFragment : BaseFragment(), WPMediaGalleryListener, BackPressL
     }
 
     override fun onRequestAllowBackPress(): Boolean {
-        return if (wpMediaGallery.getSelectedCount() > 0) {
+        return if (binding.wpMediaGallery.getSelectedCount() > 0) {
             confirmDiscard()
             false
         } else {
@@ -209,11 +216,11 @@ class WPMediaPickerFragment : BaseFragment(), WPMediaGalleryListener, BackPressL
 
     private fun showEmptyView(show: Boolean) {
         if (show) {
-            emptyText.show()
-            wpMediaGallery.hide()
+            binding.emptyText.show()
+            binding.wpMediaGallery.hide()
         } else {
-            emptyText.hide()
-            wpMediaGallery.show()
+            binding.emptyText.hide()
+            binding.wpMediaGallery.show()
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaViewerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaViewerFragment.kt
@@ -2,9 +2,7 @@ package com.woocommerce.android.ui.wpmediapicker
 
 import android.graphics.drawable.Drawable
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
@@ -13,22 +11,33 @@ import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.request.RequestListener
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.databinding.FragmentWpmediaViewerBinding
 import com.woocommerce.android.di.GlideApp
-import kotlinx.android.synthetic.main.fragment_wpmedia_viewer.*
 
 /**
  * Fullscreen single image viewer
  */
-class WPMediaViewerFragment : androidx.fragment.app.Fragment(), RequestListener<Drawable> {
+class WPMediaViewerFragment : androidx.fragment.app.Fragment(R.layout.fragment_wpmedia_viewer),
+    RequestListener<Drawable> {
     private val navArgs: WPMediaViewerFragmentArgs by navArgs()
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.fragment_wpmedia_viewer, container, false)
+    private var _binding: FragmentWpmediaViewerBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        _binding = FragmentWpmediaViewerBinding.bind(view)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        iconBack.setOnClickListener {
+        binding.iconBack.setOnClickListener {
             findNavController().navigateUp()
         }
         loadImage()
@@ -40,11 +49,11 @@ class WPMediaViewerFragment : androidx.fragment.app.Fragment(), RequestListener<
     }
 
     private fun loadImage() {
-        progressBar.isVisible = true
+        binding.progressBar.isVisible = true
         GlideApp.with(this)
                 .load(navArgs.imageUrl)
                 .listener(this)
-                .into(photoView)
+                .into(binding.photoView)
     }
 
     /**
@@ -56,7 +65,7 @@ class WPMediaViewerFragment : androidx.fragment.app.Fragment(), RequestListener<
         target: com.bumptech.glide.request.target.Target<Drawable>?,
         isFirstResource: Boolean
     ): Boolean {
-        progressBar.isVisible = false
+        binding.progressBar.isVisible = false
         return false
     }
 
@@ -70,7 +79,7 @@ class WPMediaViewerFragment : androidx.fragment.app.Fragment(), RequestListener<
         dataSource: DataSource?,
         isFirstResource: Boolean
     ): Boolean {
-        progressBar.isVisible = false
+        binding.progressBar.isVisible = false
         return false
     }
 }


### PR DESCRIPTION
This PR converts the WP media picker to view binding. To test, add images from the WP media library in product detail and verify it all works correctly.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
