### PR TITLE
[Tooling] DRY GitHub Releases code into a private lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -220,7 +220,7 @@ end
     android_build_preflight()
 
     # Create the file names
-    version=android_get_release_version()
+    version = android_get_release_version()
     build_bundle(version: version, flavor:"Vanilla")
 
     project_root = File.dirname(File.expand_path(File.dirname(__FILE__)))
@@ -240,17 +240,7 @@ end
       json_key: './google-upload-credentials.json',
     )
 
-    if (options[:create_release])
-      # APKs built on CI are not signed with master key, which means Google Sign-In won't work with those.
-      # So don't attach them to the release, as this ends up being confusing for beta-testers.
-      apk_file_path = File.join(project_root, "artifacts", universal_apk_name(version)) unless is_ci
-      create_release(
-        repository: GHHELPER_REPO, 
-        version: version["name"], 
-        release_notes_file_path: release_notes_path,
-        release_assets: [apk_file_path, aab_file_path].compact.join(',')
-      )
-    end
+    create_gh_release(version: version) if (options[:create_release])
   end
 
   #####################################################################################
@@ -273,7 +263,7 @@ end
     android_build_preflight() unless (options[:skip_prechecks])
 
     # Create the file names
-    version=android_get_release_version()
+    version = android_get_release_version()
     build_bundle(version: version, flavor:"Vanilla")
 
     project_root = File.dirname(File.expand_path(File.dirname(__FILE__)))
@@ -293,18 +283,7 @@ end
       json_key: './google-upload-credentials.json',
     )
 
-    if (options[:create_release])
-      # APKs built on CI are not signed with master key, which means Google Sign-In won't work with those.
-      # So don't attach them to the release, as this ends up being confusing for beta-testers.
-      apk_file_path = File.join(project_root, "artifacts", universal_apk_name(version)) unless is_ci
-      create_release(
-        repository: GHHELPER_REPO, 
-        version: version["name"], 
-        release_notes_file_path: release_notes_path,
-        prerelease: true,
-        release_assets: [apk_file_path, aab_file_path].compact.join(',')
-      )
-    end
+    create_gh_release(version: version, prerelease: true) if (options[:create_release])
   end
 
 #####################################################################################
@@ -457,6 +436,30 @@ end
     FileUtils.rm_rf("#{temp_dir}")
   end
 
+  # Creates a new GitHub Release for the given version
+  #
+  # @param [Hash<String>] version The version to create. Expects keys "name" and "code"
+  # @param [Bool] prerelease If true, the GitHub Release will have the prerelease flag
+  #
+  private_lane :create_gh_release do | options |
+    version = options[:version]
+    prerelease = options[:prerelease].nil? ? false : options[:prerelease]
+
+    # APKs built on CI are not signed with master key, which means Google Sign-In won't work with those.
+    # So don't attach them to the release, as this ends up being confusing for beta-testers.
+    apk_file_path = File.join(project_root, 'artifacts', universal_apk_name(version)) unless is_ci
+    aab_file_path = File.join(project_root, 'artifacts', aab_file_name(version))
+    release_assets = [apk_file_path, aab_file_path].compact
+
+    create_release(
+      repository: GHHELPER_REPO,
+      version: version["name"],
+      release_notes_file_path: release_notes_path,
+      prerelease: prerelease,
+      release_assets: release_assets.join(',')
+    )
+  end
+
   private_lane :send_strings_for_translation do | options |
     sh("cd .. && mkdir -p #{update_strings_path} && cp #{main_strings_path} #{update_strings_path} && git add #{update_strings_path}strings.xml")
     sh("git diff-index --quiet HEAD || git commit -m \"Send strings to translation.\"")
@@ -470,7 +473,11 @@ end
     "#{ENV["PROJECT_ROOT_FOLDER"]}WooCommerce/metadata/release_notes.txt"
   end
 
+  def aab_file_name(version)
+    "wcandroid-#{version["name"]}.aab"
+  end
+
   def universal_apk_name(version)
-    "wcandroid-#{ version["name"] }-universal.apk"
+    "wcandroid-#{version["name"]}-universal.apk"
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,7 +5,6 @@ unless FastlaneCore::Helper.bundler?
   UI.user_error!('Please run fastlane via `bundle exec`')
 end
 
-platform :android do
 ########################################################################
 # Environment
 ########################################################################
