### PR TITLE
Confirm the context's not null before changing toolbar's elevation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -435,7 +435,9 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store),
             ?.let { appBar ->
                 appBar.addView(tabLayout, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT))
                 appBar.post {
-                    appBar.elevation = resources.getDimensionPixelSize(R.dimen.appbar_elevation).toFloat()
+                    if (context != null) {
+                        appBar.elevation = resources.getDimensionPixelSize(R.dimen.appbar_elevation).toFloat()
+                    }
                 }
             }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -721,7 +721,9 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
                 appBar.addView(tabLayout)
             }
             appBar.post {
-                appBar.elevation = resources.getDimensionPixelSize(R.dimen.appbar_elevation).toFloat()
+                if (context != null) {
+                    appBar.elevation = resources.getDimensionPixelSize(R.dimen.appbar_elevation).toFloat()
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #3503, I couldn't reproduce the crash, but it seems the code to update the toolbar elevation is getting executed after the fragment was detached.

I added a check to confirm the fragment's context is not null before execution.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
