### PR TITLE
Shipping refund: Add shipping lines selection in order refund selection screen.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/RefundsExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/RefundsExt.kt
@@ -1,10 +1,10 @@
 package com.woocommerce.android.extensions
 
-import com.woocommerce.android.ui.refunds.RefundProductListAdapter.RefundListItem
+import com.woocommerce.android.ui.refunds.RefundProductListAdapter.ProductRefundListItem
 import java.math.BigDecimal
 import java.math.RoundingMode.HALF_UP
 
-fun List<RefundListItem>.calculateTotals(): Pair<BigDecimal, BigDecimal> {
+fun List<ProductRefundListItem>.calculateTotals(): Pair<BigDecimal, BigDecimal> {
     var taxes = BigDecimal.ZERO
     var subtotal = BigDecimal.ZERO
     this.forEach { item ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -123,10 +123,6 @@ data class Order(
             shippingName, shippingAddress, shippingCountry
         )
     }
-
-    fun getTotalShippingTaxes(): BigDecimal {
-        return shippingLines.sumByBigDecimal { it.totalTax }
-    }
 }
 
 // Conversion is needed for refunding shipping line items.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -125,24 +125,6 @@ data class Order(
     }
 }
 
-// Conversion is needed for refunding shipping line items.
-// Properties that are irrelevant for the refund process are set as either (-1), or empty string.
-fun ShippingLine.toItem(): Item {
-    return Item(
-        itemId = itemId,
-        productId = -1, /* irrelevant */
-        name = methodTitle,
-        price = (-1).toBigDecimal(), /* irrelevant */
-        sku = "", /* irrelevant */
-        quantity = 1,
-        subtotal = (-1).toBigDecimal(), /* irrelevant */
-        totalTax = totalTax,
-        total = total,
-        variationId = -1, /* irrelevant */
-        attributesList = "" /* irrelevant */
-    )
-}
-
 fun WCOrderModel.toAppModel(): Order {
     return Order(
         identifier = OrderIdentifier(this),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -123,6 +123,13 @@ data class Order(
             shippingName, shippingAddress, shippingCountry
         )
     }
+
+    fun getTotalShippingTaxes(): BigDecimal {
+        if (shippingLines.isEmpty())
+            return 0.toBigDecimal()
+        else
+            return shippingLines.map { it.totalTax }.reduce { acc, tax -> return acc.add(tax) }
+    }
 }
 
 // Conversion is needed for refunding shipping line items.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -125,10 +125,7 @@ data class Order(
     }
 
     fun getTotalShippingTaxes(): BigDecimal {
-        if (shippingLines.isEmpty())
-            return 0.toBigDecimal()
-        else
-            return shippingLines.map { it.totalTax }.reduce { acc, tax -> return acc.add(tax) }
+        return shippingLines.sumByBigDecimal { it.totalTax }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -621,7 +621,6 @@ class IssueRefundViewModel @AssistedInject constructor(
             .sumByBigDecimal { it.total }
     }
 
-
     private fun calculatePartialShippingTaxes(selectedShippingLinesId: List<Long>): BigDecimal {
         return order.shippingLines
             .filter { it.itemId in selectedShippingLinesId }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -467,10 +467,7 @@ class IssueRefundViewModel @AssistedInject constructor(
             else
                 resourceProvider.getString(R.string.order_refunds_items_select_all)
 
-        var grandTotal = productsRefund
-        if (refundByItemsState.isShippingMainSwitchChecked == true) {
-            grandTotal = grandTotal.add(refundByItemsState.shippingRefund)
-        }
+        val grandTotal = productsRefund + refundByItemsState.shippingRefund
 
         refundByItemsState = refundByItemsState.copy(
                 productsRefund = productsRefund,
@@ -588,15 +585,13 @@ class IssueRefundViewModel @AssistedInject constructor(
             refundByItemsState = refundByItemsState.copy(
                 shippingRefund = shippingRefund,
                 formattedShippingRefundTotal = formatCurrency(shippingRefund),
-                grandTotalRefund = productsRefund.add(shippingRefund),
-                isShippingMainSwitchChecked = true
+                grandTotalRefund = productsRefund.add(shippingRefund)
             )
         } else {
             refundByItemsState = refundByItemsState.copy(
                 shippingRefund = 0.toBigDecimal(),
                 formattedShippingRefundTotal = formatCurrency(0.toBigDecimal()),
-                grandTotalRefund = productsRefund,
-                isShippingMainSwitchChecked = false
+                grandTotalRefund = productsRefund
             )
         }
     }
@@ -678,7 +673,7 @@ class IssueRefundViewModel @AssistedInject constructor(
         val shippingRefund: BigDecimal = BigDecimal.ZERO,
         val formattedShippingRefundTotal: String? = null,
         val isShippingRefundAvailable: Boolean? = null,
-        val isShippingMainSwitchChecked: Boolean? = null,
+        val isShippingMainSwitchChecked: Boolean = shippingRefund > BigDecimal.ZERO,
         val selectedShippingLines: List<Long>? = null,
         val isFeesVisible: Boolean? = null,
         val selectedItemsHeader: String? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -621,23 +621,16 @@ class IssueRefundViewModel @AssistedInject constructor(
     }
 
     private fun calculatePartialShippingSubtotal(selectedShippingLinesId: List<Long>): BigDecimal {
-        if (selectedShippingLinesId.isEmpty())
-            return 0.toBigDecimal()
-        else
-            return order.shippingLines
-                .filter { selectedShippingLinesId.contains(it.itemId) }
-                .map { it.total }
-                .reduce { acc, subtotal -> return acc + subtotal }
+        return order.shippingLines
+            .filter { it.itemId in selectedShippingLinesId }
+            .sumByBigDecimal { it.total }
     }
 
+
     private fun calculatePartialShippingTaxes(selectedShippingLinesId: List<Long>): BigDecimal {
-        if (selectedShippingLinesId.isEmpty())
-            return 0.toBigDecimal()
-        else
-            return order.shippingLines
-                .filter { selectedShippingLinesId.contains(it.itemId) }
-                .map { it.totalTax }
-                .reduce { acc, subtotal -> return acc + subtotal }
+        return order.shippingLines
+            .filter { it.itemId in selectedShippingLinesId }
+            .sumByBigDecimal { it.totalTax }
     }
 
     private fun calculatePartialShippingTotal(selectedShippingLinesId: List<Long>): BigDecimal {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -573,12 +573,14 @@ class IssueRefundViewModel @AssistedInject constructor(
 
             refundByItemsState = refundByItemsState.copy(
                 shippingRefund = shippingRefund,
-                formattedShippingRefundTotal = formatCurrency(shippingRefund)
+                formattedShippingRefundTotal = formatCurrency(shippingRefund),
+                isShippingMainSwitchChecked = true
             )
         } else {
             refundByItemsState = refundByItemsState.copy(
                 shippingRefund = 0.toBigDecimal(),
-                formattedShippingRefundTotal = formatCurrency(0.toBigDecimal())
+                formattedShippingRefundTotal = formatCurrency(0.toBigDecimal()),
+                isShippingMainSwitchChecked = false
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -63,6 +63,7 @@ import org.wordpress.android.fluxc.store.WCGatewayStore
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCRefundStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
+import org.wordpress.android.fluxc.utils.sumBy as sumByBigDecimal
 import java.math.BigDecimal
 import kotlin.math.min
 
@@ -185,7 +186,7 @@ class IssueRefundViewModel @AssistedInject constructor(
                     subtotal = formatCurrency(BigDecimal.ZERO),
                     taxes = formatCurrency(BigDecimal.ZERO),
                     shippingSubtotal = formatCurrency(order.shippingTotal),
-                    shippingTaxes = formatCurrency(order.getTotalShippingTaxes()),
+                    shippingTaxes = formatCurrency(order.shippingLines.sumByBigDecimal { it.totalTax }),
                     feesTotal = formatCurrency(order.feesTotal),
                     formattedProductsRefund = formatCurrency(BigDecimal.ZERO),
                     isShippingRefundAvailable = order.shippingTotal > BigDecimal.ZERO,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -207,7 +207,7 @@ class IssueRefundViewModel @AssistedInject constructor(
         val shippingLines = order.shippingLines.map {
             RefundListItem(it.toItem(), 1, 1)
         }
-        updateRefundShippingLines(shippingLines)
+        _refundShippingLines.value = shippingLines
 
         if (productsRefundLiveData.hasInitialValue) {
             val decimals = wooStore.getSiteSettings(selectedSite.get())?.currencyDecimalNumber
@@ -538,10 +538,6 @@ class IssueRefundViewModel @AssistedInject constructor(
                     selectedItems
                 )
         )
-    }
-
-    private fun updateRefundShippingLines(items: List<RefundListItem>) {
-        _refundShippingLines.value = items.filter { it.maxQuantity > 0 }
     }
 
     private fun validateInput(): InputValidationState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundDetailViewModel.kt
@@ -12,7 +12,7 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Refund
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.refunds.RefundProductListAdapter.RefundListItem
+import com.woocommerce.android.ui.refunds.RefundProductListAdapter.ProductRefundListItem
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.LiveDataDelegate
@@ -38,8 +38,8 @@ class RefundDetailViewModel @AssistedInject constructor(
     final val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 
-    private val _refundItems = MutableLiveData<List<RefundListItem>>()
-    final val refundItems: LiveData<List<RefundListItem>> = _refundItems
+    private val _refundItems = MutableLiveData<List<ProductRefundListItem>>()
+    final val refundItems: LiveData<List<ProductRefundListItem>> = _refundItems
 
     private lateinit var formatCurrency: (BigDecimal) -> String
 
@@ -66,7 +66,7 @@ class RefundDetailViewModel @AssistedInject constructor(
         val refundedProducts = groupedRefunds.keys.mapNotNull { id ->
             order.items.firstOrNull { it.uniqueId == id }?.let { item ->
                 groupedRefunds[id]?.sumBy { it.quantity }?.let { quantity ->
-                    RefundListItem(item, quantity = quantity)
+                    ProductRefundListItem(item, quantity = quantity)
                 }
             }
         }
@@ -84,7 +84,7 @@ class RefundDetailViewModel @AssistedInject constructor(
     private fun displayRefundDetails(refund: Refund, order: Order) {
         if (refund.items.isNotEmpty()) {
             val items = refund.items.map { refundItem ->
-                RefundListItem(
+                ProductRefundListItem(
                     order.items.first { it.uniqueId == refundItem.uniqueId },
                     quantity = refundItem.quantity
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundProductListAdapter.kt
@@ -30,7 +30,7 @@ class RefundProductListAdapter(
     private val isProductDetailList: Boolean,
     private val onItemClicked: (Long) -> Unit = { }
 ) : RecyclerView.Adapter<RefundViewHolder>() {
-    private var items = mutableListOf<RefundListItem>()
+    private var items = mutableListOf<ProductRefundListItem>()
 
     override fun onCreateViewHolder(parent: ViewGroup, itemType: Int): RefundViewHolder {
         return if (isProductDetailList)
@@ -45,7 +45,7 @@ class RefundProductListAdapter(
 
     override fun getItemCount(): Int = items.size
 
-    fun update(newItems: List<RefundListItem>) {
+    fun update(newItems: List<ProductRefundListItem>) {
         val diffResult = DiffUtil.calculateDiff(OrderItemDiffCallback(items, newItems))
         items = newItems.toMutableList()
         diffResult.dispatchUpdatesTo(this)
@@ -54,7 +54,7 @@ class RefundProductListAdapter(
     abstract class RefundViewHolder(parent: ViewGroup, @LayoutRes layout: Int) : RecyclerView.ViewHolder(
             LayoutInflater.from(parent.context).inflate(layout, parent, false)
     ) {
-        abstract fun bind(item: RefundListItem)
+        abstract fun bind(item: ProductRefundListItem)
     }
 
     class RefundDetailViewHolder(
@@ -69,7 +69,7 @@ class RefundProductListAdapter(
         private val productImageView: ImageView = itemView.findViewById(R.id.refundItem_icon)
 
         @SuppressLint("SetTextI18n")
-        override fun bind(item: RefundListItem) {
+        override fun bind(item: ProductRefundListItem) {
             nameTextView.text = item.orderItem.name
 
             if (item.orderItem.sku.isBlank()) {
@@ -116,7 +116,7 @@ class RefundProductListAdapter(
         private val productImageView: ImageView = itemView.findViewById(R.id.refundItem_icon)
 
         @SuppressLint("SetTextI18n")
-        override fun bind(item: RefundListItem) {
+        override fun bind(item: ProductRefundListItem) {
             nameTextView.text = item.orderItem.name
 
             descriptionTextView.text = itemView.context.getString(
@@ -142,7 +142,7 @@ class RefundProductListAdapter(
     }
 
     @Parcelize
-    data class RefundListItem(
+    data class ProductRefundListItem(
         val orderItem: Order.Item,
         val maxQuantity: Int = 0,
         val quantity: Int = 0
@@ -159,8 +159,8 @@ class RefundProductListAdapter(
     }
 
     class OrderItemDiffCallback(
-        private val oldList: List<RefundListItem>,
-        private val newList: List<RefundListItem>
+        private val oldList: List<ProductRefundListItem>,
+        private val newList: List<ProductRefundListItem>
     ) : Callback() {
         override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
             return oldList[oldItemPosition].orderItem.uniqueId == newList[newItemPosition].orderItem.uniqueId

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundShippingListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundShippingListAdapter.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.refunds
 
+import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -8,7 +9,9 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.switchmaterial.SwitchMaterial
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.hide
-import com.woocommerce.android.ui.refunds.RefundProductListAdapter.RefundListItem
+import com.woocommerce.android.model.Order
+import kotlinx.android.parcel.Parcelize
+import org.wordpress.android.fluxc.model.refunds.WCRefundModel.WCRefundItem
 import java.math.BigDecimal
 
 class RefundShippingListAdapter(
@@ -19,7 +22,7 @@ class RefundShippingListAdapter(
         fun onShippingLineSwitchChanged(isChecked: Boolean, itemId: Long)
     }
 
-    private var items = mutableListOf<RefundListItem>()
+    private var items = mutableListOf<ShippingRefundListItem>()
     private var selectedItemIds = mutableListOf<Long>()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -34,10 +37,10 @@ class RefundShippingListAdapter(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.price.text = formatCurrency(items[position].orderItem.total)
-        holder.name.text = items[position].orderItem.name
+        holder.price.text = formatCurrency(items[position].shippingLine.total)
+        holder.name.text = items[position].shippingLine.methodTitle
 
-        holder.switch.isChecked = selectedItemIds.contains(items[position].orderItem.itemId)
+        holder.switch.isChecked = selectedItemIds.contains(items[position].shippingLine.itemId)
 
         // Only show individual toggle if items size is more than 1.
         // Otherwise the main toggle is enough.
@@ -46,7 +49,7 @@ class RefundShippingListAdapter(
         }
 
         holder.switch.setOnCheckedChangeListener { _, isChecked: Boolean ->
-            checkedChangeListener.onShippingLineSwitchChanged(isChecked, items[position].orderItem.itemId)
+            checkedChangeListener.onShippingLineSwitchChanged(isChecked, items[position].shippingLine.itemId)
         }
 
         if (position == items.size - 1) {
@@ -54,7 +57,7 @@ class RefundShippingListAdapter(
         }
     }
 
-    fun update(newItems: List<RefundListItem>) {
+    fun update(newItems: List<ShippingRefundListItem>) {
         items = newItems.toMutableList()
     }
 
@@ -67,5 +70,19 @@ class RefundShippingListAdapter(
         val name: TextView = view.findViewById(R.id.issueRefund_shippingName)
         val switch: SwitchMaterial = view.findViewById(R.id.issueRefund_shippingLineSwitch)
         val divider: View = view.findViewById(R.id.issueRefund_shippingDivider)
+    }
+
+    @Parcelize
+    data class ShippingRefundListItem(
+        val shippingLine: Order.ShippingLine
+    ) : Parcelable {
+        fun toDataModel(): WCRefundItem {
+            return WCRefundItem(
+                shippingLine.itemId,
+                quantity = 1, /* Hardcoded because a shipping line always has a quantity of 1 */
+                subtotal = shippingLine.total,
+                totalTax = shippingLine.totalTax
+            )
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundShippingListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundShippingListAdapter.kt
@@ -1,0 +1,71 @@
+package com.woocommerce.android.ui.refunds
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.switchmaterial.SwitchMaterial
+import com.woocommerce.android.R
+import com.woocommerce.android.extensions.hide
+import com.woocommerce.android.ui.refunds.RefundProductListAdapter.RefundListItem
+import java.math.BigDecimal
+
+class RefundShippingListAdapter(
+    private val checkedChangeListener: OnCheckedChangeListener,
+    private val formatCurrency: (BigDecimal) -> String
+) : RecyclerView.Adapter<RefundShippingListAdapter.ViewHolder>() {
+    interface OnCheckedChangeListener {
+        fun onShippingLineSwitchChanged(isChecked: Boolean, itemId: Long)
+    }
+
+    private var items = mutableListOf<RefundListItem>()
+    private var selectedItemIds = mutableListOf<Long>()
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.refund_shipping_list_item, parent, false)
+
+        return ViewHolder(view)
+    }
+
+    override fun getItemCount(): Int {
+        return items.size
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.price.text = formatCurrency(items[position].orderItem.total)
+        holder.name.text = items[position].orderItem.name
+
+        holder.switch.isChecked = selectedItemIds.contains(items[position].orderItem.itemId)
+
+        // Only show individual toggle if items size is more than 1.
+        // Otherwise the main toggle is enough.
+        if (items.size > 1) {
+            holder.switch.visibility = View.VISIBLE
+        }
+
+        holder.switch.setOnCheckedChangeListener { _, isChecked: Boolean ->
+            checkedChangeListener.onShippingLineSwitchChanged(isChecked, items[position].orderItem.itemId)
+        }
+
+        if (position == items.size - 1) {
+            holder.divider.hide()
+        }
+    }
+
+    fun update(newItems: List<RefundListItem>) {
+        items = newItems.toMutableList()
+    }
+
+    fun updateToggleStates(shippingLineIds: List<Long>) {
+        selectedItemIds = shippingLineIds.toMutableList()
+    }
+
+    class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val price: TextView = view.findViewById(R.id.issueRefund_shippingPrice)
+        val name: TextView = view.findViewById(R.id.issueRefund_shippingName)
+        val switch: SwitchMaterial = view.findViewById(R.id.issueRefund_shippingLineSwitch)
+        val divider: View = view.findViewById(R.id.issueRefund_shippingDivider)
+    }
+}

--- a/WooCommerce/src/main/res/layout/fragment_refund_by_items.xml
+++ b/WooCommerce/src/main/res/layout/fragment_refund_by_items.xml
@@ -17,70 +17,71 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-            <LinearLayout
+            <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:layout_height="wrap_content">
 
-                <androidx.constraintlayout.widget.ConstraintLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/issueRefund_selectedItems"
+                    style="@style/Woo.Card.Title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/issueRefund_selectButton"
+                    app:layout_constraintBottom_toTopOf="@id/issueRefund_productsList"
+                    tools:text="5 items selected" />
 
-                    <com.google.android.material.textview.MaterialTextView
-                        android:id="@+id/issueRefund_selectedItems"
-                        style="@style/Woo.Card.Title"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="@id/issueRefund_selectButton"
-                        app:layout_constraintBottom_toTopOf="@id/issueRefund_productsList"
-                        tools:text="5 items selected" />
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/issueRefund_selectButton"
+                    style="@style/Woo.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/order_refunds_items_select_all"
+                    android:textAllCaps="false"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/issueRefund_selectButton"
-                        style="@style/Woo.Button.TextButton"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/order_refunds_items_select_all"
-                        android:textAllCaps="false"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintTop_toTopOf="parent" />
-
-                    <include
-                        android:id="@+id/issueRefund_productsList"
-                        layout="@layout/refund_by_items_products"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/issueRefund_selectButton" />
-
-                </androidx.constraintlayout.widget.ConstraintLayout>
-
-                <LinearLayout
+                <include
+                    android:id="@+id/issueRefund_productsList"
+                    layout="@layout/refund_by_items_products"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:animateLayoutChanges="true"
-                    android:orientation="vertical"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/issueRefund_selectButton" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            style="@style/Woo.Card"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+            <LinearLayout
+                android:id="@+id/issueRefund_shippingContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:animateLayoutChanges="true"
+                android:orientation="vertical"
+                android:visibility="gone"
+                tools:visibility="gone">
+
+                <com.google.android.material.switchmaterial.SwitchMaterial
+                    android:id="@+id/issueRefund_shippingMainSwitch"
+                    style="@style/Woo.Card.Body.High"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:importantForAccessibility="no"
+                    android:text="@string/order_refunds_refund_shipping" />
+
+                <include
+                    android:id="@+id/issueRefund_shippingSection"
+                    layout="@layout/refund_by_items_shipping"
                     android:visibility="gone"
-                    tools:visibility="gone">
+                    tools:visibility="visible" />
 
-                    <com.google.android.material.switchmaterial.SwitchMaterial
-                        android:id="@+id/issueRefund_shippingSwitch"
-                        style="@style/Woo.Card.Body.High"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:gravity="center_vertical"
-                        android:importantForAccessibility="no"
-                        android:text="@string/order_refunds_refund_shipping" />
-
-                    <include
-                        android:id="@+id/issueRefund_shippingSection"
-                        layout="@layout/refund_by_items_shipping" />
-
-                </LinearLayout>
             </LinearLayout>
-
         </com.google.android.material.card.MaterialCardView>
 
         <!-- Button: Next -->

--- a/WooCommerce/src/main/res/layout/fragment_refund_by_items.xml
+++ b/WooCommerce/src/main/res/layout/fragment_refund_by_items.xml
@@ -54,17 +54,17 @@
         </com.google.android.material.card.MaterialCardView>
 
         <com.google.android.material.card.MaterialCardView
+            android:id="@+id/issueRefund_shippingContainer"
             style="@style/Woo.Card"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            tools:visibility="visible">
             <LinearLayout
-                android:id="@+id/issueRefund_shippingContainer"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:animateLayoutChanges="true"
-                android:orientation="vertical"
-                android:visibility="gone"
-                tools:visibility="gone">
+                android:orientation="vertical">
 
                 <com.google.android.material.switchmaterial.SwitchMaterial
                     android:id="@+id/issueRefund_shippingMainSwitch"

--- a/WooCommerce/src/main/res/layout/refund_by_items_products.xml
+++ b/WooCommerce/src/main/res/layout/refund_by_items_products.xml
@@ -48,27 +48,6 @@
         tools:text="$45.00" />
 
     <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/issueRefund_lblShipping"
-        style="@style/Woo.Card.Body.High"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/minor_50"
-        android:text="@string/shipping"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/issueRefund_shippingTotal"
-        app:layout_constraintTop_toBottomOf="@+id/issueRefund_lblSubtotal" />
-
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/issueRefund_shippingTotal"
-        style="@style/Woo.Card.Body.High"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/issueRefund_lblShipping"
-        tools:text="$1.00" />
-
-    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/issueRefund_lblFees"
         style="@style/Woo.Card.Body.High"
         android:layout_width="0dp"
@@ -77,7 +56,7 @@
         android:text="@string/orderdetail_payment_fees"
         app:layout_constraintEnd_toStartOf="@+id/issueRefund_feesTotal"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/issueRefund_shippingTotal" />
+        app:layout_constraintTop_toBottomOf="@id/issueRefund_subtotal" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/issueRefund_feesTotal"
@@ -165,13 +144,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:constraint_referenced_ids="issueRefund_shippingRefundNotice,issueRefund_dividerBelowList,issueRefund_dividerBelowTaxes,issueRefund_taxesTotal,issueRefund_subtotal,issueRefund_productsTotal,issueRefund_lblProductsTotal,issueRefund_lblTaxes,issueRefund_lblSubtotal" />
-
-    <androidx.constraintlayout.widget.Group
-        android:id="@+id/issueRefund_shippingRefundGroup"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        app:constraint_referenced_ids="issueRefund_shippingTotal,issueRefund_lblShipping" />
 
     <androidx.constraintlayout.widget.Group
         android:id="@+id/issueRefund_feesGroup"

--- a/WooCommerce/src/main/res/layout/refund_by_items_shipping.xml
+++ b/WooCommerce/src/main/res/layout/refund_by_items_shipping.xml
@@ -14,58 +14,23 @@
 
         <View
             style="@style/Woo.Divider"
-            android:layout_marginStart="@dimen/major_100"/>
+            android:layout_marginTop="@dimen/major_75"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginEnd="@dimen/minor_00"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/issueRefund_shippingLines"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:nestedScrollingEnabled="false"
+            tools:itemCount="2"
+            tools:listitem="@layout/refund_shipping_list_item"
+            tools:targetApi="lollipop" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
-
-            <FrameLayout
-                android:id="@+id/issueRefund_shippingIconFrame"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginTop="@dimen/major_75"
-                android:background="@drawable/picture_frame"
-                android:padding="1dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent">
-
-                <ImageView
-                    android:id="@+id/issueRefund_shippingIcon"
-                    android:layout_width="@dimen/image_minor_100"
-                    android:layout_height="@dimen/image_minor_100"
-                    android:contentDescription="@string/orderdetail_product_image_contentdesc"
-                    android:padding="@dimen/minor_100"
-                    android:scaleType="centerCrop"
-                    app:srcCompat="@drawable/ic_gridicons_shipping"
-                    tools:visibility="visible" />
-
-            </FrameLayout>
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/issueRefund_shippingName"
-                style="@style/Woo.Card.Title"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:maxLines="2"
-                app:layout_constrainedWidth="true"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toEndOf="@+id/issueRefund_shippingIconFrame"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:text="USPS Flatrate shipping" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/issueRefund_shippingDescription"
-                style="@style/Woo.Card.Body"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                app:layout_constraintStart_toEndOf="@+id/issueRefund_shippingIconFrame"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/issueRefund_shippingName"
-                tools:text="$10.00" />
 
             <View
                 android:id="@+id/issueRefund_dividerBelowShipping"
@@ -74,7 +39,7 @@
                 android:layout_marginStart="@dimen/major_100"
                 android:layout_marginEnd="@dimen/minor_00"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/issueRefund_shippingIconFrame" />
+                app:layout_constraintTop_toTopOf="parent" />
 
             <LinearLayout
                 android:id="@+id/issueRefund_shippingSubtotalSection"
@@ -160,9 +125,25 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
+            android:layout_marginTop="@dimen/major_75"
+            android:layout_marginBottom="@dimen/major_75"
             android:text="@string/order_refunds_shipping_refund" />
 
-        <com.google.android.material.button.MaterialButton
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/issueRefund_shippingTotal"
+            style="@style/Woo.Card.Body.Bold"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/major_75"
+            android:layout_marginBottom="@dimen/major_75"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/issueRefund_dividerBelowTaxes"
+            tools:text="$1.00" />
+
+            <!-- This button is needed for a future purpose. Commented out for now. -->
+            <!--
+            <com.google.android.material.button.MaterialButton
             android:id="@+id/issueRefund_shippingRefundTotalButton"
             style="@style/Woo.Button.TextButton"
             android:layout_width="wrap_content"
@@ -172,6 +153,7 @@
             android:includeFontPadding="false"
             android:textAllCaps="false"
             tools:text="$49.00" />
+            -->
 
     </LinearLayout>
 

--- a/WooCommerce/src/main/res/layout/refund_shipping_list_item.xml
+++ b/WooCommerce/src/main/res/layout/refund_shipping_list_item.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+    <FrameLayout
+        android:id="@+id/issueRefund_shippingIconFrame"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginTop="@dimen/major_75"
+        android:background="@drawable/picture_frame"
+        android:padding="1dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:layout_width="@dimen/image_minor_100"
+            android:layout_height="@dimen/image_minor_100"
+            android:contentDescription="@string/orderdetail_product_image_contentdesc"
+            android:padding="@dimen/minor_100"
+            android:scaleType="centerCrop"
+            app:srcCompat="@drawable/ic_gridicons_shipping"
+            tools:visibility="visible" />
+    </FrameLayout>
+
+    <com.google.android.material.textview.MaterialTextView
+        style="@style/Woo.Card.Title"
+        android:id="@+id/issueRefund_shippingName"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:maxLines="2"
+        app:layout_constrainedWidth="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toEndOf="@id/issueRefund_shippingIconFrame"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="UPS Flatrate shipping" />
+
+    <com.google.android.material.textview.MaterialTextView
+        style="@style/Woo.Card.Body"
+        android:id="@+id/issueRefund_shippingPrice"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toEndOf="@+id/issueRefund_shippingIconFrame"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/issueRefund_shippingName"
+        tools:text="$24.00" />
+
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        style="@style/Woo.Card.Body.High"
+        android:id="@+id/issueRefund_shippingLineSwitch"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:gravity="center_vertical"
+        android:importantForAccessibility="no"
+        app:layout_constraintStart_toEndOf="@id/issueRefund_shippingName"
+        app:layout_constraintTop_toTopOf="parent"
+        android:visibility="gone" />
+
+    <View
+        style="@style/Woo.Divider"
+        android:id="@+id/issueRefund_shippingDivider"
+        android:layout_marginTop="@dimen/major_75"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginEnd="@dimen/minor_00"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/issueRefund_shippingIconFrame" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -494,8 +494,8 @@
         <item quantity="other">%d items</item>
     </plurals>
     <string name="order_refunds_refund_info_title">Refunded products</string>
-    <string name="order_refunds_shipping_refund_notice">You can refund shipping and tax amounts %s</string>
-    <string name="order_refunds_shipping_refund_notice_fees">You can refund fees, shipping and tax amounts %s</string>
+    <string name="order_refunds_shipping_refund_notice">You can refund tax amounts %s</string>
+    <string name="order_refunds_shipping_refund_notice_fees">You can refund fees and tax amounts %s</string>
     <string name="order_refunds_store_admin_link_text">in your store admin</string>
     <!--
         Add Order Note


### PR DESCRIPTION
This is step 3 out of 4 for this feature development, [as outlined here.](https://github.com/woocommerce/woocommerce-android/issues/3319#issuecomment-783276159)

This PR deals with showing the toggle that allows user to select shipping line(s) to be refunded.

To test this, please prepare three different Orders:
1. An order with no shipping line items.
2. An order with one shipping line item.
3. An order with more than one shipping line items. This can be created in core by editing an Order, then click "Add Item(s)", then add a Shipping line item from there.

## To test:

Go to **Order list**, select an **Order**, then tap **"Issue Refund"**. 

| Case                        | Before | With this PR: step 1 | With this PR: step 2 |
|-----------------------------|--------|-------|-------|
| Order with no shipping lines        |  ![order-no-shipping-lines](https://user-images.githubusercontent.com/266376/110299851-ccec0880-8028-11eb-9dc8-84fa8e08b95e.png)  | Should stay the same as the "Before" state, no shipping refund switch shown. | Should stay the same as the "Before" state, no shipping refund switch shown.  |
| Order with 1 shipping line  |   As above, main switch ("Refund shipping") should not be shown.   |  ![order-1-shipping-line-01](https://user-images.githubusercontent.com/266376/110299800-b776de80-8028-11eb-8ef1-48cff1eb0069.png) |   ![order-1-shipping-line-02](https://user-images.githubusercontent.com/266376/110299774-af1ea380-8028-11eb-9372-32d9adbe0106.png)  |
|  |  | Should show main switch.  |  Should only show the main switch, and no individual switch next to the shipping line. |
| Order with 2 shipping lines |    As above, main switch ("Refund shipping") should not be shown.   | ![order-2-shipping-lines-01](https://user-images.githubusercontent.com/266376/110299696-93b39880-8028-11eb-80a3-ae839e88b4ab.png)  |  ![order-2-shipping-lines-02](https://user-images.githubusercontent.com/266376/110299642-84344f80-8028-11eb-9a9f-e1bd5daa4e0a.png)   |
|  |  | Should show main switch.  |   Should show the main switch and individual switch next to each shipping line.  |


When testing, please pay attention to:
- **Grand total** (products + shipping refund) as shown on the toolbar at the top, next to the "X" button. The number should stay correct as you toggle the shipping refund option, as well as when making configuration changes. This is the part where I could use some help because I might be missing some edge cases when counting grand total. 
- **Refund subtotal, taxes, and total** as shown below the list of shipping item. The number should stay correct as you toggle the shipping refund option, as well as when making configuration changes. 
- **Toggle selections** on Order with multiple shipping line items. Checked and un-checked items should stay checked/un-checked as you make configuration changes, and as you toggle the main refund switch.

