### PR TITLE
Issue/3544 products initial load

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -241,7 +241,7 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
             new.isSkeletonShown?.takeIfNotEqualTo(old?.isSkeletonShown) { showSkeleton(it) }
             new.isLoadingMore?.takeIfNotEqualTo(old?.isLoadingMore) { showLoadMoreProgress(it) }
             new.isRefreshing?.takeIfNotEqualTo(old?.isRefreshing) {
-                setIsRefreshing(false)
+                setIsRefreshing(it)
             }
             new.isEmptyViewVisible?.takeIfNotEqualTo(old?.isEmptyViewVisible) { isEmptyViewVisible ->
                 if (isEmptyViewVisible) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -232,11 +232,17 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
         return true
     }
 
+    private fun setIsRefreshing(isRefreshing: Boolean) {
+        binding.productsRefreshLayout.isRefreshing = isRefreshing
+    }
+
     private fun setupObservers(viewModel: ProductListViewModel) {
         viewModel.viewStateLiveData.observe(viewLifecycleOwner) { old, new ->
             new.isSkeletonShown?.takeIfNotEqualTo(old?.isSkeletonShown) { showSkeleton(it) }
             new.isLoadingMore?.takeIfNotEqualTo(old?.isLoadingMore) { showLoadMoreProgress(it) }
-            new.isRefreshing?.takeIfNotEqualTo(old?.isRefreshing) { binding.productsRefreshLayout.isRefreshing = it }
+            new.isRefreshing?.takeIfNotEqualTo(old?.isRefreshing) {
+                setIsRefreshing(false)
+            }
             new.isEmptyViewVisible?.takeIfNotEqualTo(old?.isEmptyViewVisible) { isEmptyViewVisible ->
                 if (isEmptyViewVisible) {
                     when {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -83,8 +83,6 @@ class ProductListViewModel @AssistedInject constructor(
 
     private fun isLoading() = viewState.isLoading == true
 
-    private fun isRefreshing() = viewState.isRefreshing == true
-
     fun getSearchQuery() = viewState.query
 
     fun onSearchQueryChanged(query: String) {
@@ -299,18 +297,14 @@ class ProductListViewModel @AssistedInject constructor(
         }
 
         viewState = viewState.copy(
-            isLoading = true,
+            isSkeletonShown = false,
+            isLoading = false,
+            isLoadingMore = false,
+            isRefreshing = false,
+            isAddProductButtonVisible = true,
             canLoadMore = productRepository.canLoadMoreProducts,
             isEmptyViewVisible = _productList.value?.isEmpty() == true,
             displaySortAndFilterCard = productFilterOptions.isNotEmpty() || _productList.value?.isNotEmpty() == true
-        )
-
-        viewState = viewState.copy(
-                isSkeletonShown = false,
-                isLoading = false,
-                isLoadingMore = false,
-                isRefreshing = false,
-                isAddProductButtonVisible = true
         )
 
         if (scrollToTop) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -285,6 +285,10 @@ class ProductListViewModel @AssistedInject constructor(
             viewState = viewState.copy(isRefreshing = true)
             loadProducts(scrollToTop = scrollToTop)
         } else {
+            // we have to set isRefreshing to null first since it will already be false here, but the refresh layout
+            // will be showing the loading progress since the user did a pull-to-refresh - without this, the loading
+            // progress will continue to show indefnitely
+            viewState = viewState.copy(isRefreshing = null)
             viewState = viewState.copy(isRefreshing = false)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -197,7 +197,6 @@ class ProductListViewModel @AssistedInject constructor(
         isRefreshing: Boolean = false
     ) {
         if (isLoading()) {
-            resetViewState()
             WooLog.d(WooLog.T.PRODUCTS, "already loading products")
             return
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -258,8 +258,6 @@ class ProductListViewModel @AssistedInject constructor(
                 }
             }
         }
-
-        resetViewState()
     }
 
     /**
@@ -330,6 +328,8 @@ class ProductListViewModel @AssistedInject constructor(
         if (scrollToTop) {
             triggerEvent(ScrollToTop)
         }
+
+        resetViewState()
     }
 
     private fun getSortingTitle(): Int {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -83,7 +83,7 @@ class ProductListViewModel @AssistedInject constructor(
 
     private fun isLoading() = viewState.isLoading == true
 
-    private fun isRefreshing() = viewState.isRefreshing == true
+    private fun isRefreshing() = viewState.isRefreshing != false
 
     fun getSearchQuery() = viewState.query
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -226,20 +226,16 @@ class ProductListViewModel @AssistedInject constructor(
 
             loadJob = launch {
                 val showSkeleton: Boolean
-                val isRefreshing: Boolean
                 if (loadMore) {
                     showSkeleton = false
-                    isRefreshing = false
                 } else {
                     // if this is the initial load, first get the products from the db and show them immediately
                     val productsInDb = productRepository.getProductList(productFilterOptions)
                     if (productsInDb.isEmpty()) {
                         showSkeleton = true
-                        isRefreshing = false
                     } else {
                         _productList.value = productsInDb
                         showSkeleton = false
-                        isRefreshing = true
                     }
                 }
                 viewState = viewState.copy(
@@ -247,7 +243,7 @@ class ProductListViewModel @AssistedInject constructor(
                         isLoadingMore = loadMore,
                         isSkeletonShown = showSkeleton,
                         isEmptyViewVisible = false,
-                        isRefreshing = isRefreshing,
+                        isRefreshing = !showSkeleton && !loadMore,
                         displaySortAndFilterCard = !showSkeleton,
                         isAddProductButtonVisible = !showSkeleton
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -281,11 +281,12 @@ class ProductListViewModel @AssistedInject constructor(
     }
 
     fun refreshProducts(scrollToTop: Boolean = false) {
-        if (!checkConnection()) {
-            return
+        if (checkConnection()) {
+            viewState = viewState.copy(isRefreshing = true)
+            loadProducts(scrollToTop = scrollToTop)
+        } else {
+            viewState = viewState.copy(isRefreshing = false)
         }
-        viewState = viewState.copy(isRefreshing = true)
-        loadProducts(scrollToTop = scrollToTop)
     }
 
     private suspend fun fetchProductList(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -83,7 +83,7 @@ class ProductListViewModel @AssistedInject constructor(
 
     private fun isLoading() = viewState.isLoading == true
 
-    private fun isRefreshing() = viewState.isRefreshing != false
+    private fun isRefreshing() = viewState.isRefreshing == true
 
     fun getSearchQuery() = viewState.query
 
@@ -226,16 +226,20 @@ class ProductListViewModel @AssistedInject constructor(
 
             loadJob = launch {
                 val showSkeleton: Boolean
+                val isRefreshing: Boolean
                 if (loadMore) {
                     showSkeleton = false
+                    isRefreshing = false
                 } else {
                     // if this is the initial load, first get the products from the db and show them immediately
                     val productsInDb = productRepository.getProductList(productFilterOptions)
                     if (productsInDb.isEmpty()) {
                         showSkeleton = true
+                        isRefreshing = false
                     } else {
                         _productList.value = productsInDb
-                        showSkeleton = !isRefreshing()
+                        showSkeleton = false
+                        isRefreshing = true
                     }
                 }
                 viewState = viewState.copy(
@@ -243,6 +247,7 @@ class ProductListViewModel @AssistedInject constructor(
                         isLoadingMore = loadMore,
                         isSkeletonShown = showSkeleton,
                         isEmptyViewVisible = false,
+                        isRefreshing = isRefreshing,
                         displaySortAndFilterCard = !showSkeleton,
                         isAddProductButtonVisible = !showSkeleton
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -263,10 +263,6 @@ class ProductListViewModel @AssistedInject constructor(
      * Resets the view state following a refresh
      */
     private fun resetViewState() {
-        // The refresh progress automatically appears when the user performs a PTR, and in this situation isRefreshing
-        // will still be false. Setting it to null first will ensure the fragment's observer removes the progress.
-        viewState = viewState.copy(isRefreshing = null)
-
         viewState = viewState.copy(
             isSkeletonShown = false,
             isLoading = false,


### PR DESCRIPTION
Fixes #3544 - The PR changes the product list skeleton to appear only when there are no cached products when you first go to the products tab. I also did a general cleanup of setting the view state

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
