### PR TITLE
Update FluxC hash to the latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '183ed03893318f3d947cf9c3e094b45304ede4e1'
+    fluxCVersion = '96c59a96a69f31634198fa4a481b90a0c405ab39'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
This tiny PR just updates the fluxC hash to the latest one. This includes the hotfixes we've released in 6.0 as well as the changes made to FluxC after the fix. 

#### To test
Make sure the app builds.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
