### PR TITLE
Shipping Labels Payments: Part 2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
@@ -90,6 +90,7 @@ class ShippingLabelRepository @Inject constructor(
         ).let { result ->
             if (result.isError) return@let WooResult(error = result.error)
 
+            accountSettings = null
             WooResult(Unit)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
@@ -82,6 +82,18 @@ class ShippingLabelRepository @Inject constructor(
             }
     }
 
+    suspend fun updatePaymentSettings(selectedPaymentMethodId: Int, emailReceipts: Boolean): WooResult<Unit> {
+        return shippingLabelStore.updateAccountSettings(
+            site = selectedSite.get(),
+            selectedPaymentMethodId = selectedPaymentMethodId,
+            isEmailReceiptEnabled = emailReceipts
+        ).let { result ->
+            if (result.isError) return@let WooResult(error = result.error)
+
+            WooResult(Unit)
+        }
+    }
+
     fun clearCache() {
         accountSettings = null
         availablePackages = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -113,7 +113,7 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
 
     private fun subscribeObservers(binding: FragmentCreateShippingLabelBinding) {
         viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
-            new.uiState?.takeIfNotEqualTo(old?.uiState) { state ->
+            new.uiState.takeIfNotEqualTo(old?.uiState) { state ->
                 when (state) {
                     Loading -> {
                         showSkeleton(true, binding)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.Address
+import com.woocommerce.android.model.PaymentMethod
 import com.woocommerce.android.model.ShippingLabelPackage
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -25,6 +26,8 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLab
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelAddressFragment.Companion.EDIT_ADDRESS_RESULT
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPackagesFragment.Companion.EDIT_PACKAGES_CLOSED
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPackagesFragment.Companion.EDIT_PACKAGES_RESULT
+import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPaymentFragment.Companion.EDIT_PAYMENTS_CLOSED
+import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPaymentFragment.Companion.EDIT_PAYMENTS_RESULT
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SELECTED_ADDRESS_ACCEPTED
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SELECTED_ADDRESS_TO_BE_EDITED
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SUGGESTED_ADDRESS_DISCARDED
@@ -94,6 +97,12 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
         }
         handleResult<List<ShippingLabelPackage>>(EDIT_PACKAGES_RESULT) {
             viewModel.onPackagesUpdated(it)
+        }
+        handleNotice(EDIT_PAYMENTS_CLOSED) {
+            viewModel.onPaymentsEditCanceled()
+        }
+        handleResult<PaymentMethod>(EDIT_PAYMENTS_RESULT) {
+            viewModel.onPaymentsUpdated(it)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -58,9 +58,6 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
 
     val viewModel: CreateShippingLabelViewModel by viewModels { viewModelFactory }
 
-    private var _binding: FragmentCreateShippingLabelBinding? = null
-    private val binding get() = _binding!!
-
     private val skeletonView: SkeletonView = SkeletonView()
 
     override fun getFragmentTitle() = getString(R.string.shipping_label_create_title)
@@ -68,10 +65,10 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        _binding = FragmentCreateShippingLabelBinding.bind(view)
+        val binding = FragmentCreateShippingLabelBinding.bind(view)
 
-        initializeViewModel()
-        initializeViews()
+        initializeViewModel(binding)
+        initializeViews(binding)
     }
 
     override fun onPause() {
@@ -79,8 +76,8 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
         progressDialog?.dismiss()
     }
 
-    private fun initializeViewModel() {
-        subscribeObservers()
+    private fun initializeViewModel(binding: FragmentCreateShippingLabelBinding) {
+        subscribeObservers(binding)
         setupResultHandlers()
     }
 
@@ -114,22 +111,17 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
         }
     }
 
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
-    }
-
-    private fun subscribeObservers() {
+    private fun subscribeObservers(binding: FragmentCreateShippingLabelBinding) {
         viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
             new.uiState?.takeIfNotEqualTo(old?.uiState) { state ->
                 when (state) {
                     Loading -> {
-                        binding.loadingProgress.isVisible = true
+                        showSkeleton(true, binding)
                         binding.errorView.isVisible = false
                         binding.contentLayout.isVisible = false
                     }
                     Failed -> {
-                        binding.loadingProgress.isVisible = false
+                        showSkeleton(false, binding)
                         binding.contentLayout.isVisible = false
                         binding.errorView.show(
                             type = WCEmptyView.EmptyViewType.NETWORK_ERROR,
@@ -137,7 +129,7 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
                         )
                     }
                     WaitingForInput -> {
-                        binding.loadingProgress.isVisible = false
+                        showSkeleton(false, binding)
                         binding.errorView.isVisible = false
                         binding.contentLayout.isVisible = true
                     }
@@ -223,7 +215,15 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
         progressDialog = null
     }
 
-    private fun initializeViews() {
+    fun showSkeleton(show: Boolean, binding: FragmentCreateShippingLabelBinding) {
+        if (show) {
+            skeletonView.show(binding.contentLayout, R.layout.skeleton_create_shipping_label, delayed = false)
+        } else {
+            skeletonView.hide()
+        }
+    }
+
+    private fun initializeViews(binding: FragmentCreateShippingLabelBinding) {
         binding.originStep.continueButtonClickListener = { viewModel.onContinueButtonTapped(ORIGIN_ADDRESS) }
         binding.shippingStep.continueButtonClickListener = { viewModel.onContinueButtonTapped(SHIPPING_ADDRESS) }
         binding.packagingStep.continueButtonClickListener = { viewModel.onContinueButtonTapped(PACKAGING) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -408,7 +408,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
 
     @Parcelize
     data class ViewState(
-        val uiState: UiState? = null,
+        val uiState: UiState = WaitingForInput,
         val originAddressStep: Step? = null,
         val shippingAddressStep: Step? = null,
         val packagingDetailsStep: Step? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
@@ -24,7 +24,8 @@ import com.woocommerce.android.viewmodel.ViewModelFactory
 import com.woocommerce.android.widgets.CustomProgressDialog
 import javax.inject.Inject
 
-class EditShippingLabelPaymentFragment : BaseFragment(R.layout.fragment_edit_shipping_label_payment), BackPressListener {
+class EditShippingLabelPaymentFragment
+    : BaseFragment(R.layout.fragment_edit_shipping_label_payment), BackPressListener {
     companion object {
         const val EDIT_PAYMENTS_CLOSED = "edit_payments_closed"
         const val EDIT_PAYMENTS_RESULT = "edit_payments_result"
@@ -121,7 +122,7 @@ class EditShippingLabelPaymentFragment : BaseFragment(R.layout.fragment_edit_shi
             }
         }
         viewModel.event.observe(viewLifecycleOwner) { event ->
-            when(event) {
+            when (event) {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is ExitWithResult<*> -> navigateBackWithResult(EDIT_PAYMENTS_RESULT, event.data)
                 is Exit -> navigateBackWithNotice(EDIT_PAYMENTS_CLOSED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
@@ -7,13 +7,18 @@ import android.view.MenuItem
 import android.view.View
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.observe
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentEditShippingLabelPaymentBinding
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ViewModelFactory
+import com.woocommerce.android.widgets.CustomProgressDialog
 import javax.inject.Inject
 
 class EditShippingLabelPaymentFragment : BaseFragment(R.layout.fragment_edit_shipping_label_payment) {
@@ -25,6 +30,7 @@ class EditShippingLabelPaymentFragment : BaseFragment(R.layout.fragment_edit_shi
     private val paymentMethodsAdapter by lazy { ShippingLabelPaymentMethodsAdapter(viewModel::onPaymentMethodSelected) }
 
     private lateinit var doneMenuItem: MenuItem
+    private var progressDialog: CustomProgressDialog? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -49,6 +55,16 @@ class EditShippingLabelPaymentFragment : BaseFragment(R.layout.fragment_edit_shi
             viewModel.onEmailReceiptsCheckboxChanged(isChecked)
         }
         setupObservers(binding)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.menu_done -> {
+                viewModel.saveSettings()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
     }
 
     private fun setupObservers(binding: FragmentEditShippingLabelPaymentBinding) {
@@ -81,6 +97,34 @@ class EditShippingLabelPaymentFragment : BaseFragment(R.layout.fragment_edit_shi
                     doneMenuItem.isVisible = it
                 }
             }
+            new.showSavingProgressDialog.takeIfNotEqualTo(old?.showSavingProgressDialog) { show ->
+                if (show) {
+                    showSavingProgressDialog()
+                } else {
+                    hideProgressDialog()
+                }
+            }
         }
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when(event) {
+                is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+                is Exit -> findNavController().navigateUp()
+                else -> event.isHandled = false
+            }
+        }
+    }
+
+    private fun showSavingProgressDialog() {
+        hideProgressDialog()
+        progressDialog = CustomProgressDialog.show(
+            title = getString(R.string.shipping_label_payments_saving_dialog_title),
+            message = getString(R.string.shipping_label_payments_saving_dialog_message)
+        ).also { it.show(parentFragmentManager, CustomProgressDialog.TAG) }
+        progressDialog?.isCancelable = false
+    }
+
+    private fun hideProgressDialog() {
+        progressDialog?.dismiss()
+        progressDialog = null
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
@@ -40,6 +40,8 @@ class EditShippingLabelPaymentFragment : BaseFragment(R.layout.fragment_edit_shi
     private lateinit var doneMenuItem: MenuItem
     private var progressDialog: CustomProgressDialog? = null
 
+    override fun getFragmentTitle() = getString(R.string.orderdetail_shipping_label_item_payment)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentViewModel.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRepository
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -68,8 +69,9 @@ class EditShippingLabelPaymentViewModel @AssistedInject constructor(
     fun saveSettings() {
         launch {
             viewState = viewState.copy(showSavingProgressDialog = true)
+            val selectedPaymentMethod = viewState.paymentMethods.find { it.isSelected }!!.paymentMethod
             val result = shippingLabelRepository.updatePaymentSettings(
-                selectedPaymentMethodId = viewState.paymentMethods.find { it.isSelected }!!.paymentMethod.id,
+                selectedPaymentMethodId = selectedPaymentMethod.id,
                 emailReceipts = viewState.emailReceipts
             )
             viewState = viewState.copy(showSavingProgressDialog = false)
@@ -77,9 +79,13 @@ class EditShippingLabelPaymentViewModel @AssistedInject constructor(
             if (result.isError) {
                 triggerEvent(ShowSnackbar(R.string.shipping_label_payments_saving_error))
             } else {
-                triggerEvent(Exit)
+                triggerEvent(ExitWithResult(selectedPaymentMethod))
             }
         }
+    }
+
+    fun onBackButtonClicked() {
+        triggerEvent(Exit)
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -114,11 +114,11 @@ class ShippingLabelsStateMachine @Inject constructor() {
         state<State.DataLoading> {
             on<Event.DataLoaded> { event ->
                 val data = Data(
-                    event.originAddress,
-                    event.shippingAddress,
-                    null,
-                    emptyList(),
-                    setOf(FlowStep.ORIGIN_ADDRESS)
+                    originAddress = event.originAddress,
+                    shippingAddress = event.shippingAddress,
+                    currentPaymentMethod = event.currentPaymentMethod,
+                    shippingPackages = emptyList(),
+                    flowSteps = setOf(FlowStep.ORIGIN_ADDRESS)
                 )
                 transitionTo(State.WaitingForInput(data), SideEffect.UpdateViewState(data))
             }
@@ -435,7 +435,12 @@ class ShippingLabelsStateMachine @Inject constructor() {
 
     sealed class Event {
         data class FlowStarted(val orderId: String) : Event()
-        data class DataLoaded(val originAddress: Address, val shippingAddress: Address) : Event()
+        data class DataLoaded(
+            val originAddress: Address,
+            val shippingAddress: Address,
+            val currentPaymentMethod: PaymentMethod?
+        ) : Event()
+
         object DataLoadingFailed : Event()
 
         data class AddressInvalid(val address: Address, val validationResult: ValidationResult) : Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -315,7 +315,12 @@ class ShippingLabelsStateMachine @Inject constructor() {
 
         state<State.ShippingCarrierSelection> {
             on<Event.ShippingCarrierSelected> {
-                val newData = data.copy(flowSteps = data.flowSteps + FlowStep.PAYMENT)
+                val stepsToAdd = if (data.currentPaymentMethod != null) {
+                    listOf(FlowStep.PAYMENT, FlowStep.DONE)
+                } else {
+                    listOf(FlowStep.PAYMENT)
+                }
+                val newData = data.copy(flowSteps = data.flowSteps + stepsToAdd)
                 transitionTo(State.WaitingForInput(newData))
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -120,10 +120,16 @@ class ShippingLabelsStateMachine @Inject constructor() {
                     shippingPackages = emptyList(),
                     flowSteps = setOf(FlowStep.ORIGIN_ADDRESS)
                 )
-                transitionTo(State.WaitingForInput(data), SideEffect.UpdateViewState(data))
+                transitionTo(State.WaitingForInput(data))
             }
             on<Event.DataLoadingFailed> {
                 transitionTo(State.DataLoadingFailure, SideEffect.ShowError(DataLoadingError))
+            }
+        }
+
+        state<State.DataLoadingFailure> {
+            on<Event.FlowStarted> { event ->
+                transitionTo(State.DataLoading, SideEffect.LoadData(event.orderId))
             }
         }
 
@@ -181,7 +187,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
                     originAddress = event.address,
                     flowSteps = data.flowSteps + FlowStep.SHIPPING_ADDRESS
                 )
-                transitionTo(State.WaitingForInput(newData), SideEffect.UpdateViewState(newData))
+                transitionTo(State.WaitingForInput(newData))
             }
             on<Event.AddressChangeSuggested> { event ->
                 transitionTo(
@@ -206,13 +212,13 @@ class ShippingLabelsStateMachine @Inject constructor() {
                     originAddress = event.address,
                     flowSteps = data.flowSteps + FlowStep.SHIPPING_ADDRESS
                 )
-                transitionTo(State.WaitingForInput(newData), SideEffect.UpdateViewState(newData))
+                transitionTo(State.WaitingForInput(newData))
             }
             on<Event.EditAddressRequested> { event ->
                 transitionTo(State.OriginAddressEditing(data), SideEffect.OpenAddressEditor(event.address, ORIGIN))
             }
             on<Event.SuggestedAddressDiscarded> {
-                transitionTo(State.WaitingForInput(data), SideEffect.UpdateViewState(data))
+                transitionTo(State.WaitingForInput(data))
             }
         }
 
@@ -222,10 +228,10 @@ class ShippingLabelsStateMachine @Inject constructor() {
                     originAddress = event.address,
                     flowSteps = data.flowSteps + FlowStep.SHIPPING_ADDRESS
                 )
-                transitionTo(State.WaitingForInput(newData), SideEffect.UpdateViewState(newData))
+                transitionTo(State.WaitingForInput(newData))
             }
             on<Event.AddressEditCanceled> {
-                transitionTo(State.WaitingForInput(data), SideEffect.UpdateViewState(data))
+                transitionTo(State.WaitingForInput(data))
             }
         }
 
@@ -235,7 +241,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
                     shippingAddress = event.address,
                     flowSteps = data.flowSteps + FlowStep.PACKAGING
                 )
-                transitionTo(State.WaitingForInput(newData), SideEffect.UpdateViewState(newData))
+                transitionTo(State.WaitingForInput(newData))
             }
             on<Event.AddressChangeSuggested> { event ->
                 transitionTo(
@@ -260,7 +266,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
                     shippingAddress = event.address,
                     flowSteps = data.flowSteps + FlowStep.PACKAGING
                 )
-                transitionTo(State.WaitingForInput(newData), SideEffect.UpdateViewState(newData))
+                transitionTo(State.WaitingForInput(newData))
             }
             on<Event.EditAddressRequested> { event ->
                 transitionTo(
@@ -269,7 +275,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
                 )
             }
             on<Event.SuggestedAddressDiscarded> {
-                transitionTo(State.WaitingForInput(data), SideEffect.UpdateViewState(data))
+                transitionTo(State.WaitingForInput(data))
             }
         }
 
@@ -279,10 +285,10 @@ class ShippingLabelsStateMachine @Inject constructor() {
                     shippingAddress = event.address,
                     flowSteps = data.flowSteps + FlowStep.PACKAGING
                 )
-                transitionTo(State.WaitingForInput(newData), SideEffect.UpdateViewState(newData))
+                transitionTo(State.WaitingForInput(newData))
             }
             on<Event.AddressEditCanceled> {
-                transitionTo(State.WaitingForInput(data), SideEffect.UpdateViewState(data))
+                transitionTo(State.WaitingForInput(data))
             }
         }
 
@@ -292,25 +298,25 @@ class ShippingLabelsStateMachine @Inject constructor() {
                     shippingPackages = event.shippingPackages,
                     flowSteps = data.flowSteps + FlowStep.CUSTOMS
                 )
-                transitionTo(State.WaitingForInput(newData), SideEffect.UpdateViewState(newData))
+                transitionTo(State.WaitingForInput(newData))
             }
 
             on<Event.EditPackagingCanceled> {
-                transitionTo(State.WaitingForInput(data), SideEffect.UpdateViewState(data))
+                transitionTo(State.WaitingForInput(data))
             }
         }
 
         state<State.CustomsDeclaration> {
             on<Event.CustomsFormFilledOut> {
                 val newData = data.copy(flowSteps = data.flowSteps + FlowStep.CARRIER)
-                transitionTo(State.WaitingForInput(newData), SideEffect.UpdateViewState(newData))
+                transitionTo(State.WaitingForInput(newData))
             }
         }
 
         state<State.ShippingCarrierSelection> {
             on<Event.ShippingCarrierSelected> {
                 val newData = data.copy(flowSteps = data.flowSteps + FlowStep.PAYMENT)
-                transitionTo(State.WaitingForInput(newData), SideEffect.UpdateViewState(newData))
+                transitionTo(State.WaitingForInput(newData))
             }
         }
 
@@ -320,11 +326,11 @@ class ShippingLabelsStateMachine @Inject constructor() {
                     currentPaymentMethod = it.paymentMethod,
                     flowSteps = data.flowSteps + FlowStep.DONE
                 )
-                transitionTo(State.WaitingForInput(newData), SideEffect.UpdateViewState(newData))
+                transitionTo(State.WaitingForInput(newData))
             }
 
             on<Event.EditPaymentCanceled> {
-                transitionTo(State.WaitingForInput(data), SideEffect.UpdateViewState(data))
+                transitionTo(State.WaitingForInput(data))
             }
         }
 
@@ -481,7 +487,6 @@ class ShippingLabelsStateMachine @Inject constructor() {
         object NoOp : SideEffect()
         data class LoadData(val orderId: String) : SideEffect()
         data class ShowError(val error: Error) : SideEffect()
-        data class UpdateViewState(val data: Data) : SideEffect()
 
         data class ValidateAddress(val address: Address, val type: AddressType) : SideEffect()
         data class ShowAddressSuggestion(

--- a/WooCommerce/src/main/res/layout/fragment_create_shipping_label.xml
+++ b/WooCommerce/src/main/res/layout/fragment_create_shipping_label.xml
@@ -1,14 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:tools="http://schemas.android.com/tools">
+    android:fillViewport="true">
 
-    <com.woocommerce.android.widgets.WCElevatedLinearLayout
+    <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:layout_height="wrap_content">
+
+        <com.woocommerce.android.widgets.WCEmptyView
+            android:id="@+id/error_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            android:layout_gravity="center"/>
+
+        <ProgressBar
+            android:id="@+id/loading_progress"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"/>
+
+        <com.woocommerce.android.widgets.WCElevatedLinearLayout
+            android:id="@+id/content_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
         <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
             android:id="@+id/originStep"
@@ -77,6 +97,6 @@
             app:details="@string/shipping_label_create_payment_description"
             app:icon="@drawable/ic_gridicons_credit_card" />
 
-    </com.woocommerce.android.widgets.WCElevatedLinearLayout>
-
+        </com.woocommerce.android.widgets.WCElevatedLinearLayout>
+    </FrameLayout>
 </ScrollView>

--- a/WooCommerce/src/main/res/layout/fragment_create_shipping_label.xml
+++ b/WooCommerce/src/main/res/layout/fragment_create_shipping_label.xml
@@ -18,12 +18,6 @@
             app:layout_constraintTop_toTopOf="parent"
             android:layout_gravity="center"/>
 
-        <ProgressBar
-            android:id="@+id/loading_progress"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"/>
-
         <com.woocommerce.android.widgets.WCElevatedLinearLayout
             android:id="@+id/content_layout"
             android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/layout/skeleton_create_shipping_label.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_create_shipping_label.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.woocommerce.android.widgets.WCElevatedLinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <include layout="@layout/skeleton_create_shipping_label_item" />
+    <include layout="@layout/skeleton_create_shipping_label_item" />
+    <include layout="@layout/skeleton_create_shipping_label_item" />
+    <include layout="@layout/skeleton_create_shipping_label_item" />
+    <include layout="@layout/skeleton_create_shipping_label_item" />
+    <include layout="@layout/skeleton_create_shipping_label_item" />
+
+</com.woocommerce.android.widgets.WCElevatedLinearLayout>

--- a/WooCommerce/src/main/res/layout/skeleton_create_shipping_label_item.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_create_shipping_label_item.xml
@@ -1,0 +1,49 @@
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:animateLayoutChanges="true">
+
+    <View
+        android:id="@+id/icon"
+        android:layout_width="@dimen/image_minor_50"
+        android:layout_height="@dimen/image_minor_50"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginEnd="@dimen/major_100"
+        android:background="@color/skeleton_color"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/title"
+        tools:visibility="visible" />
+
+    <View
+        android:id="@+id/title"
+        android:layout_width="200dp"
+        android:layout_height="@dimen/skeleton_list_item_title_text_height_100"
+        android:layout_marginTop="@dimen/major_100"
+        android:layout_marginStart="@dimen/major_200"
+        android:background="@color/skeleton_color"
+        app:layout_constraintStart_toEndOf="@id/icon"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <View
+        android:id="@+id/description"
+        android:layout_width="320dp"
+        android:layout_height="@dimen/skeleton_list_item_body_text_height_100"
+        android:layout_marginTop="@dimen/minor_50"
+        android:background="@color/skeleton_color"
+        app:layout_constraintTop_toBottomOf="@id/title"
+        app:layout_constraintStart_toStartOf="@id/title"/>
+
+    <View
+        android:id="@+id/divider"
+        style="@style/Woo.Divider"
+        android:layout_width="@dimen/minor_00"
+        android:layout_marginTop="@dimen/major_100"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@id/title"
+        app:layout_constraintTop_toBottomOf="@id/description"
+        app:layout_goneMarginStart="@dimen/major_100" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -373,6 +373,7 @@
     <string name="shipping_label_create_customs_description">Fill out customs form</string>
     <string name="shipping_label_create_carrier_description">Select your shipping carrier and rates</string>
     <string name="shipping_label_create_payment_description">Add a new credit card</string>
+    <string name="shipping_label_selected_payment_description">Credit card ending in %1$s</string>
     <string name="shipping_label_edit_address_name">Name</string>
     <string name="shipping_label_edit_address_company">Company</string>
     <string name="shipping_label_edit_address_phone">Phone</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -429,9 +429,12 @@
     <string name="shipping_label_payments_account_info"><![CDATA[Credit cards are retrieved from the following WordPress.com account: %1$s <%2$s>]]></string>
     <string name="shipping_label_payments_email_receipts_checkbox">Email the label purchase receipts to %1$s (%2$s) at %3$s</string>
     <string name="shipping_label_payments_expiration_date">Expire %1$s</string>
+    <string name="shipping_label_payments_saving_dialog_title">Saving your settings</string>
+    <string name="shipping_label_payments_saving_dialog_message">Please wait…</string>
+    <string name="shipping_label_payments_saving_error">Error while saving your settings</string>
     <!--
-        Refunds
-    -->
+            Refunds
+        -->
     <string name="order_refunds_available_for_refund">%s available for refund</string>
     <string name="order_refunds_title_with_amount">Refund %s</string>
     <string name="order_refunds_confirmation">Are you sure you want to issue a refund? This can’t be undone.</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -374,6 +374,8 @@
     <string name="shipping_label_create_carrier_description">Select your shipping carrier and rates</string>
     <string name="shipping_label_create_payment_description">Add a new credit card</string>
     <string name="shipping_label_selected_payment_description">Credit card ending in %1$s</string>
+    <string name="shipping_label_loading_data_progress_title">Fetching your settings</string>
+    <string name="shipping_label_loading_data_progress_message">Please wait…</string>
     <string name="shipping_label_edit_address_name">Name</string>
     <string name="shipping_label_edit_address_company">Company</string>
     <string name="shipping_label_edit_address_phone">Phone</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
@@ -59,6 +59,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
     private val data = Data(
         originAddress = originAddress,
         shippingAddress = shippingAddress,
+        currentPaymentMethod = null,
         shippingPackages = emptyList(),
         flowSteps = setOf(ORIGIN_ADDRESS)
     )
@@ -176,7 +177,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
             paymentStep = otherNotDone
         )
 
-        stateFlow.value = Transition(State.WaitingForInput(data), SideEffect.UpdateViewState(data))
+        stateFlow.value = Transition(State.WaitingForInput(data), null)
 
         assertThat(viewState).isEqualTo(expectedViewState)
     }
@@ -199,7 +200,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
             originAddress = originAddressValidated,
             flowSteps = data.flowSteps + FlowStep.SHIPPING_ADDRESS
         )
-        stateFlow.value = Transition(State.WaitingForInput(newData), SideEffect.UpdateViewState(newData))
+        stateFlow.value = Transition(State.WaitingForInput(newData), null)
 
         assertThat(viewState).isEqualTo(expectedViewState)
     }
@@ -223,14 +224,14 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
             shippingAddress = shippingAddressValidated,
             flowSteps = data.flowSteps + FlowStep.SHIPPING_ADDRESS + FlowStep.PACKAGING
         )
-        stateFlow.value = Transition(State.WaitingForInput(newData), SideEffect.UpdateViewState(newData))
+        stateFlow.value = Transition(State.WaitingForInput(newData), null)
 
         assertThat(viewState).isEqualTo(expectedViewState)
     }
 
     @Test
     fun `Continue click in origin address triggers validation`() = coroutinesTestRule.testDispatcher.runBlockingTest {
-        stateFlow.value = Transition(State.WaitingForInput(data), SideEffect.UpdateViewState(data))
+        stateFlow.value = Transition(State.WaitingForInput(data), null)
 
         viewModel.onContinueButtonTapped(ORIGIN_ADDRESS)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
@@ -10,6 +10,8 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.FlowStep
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.SideEffect
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.State
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Transition
 import com.woocommerce.android.util.CoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
@@ -28,7 +30,7 @@ class ShippingLabelsStateMachineTest {
     private val orderId = "123"
     private val originAddress = CreateShippingLabelTestUtils.generateAddress()
     private val shippingAddress = originAddress.copy(company = "McDonald's")
-    private val data = Data(originAddress, shippingAddress, emptyList(), setOf(FlowStep.ORIGIN_ADDRESS))
+    private val data = Data(originAddress, shippingAddress, null, emptyList(), setOf(FlowStep.ORIGIN_ADDRESS))
 
     @get:Rule
     var coroutinesTestRule = CoroutineTestRule()
@@ -41,39 +43,40 @@ class ShippingLabelsStateMachineTest {
     @Test
     fun `Test the data login sequence of events after start`() = coroutinesTestRule.testDispatcher.runBlockingTest {
         val expectedSideEffectCount = 3 // necessary to terminate the flow
-        var sideEffect: SideEffect? = null
+        var transition: Transition? = null
         launch {
             stateMachine.transitions.take(expectedSideEffectCount).collect {
-                sideEffect = it.sideEffect
+                transition = it
             }
         }
 
-        assertThat(sideEffect).isEqualTo(SideEffect.NoOp)
+        assertThat(transition?.sideEffect).isEqualTo(SideEffect.NoOp)
 
         stateMachine.start(orderId)
 
-        assertThat(sideEffect).isEqualTo(SideEffect.LoadData(orderId))
+        assertThat(transition?.state).isEqualTo(State.DataLoading)
+        assertThat(transition?.sideEffect).isEqualTo(SideEffect.LoadData(orderId))
 
-        stateMachine.handleEvent(Event.DataLoaded(originAddress, shippingAddress))
+        stateMachine.handleEvent(Event.DataLoaded(originAddress, shippingAddress, null))
 
-        assertThat(sideEffect).isEqualTo(SideEffect.UpdateViewState(data))
+        assertThat(transition?.state).isEqualTo(State.WaitingForInput(data))
     }
 
     @Test
     fun `Test successful address verification`() = coroutinesTestRule.testDispatcher.runBlockingTest {
         val expectedSideEffectCount = 5 // necessary to terminate the flow
-        var sideEffect: SideEffect? = null
+        var transition: Transition? = null
         launch {
             stateMachine.transitions.take(expectedSideEffectCount).collect {
-                sideEffect = it.sideEffect
+                transition = it
             }
         }
 
         stateMachine.start(orderId)
-        stateMachine.handleEvent(Event.DataLoaded(originAddress, shippingAddress))
+        stateMachine.handleEvent(Event.DataLoaded(originAddress, shippingAddress, null))
         stateMachine.handleEvent(Event.OriginAddressValidationStarted)
 
-        assertThat(sideEffect).isEqualTo(SideEffect.ValidateAddress(data.originAddress, ORIGIN))
+        assertThat(transition?.sideEffect).isEqualTo(SideEffect.ValidateAddress(data.originAddress, ORIGIN))
 
         val newData = data.copy(
             originAddress = data.originAddress,
@@ -81,7 +84,7 @@ class ShippingLabelsStateMachineTest {
         )
         stateMachine.handleEvent(Event.AddressValidated(data.originAddress))
 
-        assertThat(sideEffect).isEqualTo(SideEffect.UpdateViewState(newData))
+        assertThat(transition?.state).isEqualTo(State.WaitingForInput(newData))
     }
 
     @Test
@@ -101,7 +104,7 @@ class ShippingLabelsStateMachineTest {
         )
 
         stateMachine.start(orderId)
-        stateMachine.handleEvent(Event.DataLoaded(originAddress, shippingAddress))
+        stateMachine.handleEvent(Event.DataLoaded(originAddress, shippingAddress, null))
         stateMachine.handleEvent(Event.PackageSelectionStarted)
 
         assertThat(stateMachine.transitions.value.sideEffect).isEqualTo(SideEffect.ShowPackageOptions(emptyList()))
@@ -113,6 +116,6 @@ class ShippingLabelsStateMachineTest {
             flowSteps = data.flowSteps + FlowStep.CUSTOMS
         )
 
-        assertThat(stateMachine.transitions.value.sideEffect).isEqualTo(SideEffect.UpdateViewState(newData))
+        assertThat(stateMachine.transitions.value.state).isEqualTo(State.WaitingForInput(newData))
     }
 }


### PR DESCRIPTION
Second part of #3536, this adds the following:

1. Ability to save changes.
2. Updates the state machine to handle the payment screen events: canceling and saving.
3. Updates the state machine logic to allow loading WCS settings at startup, and handling error state: 512db41e9b89b10d75f32853b5ebcda7762b8c6d c88207f5135f7a17d49678890c44e8f9430ac8c5
4. Display the current selected card in the payment step item.
5. Makes selecting a card optional if the account settings have an already selected card.

### Testing
#### Case 1: card available
1. Make sure your WCS settings have a selected payment method.
2. Prepare an order that satisfies the shipping labels creation conditions.
3. Open the order detail in the app.
4. Click on Create shipping label.
5. Confirm that the payment step displays the credit card info (last 4 digits).
6. Pass the first steps until you reach the payment step.
7. Confirm that the step is marked as done automatically, and that you can still edit it using the edit button.
8. Make some changes, and click on done.
9. Confirm the settings are saved.

#### Case 2: no selected card
1. Make sure you don't have a payment method in WCS settings (the only way I found is deleting the payment methods from WordPress.com).
2. Prepare an order that satisfies the shipping labels creation conditions.
3. Open the order detail in the app.
4. Click on Create shipping label.
5. Confirm that the payment step displays "Add a new credit card".
6. Pass the first steps until you reach the payment step.
7. Confirm that the step is required, and that you can edit settings using the continue button.

Please note that in M3, we will enable the feature only when the account has some credit cards, empty cards list is not handled yet.
Another point, from my testing, when the account has some credit cards, one will be picked automatically by WCS (`selected_payment_method_id` won't be null), but the code logic is done in a way that even if this changes in the future (ie: a status where credit cards list is not empty, but `selected_payment_method_id` is null), it will work.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
