### PR TITLE
Fix issue of popping backstack after saving state

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/navigation/KeepStateNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/navigation/KeepStateNavigator.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.navigation
 
 import android.content.Context
 import android.os.Bundle
+import android.util.Log
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.navigation.NavDestination
@@ -41,6 +42,14 @@ class KeepStateNavigator(
         val cls = Class.forName(destination.className)
         if (!TopLevelFragment::class.java.isAssignableFrom(cls)) {
             return super.navigate(destination, args, navOptions, navigatorExtras)
+        }
+
+        if (manager.isStateSaved) {
+            Log.i(
+                KeepStateNavigator::class.simpleName, "Ignoring navigate() call: FragmentManager has already" +
+                " saved its state"
+            )
+            return null
         }
 
         val tag = destination.id.toString()


### PR DESCRIPTION
Fixes #3760, I couldn't reproduce the issue at all, and it seems like a very edge case, as the bottom navigation is hidden for all child fragments.

### Fix
As there is no way to ask the fragmentManager to `allowStateLoss` when popping back stack, I added a fix to ignore the call to the navigation if the fragmentManager's state has already been saved.
This won't impact the UX hopefully, as it will happen only if the call is made after the app went to the background, or during a rotation, so when the user comes back to the app, they will just have to re-click on the bottom navigation item to navigate.

### Testing
Just make sure the app's navigation is not impacted.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
