### PR TITLE
Issue/3232 viewbinding refunds

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByAmountFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByAmountFragment.kt
@@ -1,13 +1,12 @@
 package com.woocommerce.android.ui.refunds
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.lifecycle.Observer
 import androidx.navigation.navGraphViewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.databinding.FragmentRefundByAmountBinding
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.refunds.IssueRefundViewModel.IssueRefundEvent.HideValidationError
@@ -15,22 +14,19 @@ import com.woocommerce.android.ui.refunds.IssueRefundViewModel.IssueRefundEvent.
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import dagger.Lazy
-import kotlinx.android.synthetic.main.fragment_refund_by_amount.*
 import javax.inject.Inject
 
-class RefundByAmountFragment : BaseFragment() {
+class RefundByAmountFragment : BaseFragment(R.layout.fragment_refund_by_amount) {
     @Inject lateinit var viewModelFactory: Lazy<ViewModelFactory>
     @Inject lateinit var currencyFormatter: CurrencyFormatter
+
+    private var _binding: FragmentRefundByAmountBinding? = null
+    private val binding get() = _binding!!
 
     private val viewModel: IssueRefundViewModel by navGraphViewModels(R.id.nav_graph_refunds) {
         viewModelFactory.get()
     }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        super.onCreate(savedInstanceState)
-        return inflater.inflate(R.layout.fragment_refund_by_amount, container, false)
-    }
-
+    
     override fun onResume() {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
@@ -39,12 +35,19 @@ class RefundByAmountFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        _binding = FragmentRefundByAmountBinding.bind(view)
+
         initializeViews()
         setupObservers()
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
     private fun initializeViews() {
-        issueRefund_btnNextFromAmount.setOnClickListener {
+        binding.issueRefundBtnNextFromAmount.setOnClickListener {
             viewModel.onNextButtonTappedFromAmounts()
         }
     }
@@ -52,28 +55,28 @@ class RefundByAmountFragment : BaseFragment() {
     private fun setupObservers() {
         viewModel.refundByAmountStateLiveData.observe(viewLifecycleOwner) { old, new ->
             new.availableForRefund?.takeIfNotEqualTo(old?.availableForRefund) {
-                issueRefund_txtAvailableForRefund.text = it
+                binding.issueRefundTxtAvailableForRefund.text = it
             }
             new.currency?.takeIfNotEqualTo(old?.currency) {
-                issueRefund_refundAmount.initView(new.currency, new.decimals, currencyFormatter)
+                binding.issueRefundRefundAmount.initView(new.currency, new.decimals, currencyFormatter)
             }
             new.enteredAmount.takeIfNotEqualTo(old?.enteredAmount) {
-                issueRefund_refundAmount.setValue(new.enteredAmount)
+                binding.issueRefundRefundAmount.setValue(new.enteredAmount)
             }
             new.isNextButtonEnabled?.takeIfNotEqualTo(old?.isNextButtonEnabled) {
-                issueRefund_btnNextFromAmount.isEnabled = it
+                binding.issueRefundBtnNextFromAmount.isEnabled = it
             }
         }
 
         viewModel.event.observe(viewLifecycleOwner, Observer { event ->
             when (event) {
-                is ShowValidationError -> issueRefund_refundAmount.error = event.message
-                is HideValidationError -> issueRefund_refundAmount.error = null
+                is ShowValidationError -> binding.issueRefundRefundAmount.error = event.message
+                is HideValidationError -> binding.issueRefundRefundAmount.error = null
                 else -> event.isHandled = false
             }
         })
 
-        issueRefund_refundAmount.value.observe(viewLifecycleOwner, Observer {
+        binding.issueRefundRefundAmount.value.observe(viewLifecycleOwner, Observer {
             viewModel.onManualRefundAmountChanged(it)
         })
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByAmountFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByAmountFragment.kt
@@ -26,7 +26,7 @@ class RefundByAmountFragment : BaseFragment(R.layout.fragment_refund_by_amount) 
     private val viewModel: IssueRefundViewModel by navGraphViewModels(R.id.nav_graph_refunds) {
         viewModelFactory.get()
     }
-    
+
     override fun onResume() {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByItemsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByItemsFragment.kt
@@ -56,7 +56,7 @@ class RefundByItemsFragment : BaseFragment(R.layout.fragment_refund_by_items) {
 
         _binding = FragmentRefundByItemsBinding.bind(view)
         _productsBinding = binding.issueRefundProductsList
-        
+
         initializeViews()
         setupObservers()
     }
@@ -71,11 +71,11 @@ class RefundByItemsFragment : BaseFragment(R.layout.fragment_refund_by_items) {
         productsBinding.issueRefundProducts.layoutManager = LinearLayoutManager(context)
         productsBinding.issueRefundProducts.setHasFixedSize(true)
         productsBinding.issueRefundProducts.isMotionEventSplittingEnabled = false
-        
+
         binding.issueRefundSelectButton.setOnClickListener {
             viewModel.onSelectButtonTapped()
         }
-        
+
         binding.issueRefundBtnNextFromItems.setOnClickListener {
             viewModel.onNextButtonTappedFromItems()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByItemsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByItemsFragment.kt
@@ -4,9 +4,7 @@ import android.os.Bundle
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.method.LinkMovementMethod
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.TextView
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
@@ -14,6 +12,8 @@ import androidx.navigation.navGraphViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.databinding.FragmentRefundByItemsBinding
+import com.woocommerce.android.databinding.RefundByItemsProductsBinding
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.show
@@ -28,23 +28,22 @@ import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.WooClickableSpan
 import dagger.Lazy
-import kotlinx.android.synthetic.main.fragment_refund_by_items.*
-import kotlinx.android.synthetic.main.refund_by_items_products.*
 import java.math.BigDecimal
 import javax.inject.Inject
 
-class RefundByItemsFragment : BaseFragment() {
+class RefundByItemsFragment : BaseFragment(R.layout.fragment_refund_by_items) {
     @Inject lateinit var viewModelFactory: Lazy<ViewModelFactory>
     @Inject lateinit var currencyFormatter: CurrencyFormatter
     @Inject lateinit var imageMap: ProductImageMap
 
+    private var _binding: FragmentRefundByItemsBinding? = null
+    private val binding get() = _binding!!
+
+    private var _productsBinding: RefundByItemsProductsBinding? = null
+    private val productsBinding get() = _productsBinding!!
+
     private val viewModel: IssueRefundViewModel by navGraphViewModels(R.id.nav_graph_refunds) {
         viewModelFactory.get()
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        super.onCreate(savedInstanceState)
-        return inflater.inflate(R.layout.fragment_refund_by_items, container, false)
     }
 
     override fun onResume() {
@@ -55,20 +54,29 @@ class RefundByItemsFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        _binding = FragmentRefundByItemsBinding.bind(view)
+        _productsBinding = binding.issueRefundProductsList
+        
         initializeViews()
         setupObservers()
     }
 
-    private fun initializeViews() {
-        issueRefund_products.layoutManager = LinearLayoutManager(context)
-        issueRefund_products.setHasFixedSize(true)
-        issueRefund_products.isMotionEventSplittingEnabled = false
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+        _productsBinding = null
+    }
 
-        issueRefund_selectButton.setOnClickListener {
+    private fun initializeViews() {
+        productsBinding.issueRefundProducts.layoutManager = LinearLayoutManager(context)
+        productsBinding.issueRefundProducts.setHasFixedSize(true)
+        productsBinding.issueRefundProducts.isMotionEventSplittingEnabled = false
+        
+        binding.issueRefundSelectButton.setOnClickListener {
             viewModel.onSelectButtonTapped()
         }
-
-        issueRefund_btnNextFromItems.setOnClickListener {
+        
+        binding.issueRefundBtnNextFromItems.setOnClickListener {
             viewModel.onNextButtonTappedFromItems()
         }
 
@@ -85,7 +93,7 @@ class RefundByItemsFragment : BaseFragment() {
     private fun setupObservers() {
         viewModel.refundByItemsStateLiveData.observe(viewLifecycleOwner) { old, new ->
             new.currency?.takeIfNotEqualTo(old?.currency) {
-                issueRefund_products.adapter = RefundProductListAdapter(
+                productsBinding.issueRefundProducts.adapter = RefundProductListAdapter(
                         currencyFormatter.buildBigDecimalFormatter(new.currency),
                         imageMap,
                         false,
@@ -93,49 +101,49 @@ class RefundByItemsFragment : BaseFragment() {
                 )
             }
             new.isNextButtonEnabled?.takeIfNotEqualTo(old?.isNextButtonEnabled) {
-                issueRefund_btnNextFromItems.isEnabled = it
+                binding.issueRefundBtnNextFromItems.isEnabled = it
             }
             new.formattedProductsRefund?.takeIfNotEqualTo(old?.formattedProductsRefund) {
-                issueRefund_productsTotal.text = it
+                productsBinding.issueRefundProductsTotal.text = it
             }
             new.shippingSubtotal?.takeIfNotEqualTo(old?.shippingSubtotal) {
-                issueRefund_shippingTotal.text = it
+                productsBinding.issueRefundShippingTotal.text = it
             }
             new.feesTotal?.takeIfNotEqualTo(old?.feesTotal) {
-                issueRefund_feesTotal.text = it
+                productsBinding.issueRefundFeesTotal.text = it
             }
             new.taxes?.takeIfNotEqualTo(old?.taxes) {
-                issueRefund_taxesTotal.text = it
+                productsBinding.issueRefundTaxesTotal.text = it
             }
             new.subtotal?.takeIfNotEqualTo(old?.subtotal) {
-                issueRefund_subtotal.text = it
+                productsBinding.issueRefundSubtotal.text = it
             }
             new.selectedItemsHeader?.takeIfNotEqualTo(old?.selectedItemsHeader) {
-                issueRefund_selectedItems.text = it
+                binding.issueRefundSelectedItems.text = it
             }
             new.selectButtonTitle?.takeIfNotEqualTo(old?.selectButtonTitle) {
-                issueRefund_selectButton.text = it
+                binding.issueRefundSelectButton.text = it
             }
             new.isShippingRefundVisible?.takeIfNotEqualTo(old?.isShippingRefundVisible) { isVisible ->
                 if (isVisible) {
-                    issueRefund_shippingRefundGroup.show()
+                    productsBinding.issueRefundShippingRefundGroup.show()
                 } else {
-                    issueRefund_shippingRefundGroup.hide()
+                    productsBinding.issueRefundShippingRefundGroup.hide()
                 }
             }
             new.isShippingNoticeVisible?.takeIfNotEqualTo(old?.isShippingNoticeVisible) { isVisible ->
                 if (isVisible) {
-                    issueRefund_shippingRefundNotice.show()
+                    productsBinding.issueRefundShippingRefundNotice.show()
                 } else {
-                    issueRefund_shippingRefundNotice.hide()
+                    productsBinding.issueRefundShippingRefundNotice.hide()
                 }
             }
             new.isFeesVisible?.takeIfNotEqualTo(old?.isFeesVisible) { isVisible ->
                 if (isVisible) {
-                    issueRefund_feesGroup.show()
+                    productsBinding.issueRefundFeesGroup.show()
                     updateRefundNoticeView(getString(R.string.order_refunds_shipping_refund_notice_fees))
                 } else {
-                    issueRefund_feesGroup.hide()
+                    productsBinding.issueRefundFeesGroup.hide()
                     updateRefundNoticeView(getString(R.string.order_refunds_shipping_refund_notice))
                 }
             }
@@ -150,7 +158,7 @@ class RefundByItemsFragment : BaseFragment() {
         }
 
         viewModel.refundItems.observe(viewLifecycleOwner, Observer { list ->
-            val adapter = issueRefund_products.adapter as RefundProductListAdapter
+            val adapter = productsBinding.issueRefundProducts.adapter as RefundProductListAdapter
             adapter.update(list)
         })
 
@@ -195,7 +203,7 @@ class RefundByItemsFragment : BaseFragment() {
             noticeText.length,
             Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
 
-        issueRefund_shippingRefundNotice.setText(spannable, TextView.BufferType.SPANNABLE)
-        issueRefund_shippingRefundNotice.movementMethod = LinkMovementMethod.getInstance()
+        productsBinding.issueRefundShippingRefundNotice.setText(spannable, TextView.BufferType.SPANNABLE)
+        productsBinding.issueRefundShippingRefundNotice.movementMethod = LinkMovementMethod.getInstance()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundDetailFragment.kt
@@ -1,15 +1,14 @@
 package com.woocommerce.android.ui.refunds
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
-import kotlinx.android.synthetic.main.fragment_refund_detail.*
+import com.woocommerce.android.databinding.FragmentRefundDetailBinding
+import com.woocommerce.android.databinding.RefundByItemsProductsBinding
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
@@ -18,20 +17,20 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.ViewModelFactory
-import kotlinx.android.synthetic.main.refund_by_items_products.*
 import javax.inject.Inject
 
-class RefundDetailFragment : BaseFragment() {
+class RefundDetailFragment : BaseFragment(R.layout.fragment_refund_detail) {
     @Inject lateinit var viewModelFactory: ViewModelFactory
     @Inject lateinit var currencyFormatter: CurrencyFormatter
     @Inject lateinit var imageMap: ProductImageMap
 
     private val viewModel: RefundDetailViewModel by viewModels { viewModelFactory }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        super.onCreate(savedInstanceState)
-        return inflater.inflate(R.layout.fragment_refund_detail, container, false)
-    }
+    private var _binding: FragmentRefundDetailBinding? = null
+    private val binding get() = _binding!!
+
+    private var _productsBinding: RefundByItemsProductsBinding? = null
+    private val productsBinding get() = _productsBinding!!
 
     override fun onResume() {
         super.onResume()
@@ -41,13 +40,22 @@ class RefundDetailFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        _binding = FragmentRefundDetailBinding.bind(view)
+        _productsBinding = binding.issueRefundProductsList
+
         initializeViews()
         setupObservers(viewModel)
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+        _productsBinding = null
+    }
+
     private fun initializeViews() {
-        issueRefund_products.layoutManager = LinearLayoutManager(context)
-        issueRefund_products.setHasFixedSize(true)
+        productsBinding.issueRefundProducts.layoutManager = LinearLayoutManager(context)
+        productsBinding.issueRefundProducts.setHasFixedSize(true)
     }
 
     private fun setupObservers(viewModel: RefundDetailViewModel) {
@@ -56,20 +64,20 @@ class RefundDetailFragment : BaseFragment() {
                 activity?.title = new.screenTitle
             }
             new.refundAmount?.takeIfNotEqualTo(old?.refundAmount) {
-                refundDetail_refundAmount.text = new.refundAmount
-                issueRefund_productsTotal.text = new.refundAmount
+                binding.refundDetailRefundAmount.text = new.refundAmount
+                productsBinding.issueRefundProductsTotal.text = new.refundAmount
             }
             new.subtotal?.takeIfNotEqualTo(old?.subtotal) {
-                issueRefund_subtotal.text = new.subtotal
+                productsBinding.issueRefundSubtotal.text = new.subtotal
             }
             new.taxes?.takeIfNotEqualTo(old?.taxes) {
-                issueRefund_taxesTotal.text = new.taxes
+                productsBinding.issueRefundTaxesTotal.text = new.taxes
             }
             new.refundMethod?.takeIfNotEqualTo(old?.refundMethod) {
-                refundDetail_refundMethod.text = new.refundMethod
+                binding.refundDetailRefundMethod.text = new.refundMethod
             }
             new.currency?.takeIfNotEqualTo(old?.currency) {
-                issueRefund_products.adapter = RefundProductListAdapter(
+                productsBinding.issueRefundProducts.adapter = RefundProductListAdapter(
                         currencyFormatter.buildBigDecimalFormatter(new.currency),
                         imageMap,
                         isProductDetailList = true,
@@ -80,33 +88,33 @@ class RefundDetailFragment : BaseFragment() {
             }
             new.areItemsVisible?.takeIfNotEqualTo(old?.areItemsVisible) { isVisible ->
                 if (isVisible) {
-                    refundDetail_refundItems.show()
+                    binding.refundDetailRefundItems.show()
                 } else {
-                    refundDetail_refundItems.hide()
+                    binding.refundDetailRefundItems.hide()
                 }
             }
             new.areDetailsVisible?.takeIfNotEqualTo(old?.areDetailsVisible) { isVisible ->
                 if (isVisible) {
-                    refundDetail_detailsCard.show()
-                    refundDetail_reasonCard.show()
-                    issueRefund_totalsGroup.show()
+                    binding.refundDetailDetailsCard.show()
+                    binding.refundDetailReasonCard.show()
+                    productsBinding.issueRefundTotalsGroup.show()
                 } else {
-                    refundDetail_detailsCard.hide()
-                    refundDetail_reasonCard.hide()
-                    issueRefund_totalsGroup.hide()
+                    binding.refundDetailDetailsCard.hide()
+                    binding.refundDetailReasonCard.hide()
+                    productsBinding.issueRefundTotalsGroup.hide()
                 }
             }
 
             if (new.refundReason.isNullOrEmpty()) {
-                refundDetail_reasonCard.hide()
+                binding.refundDetailReasonCard.hide()
             } else {
-                refundDetail_reasonCard.show()
-                refundDetail_refundReason.text = new.refundReason
+                binding.refundDetailReasonCard.show()
+                binding.refundDetailRefundReason.text = new.refundReason
             }
         }
 
         viewModel.refundItems.observe(viewLifecycleOwner, Observer { list ->
-            val adapter = issueRefund_products.adapter as RefundProductListAdapter
+            val adapter = productsBinding.issueRefundProducts.adapter as RefundProductListAdapter
             adapter.update(list)
         })
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundSummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundSummaryFragment.kt
@@ -1,9 +1,7 @@
 package com.woocommerce.android.ui.refunds
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.Toast
 import androidx.core.widget.doOnTextChanged
 import androidx.lifecycle.Observer
@@ -11,6 +9,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.navGraphViewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.databinding.FragmentRefundSummaryBinding
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.extensions.navigateSafely
@@ -24,10 +23,9 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import dagger.Lazy
-import kotlinx.android.synthetic.main.fragment_refund_summary.*
 import javax.inject.Inject
 
-class RefundSummaryFragment : BaseFragment(), BackPressListener {
+class RefundSummaryFragment : BaseFragment(R.layout.fragment_refund_summary), BackPressListener {
     companion object {
         const val REFUND_ORDER_NOTICE_KEY = "refund_order_notice"
     }
@@ -38,10 +36,8 @@ class RefundSummaryFragment : BaseFragment(), BackPressListener {
         viewModelFactory.get()
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        super.onCreate(savedInstanceState)
-        return inflater.inflate(R.layout.fragment_refund_summary, container, false)
-    }
+    private var _binding: FragmentRefundSummaryBinding? = null
+    private val binding get() = _binding!!
 
     override fun onResume() {
         super.onResume()
@@ -51,8 +47,15 @@ class RefundSummaryFragment : BaseFragment(), BackPressListener {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        _binding = FragmentRefundSummaryBinding.bind(view)
+
         initializeViews()
         setupObservers()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     private fun setupObservers() {
@@ -72,34 +75,38 @@ class RefundSummaryFragment : BaseFragment(), BackPressListener {
 
         viewModel.refundSummaryStateLiveData.observe(viewLifecycleOwner) { old, new ->
             new.isFormEnabled?.takeIfNotEqualTo(old?.isFormEnabled) {
-                refundSummary_btnRefund.isEnabled = new.isFormEnabled
-                refundSummary_reason.isEnabled = new.isFormEnabled
+                binding.refundSummaryBtnRefund.isEnabled = new.isFormEnabled
+                binding.refundSummaryReason.isEnabled = new.isFormEnabled
             }
             new.isSubmitButtonEnabled?.takeIfNotEqualTo(old?.isSubmitButtonEnabled) {
-                refundSummary_btnRefund.isEnabled = new.isSubmitButtonEnabled
+                binding.refundSummaryBtnRefund.isEnabled = new.isSubmitButtonEnabled
             }
-            new.refundAmount?.takeIfNotEqualTo(old?.refundAmount) { refundSummary_refundAmount.text = it }
+            new.refundAmount?.takeIfNotEqualTo(old?.refundAmount) {
+                binding.refundSummaryRefundAmount.text = it
+            }
             new.previouslyRefunded?.takeIfNotEqualTo(old?.previouslyRefunded) {
-                refundSummary_previouslyRefunded.text = it
+                binding.refundSummaryPreviouslyRefunded.text = it
             }
-            new.refundMethod?.takeIfNotEqualTo(old?.refundMethod) { refundSummary_method.text = it }
+            new.refundMethod?.takeIfNotEqualTo(old?.refundMethod) {
+                binding.refundSummaryMethod.text = it
+            }
             new.isMethodDescriptionVisible?.takeIfNotEqualTo(old?.isMethodDescriptionVisible) { visible ->
                 if (visible)
-                    refundSummary_methodDescription.show()
+                    binding.refundSummaryMethodDescription.show()
                 else
-                    refundSummary_methodDescription.hide()
+                    binding.refundSummaryMethodDescription.hide()
             }
         }
     }
 
     private fun initializeViews() {
-        refundSummary_btnRefund.setOnClickListener {
-            viewModel.onRefundIssued(refundSummary_reason.text.toString())
+        binding.refundSummaryBtnRefund.setOnClickListener {
+            viewModel.onRefundIssued(binding.refundSummaryReason.text.toString())
         }
 
-        refundSummary_reason.doOnTextChanged { _, _, _, _ ->
-            val maxLength = refundSummary_reasonLayout.counterMaxLength
-            viewModel.onRefundSummaryTextChanged(maxLength, refundSummary_reason.length())
+        binding.refundSummaryReason.doOnTextChanged { _, _, _, _ ->
+            val maxLength = binding.refundSummaryReasonLayout.counterMaxLength
+            viewModel.onRefundSummaryTextChanged(maxLength, binding.refundSummaryReason.length())
         }
     }
 


### PR DESCRIPTION
This PR converts the refund flow to view binding. To test, simply use the refund features and verify everything works.

Note: I chose not to convert `IssueRefundFragment` because we have [an open issue](https://github.com/woocommerce/woocommerce-android/issues/3489) to remove it.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
