### PR TITLE
Shipping Label Packages: load last used package

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingAccountSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingAccountSettings.kt
@@ -1,0 +1,33 @@
+package com.woocommerce.android.model
+
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingAccountSettings
+
+data class ShippingAccountSettings(
+    val canManagePayments: Boolean,
+    val selectedPaymentId: Int?,
+    val paymentMethods: List<PaymentMethod>,
+    val lastUsedBoxId: String?
+)
+
+data class PaymentMethod(
+    val id: Int,
+    val name: String,
+    val cardType: String,
+    val cardDigits: String
+)
+
+fun WCShippingAccountSettings.toAppModel(): ShippingAccountSettings {
+    return ShippingAccountSettings(
+        canManagePayments = canManagePayments,
+        selectedPaymentId = selectedPaymentMethodId,
+        paymentMethods = paymentMethods.map {
+            PaymentMethod(
+                id = it.paymentMethodId,
+                name = it.name,
+                cardType = it.cardType,
+                cardDigits = it.cardDigits
+            )
+        },
+        lastUsedBoxId = lastUsedBoxId
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingPackage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingPackage.kt
@@ -7,7 +7,7 @@ import org.wordpress.android.fluxc.model.shippinglabels.WCPackagesResult.Predefi
 
 @Parcelize
 data class ShippingPackage(
-    val id: String? = null,
+    val id: String,
     val title: String,
     val isLetter: Boolean,
     val category: String,
@@ -28,6 +28,7 @@ data class PackageDimensions(
 fun CustomPackage.toAppModel(): ShippingPackage {
     val dimensionsParts = dimensions.split("x")
     return ShippingPackage(
+        id = title,
         title = title,
         isLetter = isLetter,
         dimensions = PackageDimensions(
@@ -43,6 +44,7 @@ fun PredefinedOption.toAppModel(): List<ShippingPackage> {
     return predefinedPackages.map {
         val dimensionsParts = it.dimensions.split("x")
         ShippingPackage(
+            id = it.id,
             title = it.title,
             isLetter = it.isLetter,
             dimensions = PackageDimensions(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.shippinglabels
 
 import com.woocommerce.android.annotations.OpenClassOnDebug
+import com.woocommerce.android.model.ShippingAccountSettings
 import com.woocommerce.android.model.ShippingLabel
 import com.woocommerce.android.model.ShippingPackage
 import com.woocommerce.android.model.toAppModel
@@ -60,6 +61,14 @@ class ShippingLabelRepository @Inject constructor(
             }
 
             WooResult(list)
+        }
+    }
+
+    suspend fun getAccountSettings(): WooResult<ShippingAccountSettings> {
+        return shippingLabelStore.getAccountSettings(selectedSite.get()).let { result ->
+            if (result.isError) return@let WooResult(error = result.error)
+
+            WooResult(result.model!!.toAppModel())
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -40,6 +40,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsS
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import kotlinx.android.parcel.Parcelize
@@ -48,6 +49,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
+import java.text.DecimalFormat
 
 @ExperimentalCoroutinesApi
 class CreateShippingLabelViewModel @AssistedInject constructor(
@@ -59,7 +61,8 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
     private val addressValidator: ShippingLabelAddressValidator,
     private val site: SelectedSite,
     private val wooStore: WooCommerceStore,
-    private val accountStore: AccountStore
+    private val accountStore: AccountStore,
+    private val resourceProvider: ResourceProvider
 ) : ScopedViewModel(savedState, dispatchers) {
     companion object {
         private const val STATE_KEY = "state"
@@ -205,7 +208,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                 viewState.copy(
                     originAddressStep = Step.done(data.originAddress.toString()),
                     shippingAddressStep = Step.done(data.shippingAddress.toString()),
-                    packagingDetailsStep = Step.done(),
+                    packagingDetailsStep = Step.done(getPackageDetailsDescription(data.shippingPackages)),
                     customsStep = Step.current(),
                     carrierStep = Step.notDone(),
                     paymentStep = Step.notDone()
@@ -215,7 +218,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                 viewState.copy(
                     originAddressStep = Step.done(data.originAddress.toString()),
                     shippingAddressStep = Step.done(data.shippingAddress.toString()),
-                    packagingDetailsStep = Step.done(),
+                    packagingDetailsStep = Step.done(getPackageDetailsDescription(data.shippingPackages)),
                     customsStep = Step.done(),
                     carrierStep = Step.current(),
                     paymentStep = Step.notDone()
@@ -225,7 +228,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                 viewState.copy(
                     originAddressStep = Step.done(data.originAddress.toString()),
                     shippingAddressStep = Step.done(data.shippingAddress.toString()),
-                    packagingDetailsStep = Step.done(),
+                    packagingDetailsStep = Step.done(getPackageDetailsDescription(data.shippingPackages)),
                     customsStep = Step.done(),
                     carrierStep = Step.done(),
                     paymentStep = Step.current()
@@ -235,7 +238,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                 viewState.copy(
                     originAddressStep = Step.done(data.originAddress.toString()),
                     shippingAddressStep = Step.done(data.shippingAddress.toString()),
-                    packagingDetailsStep = Step.done(),
+                    packagingDetailsStep = Step.done(getPackageDetailsDescription(data.shippingPackages)),
                     customsStep = Step.done(),
                     carrierStep = Step.done(),
                     paymentStep = Step.done()
@@ -283,6 +286,39 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
             is ValidationResult.NameMissing -> AddressInvalid(address, result)
             is ValidationResult.Error -> AddressValidationFailed
         }
+    }
+
+    private fun getPackageDetailsDescription(shippingPackages: List<ShippingLabelPackage>): String {
+        val firstLine = if (shippingPackages.size == 1) {
+            shippingPackages.first().selectedPackage!!.title
+        } else {
+            // TODO properly test this during M3
+            resourceProvider.getString(
+                string.shipping_label_multi_packages_items_count,
+                shippingPackages.sumBy { it.items.size },
+                shippingPackages.size
+            )
+        }
+
+        val weightDimension = wooStore.getProductSettings(site.get())?.weightUnit ?: ""
+        val stringResource = if (shippingPackages.size == 1) {
+            string.shipping_label_single_package_total_weight
+        } else {
+            string.shipping_label_multi_packages_total_weight
+        }
+        val weightFormatted = with(DecimalFormat()) {
+            maximumFractionDigits = 4
+            minimumFractionDigits = 0
+            format(shippingPackages.sumByDouble { it.weight })
+        }
+
+        val secondLine = resourceProvider.getString(
+            stringResource,
+            weightFormatted,
+            weightDimension
+        )
+
+        return "$firstLine\n$secondLine"
     }
 
     fun onAddressEditConfirmed(address: Address) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackagesAdapter.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
+import com.woocommerce.android.R
 import com.woocommerce.android.databinding.ShippingPackageListHeaderBinding
 import com.woocommerce.android.databinding.ShippingPackageListItemBinding
 import com.woocommerce.android.model.ShippingPackage
@@ -80,7 +81,12 @@ class ShippingPackagesAdapter(
 
     private class HeaderViewHolder(private val binding: ShippingPackageListHeaderBinding) : ViewHolder(binding.root) {
         fun bind(title: String) {
-            binding.root.text = title
+            if (title == ShippingPackage.CUSTOM_PACKAGE_CATEGORY) {
+                binding.root.text =
+                    binding.root.context.getString(R.string.shipping_label_packages_custom_section_title)
+            } else {
+                binding.root.text = title
+            }
         }
     }
 

--- a/WooCommerce/src/main/res/drawable/shipping_package_item_bg.xml
+++ b/WooCommerce/src/main/res/drawable/shipping_package_item_bg.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="?attr/colorSurface" />
+    <item android:drawable="@color/color_surface_elevated_04"/>
     <item android:drawable="?attr/selectableItemBackground" />
 </layer-list>

--- a/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<com.woocommerce.android.widgets.WCElevatedConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="@color/color_surface"
-    android:orientation="vertical">
+    android:layout_height="wrap_content">
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/package_name"
@@ -51,7 +49,7 @@
         android:id="@+id/items_section_title"
         android:layout_width="0dp"
         android:layout_height="@dimen/major_300"
-        android:background="@color/default_window_background"
+        android:background="?android:attr/colorBackground"
         android:gravity="center_vertical"
         android:paddingStart="@dimen/major_100"
         android:paddingEnd="@dimen/major_100"
@@ -136,4 +134,4 @@
         app:layout_constraintStart_toStartOf="@id/weight_edit_text"
         app:layout_constraintTop_toBottomOf="@id/weight_edit_text" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</com.woocommerce.android.widgets.WCElevatedConstraintLayout>

--- a/WooCommerce/src/main/res/layout/shipping_package_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_package_list_item.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@drawable/clickable_list_item_color_surface_bg"
+    android:background="@drawable/shipping_package_item_bg"
     android:orientation="vertical">
 
     <com.google.android.material.textview.MaterialTextView

--- a/WooCommerce/src/main/res/layout/skeleton_shipping_label_package_details.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_shipping_label_package_details.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<com.woocommerce.android.widgets.WCElevatedLinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/color_surface"
@@ -76,4 +76,4 @@
         android:layout_margin="@dimen/major_75"
         android:background="@drawable/skeleton_background" />
 
-</LinearLayout>
+</com.woocommerce.android.widgets.WCElevatedLinearLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -405,6 +405,11 @@
     <string name="shipping_label_package_selector_title">Selected Package</string>
     <string name="shipping_label_package_details_weight_error">Invalid weight</string>
     <string name="shipping_label_missing_data_snackbar_message">Certain required fields are blank.</string>
+    <string name="shipping_label_package_details_fetch_products_error">Can\'t fetch products</string>
+    <string name="shipping_label_packages_custom_section_title">Custom packages</string>
+    <string name="shipping_label_single_package_total_weight">Total package weight: %1$s %2$s</string>
+    <string name="shipping_label_multi_packages_items_count">%1$d items in %2$d packages</string>
+    <string name="shipping_label_multi_packages_total_weight">Total package weight: %1$s %2$s</string>
     <!--
         Refunds
     -->
@@ -1511,6 +1516,4 @@
     <string name="product_downloadable_files_add_manually">Enter file URL</string>
     <string name="product_downloadable_files_name_invalid">Please enter a valid name</string>
     <string name="product_downloadable_files_download_settings">Download Settings</string>
-    <string name="shipping_label_package_details_fetch_products_error">Can\'t fetch products</string>
-    <string name="shipping_label_packages_custom_section_title">Custom packages</string>
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1511,4 +1511,5 @@
     <string name="product_downloadable_files_name_invalid">Please enter a valid name</string>
     <string name="product_downloadable_files_download_settings">Download Settings</string>
     <string name="shipping_label_package_details_fetch_products_error">Can\'t fetch products</string>
+    <string name="shipping_label_packages_custom_section_title">Custom packages</string>
 </resources>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
@@ -23,6 +23,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Transition
 import com.woocommerce.android.util.CoroutineTestRule
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -47,6 +48,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
     private val site: SelectedSite = mock()
     private val wooStore: WooCommerceStore = mock()
     private val accountStore: AccountStore = mock()
+    private val resourceProvider: ResourceProvider = mock()
     private lateinit var stateFlow: MutableStateFlow<Transition>
 
     private val originAddress = CreateShippingLabelTestUtils.generateAddress()
@@ -139,7 +141,8 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
                 addressValidator,
                 site,
                 wooStore,
-                accountStore
+                accountStore,
+                resourceProvider
             )
         )
 

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '304e89c629658b555f8b9f0cebb8234efb5929a3'
+    fluxCVersion = 'fbf17994b480304a53ac549377ec9b94fa7d316e'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Last part of #3019, this adds logic to load the last used package from the backend, and fixes the "custom packages" section title.

I added also one commit to update colors to fix the dark theming: 129b0f1, for `shipping_package_list_item`, I didn't use a MaterialCardView or WCElevatedLinearLayout because we don't need the bottom shadow, as we need to show dividers for all items.

This is not ready to merge, the PR https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1861 has to be merged first.

Unit tests for the whole feature will be done in another PR.

#### Testing

1. Create a shipping label using wp-admin.
2. Prepare another order on the web that satisfies SL creation preconditions.
3. Go to Orders -> Open the order
4. Pass the steps of origin and destination addresses.
5. Click on Continue of Package details.
6. Confirm that the used package in the first step is used by default.
7. Go to the web and delete this package from shipping settings.
8. Repeat steps 3 -> 5
9. Confirm that the packages spinner value is empty. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
