### PR TITLE
Use array of longs for passing product ids

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModel.kt
@@ -34,12 +34,7 @@ class GroupedProductListViewModel @AssistedInject constructor(
 ) : ScopedViewModel(savedState, dispatchers) {
     private val navArgs: GroupedProductListFragmentArgs by savedState.navArgs()
 
-    private val originalProductIds =
-        navArgs.productIds
-            .takeIf { it.isNotEmpty() }
-            ?.split(",")
-            ?.mapNotNull { it.toLongOrNull() }
-            .orEmpty()
+    private val originalProductIds = navArgs.productIds.toList()
 
     private val _productList = MutableLiveData<List<Product>>()
     val productList: LiveData<List<Product>> = _productList

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/LinkedProductsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/LinkedProductsFragment.kt
@@ -115,7 +115,11 @@ class LinkedProductsFragment : BaseProductFragment(R.layout.fragment_linked_prod
         // products screen
         val action = if (productIds.isNullOrEmpty()) {
             ProductDetailFragmentDirections
-                .actionGlobalProductSelectionListFragment(viewModel.getRemoteProductId(), groupedProductType, longArrayOf())
+                .actionGlobalProductSelectionListFragment(
+                    remoteProductId = viewModel.getRemoteProductId(),
+                    groupedProductListType = groupedProductType,
+                    excludedProductIds = longArrayOf()
+                )
         } else {
             GroupedProductListFragmentDirections.actionGlobalGroupedProductListFragment(
                 viewModel.getRemoteProductId(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/LinkedProductsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/LinkedProductsFragment.kt
@@ -115,11 +115,11 @@ class LinkedProductsFragment : BaseProductFragment(R.layout.fragment_linked_prod
         // products screen
         val action = if (productIds.isNullOrEmpty()) {
             ProductDetailFragmentDirections
-                .actionGlobalProductSelectionListFragment(viewModel.getRemoteProductId(), groupedProductType)
+                .actionGlobalProductSelectionListFragment(viewModel.getRemoteProductId(), groupedProductType, longArrayOf())
         } else {
             GroupedProductListFragmentDirections.actionGlobalGroupedProductListFragment(
                 viewModel.getRemoteProductId(),
-                productIds.joinToString(","),
+                productIds.toLongArray(),
                 groupedProductType
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -528,7 +528,7 @@ class ProductDetailCardBuilder(
             showTitle = showTitle
         ) {
             viewModel.onEditProductCardClicked(
-                ViewGroupedProducts(this.remoteId, this.groupedProductIds.joinToString(",")),
+                ViewGroupedProducts(this.remoteId, this.groupedProductIds),
                 Stat.PRODUCT_DETAIL_VIEW_GROUPED_PRODUCTS_TAPPED
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
@@ -59,7 +59,7 @@ sealed class ProductNavigationTarget : Event() {
     data class ViewProductTypes(val isAddProduct: Boolean) : ProductNavigationTarget()
     data class ViewProductReviews(val remoteId: Long) : ProductNavigationTarget()
     object ViewProductAdd : ProductNavigationTarget()
-    data class ViewGroupedProducts(val remoteId: Long, val groupedProductIds: String) : ProductNavigationTarget()
+    data class ViewGroupedProducts(val remoteId: Long, val groupedProductIds: List<Long>) : ProductNavigationTarget()
     data class ViewLinkedProducts(val remoteId: Long) : ProductNavigationTarget()
     data class ViewProductSelectionList(
         val remoteId: Long,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -229,7 +229,7 @@ class ProductNavigator @Inject constructor() {
 
             is ViewGroupedProducts -> {
                 val action = ProductDetailFragmentDirections
-                    .actionGlobalGroupedProductListFragment(target.remoteId, target.groupedProductIds, GROUPED)
+                    .actionGlobalGroupedProductListFragment(target.remoteId, target.groupedProductIds.toLongArray(), GROUPED)
                 fragment.findNavController().navigateSafely(action)
             }
 
@@ -244,7 +244,8 @@ class ProductNavigator @Inject constructor() {
                     .actionGlobalProductSelectionListFragment(
                         target.remoteId,
                         target.groupedProductType,
-                        target.excludedProductIds.joinToString(","))
+                        target.excludedProductIds.toLongArray()
+                    )
                 fragment.findNavController().navigateSafely(action)
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -229,7 +229,11 @@ class ProductNavigator @Inject constructor() {
 
             is ViewGroupedProducts -> {
                 val action = ProductDetailFragmentDirections
-                    .actionGlobalGroupedProductListFragment(target.remoteId, target.groupedProductIds.toLongArray(), GROUPED)
+                    .actionGlobalGroupedProductListFragment(
+                        remoteProductId = target.remoteId,
+                        productIds = target.groupedProductIds.toLongArray(),
+                        groupedProductListType = GROUPED
+                    )
                 fragment.findNavController().navigateSafely(action)
             }
 
@@ -242,9 +246,9 @@ class ProductNavigator @Inject constructor() {
             is ViewProductSelectionList -> {
                 val action = ProductDetailFragmentDirections
                     .actionGlobalProductSelectionListFragment(
-                        target.remoteId,
-                        target.groupedProductType,
-                        target.excludedProductIds.toLongArray()
+                        remoteProductId = target.remoteId,
+                        groupedProductListType = target.groupedProductType,
+                        excludedProductIds = target.excludedProductIds.toLongArray()
                     )
                 fragment.findNavController().navigateSafely(action)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModel.kt
@@ -61,12 +61,7 @@ class ProductSelectionListViewModel @AssistedInject constructor(
     private var loadJob: Job? = null
     private var searchJob: Job? = null
 
-    private val excludedProductIds =
-        navArgs.excludedProductIds
-            .takeIf { it.isNotEmpty() }
-            ?.split(",")
-            ?.mapNotNull { it.toLongOrNull() }
-            .orEmpty()
+    private val excludedProductIds = navArgs.excludedProductIds.toList()
 
     init {
         if (_productList.value == null) {

--- a/WooCommerce/src/main/res/navigation/nav_graph_products.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_products.xml
@@ -325,8 +325,7 @@
             app:argType="long" />
         <argument
             android:name="productIds"
-            android:defaultValue='""'
-            app:argType="string" />
+            app:argType="long[]" />
         <argument
             android:name="groupedProductListType"
             app:argType="com.woocommerce.android.ui.products.GroupedProductListType"/>
@@ -344,8 +343,7 @@
             app:argType="com.woocommerce.android.ui.products.GroupedProductListType"/>
         <argument
             android:name="excludedProductIds"
-            android:defaultValue='""'
-            app:argType="string" />
+            app:argType="long[]" />
     </fragment>
     <fragment
         android:id="@+id/linkedProductsFragment"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/GroupedProductListViewModelTest.kt
@@ -24,7 +24,7 @@ import org.junit.Test
 class GroupedProductListViewModelTest : BaseUnitTest() {
     companion object {
         private const val PRODUCT_REMOTE_ID = 1L
-        private const val GROUPED_PRODUCT_IDS = "2,3,4,5"
+        private val GROUPED_PRODUCT_IDS = longArrayOf(2, 3, 4, 5)
     }
 
     private val networkStatus: NetworkStatus = mock()
@@ -44,7 +44,7 @@ class GroupedProductListViewModelTest : BaseUnitTest() {
     private val coroutineDispatchers = CoroutineDispatchers(
         Dispatchers.Unconfined, Dispatchers.Unconfined, Dispatchers.Unconfined)
     private val productList = ProductTestUtils.generateProductList()
-    private val groupedProductIds = GROUPED_PRODUCT_IDS.split(",").map { it.toLong() }
+    private val groupedProductIds = GROUPED_PRODUCT_IDS.toList()
 
     private lateinit var viewModel: GroupedProductListViewModel
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModelTest.kt
@@ -44,7 +44,7 @@ class ProductSelectionListViewModelTest : BaseUnitTest() {
             ProductSelectionListFragmentArgs(
                 remoteProductId = PRODUCT_REMOTE_ID,
                 groupedProductListType = GroupedProductListType.GROUPED,
-                excludedProductIds = excludedProductIds.joinToString(",")
+                excludedProductIds = excludedProductIds.toLongArray()
             )
         )
     )


### PR DESCRIPTION
This PR is a small improvement to use `Array<Long>` instead of splitting `String` with product ids values.

I just seen this while working on #3100 and thought it might go as a separate PR.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
