### PR TITLE
Shipping Labels: view order summary and Woo discount p1

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
@@ -56,4 +56,6 @@ sealed class CreateShippingLabelEvent : MultiLiveEvent.Event() {
     ) : CreateShippingLabelEvent()
 
     object ShowPaymentDetails : CreateShippingLabelEvent()
+
+    object ShowWooDiscountBottomSheet: CreateShippingLabelEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
@@ -57,5 +57,5 @@ sealed class CreateShippingLabelEvent : MultiLiveEvent.Event() {
 
     object ShowPaymentDetails : CreateShippingLabelEvent()
 
-    object ShowWooDiscountBottomSheet: CreateShippingLabelEvent()
+    object ShowWooDiscountBottomSheet : CreateShippingLabelEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -7,6 +7,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentCreateShippingLabelBinding
 import com.woocommerce.android.databinding.ViewShippingLabelOrderSummaryBinding
@@ -25,6 +26,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingL
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowPaymentDetails
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowShippingRates
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowSuggestedAddress
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowWooDiscountBottomSheet
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.OrderSummaryState
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.Step
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.UiState.Failed
@@ -222,6 +224,12 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
                         )
                     findNavController().navigateSafely(action)
                 }
+                is ShowWooDiscountBottomSheet -> {
+                    BottomSheetDialog(requireContext()).apply {
+                        setContentView(R.layout.dialog_woo_discount_info)
+                        show()
+                    }
+                }
                 else -> event.isHandled = false
             }
         })
@@ -283,6 +291,10 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
         binding.customsStep.editButtonClickListener = { viewModel.onEditButtonTapped(CUSTOMS) }
         binding.carrierStep.editButtonClickListener = { viewModel.onEditButtonTapped(CARRIER) }
         binding.paymentStep.editButtonClickListener = { viewModel.onEditButtonTapped(PAYMENT) }
+
+        binding.orderSummaryLayout.discountInfo.setOnClickListener {
+            viewModel.onWooDiscountInfoClicked()
+        }
     }
 
     private fun ShippingLabelCreationStepView.update(data: Step) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.databinding.FragmentCreateShippingLabelBinding
 import com.woocommerce.android.databinding.ViewShippingLabelOrderSummaryBinding
 import com.woocommerce.android.extensions.handleNotice
 import com.woocommerce.android.extensions.handleResult
+import com.woocommerce.android.extensions.isNotEqualTo
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.Address
@@ -313,14 +314,14 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
         root.isVisible = true
         subtotalPrice.text = currencyFormatter.formatCurrency(state.price, "USD")
 
-        if (state.discount != null) {
+        if (state.discount.isNotEqualTo(BigDecimal.ZERO)) {
             discountGroup.isVisible = true
             discountPrice.text = currencyFormatter.formatCurrency(state.discount, "USD")
         } else {
             discountGroup.isVisible = false
         }
 
-        val totalPriceValue = state.price - (state.discount ?: BigDecimal.ZERO)
+        val totalPriceValue = state.price - state.discount
         totalPrice.text = currencyFormatter.formatCurrency(totalPriceValue, "USD")
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -305,8 +305,8 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
         data.isHighlighted?.let { isHighlighted = it }
     }
 
