### PR TITLE
Shipping labels: A couple of edit address form tweaks

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -86,7 +86,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                         is SideEffect.LoadData -> handleResult { loadData(sideEffect.orderId) }
                         is SideEffect.ValidateAddress -> handleResult(
                             progressDialogTitle = string.shipping_label_edit_address_validation_progress_title,
-                            progressDialogMessage = string.shipping_label_edit_address_validation_progress_message
+                            progressDialogMessage = string.shipping_label_edit_address_progress_message
                         ) {
                             validateAddress(sideEffect.address, sideEffect.type)
                         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -191,7 +191,7 @@ class EditShippingLabelAddressFragment
                     if (isVisible) {
                         showProgressDialog(
                             getString(R.string.shipping_label_edit_address_validation_progress_title),
-                            getString(R.string.shipping_label_edit_address_validation_progress_message)
+                            getString(R.string.shipping_label_edit_address_progress_message)
                         )
                     } else {
                         hideProgressDialog()
@@ -200,8 +200,8 @@ class EditShippingLabelAddressFragment
             new.isLoadingProgressDialogVisible?.takeIfNotEqualTo(old?.isLoadingProgressDialogVisible) { isVisible ->
                 if (isVisible) {
                     showProgressDialog(
-                        getString(R.string.shipping_label_edit_address_validation_progress_title),
-                        getString(R.string.shipping_label_edit_address_loading_progress_title)
+                        getString(R.string.shipping_label_edit_address_loading_progress_title),
+                        getString(R.string.shipping_label_edit_address_progress_message)
                     )
                 } else {
                     hideProgressDialog()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -134,6 +134,7 @@ class EditShippingLabelAddressViewModel @AssistedInject constructor(
                 viewState = viewState.copy(
                     nameError = R.string.shipping_label_error_required_field
                 )
+                triggerEvent(ShowSnackbar(R.string.shipping_label_missing_data_snackbar_message))
             }
         }
     }
@@ -177,6 +178,8 @@ class EditShippingLabelAddressViewModel @AssistedInject constructor(
         viewState.address?.let { address ->
             if (areRequiredFieldsValid(address)) {
                 triggerEvent(ExitWithResult(address))
+            } else {
+                triggerEvent(ShowSnackbar(R.string.shipping_label_missing_data_snackbar_message))
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -97,8 +97,9 @@ class EditShippingLabelAddressViewModel @AssistedInject constructor(
     private fun loadCountriesAndStates() {
         launch {
             if (countries.isEmpty()) {
-                viewState = viewState.copy(isValidationProgressDialogVisible = true)
+                viewState = viewState.copy(isLoadingProgressDialogVisible = true)
                 dataStore.fetchCountriesAndStates(site.get())
+                viewState = viewState.copy(isLoadingProgressDialogVisible = false)
             }
             viewState = viewState.copy(
                 isValidationProgressDialogVisible = false,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -44,9 +44,8 @@ class EditShippingLabelAddressViewModel @AssistedInject constructor(
     val viewStateData = LiveDataDelegate(savedState, ViewState(arguments.address))
     private var viewState by viewStateData
 
-    private val countries: List<WCLocationModel> by lazy {
-        dataStore.getCountries()
-    }
+    private val countries: List<WCLocationModel>
+        get() = dataStore.getCountries()
 
     private val states: List<WCLocationModel>
         get() = viewState.address?.country?.let { dataStore.getStates(it) } ?: emptyList()

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -16,7 +16,7 @@ Language: es
     <string name="shipping_label_error_address_not_found">No se encuentra la dirección</string>
     <string name="shipping_label_edit_address_error_warning">No hemos podido verificar automáticamente la dirección de envío. Puedes verlo en Google Maps o puedes contactar con el cliente para asegurarte de que la dirección es correcta.</string>
     <string name="shipping_label_edit_address_validation_error">Error al validar la dirección</string>
-    <string name="shipping_label_edit_address_validation_progress_message">Por favor, espera…</string>
+    <string name="shipping_label_edit_address_progress_message">Por favor, espera…</string>
     <string name="shipping_label_edit_address_validation_progress_title">Validación de la dirección en curso</string>
     <string name="shipping_label_edit_data_loading_error">No se han podido cargar los datos de la dirección</string>
     <string name="shipping_label_edit_address_use_address_as_is">Usar la dirección especificada</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -16,7 +16,7 @@ Language: fr
     <string name="shipping_label_error_address_not_found">Adresse introuvable</string>
     <string name="shipping_label_edit_address_error_warning">Nous n’avons pas pu vérifier l’adresse d’expédition automatiquement. Affichez-la dans Google Maps ou essayez de contacter le client pour vous assurer que l’adresse est correcte.</string>
     <string name="shipping_label_edit_address_validation_error">Échec de la validation de l’adresse</string>
-    <string name="shipping_label_edit_address_validation_progress_message">Veuillez patienter…</string>
+    <string name="shipping_label_edit_address_progress_message">Veuillez patienter…</string>
     <string name="shipping_label_edit_address_validation_progress_title">Validation de l’adresse en cours</string>
     <string name="shipping_label_edit_data_loading_error">Impossible de charger les données d’adresse</string>
     <string name="shipping_label_edit_address_use_address_as_is">Utiliser l’adresse saisie</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -16,7 +16,7 @@ Language: he_IL
     <string name="shipping_label_error_address_not_found">הכתובת לא נמצאה</string>
     <string name="shipping_label_edit_address_error_warning">לא הצלחנו לאמת באופן אוטומטי את הכתובת למשלוח. ניתן להציג אותה ב-Google Maps או לנסות ליצור קשר עם הלקוח כדי לוודא שהכתובת נכונה.</string>
     <string name="shipping_label_edit_address_validation_error">אימות הכתובת נכשל</string>
-    <string name="shipping_label_edit_address_validation_progress_message">רק רגע…</string>
+    <string name="shipping_label_edit_address_progress_message">רק רגע…</string>
     <string name="shipping_label_edit_address_validation_progress_title">אימות הכתובת בתהליך</string>
     <string name="shipping_label_edit_data_loading_error">אין אפשרות לטעון את נתוני הכתובת</string>
     <string name="shipping_label_edit_address_use_address_as_is">להשתמש בכתובת כפי שהוזנה</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -16,7 +16,7 @@ Language: it
     <string name="shipping_label_error_address_not_found">Indirizzo non trovato</string>
     <string name="shipping_label_edit_address_error_warning">Impossibile verificare automaticamente l\'indirizzo di spedizione. Visualizzalo su Google Maps o prova a contattare il cliente per assicurarti che l\'indirizzo sia corretto.</string>
     <string name="shipping_label_edit_address_validation_error">Convalida dell\'indirizzo non riuscita</string>
-    <string name="shipping_label_edit_address_validation_progress_message">Attendi…</string>
+    <string name="shipping_label_edit_address_progress_message">Attendi…</string>
     <string name="shipping_label_edit_address_validation_progress_title">Convalida dell\'indirizzo in corso</string>
     <string name="shipping_label_edit_data_loading_error">Impossibile caricare i dati dell\'indirizzo</string>
     <string name="shipping_label_edit_address_use_address_as_is">Usa l\'indirizzo inserito</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -16,7 +16,7 @@ Language: ja_JP
     <string name="shipping_label_error_address_not_found">住所が見つかりませんでした</string>
     <string name="shipping_label_edit_address_error_warning">自動的に配送先住所を確認できませんでした。 Google マップで表示するか、顧客に連絡して住所が正しいことを確認してください。</string>
     <string name="shipping_label_edit_address_validation_error">住所の確認に失敗しました</string>
-    <string name="shipping_label_edit_address_validation_progress_message">しばらくお待ちください…</string>
+    <string name="shipping_label_edit_address_progress_message">しばらくお待ちください…</string>
     <string name="shipping_label_edit_address_validation_progress_title">住所の確認中です</string>
     <string name="shipping_label_edit_data_loading_error">住所データを読み込むことができませんでした</string>
     <string name="shipping_label_edit_address_use_address_as_is">入力した住所を使用</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -16,7 +16,7 @@ Language: pt_BR
     <string name="shipping_label_error_address_not_found">O endereço não foi encontrado</string>
     <string name="shipping_label_edit_address_error_warning">Não foi possível verificar automaticamente o endereço de envio. Encontre-o no Google Maps ou tente entrar em contato com o cliente para confirmar se o endereço está correto.</string>
     <string name="shipping_label_edit_address_validation_error">Ocorreu uma falha na validação do endereço</string>
-    <string name="shipping_label_edit_address_validation_progress_message">Aguarde…</string>
+    <string name="shipping_label_edit_address_progress_message">Aguarde…</string>
     <string name="shipping_label_edit_address_validation_progress_title">Validação de endereço em andamento</string>
     <string name="shipping_label_edit_data_loading_error">Não foi possível carregar os dados de endereço</string>
     <string name="shipping_label_edit_address_use_address_as_is">Usar o endereço conforme inserido</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -16,7 +16,7 @@ Language: ru
     <string name="shipping_label_error_address_not_found">Адрес не найден</string>
     <string name="shipping_label_edit_address_error_warning">Не удалось автоматически проверить почтовый адрес. Укажите его на Google Картах или свяжитесь с клиентом и убедитесь, что адрес указан верно.</string>
     <string name="shipping_label_edit_address_validation_error">Сбой проверки адреса</string>
-    <string name="shipping_label_edit_address_validation_progress_message">Пожалуйста, подождите…</string>
+    <string name="shipping_label_edit_address_progress_message">Пожалуйста, подождите…</string>
     <string name="shipping_label_edit_address_validation_progress_title">Выполняется проверка адреса</string>
     <string name="shipping_label_edit_data_loading_error">Не удалось загрузить данные адреса</string>
     <string name="shipping_label_edit_address_use_address_as_is">Использовать введённый адрес</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -16,7 +16,7 @@ Language: sv_SE
     <string name="shipping_label_error_address_not_found">Adress hittades inte</string>
     <string name="shipping_label_edit_address_error_warning">Vi kunde inte verifiera leveransadressen automatiskt. Visa i Google Maps eller testa att kontakta kunden för att verifiera att adressen stämmer.</string>
     <string name="shipping_label_edit_address_validation_error">Adressvalideringen misslyckades</string>
-    <string name="shipping_label_edit_address_validation_progress_message">Vänta …</string>
+    <string name="shipping_label_edit_address_progress_message">Vänta …</string>
     <string name="shipping_label_edit_address_validation_progress_title">Adressvalideringen pågår</string>
     <string name="shipping_label_edit_data_loading_error">Det gick inte att läsa in adressdata</string>
     <string name="shipping_label_edit_address_use_address_as_is">Använd adressen som angavs</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -16,7 +16,7 @@ Language: tr
     <string name="shipping_label_error_address_not_found">Adres bulunamadı</string>
     <string name="shipping_label_edit_address_error_warning">Gönderim adresini otomatik olarak doğrulayamadık. Bunu Google Haritalar\'da görüntüleyin veya adresin doğru olduğundan emin olmak için müşteriyle iletişim kurmayı deneyin.</string>
     <string name="shipping_label_edit_address_validation_error">Adres doğrulanamadı</string>
-    <string name="shipping_label_edit_address_validation_progress_message">Lütfen bekleyin…</string>
+    <string name="shipping_label_edit_address_progress_message">Lütfen bekleyin…</string>
     <string name="shipping_label_edit_address_validation_progress_title">Adres doğrulama işlemi devam ediyor</string>
     <string name="shipping_label_edit_data_loading_error">Adres verileri yüklenemiyor </string>
     <string name="shipping_label_edit_address_use_address_as_is">Adresi girildiği gibi kullan</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -372,7 +372,7 @@
     <string name="shipping_label_edit_data_loading_error">Unable to load the address data</string>
     <string name="shipping_label_edit_address_validation_progress_title">Address validation in progress</string>
     <string name="shipping_label_edit_address_loading_progress_title">Loading address data</string>
-    <string name="shipping_label_edit_address_validation_progress_message">Please wait…</string>
+    <string name="shipping_label_edit_address_progress_message">Please wait…</string>
     <string name="shipping_label_edit_address_validation_error">Address validation failed</string>
     <string name="shipping_label_edit_address_error_warning">We were unable to automatically verify the shipping address. View it on Google Maps or try contacting the customer to make sure the address is correct.</string>
     <string name="shipping_label_error_address_not_found">Address was not found</string>
@@ -402,6 +402,7 @@
     <string name="shipping_label_package_details_title_template">Package %1$d</string>
     <string name="shipping_label_packages_loading_title">Loading Packages!</string>
     <string name="shipping_label_packages_loading_message">Please wait…</string>
+    <string name="shipping_label_missing_data_snackbar_message">Certain required fields are blank.</string>
     <!--
         Refunds
     -->


### PR DESCRIPTION
This PR fixes a couple of minor problems with the edit address screen:

- Validation progress dialog is shown for data loading.
- If there was an empty required field that's out of the view, it looked like the buttons didn't work. Snackbar message is now displayed, as well.
- After the country/state data was loaded for the first time, the country wasn't preselected.

**To test:**
1. Clear the app data before testing
2. Open an order that satisfies the SL preconditions
3. Tap on the Create shipping label button for the origin address 
4. Tap on the Continue button (the address must be invalid so that the edit form is opened)
5. Notice the correct progress dialog is shown
6. After the loading's done, notice the country is selected
7. Remove the name and company name
8. Tap on the Use addresss as is button
9. Notice a snackbar is shown 