### PR TITLE
Issue/3206 edit attributes menu

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
@@ -2,6 +2,9 @@ package com.woocommerce.android.ui.products.variations
 
 import android.os.Bundle
 import android.os.Parcelable
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
@@ -26,6 +29,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.products.OnLoadMoreListener
 import com.woocommerce.android.ui.products.variations.VariationListViewModel.ShowVariationDetail
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -39,6 +43,7 @@ class VariationListFragment : BaseFragment(R.layout.fragment_variation_list),
     companion object {
         const val TAG: String = "VariationListFragment"
         private const val LIST_STATE_KEY = "list_state"
+        private const val ID_EDIT_ATTRIBUTES = 1
     }
 
     @Inject lateinit var viewModelFactory: ViewModelFactory
@@ -84,6 +89,24 @@ class VariationListFragment : BaseFragment(R.layout.fragment_variation_list),
     override fun onSaveInstanceState(outState: Bundle) {
         layoutManager?.let {
             outState.putParcelable(LIST_STATE_KEY, it.onSaveInstanceState())
+        }
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        super.onCreateOptionsMenu(menu, inflater)
+
+        if (FeatureFlag.ADD_EDIT_VARIATIONS.isEnabled()) {
+            val mnuEditAttr = menu.add(Menu.NONE, ID_EDIT_ATTRIBUTES, Menu.NONE, R.string.product_variations_edit_attr)
+            mnuEditAttr.setShowAsAction(MenuItem.SHOW_AS_ACTION_NEVER)
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            ID_EDIT_ATTRIBUTES -> {
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
@@ -98,6 +98,15 @@ class VariationListFragment : BaseFragment(R.layout.fragment_variation_list),
         if (FeatureFlag.ADD_EDIT_VARIATIONS.isEnabled()) {
             val mnuEditAttr = menu.add(Menu.NONE, ID_EDIT_ATTRIBUTES, Menu.NONE, R.string.product_variations_edit_attr)
             mnuEditAttr.setShowAsAction(MenuItem.SHOW_AS_ACTION_NEVER)
+            mnuEditAttr.isVisible = false
+        }
+    }
+
+    override fun onPrepareOptionsMenu(menu: Menu) {
+        super.onPrepareOptionsMenu(menu)
+
+        if (FeatureFlag.ADD_EDIT_VARIATIONS.isEnabled()) {
+            menu.findItem(ID_EDIT_ATTRIBUTES)?.isVisible = !viewModel.isEmpty()
         }
     }
 
@@ -155,11 +164,13 @@ class VariationListFragment : BaseFragment(R.layout.fragment_variation_list),
                 } else {
                     WooAnimUtils.fadeOut(binding.emptyView)
                 }
+                requireActivity().invalidateOptionsMenu()
             }
         }
 
         viewModel.variationList.observe(viewLifecycleOwner, Observer {
             showVariations(it, viewModel.viewStateLiveData.liveData.value?.parentProduct)
+            requireActivity().invalidateOptionsMenu()
         })
 
         viewModel.event.observe(viewLifecycleOwner, Observer { event ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
@@ -104,6 +104,8 @@ class VariationListViewModel @AssistedInject constructor(
         }
     }
 
+    fun isEmpty() = _variationList.value?.isEmpty() ?: true
+
     private suspend fun fetchVariations(remoteProductId: Long, loadMore: Boolean = false) {
         if (networkStatus.isConnected()) {
             val fetchedVariations = variationListRepository.fetchProductVariations(remoteProductId, loadMore)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -8,10 +8,12 @@ import com.woocommerce.android.BuildConfig
  */
 enum class FeatureFlag {
     SHIPPING_LABELS_M2,
+    ADD_EDIT_VARIATIONS,
     DB_DOWNGRADE;
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
             SHIPPING_LABELS_M2 -> BuildConfig.DEBUG || isTesting()
+            ADD_EDIT_VARIATIONS -> BuildConfig.DEBUG
             DB_DOWNGRADE -> {
                 BuildConfig.DEBUG || context != null && PackageUtils.isBetaBuild(context)
             }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -61,6 +61,7 @@
     <string name="shipping_labels">Shipping Labels</string>
     <string name="product_variations">Variations</string>
     <string name="product_variation_options">%1$s (%2$s options)</string>
+    <string name="product_variations_edit_attr">Edit attributes</string>
     <string name="review_notifications">Reviews</string>
     <string name="version_with_name_param">Version %s</string>
     <string name="share_store_button">Share your store</string>


### PR DESCRIPTION
Closes #3206 - this small PR simply adds the "Edit attributes" menu to the variation detail. This menu only appears in debug builds, and is hidden for variable products that have no variations. It also does nothing when clicked (coming soon).

![Screenshot_20210202_115830](https://user-images.githubusercontent.com/3903757/106634737-0fb05180-654e-11eb-9e1b-cdd86d52c085.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
