### PR TITLE
issue/3600-remove-sqlscout 

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -211,11 +211,6 @@ dependencies {
     implementation "org.greenrobot:eventbus:$eventBusVersion"
     implementation "com.google.android.play:core:$googlePlayCoreVersion"
 
-    // For use with SqlScout, a Sqlite plugin for Android Studio
-    // https://plugins.jetbrains.com/plugin/8322-sqlscout-sqlite-support-
-    debugImplementation 'com.idescout.sql:sqlscout-server:4.1'
-    releaseImplementation 'com.idescout.sql:sqlscout-server-noop:4.1'
-
     // Debug dependencies
     debugImplementation "com.facebook.flipper:flipper:$flipperVersion"
     debugImplementation "com.facebook.soloader:soloader:0.9.0"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -10,7 +10,6 @@ import androidx.multidex.MultiDexApplication
 import com.android.volley.VolleyLog
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
-import com.idescout.sql.SqlScoutServer
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.di.AppComponent
@@ -113,9 +112,6 @@ open class WooCommerce : MultiDexApplication(), HasAndroidInjector, ApplicationL
         // https://github.com/woocommerce/woocommerce-android/issues/817
         if (!BuildConfig.DEBUG) {
             VolleyLog.DEBUG = false
-        } else {
-            // We are in a debug build. Let's enable sqlScout
-            SqlScoutServer.create(this, getPackageName())
         }
 
         val wellSqlConfig = WooWellSqlConfig(applicationContext)

--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven {
-            url 'http://www.idescout.com/maven/repo/'
-        }
     }
 
     task checkstyle(type: Checkstyle) {


### PR DESCRIPTION
Closes #3600 by removing the SQLScout dependency, which was added in #1331 and modified in #1460.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
