### PR TITLE
In add new product setting, set review flag to be enabled by default.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductHelper.kt
@@ -48,7 +48,7 @@ object ProductHelper {
             dateCreated = Date(),
             firstImageUrl = null,
             totalSales = 0,
-            reviewsAllowed = false,
+            reviewsAllowed = true,
             isVirtual = productType == VARIABLE,
             ratingCount = 0,
             averageRating = 0f,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -24,6 +24,7 @@ import com.woocommerce.android.ui.products.categories.ProductCategoriesRepositor
 import com.woocommerce.android.ui.products.models.ProductProperty.ComplexProperty
 import com.woocommerce.android.ui.products.models.ProductProperty.Editable
 import com.woocommerce.android.ui.products.models.ProductProperty.PropertyGroup
+import com.woocommerce.android.ui.products.models.ProductProperty.RatingBar
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.PRIMARY
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.SECONDARY
@@ -114,6 +115,12 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                     defaultPricingGroup,
                     R.drawable.ic_gridicons_money,
                     showTitle = false
+                ),
+                RatingBar(
+                    string.product_reviews,
+                    resources.getString(string.product_ratings_count_zero),
+                    0F,
+                    drawable.ic_reviews
                 ),
                 PropertyGroup(
                     string.product_inventory,


### PR DESCRIPTION
This is for #3179 

# Testing
1. Create a new product, and go to the Product Settings option
2. Make sure that the "Enable reviews" option is enabled by default.


Before | After
--- | ---
![Enable reviews un-checked](https://user-images.githubusercontent.com/266376/110910684-44c97400-8344-11eb-97b6-0de842271873.png) | ![Enable reviews checked by default](https://user-images.githubusercontent.com/266376/110910758-5b6fcb00-8344-11eb-9e9d-4e5f4c1a2b4b.png)



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
