### PR TITLE
Shipping Labels: update the caching logic

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
@@ -84,5 +84,6 @@ class ShippingLabelRepository @Inject constructor(
 
     fun clearCache() {
         accountSettings = null
+        availablePackages = null
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation
 
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.ShippingLabelPackage
-import com.woocommerce.android.model.ShippingPackage
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.ValidationResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -50,7 +49,6 @@ sealed class CreateShippingLabelEvent : MultiLiveEvent.Event() {
 
     data class ShowPackageDetails(
         val orderIdentifier: OrderIdentifier,
-        val shippingLabelPackages: List<ShippingLabelPackage>,
-        val availablePackages: List<ShippingPackage>
+        val shippingLabelPackages: List<ShippingLabelPackage>
     ) : CreateShippingLabelEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -146,8 +146,7 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
                     val action = CreateShippingLabelFragmentDirections
                         .actionCreateShippingLabelFragmentToEditShippingLabelPackagesFragment(
                             orderId = event.orderIdentifier,
-                            shippingLabelPackages = event.shippingLabelPackages.toTypedArray(),
-                            availablePackages = event.availablePackages.toTypedArray()
+                            shippingLabelPackages = event.shippingLabelPackages.toTypedArray()
                         )
                     findNavController().navigateSafely(action)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -379,6 +379,11 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
         }
     }
 
+    override fun onCleared() {
+        super.onCleared()
+        shippingLabelRepository.clearCache()
+    }
+
     @Parcelize
     data class ViewState(
         val originAddressStep: Step? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -8,7 +8,6 @@ import com.woocommerce.android.R.string
 import com.woocommerce.android.di.ViewModelAssistedFactory
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.ShippingLabelPackage
-import com.woocommerce.android.model.ShippingPackage
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRepository
@@ -30,7 +29,6 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.AddressValidationFailed
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.EditAddressRequested
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.EditPackagingCanceled
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.LoadPackagesFailed
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.PackagesSelected
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.SuggestedAddressAccepted
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.SuggestedAddressDiscarded
@@ -73,8 +71,6 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 
-    private var availablePackages: List<ShippingPackage> = emptyList()
-
     init {
         initializeStateMachine()
     }
@@ -109,7 +105,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                                 sideEffect.type
                             )
                         )
-                        is SideEffect.ShowPackageOptions -> loadAndOpenPackagesDetails(sideEffect.shippingPackages)
+                        is SideEffect.ShowPackageOptions -> openPackagesDetails(sideEffect.shippingPackages)
                         is SideEffect.ShowCustomsForm -> Event.CustomsFormFilledOut
                         is SideEffect.ShowCarrierOptions -> Event.ShippingCarrierSelected
                         is SideEffect.ShowPaymentDetails -> Event.PaymentSelected
@@ -147,27 +143,11 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
         }
     }
 
