### PR TITLE
Issue/3556 product detail done button p1

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductEditorFragment.kt
@@ -2,13 +2,9 @@ package com.woocommerce.android.ui.products
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
-import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -34,17 +30,11 @@ abstract class BaseProductEditorFragment(@LayoutRes private val layoutRes: Int) 
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        setHasOptionsMenu(true)
         return inflater.inflate(layoutRes, container, false)
     }
 
-    protected var doneButton: MenuItem? = null
-
-    abstract fun onDoneButtonClicked()
     abstract fun onExit()
 
-    abstract val isDoneButtonVisible: Boolean
-    abstract val isDoneButtonEnabled: Boolean
     abstract val lastEvent: Event?
 
     override fun onResume() {
@@ -57,31 +47,6 @@ abstract class BaseProductEditorFragment(@LayoutRes private val layoutRes: Int) 
         activity?.let {
             ActivityUtils.hideKeyboard(it)
         }
-    }
-
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
-
-        inflater.inflate(R.menu.menu_done, menu)
-        doneButton = menu.findItem(R.id.menu_done)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.menu_done -> {
-                ActivityUtils.hideKeyboard(activity)
-                onDoneButtonClicked()
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
-        }
-    }
-
-    override fun onPrepareOptionsMenu(menu: Menu) {
-        super.onPrepareOptionsMenu(menu)
-
-        doneButton?.isVisible = isDoneButtonVisible
-        doneButton?.isEnabled = isDoneButtonEnabled
     }
 
     override fun onRequestAllowBackPress(): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
@@ -1,9 +1,6 @@
 package com.woocommerce.android.ui.products
 
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
 import android.view.View
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
@@ -39,8 +36,6 @@ class GroupedProductListFragment : BaseFragment(R.layout.fragment_grouped_produc
         GroupedProductListAdapter(viewModel::onProductDeleted)
     }
 
-    private var doneMenuItem: MenuItem? = null
-
     private var _binding: FragmentGroupedProductListBinding? = null
     private val binding get() = _binding!!
 