@@ -37,9 +36,11 @@ SUPPORTED_LOCALES = [
 main_strings_path = "./WooCommerce/src/main/res/values/strings.xml"
 update_strings_path = "./fastlane/resources/values/"
 
+platform :android do
 ########################################################################
 # Release Lanes
 ########################################################################
+
   #####################################################################################
   # code_freeze
   # -----------------------------------------------------------------------------------
@@ -58,8 +59,8 @@ update_strings_path = "./fastlane/resources/values/"
 
     android_bump_version_release()
     new_version = android_get_app_version()
-    extract_release_notes_for_version(version: new_version, 
-      release_notes_file_path:"#{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt", 
+    extract_release_notes_for_version(version: new_version,
+      release_notes_file_path:"#{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt",
       extracted_notes_file_path:release_notes_path)
     android_update_release_notes(new_version: new_version)
     setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{new_version}")
@@ -67,8 +68,7 @@ update_strings_path = "./fastlane/resources/values/"
 
     localize_libs()
     send_strings_for_translation()
-    get_prs_list(repository:GHHELPER_REPO, start_tag:"#{old_version}", report_path:"#{File.expand_path('~')}/wcandroid_prs_list_#{old_version}_#{new_version}.txt")
-    
+    get_prs_list(repository: GHHELPER_REPO, start_tag:"#{old_version}", report_path:"#{File.expand_path('~')}/wcandroid_prs_list_#{old_version}_#{new_version}.txt")
   end
 
   #####################################################################################
@@ -88,43 +88,43 @@ update_strings_path = "./fastlane/resources/values/"
     android_completecodefreeze_prechecks(options)
     android_tag_build()
   end
-  
-#####################################################################################
-# update_appstore_strings
-# -----------------------------------------------------------------------------------
-# This lane gets the data from the txt files in the WooCommerce/metadata/ folder
-# and updates the .pot file that is then picked by GlotPress for translations.
-# -----------------------------------------------------------------------------------
-# Usage:
-# fastlane update_appstore_strings version:<version>
-#
-# Example:
-# fastlane update_appstore_strings version:1.1
-#####################################################################################
-desc "Updates the PlayStoreStrings.pot file"
-lane :update_appstore_strings do |options|
-  prj_folder = Dir.pwd + "/.."
 
-  files = {
-    release_note: prj_folder + "/WooCommerce/metadata/release_notes.txt",
-    play_store_promo: prj_folder + "/WooCommerce/metadata/short_description.txt",
-    play_store_desc: prj_folder + "/WooCommerce/metadata/full_description.txt",
-    play_store_app_title: prj_folder + "/WooCommerce/metadata/title.txt",
-    play_store_screenshot_1: prj_folder + "/WooCommerce/metadata/promo_screenshot_1.txt",
-    play_store_screenshot_1_b: prj_folder + "/WooCommerce/metadata/promo_screenshot_1_b.txt",
-    play_store_screenshot_2: prj_folder + "/WooCommerce/metadata/promo_screenshot_2.txt",
-    play_store_screenshot_3: prj_folder + "/WooCommerce/metadata/promo_screenshot_3.txt",
-    play_store_screenshot_4: prj_folder + "/WooCommerce/metadata/promo_screenshot_4.txt",
-    play_store_screenshot_5: prj_folder + "/WooCommerce/metadata/promo_screenshot_5.txt",
-    play_store_screenshot_6: prj_folder + "/WooCommerce/metadata/promo_screenshot_6.txt",
-    play_store_screenshot_7: prj_folder + "/WooCommerce/metadata/promo_screenshot_7.txt",
-    play_store_screenshot_8: prj_folder + "/WooCommerce/metadata/promo_screenshot_8.txt"
-  }
+  #####################################################################################
+  # update_appstore_strings
+  # -----------------------------------------------------------------------------------
+  # This lane gets the data from the txt files in the WooCommerce/metadata/ folder
+  # and updates the .pot file that is then picked by GlotPress for translations.
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # fastlane update_appstore_strings version:<version>
+  #
+  # Example:
+  # fastlane update_appstore_strings version:1.1
+  #####################################################################################
+  desc "Updates the PlayStoreStrings.pot file"
+  lane :update_appstore_strings do |options|
+    prj_folder = Dir.pwd + "/.."
 
-  android_update_metadata_source(po_file_path: prj_folder + "/WooCommerce/metadata/PlayStoreStrings.pot",
-    source_files: files,
-    release_version: options[:version])
-end
+    files = {
+      release_note: prj_folder + "/WooCommerce/metadata/release_notes.txt",
+      play_store_promo: prj_folder + "/WooCommerce/metadata/short_description.txt",
+      play_store_desc: prj_folder + "/WooCommerce/metadata/full_description.txt",
+      play_store_app_title: prj_folder + "/WooCommerce/metadata/title.txt",
+      play_store_screenshot_1: prj_folder + "/WooCommerce/metadata/promo_screenshot_1.txt",
+      play_store_screenshot_1_b: prj_folder + "/WooCommerce/metadata/promo_screenshot_1_b.txt",
+      play_store_screenshot_2: prj_folder + "/WooCommerce/metadata/promo_screenshot_2.txt",
+      play_store_screenshot_3: prj_folder + "/WooCommerce/metadata/promo_screenshot_3.txt",
+      play_store_screenshot_4: prj_folder + "/WooCommerce/metadata/promo_screenshot_4.txt",
+      play_store_screenshot_5: prj_folder + "/WooCommerce/metadata/promo_screenshot_5.txt",
+      play_store_screenshot_6: prj_folder + "/WooCommerce/metadata/promo_screenshot_6.txt",
+      play_store_screenshot_7: prj_folder + "/WooCommerce/metadata/promo_screenshot_7.txt",
+      play_store_screenshot_8: prj_folder + "/WooCommerce/metadata/promo_screenshot_8.txt"
+    }
+
+    android_update_metadata_source(po_file_path: prj_folder + "/WooCommerce/metadata/PlayStoreStrings.pot",
+      source_files: files,
+      release_version: options[:version])
+  end
 
   #####################################################################################
   # new_beta_release
@@ -286,30 +286,30 @@ end
     create_gh_release(version: version, prerelease: true) if (options[:create_release])
   end
 
-#####################################################################################
-# localize_libs
-# -----------------------------------------------------------------------------------
-# This lane gets the data from the dependencies and updates the main strings.xml file
-# -----------------------------------------------------------------------------------
-# Usage:
-# fastlane localize_libs
-#
-# Example:
-# fastlane localize_libs
-#####################################################################################
-desc "Merge libraries strings files into the main app one"
-lane :localize_libs do | options |
-  libraries_strings_path = [
-    {library: "Login Library", strings_path: "./libs/login/WordPressLoginFlow/src/main/res/values/strings.xml", exclusions: ["default_web_client_id"]}
-  ]
+  #####################################################################################
+  # localize_libs
+  # -----------------------------------------------------------------------------------
+  # This lane gets the data from the dependencies and updates the main strings.xml file
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # fastlane localize_libs
+  #
+  # Example:
+  # fastlane localize_libs
+  #####################################################################################
+  desc "Merge libraries strings files into the main app one"
+  lane :localize_libs do | options |
+    libraries_strings_path = [
+      {library: "Login Library", strings_path: "./libs/login/WordPressLoginFlow/src/main/res/values/strings.xml", exclusions: ["default_web_client_id"]}
+    ]
 
-  if (an_localize_libs(app_strings_path: main_strings_path, libs_strings_path: libraries_strings_path)) then
-    UI.important("Your #{main_strings_path} has changed.")
-    UI.input("Please, review the changes, commit them and press return to continue.")
+    if (an_localize_libs(app_strings_path: main_strings_path, libs_strings_path: libraries_strings_path)) then
+      UI.important("Your #{main_strings_path} has changed.")
+      UI.input("Please, review the changes, commit them and press return to continue.")
+    end
   end
-end
 
-#####################################################################################
+  #####################################################################################
   # download_metadata_string
   # -----------------------------------------------------------------------------------
   # This lane downloads the translated metadata (release notes,
@@ -344,13 +344,13 @@ end
     sh("git add #{download_path} && (git diff-index --quiet HEAD || git commit -m \"Update metadata translations for #{options[:version]}\") && git push")
   end
 
-########################################################################
-# Helper Lanes
-########################################################################
-desc "Get a list of pull request from `start_tag` to the current state"
-lane :get_pullrequests_list do | options |
-  get_prs_list(repository:GHHELPER_REPO, start_tag:"#{options[:start_tag]}", report_path:"#{File.expand_path('~')}/wcandroid_prs_list.txt")
-end
+  ########################################################################
+  # Helper Lanes
+  ########################################################################
+  desc "Get a list of pull request from `start_tag` to the current state"
+  lane :get_pullrequests_list do | options |
+    get_prs_list(repository:GHHELPER_REPO, start_tag:"#{options[:start_tag]}", report_path:"#{File.expand_path('~')}/wcandroid_prs_list.txt")
+  end
 
   #####################################################################################
   # build_bundle
@@ -415,19 +415,19 @@ end
     temp_dir = Dir.mktmpdir()
 
     command = ""
-    if is_ci 
+    if is_ci
       command << "bundletool build-apks --bundle=\"#{bundle_path}\" \\
-      --output=\"#{temp_dir}/universal.apks\" \\
-      --mode=universal"
+        --output=\"#{temp_dir}/universal.apks\" \\
+        --mode=universal"
     else
       command = "source ./tools/gradle-functions.sh"
       command << "&& bundletool build-apks --bundle=\"#{bundle_path}\" \\
-      --output=\"#{temp_dir}/universal.apks\" \\
-      --mode=universal \\
-      --ks=\"$(get_gradle_property gradle.properties storeFile)\" \\
-      --ks-pass=\"pass:$(get_gradle_property gradle.properties storePassword)\" \\
-      --ks-key-alias=\"$(get_gradle_property gradle.properties keyAlias)\" \\
-      --key-pass=\"pass:$(get_gradle_property gradle.properties keyPassword)\""
+        --output=\"#{temp_dir}/universal.apks\" \\
+        --mode=universal \\
+        --ks=\"$(get_gradle_property gradle.properties storeFile)\" \\
+        --ks-pass=\"pass:$(get_gradle_property gradle.properties storePassword)\" \\
+        --ks-key-alias=\"$(get_gradle_property gradle.properties keyAlias)\" \\
+        --key-pass=\"pass:$(get_gradle_property gradle.properties keyPassword)\""
     end
     sh(command)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -240,7 +240,7 @@ platform :android do
       json_key: './google-upload-credentials.json',
     )
 
-    create_gh_release(version: version) if (options[:create_release])
+    create_gh_release(version: version) if options[:create_release]
   end
 
   #####################################################################################
@@ -283,7 +283,7 @@ platform :android do
       json_key: './google-upload-credentials.json',
     )
 
