### PR TITLE
issue/3745-material-1.3.0

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -144,7 +144,7 @@ dependencies {
     implementation "androidx.recyclerview:recyclerview-selection:1.1.0"
     implementation "androidx.multidex:multidex:2.0.1"
     implementation "androidx.appcompat:appcompat:1.2.0"
-    implementation "com.google.android.material:material:1.2.1"
+    implementation "com.google.android.material:material:1.3.0"
     implementation "androidx.cardview:cardview:1.0.0"
     implementation ("androidx.browser:browser:1.3.0") {
         exclude group: 'com.google.guava', module: 'listenablefuture'


### PR DESCRIPTION
Closes #3745 - This small PR simply updates to [Material Components 1.3.0](https://github.com/material-components/material-components-android/releases/tag/1.3.0).

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
