### PR TITLE
Issue/3627 product settings done button

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -12,7 +12,7 @@ import androidx.navigation.fragment.findNavController
  *
  * @param [key] A unique string that is the same as the one used in [handleResult]
  * @param [result] A result value to be returned
- * @param [destinationId] an optional destinationId, that can be used to navigating up to a specified destination
+ * @param [destinationId] an optional destinationId, that can be used to navigate up to a specified destination
  *
  */
 fun <T> Fragment.navigateBackWithResult(key: String, result: T, @IdRes destinationId: Int? = null) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/BaseProductSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/BaseProductSettingsFragment.kt
@@ -1,14 +1,7 @@
 package com.woocommerce.android.ui.products.settings
 
-import android.content.DialogInterface
-import android.os.Bundle
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
-import android.view.View
 import androidx.annotation.LayoutRes
 import androidx.navigation.fragment.findNavController
-import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.dialog.WooDialog
@@ -22,55 +15,8 @@ import org.wordpress.android.util.ActivityUtils
  * expected to be lightweight.
  */
 abstract class BaseProductSettingsFragment : BaseFragment, BackPressListener {
-    companion object {
-        private const val KEY_IS_CONFIRMING_DISCARD = "is_confirming_discard"
-    }
-
     constructor() : super()
     constructor(@LayoutRes layoutId: Int) : super(layoutId)
-
-    private var isConfirmingDiscard = false
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        setHasOptionsMenu(true)
-        if (savedInstanceState?.getBoolean(KEY_IS_CONFIRMING_DISCARD) == true) {
-            confirmDiscard()
-        }
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        outState.putBoolean(KEY_IS_CONFIRMING_DISCARD, isConfirmingDiscard)
-        super.onSaveInstanceState(outState)
-    }
-
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
-        menu.clear()
-        inflater.inflate(R.menu.menu_done, menu)
-    }
-
-    override fun onPrepareOptionsMenu(menu: Menu) {
-        super.onPrepareOptionsMenu(menu)
-        menu.findItem(R.id.menu_done)?.isVisible = hasChanges()
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.menu_done -> {
-                if (hasChanges()) {
-                    if (validateChanges()) {
-                        navigateBackWithResult()
-                    }
-                } else {
-                    findNavController().navigateUp()
-                }
-                true
-            }
-        else ->
-            super.onOptionsItemSelected(item)
-        }
-    }
 
     override fun onStop() {
         super.onStop()
@@ -80,26 +26,13 @@ abstract class BaseProductSettingsFragment : BaseFragment, BackPressListener {
 
     override fun onRequestAllowBackPress(): Boolean {
         if (hasChanges()) {
-            confirmDiscard()
-            return false
+            if (validateChanges()) {
+                navigateBackWithResult()
+            }
+        } else {
+            findNavController().navigateUp()
         }
         return true
-    }
-
-    private fun confirmDiscard() {
-        isConfirmingDiscard = true
-        WooDialog.showDialog(
-                requireActivity(),
-                messageId = R.string.discard_message,
-                positiveButtonId = R.string.discard,
-                posBtnAction = DialogInterface.OnClickListener { _, _ ->
-                    isConfirmingDiscard = false
-                    findNavController().navigateUp()
-                },
-                negativeButtonId = R.string.keep_editing,
-                negBtnAction = DialogInterface.OnClickListener { _, _ ->
-                    isConfirmingDiscard = false
-                })
     }
 
     /**
@@ -109,13 +42,6 @@ abstract class BaseProductSettingsFragment : BaseFragment, BackPressListener {
     private fun navigateBackWithResult() {
         val (key, result) = getChangesResult()
         navigateBackWithResult(key, result)
-    }
-
-    /**
-     * Descendants should call this when edits are made so we can show/hide the done button
-     */
-    fun changesMade() {
-        activity?.invalidateOptionsMenu()
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/BaseProductSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/BaseProductSettingsFragment.kt
@@ -25,12 +25,14 @@ abstract class BaseProductSettingsFragment : BaseFragment, BackPressListener {
     }
 
     override fun onRequestAllowBackPress(): Boolean {
-        if (hasChanges() && validateChanges()) {
-            navigateBackWithResult()
+        if (hasChanges()) {
+            if (validateChanges()) {
+                navigateBackWithResult()
+            }
         } else {
             findNavController().navigateUp()
         }
-        return true
+        return false
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/BaseProductSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/BaseProductSettingsFragment.kt
@@ -26,6 +26,11 @@ abstract class BaseProductSettingsFragment : BaseFragment, BackPressListener {
 
     override fun onRequestAllowBackPress(): Boolean {
         if (hasChanges()) {
+            // we only want to return to the previous screen if the changes are valid, which means if they're
+            // not the user will have to correct them in order to go back. currently this only applies to the
+            // product visibility screen if the user chooses "Password protected" without entering a password,
+            // which is easily correctly by the user. however, we may need to re-think this if more settings
+            // are added that require validation.
             if (validateChanges()) {
                 navigateBackWithResult()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/BaseProductSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/BaseProductSettingsFragment.kt
@@ -25,10 +25,8 @@ abstract class BaseProductSettingsFragment : BaseFragment, BackPressListener {
     }
 
     override fun onRequestAllowBackPress(): Boolean {
-        if (hasChanges()) {
-            if (validateChanges()) {
-                navigateBackWithResult()
-            }
+        if (hasChanges() && validateChanges()) {
+            navigateBackWithResult()
         } else {
             findNavController().navigateUp()
         }
@@ -36,8 +34,7 @@ abstract class BaseProductSettingsFragment : BaseFragment, BackPressListener {
     }
 
     /**
-     * Called when the Done button is tapped and changes have been made. Navigates back to the main product
-     * settings fragment and passes it a bundle containing the changes.
+     * Navigates back to the main product settings fragment and passes it a bundle containing the changes
      */
     private fun navigateBackWithResult() {
         val (key, result) = getChangesResult()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductCatalogVisibilityFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductCatalogVisibilityFragment.kt
@@ -47,10 +47,6 @@ class ProductCatalogVisibilityFragment : BaseProductSettingsFragment(R.layout.fr
         binding.btnVisibilityCatalog.setOnClickListener(this)
         binding.btnVisibilitySearch.setOnClickListener(this)
         binding.btnVisibilityHidden.setOnClickListener(this)
-
-        binding.btnFeatured.setOnCheckedChangeListener { _, isChecked ->
-            changesMade()
-        }
     }
 
     override fun onDestroyView() {
@@ -71,8 +67,6 @@ class ProductCatalogVisibilityFragment : BaseProductSettingsFragment(R.layout.fr
             binding.btnVisibilitySearch.isChecked = it == binding.btnVisibilitySearch
             binding.btnVisibilityHidden.isChecked = it == binding.btnVisibilityHidden
             selectedCatalogVisibility = getVisibilityForButtonId(it.id)
-
-            changesMade()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductMenuOrderFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductMenuOrderFragment.kt
@@ -27,9 +27,6 @@ class ProductMenuOrderFragment : BaseProductSettingsFragment(R.layout.fragment_p
         _binding = FragmentProductMenuOrderBinding.bind(view)
 
         binding.productMenuOrder.setText(navArgs.menuOrder.toString())
-        binding.productMenuOrder.setOnTextChangedListener {
-            changesMade()
-        }
     }
 
     override fun onDestroyView() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSettingsFragment.kt
@@ -1,9 +1,6 @@
 package com.woocommerce.android.ui.products.settings
 
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
 import android.view.View
 import android.widget.CompoundButton
 import androidx.lifecycle.Observer
@@ -32,7 +29,6 @@ class ProductSettingsFragment : BaseProductFragment(R.layout.fragment_product_se
 
         _binding = FragmentProductSettingsBinding.bind(view)
 
-        setHasOptionsMenu(true)
         setupObservers()
 
         binding.productStatus.setOnClickListener {
@@ -141,28 +137,6 @@ class ProductSettingsFragment : BaseProductFragment(R.layout.fragment_product_se
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
-    }
-
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        menu.clear()
-        inflater.inflate(R.menu.menu_done, menu)
-        super.onCreateOptionsMenu(menu, inflater)
-    }
-
-    override fun onPrepareOptionsMenu(menu: Menu) {
-        super.onPrepareOptionsMenu(menu)
-        menu.findItem(R.id.menu_done)?.isVisible = viewModel.hasSettingsChanges()
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.menu_done -> {
-                AnalyticsTracker.track(Stat.PRODUCT_SETTINGS_DONE_BUTTON_TAPPED)
-                viewModel.onBackButtonClicked(ExitSettings(shouldShowDiscardDialog = false))
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
-        }
     }
 
     override fun onRequestAllowBackPress(): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSlugFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSlugFragment.kt
@@ -26,9 +26,6 @@ class ProductSlugFragment : BaseProductSettingsFragment(R.layout.fragment_produc
         _binding = FragmentProductSlugBinding.bind(view)
 
         binding.editSlug.setText(navArgs.slug)
-        binding.editSlug.setOnTextChangedListener {
-            changesMade()
-        }
     }
 
     override fun onDestroyView() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductStatusFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductStatusFragment.kt
@@ -77,8 +77,6 @@ class ProductStatusFragment : BaseProductSettingsFragment(R.layout.fragment_prod
             binding.btnPending.isChecked = it == binding.btnPending
             binding.btnTrashed.isChecked = it == binding.btnTrashed
             selectedStatus = getStatusForButtonId(it.id)
-
-            changesMade()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductVisibilityFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductVisibilityFragment.kt
@@ -56,7 +56,6 @@ class ProductVisibilityFragment : BaseProductSettingsFragment(R.layout.fragment_
         }
 
         binding.editPassword.setOnTextChangedListener {
-            changesMade()
             if (it.toString().isNotBlank()) {
                 binding.editPassword.clearError()
             }
@@ -81,8 +80,6 @@ class ProductVisibilityFragment : BaseProductSettingsFragment(R.layout.fragment_
 
             selectedVisibility = getVisibilityForButtonId(it.id)
             showPassword(it == binding.btnPasswordProtected)
-
-            changesMade()
         }
     }
 


### PR DESCRIPTION
Closes #3627 by removing the "Done" button from the product settings screens (except for the Aztec-based purchase note screen). To test, simply go to the various product settings screens and verify that changes are auto-saved to the draft.

Note that this targets `release/6.1'.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
