### PR TITLE
Issue/fix statusbar color lollipop

### DIFF
--- a/WooCommerce/src/main/res/values-v23/themes.xml
+++ b/WooCommerce/src/main/res/values-v23/themes.xml
@@ -9,11 +9,4 @@
         <item name="android:statusBarColor">@color/color_status_bar</item>
         <item name="android:windowLightStatusBar">?attr/isLightTheme</item>
     </style>
-
-    <style name="Theme.Woo.Splash" parent="Theme.Woo">
-        <item name="android:navigationBarColor">@color/splash_background</item>
-        <item name="android:statusBarColor">@color/splash_background</item>
-        <item name="android:windowBackground">@drawable/bg_splash</item>
-        <item name="android:windowLightStatusBar">false</item>
-    </style>
 </resources>

--- a/WooCommerce/src/main/res/values-v23/themes.xml
+++ b/WooCommerce/src/main/res/values-v23/themes.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!--
+        We can set statusBarColor in API 21, but windowLightStatusBar isn't supported until API 23,
+        so if we change the status bar color in the main themes.xml the status bar text won't be
+        readable in API 21
+    -->
+    <style name="Theme.Woo" parent="Theme.WooBase">
+        <item name="android:statusBarColor">@color/color_status_bar</item>
+        <item name="android:windowLightStatusBar">?attr/isLightTheme</item>
+    </style>
+
+    <style name="Theme.Woo.Splash" parent="Theme.Woo">
+        <item name="android:navigationBarColor">@color/splash_background</item>
+        <item name="android:statusBarColor">@color/splash_background</item>
+        <item name="android:windowBackground">@drawable/bg_splash</item>
+        <item name="android:windowLightStatusBar">false</item>
+    </style>
+</resources>

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -35,7 +35,6 @@
         <item name="android:colorControlActivated">@color/color_primary</item>
         <item name="scrimBackground">@color/color_scrim_background</item>
         <item name="android:navigationBarColor">@color/nav_bar</item>
-        <item name="android:statusBarColor">@color/color_status_bar</item>
         <item name="elevationOverlayEnabled">true</item>
         <item name="elevationOverlayColor">@color/woo_white</item>
         <item name="android:textColorLink">@color/color_secondary</item>


### PR DESCRIPTION
As @hichamboushaba pointed out [here](https://github.com/woocommerce/woocommerce-android/pull/3740#issuecomment-806524716), the changes made in #3740 make the status bar text unreadable on API 21. This PR resolves this by moving the status bar color to a v23 `themes.xml`. And I've included a comment to make sure I don't remove the v23 themes file again :)

Here's the status bar now on Lollipop (API 21):

![lollipop](https://user-images.githubusercontent.com/3903757/112464230-9d801000-8d39-11eb-9e18-a697f5843258.png)


And on Marshmallow (API 23):

![marshmallow](https://user-images.githubusercontent.com/3903757/112464253-a375f100-8d39-11eb-8b3d-a7e174b79276.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