@@ -50,7 +45,6 @@ class GroupedProductListFragment : BaseFragment(R.layout.fragment_grouped_produc
         super.onViewCreated(view, savedInstanceState)
 
         _binding = FragmentGroupedProductListBinding.bind(view)
-        setHasOptionsMenu(true)
 
         setupObservers()
         setupResultHandlers()
@@ -72,31 +66,10 @@ class GroupedProductListFragment : BaseFragment(R.layout.fragment_grouped_produc
         AnalyticsTracker.trackViewShown(this)
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        menu.clear()
-        inflater.inflate(R.menu.menu_done, menu)
-        doneMenuItem = menu.findItem(R.id.menu_done)
-        doneMenuItem?.isVisible = viewModel.hasChanges
-        super.onCreateOptionsMenu(menu, inflater)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.menu_done -> {
-                viewModel.onDoneButtonClicked()
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
-        }
-    }
-
     private fun setupObservers() {
         viewModel.productListViewStateData.observe(viewLifecycleOwner) { old, new ->
             new.isSkeletonShown?.takeIfNotEqualTo(old?.isSkeletonShown) { showSkeleton(it) }
             new.isLoadingMore?.takeIfNotEqualTo(old?.isLoadingMore) { binding.loadMoreProgress.isVisible = it }
-            new.isDoneButtonVisible?.takeIfNotEqualTo(old?.isDoneButtonVisible) {
-                doneMenuItem?.isVisible = it
-            }
             new.isAddProductButtonVisible.takeIfNotEqualTo(old?.isAddProductButtonVisible) {
                 showAddProductButton(it)
             }
@@ -105,7 +78,6 @@ class GroupedProductListFragment : BaseFragment(R.layout.fragment_grouped_produc
         viewModel.event.observe(viewLifecycleOwner, Observer { event ->
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
-                is ShowDialog -> event.showDialog()
                 is Exit -> findNavController().navigateUp()
                 is ExitWithResult<*> -> {
                     navigateBackWithResult(viewModel.getKeyForGroupedProductListType(), event.data as List<*>)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
@@ -18,7 +18,6 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.SkeletonView

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModel.kt
@@ -108,12 +108,11 @@ class GroupedProductListViewModel @AssistedInject constructor(
     }
 
     fun onBackButtonClicked(): Boolean {
-        return if (hasChanges) {
+        if (hasChanges) {
             triggerEvent(ExitWithResult(selectedProductIds))
-            false
-        } else {
-            true
+            return false
         }
+        return true
     }
 
     private fun loadProducts(loadMore: Boolean = false) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModel.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.products
 
-import android.content.DialogInterface
 import android.os.Parcelable
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -19,9 +18,7 @@ import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductSelectionList
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.LiveDataDelegate
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -97,31 +94,22 @@ class GroupedProductListViewModel @AssistedInject constructor(
         _productList.value = if (selectedProductIds.isNotEmpty()) {
             groupedProductListRepository.getProductList(selectedProductIds)
         } else emptyList()
-        productListViewState = productListViewState.copy(isDoneButtonVisible = hasChanges)
     }
 
     fun onAddProductButtonClicked() {
         track(ConnectedProductsListAction.ADD_TAPPED)
-        triggerEvent(ViewProductSelectionList(
-            navArgs.remoteProductId,
-            navArgs.groupedProductListType,
-            excludedProductIds = selectedProductIds)
+        triggerEvent(
+            ViewProductSelectionList(
+                navArgs.remoteProductId,
+                navArgs.groupedProductListType,
+                excludedProductIds = selectedProductIds
+            )
         )
-    }
-
-    fun onDoneButtonClicked() {
-        track(ConnectedProductsListAction.DONE_TAPPED)
-        triggerEvent(ExitWithResult(selectedProductIds))
     }
 
     fun onBackButtonClicked(): Boolean {
         return if (hasChanges) {
-            triggerEvent(ShowDialog.buildDiscardDialogEvent(
-                positiveBtnAction = DialogInterface.OnClickListener { _, _ ->
-                    triggerEvent(Exit)
-                },
-                negativeButtonId = string.keep_changes
-            ))
+            triggerEvent(ExitWithResult(selectedProductIds))
             false
         } else {
             true
@@ -179,8 +167,7 @@ class GroupedProductListViewModel @AssistedInject constructor(
     data class GroupedProductListViewState(
         val selectedProductIds: List<Long>,
         val isSkeletonShown: Boolean? = null,
-        val isLoadingMore: Boolean? = null,
-        val isDoneButtonVisible: Boolean? = null
+        val isLoadingMore: Boolean? = null
     ) : Parcelable {
         val isAddProductButtonVisible: Boolean
             get() = isSkeletonShown == false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/LinkedProductsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/LinkedProductsFragment.kt
@@ -45,19 +45,6 @@ class LinkedProductsFragment : BaseProductFragment(R.layout.fragment_linked_prod
             mapOf(KEY_LINKED_PRODUCTS_ACTION to LinkedProductsAction.SHOWN.value))
     }
 
-    /*override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.menu_done -> {
-                ActivityUtils.hideKeyboard(activity)
-                viewModel.onDoneButtonClicked(ExitLinkedProducts(shouldShowDiscardDialog = false))
-                AnalyticsTracker.track(Stat.LINKED_PRODUCTS,
-                    mapOf(KEY_LINKED_PRODUCTS_ACTION to LinkedProductsAction.DONE.value))
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
-        }
-    }*/
-
     private fun setupObservers() {
         viewModel.event.observe(viewLifecycleOwner, Observer { event ->
             when (event) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/LinkedProductsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/LinkedProductsFragment.kt
@@ -1,9 +1,6 @@
 package com.woocommerce.android.ui.products
 
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
 import android.view.View
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
@@ -20,7 +17,6 @@ import com.woocommerce.android.extensions.show
 import com.woocommerce.android.ui.products.GroupedProductListType.CROSS_SELLS
 import com.woocommerce.android.ui.products.GroupedProductListType.UPSELLS
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitLinkedProducts
-import org.wordpress.android.util.ActivityUtils
 
 class LinkedProductsFragment : BaseProductFragment(R.layout.fragment_linked_products) {
     private var _binding: FragmentLinkedProductsBinding? = null
@@ -32,7 +28,6 @@ class LinkedProductsFragment : BaseProductFragment(R.layout.fragment_linked_prod
         super.onViewCreated(view, savedInstanceState)
 
         _binding = FragmentLinkedProductsBinding.bind(view)
-        setHasOptionsMenu(true)
 
         setupObservers()
         updateProductView()
@@ -50,13 +45,7 @@ class LinkedProductsFragment : BaseProductFragment(R.layout.fragment_linked_prod
             mapOf(KEY_LINKED_PRODUCTS_ACTION to LinkedProductsAction.SHOWN.value))
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        menu.clear()
-        inflater.inflate(R.menu.menu_done, menu)
-        super.onCreateOptionsMenu(menu, inflater)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    /*override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_done -> {
                 ActivityUtils.hideKeyboard(activity)
@@ -67,7 +56,7 @@ class LinkedProductsFragment : BaseProductFragment(R.layout.fragment_linked_prod
             }
             else -> super.onOptionsItemSelected(item)
         }
-    }
+    }*/
 
     private fun setupObservers() {
         viewModel.event.observe(viewLifecycleOwner, Observer { event ->
@@ -79,13 +68,11 @@ class LinkedProductsFragment : BaseProductFragment(R.layout.fragment_linked_prod
 
         handleResult<List<Long>>(UPSELLS.resultKey) {
             viewModel.updateProductDraft(upsellProductIds = it)
-            changesMade()
             updateProductView()
         }
 
         handleResult<List<Long>>(CROSS_SELLS.resultKey) {
             viewModel.updateProductDraft(crossSellProductIds = it)
-            changesMade()
             updateProductView()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -625,6 +625,7 @@ class ProductDetailViewModel @AssistedInject constructor(
             return false
         } else {
             if (event is ExitProductTags) {
+                onProductTagsBackButtonClicked()
                 clearProductTagsState()
             }
             return true
@@ -1284,7 +1285,7 @@ class ProductDetailViewModel @AssistedInject constructor(
         return sortedList.toList()
     }
 
-    fun onProductTagDoneMenuActionClicked() {
+    fun onProductTagsBackButtonClicked() {
         val tags = _addedProductTags.getList()
         // check if there are tags entered that do not exist on the site. If so,
         // call the API to add the tags to the site first
@@ -1323,7 +1324,6 @@ class ProductDetailViewModel @AssistedInject constructor(
             // Since the tag does not exist for the site, add the tag to
             // a list of newly added tags
             _addedProductTags.addNewItem(ProductTag(name = tagName))
-            updateTagsMenuAction()
             loadProductTags()
         }
     }
@@ -1333,7 +1333,6 @@ class ProductDetailViewModel @AssistedInject constructor(
      */
     fun onProductTagSelected(tag: ProductTag) {
         updateProductDraft(tags = tag.addTag(viewState.productDraft))
-        updateTagsMenuAction()
         loadProductTags()
     }
 
@@ -1347,15 +1346,7 @@ class ProductDetailViewModel @AssistedInject constructor(
         } else {
             updateProductDraft(tags = tag.removeTag(viewState.productDraft))
         }
-        updateTagsMenuAction()
         loadProductTags()
-    }
-
-    private fun updateTagsMenuAction() {
-        productTagsViewState = productTagsViewState.copy(
-            shouldDisplayDoneMenuButton = viewState.productDraft?.tags?.isNotEmpty() == true ||
-                !_addedProductTags.isEmpty()
-        )
     }
 
     /**
@@ -1399,11 +1390,11 @@ class ProductDetailViewModel @AssistedInject constructor(
     }
 
     /**
-     * Called when user exits the product tag fragment to clear the stored filter and the done button state
+     * Called when user exits the product tag fragment to clear the stored filter
      * (otherwise it will be retained when the user returns to the tag fragment)
      */
     fun clearProductTagsState() {
-        productTagsViewState = productTagsViewState.copy(currentFilter = "", shouldDisplayDoneMenuButton = false)
+        productTagsViewState = productTagsViewState.copy(currentFilter = "")
     }
 
     /**
@@ -1584,7 +1575,6 @@ class ProductDetailViewModel @AssistedInject constructor(
         val canLoadMore: Boolean? = null,
         val isRefreshing: Boolean? = null,
         val isEmptyViewVisible: Boolean? = null,
-        val shouldDisplayDoneMenuButton: Boolean? = null,
         val isProgressDialogShown: Boolean? = null,
         val currentFilter: String = ""
     ) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -578,16 +578,10 @@ class ProductDetailViewModel @AssistedInject constructor(
      *
      * Each product screen has it's own [ProductExitEvent]
      * For product detail, we show a discard dialog if any changes have been made to the
-     * [Product] model locall, that still need to be saved to the backend.
+     * [Product] model locally that still need to be saved to the backend.
      */
     fun onBackButtonClicked(event: ProductExitEvent): Boolean {
         val isProductDetailUpdated = viewState.isProductUpdated ?: false
-
-        val isProductSubDetailUpdated = viewState.productDraft?.let { draft ->
-            viewState.productBeforeEnteringFragment?.isSameProduct(draft) == false ||
-                viewState.isPasswordChanged
-        } ?: false
-
         val isUploadingImages = ProductImagesService.isUploadingForProduct(getRemoteProductId())
 
         if (event is ExitProductDetail && isProductDetailUpdated) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductExternalLinkFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductExternalLinkFragment.kt
@@ -1,9 +1,6 @@
 package com.woocommerce.android.ui.products
 
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
 import android.view.View
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
@@ -34,16 +31,13 @@ class ProductExternalLinkFragment : BaseProductFragment(R.layout.fragment_produc
         super.onViewCreated(view, savedInstanceState)
 
         _binding = FragmentProductExternalLinkBinding.bind(view)
-        setHasOptionsMenu(true)
         setupObservers(viewModel)
 
         binding.productUrl.setOnTextChangedListener {
             viewModel.updateProductDraft(externalUrl = it.toString())
-            changesMade()
         }
         binding.productButtonText.setOnTextChangedListener {
             viewModel.updateProductDraft(buttonText = it.toString())
-            changesMade()
         }
     }
 
@@ -53,23 +47,6 @@ class ProductExternalLinkFragment : BaseProductFragment(R.layout.fragment_produc
     }
 
     override fun getFragmentTitle() = getString(R.string.product_external_link)
-
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        menu.clear()
-        inflater.inflate(R.menu.menu_done, menu)
-        super.onCreateOptionsMenu(menu, inflater)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.menu_done -> {
-                ActivityUtils.hideKeyboard(activity)
-                viewModel.onDoneButtonClicked(ExitExternalLink(shouldShowDiscardDialog = false))
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
-        }
-    }
 
     private fun setupObservers(viewModel: ProductDetailViewModel) {
         viewModel.event.observe(viewLifecycleOwner, Observer { event ->
@@ -90,6 +67,7 @@ class ProductExternalLinkFragment : BaseProductFragment(R.layout.fragment_produc
     }
 
     override fun onRequestAllowBackPress(): Boolean {
+        ActivityUtils.hideKeyboard(activity)
         return viewModel.onBackButtonClicked(ExitExternalLink())
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -60,10 +60,6 @@ class ProductImagesFragment : BaseProductEditorFragment(R.layout.fragment_produc
     private var _binding: FragmentProductImagesBinding? = null
     private val binding get() = _binding!!
 
-    override val isDoneButtonVisible: Boolean
-        get() = viewModel.viewStateData.liveData.value?.isDoneButtonVisible ?: false
-
-    override val isDoneButtonEnabled: Boolean = true
     override val lastEvent: Event?
         get() = viewModel.event.value
 
@@ -152,9 +148,6 @@ class ProductImagesFragment : BaseProductEditorFragment(R.layout.fragment_produc
             }
             new.images.takeIfNotEqualTo(old?.images) { images ->
                 updateImages(images ?: emptyList(), new.uploadingImageUris)
-            }
-            new.isDoneButtonVisible?.takeIfNotEqualTo(old?.isDoneButtonVisible) { isVisible ->
-                doneButton?.isVisible = isVisible
             }
             new.isWarningVisible?.takeIfNotEqualTo(old?.isWarningVisible) { isVisible ->
                 binding.textWarning.isVisible = isVisible
@@ -354,11 +347,16 @@ class ProductImagesFragment : BaseProductEditorFragment(R.layout.fragment_produc
         }
     }
 
-    override fun onDoneButtonClicked() {
-        viewModel.onDoneButtonClicked()
-    }
-
     override fun onExit() {
         viewModel.onNavigateBackButtonClicked()
+    }
+
+    // TODO: remove
+    override val isDoneButtonVisible: Boolean
+        get() = false
+    override val isDoneButtonEnabled: Boolean
+        get() = false
+    override fun onDoneButtonClicked() {
+        //
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -350,13 +350,4 @@ class ProductImagesFragment : BaseProductEditorFragment(R.layout.fragment_produc
     override fun onExit() {
         viewModel.onNavigateBackButtonClicked()
     }
-
-    // TODO: remove
-    override val isDoneButtonVisible: Boolean
-        get() = false
-    override val isDoneButtonEnabled: Boolean
-        get() = false
-    override fun onDoneButtonClicked() {
-        //
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -75,6 +75,8 @@ class ProductImagesFragment : BaseProductEditorFragment(R.layout.fragment_produc
             capturedPhotoUri = bundle.getParcelable(KEY_CAPTURED_PHOTO_URI)
         }
 
+        setHasOptionsMenu(true)
+
         setupObservers(viewModel)
         setupResultHandlers(viewModel)
         setupViews()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
@@ -222,13 +222,4 @@ class ProductInventoryFragment : BaseProductEditorFragment(R.layout.fragment_pro
     override fun onExit() {
         viewModel.onExit()
     }
-
-    // TODO remove
-    override val isDoneButtonVisible: Boolean
-        get() = false
-    override val isDoneButtonEnabled: Boolean
-        get() = false
-    override fun onDoneButtonClicked() {
-        //
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
@@ -24,10 +24,6 @@ class ProductInventoryFragment : BaseProductEditorFragment(R.layout.fragment_pro
     ProductItemSelectorDialogListener {
     private val viewModel: ProductInventoryViewModel by viewModels { viewModelFactory.get() }
 
-    override val isDoneButtonVisible: Boolean
-        get() = viewModel.viewStateData.liveData.value?.isDoneButtonVisible ?: false
-    override val isDoneButtonEnabled: Boolean
-        get() = viewModel.viewStateData.liveData.value?.isDoneButtonEnabled ?: false
     override val lastEvent: Event?
         get() = viewModel.event.value
 
@@ -66,12 +62,6 @@ class ProductInventoryFragment : BaseProductEditorFragment(R.layout.fragment_pro
         viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
             new.skuErrorMessage?.takeIfNotEqualTo(old?.skuErrorMessage) {
                 displaySkuError(it)
-            }
-            new.isDoneButtonVisible?.takeIfNotEqualTo(old?.isDoneButtonVisible) { isVisible ->
-                doneButton?.isVisible = isVisible
-            }
-            new.isDoneButtonEnabled.takeIfNotEqualTo(old?.isDoneButtonEnabled) { isEnabled ->
-                doneButton?.isEnabled = isEnabled
             }
             new.isStockManagementVisible?.takeIfNotEqualTo(old?.isStockManagementVisible) { isVisible ->
                 binding.stockManagementPanel.isVisible = isVisible
@@ -229,11 +219,16 @@ class ProductInventoryFragment : BaseProductEditorFragment(R.layout.fragment_pro
         }
     }
 
-    override fun onDoneButtonClicked() {
-        viewModel.onDoneButtonClicked()
-    }
-
     override fun onExit() {
         viewModel.onExit()
+    }
+
+    // TODO remove
+    override val isDoneButtonVisible: Boolean
+        get() = false
+    override val isDoneButtonEnabled: Boolean
+        get() = false
+    override fun onDoneButtonClicked() {
+        //
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
@@ -26,7 +26,6 @@ import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
 import java.util.Date
@@ -312,14 +311,5 @@ class ProductPricingFragment
                 }
             }
         }
-    }
-
-    // TODO remove
-    override val isDoneButtonVisible: Boolean
-        get() = false
-    override val isDoneButtonEnabled: Boolean
-        get() = false
-    override fun onDoneButtonClicked() {
-        //
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
@@ -35,10 +35,6 @@ class ProductPricingFragment
     : BaseProductEditorFragment(R.layout.fragment_product_pricing), ProductItemSelectorDialogListener {
     private val viewModel: ProductPricingViewModel by viewModels { viewModelFactory.get() }
 
-    override val isDoneButtonVisible: Boolean
-        get() = viewModel.viewStateData.liveData.value?.isDoneButtonVisible ?: false
-    override val isDoneButtonEnabled: Boolean
-        get() = viewModel.viewStateData.liveData.value?.isDoneButtonEnabled ?: false
     override val lastEvent: Event?
         get() = viewModel.event.value
 
@@ -99,12 +95,6 @@ class ProductPricingFragment
                     View.GONE
                 }
             }
-            new.isDoneButtonVisible?.takeIfNotEqualTo(old?.isDoneButtonVisible) { isVisible ->
-                doneButton?.isVisible = isVisible
-            }
-            new.isDoneButtonEnabled.takeIfNotEqualTo(old?.isDoneButtonEnabled) { isEnabled ->
-                doneButton?.isEnabled = isEnabled
-            }
             new.isTaxSectionVisible?.takeIfNotEqualTo(old?.isTaxSectionVisible) { isVisible ->
                 if (isVisible) {
                     binding.productTaxSection.show()
@@ -120,7 +110,6 @@ class ProductPricingFragment
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is ExitWithResult<*> -> navigateBackWithResult(KEY_PRICING_DIALOG_RESULT, event.data)
                 is Exit -> findNavController().navigateUp()
-                is ShowDialog -> event.showDialog()
                 else -> event.isHandled = false
             }
         })
@@ -203,10 +192,6 @@ class ProductPricingFragment
                 }
             }
         }
-    }
-
-    override fun onDoneButtonClicked() {
-        viewModel.onDoneButtonClicked()
     }
 
     override fun onExit() {
@@ -327,5 +312,14 @@ class ProductPricingFragment
                 }
             }
         }
+    }
+
+    // TODO remove
+    override val isDoneButtonVisible: Boolean
+        get() = false
+    override val isDoneButtonEnabled: Boolean
+        get() = false
+    override fun onDoneButtonClicked() {
+        //
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingFragment.kt
@@ -30,9 +30,6 @@ import com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
 class ProductShippingFragment : BaseProductEditorFragment(R.layout.fragment_product_shipping) {
     private val viewModel: ProductShippingViewModel by viewModels { viewModelFactory.get() }
 
-    override val isDoneButtonVisible: Boolean
-        get() = viewModel.viewStateData.liveData.value?.isDoneButtonVisible ?: false
-    override val isDoneButtonEnabled: Boolean = true
     override val lastEvent: Event?
         get() = viewModel.event.value
 
@@ -60,9 +57,6 @@ class ProductShippingFragment : BaseProductEditorFragment(R.layout.fragment_prod
         viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
             new.isShippingClassSectionVisible?.takeIfNotEqualTo(old?.isShippingClassSectionVisible) { isVisible ->
                 binding.productShippingClassSpinner.isVisible = isVisible
-            }
-            new.isDoneButtonVisible?.takeIfNotEqualTo(old?.isDoneButtonVisible) { isVisible ->
-                doneButton?.isVisible = isVisible
             }
             new.shippingData.weight?.takeIfNotEqualTo(old?.shippingData?.weight) { weight ->
                 showValue(binding.productWeight, R.string.product_weight, weight, viewModel.parameters.weightUnit)
@@ -149,11 +143,15 @@ class ProductShippingFragment : BaseProductEditorFragment(R.layout.fragment_prod
         findNavController().navigateSafely(action)
     }
 
-    override fun onDoneButtonClicked() {
-        viewModel.onDoneButtonClicked()
-    }
-
     override fun onExit() {
         viewModel.onExit()
+    }
+
+    // TODO remove
+    override val isDoneButtonVisible: Boolean
+        get() = false
+    override val isDoneButtonEnabled: Boolean = false
+    override fun onDoneButtonClicked() {
+        //
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingFragment.kt
@@ -146,12 +146,4 @@ class ProductShippingFragment : BaseProductEditorFragment(R.layout.fragment_prod
     override fun onExit() {
         viewModel.onExit()
     }
-
-    // TODO remove
-    override val isDoneButtonVisible: Boolean
-        get() = false
-    override val isDoneButtonEnabled: Boolean = false
-    override fun onDoneButtonClicked() {
-        //
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingViewModel.kt
@@ -1,19 +1,15 @@
 package com.woocommerce.android.ui.products
 
-import android.content.DialogInterface
 import android.os.Parcelable
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import com.woocommerce.android.RequestCodes
-import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.di.ViewModelAssistedFactory
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import kotlinx.android.parcel.Parcelize
@@ -33,7 +29,6 @@ class ProductShippingViewModel @AssistedInject constructor(
         savedState,
         ViewState(
             shippingData = navArgs.shippingData,
-            isDoneButtonVisible = false,
             isShippingClassSectionVisible = navArgs.requestCode == RequestCodes.PRODUCT_DETAIL_SHIPPING
         )
     )
@@ -69,25 +64,11 @@ class ProductShippingViewModel @AssistedInject constructor(
                 shippingClassId = shippingClassId
             )
         )
-        viewState = viewState.copy(isDoneButtonVisible = hasChanges)
-    }
-
-    fun onDoneButtonClicked() {
-        AnalyticsTracker.track(
-            Stat.PRODUCT_SHIPPING_SETTINGS_DONE_BUTTON_TAPPED,
-            mapOf(AnalyticsTracker.KEY_HAS_CHANGED_DATA to true)
-        )
-
-        triggerEvent(ExitWithResult(shippingData))
     }
 
     fun onExit() {
         if (hasChanges) {
-            triggerEvent(ShowDialog.buildDiscardDialogEvent(
-                positiveBtnAction = DialogInterface.OnClickListener { _, _ ->
-                    triggerEvent(Exit)
-                }
-            ))
+            triggerEvent(ExitWithResult(shippingData))
         } else {
             triggerEvent(Exit)
         }
@@ -105,7 +86,6 @@ class ProductShippingViewModel @AssistedInject constructor(
     @Parcelize
     data class ViewState(
         val shippingData: ShippingData = ShippingData(),
-        val isDoneButtonVisible: Boolean? = null,
         val isShippingClassSectionVisible: Boolean? = null
     ) : Parcelable
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ProductCategoriesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ProductCategoriesFragment.kt
@@ -1,9 +1,6 @@
 package com.woocommerce.android.ui.products.categories
 
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
 import android.view.View
 import androidx.core.view.isVisible
 import androidx.lifecycle.Observer

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ProductCategoriesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ProductCategoriesFragment.kt
@@ -49,17 +49,6 @@ class ProductCategoriesFragment : BaseProductFragment(R.layout.fragment_product_
         _binding = null
     }
 
-    // TODO
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.menu_done -> {
-                viewModel.onDoneButtonClicked(ExitProductCategories(shouldShowDiscardDialog = false))
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
-        }
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ProductCategoriesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ProductCategoriesFragment.kt
@@ -49,12 +49,7 @@ class ProductCategoriesFragment : BaseProductFragment(R.layout.fragment_product_
         _binding = null
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        menu.clear()
-        inflater.inflate(R.menu.menu_done, menu)
-        super.onCreateOptionsMenu(menu, inflater)
-    }
-
+    // TODO
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_done -> {
@@ -70,7 +65,6 @@ class ProductCategoriesFragment : BaseProductFragment(R.layout.fragment_product_
 
         _binding = FragmentProductCategoriesListBinding.bind(view)
 
-        setHasOptionsMenu(true)
         setupObservers(viewModel)
         setupResultHandlers()
         viewModel.fetchProductCategories()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsFragment.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.ui.products.downloads
 
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.lifecycle.observe
@@ -68,6 +70,12 @@ class ProductDownloadsFragment : BaseProductFragment(R.layout.fragment_product_d
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        menu.clear()
+        inflater.inflate(R.menu.menu_product_downloads_list, menu)
+        super.onCreateOptionsMenu(menu, inflater)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsFragment.kt
@@ -1,8 +1,6 @@
 package com.woocommerce.android.ui.products.downloads
 
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.lifecycle.observe
@@ -72,18 +70,8 @@ class ProductDownloadsFragment : BaseProductFragment(R.layout.fragment_product_d
         _binding = null
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        menu.clear()
-        inflater.inflate(R.menu.menu_product_downloads_list, menu)
-        super.onCreateOptionsMenu(menu, inflater)
-    }
-
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
-            R.id.menu_done -> {
-                viewModel.onDoneButtonClicked(ExitProductDownloads(shouldShowDiscardDialog = false))
-                true
-            }
             R.id.menu_product_downloads_settings -> {
                 viewModel.onDownloadsSettingsClicked()
                 true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsFragment.kt
@@ -51,7 +51,6 @@ class ProductTagsFragment : BaseProductFragment(R.layout.fragment_product_tags),
 
         _binding = FragmentProductTagsBinding.bind(view)
 
-        setHasOptionsMenu(true)
         setupObservers(viewModel)
         viewModel.loadProductTags()
     }
@@ -67,22 +66,6 @@ class ProductTagsFragment : BaseProductFragment(R.layout.fragment_product_tags),
     override fun onResume() {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
-    }
-
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        menu.clear()
-        inflater.inflate(R.menu.menu_done, menu)
-        super.onCreateOptionsMenu(menu, inflater)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.menu_done -> {
-                viewModel.onProductTagDoneMenuActionClicked()
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
-        }
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
@@ -139,9 +122,6 @@ class ProductTagsFragment : BaseProductFragment(R.layout.fragment_product_tags),
             }
             new.isLoadingMore?.takeIfNotEqualTo(old?.isLoadingMore) { showLoadMoreProgress(it) }
             new.isProgressDialogShown?.takeIfNotEqualTo(old?.isProgressDialogShown) { showProgressDialog(it) }
-            new.shouldDisplayDoneMenuButton?.takeIfNotEqualTo(old?.shouldDisplayDoneMenuButton) {
-                showUpdateMenuItem(it)
-            }
             new.isEmptyViewVisible?.takeIfNotEqualTo(old?.isEmptyViewVisible) { isEmptyViewVisible ->
                 if (isEmptyViewVisible && !binding.emptyView.isVisible) {
                     WooAnimUtils.fadeIn(binding.emptyView)
@@ -229,7 +209,8 @@ class ProductTagsFragment : BaseProductFragment(R.layout.fragment_product_tags),
     }
 
     override fun onRequestAllowBackPress(): Boolean {
-        return viewModel.onBackButtonClicked(ExitProductTags())
+        viewModel.onProductTagsBackButtonClicked()
+        return false
     }
 
     override fun onProductTagAdded(productTag: ProductTag) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsFragment.kt
@@ -3,9 +3,6 @@ package com.woocommerce.android.ui.products.tags
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
 import android.view.View
 import androidx.core.view.isVisible
 import androidx.lifecycle.Observer

--- a/WooCommerce/src/main/res/menu/menu_product_downloads_list.xml
+++ b/WooCommerce/src/main/res/menu/menu_product_downloads_list.xml
@@ -1,15 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
-    <item
-        android:id="@+id/menu_done"
-        android:title="@string/done"
-        app:showAsAction="always"
-        tools:ignore="AlwaysShowAction" />
-
+    xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/menu_product_downloads_settings"
         android:title="@string/product_downloadable_files_download_settings"
-        app:showAsAction="never"/>
+        app:showAsAction="never" />
 </menu>


### PR DESCRIPTION
This is the first part of #3556, in which we ditch the "Done" button in product sub-detail screens. I was hoping to address this in a single PR, but it turned out to be larger than expected (a common theme of mine lately!) so I decided to break it into separate PRs and target a feature branch.

Also, I realize there are failing tests due to the missing "Done" button in the sub-detail screens. I would prefer to fix those in a subsequent PR since so many changes need to be made.

To test, make changes in the following fragments, verify the changes are saved to the product draft when exiting them, verify the main product details screen shows an "Update" button when changes have been made, and verify that tapping the back button in the detail shows the discard dialog when you back out after changes have been made:

* Grouped products
* Linked products
* Product external link
* Product images
* Product inventory
* Product pricing
* Product shipping
* Product categories
* Product downloads
* Product tags

Note that there is still a **lot** of clean-up to be done, but that will come later. For now simply verify that those screens are working, but if you seen something of concern in the code please feel free to raise it.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
