### PR TITLE
Shipping Labels state machine: handle editing of previous steps

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -28,8 +28,14 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingL
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowShippingRates
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowSuggestedAddress
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowWooDiscountBottomSheet
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.FlowStep.CARRIER
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.FlowStep.CUSTOMS
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.FlowStep.ORIGIN_ADDRESS
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.FlowStep.PACKAGING
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.FlowStep.PAYMENT
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.FlowStep.SHIPPING_ADDRESS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.OrderSummaryState
-import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.Step
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.StepUiState
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.UiState.Failed
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.UiState.Loading
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.UiState.WaitingForInput
@@ -44,12 +50,6 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrier
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SELECTED_ADDRESS_ACCEPTED
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SELECTED_ADDRESS_TO_BE_EDITED
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SUGGESTED_ADDRESS_DISCARDED
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.FlowStep.CARRIER
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.FlowStep.CUSTOMS
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.FlowStep.ORIGIN_ADDRESS
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.FlowStep.PACKAGING
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.FlowStep.PAYMENT
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.FlowStep.SHIPPING_ADDRESS
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ViewModelFactory
@@ -298,7 +298,8 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
         }
     }
 
-    private fun ShippingLabelCreationStepView.update(data: Step) {
+    private fun ShippingLabelCreationStepView.update(data: StepUiState) {
+        isVisible = data.isVisible
         data.details?.let { details = it }
         data.isEnabled?.let { isViewEnabled = it }
         data.isContinueButtonVisible?.let { isContinueButtonVisible = it }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -26,7 +26,6 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAd
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.DESTINATION
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.ORIGIN
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.ValidationResult
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Data
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Error
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Error.AddressValidationError
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Error.DataLoadingError
@@ -46,9 +45,20 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.ShippingCarrierSelectionCanceled
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.SuggestedAddressAccepted
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.SuggestedAddressDiscarded
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.FlowStep
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.SideEffect
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.State
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StateMachineData
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.CarrierStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.CustomsStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.OriginAddressStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.PackagingStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.PaymentsStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.ShippingAddressStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.DONE
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.NOT_READY
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.READY
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepsState
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -119,7 +129,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                             progressDialogTitle = string.shipping_label_edit_address_validation_progress_title,
                             progressDialogMessage = string.shipping_label_edit_address_progress_message
                         ) {
-                            validateAddress(transition.state.data.originAddress, ORIGIN)
+                            validateAddress(transition.state.data.stepsState.originAddressStep.data, ORIGIN)
                         }
                     }
                     is State.ShippingAddressValidation -> {
@@ -127,7 +137,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                             progressDialogTitle = string.shipping_label_edit_address_validation_progress_title,
                             progressDialogMessage = string.shipping_label_edit_address_progress_message
                         ) {
-                            validateAddress(transition.state.data.shippingAddress, DESTINATION)
+                            validateAddress(transition.state.data.stepsState.shippingAddressStep.data, DESTINATION)
                         }
                     }
                     else -> {
@@ -154,7 +164,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                         )
                         is SideEffect.ShowPackageOptions -> openPackagesDetails(sideEffect.shippingPackages)
                         is SideEffect.ShowCustomsForm -> handleResult { Event.CustomsFormFilledOut }
-                        is SideEffect.ShowCarrierOptions -> openShippingCarrierRates(sideEffect.data)
+                        is SideEffect.ShowCarrierOptions -> handleResult { Event.ShippingCarrierSelected }
                         is SideEffect.ShowPaymentOptions -> openPaymentDetails()
                     }
                 }
@@ -181,13 +191,13 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
         }
     }
 
-    private fun openShippingCarrierRates(data: Data) {
+    private fun openShippingCarrierRates(data: StateMachineData) {
         triggerEvent(
             ShowShippingRates(
                 data.remoteOrderId,
-                data.originAddress,
-                data.shippingAddress,
-                data.shippingPackages
+                data.stepsState.originAddressStep.data,
+                data.stepsState.shippingAddressStep.data,
+                data.stepsState.packagingStep.data
             )
         )
     }
@@ -205,92 +215,54 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
         triggerEvent(ShowPaymentDetails)
     }
 