-    private fun ViewShippingLabelOrderSummaryBinding.update(state: OrderSummaryState?) {
-        if (state == null) {
+    private fun ViewShippingLabelOrderSummaryBinding.update(state: OrderSummaryState) {
+        if (!state.isVisible) {
             root.isVisible = false
             return
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingL
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowPaymentDetails
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowShippingRates
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowSuggestedAddress
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowWooDiscountBottomSheet
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.UiState.Failed
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.UiState.Loading
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.UiState.WaitingForInput
@@ -422,6 +423,10 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
         stateMachine.handleEvent(ShippingCarrierSelectionCanceled)
     }
 
+    fun onWooDiscountInfoClicked() {
+        triggerEvent(ShowWooDiscountBottomSheet)
+    }
+
     fun onEditButtonTapped(step: FlowStep) {
         when (step) {
             FlowStep.ORIGIN_ADDRESS -> Event.EditOriginAddressRequested
@@ -485,7 +490,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
     data class OrderSummaryState(
         val price: BigDecimal,
         val discount: BigDecimal?
-    ): Parcelable
+    ) : Parcelable
 
     @Parcelize
     data class Step(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -215,7 +215,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                     customsStep = Step.notDone(),
                     carrierStep = Step.notDone(),
                     paymentStep = Step.notDone(data.currentPaymentMethod.stepDescription),
-                    orderSummaryState = null
+                    orderSummaryState = OrderSummaryState()
                 )
             }
             FlowStep.SHIPPING_ADDRESS -> {
@@ -226,7 +226,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                     customsStep = Step.notDone(),
                     carrierStep = Step.notDone(),
                     paymentStep = Step.notDone(data.currentPaymentMethod.stepDescription),
-                    orderSummaryState = null
+                    orderSummaryState = OrderSummaryState()
                 )
             }
             FlowStep.PACKAGING -> {
@@ -237,7 +237,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                     customsStep = Step.notDone(),
                     carrierStep = Step.notDone(),
                     paymentStep = Step.notDone(data.currentPaymentMethod.stepDescription),
-                    orderSummaryState = null
+                    orderSummaryState = OrderSummaryState()
                 )
             }
             FlowStep.CUSTOMS -> {
@@ -248,7 +248,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                     customsStep = Step.current(),
                     carrierStep = Step.notDone(),
                     paymentStep = Step.notDone(data.currentPaymentMethod.stepDescription),
-                    orderSummaryState = null
+                    orderSummaryState = OrderSummaryState()
                 )
             }
             FlowStep.CARRIER -> {
@@ -258,7 +258,8 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                     packagingDetailsStep = Step.done(getPackageDetailsDescription(data.shippingPackages)),
                     customsStep = Step.done(),
                     carrierStep = Step.current(),
-                    paymentStep = Step.notDone(data.currentPaymentMethod.stepDescription)
+                    paymentStep = Step.notDone(data.currentPaymentMethod.stepDescription),
+                    orderSummaryState = OrderSummaryState()
                 )
             }
             FlowStep.PAYMENT -> {
@@ -269,7 +270,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                     customsStep = Step.done(),
                     carrierStep = Step.done(),
                     paymentStep = Step.current(data.currentPaymentMethod.stepDescription),
-                    orderSummaryState = null
+                    orderSummaryState = OrderSummaryState()
                 )
             }
             FlowStep.DONE -> {
@@ -281,7 +282,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                     carrierStep = Step.done(),
                     paymentStep = Step.done(data.currentPaymentMethod.stepDescription),
                     orderSummaryState = OrderSummaryState(
-                        BigDecimal.TEN, BigDecimal.ONE
+                        isVisible = true, price = BigDecimal.TEN, discount = BigDecimal.ONE
                     )
                 )
             }
@@ -471,7 +472,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
         val customsStep: Step? = null,
         val carrierStep: Step? = null,
         val paymentStep: Step? = null,
-        val orderSummaryState: OrderSummaryState? = null,
+        val orderSummaryState: OrderSummaryState = OrderSummaryState(),
         val progressDialogState: ProgressDialogState = ProgressDialogState()
     ) : Parcelable
 
@@ -488,8 +489,9 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
 
     @Parcelize
     data class OrderSummaryState(
-        val price: BigDecimal,
-        val discount: BigDecimal?
+        val isVisible: Boolean = false,
+        val price: BigDecimal = BigDecimal.ZERO,
+        val discount: BigDecimal? = null
     ) : Parcelable
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -270,7 +270,10 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                     customsStep = Step.done(),
                     carrierStep = Step.done(),
                     paymentStep = Step.current(data.currentPaymentMethod.stepDescription),
-                    orderSummaryState = OrderSummaryState()
+                    // TODO caculate the order summary value from the selected shipping rates
+                    orderSummaryState = OrderSummaryState(
+                        isVisible = true, price = BigDecimal.TEN, discount = BigDecimal.ONE
+                    )
                 )
             }
             FlowStep.DONE -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -59,6 +59,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
