### PR TITLE
Issue-3602. Order Creation flag

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.util
 
 import android.content.Context
-import com.woocommerce.android.BuildConfig
 
 /**
  * "Feature flags" are used to hide in-progress features from release versions
@@ -9,23 +8,16 @@ import com.woocommerce.android.BuildConfig
 enum class FeatureFlag {
     SHIPPING_LABELS_M2,
     ADD_EDIT_VARIATIONS,
-    DB_DOWNGRADE;
+    DB_DOWNGRADE,
+    ORDER_CREATION;
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
-            SHIPPING_LABELS_M2 -> BuildConfig.DEBUG || isTesting()
-            ADD_EDIT_VARIATIONS -> BuildConfig.DEBUG
+            SHIPPING_LABELS_M2 -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
+            ADD_EDIT_VARIATIONS -> PackageUtils.isDebugBuild()
             DB_DOWNGRADE -> {
-                BuildConfig.DEBUG || context != null && PackageUtils.isBetaBuild(context)
+                PackageUtils.isDebugBuild() || context != null && PackageUtils.isBetaBuild(context)
             }
-        }
-    }
-
-    private fun isTesting(): Boolean {
-        return try {
-            Class.forName("com.woocommerce.android.viewmodel.BaseUnitTest")
-            true
-        } catch (e: ClassNotFoundException) {
-            false
+            ORDER_CREATION -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/PackageUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/PackageUtils.kt
@@ -15,6 +15,15 @@ object PackageUtils {
      */
     fun isDebugBuild() = BuildConfig.DEBUG
 
+    fun isTesting(): Boolean {
+        return try {
+            Class.forName("com.woocommerce.android.viewmodel.BaseUnitTest")
+            true
+        } catch (e: ClassNotFoundException) {
+            false
+        }
+    }
+
     fun isBetaBuild(context: Context): Boolean {
         val versionName = getVersionName(context).toLowerCase(Locale.ROOT)
         return (versionName.contains("beta") || versionName.contains("rc"))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/PackageUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/PackageUtils.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import androidx.core.content.pm.PackageInfoCompat
-import org.wordpress.android.util.BuildConfig
+import com.woocommerce.android.BuildConfig
 import java.util.Locale
 
 object PackageUtils {


### PR DESCRIPTION
- Issue: https://github.com/woocommerce/woocommerce-android/issues/3602
- Description: ORDER_CREATION feature flag which is enabled when it's a debug build or when tests are running. I took the courage to make a tiny refactoring, just let me know if you don't think that it's an improvement.
- Testing instructions: Nothing changes in the app behavior. So far the flag is not used.

it's my first PR. I was trying to follow the process as much as I can, but please, let me know if anything doesn't follow your process (including commit message, PR description, or anything). Thanks =)