### PR TITLE
fix/rollback-to-commons-text-1.8

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -274,6 +274,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion"
 
+    // Use caution when updating these, as commons-text 1.9 caused the reviews tab to crash on API 21
     implementation "org.apache.commons:commons-lang3:3.9"
     implementation "org.apache.commons:commons-text:1.8"
 

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -275,7 +275,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion"
 
     implementation "org.apache.commons:commons-lang3:3.9"
-    implementation "org.apache.commons:commons-text:1.9"
+    implementation "org.apache.commons:commons-text:1.8"
 
     implementation "com.tinder.statemachine:statemachine:$stateMachineVersion"
 }


### PR DESCRIPTION
This PR reverts the changes made in #3684 and rolls back to commons-text v1.8. This change is being made because @malinajirka discovered the app was crashing when visiting the reviews tab on API 21, and the crash is related to the updated library.

```
Process: com.woocommerce.android, PID: 2478
    java.lang.NoClassDefFoundError: org.apache.commons.lang3.-$$Lambda$Validate$0cAgQbsjQIo0VHKh79UWkAcDRWk
        at org.apache.commons.lang3.Validate.notNull(Validate.java:225)
        at org.apache.commons.lang3.time.DateUtils.validateDateNotNull(DateUtils.java:1789)
        at org.apache.commons.lang3.time.DateUtils.add(DateUtils.java:515)
        at org.apache.commons.lang3.time.DateUtils.addMonths(DateUtils.java:416)
        at com.woocommerce.android.model.TimeGroup$Companion.getTimeGroupForDate(TimeGroup.kt:21)
        at com.woocommerce.android.ui.reviews.ReviewListAdapter.setReviews(ReviewListAdapter.kt:60)
```

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
