### PR TITLE
Fix NullPointerException when calling shouldExpandToolbar

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -144,9 +144,11 @@ class MainActivity : AppUpgradeActivity(),
             if (!isFullScreenFragment && !isDialogDestination) {
                 // re-expand the AppBar when returning to top level fragment, collapse it when entering a child fragment
                 if (f is TopLevelFragment) {
-                    // We need to post this to the view handler to make sure isScrolledToTop returns the correct value
+                    // We need to post this to the view handler to make sure shouldExpandToolbar returns the correct value
                     f.view?.post {
-                        expandToolbar(expand = f.shouldExpandToolbar(), animate = false)
+                        if (f.view != null) {
+                            expandToolbar(expand = f.shouldExpandToolbar(), animate = false)
+                        }
                     }
                 } else {
                     expandToolbar(expand = false, animate = false)


### PR DESCRIPTION
Fixes #3504, I couldn't reproduce the crash, but I think the cause is that we are posting the logic to update the toolbar status on the fragment view's queue, and if it gets destroyed before getting a chance to get executed, we will try to access `binding` after `onDestroyView`.

I added a check to make sure `fragment.view` is not null before the execution, I think this'll solve the issue.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
