### PR TITLE
Added SKU to order detail screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,8 @@
 
 6.0
 -----
-* [*] Fixed a bug where the Top Performers were diisplayed twice. [https://github.com/woocommerce/woocommerce-android/pull/3514]
+* [*] Fixed a bug where the Top Performers were displayed twice. [https://github.com/woocommerce/woocommerce-android/pull/3514]
+* [**] Due to popular demand, the product SKU is displayed once again in Order Details screen. [https://github.com/woocommerce/woocommerce-android/pull/3517]
 
 5.9
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.core.view.isVisible
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.OrderDetailProductItemBinding
 import com.woocommerce.android.di.GlideApp
@@ -23,7 +22,6 @@ class OrderDetailProductItemView @JvmOverloads constructor(
     fun initView(
         item: Order.Item,
         productImage: String?,
-        expanded: Boolean,
         formatCurrencyForDisplay: (BigDecimal) -> String
     ) {
         binding.productInfoName.text = item.name
@@ -31,24 +29,15 @@ class OrderDetailProductItemView @JvmOverloads constructor(
         val orderTotal = formatCurrencyForDisplay(item.total)
         binding.productInfoTotal.text = orderTotal
 
-        // Modify views for expanded or collapsed mode
-        binding.productInfoTotalTax.isVisible = expanded
-        binding.productInfoLblTax.isVisible = expanded
-
-        val maxLinesInName = if (expanded) Int.MAX_VALUE else 2
-        binding.productInfoName.maxLines = maxLinesInName
-
         val productPrice = formatCurrencyForDisplay(item.price)
         val attributes = item.attributesList.takeIf { it.isNotEmpty() }?.let { "$it \u2981 " } ?: StringUtils.EMPTY
-
         binding.productInfoAttributes.text = context.getString(
             R.string.orderdetail_product_lineitem_attributes,
             attributes, item.quantity.toString(), productPrice
         )
 
-        if (expanded) {
-            binding.productInfoTotalTax.text = formatCurrencyForDisplay(item.totalTax)
-        }
+        val productSku = context.getString(R.string.orderdetail_product_lineitem_sku_value, item.sku)
+        binding.productInfoSKU.text = productSku
 
         productImage?.let {
             val imageSize = context.resources.getDimensionPixelSize(R.dimen.image_minor_100)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailProductListAdapter.kt
@@ -32,7 +32,7 @@ class OrderDetailProductListAdapter(
         val productId = ProductHelper.productOrVariationId(item.productId, item.variationId)
         val imageSize = holder.view.resources.getDimensionPixelSize(R.dimen.image_minor_100)
         val productImage = PhotonUtils.getPhotonImageUrl(productImageMap.get(productId), imageSize, imageSize)
-        holder.view.initView(orderItems[position], productImage, false, formatCurrencyForDisplay)
+        holder.view.initView(orderItems[position], productImage, formatCurrencyForDisplay)
         holder.view.setOnClickListener {
             productItemListener.openOrderProductDetail(productId)
         }

--- a/WooCommerce/src/main/res/layout/order_detail_product_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_product_item.xml
@@ -33,6 +33,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:ellipsize="end"
+        android:maxLines="2"
         app:layout_constrainedWidth="true"
         app:layout_constraintBaseline_toBaselineOf="@+id/productInfo_total"
         app:layout_constraintEnd_toStartOf="@+id/productInfo_total"
@@ -60,28 +61,12 @@
         tools:text="Red, Medium • $15.00 x 2" />
 
     <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/productInfo_lblTax"
+        android:id="@+id/productInfo_SKU"
         style="@style/Woo.ListItem.Body"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/orderdetail_product_lineitem_tax"
+        android:text="@string/orderdetail_product_lineitem_sku_value"
         app:layout_constraintStart_toEndOf="@+id/productInfo_iconFrame"
         app:layout_constraintTop_toBottomOf="@+id/productInfo_attributes"
-        tools:text="Tax:"
-        tools:visibility="visible" />
-
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/productInfo_totalTax"
-        style="@style/Woo.ListItem.Body"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/minor_50"
-        android:layout_marginEnd="@dimen/minor_50"
-        app:layout_constrainedWidth="true"
-        app:layout_constraintEnd_toStartOf="@+id/productInfo_total"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toEndOf="@+id/productInfo_lblTax"
-        app:layout_constraintTop_toBottomOf="@+id/productInfo_attributes"
-        tools:text="$0.75"
         tools:visibility="visible" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Fixes #3513. This PR adds the SKU  back to the order detail screen.

#### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/106570232-a1728b80-655b-11eb-90b5-aae3265b5955.png" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/106570242-a33c4f00-655b-11eb-8e61-74c3f482262a.png" width="300"/>

#### To test
- Click on an order that has atleast one shipping label. Notice the product SKU is displayed as part of the product list.
- Click on an order that does not have any shipping labels. Notice the product SKU is displayed as part of the product list.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
