### PR TITLE
Introduce "Manage card reader" section in settings (in debug builds)

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CardReaderSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CardReaderSettingsFragment.kt
@@ -1,0 +1,30 @@
+package com.woocommerce.android.ui.prefs
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.databinding.FragmentSettingsCardReaderBinding
+
+class CardReaderSettingsFragment : Fragment(R.layout.fragment_settings_card_reader) {
+    companion object {
+        const val TAG = "card-reader-settings"
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val binding = FragmentSettingsCardReaderBinding.bind(view)
+        binding.connectReaderButton.setOnClickListener {
+            // TODO card reader implement connect reader button
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        AnalyticsTracker.trackViewShown(this)
+
+        activity?.setTitle(R.string.settings_card_reader)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -118,7 +118,7 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
             AppPrefs.setImageOptimizationEnabled(isChecked)
         }
 
-        binding.storeSettingsContainer.visibility = if(FeatureFlag.CARD_READER.isEnabled()) View.VISIBLE else View.GONE
+        binding.storeSettingsContainer.visibility = if (FeatureFlag.CARD_READER.isEnabled()) View.VISIBLE else View.GONE
         binding.optionCardReader.setOnClickListener {
             // TODO cardreader Add tracking
             findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_cardReaderSettingsFragment)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -39,6 +39,7 @@ import com.woocommerce.android.ui.sitepicker.SitePickerActivity
 import com.woocommerce.android.util.AnalyticsUtils
 import com.woocommerce.android.util.AppThemeUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.ThemeOption
 import com.woocommerce.android.widgets.WCPromoTooltip
 import com.woocommerce.android.widgets.WCPromoTooltip.Feature
@@ -115,6 +116,12 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
                     mapOf(AnalyticsTracker.KEY_STATE to AnalyticsUtils.getToggleStateLabel(isChecked))
             )
             AppPrefs.setImageOptimizationEnabled(isChecked)
+        }
+
+        binding.storeSettingsContainer.visibility = if(FeatureFlag.CARD_READER.isEnabled()) View.VISIBLE else View.GONE
+        binding.optionCardReader.setOnClickListener {
+            // TODO cardreader Add tracking
+            findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_cardReaderSettingsFragment)
         }
 
         binding.optionHelpAndSupport.setOnClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -9,7 +9,8 @@ enum class FeatureFlag {
     SHIPPING_LABELS_M2,
     ADD_EDIT_VARIATIONS,
     DB_DOWNGRADE,
-    ORDER_CREATION;
+    ORDER_CREATION,
+    CARD_READER;
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
             SHIPPING_LABELS_M2 -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
@@ -18,6 +19,7 @@ enum class FeatureFlag {
                 PackageUtils.isDebugBuild() || context != null && PackageUtils.isBetaBuild(context)
             }
             ORDER_CREATION -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
+            CARD_READER -> PackageUtils.isDebugBuild()
         }
     }
 }

--- a/WooCommerce/src/main/res/layout/fragment_settings_card_reader.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_card_reader.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/colorSurface">
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/connect_reader_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/settings_card_reader_connect"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -24,8 +24,34 @@
         tools:optionTitle="testwooshop.mystagingwebsite.com"
         tools:optionValue="Woo Tester" />
 
-    <View style="@style/Woo.Divider" />
 
+    <LinearLayout
+        android:id="@+id/store_settings_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"
+        android:orientation="vertical">
+
+        <View style="@style/Woo.Divider" />
+        <!--
+                Store Settings
+            -->
+        <com.woocommerce.android.ui.prefs.WCSettingsCategoryHeaderView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/settings_store" />
+        <!--
+            Card Reader
+        -->
+        <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+            android:id="@+id/option_card_reader"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:optionTitle="@string/settings_card_reader" />
+
+    </LinearLayout>
+
+    <View style="@style/Woo.Divider" />
     <!--
         Help & support
     -->

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -24,6 +24,17 @@
         tools:optionTitle="testwooshop.mystagingwebsite.com"
         tools:optionValue="Woo Tester" />
 