+import java.math.BigDecimal
 import java.text.DecimalFormat
 
 class CreateShippingLabelViewModel @AssistedInject constructor(
@@ -212,7 +213,8 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                     packagingDetailsStep = Step.notDone(),
                     customsStep = Step.notDone(),
                     carrierStep = Step.notDone(),
-                    paymentStep = Step.notDone(data.currentPaymentMethod.stepDescription)
+                    paymentStep = Step.notDone(data.currentPaymentMethod.stepDescription),
+                    orderSummaryState = null
                 )
             }
             FlowStep.SHIPPING_ADDRESS -> {
@@ -222,7 +224,8 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                     packagingDetailsStep = Step.notDone(),
                     customsStep = Step.notDone(),
                     carrierStep = Step.notDone(),
-                    paymentStep = Step.notDone(data.currentPaymentMethod.stepDescription)
+                    paymentStep = Step.notDone(data.currentPaymentMethod.stepDescription),
+                    orderSummaryState = null
                 )
             }
             FlowStep.PACKAGING -> {
@@ -232,7 +235,8 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                     packagingDetailsStep = Step.current(),
                     customsStep = Step.notDone(),
                     carrierStep = Step.notDone(),
-                    paymentStep = Step.notDone(data.currentPaymentMethod.stepDescription)
+                    paymentStep = Step.notDone(data.currentPaymentMethod.stepDescription),
+                    orderSummaryState = null
                 )
             }
             FlowStep.CUSTOMS -> {
@@ -242,7 +246,8 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                     packagingDetailsStep = Step.done(getPackageDetailsDescription(data.shippingPackages)),
                     customsStep = Step.current(),
                     carrierStep = Step.notDone(),
-                    paymentStep = Step.notDone(data.currentPaymentMethod.stepDescription)
+                    paymentStep = Step.notDone(data.currentPaymentMethod.stepDescription),
+                    orderSummaryState = null
                 )
             }
             FlowStep.CARRIER -> {
@@ -262,7 +267,8 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                     packagingDetailsStep = Step.done(getPackageDetailsDescription(data.shippingPackages)),
                     customsStep = Step.done(),
                     carrierStep = Step.done(),
-                    paymentStep = Step.current(data.currentPaymentMethod.stepDescription)
+                    paymentStep = Step.current(data.currentPaymentMethod.stepDescription),
+                    orderSummaryState = null
                 )
             }
             FlowStep.DONE -> {
@@ -272,7 +278,10 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                     packagingDetailsStep = Step.done(getPackageDetailsDescription(data.shippingPackages)),
                     customsStep = Step.done(),
                     carrierStep = Step.done(),
-                    paymentStep = Step.done(data.currentPaymentMethod.stepDescription)
+                    paymentStep = Step.done(data.currentPaymentMethod.stepDescription),
+                    orderSummaryState = OrderSummaryState(
+                        BigDecimal.TEN, BigDecimal.ONE
+                    )
                 )
             }
         }
@@ -457,6 +466,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
         val customsStep: Step? = null,
         val carrierStep: Step? = null,
         val paymentStep: Step? = null,
+        val orderSummaryState: OrderSummaryState? = null,
         val progressDialogState: ProgressDialogState = ProgressDialogState()
     ) : Parcelable
 
@@ -470,6 +480,12 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
         @StringRes val title: Int = 0,
         @StringRes val message: Int = 0
     ) : Parcelable