-    create_gh_release(version: version, prerelease: true) if (options[:create_release])
+    create_gh_release(version: version, prerelease: true) if options[:create_release]
   end
 
   #####################################################################################
@@ -443,7 +443,7 @@ platform :android do
   #
   private_lane :create_gh_release do | options |
     version = options[:version]
-    prerelease = options[:prerelease].nil? ? false : options[:prerelease]
+    prerelease = options[:prerelease] || false
 
     # APKs built on CI are not signed with master key, which means Google Sign-In won't work with those.
     # So don't attach them to the release, as this ends up being confusing for beta-testers.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -224,7 +224,7 @@ platform :android do
     build_bundle(version: version, flavor:"Vanilla")
 
     project_root = File.dirname(File.expand_path(File.dirname(__FILE__)))
-    aab_file_path = File.join(project_root, "artifacts", "wcandroid-#{ version["name"] }.aab")
+    aab_file_path = File.join(project_root, "artifacts", aab_file_name(version))
 
     UI.error("Unable to find a build artifact at #{aab_file_path}") unless File.exist? aab_file_path
 
@@ -267,7 +267,7 @@ platform :android do
     build_bundle(version: version, flavor:"Vanilla")
 
     project_root = File.dirname(File.expand_path(File.dirname(__FILE__)))
