### PR TITLE
Shipping labels: Use store address in the flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Address.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Address.kt
@@ -82,7 +82,8 @@ data class Address(
 
     override fun toString(): String {
         return StringBuilder()
-            .appendWithIfNotEmpty("$firstName $lastName".trim())
+            .appendWithIfNotEmpty(this.company)
+            .appendWithIfNotEmpty("$firstName $lastName".trim(), "\n")
             .appendWithIfNotEmpty(this.address1, "\n")
             .appendWithIfNotEmpty(this.address2, "\n")
             .appendWithIfNotEmpty(this.city, "\n")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -44,6 +44,7 @@ import kotlinx.android.parcel.Parcelize
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 
 @ExperimentalCoroutinesApi
@@ -55,7 +56,8 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
     private val stateMachine: ShippingLabelsStateMachine,
     private val addressValidator: ShippingLabelAddressValidator,
     private val site: SelectedSite,
-    private val wooStore: WooCommerceStore
+    private val wooStore: WooCommerceStore,
+    private val accountStore: AccountStore
 ) : ScopedViewModel(savedState, dispatchers) {
     companion object {
         private const val STATE_KEY = "state"
@@ -256,9 +258,9 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
     private fun getStoreAddress(): Address {
         val siteSettings = wooStore.getSiteSettings(site.get())
         return Address(
-                company = "",
-                firstName = "",
-                lastName = "",
+                company = site.get().name,
+                firstName = accountStore.account.firstName,
+                lastName = accountStore.account.lastName,
                 phone = "",
                 email = "",
                 country = siteSettings?.countryCode ?: "",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -276,7 +276,9 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
         return when (val result = addressValidator.validateAddress(address, type)) {
             ValidationResult.Valid -> AddressValidated(address)
             is ValidationResult.SuggestedChanges -> AddressChangeSuggested(result.suggested)
-            is ValidationResult.NotFound, is ValidationResult.Invalid -> AddressInvalid(address, result)
+            is ValidationResult.NotFound,
+            is ValidationResult.Invalid,
+            is ValidationResult.NameMissing -> AddressInvalid(address, result)
             is ValidationResult.Error -> AddressValidationFailed
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingL
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowSuggestedAddress
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.ORIGIN
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.ValidationResult
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.ValidationResult.NameMissing
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -129,6 +130,11 @@ class EditShippingLabelAddressViewModel @AssistedInject constructor(
             is ValidationResult.Error -> triggerEvent(
                 ShowSnackbar(R.string.shipping_label_edit_address_validation_error)
             )
+            is NameMissing -> {
+                viewState = viewState.copy(
+                    nameError = R.string.shipping_label_error_required_field
+                )
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -154,7 +154,7 @@ class EditShippingLabelAddressViewModel @AssistedInject constructor(
         }
 
         viewState = viewState.copy(
-            nameError = getErrorOrClear(address.firstName + address.lastName),
+            nameError = getErrorOrClear(address.firstName + address.lastName + address.company),
             addressError = getErrorOrClear(address.address1),
             cityError = getErrorOrClear(address.city),
             zipError = getErrorOrClear(address.postcode)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressSuggestionFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressSuggestionFragment.kt
@@ -123,7 +123,7 @@ class ShippingLabelAddressSuggestionFragment
             return this.toString()
         }
 
-        val stringBuilder = StringBuilder().appendWithIfNotEmpty("$firstName $lastName".trim())
+        val stringBuilder = StringBuilder().appendWithIfNotEmpty(company)
 
         fun append(thisLine: String, otherLine: String, separator: String = "<br>") {
             if (thisLine.isNotEmpty()) {
@@ -135,6 +135,7 @@ class ShippingLabelAddressSuggestionFragment
             }
         }
 
+        stringBuilder.appendWithIfNotEmpty("$firstName $lastName".trim(), "<br>")
         append(this.address1, other.address1)
         append(this.address2, other.address2)
         append(this.city, other.city)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressValidator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressValidator.kt
@@ -36,18 +36,16 @@ class ShippingLabelAddressValidator @Inject constructor(
             return if (result.isError) {
                 // TODO: Add analytics
                 ValidationResult.Error(result.error.type)
-            } else {
-                when (result.model) {
-                    null -> ValidationResult.Error(GENERIC_ERROR)
-                    is InvalidRequest -> ValidationResult.NotFound((result.model as InvalidRequest).message)
-                    is InvalidAddress -> ValidationResult.Invalid((result.model as InvalidAddress).message)
-                    is WCAddressVerificationResult.Valid -> {
-                        val suggestion = (result.model as WCAddressVerificationResult.Valid).suggestedAddress.toAppModel()
-                        if (suggestion.toString() != address.toString()) {
-                            ValidationResult.SuggestedChanges(suggestion)
-                        } else {
-                            ValidationResult.Valid
-                        }
+            } else when (result.model) {
+                null -> ValidationResult.Error(GENERIC_ERROR)
+                is InvalidRequest -> ValidationResult.NotFound((result.model as InvalidRequest).message)
+                is InvalidAddress -> ValidationResult.Invalid((result.model as InvalidAddress).message)
+                is WCAddressVerificationResult.Valid -> {
+                    val suggestion = (result.model as WCAddressVerificationResult.Valid).suggestedAddress.toAppModel()
+                    if (suggestion.toString() != address.toString()) {
+                        ValidationResult.SuggestedChanges(suggestion)
+                    } else {
+                        ValidationResult.Valid
                     }
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressValidator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressValidator.kt
@@ -22,33 +22,48 @@ class ShippingLabelAddressValidator @Inject constructor(
     private val selectedSite: SelectedSite
 ) {
     suspend fun validateAddress(address: Address, type: AddressType): ValidationResult {
-        val result = withContext(Dispatchers.IO) {
-            shippingLabelStore.verifyAddress(selectedSite.get(), address.toShippingLabelAddress(), type.toDataType())
-        }
-
-        return if (result.isError) {
-            // TODO: Add analytics
-            ValidationResult.Error(result.error.type)
+        if (isNameMissing(address)) {
+            return ValidationResult.NameMissing
         } else {
-            when (result.model) {
-                null -> ValidationResult.Error(GENERIC_ERROR)
-                is InvalidRequest -> ValidationResult.NotFound((result.model as InvalidRequest).message)
-                is InvalidAddress -> ValidationResult.Invalid((result.model as InvalidAddress).message)
-                is WCAddressVerificationResult.Valid -> {
-                    val suggestion = (result.model as WCAddressVerificationResult.Valid).suggestedAddress.toAppModel()
-                    if (suggestion.toString() != address.toString()) {
-                        ValidationResult.SuggestedChanges(suggestion)
-                    } else {
-                        ValidationResult.Valid
+            val result = withContext(Dispatchers.IO) {
+                shippingLabelStore.verifyAddress(
+                    selectedSite.get(),
+                    address.toShippingLabelAddress(),
+                    type.toDataType()
+                )
+            }
+
+            return if (result.isError) {
+                // TODO: Add analytics
+                ValidationResult.Error(result.error.type)
+            } else {
+                when (result.model) {
+                    null -> ValidationResult.Error(GENERIC_ERROR)
+                    is InvalidRequest -> ValidationResult.NotFound((result.model as InvalidRequest).message)
+                    is InvalidAddress -> ValidationResult.Invalid((result.model as InvalidAddress).message)
+                    is WCAddressVerificationResult.Valid -> {
+                        val suggestion = (result.model as WCAddressVerificationResult.Valid).suggestedAddress.toAppModel()
+                        if (suggestion.toString() != address.toString()) {
+                            ValidationResult.SuggestedChanges(suggestion)
+                        } else {
+                            ValidationResult.Valid
+                        }
                     }
                 }
             }
         }
     }
 
+    private fun isNameMissing(address: Address): Boolean {
+        return (address.firstName + address.lastName).isBlank() && address.company.isBlank()
+    }
+
     sealed class ValidationResult : Parcelable {
         @Parcelize
         object Valid : ValidationResult()
+
+        @Parcelize
+        object NameMissing : ValidationResult()
 
         @Parcelize
         data class SuggestedChanges(val suggested: Address) : ValidationResult()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
@@ -31,6 +31,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 
 @ExperimentalCoroutinesApi
@@ -45,6 +46,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
     private val addressValidator: ShippingLabelAddressValidator = mock()
     private val site: SelectedSite = mock()
     private val wooStore: WooCommerceStore = mock()
+    private val accountStore: AccountStore = mock()
     private lateinit var stateFlow: MutableStateFlow<Transition>
 
     private val originAddress = CreateShippingLabelTestUtils.generateAddress()
@@ -135,7 +137,8 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
                 stateMachine,
                 addressValidator,
                 site,
-                wooStore
+                wooStore,
+                accountStore
             )
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
@@ -6,6 +6,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRepository
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.Step
@@ -30,6 +31,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.wordpress.android.fluxc.store.WooCommerceStore
 
 @ExperimentalCoroutinesApi
 class CreateShippingLabelViewModelTest : BaseUnitTest() {
@@ -41,6 +43,8 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
     private val shippingLabelRepository: ShippingLabelRepository = mock()
     private val stateMachine: ShippingLabelsStateMachine = mock()
     private val addressValidator: ShippingLabelAddressValidator = mock()
+    private val site: SelectedSite = mock()
+    private val wooStore: WooCommerceStore = mock()
     private lateinit var stateFlow: MutableStateFlow<Transition>
 
     private val originAddress = CreateShippingLabelTestUtils.generateAddress()
@@ -129,7 +133,9 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
                 orderDetailRepository,
                 shippingLabelRepository,
                 stateMachine,
-                addressValidator
+                addressValidator,
+                site,
+                wooStore
             )
         )
 

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '304e89c629658b555f8b9f0cebb8234efb5929a3'
+    fluxCVersion = '9bc869ef0be78c1c65377c8047f2ab01489e43d1'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
This PR fixes the origin address in the shipping label creation flow. For the testing purposes the order billing address was used, since the store address was not being fetched. It's now been added in the FluxC, so it's used now.

_Note_: The site settings only contain the address, so the name or company name will need to be filled out by hand.

**To test:**
1. Open an order that satisfies the SL requirements
2. Tap on the Create shipping label button
3. Verify the correct store address (stored in Woo settings) is displayed as the origin shipping address