### PR TITLE
Order details: Show menu when tracking info area is tapped.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShipmentTrackingListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShipmentTrackingListAdapter.kt
@@ -66,6 +66,17 @@ class OrderDetailShipmentTrackingListAdapter(
                     )
                 }
             }
+            with(viewBinding.trackingInfoContent) {
+                setOnClickListener {
+                    OrderShipmentTrackingHelper.showTrackingOrDeleteOptionPopup(
+                        anchor = viewBinding.trackingBtnTrack,
+                        context = context,
+                        trackingLink = shipmentTracking.trackingLink,
+                        trackingNumber = shipmentTracking.trackingNumber,
+                        onDeleteTrackingClicked = onDeleteShipmentTrackingClicked
+                    )
+                }
+            }
         }
     }
 

--- a/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_list_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_shipment_tracking_list_item.xml
@@ -6,7 +6,7 @@
     android:layout_height="wrap_content">
 
     <LinearLayout
-        android:id="@+id/tracking_copyNumber"
+        android:id="@+id/tracking_infoContent"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/major_75"
@@ -51,7 +51,7 @@
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/tracking_copyNumber"
+        app:layout_constraintStart_toEndOf="@+id/tracking_infoContent"
         app:layout_constraintTop_toTopOf="parent"
         tools:visibility="gone" />
 


### PR DESCRIPTION
This is for #3576.

@Garance91540 suggested to show the menu items when the row is tapped, which is what this PR is adding.

## Testing instruction

(This is mostly taken from #3576)

| Instruction 	| Video (light) | Video (dark)
|-	|-	|-	
| 1. Install and activate the WooCommerce Shipment Tracking extension. <br><br> 2. Open the order details for any order eligible for shipment tracking. <br><br> 3. If there isn't already a tracking number, add one. <br><br> 4. Try tapping on the row with the tracking number. <br><br> 5. This will show the menu with items: <br />- "Copy tracking number" <br> - "Track shipment" <br>- "Delete tracking"  <br><br> 6. Test each of the three menu items's functionalities. They should work as usual.	|  <video src="https://user-images.githubusercontent.com/266376/111117168-bea66b00-8599-11eb-83b4-26c822b6e433.mp4" data-canonical-src="https://user-images.githubusercontent.com/266376/111117168-bea66b00-8599-11eb-83b4-26c822b6e433.mp4" controls="controls" muted="muted" class="d-block rounded-bottom-2 width-fit" style="max-height:640px;" /> | <video src="https://user-images.githubusercontent.com/266376/111118862-eeef0900-859b-11eb-942c-2b4bfd3d72fb.mp4" data-canonical-src="https://user-images.githubusercontent.com/266376/111118862-eeef0900-859b-11eb-942c-2b4bfd3d72fb.mp4" controls="controls" muted="muted" class="d-block rounded-bottom-2 width-fit" style="max-height:640px;" />




Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
