### PR TITLE
Issue/3730 remove empty attributes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1070,12 +1070,13 @@ class ProductDetailViewModel @AssistedInject constructor(
         // get the current draft attributes
         val draftAttributes = getProductDraftAttributes()
 
-        // create an updated list without this attribute, then add a new one with the updated terms unless there are none
+        // create an updated list without this attribute...
         val updatedAttributes = ArrayList<ProductAttribute>().also {
             it.addAll(draftAttributes.filter { attribute ->
                 attribute.id != attributeId && attribute.name != attributeName
             })
         }.also {
+            // ...then add this attribute back with the updated list of terms unless there are none
             if (updatedTerms.isNotEmpty()) {
                 it.add(
                     ProductAttribute(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1070,11 +1070,11 @@ class ProductDetailViewModel @AssistedInject constructor(
         // get the current draft attributes
         val draftAttributes = getProductDraftAttributes()
 
-        // create an updated list without this attribute, then add a new one with the updated terms
+        // create an updated list without this attribute, then add a new one with the updated terms unless there are none
         val updatedAttributes = ArrayList<ProductAttribute>().also {
-            draftAttributes.filter {
-                it.id != attributeId && it.name != attributeName
-            }
+            it.addAll(draftAttributes.filter { attribute ->
+                attribute.id != attributeId && attribute.name != attributeName
+            })
         }.also {
             if (updatedTerms.isNotEmpty()) {
                 it.add(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1076,13 +1076,17 @@ class ProductDetailViewModel @AssistedInject constructor(
                 it.id != attributeId && it.name != attributeName
             }
         }.also {
-            it.add(ProductAttribute(
-                id = attributeId,
-                name = attributeName,
-                terms = updatedTerms,
-                isVisible = thisAttribute.isVisible,
-                isVariation = thisAttribute.isVariation
-            ))
+            if (updatedTerms.isNotEmpty()) {
+                it.add(
+                    ProductAttribute(
+                        id = attributeId,
+                        name = attributeName,
+                        terms = updatedTerms,
+                        isVisible = thisAttribute.isVisible,
+                        isVariation = thisAttribute.isVariation
+                    )
+                )
+            }
         }
 
         updateProductDraft(attributes = updatedAttributes)


### PR DESCRIPTION
This PR resolves two issues with the recent attribute changes:

Fixes #3730 - if you remove the only term from a local attribute, that attribute should be removed
Fixes #3731 - if you remove a term from an attribute, all the other attributes are lost

I decided to address these together since the bugs were in the same section of code.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
