### PR TITLE
Issue/3232 viewbinding widgets

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
@@ -128,7 +128,7 @@ class VariationListFragment : BaseFragment(R.layout.fragment_variation_list),
             new.isEmptyViewVisible?.takeIfNotEqualTo(old?.isEmptyViewVisible) { isEmptyViewVisible ->
                 if (isEmptyViewVisible) {
                     WooAnimUtils.fadeIn(binding.emptyView)
-                    binding.emptyView.button.visibility = View.GONE
+                    binding.emptyView.showButton(false)
                 } else {
                     WooAnimUtils.fadeOut(binding.emptyView)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/ActionableEmptyView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/ActionableEmptyView.kt
@@ -4,21 +4,16 @@ import android.content.Context
 import android.os.Build
 import android.util.AttributeSet
 import android.view.Gravity
+import android.view.LayoutInflater
 import android.view.View
-import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.RelativeLayout
-import com.google.android.material.button.MaterialButton
-import com.google.android.material.textview.MaterialTextView
 import com.woocommerce.android.R
-import kotlinx.android.synthetic.main.actionable_empty_view.view.*
+import com.woocommerce.android.databinding.ActionableEmptyViewBinding
 import org.wordpress.android.util.DisplayUtils
 
 class ActionableEmptyView : LinearLayout {
-    lateinit var button: MaterialButton
-    lateinit var image: ImageView
-    lateinit var layout: View
-    lateinit var title: MaterialTextView
+    private val binding = ActionableEmptyViewBinding.inflate(LayoutInflater.from(context))
 
     constructor(context: Context, attrs: AttributeSet) : super(context, attrs) {
         initView(context, attrs)
@@ -34,12 +29,6 @@ class ActionableEmptyView : LinearLayout {
         gravity = Gravity.CENTER
         orientation = VERTICAL
 
-        layout = View.inflate(context, R.layout.actionable_empty_view, this)
-
-        image = layout.findViewById(R.id.empty_view_image)
-        title = layout.findViewById(R.id.empty_view_text)
-        button = layout.findViewById(R.id.empty_view_button)
-
         attrs.let {
             val typedArray = context.obtainStyledAttributes(it, R.styleable.ActionableEmptyView, 0, 0)
 
@@ -49,33 +38,37 @@ class ActionableEmptyView : LinearLayout {
             val titleAppearance = typedArray.getResourceId(R.styleable.ActionableEmptyView_aevTitleAppearance, 0)
 
             if (imageResource != 0) {
-                image.setImageResource(imageResource)
-                image.visibility = View.VISIBLE
+                binding.emptyViewImage.setImageResource(imageResource)
+                binding.emptyViewImage.visibility = View.VISIBLE
             }
 
             if (titleAppearance != 0) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    title.setTextAppearance(titleAppearance)
+                    binding.emptyViewText.setTextAppearance(titleAppearance)
                 } else {
-                    title.setTextAppearance(context, titleAppearance)
+                    binding.emptyViewText.setTextAppearance(context, titleAppearance)
                 }
             }
 
             if (!titleAttribute.isNullOrEmpty()) {
-                title.text = titleAttribute
+                binding.emptyViewText.text = titleAttribute
             } else {
                 throw RuntimeException("$context: ActionableEmptyView must have a title (aevTitle)")
             }
 
             if (!buttonAttribute.isNullOrEmpty()) {
-                button.text = buttonAttribute
-                button.visibility = View.VISIBLE
+                binding.emptyViewButton.text = buttonAttribute
+                binding.emptyViewButton.visibility = View.VISIBLE
             }
 
             typedArray.recycle()
         }
 
         checkOrientation()
+    }
+
+    fun showButton(show: Boolean) {
+        binding.emptyViewButton.visibility = if (show) View.VISIBLE else View.GONE
     }
 
     /**
@@ -91,17 +84,17 @@ class ActionableEmptyView : LinearLayout {
 
         if (isSearching) {
             params = RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
-            layout.setPadding(0, context.resources.getDimensionPixelSize(R.dimen.major_300), 0, 0)
+            binding.root.setPadding(0, context.resources.getDimensionPixelSize(R.dimen.major_300), 0, 0)
 
-            image.visibility = View.GONE
-            button.visibility = View.GONE
+            binding.emptyViewImage.visibility = View.GONE
+            binding.emptyViewButton.visibility = View.GONE
         } else {
             params = RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
-            layout.setPadding(0, 0, 0, 0)
+            binding.root.setPadding(0, 0, 0, 0)
         }
 
         params.topMargin = topMargin
-        layout.layoutParams = params
+        binding.root.layoutParams = params
     }
 
     /**
@@ -109,7 +102,7 @@ class ActionableEmptyView : LinearLayout {
      */
     private fun checkOrientation() {
         val isLandscape = DisplayUtils.isLandscape(context)
-        empty_view_image.visibility = if (empty_view_image.visibility == View.VISIBLE && !isLandscape) {
+        binding.emptyViewImage.visibility = if (binding.emptyViewImage.visibility == View.VISIBLE && !isLandscape) {
             View.VISIBLE
         } else {
             View.GONE

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/ActionableEmptyView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/ActionableEmptyView.kt
@@ -8,6 +8,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.widget.LinearLayout
 import android.widget.RelativeLayout
+import androidx.core.view.isVisible
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.ActionableEmptyViewBinding
 import org.wordpress.android.util.DisplayUtils
@@ -68,7 +69,7 @@ class ActionableEmptyView : LinearLayout {
     }
 
     fun showButton(show: Boolean) {
-        binding.emptyViewButton.visibility = if (show) View.VISIBLE else View.GONE
+        binding.emptyViewButton.isVisible = show
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/ActionableEmptyView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/ActionableEmptyView.kt
@@ -13,7 +13,7 @@ import com.woocommerce.android.databinding.ActionableEmptyViewBinding
 import org.wordpress.android.util.DisplayUtils
 
 class ActionableEmptyView : LinearLayout {
-    private val binding = ActionableEmptyViewBinding.inflate(LayoutInflater.from(context))
+    private val binding = ActionableEmptyViewBinding.inflate(LayoutInflater.from(context), this, true)
 
     constructor(context: Context, attrs: AttributeSet) : super(context, attrs) {
         initView(context, attrs)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCEmptyView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCEmptyView.kt
@@ -9,6 +9,7 @@ import android.widget.LinearLayout
 import androidx.annotation.DrawableRes
 import androidx.core.text.HtmlCompat
 import androidx.core.text.HtmlCompat.FROM_HTML_MODE_LEGACY
+import androidx.core.view.isVisible
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.WcEmptyViewBinding
 import com.woocommerce.android.util.WooAnimUtils
@@ -57,8 +58,7 @@ class WCEmptyView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? =
      * Hide the image in landscape since there isn't enough room for it on most devices
      */
     private fun checkOrientation() {
-        val isLandscape = DisplayUtils.isLandscape(context)
-        binding.emptyViewImage.visibility = if (isLandscape) View.GONE else View.VISIBLE
+        binding.emptyViewImage.isVisible = !DisplayUtils.isLandscape(context)
     }
 
     fun show(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCEmptyView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCEmptyView.kt
@@ -3,12 +3,14 @@ package com.woocommerce.android.widgets
 import android.content.Context
 import android.os.Handler
 import android.util.AttributeSet
+import android.view.LayoutInflater
 import android.view.View
 import android.widget.LinearLayout
 import androidx.annotation.DrawableRes
 import androidx.core.text.HtmlCompat
 import androidx.core.text.HtmlCompat.FROM_HTML_MODE_LEGACY
 import com.woocommerce.android.R
+import com.woocommerce.android.databinding.WcEmptyViewBinding
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.DASHBOARD
@@ -24,10 +26,11 @@ import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.PRODUCT_LIST
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.PRODUCT_TAG_LIST
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.REVIEW_LIST
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.SEARCH_RESULTS
-import kotlinx.android.synthetic.main.wc_empty_view.view.*
 import org.wordpress.android.util.DisplayUtils
 
 class WCEmptyView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null) : LinearLayout(ctx, attrs) {
+    private val binding = WcEmptyViewBinding.inflate(LayoutInflater.from(context), this, true)
+
     enum class EmptyViewType {
         DASHBOARD,
         ORDER_LIST,
@@ -45,7 +48,6 @@ class WCEmptyView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? =
     }
 
     init {
-        View.inflate(context, R.layout.wc_empty_view, this)
         checkOrientation()
     }
 
@@ -56,7 +58,7 @@ class WCEmptyView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? =
      */
     private fun checkOrientation() {
         val isLandscape = DisplayUtils.isLandscape(context)
-        empty_view_image.visibility = if (isLandscape) View.GONE else View.VISIBLE
+        binding.emptyViewImage.visibility = if (isLandscape) View.GONE else View.VISIBLE
     }
 
     fun show(
@@ -188,24 +190,24 @@ class WCEmptyView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? =
             title
         }
 
-        empty_view_title.text = HtmlCompat.fromHtml(titleHtml, FROM_HTML_MODE_LEGACY)
-        empty_view_image.setImageDrawable(context.getDrawable(drawableId))
+        binding.emptyViewTitle.text = HtmlCompat.fromHtml(titleHtml, FROM_HTML_MODE_LEGACY)
+        binding.emptyViewImage.setImageDrawable(context.getDrawable(drawableId))
 
         if (message != null) {
-            empty_view_message.text = HtmlCompat.fromHtml(message, FROM_HTML_MODE_LEGACY)
-            empty_view_message.visibility = View.VISIBLE
+            binding.emptyViewMessage.text = HtmlCompat.fromHtml(message, FROM_HTML_MODE_LEGACY)
+            binding.emptyViewMessage.visibility = View.VISIBLE
         } else {
-            empty_view_message.visibility = View.GONE
+            binding.emptyViewMessage.visibility = View.GONE
         }
 
         if (onButtonClick != null) {
-            empty_view_button.text = buttonText
-            empty_view_button.visibility = View.VISIBLE
-            empty_view_button.setOnClickListener {
+            binding.emptyViewButton.text = buttonText
+            binding.emptyViewButton.visibility = View.VISIBLE
+            binding.emptyViewButton.setOnClickListener {
                 onButtonClick.invoke()
             }
         } else {
-            empty_view_button.visibility = View.GONE
+            binding.emptyViewButton.visibility = View.GONE
         }
 
         if (visibility != View.VISIBLE) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
@@ -5,13 +5,14 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.util.AttributeSet
 import android.util.SparseArray
+import android.view.LayoutInflater
 import android.view.View
 import androidx.annotation.AttrRes
 import androidx.lifecycle.LiveData
 import com.google.android.material.textfield.TextInputLayout
 import com.woocommerce.android.R
+import com.woocommerce.android.databinding.ViewMaterialOutlinedCurrencyEdittextBinding
 import com.woocommerce.android.util.CurrencyFormatter
-import kotlinx.android.synthetic.main.view_material_outlined_currency_edittext.view.*
 import java.math.BigDecimal
 
 /**
@@ -32,6 +33,8 @@ class WCMaterialOutlinedCurrencyEditTextView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     @AttrRes defStyleRes: Int = R.attr.wcMaterialOutlinedCurrencyEditTextViewStyle
 ) : TextInputLayout(ctx, attrs, defStyleRes) {
+    private val binding = ViewMaterialOutlinedCurrencyEdittextBinding.inflate(LayoutInflater.from(context), this)
+
     companion object {
         private const val KEY_SUPER_STATE = "WC-OUTLINED-CURRENCY-VIEW-SUPER-STATE"
     }
@@ -51,33 +54,33 @@ class WCMaterialOutlinedCurrencyEditTextView @JvmOverloads constructor(
     }
 
     val value: LiveData<BigDecimal>
-        get() = currency_edit_text.value
+        get() = binding.currencyEditText.value
 
     fun initView(
         currency: String,
         decimals: Int,
         currencyFormatter: CurrencyFormatter
     ) {
-        currency_edit_text.initView(currency, decimals, currencyFormatter)
+        binding.currencyEditText.initView(currency, decimals, currencyFormatter)
     }
 
-    fun getText() = currency_edit_text.text.toString()
+    fun getText() = binding.currencyEditText.text.toString()
 
     fun setValue(currentValue: BigDecimal) {
-        currency_edit_text.setValue(currentValue)
+        binding.currencyEditText.setValue(currentValue)
     }
 
     override fun setEnabled(enabled: Boolean) {
         super.setEnabled(enabled)
 
-        currency_edit_text?.isEnabled = enabled
+        binding.currencyEditText.isEnabled = enabled
     }
 
-    fun getCurrencyEditText(): CurrencyEditText = currency_edit_text
+    fun getCurrencyEditText(): CurrencyEditText = binding.currencyEditText
 
     override fun onSaveInstanceState(): Parcelable? {
         val bundle = Bundle()
-        currency_edit_text.onSaveInstanceState()?.let {
+        binding.currencyEditText.onSaveInstanceState()?.let {
             bundle.putParcelable(KEY_SUPER_STATE, WCSavedState(super.onSaveInstanceState(), it))
         }
         return bundle
@@ -91,7 +94,7 @@ class WCMaterialOutlinedCurrencyEditTextView @JvmOverloads constructor(
     }
 
     private fun restoreViewState(state: WCSavedState): Parcelable {
-        currency_edit_text.onRestoreInstanceState(state.savedState)
+        binding.currencyEditText.onRestoreInstanceState(state.savedState)
         return state.superState
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
@@ -7,13 +7,13 @@ import android.text.Editable
 import android.text.InputFilter
 import android.util.AttributeSet
 import android.util.SparseArray
-import android.view.View
+import android.view.LayoutInflater
 import android.view.inputmethod.EditorInfo
 import androidx.annotation.AttrRes
 import androidx.core.widget.doAfterTextChanged
 import com.google.android.material.textfield.TextInputLayout
 import com.woocommerce.android.R
-import kotlinx.android.synthetic.main.view_material_outlined_edittext.view.*
+import com.woocommerce.android.databinding.ViewMaterialOutlinedEdittextBinding
 
 /**
  * Custom View that encapsulates a [TextInputLayout] and [TextInputEditText], and as such has the following
@@ -36,11 +36,12 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     @AttrRes defStyleAttr: Int = R.attr.wcMaterialOutlinedEditTextViewStyle
 ) : TextInputLayout(ctx, attrs, defStyleAttr) {
+    private val binding = ViewMaterialOutlinedEdittextBinding.inflate(LayoutInflater.from(context), this)
+
     companion object {
         private const val KEY_SUPER_STATE = "WC-OUTLINED-EDITTEXT-VIEW-SUPER-STATE"
     }
     init {
-        View.inflate(context, R.layout.view_material_outlined_edittext, this)
         if (attrs != null) {
             val a = context.obtainStyledAttributes(
                     attrs,
@@ -48,7 +49,7 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
             )
             try {
                 // Set the edit text input type
-                edit_text.inputType = a.getInt(
+                binding.editText.inputType = a.getInt(
                         R.styleable.WCMaterialOutlinedEditTextView_android_inputType,
                         EditorInfo.TYPE_TEXT_VARIATION_NORMAL
                 )
@@ -72,27 +73,27 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
     }
 
     fun setText(selectedText: String) {
-        edit_text.setText(selectedText)
+        binding.editText.setText(selectedText)
     }
 
-    fun getText() = edit_text.text.toString()
+    fun getText() = binding.editText.text.toString()
 
     fun setSelection(start: Int, stop: Int) {
-        edit_text.setSelection(start, stop)
+        binding.editText.setSelection(start, stop)
     }
 
     fun setOnTextChangedListener(cb: (text: Editable?) -> Unit) {
-        edit_text.doAfterTextChanged {
+        binding.editText.doAfterTextChanged {
             cb(it)
         }
     }
 
     fun setOnEditorActionListener(cb: (text: String) -> Boolean) {
-        edit_text.setOnEditorActionListener { _, action, _ ->
+        binding.editText.setOnEditorActionListener { _, action, _ ->
             if (action == EditorInfo.IME_ACTION_DONE) {
-                val text = edit_text.text.toString()
+                val text = binding.editText.text.toString()
                 if (text.isNotEmpty()) {
-                    edit_text.setText("")
+                    binding.editText.setText("")
                     cb.invoke(text)
                 } else false
             } else {
@@ -106,18 +107,18 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
     }
 
     fun setMaxLength(max: Int) {
-        edit_text.filters += InputFilter.LengthFilter(max)
+        binding.editText.filters += InputFilter.LengthFilter(max)
     }
 
     override fun setEnabled(enabled: Boolean) {
         super.setEnabled(enabled)
 
-        edit_text?.isEnabled = enabled
+        binding.editText.isEnabled = enabled
     }
 
     override fun onSaveInstanceState(): Parcelable? {
         val bundle = Bundle()
-        edit_text.onSaveInstanceState()?.let {
+        binding.editText.onSaveInstanceState()?.let {
             bundle.putParcelable(KEY_SUPER_STATE, WCSavedState(super.onSaveInstanceState(), it))
         }
         return bundle
@@ -131,7 +132,7 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
     }
 
     private fun restoreViewState(state: WCSavedState): Parcelable {
-        edit_text.onRestoreInstanceState(state.savedState)
+        binding.editText.onRestoreInstanceState(state.savedState)
         return state.superState
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedSpinnerView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedSpinnerView.kt
@@ -5,12 +5,13 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.util.AttributeSet
 import android.util.SparseArray
+import android.view.LayoutInflater
 import android.view.View
 import androidx.annotation.AttrRes
 import com.google.android.material.textfield.TextInputLayout
 import com.woocommerce.android.R
+import com.woocommerce.android.databinding.ViewMaterialOutlinedSpinnerBinding
 import com.woocommerce.android.extensions.setHtmlText
-import kotlinx.android.synthetic.main.view_material_outlined_spinner.view.*
 
 /**
  * Custom View that mimics a TextInputEditText with a spinner that opens a selector dialog it.
@@ -22,11 +23,13 @@ class WCMaterialOutlinedSpinnerView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     @AttrRes defStyleAttr: Int = R.attr.wcMaterialOutlinedSpinnerViewStyle
 ) : TextInputLayout(ctx, attrs, defStyleAttr) {
+    private val binding = ViewMaterialOutlinedSpinnerBinding.inflate(LayoutInflater.from(context), this)
+
     companion object {
         private const val KEY_SUPER_STATE = "WC-OUTLINED-SPINNER-VIEW-SUPER-STATE"
     }
+
     init {
-        View.inflate(context, R.layout.view_material_outlined_spinner, this)
         if (attrs != null) {
             val a = context.obtainStyledAttributes(attrs, R.styleable.WCMaterialOutlinedSpinnerView)
             try {
@@ -43,28 +46,28 @@ class WCMaterialOutlinedSpinnerView @JvmOverloads constructor(
     }
 
     fun setClickListener(onClickListener: ((view: View) -> Unit)) {
-        spinner_edit_text.setOnClickListener(onClickListener)
+        binding.spinnerEditText.setOnClickListener(onClickListener)
     }
 
     fun setText(selectedText: String) {
-        spinner_edit_text.setText(selectedText)
+        binding.spinnerEditText.setText(selectedText)
     }
 
     fun setHtmlText(selectedText: String) {
-        spinner_edit_text.setHtmlText(selectedText)
+        binding.spinnerEditText.setHtmlText(selectedText)
     }
 
-    fun getText() = spinner_edit_text.text.toString()
+    fun getText() = binding.spinnerEditText.text.toString()
 
     override fun setEnabled(enabled: Boolean) {
         super.setEnabled(enabled)
 
-        spinner_edit_text?.isEnabled = enabled
+        binding.spinnerEditText.isEnabled = enabled
     }
 
     override fun onSaveInstanceState(): Parcelable? {
         val bundle = Bundle()
-        spinner_edit_text.onSaveInstanceState()?.let {
+        binding.spinnerEditText.onSaveInstanceState()?.let {
             bundle.putParcelable(KEY_SUPER_STATE, WCSavedState(super.onSaveInstanceState(), it))
         }
         return bundle
@@ -78,7 +81,7 @@ class WCMaterialOutlinedSpinnerView @JvmOverloads constructor(
     }
 
     private fun restoreViewState(state: WCSavedState): Parcelable {
-        spinner_edit_text.onRestoreInstanceState(state.savedState)
+        binding.spinnerEditText.onRestoreInstanceState(state.savedState)
         return state.superState
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCToggleSingleOptionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCToggleSingleOptionView.kt
@@ -40,7 +40,8 @@ class WCToggleSingleOptionView @JvmOverloads constructor(
             val a = context.obtainStyledAttributes(attrs, R.styleable.WCToggleSingleOptionView)
             try {
                 // Set the view title
-                binding.switchSettingTitle.text = a.getString(R.styleable.WCToggleSingleOptionView_switchTitle).orEmpty()
+                binding.switchSettingTitle.text = a.getString(R.styleable.WCToggleSingleOptionView_switchTitle)
+                    .orEmpty()
 
                 // Set the summary and switch state
                 binding.switchSettingSwitch.isChecked =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCToggleSingleOptionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCToggleSingleOptionView.kt
@@ -4,7 +4,7 @@ import android.R.attr
 import android.content.Context
 import android.util.AttributeSet
 import android.util.TypedValue
-import android.view.View
+import android.view.LayoutInflater
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
 import android.widget.Checkable
@@ -12,7 +12,7 @@ import android.widget.CompoundButton
 import android.widget.CompoundButton.OnCheckedChangeListener
 import android.widget.LinearLayout
 import com.woocommerce.android.R
-import kotlinx.android.synthetic.main.view_toggle_single_option.view.*
+import com.woocommerce.android.databinding.ViewToggleSingleOptionBinding
 
 /**
  * Custom toggle component that mimics a [android.preference.SwitchPreference]. This view will display
@@ -26,8 +26,9 @@ class WCToggleSingleOptionView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : LinearLayout(ctx, attrs, defStyleAttr), Checkable {
+    private val binding = ViewToggleSingleOptionBinding.inflate(LayoutInflater.from(context), this)
+
     init {
-        View.inflate(context, R.layout.view_toggle_single_option, this)
         orientation = VERTICAL
 
         // Sets the selectable background
@@ -39,18 +40,18 @@ class WCToggleSingleOptionView @JvmOverloads constructor(
             val a = context.obtainStyledAttributes(attrs, R.styleable.WCToggleSingleOptionView)
             try {
                 // Set the view title
-                switchSetting_title.text = a.getString(R.styleable.WCToggleSingleOptionView_switchTitle).orEmpty()
+                binding.switchSettingTitle.text = a.getString(R.styleable.WCToggleSingleOptionView_switchTitle).orEmpty()
 
                 // Set the summary and switch state
-                switchSetting_switch.isChecked =
+                binding.switchSettingSwitch.isChecked =
                         a.getBoolean(R.styleable.WCToggleSingleOptionView_switchChecked, false)
-                switchSetting_switch.text =
+                binding.switchSettingSwitch.text =
                         a.getString(R.styleable.WCToggleSingleOptionView_switchSummary).orEmpty()
 
                 // Set the component state text to something meaningful - this text is announced to the user after
                 // the content description.
-                switchSetting_switch.textOn = resources.getString(R.string.toggle_option_checked)
-                switchSetting_switch.textOff = resources.getString(R.string.toggle_option_not_checked)
+                binding.switchSettingSwitch.textOn = resources.getString(R.string.toggle_option_checked)
+                binding.switchSettingSwitch.textOff = resources.getString(R.string.toggle_option_not_checked)
 
                 setOnClickListener { toggle() }
             } finally {
@@ -60,7 +61,7 @@ class WCToggleSingleOptionView @JvmOverloads constructor(
     }
 
     private val checkable: CompoundButton by lazy {
-        switchSetting_switch
+        binding.switchSettingSwitch
     }
     var listener: OnCheckedChangeListener? = null
 
@@ -81,8 +82,8 @@ class WCToggleSingleOptionView @JvmOverloads constructor(
     override fun setEnabled(enabled: Boolean) {
         super.setEnabled(enabled)
 
-        switchSetting_switch?.isEnabled = enabled
-        switchSetting_title?.isEnabled = enabled
+        binding.switchSettingSwitch.isEnabled = enabled
+        binding.switchSettingTitle.isEnabled = enabled
     }
 
     private fun onCheckChanged() {


### PR DESCRIPTION
This PR converts our custom widgets to view binding. Each of the converted widgets is listed below along with a place in the app they're used.

* `ActionableEmptyView` - used when you're viewing a product variation which has no variations, and you tap "Variations" to view the variation list

* `WCEmptyView` - search the order list with a query that will have no matches

* `WCMaterialOutlinedCurrencyEditTextView` - used in the product pricing fragment

* `WCMaterialOutlinedEditTextView` - used in the product shipping fragment

* `WCMaterialOutlinedSpinnerView` - used in product pricing fragment when scheduling sale dates

* `WCProductImageGalleryView` - used in product detail to show the product images

* `WCToggleSingleOptionView` -  used in product pricing fragment when enabling/disabling sale

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
