### PR TITLE
[Tooling] Mute fastlane's CHANGELOG and update check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
           cache_key_prefix: installable-build-v2
       - run:
           name: Copy Secrets
-          command: bundle exec fastlane run configure_apply
+          command: FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane run configure_apply
       - android/restore-gradle-cache
       - run:
           name: Build APK
@@ -121,7 +121,7 @@ jobs:
           cache_key_prefix: release-build-v2
       - run:
           name: Copy Secrets
-          command: bundle exec fastlane run configure_apply
+          command: FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane run configure_apply
       - run:
           name: Install other tools
           command: |
@@ -138,6 +138,8 @@ jobs:
             APP_VERSION=$(./gradlew -q printVersionName | tail -1)
             echo "export SLACK_FAILURE_MESSAGE=':red_circle: Build for WooCommerce Android $APP_VERSION failed!'" >> $BASH_ENV
             echo "export SLACK_SUCCESS_MESSAGE=':tada: WooCommerce Android $APP_VERSION has been deployed!'" >> $BASH_ENV
+            # Prevent fastlane from checking for updates, also removing the verbose fastlane changelog at the end of each invocation.
+            echo "export FASTLANE_SKIP_UPDATE_CHECK=1" >> $BASH_ENV
             mv ~/.android/debug_a8c.keystore ~/.android/debug.keystore
             if [[ $APP_VERSION == *"-rc-"* ]]; then
               bundle exec fastlane build_and_upload_beta skip_confirm:true create_release:true


### PR DESCRIPTION
This adds a magic env var that will prevent fastlane from checking for an update at the end of every invocation, and thus remove the quite verbose fastlane changelog output that gets printed at the end of every fastlane step. This should make logs less spammy especially when debugging CI failures, and show more info even when CircleCI truncates the logs to only the last lines on its UI.

Similar to https://github.com/woocommerce/woocommerce-ios/pull/3855.

This skip gets applied to "Copy Secrets" steps – even if that will soon be replaced by the Rust version of Gradle and that fastlane invocation will probably get removed soon – but also on the `build_and_upload_*` lanes for the Release Build jobs – for which we will still continue to use fastlane anyway.

## To test

Check on CI that the steps invoking `fastlane` don't print the fastlane changelog at the end anymore.

**Before:** (see [Copy Secrets step on Installable Build job on develop](https://app.circleci.com/pipelines/github/woocommerce/woocommerce-android/10161/workflows/4a0cd2a8-13a6-4549-bda3-6ce0fb46edc2/jobs/31952))
```
[10:09:12]: -----------------------------
[10:09:12]: --- Step: configure_apply ---
[10:09:12]: -----------------------------
[10:09:12]: Applied configuration
[10:09:12]: Result: true

#######################################################################
# fastlane 2.178.0 is available. You are on 2.174.0.
# You should use the latest version.
# Please update using `bundle update fastlane`.
#######################################################################

2.178.0 Improvements

…[a quite long fastlane changelog here]…
....
....
loooong
....
....
....
....


To see all new releases, open https://github.com/fastlane/fastlane/releases

Please update using `bundle update fastlane`
CircleCI received exit code 0
```

**After:** (see [CI on this PR](https://app.circleci.com/pipelines/github/woocommerce/woocommerce-android/10168/workflows/333b44be-a775-44b3-861b-78b3a0df2513/jobs/31979))
```
[17:56:30]: -----------------------------
[17:56:30]: --- Step: configure_apply ---
[17:56:30]: -----------------------------
[17:56:30]: Applied configuration
[17:56:30]: Result: true
CircleCI received exit code 0
```