### PR TITLE
Fix Slow Tags Creation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 6.2
 -----
+* [*] Fix adding tags taking a long time. 
 
 
 6.1

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,13 +2,12 @@
 
 6.2
 -----
-* [*] Fix adding tags taking a long time. 
 
 
 6.1
 -----
 * [**] When editing a product, it's no longer necessary to tap "Done" in every screen to save changes to the local product. Instead, all changes are automatically saved locally, and tapping "Update" in the main product detail screen will send those changes to the server. [https://github.com/woocommerce/woocommerce-android/pull/3598]
- 
+* [*] Fix adding tags taking a long time.
 * [*] Fixed a bug where the app doesn't show the updated product settings. [https://github.com/woocommerce/woocommerce-android/pull/3599]
 * [*] Fixed a bug the field of product price couldn't be edited if the device's language uses a different numerals system (e.g. Arabic) [https://github.com/woocommerce/woocommerce-android/pull/3589]
 * [*] Fixed a bug where the app doesn't receive push notification for support request reply [https://github.com/woocommerce/woocommerce-android/pull/3607]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsRepository.kt
@@ -35,7 +35,7 @@ class ProductTagsRepository @Inject constructor(
     }
 
     private var loadContinuation: CancellableContinuation<Boolean>? = null
-    private var addProductTagsContinuation: Continuation<Boolean>? = null
+    private var addProductTagsContinuation: CancellableContinuation<Boolean>? = null
     private var offset = 0
 
     var canLoadMoreProductTags = true
@@ -88,7 +88,7 @@ class ProductTagsRepository @Inject constructor(
      */
     suspend fun addProductTags(tagNames: List<String>): List<ProductTag> {
         try {
-            suspendCoroutineWithTimeout<Boolean>(AppConstants.REQUEST_TIMEOUT) {
+            suspendCancellableCoroutineWithTimeout<Boolean>(AppConstants.REQUEST_TIMEOUT) {
                 addProductTagsContinuation = it
 
                 val payload = WCProductStore.AddProductTagsPayload(selectedSite.get(), tagNames)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsRepository.kt
@@ -9,7 +9,6 @@ import com.woocommerce.android.model.toProductTag
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.suspendCancellableCoroutineWithTimeout
-import com.woocommerce.android.util.suspendCoroutineWithTimeout
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CancellationException
 import org.greenrobot.eventbus.Subscribe

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsRepository.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.CancellationException
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.WCProductAction.ADDED_PRODUCT_TAGS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_TAGS
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.store.WCProductStore
@@ -129,6 +130,11 @@ class ProductTagsRepository @Inject constructor(
                     loadContinuation?.resume(true)
                 }
                 loadContinuation = null
+            }
+            ADDED_PRODUCT_TAGS -> {
+                // No need to handle errors because errors are currently handled by `OrderListViewModel`.
+                addProductTagsContinuation?.resume(false)
+                addProductTagsContinuation = null
             }
             else -> { }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsRepository.kt
@@ -88,6 +88,7 @@ class ProductTagsRepository @Inject constructor(
      */
     suspend fun addProductTags(tagNames: List<String>): List<ProductTag> {
         try {
+            addProductTagsContinuation?.cancel()
             suspendCancellableCoroutineWithTimeout<Boolean>(AppConstants.REQUEST_TIMEOUT) {
                 addProductTagsContinuation = it
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsRepository.kt
@@ -21,7 +21,6 @@ import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductTagsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductTagChanged
 import javax.inject.Inject
-import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 
 @OpenClassOnDebug


### PR DESCRIPTION
Fixes #3631 

## Findings 

I looked at Flipper and the API call for adding tags is fast and takes less than a second. It looks like the tag-adding logic (`ProductTagsRepository`) used to rely on a 10-second timeout to say that it’s “finished”. But we changed that from 10 seconds to 40 seconds in https://github.com/woocommerce/woocommerce-android/pull/3413. 

This made the suspended coroutine for adding tags take even longer: 

https://github.com/woocommerce/woocommerce-android/blob/d96a04a7a0b4cf8a04c54a62a8bebe4f986118ef/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsRepository.kt#L91-L96

## Changes

This fixes the problem by **resuming** the suspended coroutine above exactly when the API call finishes. 

https://github.com/woocommerce/woocommerce-android/blob/80eefcb0bac083694cb6dedaad2f1e9d751c2209/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsRepository.kt#L134-L138

## Testing

1. Navigate to a product → Tags. 
2. Add a tag. 
3. Press back. You should see the loader and it should not take a long time. 
4. Press Update. Confirm that the tag was added in wp-admin. 
5. Turn airplane mode on. 
6. Navigate to a product → Tags. 
7. Add a tag. 
8. Press back. You should still end up in the product details. 
9. Confirm that you see a toast saying “Error occurred when adding tags”. 

## Author Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

