### PR TITLE
Shipping Labels: fix crash in packages if a product was deleted

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -42,7 +42,7 @@ class EditShippingLabelPackagesFragment : BaseFragment(R.layout.fragment_edit_sh
 
     private val packagesAdapter: ShippingLabelPackagesAdapter by lazy {
         ShippingLabelPackagesAdapter(
-            viewModel.parameters,
+            viewModel.weightUnit,
             viewModel::onWeightEdited,
             viewModel::onPackageSpinnerClicked
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRepository
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.ProductDetailRepository
-import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -44,8 +43,9 @@ class EditShippingLabelPackagesViewModel @AssistedInject constructor(
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 
-    val parameters: SiteParameters by lazy {
-        parameterRepository.getParameters(KEY_PARAMETERS, savedState)
+    val weightUnit: String by lazy {
+        val parameters = parameterRepository.getParameters(KEY_PARAMETERS, savedState)
+        parameters.weightUnit ?: ""
     }
 
     init {
@@ -144,7 +144,7 @@ class EditShippingLabelPackagesViewModel @AssistedInject constructor(
 
     private fun Order.Item.toShippingItem(): ShippingLabelPackage.Item {
         val weight = productDetailRepository.getProduct(productId)!!.weight.let {
-            "$it ${parameters.weightUnit}"
+            "$it $weightUnit"
         }
         return ShippingLabelPackage.Item(
             productId = productId,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -14,11 +14,10 @@ import com.woocommerce.android.databinding.ShippingLabelPackageProductListItemBi
 import com.woocommerce.android.model.ShippingLabelPackage
 import com.woocommerce.android.ui.orders.shippinglabels.creation.PackageProductsAdapter.PackageProductViewHolder
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelPackagesAdapter.ShippingLabelPackageViewHolder
-import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.util.StringUtils
 
 class ShippingLabelPackagesAdapter(
-    val parameters: SiteParameters,
+    val weightUnit: String,
     val onWeightEdited: (Int, Double) -> Unit,
     val onPackageSpinnerClicked: (Int) -> Unit
 ) : RecyclerView.Adapter<ShippingLabelPackageViewHolder>() {
@@ -64,7 +63,7 @@ class ShippingLabelPackagesAdapter(
             }
             binding.weightEditText.hint = binding.root.context.getString(
                 R.string.shipping_label_package_details_weight_hint,
-                parameters.weightUnit
+                weightUnit
             )
             binding.weightEditText.setOnTextChangedListener {
                 val weight = it?.toString()?.trim('.')?.ifEmpty { null }?.toDouble() ?: Double.NaN


### PR DESCRIPTION
Fixes #3572, it excludes the deleted products to follow the same behavior as the web client.
For the case where all products are deleted, the order shouldn't be eligible for shipping label creation, and we won't reach this step.

The PR also includes another fix, to accept nullable weight unit, and avoid this [issue](https://github.com/woocommerce/woocommerce-android/pull/3559#issuecomment-778317746)

#### Testing
1. Create an order with multiple products, and destined to a US address.
2. Delete one of the products.
3. Open order details.
4. Click on create shipping label.
5. Pass the origin and destination address steps.
6. Open package details.
7. Confirm that the deleted product is excluded from the list of items.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
