### PR TITLE
Update Order class with ShippingLine item.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -1,3 +1,4 @@
+//Order.kt
 package com.woocommerce.android.model
 
 import android.os.Parcelable
@@ -6,6 +7,7 @@ import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.roundError
 import com.woocommerce.android.model.Order.Item
 import com.woocommerce.android.model.Order.OrderStatus
+import com.woocommerce.android.model.Order.ShippingLine
 import com.woocommerce.android.ui.products.ProductHelper
 import com.woocommerce.android.util.AddressUtils
 import com.woocommerce.android.util.StringUtils
@@ -48,7 +50,8 @@ data class Order(
     val billingAddress: Address,
     val shippingAddress: Address,
     val shippingMethodList: List<String?>,
-    val items: List<Item>
+    val items: List<Item>,
+    val shippingLines: List<ShippingLine>
 ) : Parcelable {
     @IgnoredOnParcel
     val isOrderPaid = paymentMethodTitle.isEmpty() && datePaid == null
@@ -87,6 +90,15 @@ data class Order(
         val uniqueId: Long = ProductHelper.productOrVariationId(productId, variationId)
     }
 
+    @Parcelize
+    data class ShippingLine(
+        val itemId: Long,
+        val methodId: String,
+        val methodTitle: String,
+        val totalTax: BigDecimal,
+        val total: BigDecimal
+    ) : Parcelable
+
     fun getBillingName(defaultValue: String): String {
         return when {
             billingAddress.firstName.isEmpty() && billingAddress.lastName.isEmpty() -> defaultValue
@@ -112,82 +124,111 @@ data class Order(
             shippingName, shippingAddress, shippingCountry
         )
     }
+
+    companion object {
+        // Conversion is needed for refunding shipping line items.
+        // Properties that are irrelevant for the refund process are set as either (-1), or empty string.
+        fun convertShippingLineToItem(shippingLine: ShippingLine): Item {
+            return Item(
+                shippingLine.itemId,
+                -1, /* irrelevant */
+                shippingLine.methodTitle,
+                (-1).toBigDecimal(), /* irrelevant */
+                "", /* irrelevant */
+                1,
+                (-1).toBigDecimal(), /* irrelevant */
+                shippingLine.totalTax,
+                shippingLine.total,
+                -1, /* irrelevant */
+                "" /* irrelevant */
+            )
+        }
+    }
 }
 
 fun WCOrderModel.toAppModel(): Order {
     return Order(
-            identifier = OrderIdentifier(this),
-            remoteId = this.remoteOrderId,
-            number = this.number,
-            localSiteId = this.localSiteId,
-            dateCreated = DateTimeUtils.dateUTCFromIso8601(this.dateCreated) ?: Date(),
-            dateModified = DateTimeUtils.dateUTCFromIso8601(this.dateModified) ?: Date(),
-            datePaid = DateTimeUtils.dateUTCFromIso8601(this.datePaid),
-            status = CoreOrderStatus.fromValue(this.status) ?: CoreOrderStatus.PENDING,
-            total = this.total.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
-            productsTotal = this.getOrderSubtotal().toBigDecimal().roundError(),
-            totalTax = this.totalTax.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
-            shippingTotal = this.shippingTotal.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
-            discountTotal = this.discountTotal.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
-            refundTotal = -this.refundTotal.toBigDecimal().roundError(), // WCOrderModel.refundTotal is NEGATIVE
-            feesTotal = this.getFeeLineList()
-                    .sumByBigDecimal { it.total?.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO },
-            currency = this.currency,
-            customerNote = this.customerNote,
-            discountCodes = this.discountCodes,
-            paymentMethod = this.paymentMethod,
-            paymentMethodTitle = this.paymentMethodTitle,
-            isCashPayment = CASH_PAYMENTS.contains(this.paymentMethod),
-            pricesIncludeTax = this.pricesIncludeTax,
-            multiShippingLinesAvailable = this.isMultiShippingLinesAvailable(),
-            billingAddress = this.getBillingAddress().let {
-                Address(
-                        it.company,
-                        it.firstName,
-                        it.lastName,
-                        this.billingPhone,
-                        it.country,
-                        it.state,
-                        it.address1,
-                        it.address2,
-                        it.city,
-                        it.postcode,
-                        this.billingEmail
+        identifier = OrderIdentifier(this),
+        remoteId = this.remoteOrderId,
+        number = this.number,
+        localSiteId = this.localSiteId,
+        dateCreated = DateTimeUtils.dateUTCFromIso8601(this.dateCreated) ?: Date(),
+        dateModified = DateTimeUtils.dateUTCFromIso8601(this.dateModified) ?: Date(),
+        datePaid = DateTimeUtils.dateUTCFromIso8601(this.datePaid),
+        status = CoreOrderStatus.fromValue(this.status) ?: CoreOrderStatus.PENDING,
+        total = this.total.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
+        productsTotal = this.getOrderSubtotal().toBigDecimal().roundError(),
+        totalTax = this.totalTax.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
+        shippingTotal = this.shippingTotal.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
+        discountTotal = this.discountTotal.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
+        refundTotal = -this.refundTotal.toBigDecimal().roundError(), // WCOrderModel.refundTotal is NEGATIVE
+        feesTotal = this.getFeeLineList()
+            .sumByBigDecimal { it.total?.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO },
+        currency = this.currency,
+        customerNote = this.customerNote,
+        discountCodes = this.discountCodes,
+        paymentMethod = this.paymentMethod,
+        paymentMethodTitle = this.paymentMethodTitle,
+        isCashPayment = CASH_PAYMENTS.contains(this.paymentMethod),
+        pricesIncludeTax = this.pricesIncludeTax,
+        multiShippingLinesAvailable = this.isMultiShippingLinesAvailable(),
+        billingAddress = this.getBillingAddress().let {
+            Address(
+                it.company,
+                it.firstName,
+                it.lastName,
+                this.billingPhone,
+                it.country,
+                it.state,
+                it.address1,
+                it.address2,
+                it.city,
+                it.postcode,
+                this.billingEmail
+            )
+        },
+        shippingAddress = this.getShippingAddress().let {
+            Address(
+                it.company,
+                it.firstName,
+                it.lastName,
+                "",
+                it.country,
+                it.state,
+                it.address1,
+                it.address2,
+                it.city,
+                it.postcode,
+                ""
+            )
+        },
+        shippingMethodList = getShippingLineList().map { it.methodTitle },
+        items = getLineItemList()
+            .filter { it.productId != null && it.id != null }
+            .map {
+                Item(
+                    it.id!!,
+                    it.productId!!,
+                    it.parentName?.fastStripHtml() ?: it.name?.fastStripHtml() ?: StringUtils.EMPTY,
+                    it.price?.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
+                    it.sku ?: "",
+                    it.quantity?.toInt() ?: 0,
+                    it.subtotal?.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
+                    it.totalTax?.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
+                    it.total?.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
+                    it.variationId ?: 0,
+                    it.getAttributesAsString()
                 )
             },
-            shippingAddress = this.getShippingAddress().let {
-                Address(
-                        it.company,
-                        it.firstName,
-                        it.lastName,
-                        "",
-                        it.country,
-                        it.state,
-                        it.address1,
-                        it.address2,
-                        it.city,
-                        it.postcode,
-                        ""
-                )
-            },
-            shippingMethodList = getShippingLineList().map { it.methodTitle },
-            items = getLineItemList()
-                    .filter { it.productId != null && it.id != null }
-                    .map {
-                        Item(
-                                it.id!!,
-                                it.productId!!,
-                                it.parentName?.fastStripHtml() ?: it.name?.fastStripHtml() ?: StringUtils.EMPTY,
-                                it.price?.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
-                                it.sku ?: "",
-                                it.quantity?.toInt() ?: 0,
-                                it.subtotal?.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
-                                it.totalTax?.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
-                                it.total?.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
-                                it.variationId ?: 0,
-                                it.getAttributesAsString()
-                        )
-                    }
+        shippingLines = getShippingLineList().map {
+            ShippingLine(
+                it.id!!,
+                it.methodId ?: StringUtils.EMPTY,
+                it.methodTitle ?: StringUtils.EMPTY,
+                it.totalTax?.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
+                it.total?.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO
+            )
+        }
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -123,26 +123,24 @@ data class Order(
             shippingName, shippingAddress, shippingCountry
         )
     }
+}
 
-    companion object {
-        // Conversion is needed for refunding shipping line items.
-        // Properties that are irrelevant for the refund process are set as either (-1), or empty string.
-        fun convertShippingLineToItem(shippingLine: ShippingLine): Item {
-            return Item(
-                shippingLine.itemId,
-                -1, /* irrelevant */
-                shippingLine.methodTitle,
-                (-1).toBigDecimal(), /* irrelevant */
-                "", /* irrelevant */
-                1,
-                (-1).toBigDecimal(), /* irrelevant */
-                shippingLine.totalTax,
-                shippingLine.total,
-                -1, /* irrelevant */
-                "" /* irrelevant */
-            )
-        }
-    }
+// Conversion is needed for refunding shipping line items.
+// Properties that are irrelevant for the refund process are set as either (-1), or empty string.
+fun ShippingLine.toItem(): Item {
+    return Item(
+        itemId = itemId,
+        productId = -1, /* irrelevant */
+        name = methodTitle,
+        price = (-1).toBigDecimal(), /* irrelevant */
+        sku = "", /* irrelevant */
+        quantity = 1,
+        subtotal = (-1).toBigDecimal(), /* irrelevant */
+        totalTax = totalTax,
+        total = total,
+        variationId = -1, /* irrelevant */
+        attributesList = "" /* irrelevant */
+    )
 }
 
 fun WCOrderModel.toAppModel(): Order {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -1,4 +1,3 @@
-//Order.kt
 package com.woocommerce.android.model
 
 import android.os.Parcelable

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'eafc9beee36308b8ddf9a8a20d5a7d1857b9510d'
+    fluxCVersion = 'b1a9a19795574a53db2a587fa0047e628412416f'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
This is the second step for this feature as mentioned in #3319, "Update Order.kt to include information related to shipping line items."

To test:
This PR has no user-facing changes yet, but try opening Orders then select an Order. The order details view should display everything as usual with no issue.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
