### PR TITLE
Issue/3603. Order creation FAB under feature flag

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/FabManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/FabManager.kt
@@ -1,0 +1,7 @@
+package com.woocommerce.android.ui.base
+
+interface FabManager {
+    fun showFabAnimated(contentDescription: Int, onClick: () -> Unit)
+    fun hideFabAnimated()
+    fun hideFabImmediately()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -2,15 +2,30 @@ package com.woocommerce.android.ui.base
 
 import androidx.annotation.LayoutRes
 import com.woocommerce.android.ui.main.MainActivity
+import com.woocommerce.android.ui.main.MainNavigationRouter
+import javax.inject.Inject
 
 /**
  * The main fragments hosted by the bottom bar should extend this class
  */
 abstract class TopLevelFragment : BaseFragment, TopLevelFragmentView {
+    @Inject internal lateinit var fabManager: FabManager
+
     constructor() : super()
     constructor(@LayoutRes layoutId: Int) : super(layoutId)
 
     abstract fun shouldExpandToolbar(): Boolean
+
+    abstract val hasFab: Boolean
+
+    override fun onDestroyView() {
+        (activity as? MainNavigationRouter)?.let {
+            if (!it.currentDestinationHasFab()) {
+                fabManager.hideFabImmediately()
+            }
+        }
+        super.onDestroyView()
+    }
 
     /**
      * Called when the fragment shows or hides a search view so we can properly disable the collapsing

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -42,6 +42,7 @@ import com.woocommerce.android.push.NotificationHandler.NotificationChannelType
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.base.FabManager
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.feedback.SurveyType
@@ -114,6 +115,7 @@ class MainActivity : AppUpgradeActivity(),
     @Inject lateinit var selectedSite: SelectedSite
     @Inject lateinit var uiMessageResolver: UIMessageResolver
     @Inject lateinit var revenueStatsAvailabilityFetcher: RevenueStatsAvailabilityFetcher
+    @Inject lateinit var fabManager: FabManager
 
     private var isBottomNavShowing = true
     private var previousDestinationId: Int? = null
@@ -647,6 +649,10 @@ class MainActivity : AppUpgradeActivity(),
             REVIEWS -> Stat.MAIN_TAB_NOTIFICATIONS_SELECTED
         }
         AnalyticsTracker.track(stat)
+
+        if (navPos != ORDERS && navPos != PRODUCTS) {
+            fabManager.hideFabAnimated()
+        }
 
         if (navPos == REVIEWS) {
             NotificationHandler.removeAllReviewNotifsFromSystemBar(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -329,6 +329,14 @@ class MainActivity : AppUpgradeActivity(),
     }
 
     /**
+     * Returns if currently navigating to top-level fragment has a FAB.
+     * Returns false if currently navigation not to a top-level fragment.
+     */
+    override fun currentDestinationHasFab(): Boolean {
+        return getActiveChildFragment() == null && getActiveTopLevelFragment()?.hasFab == true
+    }
+
+    /**
      * Returns true if the navigation controller is showing the root fragment (ie: a top level fragment is showing)
      */
     override fun isAtNavigationRoot(): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -658,10 +658,6 @@ class MainActivity : AppUpgradeActivity(),
         }
         AnalyticsTracker.track(stat)
 
-        if (navPos != ORDERS && navPos != PRODUCTS) {
-            fabManager.hideFabAnimated()
-        }
-
         if (navPos == REVIEWS) {
             NotificationHandler.removeAllReviewNotifsFromSystemBar(this)
         } else if (navPos == ORDERS) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainAddFabManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainAddFabManager.kt
@@ -1,0 +1,36 @@
+package com.woocommerce.android.ui.main
+
+import androidx.annotation.StringRes
+import androidx.core.view.isGone
+import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.woocommerce.android.R
+import com.woocommerce.android.di.ActivityScope
+import com.woocommerce.android.ui.base.FabManager
+import javax.inject.Inject
+
+@ActivityScope
+class MainAddFabManager @Inject constructor(val activity: MainActivity) : FabManager {
+    private val addButton by lazy { activity.findViewById<FloatingActionButton>(R.id.addButton) }
+
+    override fun showFabAnimated(@StringRes contentDescription: Int, onClick: () -> Unit) {
+        with(addButton) {
+            this.contentDescription = activity.getString(contentDescription)
+            show()
+            setOnClickListener { onClick() }
+        }
+    }
+
+    override fun hideFabAnimated() {
+        with(addButton) {
+            addButton.setOnClickListener(null)
+            hide()
+        }
+    }
+
+    override fun hideFabImmediately() {
+        with(addButton) {
+            addButton.setOnClickListener(null)
+            isGone = true
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainModule.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.main
 
 import com.woocommerce.android.di.ActivityScope
+import com.woocommerce.android.ui.base.FabManager
 import com.woocommerce.android.ui.base.UIMessageResolver
 import dagger.Binds
 import dagger.Module
@@ -14,4 +15,8 @@ internal abstract class MainModule {
     @ActivityScope
     @Binds
     abstract fun provideUiMessageResolver(mainUIMessageResolver: MainUIMessageResolver): UIMessageResolver
+
+    @ActivityScope
+    @Binds
+    abstract fun provideMainAddFabManager(mainAddFabManager: MainAddFabManager): FabManager
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.ui.main
 
 interface MainNavigationRouter {
+    fun currentDestinationHasFab(): Boolean
+
     fun isAtNavigationRoot(): Boolean
     fun isChildFragmentShowing(): Boolean
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -450,4 +450,6 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store),
     }
 
     override fun shouldExpandToolbar() = binding.statsScrollView.scrollY == 0
+
+    override val hasFab = false
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -147,8 +147,6 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        showFabIfFeatureEnabled()
-
         setHasOptionsMenu(true)
 
         _tabLayout = TabLayout(requireContext(), null, R.attr.tabStyle)
@@ -335,7 +333,6 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
         })
 
         viewModel.pagedListData.observe(viewLifecycleOwner, Observer {
-            showFabIfFeatureEnabled()
             updatePagedListData(it)
         })
 
@@ -351,12 +348,6 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
 
         viewModel.emptyViewType.observe(viewLifecycleOwner, Observer {
             it?.let { emptyViewType ->
-                if (emptyViewType == EmptyViewType.ORDER_LIST_LOADING) {
-                    fabManager.hideFabAnimated()
-                } else {
-                    showFabIfFeatureEnabled()
-                }
-
                 when (emptyViewType) {
                     EmptyViewType.SEARCH_RESULTS -> {
                         binding.orderStatusListView
@@ -380,6 +371,14 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
                     }
                 }
             } ?: hideEmptyView()
+        })
+
+        viewModel.isAddOrderButtonVisible.observe(viewLifecycleOwner, Observer { isVisible ->
+            if (isVisible) {
+                fabManager.showFabAnimated(R.string.orderlist_add_order_button) { viewModel.onAddOrderButtonClicked() }
+            } else {
+                fabManager.hideFabAnimated()
+            }
         })
     }
 
@@ -748,13 +747,5 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
         return binding.orderListView.ordersList.computeVerticalScrollOffset() == 0 && !isSearching
     }
 
