### PR TITLE
Make sure product settings updates are reflected in the app

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 6.1
 -----
- 
+* [*] Fixed a bug where the app doesn't show the updated product settings. [https://github.com/woocommerce/woocommerce-android/pull/3599]
 
 6.0
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '96c59a96a69f31634198fa4a481b90a0c405ab39'
+    fluxCVersion = 'b2e6989dd7d68c035d7fd3ff1c0a7ff8972ff310'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Fixes #3575, the issue was caused by a bug in FluxC that prevents any updates of the WCProductSettingsModel to be taken into account.

#### Testing
1. Open the app, and open a physical product that has the shipping section
2. Confirm that the current measurement units in the shipping section match wp-admin.
3. Go to wp-admin -> WooCommerce -> Settings -> Products
4. Change the measurement units.
5. Force close the app (to force the app to re-fetch the settings, unless you do that, it will re-fetch them after 1 hour)
6. Open the same product.
7. Open Shipping settings.
8. Confirm that the new measurement units are displayed.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
