### PR TITLE
Fix failing test in EditShippingLabelAddressViewModelTest

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
@@ -278,6 +278,7 @@ class EditShippingLabelAddressViewModelTest : BaseUnitTest() {
         viewModel.viewStateData.observeForever { _, new -> viewState = new }
 
         val emptyAddress = address.copy(
+            company = "",
             firstName = "",
             lastName = "",
             address1 = "",


### PR DESCRIPTION
This fixes this failing test: https://app.circleci.com/pipelines/github/woocommerce/woocommerce-android/9499/workflows/ba391f79-e021-4f7b-8ecb-83aede8d864b/jobs/29319

The failure is coming from this [PR](https://github.com/woocommerce/woocommerce-android/pull/3523), as it was merged before the unit tests PR, and changed the logic of required fields.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