-    override val hasFab = ORDER_CREATION.isEnabled(activity)
-
-    private fun showFabIfFeatureEnabled() {
-        if (ORDER_CREATION.isEnabled(activity)) {
-            fabManager.showFabAnimated(R.string.orderlist_add_order_button) { viewModel.onAddOrderButtonClicked() }
-        } else {
-            fabManager.hideFabImmediately()
-        }
-    }
+    override val hasFab = ORDER_CREATION.isEnabled()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -160,7 +160,7 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
             scrollUpChild = binding.orderListView.ordersList
             setOnRefreshListener {
                 AnalyticsTracker.track(Stat.ORDERS_LIST_PULLED_TO_REFRESH)
-                refreshOrders()
+                viewModel.onRefreshOrders()
             }
         }
 
@@ -363,7 +363,7 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
                     }
                     EmptyViewType.NETWORK_OFFLINE, EmptyViewType.NETWORK_ERROR -> {
                         emptyView.show(emptyViewType) {
-                            refreshOrders()
+                            viewModel.onRefreshOrders()
                         }
                     }
                     else -> {
@@ -613,10 +613,6 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
         } else if (!show && tabLayout.visibility != View.GONE) {
             tabLayout.visibility = View.GONE
         }
-    }
-
-    private fun refreshOrders() {
-        viewModel.fetchOrdersAndOrderDependencies()
     }
 
     private fun disableSearchListeners() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -20,12 +20,10 @@ import com.google.android.material.tabs.TabLayout
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
-import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.databinding.FragmentOrderListBinding
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.base.FabManager
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.main.MainActivity
@@ -66,7 +64,6 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
     @Inject internal lateinit var uiMessageResolver: UIMessageResolver
     @Inject internal lateinit var selectedSite: SelectedSite
     @Inject internal lateinit var currencyFormatter: CurrencyFormatter
