### PR TITLE
Set Reviews list item divider to use vertical orientation.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/UnreadItemDecoration.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/UnreadItemDecoration.kt
@@ -17,7 +17,7 @@ import kotlin.math.roundToInt
  * communicate unread items (such as unread product reviews)
  */
 class UnreadItemDecoration(context: Context, private val decorListener: ItemDecorationListener) :
-        DividerItemDecoration(context, HORIZONTAL) {
+        DividerItemDecoration(context, VERTICAL) {
     interface ItemDecorationListener {
         fun getItemTypeAtPosition(position: Int): ItemType
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/UnreadItemDecoration.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/UnreadItemDecoration.kt
@@ -4,9 +4,11 @@ import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.Rect
+import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.State
 import com.woocommerce.android.R
 import com.woocommerce.android.widgets.sectionedrecyclerview.SectionedRecyclerViewAdapter
 import org.wordpress.android.util.DisplayUtils
@@ -60,5 +62,14 @@ class UnreadItemDecoration(context: Context, private val decorListener: ItemDeco
                 canvas.drawRect(left, top, right, bottom, paint)
             }
         }
+    }
+
+    override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: State) {
+        // Hide the default divider between review item
+        outRect.setEmpty()
+    }
+
+    override fun onDraw(c: Canvas, parent: RecyclerView, state: State) {
+        // Draw nothing to hide divider line below review header
     }
 }


### PR DESCRIPTION
Fix for #1814.

This removes the extra line to the right side of the review list. Apparently that happened because the `DividerItemDecoration` thought it's being put in a RecyclerView with a horizontal orientation, so it added the horizontal thin line to the right.

#### Screenshots
**Before:**
<img src="https://user-images.githubusercontent.com/266376/107327594-f2e0c480-6adf-11eb-8f45-0f36336d8421.png" width="300" /> <img src="https://user-images.githubusercontent.com/266376/107327599-f70ce200-6adf-11eb-9111-87a502977349.png" width="300" />

**After:**

(not very obvious, but if you squint you can see that the image below no longer have the thin line to the right)

<img src="https://user-images.githubusercontent.com/266376/107328014-a3e75f00-6ae0-11eb-9782-d5a0ac86e3b2.png" width="300" />

#### Testing:
0. Start in Dark mode.
1. Open Reviews tab.
2. Make sure there's no visible thin line on the right side of the list
3. Change orientation, make sure the line still does not show up


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
