### PR TITLE
Add Dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    open-pull-requests-limit: 2
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "woocommerce/android-developers"
+    ignore:
+      - dependency-name: "com.android.tools.build:gradle"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,6 @@ updates:
       - "woocommerce/android-developers"
       - "woocommerce/platform-9"
     ignore:
+      # The Android Gradle Plugin is a dependency we'd like to have in sync with other
+      # in-house libraries due to compatibility with composite build.
       - dependency-name: "com.android.tools.build:gradle"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "gradle"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 5
     directory: "/"
     schedule:
       interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,6 @@ updates:
       interval: "daily"
     reviewers:
       - "woocommerce/android-developers"
+      - "woocommerce/platform-9"
     ignore:
       - dependency-name: "com.android.tools.build:gradle"


### PR DESCRIPTION
### Description

This PR adds [`Dependabot`](https://docs.github.com/en/github/administering-a-repository/about-dependabot-version-updates) tool configuration. It'll start working after merge.

Resolves #3652 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
