### PR TITLE
Issue/3630 linked products checkmark

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
@@ -27,6 +27,8 @@ class ProductItemViewHolder(val viewBinding: ProductListItemBinding) :
     private val bullet = "\u2022"
     private val statusColor = ContextCompat.getColor(context, R.color.product_status_fg_other)
     private val statusPendingColor = ContextCompat.getColor(context, R.color.product_status_fg_pending)
+    private val selectedBackgroundColor = ContextCompat.getColor(context, R.color.color_primary)
+    private val unSelectedBackgroundColor = ContextCompat.getColor(context, R.color.white)
 
     fun bind(
         product: Product,
@@ -59,16 +61,16 @@ class ProductItemViewHolder(val viewBinding: ProductListItemBinding) :
             itemView.isActivated -> {
                 size = imageSize / 2
                 viewBinding.productImage.setImageResource(R.drawable.ic_menu_action_mode_check)
-                viewBinding.productImageFrame.setBackgroundColor(ContextCompat.getColor(context, R.color.color_primary))
+                viewBinding.productImageFrame.setBackgroundColor(selectedBackgroundColor)
             }
             firstImage.isNullOrEmpty() -> {
                 size = imageSize / 2
-                viewBinding.productImageFrame.setBackgroundColor(ContextCompat.getColor(context, R.color.white))
+                viewBinding.productImageFrame.setBackgroundColor(unSelectedBackgroundColor)
                 viewBinding.productImage.setImageResource(R.drawable.ic_product)
             }
             else -> {
                 size = imageSize
-                viewBinding.productImageFrame.setBackgroundColor(ContextCompat.getColor(context, R.color.white))
+                viewBinding.productImageFrame.setBackgroundColor(unSelectedBackgroundColor)
                 val imageUrl = PhotonUtils.getPhotonImageUrl(firstImage, imageSize, imageSize)
                 GlideApp.with(context)
                     .load(imageUrl)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
@@ -68,6 +68,7 @@ class ProductItemViewHolder(val viewBinding: ProductListItemBinding) :
             }
             else -> {
                 size = imageSize
+                viewBinding.productImageFrame.setBackgroundColor(ContextCompat.getColor(context, R.color.white))
                 val imageUrl = PhotonUtils.getPhotonImageUrl(firstImage, imageSize, imageSize)
                 GlideApp.with(context)
                     .load(imageUrl)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
@@ -58,7 +58,7 @@ class ProductItemViewHolder(val viewBinding: ProductListItemBinding) :
         when {
             itemView.isActivated -> {
                 size = imageSize / 2
-                viewBinding.productImage.setImageResource(R.drawable.ic_menu_check)
+                viewBinding.productImage.setImageResource(R.drawable.ic_menu_action_mode_check)
                 viewBinding.productImageFrame.setBackgroundColor(ContextCompat.getColor(context, R.color.color_primary))
             }
             firstImage.isNullOrEmpty() -> {


### PR DESCRIPTION
Fixes #3630 Changes the selection checkmark when adding linked products to one that's more visible over the purple selection background, and resets the picture frame color when not selected.

To test:

- Go to product detail for a linked product
- Tap "Linked products"
- Tap "Edit products"
- Start adding products and notice the checkmark is visible over the selection background.

![Screenshot_20210226_155211](https://user-images.githubusercontent.com/3903757/109354185-69edbb00-784b-11eb-9103-a16deebd6d46.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