-    aab_file_path = File.join(project_root, "artifacts", "wcandroid-#{ version["name"] }.aab")
+    aab_file_path = File.join(project_root, "artifacts", aab_file_name(version))
 
     UI.error("Unable to find a build artifact at #{aab_file_path}") unless File.exist? aab_file_path
 
@@ -363,12 +363,12 @@ platform :android do
   desc "Builds an app bundle"
   lane :build_bundle do | options |
     # Create the file names
-    version=options[:version]
-    name="wcandroid-#{version["name"]}.aab"
-    apk_name=universal_apk_name(version)
-    aab_file="WooCommerce-vanilla-release.aab"
-    output_dir="WooCommerce/build/outputs/bundle/"
-    build_dir="artifacts/"
+    version = options[:version]
+    name = aab_file_name(version)
+    apk_name = universal_apk_name(version)
+    aab_file = "WooCommerce-vanilla-release.aab"
+    output_dir = "WooCommerce/build/outputs/bundle/"
+    build_dir = "artifacts/"
 
     # Build
     Dir.chdir(".") do


### PR DESCRIPTION
Continuation of https://github.com/woocommerce/woocommerce-android/pull/3583 to implement @mokagio 's suggestion in https://github.com/woocommerce/woocommerce-android/pull/3583#pullrequestreview-591735285

* Just a quick refactoring to DRY the code about the creation of GitHub release into a private lane (similar to how it's done in WPAndroid' `Fastfile`)
* Also fix the `Fastfile` inconsistent indentation overall

## To Review

Not really easily testable without creating an actual beta or release, as usual with this kind of changes.

I suggest to review it commit-per-commit:

* 404298e0ebabed85a23df6e97b6fd6927ab042aa: The extraction of the GH release logic into a private lane, the one that needs the main review focus
* 1bdc3383da7867b87d43d935428681df71b0fd4e: Fixing indentation. Could be easier to review it using GitHub's Split mode (side-by-side) rather than Unified Diff.

Or alternatively, review the whole diff but with "Ignore Whitespaces" setting turned on to avoid too much noise, or using Split (side-by-side) mode for easier highlight of whitespace-only changes.