### PR TITLE
issue/3643-consistent-back-button-6.1

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -408,17 +408,11 @@ class MainActivity : AppUpgradeActivity(),
             binding.appBarLayout.elevation = resources.getDimensionPixelSize(R.dimen.appbar_elevation).toFloat()
             showCrossIcon = when (destination.id) {
                 R.id.productFilterListFragment,
-                R.id.productShippingClassFragment,
                 R.id.issueRefundFragment,
                 R.id.addOrderShipmentTrackingFragment,
                 R.id.addOrderNoteFragment,
-                R.id.productSettingsFragment,
-                R.id.addProductCategoryFragment,
-                R.id.parentCategoryListFragment,
-                R.id.productSelectionListFragment,
                 R.id.printShippingLabelInfoFragment,
-                R.id.shippingLabelFormatOptionsFragment,
-                R.id.productDownloadsSettingsFragment -> {
+                R.id.shippingLabelFormatOptionsFragment -> {
                     true
                 }
                 R.id.productDetailFragment -> {


### PR DESCRIPTION
Closes #3643 - This PR replaces the "X" button with a standard back button in the following screens:

- productShippingClassFragment
- productSettingsFragment
- addProductCategoryFragment
- parentCategoryListFragment
- productSelectionListFragment
- productDownloadsSettingsFragment

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
