### PR TITLE
Fix crash when the product status is empty or null

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductStatusFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductStatusFragment.kt
@@ -46,7 +46,7 @@ class ProductStatusFragment : BaseProductSettingsFragment(R.layout.fragment_prod
         binding.btnPending.setOnClickListener(this)
         binding.btnTrashed.setOnClickListener(this)
 
-        getButtonForStatus(selectedStatus).isChecked = true
+        getButtonForStatus(selectedStatus)?.isChecked = true
 
         // if the post is private, we hide the "Published" button and show "Privately published."
         // making a product private is done on the product visibility screen
@@ -95,14 +95,14 @@ class ProductStatusFragment : BaseProductSettingsFragment(R.layout.fragment_prod
 
     override fun getFragmentTitle() = getString(R.string.product_status)
 
-    private fun getButtonForStatus(status: String): CheckedTextView {
+    private fun getButtonForStatus(status: String): CheckedTextView? {
         return when (ProductStatus.fromString(status)) {
             PUBLISH -> binding.btnPublished
             DRAFT -> binding.btnDraft
             PENDING -> binding.btnPending
             PRIVATE -> binding.btnPublishedPrivately
             TRASH -> binding.btnTrashed
-            else -> throw IllegalArgumentException()
+            else -> null
         }
     }
 


### PR DESCRIPTION
Fixes #3518, which I introduced when I worked on navigation refactoring, I wanted to avoid passing nullable values as results but didn't think about the case where the backend send us a null or empty status in the response.
The change on this PR is just to make sure no radio button is checked if the passed status doesn't match one of the values we expect.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
