### PR TITLE
Issue/3207 add attribute part4

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
@@ -261,6 +261,11 @@ class ProductDetailRepository @Inject constructor(
         return wooResult?.model?.map { it.toAppModel() } ?: emptyList()
     }
 
+
+    suspend fun addGlobalAttributeTerm(attributeId: Long, termName: String) {
+        globalAttributeStore.createOptionValueForAttribute(selectedSite.get(), attributeId, termName)
+    }
+
     /**
      * Returns a list of global attributes from the local db
      */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1020,6 +1020,15 @@ class ProductDetailViewModel @AssistedInject constructor(
     }
 
     /**
+     * Adds a new term to a global attribute
+     */
+    fun addGlobalAttributeTerm(attributeId: Long, termName: String) {
+        launch {
+            productRepository.addGlobalAttributeTerm(attributeId, termName)
+        }
+    }
+
+    /**
      * Clears the global attribute terms
      */
     fun resetGlobalAttributeTerms() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1005,17 +1005,9 @@ class ProductDetailViewModel @AssistedInject constructor(
     /**
      * Fetches terms for a global product attribute
      */
-    fun fetchGlobalAttributeTerms(remoteAttributeId: Long, excludeAssignedTerms: Boolean = false) {
+    fun fetchGlobalAttributeTerms(remoteAttributeId: Long) {
         launch {
-            val terms = productRepository.fetchGlobalAttributeTerms(remoteAttributeId)
-            if (excludeAssignedTerms) {
-                val assignedTerms = getProductDraftAttributeTerms(remoteAttributeId, "")
-                _attributeTermsList.value = terms.filterNot {
-                    assignedTerms.contains(it.name)
-                }
-            } else {
-                _attributeTermsList.value = terms
-            }
+            _attributeTermsList.value = productRepository.fetchGlobalAttributeTerms(remoteAttributeId)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
@@ -49,6 +49,9 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
         )
     }
 
+    private val isGlobalAttribute
+        get() = navArgs.attributeId != 0L
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
@@ -117,7 +117,7 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
         binding.termEditText.setOnEditorActionListener { _, actionId, event ->
             val termName = binding.termEditText.text?.toString() ?: ""
             if (termName.isNotBlank()) {
-                addLocalTerm(termName)
+                addTerm(termName, saveToBackend = isGlobalAttribute)
                 binding.termEditText.text?.clear()
             }
             true
@@ -199,17 +199,30 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
     }
 
     /**
-     * User entered a new term
+     * User entered a new term or tapped a global term, saveToBackend will only be true
+     * if the user entered a new term and this is a global attribute
      */
-    private fun addLocalTerm(termName: String) {
+    private fun addTerm(termName: String, saveToBackend: Boolean) {
+        // add the term to the list of assigned terms
         getAssignedTermsAdapter().addTerm(termName)
+
+        // remove it from the list of global terms
+        if (isGlobalAttribute) {
+            getGlobalTermsAdapter().removeTerm(termName)
+        }
+
+        if (saveToBackend) {
+            // TODO progress spinner or progress dialog?
+            viewModel.addGlobalAttributeTerm(navArgs.attributeId, termName)
+        }
+
         binding.assignedTermList.isVisible = !getAssignedTermsAdapter().isEmpty()
     }
 
     /**
-     * Called by the gobal adapter when a term is clicked
+     * Called by the global adapter when a term is clicked
      */
     override fun onTermClick(termName: String) {
-        // TODO
+        addTerm(termName, saveToBackend = false)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
@@ -49,29 +49,31 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
         )
     }
 
-    private val assignedTermListener by lazy() {
+    private val assignedTermListener by lazy {
         object : OnTermListener {
             override fun onTermClick(termName: String) {}
 
+            /**
+             * If the user removed a global term from the assigned term list, we need to return it to the
+             * global term list
+             */
             override fun onTermDelete(termName: String) {
-                // if this was a global term, we need to restore it to the global term list
-                viewModel.getProductDraftAttributes().forEach { attribute ->
-                    if (attribute.isGlobalAttribute && attribute.id == navArgs.attributeId) {
-                        attribute.terms.forEach { term ->
-                            if (termName == term) {
-                                getGlobalTermsAdapter().addTerm(termName)
-                                return@forEach
-                            }
-                        }
-                        return@forEach
+                viewModel.getProductDraftAttributes().find {
+                    it.isGlobalAttribute && it.id == navArgs.attributeId
+                }?.let { attribute ->
+                    attribute.terms.find {
+                        it == termName
                     }
+                }?.let { term ->
+                    getGlobalTermsAdapter().addTerm(termName)
                 }
+
                 checkViews()
             }
         }
     }
 
-    private val globalTermListener by lazy() {
+    private val globalTermListener by lazy {
         object : OnTermListener {
             override fun onTermClick(termName: String) {
                 addTerm(termName, saveToBackend = false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
@@ -52,13 +52,6 @@ class AttributeTermsListAdapter(
 
     override fun onBindViewHolder(holder: TermViewHolder, position: Int) {
         holder.bind(termNames[position])
-
-        onTermListener.let { listener ->
-            holder.itemView.setOnClickListener {
-                val item = termNames[position]
-                listener.onTermClick(item)
-            }
-        }
     }
 
     fun setOnTermListener(listener: OnTermListener) {
@@ -121,18 +114,20 @@ class AttributeTermsListAdapter(
             areItemsTheSame(oldItemPosition, newItemPosition)
     }
 
+    @SuppressLint("ClickableViewAccessibility")
     inner class TermViewHolder(val viewBinding: AttributeTermListItemBinding) :
         RecyclerView.ViewHolder(viewBinding.root) {
-        @SuppressLint("ClickableViewAccessibility")
-        fun bind(termName: String) {
-            viewBinding.termName.text = termName
-            viewBinding.termDragHandle.isVisible = showIcons
-            viewBinding.termDelete.isVisible = showIcons
+        init {
+            viewBinding.root.setOnClickListener {
+                val item = termNames[adapterPosition]
+                onTermListener.onTermClick(item)
+            }
 
             if (showIcons) {
                 viewBinding.termDelete.setOnClickListener {
-                    removeTerm(termName)
-                    onTermListener.onTermDelete(termName)
+                    val item = termNames[adapterPosition]
+                    removeTerm(item)
+                    onTermListener.onTermDelete(item)
                 }
 
                 viewBinding.termDragHandle.setOnTouchListener { _, event ->
@@ -142,6 +137,12 @@ class AttributeTermsListAdapter(
                     false
                 }
             }
+        }
+
+        fun bind(termName: String) {
+            viewBinding.termName.text = termName
+            viewBinding.termDragHandle.isVisible = showIcons
+            viewBinding.termDelete.isVisible = showIcons
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
@@ -68,7 +68,7 @@ class AttributeTermsListAdapter(
         }
     }
 
-    private fun containsTerm(termName: String): Boolean {
+    fun containsTerm(termName: String): Boolean {
         termNames.forEach { term ->
             if (term.equals(termName, ignoreCase = true)) {
                 return true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.products.variations.attributes
 
 import android.annotation.SuppressLint
 import android.view.LayoutInflater
-import android.view.MotionEvent
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
@@ -130,11 +129,8 @@ class AttributeTermsListAdapter(
                     onTermListener.onTermDelete(item)
                 }
 
-                viewBinding.termDragHandle.setOnTouchListener { _, event ->
-                    if (event.action == MotionEvent.ACTION_DOWN) {
-                        dragHelper?.startDrag(this)
-                    }
-                    false
+                viewBinding.termDragHandle.setOnClickListener {
+                    dragHelper?.startDrag(this)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
@@ -92,7 +92,7 @@ class AttributeTermsListAdapter(
         notifyItemChanged(to)
     }
 
-    private fun removeTerm(term: String) {
+    fun removeTerm(term: String) {
         val index = termNames.indexOf(term)
         if (index >= 0) {
             termNames.remove(term)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
@@ -17,12 +17,14 @@ import com.woocommerce.android.ui.products.variations.attributes.AttributeTermsL
  */
 class AttributeTermsListAdapter(
     private val showIcons: Boolean,
-    private val dragHelper: ItemTouchHelper? = null,
-    private val onTermClick: OnTermClickListener? = null
+    private val dragHelper: ItemTouchHelper? = null
 ) : RecyclerView.Adapter<TermViewHolder>() {
-    interface OnTermClickListener {
+    interface OnTermListener {
         fun onTermClick(termName: String)
+        fun onTermDelete(termName: String)
     }
+
+    private lateinit var onTermListener: OnTermListener
 
     var termNames: ArrayList<String> = ArrayList()
         set(value) {
@@ -51,12 +53,16 @@ class AttributeTermsListAdapter(
     override fun onBindViewHolder(holder: TermViewHolder, position: Int) {
         holder.bind(termNames[position])
 
-        onTermClick?.let { listener ->
+        onTermListener.let { listener ->
             holder.itemView.setOnClickListener {
                 val item = termNames[position]
                 listener.onTermClick(item)
             }
         }
+    }
+
+    fun setOnTermListener(listener: OnTermListener) {
+        onTermListener = listener
     }
 
     fun isEmpty() = termNames.isEmpty()
@@ -118,14 +124,15 @@ class AttributeTermsListAdapter(
     inner class TermViewHolder(val viewBinding: AttributeTermListItemBinding) :
         RecyclerView.ViewHolder(viewBinding.root) {
         @SuppressLint("ClickableViewAccessibility")
-        fun bind(term: String) {
-            viewBinding.termName.text = term
+        fun bind(termName: String) {
+            viewBinding.termName.text = termName
             viewBinding.termDragHandle.isVisible = showIcons
             viewBinding.termDelete.isVisible = showIcons
 
             if (showIcons) {
                 viewBinding.termDelete.setOnClickListener {
-                    removeTerm(term)
+                    removeTerm(termName)
+                    onTermListener.onTermDelete(termName)
                 }
 
                 viewBinding.termDragHandle.setOnTouchListener { _, event ->


### PR DESCRIPTION
This PR continues the work on attributes and terms by adding the ability to add terms to a global attribute, and have those terms sent to the backend. Also, if the user removes a global attribute term from the assigned term list, it now gets returned to the list of global terms.

Note that right now this saves new global attribute terms immediately, but I left a `TODO` to batch save them when the user leaves the screen. That will be addressed in a later PR.

To test:

- View options for a global attribute
- Enter a new option name
- Return to the previous screen and verify the new option appears
- Verify the new option appears on the web
- Verify saving the product saves the new term

To test:

- Return to the global attribute options
- Remove a term with the "X" button
- Verify it re-appears in the list of global terms

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
