### PR TITLE
Updated FluxC hash

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,8 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
 6.0
------ 
+-----
+* [*] Fixed a bug where the Top Performers were diisplayed twice. [https://github.com/woocommerce/woocommerce-android/pull/3514]
 
 5.9
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -85,13 +85,13 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.9.0'
+    fluxCVersion = '304e89c629658b555f8b9f0cebb8234efb5929a3'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.0.1'
     mockitoKotlinVersion = '2.1.0'
-    mockitoVersion = '2.28.2'
+    mockitoVersion = '2.28.2'     
     constraintLayoutVersion = '1.2.0'
     multidexVersion = '1.0.3'
     libaddressinputVersion = '0.0.2'


### PR DESCRIPTION
Fixes #3460. This PR updates the FluxC hash which contains the actual fix for #3460. 

#### To test
I was able to reproduce this issue by installing a fresh version of the app (without any cache) and logging into a store that has some top performers. It looks like the API response returned is correct but the app stores the same product twice in `WCTopPerformerProductModel`. 
- Install a fresh version of the app.
- Login to a store with Top performers.
- Notice that the list is not duplicated.

#### Screenshots
(LEFT: Before. RIGHT: After)
<img src="https://user-images.githubusercontent.com/22608780/106420608-fee5da00-6480-11eb-9006-602a1aaf0367.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/106420612-00af9d80-6481-11eb-8199-3dbc4c4b7de3.png" width="300"/>

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
