### PR TITLE
Add translatable="false" to strings that reference other strings

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1163,22 +1163,22 @@
     <string name="product_type_confirm_button">Yes, change</string>
 
     <!-- New Product bottom sheet -->
-    <string name="product_add_type_list_header">@string/product_type_list_header</string>
+    <string name="product_add_type_list_header" translatable="false">@string/product_type_list_header</string>
     <string name="product_add_type_simple">Simple product</string>
     <string name="product_add_type_variable">Variable product</string>
     <string name="product_add_type_grouped">Grouped product</string>
     <string name="product_add_type_external">External product</string>
     <string name="product_add_type_simple_desc">A unique item to sell</string>
     <string name="product_add_type_variable_desc">A product with variations like color or size</string>
-    <string name="product_add_type_grouped_desc">@string/product_type_grouped_desc</string>
-    <string name="product_add_type_external_desc">@string/product_type_external_desc</string>
+    <string name="product_add_type_grouped_desc" translatable="false">@string/product_type_grouped_desc</string>
+    <string name="product_add_type_external_desc" translatable="false">@string/product_type_external_desc</string>
 
     <!-- New Product screen -->
     <string name="product_add_tool_bar_title">New Product</string>
     <string name="product_add_tool_bar_menu_button_done">PUBLISH</string>
     <string name="product_publish_dialog_title">Publishing product</string>
     <string name="product_publish_draft_dialog_title">Saving draft</string>
-    <string name="product_publish_dialog_message">@string/product_update_dialog_message</string>
+    <string name="product_publish_dialog_message" translatable="false">@string/product_update_dialog_message</string>
     <string name="product_detail_publish_product_error">Error publishing product</string>
     <string name="product_detail_publish_product_success">Product published</string>
     <string name="product_detail_publish_product_draft_error">Error saving product draft</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -1162,22 +1162,22 @@
     <string name="product_type_confirm_button">Yes, change</string>
 
     <!-- New Product bottom sheet -->
-    <string name="product_add_type_list_header">@string/product_type_list_header</string>
+    <string name="product_add_type_list_header" translatable="false">@string/product_type_list_header</string>
     <string name="product_add_type_simple">Simple product</string>
     <string name="product_add_type_variable">Variable product</string>
     <string name="product_add_type_grouped">Grouped product</string>
     <string name="product_add_type_external">External product</string>
     <string name="product_add_type_simple_desc">A unique item to sell</string>
     <string name="product_add_type_variable_desc">A product with variations like color or size</string>
-    <string name="product_add_type_grouped_desc">@string/product_type_grouped_desc</string>
-    <string name="product_add_type_external_desc">@string/product_type_external_desc</string>
+    <string name="product_add_type_grouped_desc" translatable="false">@string/product_type_grouped_desc</string>
+    <string name="product_add_type_external_desc" translatable="false">@string/product_type_external_desc</string>
 
     <!-- New Product screen -->
     <string name="product_add_tool_bar_title">New Product</string>
     <string name="product_add_tool_bar_menu_button_done">PUBLISH</string>
     <string name="product_publish_dialog_title">Publishing product</string>
     <string name="product_publish_draft_dialog_title">Saving draft</string>
-    <string name="product_publish_dialog_message">@string/product_update_dialog_message</string>
+    <string name="product_publish_dialog_message" translatable="false">@string/product_update_dialog_message</string>
     <string name="product_detail_publish_product_error">Error publishing product</string>
     <string name="product_detail_publish_product_success">Product published</string>
     <string name="product_detail_publish_product_draft_error">Error saving product draft</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -1162,22 +1162,22 @@
     <string name="product_type_confirm_button">Yes, change</string>
 
     <!-- New Product bottom sheet -->
-    <string name="product_add_type_list_header" translatable="false">@string/product_type_list_header</string>
+    <string name="product_add_type_list_header">@string/product_type_list_header</string>
     <string name="product_add_type_simple">Simple product</string>
     <string name="product_add_type_variable">Variable product</string>
     <string name="product_add_type_grouped">Grouped product</string>
     <string name="product_add_type_external">External product</string>
     <string name="product_add_type_simple_desc">A unique item to sell</string>
     <string name="product_add_type_variable_desc">A product with variations like color or size</string>
-    <string name="product_add_type_grouped_desc" translatable="false">@string/product_type_grouped_desc</string>
-    <string name="product_add_type_external_desc" translatable="false">@string/product_type_external_desc</string>
+    <string name="product_add_type_grouped_desc">@string/product_type_grouped_desc</string>
+    <string name="product_add_type_external_desc">@string/product_type_external_desc</string>
 
     <!-- New Product screen -->
     <string name="product_add_tool_bar_title">New Product</string>
     <string name="product_add_tool_bar_menu_button_done">PUBLISH</string>
     <string name="product_publish_dialog_title">Publishing product</string>
     <string name="product_publish_draft_dialog_title">Saving draft</string>
-    <string name="product_publish_dialog_message" translatable="false">@string/product_update_dialog_message</string>
+    <string name="product_publish_dialog_message">@string/product_update_dialog_message</string>
     <string name="product_detail_publish_product_error">Error publishing product</string>
     <string name="product_detail_publish_product_success">Product published</string>
     <string name="product_detail_publish_product_draft_error">Error saving product draft</string>


### PR DESCRIPTION
Fixes #3710. 

Yeah, I don't know what these strings are really called in Android-world. :D

## Testing

Please do a quick regression test. 

1. Tap on Products.
2. Tap on the big red add button.
3. Confirm that these strings are still visible and not weird gibberish:

    <img src="https://user-images.githubusercontent.com/198826/111715915-89f51680-881a-11eb-9e82-482241ad23ce.png" width="300">

We should see these fixed for the other languages once we've done the translation dance next sprint. 

## Author Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