+    <View style="@style/Woo.Divider" />
+    <!--
+        Help & support
+    -->
+    <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+        android:id="@+id/option_help_and_support"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:optionTitle="@string/support_help" />
+
+
 
     <LinearLayout
         android:id="@+id/store_settings_container"
@@ -50,16 +61,6 @@
             app:optionTitle="@string/settings_card_reader" />
 
     </LinearLayout>
-
-    <View style="@style/Woo.Divider" />
-    <!--
-        Help & support
-    -->
-    <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-        android:id="@+id/option_help_and_support"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:optionTitle="@string/support_help" />
 
     <View style="@style/Woo.Divider" />
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -9,6 +9,13 @@
         android:name="com.woocommerce.android.ui.prefs.MainSettingsFragment"
         android:label="MainSettingsFragment">
         <action
+            android:id="@+id/action_mainSettingsFragment_to_cardReaderSettingsFragment"
+            app:destination="@id/cardReaderSettingsFragment"
+            app:enterAnim="@anim/activity_slide_in_from_right"
+            app:exitAnim="@anim/activity_slide_out_to_left"
+            app:popEnterAnim="@anim/activity_slide_in_from_left"
+            app:popExitAnim="@anim/activity_slide_out_to_right" />
+        <action
             android:id="@+id/action_mainSettingsFragment_to_privacySettingsFragment"
             app:destination="@id/privacySettingsFragment"
             app:enterAnim="@anim/activity_slide_in_from_right"
@@ -45,6 +52,10 @@
             app:popEnterAnim="@anim/activity_slide_in_from_left"
             app:popExitAnim="@anim/activity_slide_out_to_right" />
     </fragment>
+    <fragment
+        android:id="@+id/cardReaderSettingsFragment"
+        android:name="com.woocommerce.android.ui.prefs.CardReaderSettingsFragment"
+        android:label="CardReaderSettingsFragment" />
     <fragment
         android:id="@+id/privacySettingsFragment"
         android:name="com.woocommerce.android.ui.prefs.PrivacySettingsFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -913,6 +913,9 @@
     <string name="settings_footer">Made with love by Automattic. %1$s</string>
     <string name="settings_hiring">We\'re hiring!</string>
     <string name="settings_selected_store">Selected store</string>
+    <string name="settings_store">Store settings</string>
+    <string name="settings_card_reader">Manage card reader</string>
+    <string name="settings_card_reader_connect">Connect card reader</string>
     <string name="settings_notifs">Notifications</string>
     <string name="settings_notifs_device">Manage notifications</string>
     <string name="settings_notifs_device_detail">Sounds, urgency, and notification dot</string>


### PR DESCRIPTION
Parent issue #3725 

- Adds CardReader feature flag which is enabled only in debug builds
- Adds "Manage Card Reader" row into app settings which is shown only when the feature flag is enabled (= in debug builds) -> ACAICT the flag is not testable without significant changes to its implementation -> I didn't introduce any unit tests 
- Adds a new fragment with a "Connect card reader" button which doesn't do anything yet (coming up in another PR)

| Before | After |
|---|---|
| <img src="https://user-images.githubusercontent.com/2261188/112656220-cd511580-8e16-11eb-9979-09dc148b3a64.png" width="250px" /> | <img src="https://user-images.githubusercontent.com/2261188/112656848-6aac4980-8e17-11eb-9181-770d51d8ab9b.png" width="250px" /> |

To test:
1. Navigate to app settings and notice the new "Store settings" section with "Manage card reader" row
-----
1. Build a production build or change [this](https://github.com/woocommerce/woocommerce-android/blob/683789eca7cad63eecc2ca9a101240e2d696314a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt#L121) `if` to `false`
2. Navigate to app settings and notice the "Store settings" section is not visible and there are no extra or missing horizontal dividers

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
