### PR TITLE
Fix text input layouts crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
@@ -70,12 +70,6 @@ class WCMaterialOutlinedCurrencyEditTextView @JvmOverloads constructor(
         binding.currencyEditText.setValue(currentValue)
     }
 
-    override fun setEnabled(enabled: Boolean) {
-        super.setEnabled(enabled)
-
-        binding.currencyEditText.isEnabled = enabled
-    }
-
     fun getCurrencyEditText(): CurrencyEditText = binding.currencyEditText
 
     override fun onSaveInstanceState(): Parcelable? {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedCurrencyEditTextView.kt
@@ -6,7 +6,6 @@ import android.os.Parcelable
 import android.util.AttributeSet
 import android.util.SparseArray
 import android.view.LayoutInflater
-import android.view.View
 import androidx.annotation.AttrRes
 import androidx.lifecycle.LiveData
 import com.google.android.material.textfield.TextInputLayout
@@ -39,7 +38,6 @@ class WCMaterialOutlinedCurrencyEditTextView @JvmOverloads constructor(
         private const val KEY_SUPER_STATE = "WC-OUTLINED-CURRENCY-VIEW-SUPER-STATE"
     }
     init {
-        View.inflate(context, R.layout.view_material_outlined_currency_edittext, this)
         if (attrs != null) {
             val a = context.obtainStyledAttributes(
                     attrs,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
@@ -110,12 +110,6 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
         binding.editText.filters += InputFilter.LengthFilter(max)
     }
 
-    override fun setEnabled(enabled: Boolean) {
-        super.setEnabled(enabled)
-
-        binding.editText.isEnabled = enabled
-    }
-
     override fun onSaveInstanceState(): Parcelable? {
         val bundle = Bundle()
         binding.editText.onSaveInstanceState()?.let {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedSpinnerView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedSpinnerView.kt
@@ -59,12 +59,6 @@ class WCMaterialOutlinedSpinnerView @JvmOverloads constructor(
 
     fun getText() = binding.spinnerEditText.text.toString()
 
-    override fun setEnabled(enabled: Boolean) {
-        super.setEnabled(enabled)
-
-        binding.spinnerEditText.isEnabled = enabled
-    }
-
     override fun onSaveInstanceState(): Parcelable? {
         val bundle = Bundle()
         binding.spinnerEditText.onSaveInstanceState()?.let {


### PR DESCRIPTION
Fixes #3511, the cause of the crash is that we are trying to access `binding` in `setEnabled`, but `setEnabled` is called from the base constructor, so `binding` is null there.
But when checking the code of `super.setEnabled`, I don't think we need to make any changes ourselves, as the base implementation updates the status for all child views: 

```Java
@Override
  public void setEnabled(boolean enabled) {
    // Since we're set to addStatesFromChildren, we need to make sure that we set all
    // children to enabled/disabled otherwise any enabled children will wipe out our disabled
    // drawable state
    recursiveSetEnabled(this, enabled);
    super.setEnabled(enabled);
  }

  private static void recursiveSetEnabled(@NonNull final ViewGroup vg, final boolean enabled) {
    for (int i = 0, count = vg.getChildCount(); i < count; i++) {
      final View child = vg.getChildAt(i);
      child.setEnabled(enabled);
      if (child instanceof ViewGroup) {
        recursiveSetEnabled((ViewGroup) child, enabled);
      }
    }
  }
```
This PR just removes our override implementation.

#### Testing
Open any screen that uses one of the following widgets: `WCMaterialOutlinedEditTextView`, `WCMaterialOutlinedSpinnerView` or `WCMaterialOutlinedCurrencyEditTextView`, and confirm the app doesn't crash.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
