### PR TITLE
Merge release/6.0 into develop (new beta)

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -48,9 +48,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "6.0-rc-1"
+            versionName "6.0-rc-2"
         }
-        versionCode 197
+        versionCode 198
 
         minSdkVersion 21
         targetSdkVersion 30

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -666,8 +666,11 @@ class MainActivity : AppUpgradeActivity(),
 
         // if we're at the root scroll the active fragment to the top, otherwise clear the nav backstack
         if (isAtNavigationRoot()) {
-            getActiveTopLevelFragment()?.scrollToTop()
-            expandToolbar(expand = true, animate = true)
+            // If the fragment's view is not yet created, do nothing
+            if (getActiveTopLevelFragment()?.view != null) {
+                getActiveTopLevelFragment()?.scrollToTop()
+                expandToolbar(expand = true, animate = true)
+            }
         } else {
             navController.navigate(binding.bottomNav.currentPosition.id)
         }

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.10.0'
+    fluxCVersion = '1.10.1'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
6.0-rc-2 has just been submitted to beta testers with the following fixes:

 - https://github.com/woocommerce/woocommerce-android/issues/3562
 - Bump of FluxC to a hotfix 1.10.1 (https://github.com/woocommerce/woocommerce-android/issues/3563), containing:
   - https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1870 to fix #3553
   - https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1871 to re-fix #3183