### PR TITLE
[Tooling] Remove APKs from GitHub Releases when built on CI

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -241,11 +241,14 @@ end
     )
 
     if (options[:create_release])
-      apk_file_path = File.join(project_root, "artifacts", universal_apk_name(version))
-      create_release(repository:GHHELPER_REPO, 
+      # APKs built on CI are not signed with master key, which means Google Sign-In won't work with those.
+      # So don't attach them to the release, as this ends up being confusing for beta-testers.
+      apk_file_path = File.join(project_root, "artifacts", universal_apk_name(version)) unless is_ci
+      create_release(
+        repository: GHHELPER_REPO, 
         version: version["name"], 
-        release_notes_file_path:release_notes_path,
-        release_assets:"#{apk_file_path},#{aab_file_path}"
+        release_notes_file_path: release_notes_path,
+        release_assets: [apk_file_path, aab_file_path].compact.join(',')
       )
     end
   end
@@ -291,12 +294,15 @@ end
     )
 
     if (options[:create_release])
-      apk_file_path = File.join(project_root, "artifacts", universal_apk_name(version))
-      create_release(repository:GHHELPER_REPO, 
+      # APKs built on CI are not signed with master key, which means Google Sign-In won't work with those.
+      # So don't attach them to the release, as this ends up being confusing for beta-testers.
+      apk_file_path = File.join(project_root, "artifacts", universal_apk_name(version)) unless is_ci
+      create_release(
+        repository: GHHELPER_REPO, 
         version: version["name"], 
-        release_notes_file_path:release_notes_path,
+        release_notes_file_path: release_notes_path,
         prerelease: true,
-        release_assets:"#{apk_file_path}"
+        release_assets: [apk_file_path, aab_file_path].compact.join(',')
       )
     end
   end


### PR DESCRIPTION
This PR replicates on WCAndroid what was done on https://github.com/wordpress-mobile/WordPress-Android/pull/14017 for WPAndroid.

## What is it?

This PR removes the attachment of the APK from GH release when the CI is creating the betas and releases, because those APKs are not signed with the master key which means that Google Sign In doesn't work with those builds, which was quite confusing for beta testing.

## Why?

This lead to issues being reported during CfT that "Google Sign In doesn't work with this beta!" (while it was just because they tested with the build attached to the GH release instead of the AAB or the Universal, Signed APK from PlayStore), or – if we started telling beta testers that Google Sign In was known not to work when testing with those APKs from GH release – leading them to not test that part ("it fails but that's expected because that's the APK from GH release") meaning we could get used to skip testing that part of testing during CfT and fail to find any actual/real Google Sign-In bug if there was one.

See an example of such occurrence here: p5T066-1Ov-p2#comment-7204

## Related

I've updated our release scenarios in 169-gh-Automattic/mobile-toolbox, in order to remind us to manually download the Universal, Signed APK from the PlayStore and attach it to the GitHub release manually every time we do a new beta – at least until we hopefully find a way to automate that again some day.