### PR TITLE
Issue/3209 remove attribute

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1006,6 +1006,19 @@ class ProductDetailViewModel @AssistedInject constructor(
         }
     }
 
+    fun removeAttributeFromDraft(attributeId: Long, attributeName: String) {
+        val draftAttributes = getProductDraftAttributes()
+
+        // create an updated list without this attribute and save it to the draft
+        ArrayList<ProductAttribute>().also { updatedAttributes ->
+            updatedAttributes.addAll(draftAttributes.filterNot { attribute ->
+                attribute.id == attributeId && attribute.name == attributeName
+            })
+
+            updateProductDraft(attributes = updatedAttributes)
+        }
+    }
+
     /**
      * Adds a new term to a the product draft attributes
      */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1138,7 +1138,7 @@ class ProductDetailViewModel @AssistedInject constructor(
      * User clicked an attribute in the attribute list fragment or the add attribute fragment
      */
     fun onAttributeListItemClick(attributeId: Long, attributeName: String) {
-        triggerEvent(AddProductAttributeTerms(attributeId, attributeName))
+        triggerEvent(AddProductAttributeTerms(attributeId, attributeName, isNewAttribute = false))
     }
 
     /**
@@ -1213,7 +1213,7 @@ class ProductDetailViewModel @AssistedInject constructor(
         updateProductDraft(attributes = attributes)
 
         // take the user to the add attribute terms screen
-        triggerEvent(AddProductAttributeTerms(0L, attributeName))
+        triggerEvent(AddProductAttributeTerms(0L, attributeName, isNewAttribute = true))
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
@@ -77,6 +77,7 @@ sealed class ProductNavigationTarget : Event() {
     object AddProductAttribute : ProductNavigationTarget()
     data class AddProductAttributeTerms(
         val attributeId: Long,
-        val attributeName: String
+        val attributeName: String,
+        val isNewAttribute: Boolean
     ) : ProductNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -290,7 +290,8 @@ class ProductNavigator @Inject constructor() {
             is AddProductAttributeTerms -> {
                 val action = NavGraphProductsDirections.actionGlobalAddVariationAttributeTermsFragment(
                     target.attributeId,
-                    target.attributeName
+                    target.attributeName,
+                    target.isNewAttribute
                 )
                 fragment.findNavController().navigate(action)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
@@ -1,7 +1,11 @@
 package com.woocommerce.android.ui.products.variations.attributes
 
+import android.content.DialogInterface
 import android.os.Bundle
 import android.os.Parcelable
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import androidx.core.view.isVisible
 import androidx.lifecycle.Observer
@@ -16,6 +20,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentAddAttributeTermsBinding
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.ProductAttributeTerm
+import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.products.BaseProductFragment
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitProductAddAttributeTerms
 import com.woocommerce.android.ui.products.variations.attributes.AttributeTermsListAdapter.OnTermListener
@@ -32,6 +37,7 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
         const val TAG: String = "AddAttributeTermsFragment"
         private const val LIST_STATE_KEY_ASSIGNED = "list_state_assigned"
         private const val LIST_STATE_KEY_GLOBAL = "list_state_global"
+        private const val KEY_IS_CONFIRM_REMOVE_DIALOG_SHOWING = "is_remove_dialog_showing"
     }
 
     private var layoutManagerAssigned: LinearLayoutManager? = null
@@ -42,6 +48,8 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
 
     private val navArgs: AddAttributeTermsFragmentArgs by navArgs()
     private val skeletonView = SkeletonView()
+
+    private var isConfirmRemoveDialogShowing = false
 
     private val itemTouchHelper by lazy {
         DraggableItemTouchHelper(
@@ -107,6 +115,14 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
         initializeViews(savedInstanceState)
         setupObservers()
         getAttributeTerms()
+
+        setHasOptionsMenu(true)
+
+        savedInstanceState?.let { bundle ->
+            if (bundle.getBoolean(KEY_IS_CONFIRM_REMOVE_DIALOG_SHOWING)) {
+                confirmRemoveAttribute()
+            }
+        }
     }
 
     private fun getAttributeTerms() {
@@ -125,6 +141,21 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
         _binding = null
     }
 
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        super.onCreateOptionsMenu(menu, inflater)
+        inflater.inflate(R.menu.menu_attribute_terms, menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.menu_remove -> {
+                confirmRemoveAttribute()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
     override fun onRequestAllowBackPress(): Boolean {
         /**
          * TODO: we save attribute changes to the backend here only for testing purposes. Down the road we'll do this
@@ -141,6 +172,9 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
+        if (isConfirmRemoveDialogShowing) {
+            outState.putBoolean(KEY_IS_CONFIRM_REMOVE_DIALOG_SHOWING, true)
+        }
         layoutManagerAssigned?.let {
             outState.putParcelable(LIST_STATE_KEY_ASSIGNED, it.onSaveInstanceState())
         }
@@ -280,5 +314,27 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
             skeletonView.hide()
         }
         checkViews()
+    }
+
+    private fun confirmRemoveAttribute() {
+        isConfirmRemoveDialogShowing = true
+        WooDialog.showDialog(
+            requireActivity(),
+            messageId = R.string.product_attribute_remove,
+            positiveButtonId = R.string.remove,
+            posBtnAction = DialogInterface.OnClickListener { _, _ ->
+                isConfirmRemoveDialogShowing = false
+                removeAttribute()
+            },
+            negativeButtonId = R.string.cancel,
+            negBtnAction = DialogInterface.OnClickListener { _, _ ->
+                isConfirmRemoveDialogShowing = false
+            }
+        )
+    }
+
+    private fun removeAttribute() {
+        viewModel.removeAttributeFromDraft(navArgs.attributeId, navArgs.attributeName)
+        viewModel.onBackButtonClicked(ExitProductAddAttributeTerms())
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
@@ -146,6 +146,12 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
         inflater.inflate(R.menu.menu_attribute_terms, menu)
     }
 
+    override fun onPrepareOptionsMenu(menu: Menu) {
+        super.onPrepareOptionsMenu(menu)
+        // we don't want to show the Remove menu item if this is new attribute
+        menu.findItem(R.id.menu_remove)?.isVisible = !navArgs.isNewAttribute
+    }
+
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_remove -> {
@@ -162,6 +168,7 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
     }
 
     private fun saveChangesAndReturn() {
+        // TODO We probably want to push changes in the main attribute list screen rather than here
         viewModel.saveAttributeChanges()
         viewModel.onBackButtonClicked(ExitProductAddAttributeTerms())
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
@@ -157,13 +157,13 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
     }
 
     override fun onRequestAllowBackPress(): Boolean {
-        /**
-         * TODO: we save attribute changes to the backend here only for testing purposes. Down the road we'll do this
-         * before variations are generated (because they can't be generated until the attributes are saved)
-         */
+        saveChangesAndReturn()
+        return false
+    }
+
+    private fun saveChangesAndReturn() {
         viewModel.saveAttributeChanges()
         viewModel.onBackButtonClicked(ExitProductAddAttributeTerms())
-        return false
     }
 
     override fun onResume() {
@@ -333,8 +333,11 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
         )
     }
 
