### PR TITLE
Update editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,14 @@
+# Apply to all files
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Ruby specific rules
+[{*.rb,Fastfile,Gemfile}]
+indent_style = space
+indent_size = 2
+
 [*.{kt,kts}]
 max_line_length=120
 indent_style=space


### PR DESCRIPTION
This PR updates `.editorconfig` to add some basic rules, based on the set we agreed on in wordpress-mobile/release-toolkit#219.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
