### PR TITLE
Shipping Labels state machine enhancements

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -20,6 +20,8 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingL
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.UiState.Loading
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.UiState.WaitingForInput
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.DESTINATION
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.ORIGIN
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.ValidationResult
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Data
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Error
@@ -83,16 +85,46 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
     }
 
     private fun initializeStateMachine() {
+        val state = savedState.get<State>(STATE_KEY)
+        if (state != null) {
+            stateMachine.initialize(state)
+        } else {
+            stateMachine.start(arguments.orderIdentifier)
+        }
+
         launch {
             stateMachine.transitions.collect { transition ->
+                // save the current state
+                savedState[STATE_KEY] = transition.state
+
                 when (transition.state) {
                     is State.DataLoading -> viewState = viewState.copy(uiState = Loading)
                     is State.DataLoadingFailure -> viewState = viewState.copy(uiState = Failed)
                     is State.WaitingForInput -> {
-                        viewState = viewState.copy(uiState = WaitingForInput)
+                        viewState = viewState.copy(
+                            uiState = WaitingForInput,
+                            progressDialogState = ProgressDialogState(isShown = false)
+                        )
                         updateViewState(transition.state.data)
                     }
-                    else -> { }
+                    is State.OriginAddressValidation -> {
+                        handleResult(
+                            progressDialogTitle = string.shipping_label_edit_address_validation_progress_title,
+                            progressDialogMessage = string.shipping_label_edit_address_progress_message
+                        ) {
+                            validateAddress(transition.state.data.originAddress, ORIGIN)
+                        }
+                    }
+                    is State.ShippingAddressValidation -> {
+                        handleResult(
+                            progressDialogTitle = string.shipping_label_edit_address_validation_progress_title,
+                            progressDialogMessage = string.shipping_label_edit_address_progress_message
+                        ) {
+                            validateAddress(transition.state.data.shippingAddress, DESTINATION)
+                        }
+                    }
+                    else -> {
+                    }
                 }
                 transition.sideEffect?.let { sideEffect ->
                     when (sideEffect) {
@@ -100,12 +132,6 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                         }
                         is SideEffect.ShowError -> showError(sideEffect.error)
                         is SideEffect.LoadData -> handleResult { loadData(sideEffect.orderId) }
-                        is SideEffect.ValidateAddress -> handleResult(
-                            progressDialogTitle = string.shipping_label_edit_address_validation_progress_title,
-                            progressDialogMessage = string.shipping_label_edit_address_progress_message
-                        ) {
-                            validateAddress(sideEffect.address, sideEffect.type)
-                        }
                         is SideEffect.OpenAddressEditor -> triggerEvent(
                             ShowAddressEditor(
                                 sideEffect.address,
@@ -126,16 +152,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                         is SideEffect.ShowPaymentOptions -> openPaymentDetails()
                     }
                 }
-                // save the current state
-                savedState[STATE_KEY] = transition.state
             }
-        }
-
-        val state = savedState.get<State>(STATE_KEY)
-        if (state != null) {
-            stateMachine.initialize(state)
-        } else {
-            stateMachine.start(arguments.orderIdentifier)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -98,7 +98,10 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                 savedState[STATE_KEY] = transition.state
 
                 when (transition.state) {
-                    is State.DataLoading -> viewState = viewState.copy(uiState = Loading)
+                    is State.DataLoading -> {
+                        viewState = viewState.copy(uiState = Loading)
+                        handleResult { loadData(transition.state.orderId) }
+                    }
                     is State.DataLoadingFailure -> viewState = viewState.copy(uiState = Failed)
                     is State.WaitingForInput -> {
                         viewState = viewState.copy(
@@ -131,7 +134,6 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                         SideEffect.NoOp -> {
                         }
                         is SideEffect.ShowError -> showError(sideEffect.error)
-                        is SideEffect.LoadData -> handleResult { loadData(sideEffect.orderId) }
                         is SideEffect.OpenAddressEditor -> triggerEvent(
                             ShowAddressEditor(
                                 sideEffect.address,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -137,16 +137,10 @@ class ShippingLabelsStateMachine @Inject constructor() {
 
         state<State.WaitingForInput> {
             on<Event.OriginAddressValidationStarted> {
-                transitionTo(
-                    State.OriginAddressValidation(data),
-                    SideEffect.ValidateAddress(data.originAddress, ORIGIN)
-                )
+                transitionTo(State.OriginAddressValidation(data))
             }
             on<Event.ShippingAddressValidationStarted> {
-                transitionTo(
-                    State.ShippingAddressValidation(data),
-                    SideEffect.ValidateAddress(data.shippingAddress, DESTINATION)
-                )
+                transitionTo(State.ShippingAddressValidation(data))
             }
             on<Event.PackageSelectionStarted> {
                 transitionTo(State.PackageSelection(data), SideEffect.ShowPackageOptions(data.shippingPackages))
@@ -361,6 +355,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
 
     fun initialize(state: State) {
         stateMachine = createStateMachine(state)
+        _transitions.value = Transition(state, SideEffect.NoOp)
     }
 
     /**
@@ -501,7 +496,6 @@ class ShippingLabelsStateMachine @Inject constructor() {
         data class LoadData(val orderId: String) : SideEffect()
         data class ShowError(val error: Error) : SideEffect()
 
-        data class ValidateAddress(val address: Address, val type: AddressType) : SideEffect()
         data class ShowAddressSuggestion(
             val entered: Address,
             val suggested: Address,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -109,7 +109,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
 
         state<State.Idle> {
             on<Event.FlowStarted> { event ->
-                transitionTo(State.DataLoading, SideEffect.LoadData(event.orderId))
+                transitionTo(State.DataLoading(event.orderId))
             }
         }
 
@@ -131,7 +131,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
 
         state<State.DataLoadingFailure> {
             on<Event.FlowStarted> { event ->
-                transitionTo(State.DataLoading, SideEffect.LoadData(event.orderId))
+                transitionTo(State.DataLoading(event.orderId))
             }
         }
 
@@ -403,7 +403,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         object DataLoadingFailure : State()
 
         @Parcelize
-        object DataLoading : State()
+        data class DataLoading(val orderId: String) : State()
 
         @Parcelize
         data class WaitingForInput(val data: Data) : State()
@@ -493,7 +493,6 @@ class ShippingLabelsStateMachine @Inject constructor() {
 
     sealed class SideEffect {
         object NoOp : SideEffect()
-        data class LoadData(val orderId: String) : SideEffect()
         data class ShowError(val error: Error) : SideEffect()
 
         data class ShowAddressSuggestion(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
@@ -16,7 +16,6 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.OriginAddressValidationStarted
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.FlowStep
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.FlowStep.ORIGIN_ADDRESS
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.SideEffect
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.SideEffect.NoOp
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.State
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.State.Idle
@@ -237,10 +236,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
 
         verify(stateMachine).handleEvent(OriginAddressValidationStarted)
 
-        stateFlow.value = Transition(
-            State.OriginAddressValidation(data),
-            SideEffect.ValidateAddress(originAddress, ORIGIN)
-        )
+        stateFlow.value = Transition(State.OriginAddressValidation(data), null)
 
         verify(addressValidator).validateAddress(originAddress, ORIGIN)
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
@@ -5,7 +5,6 @@ import com.woocommerce.android.model.PackageDimensions
 import com.woocommerce.android.model.ShippingLabelPackage
 import com.woocommerce.android.model.ShippingLabelPackage.Item
 import com.woocommerce.android.model.ShippingPackage
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.ORIGIN
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Data
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.FlowStep
@@ -54,8 +53,7 @@ class ShippingLabelsStateMachineTest {
 
         stateMachine.start(orderId)
 
-        assertThat(transition?.state).isEqualTo(State.DataLoading)
-        assertThat(transition?.sideEffect).isEqualTo(SideEffect.LoadData(orderId))
+        assertThat(transition?.state).isEqualTo(State.DataLoading(orderId))
 
         stateMachine.handleEvent(Event.DataLoaded(originAddress, shippingAddress, null))
 
@@ -76,7 +74,7 @@ class ShippingLabelsStateMachineTest {
         stateMachine.handleEvent(Event.DataLoaded(originAddress, shippingAddress, null))
         stateMachine.handleEvent(Event.OriginAddressValidationStarted)
 
-        assertThat(transition?.sideEffect).isEqualTo(SideEffect.ValidateAddress(data.originAddress, ORIGIN))
+        assertThat(transition?.state).isEqualTo(State.OriginAddressValidation(data))
 
         val newData = data.copy(
             originAddress = data.originAddress,


### PR DESCRIPTION
In the PR #3571, I updated the shipping labels creation state machine to match the visible states to a UI state, which made handling data loading, and retrying easier. One of the states was `WaitingForInput`, and while doing so I got rid of the SideEffect `UpdateViewState` as it wasn't needed anymore.

Yesterday I found another issue that requires applying the same logic to more side effects: ValidateAddress, and LoadData. As for both, if a process death occurred, or the system destroyed our Activity, we'll end up in an invalid status, where the loading UI is shown, but the ViewModel doesn't do anything.
This PR updates the behavior to react to their corresponding states, instead of the side effects.

And as a result, the remaining side effects are only for events: navigation, or showing an error.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
