### PR TITLE
Merge merge/release-6.0-into-develop into develop

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -48,9 +48,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "6.0-rc-1"
+            versionName "6.0-rc-2"
         }
-        versionCode 197
+        versionCode 198
 
         minSdkVersion 21
         targetSdkVersion 30

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -666,8 +666,11 @@ class MainActivity : AppUpgradeActivity(),
 
         // if we're at the root scroll the active fragment to the top, otherwise clear the nav backstack
         if (isAtNavigationRoot()) {
-            getActiveTopLevelFragment()?.scrollToTop()
-            expandToolbar(expand = true, animate = true)
+            // If the fragment's view is not yet created, do nothing
+            if (getActiveTopLevelFragment()?.view != null) {
+                getActiveTopLevelFragment()?.scrollToTop()
+                expandToolbar(expand = true, animate = true)
+            }
         } else {
             navController.navigate(binding.bottomNav.currentPosition.id)
         }

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.10.0'
+    fluxCVersion = '1.10.1'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Supersedes https://github.com/woocommerce/woocommerce-android/pull/3564 to fix conflicts.

The `fluxCVersion` in `release/6.0` is `1.10.1` but the one in `develop` is `183ed03893318f3d947cf9c3e094b45304ede4e1`.

I initially wrongly fixed the conflict by keeping `develop`, but then realized / decided it would make more sense to make this PR move `develop`'s FluxC to `1.10.1` (which is one commit after of the SHA1), so that `develop` also includes the hotfix after this merge.