### PR TITLE
Shipping Label Payments: part 1

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingAccountSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingAccountSettings.kt
@@ -1,20 +1,27 @@
 package com.woocommerce.android.model
 
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingAccountSettings
+import org.wordpress.android.fluxc.utils.DateUtils
+import java.util.Date
 
+@Parcelize
 data class ShippingAccountSettings(
     val canManagePayments: Boolean,
     val selectedPaymentId: Int?,
     val paymentMethods: List<PaymentMethod>,
     val lastUsedBoxId: String?
-)
+) : Parcelable
 
+@Parcelize
 data class PaymentMethod(
     val id: Int,
     val name: String,
     val cardType: String,
-    val cardDigits: String
-)
+    val cardDigits: String,
+    val expirationDate: Date
+) : Parcelable
 
 fun WCShippingAccountSettings.toAppModel(): ShippingAccountSettings {
     return ShippingAccountSettings(
@@ -25,7 +32,8 @@ fun WCShippingAccountSettings.toAppModel(): ShippingAccountSettings {
                 id = it.paymentMethodId,
                 name = it.name,
                 cardType = it.cardType,
-                cardDigits = it.cardDigits
+                cardDigits = it.cardDigits,
+                expirationDate = DateUtils.getDateFromString(it.expiry)
             )
         },
         lastUsedBoxId = lastUsedBoxId

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingAccountSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingAccountSettings.kt
@@ -8,10 +8,20 @@ import java.util.Date
 
 @Parcelize
 data class ShippingAccountSettings(
+    val storeOwnerDetails: StoreOwnerDetails,
+    val isEmailReceiptEnabled: Boolean,
     val canManagePayments: Boolean,
     val selectedPaymentId: Int?,
     val paymentMethods: List<PaymentMethod>,
     val lastUsedBoxId: String?
+) : Parcelable
+
+@Parcelize
+data class StoreOwnerDetails(
+    val wpcomEmail: String,
+    val wpcomUserName: String,
+    val userName: String,
+    val name: String
 ) : Parcelable
 
 @Parcelize
@@ -25,6 +35,13 @@ data class PaymentMethod(
 
 fun WCShippingAccountSettings.toAppModel(): ShippingAccountSettings {
     return ShippingAccountSettings(
+        storeOwnerDetails = StoreOwnerDetails(
+            wpcomEmail = storeOwnerWpcomEmail,
+            wpcomUserName = storeOwnerUserName,
+            name = storeOwnerName,
+            userName = storeOwnerUserName
+        ),
+        isEmailReceiptEnabled = isEmailReceiptEnabled,
         canManagePayments = canManagePayments,
         selectedPaymentId = selectedPaymentMethodId,
         paymentMethods = paymentMethods.map {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelsModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelsModule.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.di.FragmentScope
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelsModule.CreateShippingLabelFragmentModule
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelsModule.EditShippingLabelAddressFragmentModule
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelsModule.EditShippingLabelPackagesFragmentModule
+import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelsModule.EditShippingLabelPaymentFragmentModule
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelsModule.PrintShippingLabelFragmentModule
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelsModule.ShippingLabelAddressSuggestionFragmentModule
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelsModule.ShippingLabelRefundFragmentModule
@@ -14,6 +15,8 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLab
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelAddressModule
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPackagesFragment
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPackagesModule
+import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPaymentFragment
+import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPaymentModule
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionModule
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingPackageSelectorFragment
@@ -28,7 +31,8 @@ import dagger.android.ContributesAndroidInjector
     EditShippingLabelAddressFragmentModule::class,
     ShippingLabelAddressSuggestionFragmentModule::class,
     EditShippingLabelPackagesFragmentModule::class,
-    ShippingPackageSelectorFragmentModule::class
+    ShippingPackageSelectorFragmentModule::class,
+    EditShippingLabelPaymentFragmentModule::class
 ])
 object ShippingLabelsModule {
     @Module
@@ -72,5 +76,11 @@ object ShippingLabelsModule {
         @FragmentScope
         @ContributesAndroidInjector(modules = [ShippingPackageSelectorModule::class])
         abstract fun shippingPackageSelectorFragment(): ShippingPackageSelectorFragment
+    }
+    @Module
+    abstract class EditShippingLabelPaymentFragmentModule {
+        @FragmentScope
+        @ContributesAndroidInjector(modules = [EditShippingLabelPaymentModule::class])
+        abstract fun shippingPackageSelectorFragment(): EditShippingLabelPaymentFragment
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
@@ -51,4 +51,6 @@ sealed class CreateShippingLabelEvent : MultiLiveEvent.Event() {
         val orderIdentifier: OrderIdentifier,
         val shippingLabelPackages: List<ShippingLabelPackage>
     ) : CreateShippingLabelEvent()
+
+    object ShowPaymentDetails : CreateShippingLabelEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowAddressEditor
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowPackageDetails
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowPaymentDetails
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowSuggestedAddress
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.Step
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelAddressFragment.Companion.EDIT_ADDRESS_CLOSED
@@ -157,6 +158,11 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
                             event.suggestedAddress,
                             event.type
                         )
+                    findNavController().navigateSafely(action)
+                }
+                is ShowPaymentDetails -> {
+                    val action = CreateShippingLabelFragmentDirections
+                        .actionCreateShippingLabelFragmentToEditShippingLabelPaymentFragment()
                     findNavController().navigateSafely(action)
                 }
                 else -> event.isHandled = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRepository
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowAddressEditor
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowPackageDetails
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowPaymentDetails
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowSuggestedAddress
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.ValidationResult
@@ -106,9 +107,9 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                             )
                         )
                         is SideEffect.ShowPackageOptions -> openPackagesDetails(sideEffect.shippingPackages)
-                        is SideEffect.ShowCustomsForm -> Event.CustomsFormFilledOut
-                        is SideEffect.ShowCarrierOptions -> Event.ShippingCarrierSelected
-                        is SideEffect.ShowPaymentDetails -> Event.PaymentSelected
+                        is SideEffect.ShowCustomsForm -> handleResult { Event.CustomsFormFilledOut }
+                        is SideEffect.ShowCarrierOptions -> handleResult { Event.ShippingCarrierSelected }
+                        is SideEffect.ShowPaymentOptions -> openPaymentDetails()
                     }
                 }
                 // save the current state