-    private suspend fun loadAndOpenPackagesDetails(currentShippingPackages: List<ShippingLabelPackage>) {
-        if (availablePackages.isEmpty()) {
-            val progressDialogState = ProgressDialogState(
-                isShown = true,
-                title = string.shipping_label_packages_loading_title,
-                message = string.shipping_label_packages_loading_message
-            )
-            viewState = viewState.copy(progressDialogState = progressDialogState)
-            val availablePackagesResult = shippingLabelRepository.getShippingPackages()
-            viewState = viewState.copy(progressDialogState = ProgressDialogState(isShown = false))
-            if (availablePackagesResult.isError) {
-                stateMachine.handleEvent(LoadPackagesFailed)
-                return
-            }
-            availablePackages = availablePackagesResult.model!!
-        }
+    private fun openPackagesDetails(currentShippingPackages: List<ShippingLabelPackage>) {
         triggerEvent(
             ShowPackageDetails(
                 orderIdentifier = arguments.orderIdentifier,
-                shippingLabelPackages = currentShippingPackages,
-                availablePackages = availablePackages
+                shippingLabelPackages = currentShippingPackages
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -116,8 +116,7 @@ class EditShippingLabelPackagesFragment : BaseFragment(R.layout.fragment_edit_sh
                 is OpenPackageSelectorEvent -> {
                     val action = EditShippingLabelPackagesFragmentDirections
                         .actionEditShippingLabelPackagesFragmentToShippingPackageSelectorFragment(
-                            position = event.position,
-                            availablePackages = emptyArray()
+                            position = event.position
                         )
 
                     findNavController().navigateSafely(action)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -117,7 +117,7 @@ class EditShippingLabelPackagesFragment : BaseFragment(R.layout.fragment_edit_sh
                     val action = EditShippingLabelPackagesFragmentDirections
                         .actionEditShippingLabelPackagesFragmentToShippingPackageSelectorFragment(
                             position = event.position,
-                            availablePackages = viewModel.availablePackages
+                            availablePackages = emptyArray()
                         )
 
                     findNavController().navigateSafely(action)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -47,9 +47,6 @@ class EditShippingLabelPackagesViewModel @AssistedInject constructor(
         parameterRepository.getParameters(KEY_PARAMETERS, savedState)
     }
 
-    val availablePackages
-        get() = arguments.availablePackages
-
     init {
         initState()
     }
@@ -68,10 +65,18 @@ class EditShippingLabelPackagesViewModel @AssistedInject constructor(
 
     private suspend fun createDefaultPackage(): List<ShippingLabelPackage> {
         viewState = viewState.copy(showSkeletonView = true)
+
+        val shippingPackagesResult = shippingLabelRepository.getShippingPackages()
+        if (shippingPackagesResult.isError) {
+            triggerEvent(ShowSnackbar(R.string.shipping_label_packages_loading_error))
+            triggerEvent(Exit)
+            return emptyList()
+        }
+
         val lastUsedPackage = shippingLabelRepository.getAccountSettings().let { result ->
             if (result.isError) return@let null
             val savedPackageId = result.model!!.lastUsedBoxId
-            availablePackages.find { it.id == savedPackageId }
+            shippingPackagesResult.model!!.find { it.id == savedPackageId }
         }
 
         val order = requireNotNull(orderDetailRepository.getOrder(arguments.orderId))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -291,10 +291,6 @@ class ShippingLabelsStateMachine @Inject constructor() {
             on<Event.EditPackagingCanceled> {
                 transitionTo(State.WaitingForInput(data), SideEffect.UpdateViewState(data))
             }
-
-            on<Event.LoadPackagesFailed> {
-                transitionTo(State.WaitingForInput(data), SideEffect.ShowError(Error.PackagesLoadingError))
-            }
         }
 
         state<State.CustomsDeclaration> {
@@ -433,7 +429,6 @@ class ShippingLabelsStateMachine @Inject constructor() {
         object PackageSelectionStarted : Event()
         object EditPackagingRequested : Event()
         object EditPackagingCanceled : Event()
-        object LoadPackagesFailed : Event()
         data class PackagesSelected(val shippingPackages: List<ShippingLabelPackage>) : Event()
 
         object CustomsDeclarationStarted : Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackageSelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackageSelectorFragment.kt
@@ -2,14 +2,20 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation
 
 import android.os.Bundle
 import android.view.View
+import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.observe
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentShippingPackagesSelectorBinding
 import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import javax.inject.Inject
 
@@ -18,6 +24,7 @@ class ShippingPackageSelectorFragment : BaseFragment(R.layout.fragment_shipping_
         const val SELECTED_PACKAGE_RESULT = "selected-package"
     }
 
+    @Inject lateinit var uiMessageResolver: UIMessageResolver
     @Inject lateinit var viewModelFactory: ViewModelFactory
     val viewModel: ShippingPackageSelectorViewModel by viewModels { viewModelFactory }
 
@@ -37,14 +44,24 @@ class ShippingPackageSelectorFragment : BaseFragment(R.layout.fragment_shipping_
             adapter = packagesAdapter
         }
 
-        packagesAdapter.updatePackages(viewModel.availablePackages)
-        setupObservers()
+        setupObservers(binding)
     }
 
-    private fun setupObservers() {
+    private fun setupObservers(binding: FragmentShippingPackagesSelectorBinding) {
+        viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
+            new.packagesList.takeIfNotEqualTo(old?.packagesList) { list ->
+                packagesAdapter.updatePackages(list)
+            }
+            new.isLoading.takeIfNotEqualTo(old?.isLoading) { isLoading ->
+                binding.loadingProgress.isVisible = isLoading
+                binding.packagesList.isVisible = !isLoading
+            }
+        }
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
+                is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is ExitWithResult<*> -> navigateBackWithResult(SELECTED_PACKAGE_RESULT, event.data)
+                is Exit -> findNavController().navigateUp()
                 else -> event.isHandled = false
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackageSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackageSelectorViewModel.kt
@@ -3,19 +3,26 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation
 import android.os.Parcelable
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
+import com.woocommerce.android.R
 import com.woocommerce.android.di.ViewModelAssistedFactory
 import com.woocommerce.android.model.ShippingPackage
+import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRepository
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.viewmodel.LiveDataDelegate
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import kotlinx.android.parcel.Parcelize
+import kotlinx.coroutines.launch
 
 class ShippingPackageSelectorViewModel @AssistedInject constructor(
     @Assisted savedState: SavedStateWithArgs,
     dispatchers: CoroutineDispatchers,
-    parameterRepository: ParameterRepository
+    parameterRepository: ParameterRepository,
+    private val shippingLabelRepository: ShippingLabelRepository
 ) : ScopedViewModel(savedState, dispatchers) {
     companion object {
         private const val KEY_PARAMETERS = "key_parameters"
@@ -23,11 +30,30 @@ class ShippingPackageSelectorViewModel @AssistedInject constructor(
 
     private val arguments: ShippingPackageSelectorFragmentArgs by savedState.navArgs()
 
-    val availablePackages: List<ShippingPackage>
-        get() = arguments.availablePackages.toList()
+    val viewStateData = LiveDataDelegate(savedState, ViewState())
+    private var viewState by viewStateData
 
     val dimensionUnit: String by lazy {
         parameterRepository.getParameters(KEY_PARAMETERS, savedState).dimensionUnit ?: ""
+    }
+
+    init {
+        launch {
+            loadPackages()
+        }
+    }
+
+    private fun loadPackages() {
+        launch {
+            viewState = viewState.copy(isLoading = true)
+            val packagesListResult = shippingLabelRepository.getShippingPackages()
+            if (packagesListResult.isError) {
+                triggerEvent(ShowSnackbar(R.string.shipping_label_packages_loading_error))
+                triggerEvent(Exit)
+                return@launch
+            }
+            viewState = viewState.copy(isLoading = false, packagesList = packagesListResult.model!!)
+        }
     }
 
     fun onPackageSelected(shippingPackage: ShippingPackage) {
@@ -40,6 +66,12 @@ class ShippingPackageSelectorViewModel @AssistedInject constructor(
             )
         )
     }
+
+    @Parcelize
+    data class ViewState(
+        val packagesList: List<ShippingPackage> = emptyList(),
+        val isLoading: Boolean = false
+    ) : Parcelable
 
     @AssistedInject.Factory
     interface Factory : ViewModelAssistedFactory<ShippingPackageSelectorViewModel>

--- a/WooCommerce/src/main/res/layout/fragment_shipping_packages_selector.xml
+++ b/WooCommerce/src/main/res/layout/fragment_shipping_packages_selector.xml
@@ -5,6 +5,15 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <ProgressBar
+        android:id="@+id/loading_progress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/packages_list"
         android:layout_width="0dp"

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -325,8 +325,5 @@
         <argument
             android:name="position"
             app:argType="integer" />
-        <argument
-            android:name="availablePackages"
-            app:argType="com.woocommerce.android.model.ShippingPackage[]" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -309,9 +309,6 @@
         <argument
             android:name="shippingLabelPackages"
             app:argType="com.woocommerce.android.model.ShippingLabelPackage[]" />
-        <argument
-            android:name="availablePackages"
-            app:argType="com.woocommerce.android.model.ShippingPackage[]" />
         <action
             android:id="@+id/action_editShippingLabelPackagesFragment_to_shippingPackageSelectorFragment"
             app:destination="@id/shippingPackageSelectorFragment"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
@@ -39,7 +39,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
         private const val ORDER_ID = "1-1-1"
     }
 
-    private val availablePackages = arrayOf(
+    private val availablePackages = listOf(
         ShippingPackage(
             "id1", "title1", false, "provider1", PackageDimensions(1.0, 1.0, 1.0)
         ),
@@ -68,14 +68,15 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
 
     private lateinit var viewModel: EditShippingLabelPackagesViewModel
 
-    fun setup(currentPackages: Array<ShippingLabelPackage>) {
+    suspend fun setup(currentPackages: Array<ShippingLabelPackage>) {
         val savedState: SavedStateWithArgs = spy(
             SavedStateWithArgs(
                 SavedStateHandle(),
                 null,
-                EditShippingLabelPackagesFragmentArgs(ORDER_ID, currentPackages, availablePackages)
+                EditShippingLabelPackagesFragmentArgs(ORDER_ID, currentPackages)
             )
         )
+        whenever(shippingLabelRepository.getShippingPackages()).thenReturn(WooResult(availablePackages))
         whenever(orderDetailRepository.getOrder(ORDER_ID)).thenReturn(testOrder)
         whenever(productDetailRepository.getProduct(any())).thenReturn(testProduct)
         whenever(parameterRepository.getParameters(any(), any())).thenReturn(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackageSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackageSelectorViewModelTest.kt
@@ -7,6 +7,8 @@ import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.whenever
 import com.woocommerce.android.model.PackageDimensions
 import com.woocommerce.android.model.ShippingPackage
+import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRepository
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingPackageSelectorViewModel.ViewState
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.util.CoroutineTestRule
@@ -15,14 +17,16 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 
 @ExperimentalCoroutinesApi
 class ShippingPackageSelectorViewModelTest : BaseUnitTest() {
-    private val availablePackages = arrayOf(
+    private val availablePackages = listOf(
         ShippingPackage(
             "id1", "title1", false, "provider1", PackageDimensions(1.0, 1.0, 1.0)
         ),
@@ -31,6 +35,7 @@ class ShippingPackageSelectorViewModelTest : BaseUnitTest() {
         )
     )
     private val parameterRepository: ParameterRepository = mock()
+    private val shippingRepository: ShippingLabelRepository = mock()
 
     @get:Rule
     var coroutinesTestRule = CoroutineTestRule()
@@ -38,7 +43,7 @@ class ShippingPackageSelectorViewModelTest : BaseUnitTest() {
         SavedStateWithArgs(
             SavedStateHandle(),
             null,
-            ShippingPackageSelectorFragmentArgs(0, availablePackages)
+            ShippingPackageSelectorFragmentArgs(0)
         )
     )
 
@@ -49,16 +54,23 @@ class ShippingPackageSelectorViewModelTest : BaseUnitTest() {
         whenever(parameterRepository.getParameters(any(), any())).thenReturn(
             SiteParameters("", "", "cm", 0f)
         )
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(shippingRepository.getShippingPackages()).thenReturn(WooResult(availablePackages))
+        }
         viewModel = ShippingPackageSelectorViewModel(
             savedState,
             coroutinesTestRule.testDispatchers,
-            parameterRepository
+            parameterRepository,
+            shippingRepository
         )
     }
 
     @Test
-    fun `display list of packages`() {
-        assertThat(viewModel.availablePackages).isEqualTo(availablePackages.toList())
+    fun `display list of packages`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+        var viewState: ViewState? = null
+        viewModel.viewStateData.observeForever { _, state -> viewState = state }
+
+        assertThat(viewState!!.packagesList).isEqualTo(availablePackages.toList())
         assertThat(viewModel.dimensionUnit).isEqualTo("cm")
     }
 


### PR DESCRIPTION
This PRs updates the logic of caching API responses between the Shipping Label creation form screens:

1. Make the `ShippingLabelRepository` singleton, and use it to cache the API responses.
2. Update the packages details screen to load the packages while displaying a skeleton view.
3. Update the packages selector screen to load packages from the repository, and add a ProgressBar in case the cache wasn't there (it should be rare: process death for example)

The point 1 is temporary, the goal is to create a custom scope for the Shipping Label creation form, and tell Dagger to scope the `ShippingLabelRepository` for it.

#### Testing
1. Create an order that meets the criteria of shipping label creation.
2. Open the order detail, and click on `create a shipping label`
3. Pass the address validation steps.
4. Click on package details.
5. Notice that the `loading packages` dialog is not shown, and instead, the skeleton view is displayed.
6. Click on the `package` dropdown.
7. Notice that the packages were retrieved from the cache (no progress bar)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
