### PR TITLE
Shipping Labels: hide the multi-packages UI elements

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -57,9 +57,7 @@ class ShippingLabelPackagesAdapter(
             with(binding.itemsList) {
                 layoutManager =
                     LinearLayoutManager(binding.root.context, LinearLayoutManager.VERTICAL, false)
-                val canMoveItems = shippingLabelPackages.count() > 1 ||
-                    shippingLabelPackages.firstOrNull()?.items?.count() ?: 0 > 1
-                adapter = PackageProductsAdapter(canMoveItems = canMoveItems)
+                adapter = PackageProductsAdapter()
             }
             binding.weightEditText.hint = binding.root.context.getString(
                 R.string.shipping_label_package_details_weight_hint,
@@ -138,7 +136,7 @@ class ShippingLabelPackagesAdapter(
     }
 }
 
-class PackageProductsAdapter(val canMoveItems: Boolean) : RecyclerView.Adapter<PackageProductViewHolder>() {
+class PackageProductsAdapter() : RecyclerView.Adapter<PackageProductViewHolder>() {
     var items: List<ShippingLabelPackage.Item> = emptyList()
         set(value) {
             field = value
@@ -160,7 +158,6 @@ class PackageProductsAdapter(val canMoveItems: Boolean) : RecyclerView.Adapter<P
         val binding: ShippingLabelPackageProductListItemBinding
     ) : ViewHolder(binding.root) {
         fun bind(item: ShippingLabelPackage.Item) {
-            binding.moveButton.isVisible = canMoveItems
             binding.productName.text = item.name
             val attributes = item.attributesList.takeIf { it.isNotEmpty() }?.let { "$it \u2981 " } ?: StringUtils.EMPTY
             val details = "$attributes${item.weight}"

--- a/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
@@ -35,6 +35,7 @@
         android:src="@drawable/ic_arrow_down"
         android:tint="@color/color_on_surface_high"
         app:layout_constraintBottom_toBottomOf="@id/package_name"
+        android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@id/package_name" />
 

--- a/WooCommerce/src/main/res/layout/shipping_label_package_product_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_label_package_product_list_item.xml
@@ -37,6 +37,7 @@
         android:layout_height="wrap_content"
         android:text="@string/shipping_label_package_details_move_item"
         android:textAllCaps="false"
+        android:visibility="gone"
         app:layout_constraintBottom_toTopOf="@id/divider"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
Closes #3638, this simply hides the multi-packages UI elements as they are not supported in M3:
- Hide the "move" button from the packages list.
- Hide the collapsing arrow from the packages list and carriers list.

<img width=400 src="https://user-images.githubusercontent.com/1657201/109320782-b38cd480-7850-11eb-8602-aff5f5e4ab0b.png"/> <img width=400 src="https://user-images.githubusercontent.com/1657201/109320840-c7383b00-7850-11eb-9750-6642c1a97568.png"/>


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
