### PR TITLE
Issue/3545 reset database

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -142,6 +142,9 @@ open class WooCommerce : MultiDexApplication(), HasAndroidInjector, ApplicationL
             null
         }
 
+        // Developers can uncomment the line below to clear the db tables at startup
+        // wellSqlConfig.resetDatabase()
+
         notificationHandler.createNotificationChannels(this)
 
         val lifecycleMonitor = ApplicationLifecycleMonitor(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
@@ -45,8 +45,8 @@ class WooWellSqlConfig(context: Context) : WellSqlConfig(context, ADDON_WOOCOMME
 
     /**
      * Useful during development when we want to test features with a "fresh" database. This can be
-     * called from WooCommerce.onCreate() after we initialize the database. For safety, this has no
-     * effect when called from a release build.
+     * called from WooCommerce.onCreate() after we initialize the database and access the selected
+     * site. For safety, this has no effect when called from a release build.
      */
     fun resetDatabase() {
         if (BuildConfig.DEBUG) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
@@ -57,7 +57,10 @@ class WooWellSqlConfig(context: Context) : WellSqlConfig(context, ADDON_WOOCOMME
             )
             toast.setGravity(Gravity.CENTER_HORIZONTAL or Gravity.BOTTOM, 0, 0)
             toast.show()
+
+            AppPrefs.init(context)
             AppPrefs.setDatabaseDowngraded(true)
+
             reset()
         }
     }


### PR DESCRIPTION
Fixes #3545 - the crash was occuring because neither `AppPrefs` nor `SelectedSite` was initialzed before `resetDatabase()` was being called. I also added [a comment in WooCommerce](https://github.com/woocommerce/woocommerce-android/blob/c093ccf9543bc7cc9888b74a7d723f572bc60279/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt#L146) illustrating where `resetDatabase()` should be called.

To test:

* Uncomment the line mentioned above
* Start the app and notice the "Resetting database" toast

![Screenshot_1612899617](https://user-images.githubusercontent.com/3903757/107426745-9e911100-6aee-11eb-9255-9fb7fba78269.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
