### PR TITLE
Drop FindBugs Java static analysis

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -258,7 +258,6 @@ dependencies {
 
     // Resolve conflicts between main and test APK
     androidTestImplementation "androidx.annotation:annotation:1.1.0"
-    androidTestImplementation "com.google.code.findbugs:jsr305:2.0.1"
 
     implementation "com.zendesk:support:5.0.2"
 


### PR DESCRIPTION
Pasting here comment from #3715 

> Development of this dependency stopped in 2017, the new "spiritual successor" is SpotBugs.
Either way this is Java static code analysis plugin, I'm not sure why it was added only in tests. As we are moving from Java to Kotlin, and Java is now only 8%, I'd opt to drop this dependency. I'll prepare PR for that and will check with team.

Does anyone vote for leaving this (or rather: migrating to `SpotBugs`) or we can drop it?

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