+    /**
+     * Removes this attribute from the product draft and returns to the attributes screen
+     */
     private fun removeAttribute() {
         viewModel.removeAttributeFromDraft(navArgs.attributeId, navArgs.attributeName)
-        viewModel.onBackButtonClicked(ExitProductAddAttributeTerms())
+        saveChangesAndReturn()
     }
 }

--- a/WooCommerce/src/main/res/menu/menu_attribute_terms.xml
+++ b/WooCommerce/src/main/res/menu/menu_attribute_terms.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/menu_remove"
+        android:title="@string/remove"
+        app:showAsAction="never" />
+</menu>

--- a/WooCommerce/src/main/res/navigation/nav_graph_products.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_products.xml
@@ -137,7 +137,8 @@
     <fragment
         android:id="@+id/addAttributeFragment"
         android:name="com.woocommerce.android.ui.products.variations.attributes.AddAttributeFragment"
-        android:label="addAttributeFragment" />
+        android:label="addAttributeFragment">
+    </fragment>
     <fragment
         android:id="@+id/addAttributeTermsFragment"
         android:name="com.woocommerce.android.ui.products.variations.attributes.AddAttributeTermsFragment"
@@ -150,6 +151,9 @@
             android:name="attributeName"
             app:argType="string"
             app:nullable="false" />
+        <argument
+            android:name="isNewAttribute"
+            app:argType="boolean" />
     </fragment>
     <fragment
         android:id="@+id/aztecEditorFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -72,6 +72,7 @@
     <string name="product_attribute_name_already_exists">An attribute with this name already exists</string>
     <string name="product_term_name_already_exists">An option with this name already exists</string>
     <string name="product_attributes_error_saving">Error while saving your attributes</string>
+    <string name="product_attribute_remove">Remove this attribute?</string>
     <string name="review_notifications">Reviews</string>
     <string name="version_with_name_param">Version %s</string>
     <string name="share_store_button">Share your store</string>


### PR DESCRIPTION
Closes #3209 - adds the ability to remove an attribute. To test:

- View a variable product
- Tap to view its variations
- Tap the "Edit attributes" menu item
- Tap an attribute
- On the screen that enables entering terms, tap the "Remove" menu item and confirm you want to remove it
- Verify the attribute is removed
- Then do the same thing, but choose to add a new attribute instead of tapping an existing one
- Verify the "Remove" menu item doesn't appear (since this is a new attribute)

Note that this only removes the attribute from the variable product - it doesn't remove it from the store.

![remove](https://user-images.githubusercontent.com/3903757/112670860-d7cfd700-8e37-11eb-8e41-86c61f22663b.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
