### PR TITLE
Issue/3207 add attribute part5

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -21,7 +21,6 @@ import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.WCProductFileModel
 import org.wordpress.android.fluxc.model.WCProductModel
-import org.wordpress.android.fluxc.model.attribute.WCProductAttributeModel
 import org.wordpress.android.util.DateTimeUtils
 import java.math.BigDecimal
 import java.util.Date
@@ -367,10 +366,12 @@ fun Product.toDataModel(storedProductModel: WCProductModel?): WCProductModel {
     fun attributesToJson(): String {
         val jsonArray = JsonArray()
         attributes.map {
-            WCProductAttributeModel(
-                globalAttributeId = it.id.toInt(),
+            WCProductModel.ProductAttribute(
+                id = it.id,
                 name = it.name,
-                options = it.terms.toMutableList()
+                visible = it.isVisible,
+                options = it.terms.toMutableList(),
+                variation = it.isVariation
             )
         }.forEach {
             if (it.options.isNotEmpty()) {
@@ -504,12 +505,7 @@ fun WCProductModel.toAppModel(): Product {
             )
         },
         attributes = this.getAttributeList().map {
-            ProductAttribute(
-                it.id,
-                it.name,
-                it.options,
-                it.visible
-            )
+            it.toAppModel()
         },
         saleEndDateGmt = this.dateOnSaleToGmt.formatDateToISO8601Format(),
         saleStartDateGmt = this.dateOnSaleFromGmt.formatDateToISO8601Format(),
@@ -555,13 +551,11 @@ fun WCProductModel.toProductReviewProductModel() =
 /**
  * TODO: move to FluxC model
  */
-fun WCProductAttributeModel.toJson(): JsonObject {
+fun WCProductModel.ProductAttribute.toJson(): JsonObject {
     return JsonObject().also { json ->
-        json.addProperty("id", globalAttributeId)
+        json.addProperty("id", id)
         json.addProperty("name", name)
-        json.addProperty("position", position)
         json.addProperty("visible", visible)
-        json.addProperty("variation", variation)
         json.addProperty("options", options.joinToString())
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductAttribute.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductAttribute.kt
@@ -12,9 +12,14 @@ data class ProductAttribute(
     val id: Long,
     val name: String,
     val terms: List<String>,
-    val isVisible: Boolean,
-    val isVariation: Boolean
+    val isVisible: Boolean = DEFAULT_VISIBLE,
+    val isVariation: Boolean = DEFAULT_IS_VARIATION
 ) : Parcelable {
+    companion object {
+        val DEFAULT_VISIBLE = true
+        val DEFAULT_IS_VARIATION = false
+    }
+
     /**
      * Local attributes, which are attributes available only to a specific product, have an ID of zero
      */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductAttribute.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductAttribute.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.model
 import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.model.attribute.WCProductAttributeModel
 
 /**
  * Represents an attribute which is assigned to a product
@@ -22,6 +23,14 @@ data class ProductAttribute(
 
     val isGlobalAttribute: Boolean
         get() = !isLocalAttribute
+
+    fun toDataModel() =
+        WCProductAttributeModel(
+            globalAttributeId = id.toInt(),
+            name = name,
+            visible = isVisible,
+            options = terms.toMutableList()
+        )
 }
 
 fun WCProductModel.ProductAttribute.toAppModel(): ProductAttribute {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductAttribute.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductAttribute.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.model
 import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.fluxc.model.WCProductModel
-import org.wordpress.android.fluxc.model.attribute.WCProductAttributeModel
 
 /**
  * Represents an attribute which is assigned to a product
@@ -13,7 +12,8 @@ data class ProductAttribute(
     val id: Long,
     val name: String,
     val terms: List<String>,
-    val isVisible: Boolean
+    val isVisible: Boolean,
+    val isVariation: Boolean
 ) : Parcelable {
     /**
      * Local attributes, which are attributes available only to a specific product, have an ID of zero
@@ -25,11 +25,12 @@ data class ProductAttribute(
         get() = !isLocalAttribute
 
     fun toDataModel() =
-        WCProductAttributeModel(
-            globalAttributeId = id.toInt(),
+        WCProductModel.ProductAttribute(
+            id = id,
             name = name,
             visible = isVisible,
-            options = terms.toMutableList()
+            options = terms.toMutableList(),
+            variation = isVariation
         )
 }
 
@@ -38,6 +39,7 @@ fun WCProductModel.ProductAttribute.toAppModel(): ProductAttribute {
         id = this.id,
         name = this.name,
         terms = this.options,
-        isVisible = this.visible
+        isVisible = this.visible,
+        isVariation = this.variation
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
@@ -265,12 +265,13 @@ class ProductDetailRepository @Inject constructor(
     /**
      * Saves only the list of attributes for a product
      */
-    suspend fun updateProductAttributes(remoteProductId: Long, attributes: List<ProductAttribute>) {
+    suspend fun updateProductAttributes(remoteProductId: Long, attributes: List<ProductAttribute>): Boolean {
         val wooResult = productStore.submitProductAttributeChanges(
             selectedSite.get(),
             remoteProductId,
             attributes.map { it.toDataModel() }
         )
+        return !wooResult.isError
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_UP
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_UPDATE_SUCCESS
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.model.ProductAttribute
 import com.woocommerce.android.model.ProductAttributeTerm
 import com.woocommerce.android.model.ProductGlobalAttribute
 import com.woocommerce.android.model.RequestResult
@@ -261,8 +262,15 @@ class ProductDetailRepository @Inject constructor(
         return wooResult?.model?.map { it.toAppModel() } ?: emptyList()
     }
 
-    suspend fun addGlobalAttributeTerm(attributeId: Long, termName: String) {
-        globalAttributeStore.createOptionValueForAttribute(selectedSite.get(), attributeId, termName)
+    /**
+     * Saves only the list of attributes for a product
+     */
+    suspend fun updateProductAttributes(remoteProductId: Long, attributes: List<ProductAttribute>) {
+        val wooResult = productStore.submitProductAttributeChanges(
+            selectedSite.get(),
+            remoteProductId,
+            attributes.map { it.toDataModel() }
+        )
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -167,6 +167,9 @@ class ProductDetailViewModel @AssistedInject constructor(
     private val _attributeList = MutableLiveData<List<ProductAttribute>>()
     val attributeList: LiveData<List<ProductAttribute>> = _attributeList
 
+    final val globalAttributeTermsViewStateData = LiveDataDelegate(savedState, GlobalAttributesTermsViewState())
+    private var globalAttributesTermsViewState by globalAttributeTermsViewStateData
+
     private val _attributeTermsList = MutableLiveData<List<ProductAttributeTerm>>()
     val attributeTermsList: LiveData<List<ProductAttributeTerm>> = _attributeTermsList
 
@@ -983,7 +986,9 @@ class ProductDetailViewModel @AssistedInject constructor(
      */
     fun fetchGlobalAttributeTerms(remoteAttributeId: Long) {
         launch {
+            globalAttributesTermsViewState = globalAttributesTermsViewState.copy(isSkeletonShown = true)
             _attributeTermsList.value = productRepository.fetchGlobalAttributeTerms(remoteAttributeId)
+            globalAttributesTermsViewState = globalAttributesTermsViewState.copy(isSkeletonShown = false)
         }
     }
 
@@ -1819,6 +1824,11 @@ class ProductDetailViewModel @AssistedInject constructor(
 
     @Parcelize
     data class GlobalAttributesViewState(
+        val isSkeletonShown: Boolean? = null
+    ) : Parcelable
+
+    @Parcelize
+    data class GlobalAttributesTermsViewState(
         val isSkeletonShown: Boolean? = null
     ) : Parcelable
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1006,8 +1006,8 @@ class ProductDetailViewModel @AssistedInject constructor(
      */
     fun addAttributeTermToDraft(attributeId: Long, attributeName: String, termName: String) {
         val updatedTerms = ArrayList<String>()
-        var isVisible = true
-        var isVariation = false
+        var isVisible = ProductAttribute.DEFAULT_VISIBLE
+        var isVariation = ProductAttribute.DEFAULT_IS_VARIATION
 
         // find this attribute in the draft attributes
         getDraftAttribute(attributeId, attributeName)?.let { thisAttribute ->
@@ -1181,8 +1181,8 @@ class ProductDetailViewModel @AssistedInject constructor(
                 id = 0L,
                 name = attributeName,
                 terms = emptyList(),
-                isVisible = true,
-                isVariation = true // TODO
+                isVisible = ProductAttribute.DEFAULT_VISIBLE,
+                isVariation = ProductAttribute.DEFAULT_IS_VARIATION
             )
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -98,7 +98,6 @@ import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
-import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.store.WCProductStore.ProductErrorType
 import java.math.BigDecimal
 import java.util.Collections
@@ -1012,7 +1011,7 @@ class ProductDetailViewModel @AssistedInject constructor(
         // make sure this term doesn't already exist in this attribute
         thisAttribute.terms.forEach {
             if (it.equals(termName, ignoreCase = true)) {
-                triggerEvent(ShowSnackbar(R.string.product_term_name_already_exists))
+                triggerEvent(ShowSnackbar(string.product_term_name_already_exists))
                 return
             }
         }
@@ -1032,7 +1031,7 @@ class ProductDetailViewModel @AssistedInject constructor(
                 it.id != attributeId && it.name != attributeName
             }
         }.also {
-            (ProductAttribute(
+           it.add(ProductAttribute(
                 id = attributeId,
                 name = attributeName,
                 terms = updatedTerms,
@@ -1085,7 +1084,7 @@ class ProductDetailViewModel @AssistedInject constructor(
      * Saves any attribute changes to the backend
      */
     fun saveAttributeChanges() {
-        if (hasAttributeChanges()) {
+        if (hasAttributeChanges() && checkConnection()) {
             launch {
                 viewState.productDraft?.attributes?.let { attributes ->
                     productRepository.updateProductAttributes(getRemoteProductId(), attributes)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1010,7 +1010,7 @@ class ProductDetailViewModel @AssistedInject constructor(
         var isVisible = true
         var isVariation = false
 
-        // find this attribute in the draft attributes, and if it exists add its terms to our updated term list
+        // find this attribute in the draft attributes
         getDraftAttribute(attributeId, attributeName)?.let { thisAttribute ->
             // make sure this term doesn't already exist in this attribute
             thisAttribute.terms.forEach {
@@ -1019,6 +1019,8 @@ class ProductDetailViewModel @AssistedInject constructor(
                     return
                 }
             }
+
+            // add its terms to our updated term list
             updatedTerms.addAll(thisAttribute.terms)
             isVisible = thisAttribute.isVisible
             isVariation = thisAttribute.isVariation
@@ -1031,12 +1033,12 @@ class ProductDetailViewModel @AssistedInject constructor(
         val draftAttributes = getProductDraftAttributes()
 
         // create an updated list without this attribute, then add a new one with the updated terms
-        val updatedAttributes = ArrayList<ProductAttribute>().also {
-            draftAttributes.filter {
-                it.id != attributeId && it.name != attributeName
-            }
-        }.also {
-            it.add(
+        ArrayList<ProductAttribute>().also { updatedAttributes ->
+            updatedAttributes.addAll(draftAttributes.filterNot { attribute ->
+                attribute.id == attributeId && attribute.name == attributeName
+            })
+
+            updatedAttributes.add(
                 ProductAttribute(
                     id = attributeId,
                     name = attributeName,
@@ -1045,9 +1047,9 @@ class ProductDetailViewModel @AssistedInject constructor(
                     isVariation = isVariation
                 )
             )
-        }
 
-        updateProductDraft(attributes = updatedAttributes)
+            updateProductDraft(attributes = updatedAttributes)
+        }
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -98,6 +98,7 @@ import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.store.WCProductStore.ProductErrorType
 import java.math.BigDecimal
 import java.util.Collections
@@ -1031,11 +1032,12 @@ class ProductDetailViewModel @AssistedInject constructor(
                 it.id != attributeId && it.name != attributeName
             }
         }.also {
-            it.add(ProductAttribute(
+            (ProductAttribute(
                 id = attributeId,
                 name = attributeName,
                 terms = updatedTerms,
-                isVisible = thisAttribute.isVisible
+                isVisible = thisAttribute.isVisible,
+                isVariation = thisAttribute.isVariation
             ))
         }
 
@@ -1071,7 +1073,8 @@ class ProductDetailViewModel @AssistedInject constructor(
                 id = attributeId,
                 name = attributeName,
                 terms = updatedTerms,
-                isVisible = thisAttribute.isVisible
+                isVisible = thisAttribute.isVisible,
+                isVariation = thisAttribute.isVariation
             ))
         }
 
@@ -1168,7 +1171,9 @@ class ProductDetailViewModel @AssistedInject constructor(
                 id = 0L,
                 name = attributeName,
                 terms = emptyList(),
-                isVisible = true)
+                isVisible = true,
+                isVariation = true // TODO
+            )
         )
 
         // update the draft with the new list

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1006,26 +1006,26 @@ class ProductDetailViewModel @AssistedInject constructor(
      * Adds a new term to a the product draft attributes
      */
     fun addAttributeTermToDraft(attributeId: Long, attributeName: String, termName: String) {
-        // find this attribute in the draft attributes
-        val thisAttribute = getDraftAttribute(attributeId, attributeName)
-        if (thisAttribute == null) {
-            // TODO
-            return
-        }
+        val updatedTerms = ArrayList<String>()
+        var isVisible = true
+        var isVariation = false
 
-        // make sure this term doesn't already exist in this attribute
-        thisAttribute.terms.forEach {
-            if (it.equals(termName, ignoreCase = true)) {
-                triggerEvent(ShowSnackbar(string.product_term_name_already_exists))
-                return
+        // find this attribute in the draft attributes, and if it exists add its terms to our updated term list
+        getDraftAttribute(attributeId, attributeName)?.let { thisAttribute ->
+            // make sure this term doesn't already exist in this attribute
+            thisAttribute.terms.forEach {
+                if (it.equals(termName, ignoreCase = true)) {
+                    triggerEvent(ShowSnackbar(string.product_term_name_already_exists))
+                    return
+                }
             }
+            updatedTerms.addAll(thisAttribute.terms)
+            isVisible = thisAttribute.isVisible
+            isVariation = thisAttribute.isVariation
         }
 
-        // created an updated list of terms
-        val updatedTerms = ArrayList<String>().also {
-            it.addAll(thisAttribute.terms)
-            it.add(termName)
-        }
+        // add the passed term to our updated term list
+        updatedTerms.add(termName)
 
         // get the current draft attributes
         val draftAttributes = getProductDraftAttributes()
@@ -1041,8 +1041,8 @@ class ProductDetailViewModel @AssistedInject constructor(
                     id = attributeId,
                     name = attributeName,
                     terms = updatedTerms,
-                    isVisible = thisAttribute.isVisible,
-                    isVariation = thisAttribute.isVariation
+                    isVisible = isVisible,
+                    isVariation = isVariation
                 )
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1036,13 +1036,15 @@ class ProductDetailViewModel @AssistedInject constructor(
                 it.id != attributeId && it.name != attributeName
             }
         }.also {
-           it.add(ProductAttribute(
-                id = attributeId,
-                name = attributeName,
-                terms = updatedTerms,
-                isVisible = thisAttribute.isVisible,
-                isVariation = thisAttribute.isVariation
-            ))
+            it.add(
+                ProductAttribute(
+                    id = attributeId,
+                    name = attributeName,
+                    terms = updatedTerms,
+                    isVisible = thisAttribute.isVisible,
+                    isVariation = thisAttribute.isVariation
+                )
+            )
         }
 
         updateProductDraft(attributes = updatedAttributes)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -992,12 +992,11 @@ class ProductDetailViewModel @AssistedInject constructor(
         }
     }
 
+    /**
+     * Returns the draft attribute matching the passed id and name
+     */
     private fun getDraftAttribute(attributeId: Long, attributeName: String): ProductAttribute? {
-        // get the current draft attributes
-        val draftAttributes = viewState.productDraft?.attributes ?: emptyList()
-
-        // find this attribute in the draft attributes
-        return draftAttributes.firstOrNull {
+        return getProductDraftAttributes().firstOrNull {
             it.id == attributeId && it.name == attributeName
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1087,7 +1087,10 @@ class ProductDetailViewModel @AssistedInject constructor(
         if (hasAttributeChanges() && checkConnection()) {
             launch {
                 viewState.productDraft?.attributes?.let { attributes ->
-                    productRepository.updateProductAttributes(getRemoteProductId(), attributes)
+                    val result = productRepository.updateProductAttributes(getRemoteProductId(), attributes)
+                    if (!result) {
+                        triggerEvent(ShowSnackbar(string.product_attributes_error_saving))
+                    }
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
@@ -14,12 +14,14 @@ import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentAddAttributeTermsBinding
+import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.ProductAttributeTerm
 import com.woocommerce.android.ui.products.BaseProductFragment
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitProductAddAttributeTerms
 import com.woocommerce.android.ui.products.variations.attributes.AttributeTermsListAdapter.OnTermListener
 import com.woocommerce.android.widgets.AlignedDividerDecoration
 import com.woocommerce.android.widgets.DraggableItemTouchHelper
+import com.woocommerce.android.widgets.SkeletonView
 
 /**
  * This fragment contains two lists of product attribute terms. Thee\ first is a list of terms from
@@ -39,6 +41,7 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
     private val binding get() = _binding!!
 
     private val navArgs: AddAttributeTermsFragmentArgs by navArgs()
+    private val skeletonView = SkeletonView()
 
     private val itemTouchHelper by lazy {
         DraggableItemTouchHelper(
@@ -196,6 +199,12 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
             showGlobalAttributeTerms(it)
         })
 
+        viewModel.globalAttributeTermsViewStateData.observe(viewLifecycleOwner) { old, new ->
+            new.isSkeletonShown?.takeIfNotEqualTo(old?.isSkeletonShown) {
+                showSkeleton(it)
+            }
+        }
+
         viewModel.event.observe(viewLifecycleOwner, Observer { event ->
             when (event) {
                 is ExitProductAddAttributeTerms -> findNavController().navigateUp()
@@ -242,7 +251,7 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
 
     private fun checkViews() {
         binding.assignedTermList.isVisible = !assignedTermsAdapter.isEmpty()
-        binding.globalTermContainer.isVisible = !globalTermsAdapter.isEmpty()
+        // binding.globalTermContainer.isVisible = !globalTermsAdapter.isEmpty()
     }
 
     /**
@@ -258,5 +267,13 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
         }
 
         viewModel.addAttributeTermToDraft(navArgs.attributeId, navArgs.attributeName, termName)
+    }
+
+    private fun showSkeleton(show: Boolean) {
+        if (show) {
+            skeletonView.show(binding.globalTermList, R.layout.skeleton_simple_list, true)
+        } else {
+            skeletonView.hide()
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
@@ -71,6 +71,8 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
                     globalTermsAdapter.addTerm(termName)
                 }
 
+                viewModel.removeAttributeTermFromDraft(navArgs.attributeId, navArgs.attributeName, termName)
+
                 checkViews()
             }
         }
@@ -79,7 +81,7 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
     private val globalTermListener by lazy {
         object : OnTermListener {
             override fun onTermClick(termName: String) {
-                addTerm(termName, saveToBackend = false)
+                addTerm(termName)
             }
 
             override fun onTermDelete(termName: String) {}
@@ -116,12 +118,7 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
     }
 
     override fun onRequestAllowBackPress(): Boolean {
-        val assignedTerms = assignedTermsAdapter.termNames
-        viewModel.setProductDraftAttributeTerms(
-            navArgs.attributeId,
-            navArgs.attributeName,
-            assignedTerms
-        )
+        viewModel.saveAttributeChanges()
         viewModel.onBackButtonClicked(ExitProductAddAttributeTerms())
         return false
     }
@@ -158,7 +155,7 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
         binding.termEditText.setOnEditorActionListener { _, actionId, event ->
             val termName = binding.termEditText.text?.toString() ?: ""
             if (termName.isNotBlank() && !assignedTermsAdapter.containsTerm(termName)) {
-                addTerm(termName, saveToBackend = isGlobalAttribute)
+                addTerm(termName)
                 binding.termEditText.text?.clear()
             }
             true
@@ -243,10 +240,9 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
     }
 
     /**
-     * User entered a new term or tapped a global term, saveToBackend will only be true
-     * if the user entered a new term and this is a global attribute
+     * User entered a new term or tapped a global term\
      */
-    private fun addTerm(termName: String, saveToBackend: Boolean) {
+    private fun addTerm(termName: String) {
         // add the term to the list of assigned terms
         assignedTermsAdapter.addTerm(termName)
 
@@ -255,11 +251,6 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
             globalTermsAdapter.removeTerm(termName)
         }
 
-        if (saveToBackend) {
-            // TODO batch save to backend when user leaves screen
-            viewModel.addGlobalAttributeTerm(navArgs.attributeId, termName)
-        }
-
-        checkViews()
+        viewModel.addAttributeTermToDraft(navArgs.attributeId, navArgs.attributeName, termName)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
@@ -127,6 +127,10 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
     }
 
     override fun onRequestAllowBackPress(): Boolean {
+        /**
+         * TODO: we save attribute changes to the backend here only for testing purposes. Down the road we'll either
+         * move this to the add attribute fragment, or to the variation fragment before variations are generated.
+         */
         viewModel.saveAttributeChanges()
         viewModel.onBackButtonClicked(ExitProductAddAttributeTerms())
         return false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
@@ -255,11 +255,11 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
 
     private fun checkViews() {
         binding.assignedTermList.isVisible = !assignedTermsAdapter.isEmpty()
-        // binding.globalTermContainer.isVisible = !globalTermsAdapter.isEmpty()
+        binding.textExistingOption.isVisible = !globalTermsAdapter.isEmpty()
     }
 
     /**
-     * User entered a new term or tapped a global term\
+     * User entered a new term or tapped a global term
      */
     private fun addTerm(termName: String) {
         // add the term to the list of assigned terms
@@ -276,10 +276,10 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
 
     private fun showSkeleton(show: Boolean) {
         if (show) {
-            skeletonView.show(binding.globalTermList, R.layout.skeleton_simple_list, true)
+            skeletonView.show(binding.globalTermContainer, R.layout.skeleton_simple_list, true)
         } else {
             skeletonView.hide()
-            checkViews()
         }
+        checkViews()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
@@ -52,6 +52,9 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
     private lateinit var assignedTermsAdapter: AttributeTermsListAdapter
     private lateinit var globalTermsAdapter: AttributeTermsListAdapter
 
+    /**
+     * This is the listener attached to the list of assigned terms
+     */
     private val assignedTermListener by lazy {
         object : OnTermListener {
             override fun onTermClick(termName: String) {}
@@ -78,6 +81,9 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
         }
     }
 
+    /**
+     * This is the listener attached to the list of global terms
+     */
     private val globalTermListener by lazy {
         object : OnTermListener {
             override fun onTermClick(termName: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
@@ -78,7 +78,6 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
                 }
 
                 viewModel.removeAttributeTermFromDraft(navArgs.attributeId, navArgs.attributeName, termName)
-
                 checkViews()
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
@@ -128,8 +128,8 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
 
     override fun onRequestAllowBackPress(): Boolean {
         /**
-         * TODO: we save attribute changes to the backend here only for testing purposes. Down the road we'll either
-         * move this to the add attribute fragment, or to the variation fragment before variations are generated.
+         * TODO: we save attribute changes to the backend here only for testing purposes. Down the road we'll do this
+         * before variations are generated (because they can't be generated until the attributes are saved)
          */
         viewModel.saveAttributeChanges()
         viewModel.onBackButtonClicked(ExitProductAddAttributeTerms())
@@ -271,6 +271,7 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
         }
 
         viewModel.addAttributeTermToDraft(navArgs.attributeId, navArgs.attributeName, termName)
+        checkViews()
     }
 
     private fun showSkeleton(show: Boolean) {
@@ -278,6 +279,7 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
             skeletonView.show(binding.globalTermList, R.layout.skeleton_simple_list, true)
         } else {
             skeletonView.hide()
+            checkViews()
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/CombinedAttributeListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/CombinedAttributeListAdapter.kt
@@ -21,7 +21,8 @@ class CombinedAttributeListAdapter(
         setHasStableIds(true)
     }
 
-    override fun getItemId(position: Int) = attributeList[position].id
+    // note that we can't rely on the attribute id for uniqueness since all local attributes have id = 0
+    override fun getItemId(position: Int) = attributeList[position].name.hashCode().toLong()
 
     override fun getItemCount() = attributeList.size
 

--- a/WooCommerce/src/main/res/layout/fragment_add_attribute_terms.xml
+++ b/WooCommerce/src/main/res/layout/fragment_add_attribute_terms.xml
@@ -59,7 +59,9 @@
             android:paddingTop="@dimen/major_100"
             android:paddingEnd="@dimen/major_100"
             android:text="@string/product_select_attribute_term"
-            android:textAppearance="@style/TextAppearance.Woo.Caption" />
+            android:textAppearance="@style/TextAppearance.Woo.Caption"
+            android:visibility="invisible"
+            tools:visibility="visible" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/globalTermList"

--- a/WooCommerce/src/main/res/layout/fragment_add_attribute_terms.xml
+++ b/WooCommerce/src/main/res/layout/fragment_add_attribute_terms.xml
@@ -49,9 +49,7 @@
         android:layout_height="match_parent"
         android:layout_marginTop="@dimen/minor_100"
         android:background="?attr/colorSurface"
-        android:orientation="vertical"
-        android:visibility="gone"
-        tools:visibility="visible">
+        android:orientation="vertical">
 
         <com.google.android.material.textview.MaterialTextView
             android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/layout/fragment_add_attribute_terms.xml
+++ b/WooCommerce/src/main/res/layout/fragment_add_attribute_terms.xml
@@ -52,6 +52,7 @@
         android:orientation="vertical">
 
         <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/textExistingOption"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingStart="@dimen/major_100"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -71,6 +71,7 @@
     <string name="product_enter_attribute_term">Add each option name and press enter</string>
     <string name="product_attribute_name_already_exists">An attribute with this name already exists</string>
     <string name="product_term_name_already_exists">An option with this name already exists</string>
+    <string name="product_attributes_error_saving">Error while saving your attributes</string>
     <string name="review_notifications">Reviews</string>
     <string name="version_with_name_param">Version %s</string>
     <string name="share_store_button">Share your store</string>

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '8af2d4cd8d18466493119f489e29b7bde05391fa'
+    fluxCVersion = '6be82869458f59ae38c97bad05bbc7cfa8b284ff'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.12.0'
+    fluxCVersion = '8af2d4cd8d18466493119f489e29b7bde05391fa'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '6be82869458f59ae38c97bad05bbc7cfa8b284ff'
+    fluxCVersion = 'b368eb6403ead20833150170c2221d960dd8c788'
     daggerVersion = '2.29.1'
     glideVersion = '4.10.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ ext {
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.0.1'
     mockitoKotlinVersion = '2.1.0'
-    mockitoVersion = '2.28.2'     
+    mockitoVersion = '2.28.2'
     constraintLayoutVersion = '1.2.0'
     multidexVersion = '1.0.3'
     libaddressinputVersion = '0.0.2'


### PR DESCRIPTION
This PR continues the attributes & terms work but adding the ability to save all attribute & term changes in a single call when exiting the add terms fragment (thanks to the FluxC work by @ThomazFB ). Note that this isn't the fragment we'll eventually save changes from, but for now this gives us the ability to test the logic without backing out through multiple fragments.

This PR also adds a skeleton to the global attributes shown on the term fragment.

To test:

* Add global attribute terms and verify they're saved to the backend when leaving the terms fragment
* Likewise for local attributes

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
