### PR TITLE
Fix price editing when the language uses a different numerals system

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 6.1
 -----
 * [*] Fixed a bug where the app doesn't show the updated product settings. [https://github.com/woocommerce/woocommerce-android/pull/3599]
+* [*] Fixed a bug the field of product price couldn't be edited if the device's language uses a different numerals system (e.g. Arabic) [https://github.com/woocommerce/woocommerce-android/pull/3589]
 
 6.0
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/CurrencyEditText.kt
@@ -63,7 +63,7 @@ class CurrencyEditText : AppCompatEditText {
         if (isInitialized && !isChangingText) {
             isChangingText = true
 
-            val regex = Regex("[^0-9]")
+            val regex = Regex("[^\\d]")
             var cleanValue = text.toString().replace(regex, "").toBigDecimalOrNull() ?: BigDecimal.ZERO
 
             if (decimals > 0) {


### PR DESCRIPTION
Fixes #3582, the issue was caused by the usage of the regex [^0-9], as `0-9` matches only the digits of the Arabic numerals system, and doesn't match the other unicode digits (such us [Eastern Arabic numerals](https://en.wikipedia.org/wiki/Eastern_Arabic_numerals)).
I replaced it with the more generic `\d` which accepts all kind of digits.

<img width=400 src="https://user-images.githubusercontent.com/1657201/108204405-0dd8b780-7124-11eb-885a-f10a5c35b5a3.gif" />


#### Testing
1. Change your device's language to Arabic Egypt (or any language that uses a different numerals system)
2. Open product details
3. Open the pricing subscreen
4. Try to edit the price.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
