### PR TITLE
Issue/3623 exit download settings 6.1

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsSettingsFragment.kt
@@ -1,19 +1,14 @@
 package com.woocommerce.android.ui.products.downloads
 
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
 import android.view.View
 import androidx.lifecycle.observe
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.databinding.FragmentProductDownloadsSettingsBinding
 import com.woocommerce.android.ui.products.BaseProductFragment
 import com.woocommerce.android.ui.products.ProductDetailViewModel
-import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitProductDownloads
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitProductDownloadsSettings
 
 class ProductDownloadsSettingsFragment : BaseProductFragment(R.layout.fragment_product_downloads_settings) {
@@ -25,7 +20,6 @@ class ProductDownloadsSettingsFragment : BaseProductFragment(R.layout.fragment_p
 
         _binding = FragmentProductDownloadsSettingsBinding.bind(view)
 
-        setHasOptionsMenu(true)
         setupObservers(viewModel)
     }
 
@@ -37,23 +31,6 @@ class ProductDownloadsSettingsFragment : BaseProductFragment(R.layout.fragment_p
     override fun onResume() {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
-    }
-
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        menu.clear()
-        inflater.inflate(R.menu.menu_done, menu)
-        super.onCreateOptionsMenu(menu, inflater)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.menu_done -> {
-                viewModel.onBackButtonClicked(ExitProductDownloads(shouldShowDiscardDialog = false))
-                AnalyticsTracker.track(Stat.PRODUCT_DOWNLOADABLE_FILES_SETTINGS_CHANGED)
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
-        }
     }
 
     fun setupObservers(viewModel: ProductDetailViewModel) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsSettingsFragment.kt
@@ -59,7 +59,7 @@ class ProductDownloadsSettingsFragment : BaseProductFragment(R.layout.fragment_p
     fun setupObservers(viewModel: ProductDetailViewModel) {
         viewModel.event.observe(viewLifecycleOwner, { event ->
             when (event) {
-                is ExitProductDownloads -> findNavController().navigateUp()
+                is ExitProductDownloadsSettings -> findNavController().navigateUp()
                 else -> event.isHandled = false
             }
         })


### PR DESCRIPTION
Fixes #3623 - this PR corrects the problem where tapping "X" in download settings does nothing, and also removes the "Done" button from download settings.

To test:

* View product detail for a product with downloadable files
* Tap "Downloadable files"
* Tap the options menu and view download settings
* Verify that tapping the "X" button exits the screen and any changes made are saved to the product draft

Note that this targets the `release/6.1` branch.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
