### PR TITLE
Add light Android Navigation Bar background support.

### DIFF
--- a/WooCommerce/src/main/res/values-v27/themes.xml
+++ b/WooCommerce/src/main/res/values-v27/themes.xml
@@ -8,4 +8,9 @@
         <item name="android:windowLightStatusBar">false</item>
         <item name="android:windowLightNavigationBar">false</item>
     </style>
+
+    <style name="Theme.Woo" parent="Theme.WooBase">
+        <item name="android:navigationBarColor">@color/color_surface</item>
+        <item name="android:windowLightNavigationBar">true</item>
+    </style>
 </resources>


### PR DESCRIPTION
This is for #2430

Android added support to change the background color of the Android Navigation Bar since API 21, but did not add the capability to change the button color. So if we change the background color to white, the button remains white and not visible.

[API 27 comes with the capability to support light colored bar with visible buttons](https://developer.android.com/reference/android/R.attr#windowLightNavigationBar), so this PR introduces that light bar properly **for devices with API >= 27 only**.

There are three styles of system navigation:
1. Gesture navigation, showing just a thin line at the bottom
2. 2-button navigation, showing two buttons on the bar
3. 3-button navigation, showing three buttons on the bar

This PR will affect all three styles.

## Before:

(Gesture navigation)

<img src="https://user-images.githubusercontent.com/266376/107477571-8b437b80-6baa-11eb-8281-4df9587206ae.png" width="30%" /> <img src="https://user-images.githubusercontent.com/266376/107477585-90a0c600-6baa-11eb-90c3-1d85bd7aa54b.png" width="30%" />

(2-button navigation)

<img src="https://user-images.githubusercontent.com/266376/107477951-3fdd9d00-6bab-11eb-9cff-60baaf209263.png" width="30%" /> <img src="https://user-images.githubusercontent.com/266376/107477970-4835d800-6bab-11eb-8735-ef9ec5b414c2.png" width="30%" />

(3-button navigation)

<img src="https://user-images.githubusercontent.com/266376/107478030-60a5f280-6bab-11eb-960c-98051aba4b90.png" width="30%" /> <img src="https://user-images.githubusercontent.com/266376/107478047-6ac7f100-6bab-11eb-8a64-be6e0a31e129.png" width="30%" />

## After:

(Gesture navigation)

<img src="https://user-images.githubusercontent.com/266376/107478225-b24e7d00-6bab-11eb-9672-a4aef5465b21.png" width="30%" /> <img src="https://user-images.githubusercontent.com/266376/107477585-90a0c600-6baa-11eb-90c3-1d85bd7aa54b.png" width="30%" />

(2-button navigation)
<img src="https://user-images.githubusercontent.com/266376/107478264-c2665c80-6bab-11eb-9276-ce2632c23e0c.png" width="30%" /> <img src="https://user-images.githubusercontent.com/266376/107477970-4835d800-6bab-11eb-8735-ef9ec5b414c2.png" width="30%" />

(3-button navigation)

<img src="https://user-images.githubusercontent.com/266376/107478311-d5792c80-6bab-11eb-805f-01a31ee18e84.png" width="30%" /> <img src="https://user-images.githubusercontent.com/266376/107478047-6ac7f100-6bab-11eb-8a64-be6e0a31e129.png" width="30%" />


## Testing instruction:
0. Use a device with API >= 27
1. Start in light mode, ensure that the Android Navigation Bar is now white with light gray button(s)
2. Go to Settings app > Accessibility > System navigation, and change from your current navigation style to one of the other two.
3. Check the app again and ensure the bar is still white with light gray button(s)
4. Repeat step 1 to 3 for the last navigation style.
5.  The colors in dark mode should remain the same as before so there's no need to test.

## Known limitation:
1. This only affects devices with API >= 27, so older devices still has the gray background as before.
2. Android decides what button color to be used in light mode, and does not give an option to change it, so the color in this PR will still be somewhat different than from the design on #2430


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
