### PR TITLE
issue/3232-viewbinding-help-info-logviewer

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -11,11 +11,11 @@ import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.databinding.ActivityHelpBinding
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.PackageUtils
 import dagger.android.AndroidInjection
-import kotlinx.android.synthetic.main.activity_help.*
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
@@ -29,6 +29,8 @@ class HelpActivity : AppCompatActivity() {
     @Inject lateinit var zendeskHelper: ZendeskHelper
     @Inject lateinit var selectedSite: SelectedSite
 
+    private lateinit var binding: ActivityHelpBinding
+
     private val originFromExtras by lazy {
         (intent.extras?.get(ORIGIN_KEY) as Origin?) ?: Origin.UNKNOWN
     }
@@ -41,19 +43,20 @@ class HelpActivity : AppCompatActivity() {
         AndroidInjection.inject(this)
         super.onCreate(savedInstanceState)
 
-        setContentView(R.layout.activity_help)
+        binding = ActivityHelpBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        setSupportActionBar(toolbar as Toolbar)
+        setSupportActionBar(binding.toolbar.toolbar as Toolbar)
         supportActionBar?.setHomeButtonEnabled(true)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-        contactContainer.setOnClickListener { createNewZendeskTicket() }
-        identityContainer.setOnClickListener { showIdentityDialog() }
-        myTicketsContainer.setOnClickListener { showZendeskTickets() }
-        faqContainer.setOnClickListener { showZendeskFaq() }
-        appLogContainer.setOnClickListener { showApplicationLog() }
+        binding.contactContainer.setOnClickListener { createNewZendeskTicket() }
+        binding.identityContainer.setOnClickListener { showIdentityDialog() }
+        binding.myTicketsContainer.setOnClickListener { showZendeskTickets() }
+        binding.faqContainer.setOnClickListener { showZendeskFaq() }
+        binding.appLogContainer.setOnClickListener { showApplicationLog() }
 
-        textVersion.text = getString(R.string.version_with_name_param, PackageUtils.getVersionName(this))
+        binding.textVersion.text = getString(R.string.version_with_name_param, PackageUtils.getVersionName(this))
 
         /**
         * If the user taps on a Zendesk notification, we want to show them the `My Tickets` page. However, this
@@ -117,7 +120,7 @@ class HelpActivity : AppCompatActivity() {
 
     private fun refreshContactEmailText() {
         val supportEmail = AppPrefs.getSupportEmail()
-        identityContainer.optionValue = if (supportEmail.isNotEmpty()) {
+        binding.identityContainer.optionValue = if (supportEmail.isNotEmpty()) {
             supportEmail
         } else {
             getString(R.string.support_contact_email_not_set)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerActivity.kt
@@ -17,12 +17,12 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.R
 import com.woocommerce.android.R.layout
+import com.woocommerce.android.databinding.ActivityLogviewerBinding
 import com.woocommerce.android.extensions.setHtmlText
 import com.woocommerce.android.util.AppThemeUtils
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.widgets.AlignedDividerDecoration
-import kotlinx.android.synthetic.main.activity_logviewer.*
 import org.wordpress.android.util.ToastUtils
 import java.lang.String.format
 import java.util.ArrayList
@@ -36,9 +36,11 @@ class WooLogViewerActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_logviewer)
 
-        setSupportActionBar(toolbar as Toolbar)
+        val binding = ActivityLogviewerBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        setSupportActionBar(binding.toolbar.toolbar as Toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         val divider = AlignedDividerDecoration(this,
@@ -47,9 +49,9 @@ class WooLogViewerActivity : AppCompatActivity() {
             divider.setDrawable(drawable)
         }
 
-        recycler.layoutManager = androidx.recyclerview.widget.LinearLayoutManager(this)
-        recycler.addItemDecoration(divider)
-        recycler.adapter = LogAdapter(this)
+        binding.recycler.layoutManager = androidx.recyclerview.widget.LinearLayoutManager(this)
+        binding.recycler.addItemDecoration(divider)
+        binding.recycler.adapter = LogAdapter(this)
     }
 
     private fun shareAppLog() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/InfoScreenFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/InfoScreenFragment.kt
@@ -1,29 +1,45 @@
 package com.woocommerce.android.ui.common
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.TextView
 import androidx.annotation.StringRes
-import androidx.navigation.fragment.navArgs
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.databinding.FragmentInfoScreenBinding
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.ui.common.InfoScreenFragment.InfoScreenLinkAction.LearnMoreAboutShippingLabels
 import com.woocommerce.android.util.ChromeCustomTabUtils
-import kotlinx.android.synthetic.main.fragment_info_screen.*
 import java.io.Serializable
 
-class InfoScreenFragment : Fragment() {
+class InfoScreenFragment : Fragment(R.layout.fragment_info_screen) {
     private val navArgs: InfoScreenFragmentArgs by navArgs()
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
         setHasOptionsMenu(true)
-        return inflater.inflate(R.layout.fragment_info_screen, container, false)
+
+        val binding = FragmentInfoScreenBinding.bind(view)
+        binding.infoHeading.showTextOrHide(navArgs.heading)
+        binding.infoMessage.showTextOrHide(navArgs.message)
+        binding.infoLink.showTextOrHide(navArgs.linkTitle)
+
+        if (navArgs.imageResource != 0) {
+            binding.infoImage.setImageDrawable(ContextCompat.getDrawable(requireContext(), navArgs.imageResource))
+        }
+
+        navArgs.linkAction?.let { action ->
+            when (action) {
+                is LearnMoreAboutShippingLabels -> binding.infoLink.setOnClickListener {
+                    ChromeCustomTabUtils.launchUrl(requireContext(), action.LINK)
+                }
+            }
+        }
     }
 
     override fun onResume() {
@@ -37,24 +53,6 @@ class InfoScreenFragment : Fragment() {
             (it as? AppCompatActivity)
                 ?.supportActionBar
                 ?.setHomeAsUpIndicator(R.drawable.ic_gridicons_cross_24dp)
-        }
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        info_heading.showTextOrHide(navArgs.heading)
-        info_message.showTextOrHide(navArgs.message)
-        info_link.showTextOrHide(navArgs.linkTitle)
-
-        if (navArgs.imageResource != 0) {
-            info_image.setImageDrawable(ContextCompat.getDrawable(requireContext(), navArgs.imageResource))
-        }
-
-        navArgs.linkAction?.let { action ->
-            when (action) {
-                is LearnMoreAboutShippingLabels -> info_link.setOnClickListener {
-                    ChromeCustomTabUtils.launchUrl(requireContext(), action.LINK)
-                }
-            }
         }
     }
 


### PR DESCRIPTION
This PR converts the info, help, and log viewer screens to view binding. To test, simply use those screens and verify they all work.

Note: the info screen is shown when you tap, "Find out more about creating labels from your phone" in order detail.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
