### PR TITLE
[Tooling] Update release-toolkit to 0.14.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 48f500bd9212f13d2bf71220c89a8794cdd46e03
-  tag: 0.13.0
+  revision: 0ad59f8ad1644b68f8dbe3ebc3e16bb331a24117
+  tag: 0.14.0
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.13.0)
+    fastlane-plugin-wpmreleasetoolkit (0.14.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)
@@ -53,7 +53,7 @@ GEM
     colored2 (3.1.2)
     commander-fastlane (4.4.6)
       highline (~> 1.7.2)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
     declarative (0.0.20)
     declarative-option (0.1.0)
     diffy (3.4.0)
@@ -169,7 +169,7 @@ GEM
     octokit (4.20.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.11.0)
+    oj (3.11.2)
     optimist (3.0.1)
     options (2.3.2)
     os (1.1.1)

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.13.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.14.0'


### PR DESCRIPTION
Update our tooling to [release-toolkit v0.14.0](https://github.com/wordpress-mobile/release-toolkit/releases/tag/0.14.0), which includes improvements about release notes automation.