### PR TITLE
Fix NullPointerException when bottom nav item reselected

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -666,8 +666,11 @@ class MainActivity : AppUpgradeActivity(),
 
         // if we're at the root scroll the active fragment to the top, otherwise clear the nav backstack
         if (isAtNavigationRoot()) {
-            getActiveTopLevelFragment()?.scrollToTop()
-            expandToolbar(expand = true, animate = true)
+            // If the fragment's view is not yet created, do nothing
+            if (getActiveTopLevelFragment()?.view != null) {
+                getActiveTopLevelFragment()?.scrollToTop()
+                expandToolbar(expand = true, animate = true)
+            }
         } else {
             navController.navigate(binding.bottomNav.currentPosition.id)
         }


### PR DESCRIPTION
Fixes #3561, I was able to reproduce the error by clicking two times (it has to be very fast) on one of bottom navigation items, what happens is that the item is selected, then the navigation process starts, but as it's async, the `onNavItemReselected` callback may be called before it's finished, and in this case, the fragment's view may not be created yet.

#### Testing
As it's pretty hard to reproduce even in the previous version, I'd say just play with the Bottom Nav, and try to double click when navigating, and confirm that the crash doesn't occur.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