@@ -150,6 +151,10 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                 shippingLabelPackages = currentShippingPackages
             )
         )
+    }
+
+    private fun openPaymentDetails() {
+        triggerEvent(ShowPaymentDetails)
     }
 
     private fun updateViewState(data: Data) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
@@ -52,6 +52,22 @@ class EditShippingLabelPaymentFragment : BaseFragment(R.layout.fragment_edit_shi
             new.paymentMethods.takeIfNotEqualTo(old?.paymentMethods) {
                 paymentMethodsAdapter.items = it
             }
+            new.emailReceipts.takeIfNotEqualTo(binding.emailReceiptsCheckbox.isChecked) {
+                binding.emailReceiptsCheckbox.isChecked = it
+            }
+            new.storeOwnerDetails?.takeIfNotEqualTo(old?.storeOwnerDetails) { details ->
+                binding.paymentsInfo.text = getString(
+                    R.string.shipping_label_payments_account_info,
+                    details.wpcomUserName,
+                    details.wpcomEmail
+                )
+                binding.emailReceiptsCheckbox.text = getString(
+                    R.string.shipping_label_payments_email_receipts_checkbox,
+                    details.name.ifEmpty { details.userName },
+                    details.userName,
+                    details.wpcomEmail
+                )
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
@@ -21,7 +22,9 @@ class EditShippingLabelPaymentFragment : BaseFragment(R.layout.fragment_edit_shi
 
     private val viewModel: EditShippingLabelPaymentViewModel by viewModels { viewModelFactory }
 
-    private val paymentMethodsAdapter by lazy { ShippingLabelPaymentMethodsAdapter() }
+    private val paymentMethodsAdapter by lazy { ShippingLabelPaymentMethodsAdapter(viewModel::onPaymentMethodSelected) }
+
+    private lateinit var doneMenuItem: MenuItem
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -31,6 +34,8 @@ class EditShippingLabelPaymentFragment : BaseFragment(R.layout.fragment_edit_shi
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         super.onCreateOptionsMenu(menu, inflater)
         inflater.inflate(R.menu.menu_done, menu)
+        doneMenuItem = menu.findItem(R.id.menu_done)
+        doneMenuItem.isVisible = viewModel.viewStateData.liveData.value?.hasChanges ?: false
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -39,6 +44,9 @@ class EditShippingLabelPaymentFragment : BaseFragment(R.layout.fragment_edit_shi
         binding.paymentMethodsList.apply {
             layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
             adapter = paymentMethodsAdapter
+        }
+        binding.emailReceiptsCheckbox.setOnCheckedChangeListener { _, isChecked ->
+            viewModel.onEmailReceiptsCheckboxChanged(isChecked)
         }
         setupObservers(binding)
     }
@@ -67,6 +75,11 @@ class EditShippingLabelPaymentFragment : BaseFragment(R.layout.fragment_edit_shi
                     details.userName,
                     details.wpcomEmail
                 )
+            }
+            new.hasChanges.takeIfNotEqualTo(old?.hasChanges) {
+                if (::doneMenuItem.isInitialized) {
+                    doneMenuItem.isVisible = it
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
@@ -1,0 +1,7 @@
+package com.woocommerce.android.ui.orders.shippinglabels.creation
+
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.base.BaseFragment
+
+class EditShippingLabelPaymentFragment : BaseFragment(R.layout.fragment_edit_shipping_label_payment) {
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
@@ -1,7 +1,57 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation
 
+import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.View
+import androidx.core.view.isVisible
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
+import com.woocommerce.android.databinding.FragmentEditShippingLabelPaymentBinding
+import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.viewmodel.ViewModelFactory
+import javax.inject.Inject
 
 class EditShippingLabelPaymentFragment : BaseFragment(R.layout.fragment_edit_shipping_label_payment) {
+    @Inject lateinit var uiMessageResolver: UIMessageResolver
+    @Inject lateinit var viewModelFactory: ViewModelFactory
+
+    private val viewModel: EditShippingLabelPaymentViewModel by viewModels { viewModelFactory }
+
+    private val paymentMethodsAdapter by lazy { ShippingLabelPaymentMethodsAdapter() }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setHasOptionsMenu(true)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        super.onCreateOptionsMenu(menu, inflater)
+        inflater.inflate(R.menu.menu_done, menu)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val binding = FragmentEditShippingLabelPaymentBinding.bind(view)
+        binding.paymentMethodsList.apply {
+            layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
+            adapter = paymentMethodsAdapter
+        }
+        setupObservers(binding)
+    }
+
+    private fun setupObservers(binding: FragmentEditShippingLabelPaymentBinding) {
+        viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
+            new.isLoading.takeIfNotEqualTo(old?.isLoading) { isLoading ->
+                binding.loadingProgress.isVisible = isLoading
+                binding.contentLayout.isVisible = !isLoading
+            }
+            new.paymentMethods.takeIfNotEqualTo(old?.paymentMethods) {
+                paymentMethodsAdapter.items = it
+            }
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentModule.kt
@@ -1,0 +1,31 @@
+package com.woocommerce.android.ui.orders.shippinglabels.creation
+
+import android.os.Bundle
+import androidx.lifecycle.ViewModel
+import androidx.savedstate.SavedStateRegistryOwner
+import com.woocommerce.android.di.ViewModelAssistedFactory
+import com.woocommerce.android.viewmodel.ViewModelKey
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.multibindings.IntoMap
+
+@Module
+abstract class EditShippingLabelPaymentModule {
+    companion object {
+        @Provides
+        fun provideDefaultArgs(fragment: EditShippingLabelPaymentFragment): Bundle? {
+            return fragment.arguments
+        }
+    }
+
+    @Binds
+    abstract fun bindSavedStateRegistryOwner(fragment: EditShippingLabelPaymentFragment): SavedStateRegistryOwner
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(EditShippingLabelPaymentViewModel::class)
+    abstract fun bindFactory(
+        factory: EditShippingLabelPaymentViewModel.Factory
+    ): ViewModelAssistedFactory<out ViewModel>
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentViewModel.kt
@@ -1,17 +1,69 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation
 
+import android.os.Parcelable
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import com.woocommerce.android.di.ViewModelAssistedFactory
+import com.woocommerce.android.model.PaymentMethod
+import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRepository
 import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.viewmodel.LiveDataDelegate
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import kotlinx.android.parcel.Parcelize
+import kotlinx.coroutines.launch
 
 class EditShippingLabelPaymentViewModel @AssistedInject constructor(
     @Assisted savedState: SavedStateWithArgs,
-    dispatchers: CoroutineDispatchers
+    dispatchers: CoroutineDispatchers,
+    private val shippingLabelRepository: ShippingLabelRepository
 ) : ScopedViewModel(savedState, dispatchers) {
+    val viewStateData = LiveDataDelegate(savedState, ViewState())
+    private var viewState by viewStateData
+
+    init {
+        loadPaymentMethods()
+    }
+
+    private fun loadPaymentMethods() {
+        launch {
+            viewState = viewState.copy(isLoading = true)
+            val accountSettings = shippingLabelRepository.getAccountSettings().let {
+                if (it.isError) {
+                    triggerEvent(ShowSnackbar(0))
+                    triggerEvent(Exit)
+                    return@launch
+                }
+                it.model!!
+            }
+            viewState = ViewState(
+                isLoading = false,
+                paymentMethods = accountSettings.paymentMethods.map {
+                    PaymentMethodUiModel(paymentMethod = it, isSelected = it.id == accountSettings.selectedPaymentId)
+                },
+                canManagePayments = accountSettings.canManagePayments
+            )
+        }
+    }
+
+    @Parcelize
+    data class ViewState(
+        val isLoading: Boolean = false,
+        val canManagePayments: Boolean = false,
+        val paymentMethods: List<PaymentMethodUiModel> = emptyList(),
+        val emailReceipts: Boolean = false,
+        val wpcomUserName: String? = null,
+        val wpcomEmail: String? = null
+    ) : Parcelable
+
+    @Parcelize
+    data class PaymentMethodUiModel(
+        val paymentMethod: PaymentMethod,
+        val isSelected: Boolean
+    ) : Parcelable
 
     @AssistedInject.Factory
-    interface Factory : ViewModelAssistedFactory<EditShippingLabelPackagesViewModel>
+    interface Factory : ViewModelAssistedFactory<EditShippingLabelPaymentViewModel>
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentViewModel.kt
@@ -5,6 +5,7 @@ import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import com.woocommerce.android.di.ViewModelAssistedFactory
 import com.woocommerce.android.model.PaymentMethod
+import com.woocommerce.android.model.StoreOwnerDetails
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRepository
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.LiveDataDelegate
@@ -43,7 +44,9 @@ class EditShippingLabelPaymentViewModel @AssistedInject constructor(
                 paymentMethods = accountSettings.paymentMethods.map {
                     PaymentMethodUiModel(paymentMethod = it, isSelected = it.id == accountSettings.selectedPaymentId)
                 },
-                canManagePayments = accountSettings.canManagePayments
+                canManagePayments = accountSettings.canManagePayments,
+                emailReceipts = accountSettings.isEmailReceiptEnabled,
+                storeOwnerDetails = accountSettings.storeOwnerDetails
             )
         }
     }
@@ -54,8 +57,7 @@ class EditShippingLabelPaymentViewModel @AssistedInject constructor(
         val canManagePayments: Boolean = false,
         val paymentMethods: List<PaymentMethodUiModel> = emptyList(),
         val emailReceipts: Boolean = false,
-        val wpcomUserName: String? = null,
-        val wpcomEmail: String? = null
+        val storeOwnerDetails: StoreOwnerDetails? = null
     ) : Parcelable
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentViewModel.kt
@@ -1,0 +1,17 @@
+package com.woocommerce.android.ui.orders.shippinglabels.creation
+
+import com.squareup.inject.assisted.Assisted
+import com.squareup.inject.assisted.AssistedInject
+import com.woocommerce.android.di.ViewModelAssistedFactory
+import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.viewmodel.SavedStateWithArgs
+import com.woocommerce.android.viewmodel.ScopedViewModel
+
+class EditShippingLabelPaymentViewModel @AssistedInject constructor(
+    @Assisted savedState: SavedStateWithArgs,
+    dispatchers: CoroutineDispatchers
+) : ScopedViewModel(savedState, dispatchers) {
+
+    @AssistedInject.Factory
+    interface Factory : ViewModelAssistedFactory<EditShippingLabelPackagesViewModel>
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPaymentMethodsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPaymentMethodsAdapter.kt
@@ -8,12 +8,15 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.ShippingLabelPaymentMethodListItemBinding
+import com.woocommerce.android.model.PaymentMethod
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPaymentViewModel.PaymentMethodUiModel
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelPaymentMethodsAdapter.PaymentMethodViewHolder
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class ShippingLabelPaymentMethodsAdapter : RecyclerView.Adapter<PaymentMethodViewHolder>() {
+class ShippingLabelPaymentMethodsAdapter(
+    private val onPaymentMethodSelected: (PaymentMethod) -> Unit
+) : RecyclerView.Adapter<PaymentMethodViewHolder>() {
     private val dateFormat by lazy {
         SimpleDateFormat("MM/yy", Locale.getDefault())
     }
@@ -36,7 +39,9 @@ class ShippingLabelPaymentMethodsAdapter : RecyclerView.Adapter<PaymentMethodVie
         holder.bind(items[position])
     }
 
-    inner class PaymentMethodViewHolder(val binding: ShippingLabelPaymentMethodListItemBinding) : ViewHolder(binding.root) {
+    inner class PaymentMethodViewHolder(
+        val binding: ShippingLabelPaymentMethodListItemBinding
+    ) : ViewHolder(binding.root) {
         @SuppressLint("SetTextI18n")
         fun bind(item: PaymentMethodUiModel) {
             val context = binding.root.context
@@ -50,6 +55,9 @@ class ShippingLabelPaymentMethodsAdapter : RecyclerView.Adapter<PaymentMethodVie
                 R.string.shipping_label_payments_expiration_date,
                 dateFormat.format(item.paymentMethod.expirationDate)
             )
+            binding.radioButton.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) onPaymentMethodSelected.invoke(item.paymentMethod)
+            }
         }
 
         private fun Context.getPaymentMethodTranslation(paymentMethod: String): String {
@@ -66,4 +74,3 @@ class ShippingLabelPaymentMethodsAdapter : RecyclerView.Adapter<PaymentMethodVie
         }
     }
 }
-

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPaymentMethodsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPaymentMethodsAdapter.kt
@@ -1,0 +1,69 @@
+package com.woocommerce.android.ui.orders.shippinglabels.creation
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.ViewHolder
+import com.woocommerce.android.R
+import com.woocommerce.android.databinding.ShippingLabelPaymentMethodListItemBinding
+import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPaymentViewModel.PaymentMethodUiModel
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelPaymentMethodsAdapter.PaymentMethodViewHolder
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+class ShippingLabelPaymentMethodsAdapter : RecyclerView.Adapter<PaymentMethodViewHolder>() {
+    private val dateFormat by lazy {
+        SimpleDateFormat("MM/yy", Locale.getDefault())
+    }
+    var items: List<PaymentMethodUiModel> = emptyList()
+        set(value) {
+            field = value
+            notifyDataSetChanged()
+        }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PaymentMethodViewHolder {
+        val layoutInflater = LayoutInflater.from(parent.context)
+        return PaymentMethodViewHolder(
+            ShippingLabelPaymentMethodListItemBinding.inflate(layoutInflater, parent, false)
+        )
+    }
+
+    override fun getItemCount() = items.size
+
+    override fun onBindViewHolder(holder: PaymentMethodViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    inner class PaymentMethodViewHolder(val binding: ShippingLabelPaymentMethodListItemBinding) : ViewHolder(binding.root) {
+        @SuppressLint("SetTextI18n")
+        fun bind(item: PaymentMethodUiModel) {
+            val context = binding.root.context
+            binding.radioButton.isChecked = item.isSelected
+            val cardType = context.getPaymentMethodTranslation(item.paymentMethod.cardType)
+            binding.cardTypeNumber.text = context.getString(
+                R.string.shipping_label_payments_type_digits, cardType, item.paymentMethod.cardDigits
+            )
+            binding.cardholderName.text = item.paymentMethod.name
+            binding.expirationDate.text = context.getString(
+                R.string.shipping_label_payments_expiration_date,
+                dateFormat.format(item.paymentMethod.expirationDate)
+            )
+        }
+
+        private fun Context.getPaymentMethodTranslation(paymentMethod: String): String {
+            return getString(
+                when (paymentMethod) {
+                    "amex" -> R.string.payment_method_american_express
+                    "discover" -> R.string.payment_method_discover
+                    "mastercard" -> R.string.payment_method_mastercard
+                    "visa" -> R.string.payment_method_visa
+                    "paypal" -> R.string.payment_method_paypal
+                    else -> throw IllegalArgumentException()
+                }
+            )
+        }
+    }
+}
+

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -143,7 +143,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
                 transitionTo(State.ShippingCarrierSelection(data), SideEffect.ShowCarrierOptions)
             }
             on<Event.PaymentSelectionStarted> {
-                transitionTo(State.PaymentSelection(data), SideEffect.ShowPaymentDetails)
+                transitionTo(State.PaymentSelection(data), SideEffect.ShowPaymentOptions)
             }
             on<Event.EditOriginAddressRequested> {
                 transitionTo(State.OriginAddressEditing(data), SideEffect.OpenAddressEditor(data.originAddress, ORIGIN))
@@ -164,7 +164,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
                 transitionTo(State.ShippingCarrierSelection(data), SideEffect.ShowCarrierOptions)
             }
             on<Event.EditPaymentRequested> {
-                transitionTo(State.PaymentSelection(data), SideEffect.ShowPaymentDetails)
+                transitionTo(State.PaymentSelection(data), SideEffect.ShowPaymentOptions)
             }
         }
 
@@ -468,7 +468,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         ) : SideEffect()
         object ShowCustomsForm : SideEffect()
         object ShowCarrierOptions : SideEffect()
-        object ShowPaymentDetails : SideEffect()
+        object ShowPaymentOptions : SideEffect()
     }
 
     class InvalidStateException(message: String) : Exception(message)

--- a/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_payment.xml
+++ b/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_payment.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_payment.xml
+++ b/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_payment.xml
@@ -34,19 +34,23 @@
                 tools:listitem="@layout/shipping_label_payment_method_list_item" />
 
             <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/payments_info"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/major_100"
                 android:layout_marginTop="@dimen/major_100"
                 android:layout_marginEnd="@dimen/major_100"
+                android:breakStrategy="simple"
                 android:textAppearance="?attr/textAppearanceCaption"
+                tools:ignore="UnusedAttribute"
                 tools:text="Credit cards are retrieved from the following WordPress.com account: username user@email.com" />
 
             <com.google.android.material.checkbox.MaterialCheckBox
+                android:id="@+id/email_receipts_checkbox"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/major_100"
-                android:layout_marginTop="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_150"
                 android:layout_marginEnd="@dimen/major_100"
                 android:layout_marginBottom="@dimen/major_150"
                 android:gravity="top"

--- a/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_payment.xml
+++ b/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_payment.xml
@@ -1,104 +1,81 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.woocommerce.android.widgets.WCElevatedConstraintLayout
-        android:id="@+id/contentLayout"
+    <ScrollView
+        android:id="@+id/content_layout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="match_parent">
 
-        <ProgressBar
-            android:id="@+id/loading_progress"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <androidx.constraintlayout.widget.Group
-            android:id="@+id/payment_methods_content_group"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            app:constraint_referenced_ids="selected_payment_method_text,payment_methods_list,email_hint,email_checkbox" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/selected_payment_method_text"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_75"
-            android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/shipping_label_payments_selected_payment_method"
-            android:textAppearance="?attr/textAppearanceSubtitle1"
-            app:layout_constrainedWidth="true"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/payment_methods_list"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/major_100"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/selected_payment_method_text"
-            tools:itemCount="2"
-            tools:listitem="@layout/shipping_label_payment_method_list_item" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/email_hint"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_100"
-            android:layout_marginEnd="@dimen/major_100"
-            android:textAppearance="?attr/textAppearanceCaption"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/payment_methods_list"
-            tools:text="Credit cards are retrieved from the following WordPress.com account: username <user@email.com>" />
-
-        <com.google.android.material.checkbox.MaterialCheckBox
-            android:id="@+id/email_checkbox"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_100"
-            android:layout_marginEnd="@dimen/major_100"
-            android:layout_marginBottom="@dimen/major_150"
-            android:gravity="top"
-            android:paddingStart="@dimen/minor_100"
-            android:textAppearance="?attr/textAppearanceSubtitle1"
-            app:layout_constraintBottom_toTopOf="@id/add_card_button"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/email_hint"
-            tools:ignore="RtlSymmetry"
-            tools:text="Email the label purchase receipts to username (username) at user@email.com" />
-
-        <!-- Not supported in M3 -->
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/add_card_button"
-            style="@style/Woo.Button.Outlined"
+        <com.woocommerce.android.widgets.WCElevatedLinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginEnd="@dimen/major_100"
-            android:layout_marginBottom="@dimen/major_100"
-            android:text="@string/shipping_label_payments_add_credit_card"
-            android:visibility="gone"
-            app:icon="@drawable/ic_external"
-            app:iconGravity="textEnd"
-            app:iconPadding="@dimen/minor_100"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+            android:orientation="vertical">
 
-    </com.woocommerce.android.widgets.WCElevatedConstraintLayout>
-</ScrollView>
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_75"
+                android:layout_marginEnd="@dimen/major_100"
+                android:text="@string/shipping_label_payments_selected_payment_method"
+                android:textAppearance="?attr/textAppearanceSubtitle1"
+                app:layout_constrainedWidth="true" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/payment_methods_list"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/major_100"
+                tools:itemCount="2"
+                tools:listitem="@layout/shipping_label_payment_method_list_item" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
+                android:textAppearance="?attr/textAppearanceCaption"
+                tools:text="Credit cards are retrieved from the following WordPress.com account: username user@email.com" />
+
+            <com.google.android.material.checkbox.MaterialCheckBox
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
+                android:layout_marginBottom="@dimen/major_150"
+                android:gravity="top"
+                android:paddingStart="@dimen/minor_100"
+                android:textAppearance="?attr/textAppearanceSubtitle1"
+                tools:ignore="RtlSymmetry"
+                tools:text="Email the label purchase receipts to username (username) at user@email.com" />
+
+            <!-- Not supported in M3 -->
+            <com.google.android.material.button.MaterialButton
+                style="@style/Woo.Button.Outlined"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
+                android:layout_marginBottom="@dimen/major_100"
+                android:text="@string/shipping_label_payments_add_credit_card"
+                android:visibility="gone"
+                app:icon="@drawable/ic_external"
+                app:iconGravity="textEnd"
+                app:iconPadding="@dimen/minor_100" />
+
+        </com.woocommerce.android.widgets.WCElevatedLinearLayout>
+
+    </ScrollView>
+
+    <ProgressBar
+        android:id="@+id/loading_progress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center" />
+</FrameLayout>

--- a/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_payment.xml
+++ b/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_payment.xml
@@ -1,6 +1,104 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <com.woocommerce.android.widgets.WCElevatedConstraintLayout
+        android:id="@+id/contentLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <ProgressBar
+            android:id="@+id/loading_progress"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/payment_methods_content_group"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:constraint_referenced_ids="selected_payment_method_text,payment_methods_list,email_hint,email_checkbox" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/selected_payment_method_text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_75"
+            android:layout_marginEnd="@dimen/major_100"
+            android:text="@string/shipping_label_payments_selected_payment_method"
+            android:textAppearance="?attr/textAppearanceSubtitle1"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/payment_methods_list"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/major_100"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/selected_payment_method_text"
+            tools:itemCount="2"
+            tools:listitem="@layout/shipping_label_payment_method_list_item" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/email_hint"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_100"
+            android:layout_marginEnd="@dimen/major_100"
+            android:textAppearance="?attr/textAppearanceCaption"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/payment_methods_list"
+            tools:text="Credit cards are retrieved from the following WordPress.com account: username <user@email.com>" />
+
+        <com.google.android.material.checkbox.MaterialCheckBox
+            android:id="@+id/email_checkbox"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_100"
+            android:layout_marginEnd="@dimen/major_100"
+            android:layout_marginBottom="@dimen/major_150"
+            android:gravity="top"
+            android:paddingStart="@dimen/minor_100"
+            android:textAppearance="?attr/textAppearanceSubtitle1"
+            app:layout_constraintBottom_toTopOf="@id/add_card_button"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/email_hint"
+            tools:ignore="RtlSymmetry"
+            tools:text="Email the label purchase receipts to username (username) at user@email.com" />
+
+        <!-- Not supported in M3 -->
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/add_card_button"
+            style="@style/Woo.Button.Outlined"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginEnd="@dimen/major_100"
+            android:layout_marginBottom="@dimen/major_100"
+            android:text="@string/shipping_label_payments_add_credit_card"
+            android:visibility="gone"
+            app:icon="@drawable/ic_external"
+            app:iconGravity="textEnd"
+            app:iconPadding="@dimen/minor_100"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+    </com.woocommerce.android.widgets.WCElevatedConstraintLayout>
+</ScrollView>

--- a/WooCommerce/src/main/res/layout/shipping_label_payment_method_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_label_payment_method_list_item.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <RadioButton
+        android:id="@+id/radio_button"
+        style="@style/Woo.RadioButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/major_100"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/card_type_number"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_75"
+        android:textAppearance="?attr/textAppearanceSubtitle1"
+        app:layout_constraintEnd_toStartOf="@id/expiration_date"
+        app:layout_constraintStart_toEndOf="@id/radio_button"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="MasterCard****4563" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/cardholder_name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/major_75"
+        android:textAppearance="?attr/textAppearanceBody2"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/card_type_number"
+        app:layout_constraintStart_toStartOf="@id/card_type_number"
+        app:layout_constraintTop_toBottomOf="@id/card_type_number"
+        tools:text="Marie Claire" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/expiration_date"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/major_100"
+        android:textAppearance="?attr/textAppearanceSubtitle1"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Expire 12/22" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -257,6 +257,9 @@
             app:destination="@id/editShippingLabelPackagesFragment"
             app:enterAnim="@anim/activity_fade_in"
             app:popExitAnim="@anim/activity_fade_out" />
+        <action
+            android:id="@+id/action_createShippingLabelFragment_to_editShippingLabelPaymentFragment"
+            app:destination="@id/editShippingLabelPaymentFragment" />
     </fragment>
     <fragment
         android:id="@+id/shippingLabelAddressSuggestionFragment"
@@ -326,4 +329,9 @@
             android:name="position"
             app:argType="integer" />
     </fragment>
+    <fragment
+        android:id="@+id/editShippingLabelPaymentFragment"
+        android:name="com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPaymentFragment"
+        android:label="EditShippingLabelPaymentFragment"
+        tools:layout="@layout/fragment_edit_shipping_label_payment"/>
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -410,6 +410,8 @@
     <string name="shipping_label_single_package_total_weight">Total package weight: %1$s %2$s</string>
     <string name="shipping_label_multi_packages_items_count">%1$d items in %2$d packages</string>
     <string name="shipping_label_multi_packages_total_weight">Total package weight: %1$s %2$s</string>
+    <string name="shipping_label_payments_selected_payment_method">Payment method selected</string>
+    <string name="shipping_label_payments_add_credit_card">Add another credit card</string>
     <!--
         Refunds
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -109,6 +109,14 @@
     <string name="error_no_email_app">No e-mail app was found</string>
     <string name="error_no_sms_app">No SMS app was found</string>
     <!--
+        Payment methods
+    -->
+    <string name="payment_method_american_express">American Express</string>
+    <string name="payment_method_discover">Discover</string>
+    <string name="payment_method_mastercard">MasterCard</string>
+    <string name="payment_method_visa">VISA</string>
+    <string name="payment_method_paypal">Paypal</string>
+    <!--
         Login Library Overrides
     -->
     <string name="enter_site_address" content_override="true">Enter the address of the WooCommerce store you\'d like to connect.</string>
@@ -412,6 +420,10 @@
     <string name="shipping_label_multi_packages_total_weight">Total package weight: %1$s %2$s</string>
     <string name="shipping_label_payments_selected_payment_method">Payment method selected</string>
     <string name="shipping_label_payments_add_credit_card">Add another credit card</string>
+    <string name="shipping_label_payments_type_digits">%1$s****%2$s</string>
+    <string name="shipping_label_payments_account_info"><![CDATA[Credit cards are retrieved from the following WordPress.com account: %1$s <%2$s>]]></string>
+    <string name="shipping_label_payments_email_receipts_checkbox">Email the label purchase receipts to %1$s (%2$s) at %3$s</string>
+    <string name="shipping_label_payments_expiration_date">Expire %1$s</string>
     <!--
         Refunds
     -->
@@ -1518,11 +1530,4 @@
     <string name="product_downloadable_files_add_manually">Enter file URL</string>
     <string name="product_downloadable_files_name_invalid">Please enter a valid name</string>
     <string name="product_downloadable_files_download_settings">Download Settings</string>
-    <string name="shipping_label_payments_expiration_date">Expire %1$s</string>
-    <string name="payment_method_american_express">American Express</string>
-    <string name="payment_method_discover">Discover</string>
-    <string name="payment_method_mastercard">MasterCard</string>
-    <string name="payment_method_visa">VISA</string>
-    <string name="payment_method_paypal">Paypal</string>
-    <string name="shipping_label_payments_type_digits">%1$s****%2$s</string>
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1518,4 +1518,11 @@
     <string name="product_downloadable_files_add_manually">Enter file URL</string>
     <string name="product_downloadable_files_name_invalid">Please enter a valid name</string>
     <string name="product_downloadable_files_download_settings">Download Settings</string>
+    <string name="shipping_label_payments_expiration_date">Expire %1$s</string>
+    <string name="payment_method_american_express">American Express</string>
+    <string name="payment_method_discover">Discover</string>
+    <string name="payment_method_mastercard">MasterCard</string>
+    <string name="payment_method_visa">VISA</string>
+    <string name="payment_method_paypal">Paypal</string>
+    <string name="shipping_label_payments_type_digits">%1$s****%2$s</string>
 </resources>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -422,6 +422,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
     <style name="Woo.Button.Outlined" parent="Widget.MaterialComponents.Button.OutlinedButton">
         <item name="android:textAppearance">?attr/textAppearanceSubtitle2</item>
         <item name="android:textColor">@color/button_fg_selector</item>
+        <item name="iconTint">@color/button_fg_selector</item>
         <item name="android:paddingStart">@dimen/major_100</item>
         <item name="android:paddingEnd">@dimen/major_100</item>
         <item name="drawableTintMode">src_atop</item>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.model.ShippingAccountSettings
 import com.woocommerce.android.model.ShippingLabelPackage
 import com.woocommerce.android.model.ShippingLabelPackage.Item
 import com.woocommerce.android.model.ShippingPackage
+import com.woocommerce.android.model.StoreOwnerDetails
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRepository
@@ -52,7 +53,11 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
         canManagePayments = true,
         paymentMethods = emptyList(),
         selectedPaymentId = null,
-        lastUsedBoxId = "id1"
+        lastUsedBoxId = "id1",
+        storeOwnerDetails = StoreOwnerDetails(
+            "email", "username", "username", "name"
+        ),
+        isEmailReceiptEnabled = true
     )
 
     private val testOrder = OrderTestUtils.generateTestOrder(ORDER_ID)

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.10.0'
+    fluxCVersion = '2cd228962524a4a613f132918bbe698301a8bbc7'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '2cd228962524a4a613f132918bbe698301a8bbc7'
+    fluxCVersion = '183ed03893318f3d947cf9c3e094b45304ede4e1'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
First part of #3536, this adds the ability to see the current payment settings during the label creation process.

<img width=360 src="https://user-images.githubusercontent.com/1657201/107756395-73900280-6d24-11eb-88c1-575374705e48.png"/> <img width=360 src="https://user-images.githubusercontent.com/1657201/107756401-7559c600-6d24-11eb-8530-c8e7554fa91c.png"/>

#### Testing
1. Prepare an order that satisfies the shipping labels creation conditions.
2. Open the order detail in the app.
3. Click on Create shipping label.
4. Pass all the first steps until you reach the payment step.
5. Click on continue.
6. Confirm that the list payment methods are displayed, and that the settings match what you see in wp-admin.
7. Make some changes and confirm that the done button is displayed (the done button does nothing for now).

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