+
+    @Parcelize
+    data class OrderSummaryState(
+        val price: BigDecimal,
+        val discount: BigDecimal?
+    ): Parcelable
 
     @Parcelize
     data class Step(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -281,6 +281,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                     customsStep = Step.done(),
                     carrierStep = Step.done(),
                     paymentStep = Step.done(data.currentPaymentMethod.stepDescription),
+                    // TODO caculate the order summary value from the selected shipping rates
                     orderSummaryState = OrderSummaryState(
                         isVisible = true, price = BigDecimal.TEN, discount = BigDecimal.ONE
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -495,7 +495,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
     data class OrderSummaryState(
         val isVisible: Boolean = false,
         val price: BigDecimal = BigDecimal.ZERO,
-        val discount: BigDecimal? = null
+        val discount: BigDecimal = BigDecimal.ZERO
     ) : Parcelable
 
     @Parcelize

--- a/WooCommerce/src/main/res/layout/dialog_woo_discount_info.xml
+++ b/WooCommerce/src/main/res/layout/dialog_woo_discount_info.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/bottomsheet_rounded"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:paddingVertical="@dimen/major_100">
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:srcCompat="@drawable/ic_info_outline_24dp"
+        app:tint="@color/woo_purple_60" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/major_100"
+        android:layout_marginTop="@dimen/major_100"
+        android:gravity="center"
+        android:text="@string/shipping_label_woo_discount_bottomsheet_title"
+        android:textAppearance="?attr/textAppearanceHeadline6" />
+
+    <View
+        style="@style/Woo.Divider"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginTop="@dimen/major_100" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/major_100"
+        android:layout_marginTop="@dimen/major_100"
+        android:gravity="center"
+        android:text="@string/shipping_label_woo_discount_bottomsheet_message"
+        android:textAppearance="?attr/textAppearanceBody1"
+        android:textColor="@color/color_on_surface_high" />
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_create_shipping_label.xml
+++ b/WooCommerce/src/main/res/layout/fragment_create_shipping_label.xml
@@ -6,91 +6,100 @@
     android:layout_height="match_parent"
     android:fillViewport="true">
 
-    <FrameLayout
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
         <com.woocommerce.android.widgets.WCEmptyView
             android:id="@+id/error_view"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            android:layout_gravity="center"/>
+            app:layout_constraintTop_toTopOf="parent" />
 
         <com.woocommerce.android.widgets.WCElevatedLinearLayout
-            android:id="@+id/content_layout"
+            android:id="@+id/steps_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/major_100"
             android:orientation="vertical">
 
-        <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
-            android:id="@+id/originStep"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            tools:enabled="true"
-            tools:continue_button_visible="false"
-            tools:edit_button_visible="true"
-            tools:details="Some address\nSecond line\nThird"
-            app:caption="@string/orderdetail_shipping_label_item_shipfrom"
-            app:icon="@drawable/ic_gridicons_shipping" />
+            <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
+                android:id="@+id/originStep"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:caption="@string/orderdetail_shipping_label_item_shipfrom"
+                app:icon="@drawable/ic_gridicons_shipping"
+                tools:continue_button_visible="false"
+                tools:details="Some address\nSecond line\nThird"
+                tools:edit_button_visible="true"
+                tools:enabled="true" />
 
-        <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
-            android:id="@+id/shippingStep"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            tools:enabled="true"
-            tools:continue_button_visible="true"
-            tools:edit_button_visible="false"
-            tools:details="Some address\nSecond line\nThird"
-            app:caption="@string/orderdetail_shipping_label_item_shipto"
-            app:icon="@drawable/ic_gridicons_house" />
+            <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
+                android:id="@+id/shippingStep"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:caption="@string/orderdetail_shipping_label_item_shipto"
+                app:icon="@drawable/ic_gridicons_house"
+                tools:continue_button_visible="true"
+                tools:details="Some address\nSecond line\nThird"
+                tools:edit_button_visible="false"
+                tools:enabled="true" />
 
-        <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
-            android:id="@+id/packagingStep"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            tools:enabled="false"
-            tools:continue_button_visible="false"
-            tools:edit_button_visible="false"
-            app:caption="@string/shipping_label_create_packaging_details"
-            app:details="@string/shipping_label_create_packaging_details_description"
-            app:icon="@drawable/ic_product" />
+            <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
+                android:id="@+id/packagingStep"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:caption="@string/shipping_label_create_packaging_details"
+                app:details="@string/shipping_label_create_packaging_details_description"
+                app:icon="@drawable/ic_product"
+                tools:continue_button_visible="false"
+                tools:edit_button_visible="false"
+                tools:enabled="false" />
 
-        <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
-            android:id="@+id/customsStep"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            tools:enabled="false"
-            tools:continue_button_visible="false"
-            tools:edit_button_visible="false"
-            app:caption="@string/shipping_label_create_customs"
-            app:details="@string/shipping_label_create_customs_description"
-            app:icon="@drawable/ic_gridicons_globe" />
+            <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
+                android:id="@+id/customsStep"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:caption="@string/shipping_label_create_customs"
+                app:details="@string/shipping_label_create_customs_description"
+                app:icon="@drawable/ic_gridicons_globe"
+                tools:continue_button_visible="false"
+                tools:edit_button_visible="false"
+                tools:enabled="false" />
 
-        <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
-            android:id="@+id/carrierStep"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            tools:enabled="false"
-            tools:continue_button_visible="false"
-            tools:edit_button_visible="false"
-            app:caption="@string/orderdetail_shipping_label_item_carrier"
-            app:details="@string/shipping_label_create_carrier_description"
-            app:icon="@drawable/ic_gridicons_money" />
+            <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
+                android:id="@+id/carrierStep"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:caption="@string/orderdetail_shipping_label_item_carrier"
+                app:details="@string/shipping_label_create_carrier_description"
+                app:icon="@drawable/ic_gridicons_money"
+                tools:continue_button_visible="false"
+                tools:edit_button_visible="false"
+                tools:enabled="false" />
 
-        <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
-            android:id="@+id/paymentStep"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            tools:enabled="false"
-            tools:continue_button_visible="false"
-            tools:edit_button_visible="false"
-            app:divider_visible="false"
-            app:caption="@string/orderdetail_shipping_label_item_payment"
-            app:details="@string/shipping_label_create_payment_description"
-            app:icon="@drawable/ic_gridicons_credit_card" />
-
+            <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
+                android:id="@+id/paymentStep"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:caption="@string/orderdetail_shipping_label_item_payment"
+                app:details="@string/shipping_label_create_payment_description"
+                app:divider_visible="false"
+                app:icon="@drawable/ic_gridicons_credit_card"
+                tools:continue_button_visible="false"
+                tools:edit_button_visible="false"
+                tools:enabled="false" />
         </com.woocommerce.android.widgets.WCElevatedLinearLayout>
-    </FrameLayout>
+
+        <include
+            android:id="@+id/order_summary_layout"
+            layout="@layout/view_shipping_label_order_summary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/major_100"/>
+    </LinearLayout>
 </ScrollView>

--- a/WooCommerce/src/main/res/layout/view_shipping_label_order_summary.xml
+++ b/WooCommerce/src/main/res/layout/view_shipping_label_order_summary.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.woocommerce.android.widgets.WCElevatedConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/start_guideline"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        app:layout_constraintGuide_begin="@dimen/major_100" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/end_guideline"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        app:layout_constraintGuide_end="@dimen/major_100" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_75"
+        android:text="@string/shipping_label_create_order_summary"
+        android:textAppearance="?attr/textAppearanceSubtitle2"
+        android:textColor="@color/color_on_surface_disabled"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <View
+        android:id="@+id/divider"
+        style="@style/Woo.Divider"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginTop="@dimen/major_75"
+        app:layout_constraintTop_toBottomOf="@id/title" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/subtotal_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_100"
+        android:text="@string/shipping_label_create_price_subtotal"
+        android:textAppearance="?attr/textAppearanceBody2"
+        android:textColor="@color/color_on_surface_high"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/divider" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/subtotal_price"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceBody2"
+        android:textColor="@color/color_on_surface_high"
+        app:layout_constraintBaseline_toBaselineOf="@id/subtotal_label"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintHorizontal_bias="1"
+        app:layout_constraintStart_toEndOf="@id/subtotal_label"
+        tools:text="$16.57" />
+
+    <androidx.constraintlayout.widget.Group
+        android:id="@+id/discount_group"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:constraint_referenced_ids="discount_label, discount_info, discount_price" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/discount_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/minor_50"
+        android:text="@string/shipping_label_create_price_woo_discount"
+        android:textAppearance="?attr/textAppearanceBody2"
+        android:textColor="@color/color_on_surface_high"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/subtotal_label" />
+
+    <androidx.appcompat.widget.AppCompatImageButton
+        android:id="@+id/discount_info"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/minor_50"
+        android:background="@drawable/ripple_grey_oval"
+        android:contentDescription="@string/shipping_label_create_price_woo_discount_content_description"
+        app:layout_constraintBottom_toBottomOf="@id/discount_label"
+        app:layout_constraintStart_toEndOf="@id/discount_label"
+        app:layout_constraintTop_toTopOf="@id/discount_label"
+        app:srcCompat="@drawable/ic_info_outline_24dp" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/discount_price"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceBody2"
+        android:textColor="@color/color_on_surface_high"
+        app:layout_constraintBaseline_toBaselineOf="@id/discount_label"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintHorizontal_bias="1"
+        app:layout_constraintStart_toEndOf="@id/discount_label"
+        tools:text="-$0.6" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/total_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_100"
+        android:text="@string/shipping_label_create_price_total"
+        android:textAppearance="?attr/textAppearanceBody2"
+        android:textColor="@color/color_on_surface_high"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/discount_label" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/total_price"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceBody2"
+        android:textColor="@color/color_on_surface_high"
+        android:textStyle="bold"
+        app:layout_constraintBaseline_toBaselineOf="@id/total_label"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintHorizontal_bias="1"
+        app:layout_constraintStart_toEndOf="@id/total_label"
+        tools:text="$16.57" />
+
+    <com.google.android.material.checkbox.MaterialCheckBox
+        android:id="@+id/mark_order_complete_checkbox"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/minor_100"
+        android:layout_marginTop="@dimen/major_100"
+        android:paddingStart="@dimen/major_75"
+        android:text="@string/shipping_label_create_mark_order_complete"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/total_label"
+        tools:ignore="RtlSymmetry" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/purchase_label_button"
+        style="@style/Woo.Button.Colored"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/minor_100"
+        android:layout_marginBottom="@dimen/major_100"
+        android:text="@string/shipping_label_create_purchase"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/mark_order_complete_checkbox" />
+
+</com.woocommerce.android.widgets.WCElevatedConstraintLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -448,7 +448,8 @@
         <item quantity="other">%d days</item>
     </plurals>
     <string name="shipping_label_shipping_carrier_rates_generic_error">There was an error loading shipping options</string>
-
+    <string name="shipping_label_woo_discount_bottomsheet_title">What is WooCommerce  Services discount?</string>
+    <string name="shipping_label_woo_discount_bottomsheet_message">"When purchasing shipping labels with WooCommerce, you get 5% to 40% off compared to post office rates. "</string>
     <!--
             Refunds
         -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -373,6 +373,13 @@
     <string name="shipping_label_create_customs_description">Fill out customs form</string>
     <string name="shipping_label_create_carrier_description">Select your shipping carrier and rates</string>
     <string name="shipping_label_create_payment_description">Add a new credit card</string>
+    <string name="shipping_label_create_order_summary">Shipping label order summary</string>
+    <string name="shipping_label_create_price_subtotal">Subtotal</string>
+    <string name="shipping_label_create_price_woo_discount">WooCommerce Services discount</string>
+    <string name="shipping_label_create_price_woo_discount_content_description">Learn more about WooCommerce Services discount</string>
+    <string name="shipping_label_create_price_total">Order total</string>
+    <string name="shipping_label_create_mark_order_complete">Mark this order as complete and notify the customer</string>
+    <string name="shipping_label_create_purchase">Purchase shipping label</string>
     <string name="shipping_label_selected_payment_description">Credit card ending in %1$s</string>
     <string name="shipping_label_loading_data_progress_title">Fetching your settings</string>
     <string name="shipping_label_loading_data_progress_message">Please wait…</string>


### PR DESCRIPTION
First part of #3617, this just adds the layout of the order summary, and the logic to display it. But as #3525 is not done yet, we can't have a real calculation of the order price and discount.

|  |  |
| --- | --- |
|![Screenshot_1614175365](https://user-images.githubusercontent.com/1657201/109011652-6aeae500-76b1-11eb-9f04-67f60d9c714d.png)|![Screenshot_1614175367](https://user-images.githubusercontent.com/1657201/109011663-6de5d580-76b1-11eb-9375-c7c65396bea8.png)|
|![Screenshot_1614176182](https://user-images.githubusercontent.com/1657201/109013324-4bed5280-76b3-11eb-8f2a-733abc10bf4a.png)| |


#### Testing
1. Change this [line](https://github.com/woocommerce/woocommerce-android/blob/eb824a2d966f4f20160fd35099e92485e5551fba/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt#L157) to: 
``` kotlin
      is SideEffect.ShowCarrierOptions -> handleResult { Event.ShippingCarrierSelected }
```
to allow completing the shipping carriers step.
2. Open details of an order that satisfies the shipping label creation.
3. Click on "create shipping label"
4. Confirm that the order summary is hidden.
5. Pass all steps.
6. Confirm that the order summary is displayed after reaching the payment step.
7. Click on the ℹ️ image, and confirm that the discount bottom sheet is displayed.

To test the other scenario: order without discount, use `BigDecimal.ZERO` for the discount field here: https://github.com/woocommerce/woocommerce-android/blob/a9b4af2f1aa93b37c340a7d591e0861bee928887/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt#L288-L290

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
