### PR TITLE
FluxC Product attribute model compatibility

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -21,7 +21,6 @@ import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.WCProductFileModel
 import org.wordpress.android.fluxc.model.WCProductModel
-import org.wordpress.android.fluxc.model.attribute.WCProductAttributeModel
 import org.wordpress.android.util.DateTimeUtils
 import java.math.BigDecimal
 import java.util.Date
@@ -367,10 +366,12 @@ fun Product.toDataModel(storedProductModel: WCProductModel?): WCProductModel {
     fun attributesToJson(): String {
         val jsonArray = JsonArray()
         attributes.map {
-            WCProductAttributeModel(
-                globalAttributeId = it.id.toInt(),
+            WCProductModel.ProductAttribute(
+                id = it.id,
                 name = it.name,
-                options = it.terms.toMutableList()
+                options = it.terms.toMutableList(),
+                variation = productType == ProductType.VARIABLE,
+                visible = it.isVisible
             )
         }.forEach {
             if (it.options.isNotEmpty()) {
@@ -555,11 +556,10 @@ fun WCProductModel.toProductReviewProductModel() =
 /**
  * TODO: move to FluxC model
  */
-fun WCProductAttributeModel.toJson(): JsonObject {
+fun WCProductModel.ProductAttribute.toJson(): JsonObject {
     return JsonObject().also { json ->
-        json.addProperty("id", globalAttributeId)
+        json.addProperty("id", id)
         json.addProperty("name", name)
-        json.addProperty("position", position)
         json.addProperty("visible", visible)
         json.addProperty("variation", variation)
         json.addProperty("options", options.joinToString())

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '5a15dcdb1227ad103016a4082918efc7bdc6c870'
+    fluxCVersion = 'ec16523fbcdf5ac5da8b9697d36bfc13d7cedbef'
     daggerVersion = '2.29.1'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Summary
==========
Fix `WCProductAttributeModel`class reference issues on WCAndroid after changes done at https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1913. Thanks to @malinajirka for noticing and raising this issue.

How to Test
==========

1. Go to the `Product` section
2. Select a Variable Product
3. Select Variations field
4. Click at the overflow button and select `Edit Attributes`
5. Verify that modifying and updating any Attributes selection works as expected

Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