-    @Inject internal lateinit var fabManager: FabManager
 
     private val viewModel: OrderListViewModel by viewModels { viewModelFactory }
 
@@ -751,10 +748,11 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
         return binding.orderListView.ordersList.computeVerticalScrollOffset() == 0 && !isSearching
     }
 
+    override val hasFab = ORDER_CREATION.isEnabled(activity)
+
     private fun showFabIfFeatureEnabled() {
         if (ORDER_CREATION.isEnabled(activity)) {
-            // TO-DO set correct content description
-            fabManager.showFabAnimated(string.add_products_button) { viewModel.onAddOrderButtonClicked() }
+            fabManager.showFabAnimated(R.string.orderlist_add_order_button) { viewModel.onAddOrderButtonClicked() }
         } else {
             fabManager.hideFabImmediately()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -245,6 +245,10 @@ class OrderListViewModel @AssistedInject constructor(
         activePagedListWrapper?.invalidateData()
     }
 
+    fun onAddOrderButtonClicked() {
+        // TO-DO #3604
+    }
+
     /**
      * Activates the provided list by first removing the LiveData sources for the active list,
      * then creating new LiveData sources for the provided [pagedListWrapper] and setting it as

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -74,7 +74,6 @@ class OrderListViewModel @AssistedInject constructor(
     featureFlagResolver: FeatureFlagResolver
 ) : ScopedViewModel(savedState, coroutineDispatchers), LifecycleOwner {
     private val orderCreationFeatureEnabled = featureFlagResolver.isFeatureEnabled(ORDER_CREATION)
-    private var isRefreshing: Boolean = false
 
     protected val lifecycleRegistry: LifecycleRegistry by lazy {
         LifecycleRegistry(this)
@@ -200,7 +199,6 @@ class OrderListViewModel @AssistedInject constructor(
     }
 
     fun onRefreshOrders() {
-        isRefreshing = true
         hideAddOrderButton()
         fetchOrdersAndOrderDependencies()
     }
@@ -218,7 +216,6 @@ class OrderListViewModel @AssistedInject constructor(
             }
         } else {
             showAddOrderButtonIfEnabled()
-            isRefreshing = false
             viewState = viewState.copy(isRefreshPending = true)
             showOfflineSnack()
         }
@@ -288,8 +285,8 @@ class OrderListViewModel @AssistedInject constructor(
                 _pagedListData.value = it
             }
         }
-        _isFetchingFirstPage.addSource(pagedListWrapper.isFetchingFirstPage) { isFetchingFirstPage ->
-            onFetchingFirstPage(isFetchingFirstPage)
+        _isFetchingFirstPage.addSource(pagedListWrapper.isFetchingFirstPage) { isFetchingInProgress ->
+            onFetchingFirstPage(isFetchingInProgress)
         }
         _isEmpty.addSource(pagedListWrapper.isEmpty) {
             _isEmpty.value = it
@@ -313,13 +310,11 @@ class OrderListViewModel @AssistedInject constructor(
         }
     }
 
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    fun onFetchingFirstPage(isFetchingFirstPage: Boolean) {
-        _isFetchingFirstPage.value = isFetchingFirstPage
-        if (!isFetchingFirstPage) {
+    private fun onFetchingFirstPage(isFetchingInProgress: Boolean) {
+        _isFetchingFirstPage.value = isFetchingInProgress
+        if (!isFetchingInProgress) {
             showAddOrderButtonIfEnabled()
         }
-        isRefreshing = false
     }
 
     private fun clearLiveDataSources(pagedListWrapper: PagedListWrapper<OrderListItemUIType>?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -32,7 +32,6 @@ import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.DISMI
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.GIVEN
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.UNANSWERED
 import com.woocommerce.android.model.Product
-import com.woocommerce.android.ui.base.FabManager
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.feedback.SurveyType
@@ -63,7 +62,6 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
 
     @Inject lateinit var viewModelFactory: ViewModelFactory
     @Inject lateinit var uiMessageResolver: UIMessageResolver
-    @Inject lateinit var fabManager: FabManager
 
     private lateinit var productAdapter: ProductListAdapter
 
@@ -463,4 +461,6 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
     override fun shouldExpandToolbar(): Boolean {
         return binding.productsRecycler.computeVerticalScrollOffset() == 0 && !viewModel.isSearching()
     }
+
+    override val hasFab = true
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -362,4 +362,6 @@ class ReviewListFragment : TopLevelFragment(R.layout.fragment_reviews_list),
     }
 
     override fun shouldExpandToolbar() = binding.reviewsList.computeVerticalScrollOffset() == 0
+
+    override val hasFab = false
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.util
 
 import android.content.Context
+import javax.inject.Inject
 
 /**
  * "Feature flags" are used to hide in-progress features from release versions
@@ -10,6 +11,7 @@ enum class FeatureFlag {
     ADD_EDIT_VARIATIONS,
     DB_DOWNGRADE,
     ORDER_CREATION;
+
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
             SHIPPING_LABELS_M2 -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
@@ -20,4 +22,8 @@ enum class FeatureFlag {
             ORDER_CREATION -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
         }
     }
+}
+
+class FeatureFlagResolver @Inject constructor() {
+    fun isFeatureEnabled(flag: FeatureFlag) = flag.isEnabled()
 }

--- a/WooCommerce/src/main/res/layout/activity_main.xml
+++ b/WooCommerce/src/main/res/layout/activity_main.xml
@@ -51,18 +51,18 @@
         </FrameLayout>
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/addProductButton"
+            android:id="@+id/addButton"
             style="@style/Woo.AddButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom|end"
             android:layout_margin="@dimen/major_100"
             android:animateLayoutChanges="true"
-            android:contentDescription="@string/add_products_button"
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            tools:visibility="visible" />
+            tools:visibility="visible"
+            tools:ignore="ContentDescription" />
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
     <com.woocommerce.android.ui.network.OfflineStatusBarView

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -226,6 +226,7 @@
     <string name="orderlist_search_hint">Search orders</string>
     <string name="orderlist_filtered" translatable="false">: %1$s</string>
     <string name="orderlist_loading">Looking up your orders…</string>
+    <string name="orderlist_add_order_button">Add order</string>
     <!--
         Order Detail Views
     -->


### PR DESCRIPTION
Issue: woocommerce#3603

It contains the changes from https://github.com/woocommerce/woocommerce-android/pull/3612. I'm not sure if it's possible to create a PR to the branch which is in the fork. Please let me know if this possible. If not, we'd better merge the first PR and then review this one.

* Description: FAB which is an entry to the order creation flow. Similar to the products, it disappears during orders loading.
* Testing instructions: It should be only visible in debug builds
* Images and Gif:
[Debug](https://user-images.githubusercontent.com/4923871/108626472-6def9680-7461-11eb-9933-ff41e79a9040.mp4)
[Release](https://user-images.githubusercontent.com/4923871/108626339-bd819280-7460-11eb-92f0-389a1e14034f.mp4)