### PR TITLE
Bump Zendesk SDK

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
  
 * [*] Fixed a bug where the app doesn't show the updated product settings. [https://github.com/woocommerce/woocommerce-android/pull/3599]
 * [*] Fixed a bug the field of product price couldn't be edited if the device's language uses a different numerals system (e.g. Arabic) [https://github.com/woocommerce/woocommerce-android/pull/3589]
+* [*] Fixed a bug where the app doesn't receive push notification for support request reply [https://github.com/woocommerce/woocommerce-android/pull/3607]
 
 6.0
 -----

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -258,9 +258,7 @@ dependencies {
     androidTestImplementation "androidx.annotation:annotation:1.1.0"
     androidTestImplementation "com.google.code.findbugs:jsr305:2.0.1"
 
-    implementation(group: 'com.zendesk', name: 'support', version: '4.0.0') {
-        exclude group: 'com.google.dagger'
-    }
+    implementation "com.zendesk:support:5.0.2"
 
     // ViewModel and LiveData
     implementation "androidx.lifecycle:lifecycle-extensions:$archComponentsVersion"


### PR DESCRIPTION
### Description

This PR bumps Zendesk SDK from `4.0.0` to `5.0.2` which fixes an issue of not receiving push notification for the very first support reply.

### How to test

See #3574 for details instructions

### Demo

https://user-images.githubusercontent.com/5845095/108557188-7ed0c880-72f8-11eb-90cb-a77abdc4a5a6.mp4

Resolves #3555 
Resolves #3574 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