-    private fun updateViewState(data: Data) {
-        viewState = when (data.flowSteps.maxBy { it.ordinal } ?: FlowStep.ORIGIN_ADDRESS) {
-            FlowStep.ORIGIN_ADDRESS -> {
-                viewState.copy(
-                    originAddressStep = Step.current(data.originAddress.toString()),
-                    shippingAddressStep = Step.notDone(data.shippingAddress.toString()),
-                    packagingDetailsStep = Step.notDone(),
-                    customsStep = Step.notDone(),
-                    carrierStep = Step.notDone(),
-                    paymentStep = Step.notDone(data.currentPaymentMethod.stepDescription),
-                    orderSummaryState = OrderSummaryState()
-                )
+    private fun updateViewState(stateMachineData: StateMachineData) {
+        fun <T> Step<T>.mapToUiState(): StepUiState {
+            if(!isVisible) return StepUiState.hide()
+
+            val description = when(this) {
+                is OriginAddressStep -> data.toString()
+                is ShippingAddressStep -> data.toString()
+                is PackagingStep -> {
+                    if (data.isNotEmpty()) {
+                        getPackageDetailsDescription(data)
+                    } else {
+                        null
+                    }
+                }
+                is CustomsStep -> null
+                is CarrierStep -> null
+                is PaymentsStep -> data.stepDescription
             }
-            FlowStep.SHIPPING_ADDRESS -> {
-                viewState.copy(
-                    originAddressStep = Step.done(data.originAddress.toString()),
-                    shippingAddressStep = Step.current(data.shippingAddress.toString()),
-                    packagingDetailsStep = Step.notDone(),
-                    customsStep = Step.notDone(),
-                    carrierStep = Step.notDone(),
-                    paymentStep = Step.notDone(data.currentPaymentMethod.stepDescription),
-                    orderSummaryState = OrderSummaryState()
-                )
-            }
-            FlowStep.PACKAGING -> {
-                viewState.copy(
-                    originAddressStep = Step.done(data.originAddress.toString()),
-                    shippingAddressStep = Step.done(data.shippingAddress.toString()),
-                    packagingDetailsStep = Step.current(),
-                    customsStep = Step.notDone(),
-                    carrierStep = Step.notDone(),
-                    paymentStep = Step.notDone(data.currentPaymentMethod.stepDescription),
-                    orderSummaryState = OrderSummaryState()
-                )
-            }
-            FlowStep.CUSTOMS -> {
-                viewState.copy(
-                    originAddressStep = Step.done(data.originAddress.toString()),
-                    shippingAddressStep = Step.done(data.shippingAddress.toString()),
-                    packagingDetailsStep = Step.done(getPackageDetailsDescription(data.shippingPackages)),
-                    customsStep = Step.current(),
-                    carrierStep = Step.notDone(),
-                    paymentStep = Step.notDone(data.currentPaymentMethod.stepDescription),
-                    orderSummaryState = OrderSummaryState()
-                )
-            }
-            FlowStep.CARRIER -> {
-                viewState.copy(
-                    originAddressStep = Step.done(data.originAddress.toString()),
-                    shippingAddressStep = Step.done(data.shippingAddress.toString()),
-                    packagingDetailsStep = Step.done(getPackageDetailsDescription(data.shippingPackages)),
-                    customsStep = Step.done(),
-                    carrierStep = Step.current(),
-                    paymentStep = Step.notDone(data.currentPaymentMethod.stepDescription),
-                    orderSummaryState = OrderSummaryState()
-                )
-            }
-            FlowStep.PAYMENT -> {
-                viewState.copy(
-                    originAddressStep = Step.done(data.originAddress.toString()),
-                    shippingAddressStep = Step.done(data.shippingAddress.toString()),
-                    packagingDetailsStep = Step.done(getPackageDetailsDescription(data.shippingPackages)),
-                    customsStep = Step.done(),
-                    carrierStep = Step.done(),
-                    paymentStep = Step.current(data.currentPaymentMethod.stepDescription),
-                    // TODO caculate the order summary value from the selected shipping rates
-                    orderSummaryState = OrderSummaryState(
-                        isVisible = true, price = BigDecimal.TEN, discount = BigDecimal.ONE
-                    )
-                )
-            }
-            FlowStep.DONE -> {
-                viewState.copy(
-                    originAddressStep = Step.done(data.originAddress.toString()),
-                    shippingAddressStep = Step.done(data.shippingAddress.toString()),
-                    packagingDetailsStep = Step.done(getPackageDetailsDescription(data.shippingPackages)),
-                    customsStep = Step.done(),
-                    carrierStep = Step.done(),
-                    paymentStep = Step.done(data.currentPaymentMethod.stepDescription),
-                    // TODO caculate the order summary value from the selected shipping rates
-                    orderSummaryState = OrderSummaryState(
-                        isVisible = true, price = BigDecimal.TEN, discount = BigDecimal.ONE
-                    )
-                )
+
+            return when (status) {
+                NOT_READY -> StepUiState.notDone(description)
+                READY -> StepUiState.current(description)
+                DONE -> StepUiState.done(description)
             }
         }
+
+        fun StepsState.getOrderSummary(): OrderSummaryState {
+            val isVisible = originAddressStep.status == DONE &&
+                shippingAddressStep.status == DONE &&
+                packagingStep.status == DONE &&
+                (!customsStep.isVisible || customsStep.status == DONE) &&
+                carrierStep.status == DONE
+            if (!isVisible) return OrderSummaryState()
+
+            return OrderSummaryState(
+                isVisible = true, price = BigDecimal.TEN, discount = BigDecimal.ONE
+            )
+        }
+
+        viewState = viewState.copy(
+            originAddressStep = stateMachineData.stepsState.originAddressStep.mapToUiState(),
+            shippingAddressStep = stateMachineData.stepsState.shippingAddressStep.mapToUiState(),
+            packagingDetailsStep = stateMachineData.stepsState.packagingStep.mapToUiState(),
+            customsStep = stateMachineData.stepsState.customsStep.mapToUiState(),
+            carrierStep = stateMachineData.stepsState.carrierStep.mapToUiState(),
+            paymentStep = stateMachineData.stepsState.paymentsStep.mapToUiState(),
+            orderSummaryState = stateMachineData.stepsState.getOrderSummary()
+        )
     }
 
     private fun showError(error: Error) {
@@ -440,9 +412,8 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
             FlowStep.CUSTOMS -> Event.EditCustomsRequested
             FlowStep.CARRIER -> Event.EditShippingCarrierRequested
             FlowStep.PAYMENT -> Event.EditPaymentRequested
-            FlowStep.DONE -> null
         }.also { event ->
-            event?.let {
+            event.let {
                 stateMachine.handleEvent(it)
             }
         }
@@ -456,9 +427,8 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
             FlowStep.CUSTOMS -> Event.CustomsDeclarationStarted
             FlowStep.CARRIER -> Event.ShippingCarrierSelectionStarted
             FlowStep.PAYMENT -> Event.PaymentSelectionStarted
-            FlowStep.DONE -> null
         }.also { event ->
-            event?.let { stateMachine.handleEvent(it) }
+            event.let { stateMachine.handleEvent(it) }
         }
     }
 
@@ -470,12 +440,12 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
     @Parcelize
     data class ViewState(
         val uiState: UiState = WaitingForInput,
-        val originAddressStep: Step? = null,
-        val shippingAddressStep: Step? = null,
-        val packagingDetailsStep: Step? = null,
-        val customsStep: Step? = null,
-        val carrierStep: Step? = null,
-        val paymentStep: Step? = null,
+        val originAddressStep: StepUiState? = null,
+        val shippingAddressStep: StepUiState? = null,
+        val packagingDetailsStep: StepUiState? = null,
+        val customsStep: StepUiState? = null,
+        val carrierStep: StepUiState? = null,
+        val paymentStep: StepUiState? = null,
         val orderSummaryState: OrderSummaryState = OrderSummaryState(),
         val progressDialogState: ProgressDialogState = ProgressDialogState()
     ) : Parcelable
@@ -499,7 +469,8 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
     ) : Parcelable
 
     @Parcelize
-    data class Step(
+    data class StepUiState(
+        val isVisible: Boolean = true,
         val details: String? = null,
         val isEnabled: Boolean? = null,
         val isContinueButtonVisible: Boolean? = null,
@@ -507,7 +478,10 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
         val isHighlighted: Boolean? = null
     ) : Parcelable {
         companion object {
-            fun notDone(newDetails: String? = null) = Step(
+            fun hide() = StepUiState(
+                isVisible = false
+            )
+            fun notDone(newDetails: String? = null) = StepUiState(
                 details = newDetails,
                 isEnabled = false,
                 isContinueButtonVisible = false,
@@ -515,7 +489,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                 isHighlighted = false
             )
 
-            fun current(newDetails: String? = null) = Step(
+            fun current(newDetails: String? = null) = StepUiState(
                 details = newDetails,
                 isEnabled = true,
                 isContinueButtonVisible = true,
@@ -523,7 +497,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                 isHighlighted = true
             )
 
-            fun done(newDetails: String? = null) = Step(
+            fun done(newDetails: String? = null) = StepUiState(
                 details = newDetails,
                 isEnabled = true,
                 isContinueButtonVisible = false,
@@ -531,6 +505,10 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                 isHighlighted = false
             )
         }
+    }
+
+    enum class FlowStep {
+        ORIGIN_ADDRESS, SHIPPING_ADDRESS, PACKAGING, CUSTOMS, CARRIER, PAYMENT
     }
 
     @AssistedInject.Factory

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -164,7 +164,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                         )
                         is SideEffect.ShowPackageOptions -> openPackagesDetails(sideEffect.shippingPackages)
                         is SideEffect.ShowCustomsForm -> handleResult { Event.CustomsFormFilledOut }
-                        is SideEffect.ShowCarrierOptions -> handleResult { Event.ShippingCarrierSelected }
+                        is SideEffect.ShowCarrierOptions -> openShippingCarrierRates(sideEffect.data)
                         is SideEffect.ShowPaymentOptions -> openPaymentDetails()
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -12,7 +12,15 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAd
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Error.AddressValidationError
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Error.DataLoadingError
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.UserInput
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.State.WaitingForInput
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.CarrierStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.CustomsStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.OriginAddressStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.PackagingStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.PaymentsStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.ShippingAddressStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.DONE
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.NOT_READY
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.READY
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import kotlinx.android.parcel.Parcelize
@@ -93,6 +101,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
     // the view states based on the triggered states and side-effects
     @ExperimentalCoroutinesApi
     private val _transitions = MutableStateFlow(Transition(State.Idle, SideEffect.NoOp))
+
     @ExperimentalCoroutinesApi
     val transitions: StateFlow<Transition> = _transitions
 
@@ -116,13 +125,17 @@ class ShippingLabelsStateMachine @Inject constructor() {
 
         state<State.DataLoading> {
             on<Event.DataLoaded> { event ->
-                val data = Data(
+                val steps = StepsState(
+                    originAddressStep = OriginAddressStep(READY, event.originAddress),
+                    shippingAddressStep = ShippingAddressStep(NOT_READY, event.shippingAddress),
+                    packagingStep = PackagingStep(NOT_READY, emptyList()),
+                    customsStep = CustomsStep(NOT_READY),
+                    carrierStep = CarrierStep(NOT_READY),
+                    paymentsStep = PaymentsStep(NOT_READY, event.currentPaymentMethod)
+                )
+                val data = StateMachineData(
                     remoteOrderId = event.remoteOrderId,
-                    originAddress = event.originAddress,
-                    shippingAddress = event.shippingAddress,
-                    currentPaymentMethod = event.currentPaymentMethod,
-                    shippingPackages = emptyList(),
-                    flowSteps = setOf(FlowStep.ORIGIN_ADDRESS)
+                    stepsState = steps
                 )
                 transitionTo(State.WaitingForInput(data))
             }
@@ -145,7 +158,10 @@ class ShippingLabelsStateMachine @Inject constructor() {
                 transitionTo(State.ShippingAddressValidation(data))
             }
             on<Event.PackageSelectionStarted> {
-                transitionTo(State.PackageSelection(data), SideEffect.ShowPackageOptions(data.shippingPackages))
+                transitionTo(
+                    State.PackageSelection(data),
+                    SideEffect.ShowPackageOptions(data.stepsState.packagingStep.data)
+                )
             }
             on<Event.CustomsDeclarationStarted> {
                 transitionTo(State.CustomsDeclaration(data), SideEffect.ShowCustomsForm)
@@ -157,16 +173,22 @@ class ShippingLabelsStateMachine @Inject constructor() {
                 transitionTo(State.PaymentSelection(data), SideEffect.ShowPaymentOptions)
             }
             on<Event.EditOriginAddressRequested> {
-                transitionTo(State.OriginAddressEditing(data), SideEffect.OpenAddressEditor(data.originAddress, ORIGIN))
+                transitionTo(
+                    State.OriginAddressEditing(data),
+                    SideEffect.OpenAddressEditor(data.stepsState.originAddressStep.data, ORIGIN)
+                )
             }
             on<Event.EditShippingAddressRequested> {
                 transitionTo(
                     State.ShippingAddressEditing(data),
-                    SideEffect.OpenAddressEditor(data.shippingAddress, DESTINATION)
+                    SideEffect.OpenAddressEditor(data.stepsState.shippingAddressStep.data, DESTINATION)
                 )
             }
             on<Event.EditPackagingRequested> {
-                transitionTo(State.PackageSelection(data), SideEffect.ShowPackageOptions(data.shippingPackages))
+                transitionTo(
+                    State.PackageSelection(data),
+                    SideEffect.ShowPackageOptions(data.stepsState.packagingStep.data)
+                )
             }
             on<Event.EditCustomsRequested> {
                 transitionTo(State.CustomsDeclaration(data), SideEffect.ShowCustomsForm)
@@ -182,21 +204,28 @@ class ShippingLabelsStateMachine @Inject constructor() {
         state<State.OriginAddressValidation> {
             on<Event.AddressValidated> { event ->
                 val newData = data.copy(
-                    originAddress = event.address,
-                    flowSteps = data.flowSteps + FlowStep.SHIPPING_ADDRESS
+                    stepsState = data.stepsState.completeStep(data.stepsState.originAddressStep, event.address)
                 )
                 transitionTo(State.WaitingForInput(newData))
             }
             on<Event.AddressChangeSuggested> { event ->
                 transitionTo(
                     State.OriginAddressSuggestion(data),
-                    SideEffect.ShowAddressSuggestion(data.originAddress, event.suggested, ORIGIN)
+                    SideEffect.ShowAddressSuggestion(
+                        data.stepsState.originAddressStep.data,
+                        event.suggested,
+                        ORIGIN
+                    )
                 )
             }
             on<Event.AddressInvalid> { event ->
                 transitionTo(
                     State.OriginAddressEditing(data),
-                    SideEffect.OpenAddressEditor(data.originAddress, ORIGIN, event.validationResult)
+                    SideEffect.OpenAddressEditor(
+                        data.stepsState.originAddressStep.data,
+                        ORIGIN,
+                        event.validationResult
+                    )
                 )
             }
             on<Event.AddressValidationFailed> {
@@ -207,8 +236,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         state<State.OriginAddressSuggestion> {
             on<Event.SuggestedAddressAccepted> { event ->
                 val newData = data.copy(
-                    originAddress = event.address,
-                    flowSteps = data.flowSteps + FlowStep.SHIPPING_ADDRESS
+                    stepsState = data.stepsState.completeStep(data.stepsState.originAddressStep, event.address)
                 )
                 transitionTo(State.WaitingForInput(newData))
             }
@@ -223,8 +251,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         state<State.OriginAddressEditing> {
             on<Event.AddressValidated> { event ->
                 val newData = data.copy(
-                    originAddress = event.address,
-                    flowSteps = data.flowSteps + FlowStep.SHIPPING_ADDRESS
+                    stepsState = data.stepsState.completeStep(data.stepsState.originAddressStep, event.address)
                 )
                 transitionTo(State.WaitingForInput(newData))
             }
@@ -236,21 +263,28 @@ class ShippingLabelsStateMachine @Inject constructor() {
         state<State.ShippingAddressValidation> {
             on<Event.AddressValidated> { event ->
                 val newData = data.copy(
-                    shippingAddress = event.address,
-                    flowSteps = data.flowSteps + FlowStep.PACKAGING
+                    stepsState = data.stepsState.completeStep(data.stepsState.shippingAddressStep, event.address)
                 )
                 transitionTo(State.WaitingForInput(newData))
             }
             on<Event.AddressChangeSuggested> { event ->
                 transitionTo(
                     State.ShippingAddressSuggestion(data),
-                    SideEffect.ShowAddressSuggestion(data.originAddress, event.suggested, DESTINATION)
+                    SideEffect.ShowAddressSuggestion(
+                        data.stepsState.shippingAddressStep.data,
+                        event.suggested,
+                        DESTINATION
+                    )
                 )
             }
             on<Event.AddressInvalid> { event ->
                 transitionTo(
                     State.ShippingAddressEditing(data),
-                    SideEffect.OpenAddressEditor(data.shippingAddress, DESTINATION, event.validationResult)
+                    SideEffect.OpenAddressEditor(
+                        data.stepsState.shippingAddressStep.data,
+                        DESTINATION,
+                        event.validationResult
+                    )
                 )
             }
             on<Event.AddressValidationFailed> {
@@ -261,8 +295,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         state<State.ShippingAddressSuggestion> {
             on<Event.SuggestedAddressAccepted> { event ->
                 val newData = data.copy(
-                    shippingAddress = event.address,
-                    flowSteps = data.flowSteps + FlowStep.PACKAGING
+                    stepsState = data.stepsState.completeStep(data.stepsState.shippingAddressStep, event.address)
                 )
                 transitionTo(State.WaitingForInput(newData))
             }
@@ -280,8 +313,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         state<State.ShippingAddressEditing> {
             on<Event.AddressValidated> { event ->
                 val newData = data.copy(
-                    shippingAddress = event.address,
-                    flowSteps = data.flowSteps + FlowStep.PACKAGING
+                    stepsState = data.stepsState.completeStep(data.stepsState.shippingAddressStep, event.address)
                 )
                 transitionTo(State.WaitingForInput(newData))
             }
@@ -293,8 +325,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         state<State.PackageSelection> {
             on<Event.PackagesSelected> { event ->
                 val newData = data.copy(
-                    shippingPackages = event.shippingPackages,
-                    flowSteps = data.flowSteps + FlowStep.CUSTOMS
+                    stepsState = data.stepsState.completeStep(data.stepsState.packagingStep, event.shippingPackages)
                 )
                 transitionTo(State.WaitingForInput(newData))
             }
@@ -306,19 +337,16 @@ class ShippingLabelsStateMachine @Inject constructor() {
 
         state<State.CustomsDeclaration> {
             on<Event.CustomsFormFilledOut> {
-                val newData = data.copy(flowSteps = data.flowSteps + FlowStep.CARRIER)
+                val newData = data.copy(
+                    stepsState = data.stepsState.completeStep(data.stepsState.customsStep, Unit)
+                )
                 transitionTo(State.WaitingForInput(newData))
             }
         }
 
         state<State.ShippingCarrierSelection> {
             on<Event.ShippingCarrierSelected> {
-                val stepsToAdd = if (data.currentPaymentMethod != null) {
-                    listOf(FlowStep.PAYMENT, FlowStep.DONE)
-                } else {
-                    listOf(FlowStep.PAYMENT)
-                }
-                val newData = data.copy(flowSteps = data.flowSteps + stepsToAdd)
+                val newData = data.copy(stepsState = data.stepsState.completeStep(data.stepsState.carrierStep, Unit))
                 transitionTo(State.WaitingForInput(newData))
             }
             on<Event.ShippingCarrierSelectionCanceled> {
@@ -329,8 +357,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         state<State.PaymentSelection> {
             on<Event.PaymentSelected> {
                 val newData = data.copy(
-                    currentPaymentMethod = it.paymentMethod,
-                    flowSteps = data.flowSteps + FlowStep.DONE
+                    stepsState = data.stepsState.completeStep(data.stepsState.paymentsStep, it.paymentMethod)
                 )
                 transitionTo(State.WaitingForInput(newData))
             }
@@ -370,7 +397,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         WooLog.d(T.ORDERS, event.toString())
 
         // we can ignore invalid state transitions caused by user input (most likely caused by duplicate clicks)
-        if (event !is UserInput || stateMachine.state is WaitingForInput) {
+        if (event !is UserInput || stateMachine.state is State.WaitingForInput) {
             stateMachine.transition(event)
         }
     }
@@ -379,20 +406,108 @@ class ShippingLabelsStateMachine @Inject constructor() {
      * Data passed around between states
      */
     @Parcelize
-    data class Data(
+    data class StateMachineData(
         val remoteOrderId: Long,
-        val originAddress: Address,
-        val shippingAddress: Address,
-        val currentPaymentMethod: PaymentMethod?,
-        val shippingPackages: List<ShippingLabelPackage>,
-        val flowSteps: Set<FlowStep>
+        val stepsState: StepsState
     ) : Parcelable
 
     /**
      * The main shipping label creation steps
      */
-    enum class FlowStep {
-        ORIGIN_ADDRESS, SHIPPING_ADDRESS, PACKAGING, CUSTOMS, CARRIER, PAYMENT, DONE
+    sealed class Step<T> : Parcelable {
+        abstract val status: StepStatus
+        abstract val data: T
+        open val isVisible: Boolean = true
+
+        @Parcelize
+        data class OriginAddressStep(override val status: StepStatus, override val data: Address) : Step<Address>()
+
+        @Parcelize
+        data class ShippingAddressStep(
+            override val status: StepStatus,
+            override val data: Address
+        ) : Step<Address>()
+
+        @Parcelize
+        data class PackagingStep(
+            override val status: StepStatus, override val data: List<ShippingLabelPackage>
+        ) : Step<List<ShippingLabelPackage>>()
+
+        @Parcelize
+        data class CustomsStep(
+            override val status: StepStatus, override val isVisible: Boolean = false, override val data: Unit = Unit
+        ) : Step<Unit>()
+
+        @Parcelize
+        data class CarrierStep(override val status: StepStatus, override val data: Unit = Unit) : Step<Unit>()
+
+        @Parcelize
+        data class PaymentsStep(
+            override val status: StepStatus, override val data: PaymentMethod?
+        ) : Step<PaymentMethod?>()
+    }
+
+    @Parcelize
+    data class StepsState(
+        val originAddressStep: OriginAddressStep,
+        val shippingAddressStep: ShippingAddressStep,
+        val packagingStep: PackagingStep,
+        val customsStep: CustomsStep,
+        val carrierStep: CarrierStep,
+        val paymentsStep: PaymentsStep
+    ) : Parcelable {
+        @Suppress("UNCHECKED_CAST")
+        fun <T> completeStep(currentStep: Step<T>, newData: T): StepsState {
+            return when (currentStep) {
+                is OriginAddressStep -> copy(
+                    originAddressStep = originAddressStep.copy(status = DONE, data = newData as Address),
+                    shippingAddressStep = shippingAddressStep.copy(status = READY)
+                )
+                is ShippingAddressStep -> copy(
+                    shippingAddressStep = shippingAddressStep.copy(
+                        status = DONE,
+                        data = newData as Address
+                    ),
+                    packagingStep = packagingStep.copy(status = READY)
+                )
+                is PackagingStep -> {
+                    val newPackagingStep = packagingStep.copy(
+                        status = DONE,
+                        data = newData as List<ShippingLabelPackage>
+                    )
+                    if (customsStep.isVisible) {
+                        copy(
+                            packagingStep = newPackagingStep,
+                            customsStep = customsStep.copy(status = READY),
+                            carrierStep = carrierStep.copy(status = NOT_READY)
+                        )
+                    } else {
+                        copy(
+                            packagingStep = newPackagingStep,
+                            carrierStep = carrierStep.copy(status = READY)
+                        )
+                    }
+                }
+                is CustomsStep -> copy(
+                    customsStep = customsStep.copy(status = DONE),
+                    carrierStep = carrierStep.copy(status = READY)
+                )
+                is CarrierStep -> {
+                    val paymentStatus = if (paymentsStep.data == null) READY else DONE
+                    copy(
+                        carrierStep = carrierStep.copy(status = DONE),
+                        paymentsStep = paymentsStep.copy(status = paymentStatus)
+                    )
+                }
+                is PaymentsStep -> copy(
+                    paymentsStep = paymentsStep.copy(status = DONE)
+                )
+            }
+        }
+    }
+
+    enum class StepStatus {
+        NOT_READY, READY, DONE
     }
 
     sealed class Error {
@@ -412,43 +527,43 @@ class ShippingLabelsStateMachine @Inject constructor() {
         data class DataLoading(val orderId: String) : State()
 
         @Parcelize
-        data class WaitingForInput(val data: Data) : State()
+        data class WaitingForInput(val data: StateMachineData) : State()
 
         @Parcelize
-        data class OriginAddressValidation(val data: Data) : State()
+        data class OriginAddressValidation(val data: StateMachineData) : State()
 
         @Parcelize
-        data class OriginAddressSuggestion(val data: Data) : State()
+        data class OriginAddressSuggestion(val data: StateMachineData) : State()
 
         @Parcelize
-        data class OriginAddressEditing(val data: Data) : State()
+        data class OriginAddressEditing(val data: StateMachineData) : State()
 
         @Parcelize
         object OriginAddressValidationFailure : State()
 
         @Parcelize
-        data class ShippingAddressValidation(val data: Data) : State()
+        data class ShippingAddressValidation(val data: StateMachineData) : State()
 
         @Parcelize
-        data class ShippingAddressSuggestion(val data: Data) : State()
+        data class ShippingAddressSuggestion(val data: StateMachineData) : State()
 
         @Parcelize
-        data class ShippingAddressEditing(val data: Data) : State()
+        data class ShippingAddressEditing(val data: StateMachineData) : State()
 
         @Parcelize
         object ShippingAddressValidationFailure : State()
 
         @Parcelize
-        data class PackageSelection(val data: Data) : State()
+        data class PackageSelection(val data: StateMachineData) : State()
 
         @Parcelize
-        data class CustomsDeclaration(val data: Data) : State()
+        data class CustomsDeclaration(val data: StateMachineData) : State()
 
         @Parcelize
-        data class ShippingCarrierSelection(val data: Data) : State()
+        data class ShippingCarrierSelection(val data: StateMachineData) : State()
 
         @Parcelize
-        data class PaymentSelection(val data: Data) : State()
+        data class PaymentSelection(val data: StateMachineData) : State()
     }
 
     sealed class Event {
@@ -520,7 +635,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         ) : SideEffect()
 
         object ShowCustomsForm : SideEffect()
-        data class ShowCarrierOptions(val data: Data) : SideEffect()
+        data class ShowCarrierOptions(val data: StateMachineData) : SideEffect()
         object ShowPaymentOptions : SideEffect()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -5,6 +5,7 @@ import com.tinder.StateMachine
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.PaymentMethod
 import com.woocommerce.android.model.ShippingLabelPackage
+import com.woocommerce.android.model.ShippingRate.ShippingCarrier
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.DESTINATION
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.ORIGIN
@@ -204,7 +205,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         state<State.OriginAddressValidation> {
             on<Event.AddressValidated> { event ->
                 val newData = data.copy(
-                    stepsState = data.stepsState.completeStep(data.stepsState.originAddressStep, event.address)
+                    stepsState = data.stepsState.updateStep(data.stepsState.originAddressStep, event.address)
                 )
                 transitionTo(State.WaitingForInput(newData))
             }
@@ -236,7 +237,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         state<State.OriginAddressSuggestion> {
             on<Event.SuggestedAddressAccepted> { event ->
                 val newData = data.copy(
-                    stepsState = data.stepsState.completeStep(data.stepsState.originAddressStep, event.address)
+                    stepsState = data.stepsState.updateStep(data.stepsState.originAddressStep, event.address)
                 )
                 transitionTo(State.WaitingForInput(newData))
             }
@@ -251,7 +252,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         state<State.OriginAddressEditing> {
             on<Event.AddressValidated> { event ->
                 val newData = data.copy(
-                    stepsState = data.stepsState.completeStep(data.stepsState.originAddressStep, event.address)
+                    stepsState = data.stepsState.updateStep(data.stepsState.originAddressStep, event.address)
                 )
                 transitionTo(State.WaitingForInput(newData))
             }
@@ -263,7 +264,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         state<State.ShippingAddressValidation> {
             on<Event.AddressValidated> { event ->
                 val newData = data.copy(
-                    stepsState = data.stepsState.completeStep(data.stepsState.shippingAddressStep, event.address)
+                    stepsState = data.stepsState.updateStep(data.stepsState.shippingAddressStep, event.address)
                 )
                 transitionTo(State.WaitingForInput(newData))
             }
@@ -295,7 +296,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         state<State.ShippingAddressSuggestion> {
             on<Event.SuggestedAddressAccepted> { event ->
                 val newData = data.copy(
-                    stepsState = data.stepsState.completeStep(data.stepsState.shippingAddressStep, event.address)
+                    stepsState = data.stepsState.updateStep(data.stepsState.shippingAddressStep, event.address)
                 )
                 transitionTo(State.WaitingForInput(newData))
             }
@@ -313,7 +314,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         state<State.ShippingAddressEditing> {
             on<Event.AddressValidated> { event ->
                 val newData = data.copy(
-                    stepsState = data.stepsState.completeStep(data.stepsState.shippingAddressStep, event.address)
+                    stepsState = data.stepsState.updateStep(data.stepsState.shippingAddressStep, event.address)
                 )
                 transitionTo(State.WaitingForInput(newData))
             }
@@ -325,7 +326,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         state<State.PackageSelection> {
             on<Event.PackagesSelected> { event ->
                 val newData = data.copy(
-                    stepsState = data.stepsState.completeStep(data.stepsState.packagingStep, event.shippingPackages)
+                    stepsState = data.stepsState.updateStep(data.stepsState.packagingStep, event.shippingPackages)
                 )
                 transitionTo(State.WaitingForInput(newData))
             }
@@ -338,7 +339,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         state<State.CustomsDeclaration> {
             on<Event.CustomsFormFilledOut> {
                 val newData = data.copy(
-                    stepsState = data.stepsState.completeStep(data.stepsState.customsStep, Unit)
+                    stepsState = data.stepsState.updateStep(data.stepsState.customsStep, Unit)
                 )
                 transitionTo(State.WaitingForInput(newData))
             }
@@ -346,7 +347,12 @@ class ShippingLabelsStateMachine @Inject constructor() {
 
         state<State.ShippingCarrierSelection> {
             on<Event.ShippingCarrierSelected> {
-                val newData = data.copy(stepsState = data.stepsState.completeStep(data.stepsState.carrierStep, Unit))
+                val newData = data.copy(
+                    stepsState = data.stepsState.updateStep(
+                        data.stepsState.carrierStep,
+                        emptyList()
+                    )
+                )
                 transitionTo(State.WaitingForInput(newData))
             }
             on<Event.ShippingCarrierSelectionCanceled> {
@@ -357,7 +363,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         state<State.PaymentSelection> {
             on<Event.PaymentSelected> {
                 val newData = data.copy(
-                    stepsState = data.stepsState.completeStep(data.stepsState.paymentsStep, it.paymentMethod)
+                    stepsState = data.stepsState.updateStep(data.stepsState.paymentsStep, it.paymentMethod)
                 )
                 transitionTo(State.WaitingForInput(newData))
             }
@@ -439,7 +445,10 @@ class ShippingLabelsStateMachine @Inject constructor() {
         ) : Step<Unit>()
 
         @Parcelize
-        data class CarrierStep(override val status: StepStatus, override val data: Unit = Unit) : Step<Unit>()
+        data class CarrierStep(
+            override val status: StepStatus,
+            override val data: List<ShippingCarrier> = emptyList()
+        ) : Step<List<ShippingCarrier>>()
 
         @Parcelize
         data class PaymentsStep(
@@ -457,7 +466,15 @@ class ShippingLabelsStateMachine @Inject constructor() {
         val paymentsStep: PaymentsStep
     ) : Parcelable {
         @Suppress("UNCHECKED_CAST")
-        fun <T> completeStep(currentStep: Step<T>, newData: T): StepsState {
+        fun <T> updateStep(currentStep: Step<T>, newData: T): StepsState {
+            return if (currentStep.status == DONE) {
+                editStep(currentStep, newData)
+            } else {
+                completeStep(currentStep, newData)
+            }
+        }
+
+        private fun <T> completeStep(currentStep: Step<T>, newData: T): StepsState {
             return when (currentStep) {
                 is OriginAddressStep -> copy(
                     originAddressStep = originAddressStep.copy(status = DONE, data = newData as Address),
@@ -478,8 +495,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
                     if (customsStep.isVisible) {
                         copy(
                             packagingStep = newPackagingStep,
-                            customsStep = customsStep.copy(status = READY),
-                            carrierStep = carrierStep.copy(status = NOT_READY)
+                            customsStep = customsStep.copy(status = READY)
                         )
                     } else {
                         copy(
@@ -500,9 +516,34 @@ class ShippingLabelsStateMachine @Inject constructor() {
                     )
                 }
                 is PaymentsStep -> copy(
-                    paymentsStep = paymentsStep.copy(status = DONE)
+                    paymentsStep = paymentsStep.copy(status = DONE, data = newData as PaymentMethod)
                 )
             }
+        }
+
+        private fun <T> editStep(currentStep: Step<T>, newData: T): StepsState {
+            if (currentStep.data == newData) return this
+            return when (currentStep) {
+                is OriginAddressStep -> copy(
+                    originAddressStep = originAddressStep.copy(data = newData as Address),
+                    carrierStep = invalidateCarrierStepIfNeeded()
+                )
+                is ShippingAddressStep -> copy(
+                    shippingAddressStep = shippingAddressStep.copy(data = newData as Address),
+                    carrierStep = invalidateCarrierStepIfNeeded()
+                )
+                is PackagingStep -> copy(
+                    packagingStep = packagingStep.copy(data = newData as List<ShippingLabelPackage>),
+                    carrierStep = invalidateCarrierStepIfNeeded()
+                )
+                is CustomsStep -> copy(customsStep = customsStep.copy(data = newData as Unit))
+                is CarrierStep -> copy(carrierStep = carrierStep.copy(data = newData as List<ShippingCarrier>))
+                is PaymentsStep -> copy(paymentsStep = paymentsStep.copy(data = newData as PaymentMethod))
+            }
+        }
+
+        private fun invalidateCarrierStepIfNeeded(): CarrierStep {
+            return if (carrierStep.status == DONE) carrierStep.copy(status = READY) else carrierStep
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -436,12 +436,15 @@ class ShippingLabelsStateMachine @Inject constructor() {
 
         @Parcelize
         data class PackagingStep(
-            override val status: StepStatus, override val data: List<ShippingLabelPackage>
+            override val status: StepStatus,
+            override val data: List<ShippingLabelPackage>
         ) : Step<List<ShippingLabelPackage>>()
 
         @Parcelize
         data class CustomsStep(
-            override val status: StepStatus, override val isVisible: Boolean = false, override val data: Unit = Unit
+            override val status: StepStatus,
+            override val isVisible: Boolean = false,
+            override val data: Unit = Unit
         ) : Step<Unit>()
 
         @Parcelize
@@ -452,7 +455,8 @@ class ShippingLabelsStateMachine @Inject constructor() {
 
         @Parcelize
         data class PaymentsStep(
-            override val status: StepStatus, override val data: PaymentMethod?
+            override val status: StepStatus,
+            override val data: PaymentMethod?
         ) : Step<PaymentMethod?>()
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
@@ -9,16 +9,25 @@ import com.nhaarman.mockitokotlin2.whenever
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRepository
-import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.Step
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.FlowStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.StepUiState
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.ViewState
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.ORIGIN
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Data
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.OriginAddressValidationStarted
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.FlowStep
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.FlowStep.ORIGIN_ADDRESS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.SideEffect.NoOp
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.State
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.State.Idle
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StateMachineData
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.CarrierStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.CustomsStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.OriginAddressStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.PackagingStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.PaymentsStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.ShippingAddressStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.DONE
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.NOT_READY
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.READY
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepsState
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Transition
 import com.woocommerce.android.util.CoroutineTestRule
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -56,16 +65,19 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
     private val shippingAddress = originAddress.copy(company = "McDonald's")
     private val shippingAddressValidated = shippingAddress.copy(city = "DONE")
 
-    private val data = Data(
+    private val data = StateMachineData(
         remoteOrderId = REMOTE_ORDER_ID,
-        originAddress = originAddress,
-        shippingAddress = shippingAddress,
-        currentPaymentMethod = null,
-        shippingPackages = emptyList(),
-        flowSteps = setOf(ORIGIN_ADDRESS)
+        stepsState = StepsState(
+            originAddressStep = OriginAddressStep(READY, originAddress),
+            shippingAddressStep = ShippingAddressStep(NOT_READY, shippingAddress),
+            packagingStep = PackagingStep(NOT_READY, emptyList()),
+            customsStep = CustomsStep(NOT_READY, isVisible = true),
+            carrierStep = CarrierStep(NOT_READY),
+            paymentsStep = PaymentsStep(NOT_READY, null)
+        )
     )
 
-    private val originAddressCurrent = Step(
+    private val originAddressCurrent = StepUiState(
         details = originAddress.toString(),
         isEnabled = true,
         isContinueButtonVisible = true,
@@ -80,7 +92,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
         isHighlighted = false
     )
 
-    private val shippingAddressNotDone = Step(
+    private val shippingAddressNotDone = StepUiState(
         details = shippingAddress.toString(),
         isEnabled = false,
         isContinueButtonVisible = false,
@@ -102,14 +114,14 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
         isHighlighted = false
     )
 
-    private val otherNotDone = Step(
+    private val otherNotDone = StepUiState(
         isEnabled = false,
         isContinueButtonVisible = false,
         isEditButtonVisible = false,
         isHighlighted = false
     )
 
-    private val otherCurrent = Step(
+    private val otherCurrent = StepUiState(
         isEnabled = true,
         isContinueButtonVisible = true,
         isEditButtonVisible = false,
@@ -197,10 +209,11 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
             paymentStep = otherNotDone
         )
 
-        val newData = data.copy(
-            originAddress = originAddressValidated,
-            flowSteps = data.flowSteps + FlowStep.SHIPPING_ADDRESS
+        val newStepsState = data.stepsState.copy(
+            originAddressStep = data.stepsState.originAddressStep.copy(status = DONE, data = originAddressValidated),
+            shippingAddressStep = data.stepsState.shippingAddressStep.copy(status = READY)
         )
+        val newData = data.copy(stepsState = newStepsState)
         stateFlow.value = Transition(State.WaitingForInput(newData), null)
 
         assertThat(viewState).isEqualTo(expectedViewState)
@@ -220,11 +233,16 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
             paymentStep = otherNotDone
         )
 
-        val newData = data.copy(
-            originAddress = originAddressValidated,
-            shippingAddress = shippingAddressValidated,
-            flowSteps = data.flowSteps + FlowStep.SHIPPING_ADDRESS + FlowStep.PACKAGING
+        val newStepsState = data.stepsState.copy(
+            originAddressStep = data.stepsState.originAddressStep.copy(status = DONE, data = originAddressValidated),
+            shippingAddressStep = data.stepsState.shippingAddressStep.copy(
+                status = DONE,
+                data = shippingAddressValidated
+            ),
+            packagingStep = data.stepsState.packagingStep.copy(status = READY)
         )
+
+        val newData = data.copy(stepsState = newStepsState)
         stateFlow.value = Transition(State.WaitingForInput(newData), null)
 
         assertThat(viewState).isEqualTo(expectedViewState)
@@ -234,7 +252,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
     fun `Continue click in origin address triggers validation`() = coroutinesTestRule.testDispatcher.runBlockingTest {
         stateFlow.value = Transition(State.WaitingForInput(data), null)
 
-        viewModel.onContinueButtonTapped(ORIGIN_ADDRESS)
+        viewModel.onContinueButtonTapped(FlowStep.ORIGIN_ADDRESS)
 
         verify(stateMachine).handleEvent(OriginAddressValidationStarted)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
@@ -5,11 +5,20 @@ import com.woocommerce.android.model.PackageDimensions
 import com.woocommerce.android.model.ShippingLabelPackage
 import com.woocommerce.android.model.ShippingLabelPackage.Item
 import com.woocommerce.android.model.ShippingPackage
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Data
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.FlowStep
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.SideEffect
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.State
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StateMachineData
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.CarrierStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.CustomsStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.OriginAddressStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.PackagingStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.PaymentsStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.ShippingAddressStep
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.DONE
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.NOT_READY
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.READY
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepsState
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Transition
 import com.woocommerce.android.util.CoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -29,13 +38,16 @@ class ShippingLabelsStateMachineTest {
     private val remoteOrderId = 123L
     private val originAddress = CreateShippingLabelTestUtils.generateAddress()
     private val shippingAddress = originAddress.copy(company = "McDonald's")
-    private val data = Data(
+    private val data = StateMachineData(
         remoteOrderId,
-        originAddress,
-        shippingAddress,
-        null,
-        emptyList(),
-        setOf(FlowStep.ORIGIN_ADDRESS)
+        StepsState(
+            originAddressStep = OriginAddressStep(READY, originAddress),
+            shippingAddressStep = ShippingAddressStep(NOT_READY, shippingAddress),
+            packagingStep = PackagingStep(NOT_READY, emptyList()),
+            customsStep = CustomsStep(NOT_READY),
+            carrierStep = CarrierStep(NOT_READY),
+            paymentsStep = PaymentsStep(NOT_READY, null)
+        )
     )
 
     @get:Rule
@@ -62,12 +74,14 @@ class ShippingLabelsStateMachineTest {
 
         assertThat(transition?.state).isEqualTo(State.DataLoading(remoteOrderId.toString()))
 
-        stateMachine.handleEvent(Event.DataLoaded(
-            remoteOrderId,
-            originAddress,
-            shippingAddress,
-            null
-        ))
+        stateMachine.handleEvent(
+            Event.DataLoaded(
+                remoteOrderId,
+                originAddress,
+                shippingAddress,
+                null
+            )
+        )
 
         assertThat(transition?.state).isEqualTo(State.WaitingForInput(data))
     }
@@ -88,11 +102,12 @@ class ShippingLabelsStateMachineTest {
 
         assertThat(transition?.state).isEqualTo(State.OriginAddressValidation(data))
 
-        val newData = data.copy(
-            originAddress = data.originAddress,
-            flowSteps = data.flowSteps + FlowStep.SHIPPING_ADDRESS
+        val newStepsState = data.stepsState.copy(
+            originAddressStep = data.stepsState.originAddressStep.copy(status = DONE),
+            shippingAddressStep = data.stepsState.shippingAddressStep.copy(status = READY)
         )
-        stateMachine.handleEvent(Event.AddressValidated(data.originAddress))
+        val newData = data.copy(stepsState = newStepsState)
+        stateMachine.handleEvent(Event.AddressValidated(data.stepsState.originAddressStep.data))
 
         assertThat(transition?.state).isEqualTo(State.WaitingForInput(newData))
     }
@@ -121,10 +136,11 @@ class ShippingLabelsStateMachineTest {
 
         stateMachine.handleEvent(Event.PackagesSelected(packagesList))
 
-        val newData = data.copy(
-            shippingPackages = packagesList,
-            flowSteps = data.flowSteps + FlowStep.CUSTOMS
+        val newStepsState = data.stepsState.copy(
+            packagingStep = data.stepsState.packagingStep.copy(status = DONE, data = packagesList),
+            carrierStep = data.stepsState.carrierStep.copy(status = READY)
         )
+        val newData = data.copy(stepsState = newStepsState)
 
         assertThat(stateMachine.transitions.value.state).isEqualTo(State.WaitingForInput(newData))
     }


### PR DESCRIPTION
The current behavior of the state machine doesn't offer the flexibility to edit previous steps, while keeping the next done steps untouched.
This refactoring offers more flexibility, by making each Step independent, and making the ViewModel rendering those states.
The model holding the data of the state machine has been changed too, in a way that each step holds its respective data.
<img width=400 src="https://user-images.githubusercontent.com/1657201/109308531-6e61a600-7842-11eb-9134-7af4aa77d7cd.gif"/>

#### Testing
Smoke test the Shipping Labels creation form, and make sure that editing any of the following steps: origin address, shipping address or packaging invalidates the carrier step if it was already done.
To test completing the carrier step, you need to change this [line](https://github.com/woocommerce/woocommerce-android/blob/db502dddd3b3a2596df26cf86a0c14b486ad17d9/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt#L167) to this:
```kotlin
      is SideEffect.ShowCarrierOptions -> handleResult { Event.ShippingCarrierSelected }
```

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
