### PR TITLE
Custom order status

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 6.3
 -----
 - [*] Product Type: Updated product type detail to display "Downloadable" if a product is downloadable. [https://github.com/woocommerce/woocommerce-android/pull/3679]
+- [*] Custom order status is now correctly displayed in the order details. [https://github.com/woocommerce/woocommerce-android/pull/3693]
 
 6.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -122,6 +122,55 @@ data class Order(
             shippingName, shippingAddress, shippingCountry
         )
     }
+
+    sealed class Status(val value: String) : Parcelable {
+        companion object {
+            fun fromValue(value: String): Status {
+                return fromDataModel(CoreOrderStatus.fromValue(value)) ?: Custom(value)
+            }
+
+            fun fromDataModel(status: CoreOrderStatus?): Status? {
+                return when(status) {
+                    CoreOrderStatus.PENDING -> Pending
+                    CoreOrderStatus.PROCESSING -> Processing
+                    CoreOrderStatus.ON_HOLD -> OnHold
+                    CoreOrderStatus.COMPLETED -> Completed
+                    CoreOrderStatus.CANCELLED -> Cancelled
+                    CoreOrderStatus.REFUNDED -> Refunded
+                    CoreOrderStatus.FAILED -> Failed
+                    else -> null
+                }
+            }
+        }
+
+        override fun toString(): String {
+            return value
+        }
+
+        @Parcelize
+        object Pending : Status(CoreOrderStatus.PENDING.value)
+
+        @Parcelize
+        object Processing : Status(CoreOrderStatus.PROCESSING.value)
+
+        @Parcelize
+        object OnHold : Status(CoreOrderStatus.ON_HOLD.value)
+
+        @Parcelize
+        object Completed : Status(CoreOrderStatus.COMPLETED.value)
+
+        @Parcelize
+        object Cancelled : Status(CoreOrderStatus.CANCELLED.value)
+
+        @Parcelize
+        object Refunded : Status(CoreOrderStatus.REFUNDED.value)
+
+        @Parcelize
+        object Failed : Status(CoreOrderStatus.FAILED.value)
+
+        @Parcelize
+        data class Custom(private val customValue: String) : Status(customValue)
+    }
 }
 
 fun WCOrderModel.toAppModel(): Order {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -7,6 +7,9 @@ import com.woocommerce.android.extensions.roundError
 import com.woocommerce.android.model.Order.Item
 import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.model.Order.ShippingMethod
+import com.woocommerce.android.model.Order.Status
+import com.woocommerce.android.model.Order.Status.OnHold
+import com.woocommerce.android.model.Order.Status.Pending
 import com.woocommerce.android.ui.products.ProductHelper
 import com.woocommerce.android.util.AddressUtils
 import com.woocommerce.android.util.StringUtils
@@ -31,7 +34,7 @@ data class Order(
     val dateCreated: Date,
     val dateModified: Date,
     val datePaid: Date?,
-    val status: CoreOrderStatus,
+    val status: Status,
     val total: BigDecimal,
     val productsTotal: BigDecimal,
     val totalTax: BigDecimal,
@@ -56,8 +59,7 @@ data class Order(
     val isOrderPaid = paymentMethodTitle.isEmpty() && datePaid == null
 
     @IgnoredOnParcel
-    val isAwaitingPayment = status == CoreOrderStatus.PENDING ||
-        status == CoreOrderStatus.ON_HOLD || datePaid == null
+    val isAwaitingPayment = status == Pending || status == OnHold || datePaid == null
 
     @IgnoredOnParcel
     val isRefundAvailable = refundTotal < total
@@ -182,7 +184,7 @@ fun WCOrderModel.toAppModel(): Order {
             dateCreated = DateTimeUtils.dateUTCFromIso8601(this.dateCreated) ?: Date(),
             dateModified = DateTimeUtils.dateUTCFromIso8601(this.dateModified) ?: Date(),
             datePaid = DateTimeUtils.dateUTCFromIso8601(this.datePaid),
-            status = CoreOrderStatus.fromValue(this.status) ?: CoreOrderStatus.PENDING,
+            status = Status.fromValue(status),
             total = this.total.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
             productsTotal = this.getOrderSubtotal().toBigDecimal().roundError(),
             totalTax = this.totalTax.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -132,7 +132,7 @@ data class Order(
             }
 
             fun fromDataModel(status: CoreOrderStatus?): Status? {
-                return when(status) {
+                return when (status) {
                     CoreOrderStatus.PENDING -> Pending
                     CoreOrderStatus.PROCESSING -> Processing
                     CoreOrderStatus.ON_HOLD -> OnHold

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.extensions.isNotEqualTo
 import com.woocommerce.android.extensions.whenNotNullNorEmpty
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.OrderStatus
+import com.woocommerce.android.model.Order.Status
 import com.woocommerce.android.model.OrderNote
 import com.woocommerce.android.model.OrderShipmentTracking
 import com.woocommerce.android.model.Refund
@@ -347,7 +348,7 @@ class OrderDetailViewModel @AssistedInject constructor(
         if (networkStatus.isConnected()) {
             launch {
                 if (orderDetailRepository.updateOrderStatus(orderIdSet.id, orderIdSet.remoteOrderId, newStatus)) {
-                    order = order.copy(status = CoreOrderStatus.fromValue(newStatus) ?: order.status)
+                    order = order.copy(status = Status.fromValue(newStatus))
                 } else {
                     onOrderStatusChangeReverted()
                     triggerEvent(ShowSnackbar(string.order_error_update_general))


### PR DESCRIPTION
Fixes #3381. Order details now shows the correct custom order status. I've used the [Custom Order Status plugin](https://wordpress.org/plugins/custom-order-statuses-woocommerce/) to test this.

Order List | Order Detail | Status Dialog
--- | --- | ---
![image](https://user-images.githubusercontent.com/1522856/111345830-e7a02c00-867d-11eb-8176-1cefd5455b96.png) | ![image](https://user-images.githubusercontent.com/1522856/111345877-f4bd1b00-867d-11eb-94ff-a2f0b4b13dd7.png) | ![image](https://user-images.githubusercontent.com/1522856/111345912-fedf1980-867d-11eb-993f-ad3e7ae19773.png)

**To test:**

1. Create a custom order status and use it for one of the orders
2. Go to the order list
3. Notice the custom status tag is show for the order list item
4. Open the order detail
5. Notice the same custom status tag is shown
6. Tap on the tag to change the status
7. Notice the correct custom status name is displayed in a list and the status is selected

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
