### PR TITLE
Support products and variations with decimal stock quantities

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -52,7 +52,7 @@ data class Product(
     val regularPrice: BigDecimal?,
     val taxClass: String,
     val isStockManaged: Boolean,
-    val stockQuantity: Int,
+    val stockQuantity: Double,
     val sku: String,
     val shippingClass: String,
     val shippingClassId: Long,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariation.kt
@@ -35,7 +35,7 @@ data class ProductVariation(
     val isSaleScheduled: Boolean,
     val stockStatus: ProductStockStatus,
     val backorderStatus: ProductBackorderStatus,
-    val stockQuantity: Int,
+    val stockQuantity: Double,
     val options: List<Option>,
     var priceWithCurrency: String? = null,
     val isPurchasable: Boolean,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -48,7 +48,6 @@ import com.woocommerce.android.util.FeatureFlag.ADD_EDIT_VARIATIONS
 import com.woocommerce.android.util.PriceUtils
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.ResourceProvider
-import org.wordpress.android.util.FormatUtils
 
 class ProductDetailCardBuilder(
     private val viewModel: ProductDetailViewModel,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -249,7 +249,7 @@ class ProductDetailCardBuilder(
                 ),
                 Pair(
                     resources.getString(R.string.product_stock_quantity),
-                    StringUtils.formatCount(this.stockQuantity)
+                    StringUtils.formatCountDecimal(this.stockQuantity)
                 ),
                 Pair(resources.getString(R.string.product_sku), this.sku)
             )
@@ -321,7 +321,7 @@ class ProductDetailCardBuilder(
         if (productType == SIMPLE || productType == VARIABLE) {
             if (this.isStockManaged) {
                 inventory[resources.getString(R.string.product_stock_quantity)] =
-                    FormatUtils.formatInt(this.stockQuantity)
+                    StringUtils.formatCountDecimal(this.stockQuantity)
                 inventory[resources.getString(R.string.product_backorders)] =
                     ProductBackorderStatus.backordersToDisplayString(resources, this.backorderStatus)
             } else if (productType == SIMPLE) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -672,7 +672,7 @@ class ProductDetailViewModel @AssistedInject constructor(
         manageStock: Boolean? = null,
         stockStatus: ProductStockStatus? = null,
         soldIndividually: Boolean? = null,
-        stockQuantity: Int? = null,
+        stockQuantity: Double? = null,
         backorderStatus: ProductBackorderStatus? = null,
         regularPrice: BigDecimal? = null,
         salePrice: BigDecimal? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductHelper.kt
@@ -59,7 +59,7 @@ object ProductHelper {
             regularPrice = BigDecimal.ZERO,
             taxClass = Product.TAX_CLASS_DEFAULT,
             isStockManaged = false,
-            stockQuantity = 0,
+            stockQuantity = 0.0,
             sku = "",
             slug = "",
             length = 0f,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.extensions.expand
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.products.ProductItemSelectorDialog.ProductItemSelectorDialogListener
+import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -105,7 +106,7 @@ class ProductInventoryFragment : BaseProductEditorFragment(R.layout.fragment_pro
                 }
             }
             new.inventoryData.stockQuantity?.takeIfNotEqualTo(old?.inventoryData?.stockQuantity) {
-                val quantity = it.toString()
+                val quantity = StringUtils.formatCountDecimal(it)
                 if (binding.productStockQuantity.getText() != quantity) {
                     binding.productStockQuantity.setText(quantity)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
@@ -106,7 +106,8 @@ class ProductInventoryFragment : BaseProductEditorFragment(R.layout.fragment_pro
                 }
             }
             new.inventoryData.stockQuantity?.takeIfNotEqualTo(old?.inventoryData?.stockQuantity) {
-                val quantity = StringUtils.formatCountDecimal(it)
+                val quantity = StringUtils.formatCountDecimal(it, forInput = true)
+
                 if (binding.productStockQuantity.getText() != quantity) {
                     binding.productStockQuantity.setText(quantity)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
@@ -152,7 +152,7 @@ class ProductInventoryFragment : BaseProductEditorFragment(R.layout.fragment_pro
 
         with(binding.productStockQuantity) {
             setOnTextChangedListener {
-                it.toString().toIntOrNull()?.let { quantity ->
+                it.toString().toDoubleOrNull()?.let { quantity ->
                     viewModel.onDataChanged(stockQuantity = quantity)
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModel.kt
@@ -95,7 +95,7 @@ class ProductInventoryViewModel @AssistedInject constructor(
         backorderStatus: ProductBackorderStatus? = inventoryData.backorderStatus,
         isSoldIndividually: Boolean? = inventoryData.isSoldIndividually,
         isStockManaged: Boolean? = inventoryData.isStockManaged,
-        stockQuantity: Int? = inventoryData.stockQuantity,
+        stockQuantity: Double? = inventoryData.stockQuantity,
         stockStatus: ProductStockStatus? = inventoryData.stockStatus
     ) {
         viewState = viewState.copy(
@@ -148,7 +148,7 @@ class ProductInventoryViewModel @AssistedInject constructor(
         val isStockManaged: Boolean? = null,
         val isSoldIndividually: Boolean? = null,
         val stockStatus: ProductStockStatus? = null,
-        val stockQuantity: Int? = null,
+        val stockQuantity: Double? = null,
         val backorderStatus: ProductBackorderStatus? = null
     ) : Parcelable
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
@@ -16,7 +16,7 @@ import com.woocommerce.android.ui.products.ProductStockStatus.InStock
 import com.woocommerce.android.ui.products.ProductStockStatus.OnBackorder
 import com.woocommerce.android.ui.products.ProductStockStatus.OutOfStock
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
-import org.wordpress.android.util.FormatUtils
+import com.woocommerce.android.util.StringUtils
 import org.wordpress.android.util.HtmlUtils
 import org.wordpress.android.util.PhotonUtils
 
@@ -128,7 +128,7 @@ class ProductItemViewHolder(val viewBinding: ProductListItemBinding) :
                     if (product.stockQuantity > 0) {
                         context.getString(
                             R.string.product_stock_count,
-                            FormatUtils.formatInt(product.stockQuantity)
+                            StringUtils.formatCountDecimal(product.stockQuantity)
                         )
                     } else {
                         context.getString(R.string.product_stock_status_instock)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
@@ -36,6 +36,7 @@ import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.
 import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.ViewShipping
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.PriceUtils
+import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.ResourceProvider
 import org.wordpress.android.util.FormatUtils
 
@@ -229,7 +230,8 @@ class VariationDetailCardBuilder(
                 ),
                 Pair(
                     resources.getString(R.string.product_stock_quantity),
-                    FormatUtils.formatInt(this.stockQuantity)
+                    StringUtils.formatCountDecimal(this.stockQuantity)
+
                 ),
                 Pair(resources.getString(R.string.product_sku), this.sku)
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
@@ -38,7 +38,6 @@ import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.PriceUtils
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.ResourceProvider
-import org.wordpress.android.util.FormatUtils
 
 class VariationDetailCardBuilder(
     private val viewModel: VariationDetailViewModel,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -168,7 +168,7 @@ class VariationDetailViewModel @AssistedInject constructor(
         isSaleScheduled: Boolean? = null,
         stockStatus: ProductStockStatus? = null,
         backorderStatus: ProductBackorderStatus? = null,
-        stockQuantity: Int? = null,
+        stockQuantity: Double? = null,
         options: List<Option>? = null,
         isPurchasable: Boolean? = null,
         isVirtual: Boolean? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
@@ -142,7 +142,7 @@ object StringUtils {
      */
     fun formatCountDecimal(number: Double, forInput: Boolean = false): String {
         return if (number.rem(1).equals(0.0)) {
-            if(forInput)
+            if (forInput)
                 number.toInt().toString()
             else
                 FormatUtils.formatInt(number.toInt())
@@ -150,7 +150,6 @@ object StringUtils {
             number.toString()
         }
     }
-
 
     /**
      * Returns the name of the country associated with the current store.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
@@ -127,6 +127,10 @@ object StringUtils {
             else -> number.toString()
         }
     }
+    
+    fun formatCountDecimal(number: Double): String {
+        return number.toString()
+    }
 
     /**
      * Returns the name of the country associated with the current store.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
@@ -13,6 +13,7 @@ import androidx.annotation.StringRes
 import com.woocommerce.android.util.WooLog.T.UTILS
 import com.woocommerce.android.viewmodel.ResourceProvider
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.util.FormatUtils
 import java.io.IOException
 import java.util.Locale
 import kotlin.math.abs
@@ -128,13 +129,28 @@ object StringUtils {
         }
     }
 
-    fun formatCountDecimal(number: Double): String {
-        if (number.rem(1).equals(0.0)) {
-            return formatCount(number.toInt())
+    /**
+     * If a number's fractional part is zero, remove it and return as string. Otherwise return as string while
+     * including the fractional part.
+     * If the number is to be displayed as regular text, `formatInt` is used to display commas/dot for thousands
+     * separator (depending on locale).
+     * If the number is to be displayed in an editable text input, number.toInt() is used so that the input behavior
+     * does not show the thousands separator.
+     *
+     *  @param [number] The number to be formatted
+     *  @param [forInput] Whether the formatting is used in a text input or not.
+     */
+    fun formatCountDecimal(number: Double, forInput: Boolean = false): String {
+        return if (number.rem(1).equals(0.0)) {
+            if(forInput)
+                number.toInt().toString()
+            else
+                FormatUtils.formatInt(number.toInt())
         } else {
-            return number.toString()
+            number.toString()
         }
     }
+
 
     /**
      * Returns the name of the country associated with the current store.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
@@ -131,8 +131,7 @@ object StringUtils {
     fun formatCountDecimal(number: Double): String {
         if (number.rem(1).equals(0.0)) {
             return formatCount(number.toInt())
-        }
-        else {
+        } else {
             return number.toString()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
@@ -127,7 +127,7 @@ object StringUtils {
             else -> number.toString()
         }
     }
-    
+
     fun formatCountDecimal(number: Double): String {
         return number.toString()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
@@ -129,7 +129,12 @@ object StringUtils {
     }
 
     fun formatCountDecimal(number: Double): String {
-        return number.toString()
+        if (number.rem(1).equals(0.0)) {
+            return formatCount(number.toInt())
+        }
+        else {
+            return number.toString()
+        }
     }
 
     /**

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModelTest.kt
@@ -37,7 +37,7 @@ class ProductInventoryViewModelTest : BaseUnitTest() {
         isStockManaged = false,
         isSoldIndividually = false,
         stockStatus = InStock,
-        stockQuantity = 10,
+        stockQuantity = 10.0,
         backorderStatus = No
     )
 
@@ -46,7 +46,7 @@ class ProductInventoryViewModelTest : BaseUnitTest() {
         isStockManaged = true,
         isSoldIndividually = true,
         stockStatus = OutOfStock,
-        stockQuantity = 0,
+        stockQuantity = 0.0,
         backorderStatus = Yes
     )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -46,6 +46,7 @@ object ProductTestUtils {
             ratingCount = 4
             shortDescription = "short desc"
             virtual = isVirtual
+            stockQuantity = 4.2
         }.toAppModel()
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.13.0-beta-3'
+    fluxCVersion = '5f5c55ee7a1d6064be98141875af6139d1ece912'
     daggerVersion = '2.33'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
---

### ⚠️ 👋  This PR requires another extra PR to be added before it is ready to be merged. Please don't merge yet even after it is approved, and wait for the next PR.
---

This PR is **part 2 out of 3** to fix: #3611 
Depends on: [FluxC #1931](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1931) 

## What this PR does:
1. Previously, the app silently fails if it fetches products from backend that have decimal value in `stock_quantity`. With this change, the app will be able to fetch and display products properly in that situation. Also, it will still be able to display products quantity if no decimal `stock_quantity` value is returned.
2. The app will display a rounded stock quantity value without the fractional part (e.g: a product with `10.0` stock quantity value in the database will be shown as having `10` quantity in the app). Otherwise, the fractional part will be shown properly.

## Note to self:
- [x] Once [FluxC #1931](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1931)  is approved, use its latest hash commit to `fluxCVersion` in build.gradle, and add as commit here.
## Screenshots:

Before|After - Products List|After - Simple Products Details|After - Product Variations|
-|-|-|-
![device-2021-03-31-141658](https://user-images.githubusercontent.com/266376/113105495-d46b8f80-922b-11eb-9bef-cb9fef1763b6.png)|![device-2021-03-31-140331](https://user-images.githubusercontent.com/266376/113103862-05e35b80-922a-11eb-8433-5b10c7e1e443.png)|![device-2021-03-31-140638](https://user-images.githubusercontent.com/266376/113104190-712d2d80-922a-11eb-9a6e-fce4ca845c87.png)| ![device-2021-03-31-140946](https://user-images.githubusercontent.com/266376/113104518-d6811e80-922a-11eb-887f-c802e3732fac.png)



## Testing Instructions
**On the WordPress side:**

1. install a plugin that enables decimal stock quantity. I am using [WPC Product Quantity for WooCommerce](https://wordpress.org/plugins/wpc-product-quantity/).
2. Create or edit a simple product, enable "Manage Stock", then change its stock quantity value to non-whole decimal (for example `42.42`). 
3. Create or edit a variable product, go to a variation, enable "Manage Stock", then change a variation's quantity value to non-whole decimal as well.
4. For comparison's sake, also create / edit a simple product and give it a whole number stock quantity.

**On the app side:**
1. Switch to `develop` branch and run the app.
2. Go to "Products" tab, fetch products, and see that it doesn't load anything. 
3. Switch to this PR's branch, run the app.
4. Go to "Products" tab, fetch products, and see that it now loads products again.
5. Select the simple product with decimal stock quantity, and make sure on the "Inventory" card it shows the right decimal stock quantity quantity amount. 
6. Tap the "Inventory" card, and see that the right number also shows up in the "Quantity" field.
7. Go back to "Products" list.
8. Select the variable product with decimal stock quantity, then go to the variation that has the decimal stock quantity. make sure on the "Inventory" card it shows the right decimal amount.
9. Tap the "Inventory" card, and see that the right number also shows up in the "Quantity" field.
10. Go back to "Products". Make sure a product with whole number quantity has its quantity shown as Integer without fraction (e.g.: `22 in stock` instead of `22.0 in stock`).
11. Tap the product on the previous step, make sure also under "Inventory" it doesn't show the fraction. Tap "Inventory" and make sure it also doesn't show the fraction in "Quantity".


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. (Will add note on the next PR)
