### PR TITLE
Remove redundant API call to fetch order status count when app is first opened

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -45,12 +45,10 @@ import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.generated.WCCoreActionBuilder
-import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.OnJetpackTimeoutError
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.SiteStore
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsPayload
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.utils.ErrorUtils.OnUnexpectedError
 import javax.inject.Inject

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -210,11 +210,6 @@ open class WooCommerce : MultiDexApplication(), HasAndroidInjector, ApplicationL
             dispatcher.dispatch(AccountActionBuilder.newFetchAccountAction())
             dispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction())
             dispatcher.dispatch(SiteActionBuilder.newFetchSitesAction())
-
-            selectedSite.getIfExists()?.let {
-                val payload = FetchOrderStatusOptionsPayload(it)
-                dispatcher.dispatch(WCOrderActionBuilder.newFetchOrderStatusOptionsAction(payload))
-            }
         }
     }
 


### PR DESCRIPTION
Fixes #3668. This tiny PR just removes a redundant API call to fetch the order status count for the store when the app is first opened.

#### To test
Smoke test the app, especially the order processing count to verify that it is getting updated correctly. It should be updated when the app is first opened, when the order status has changed from processing to something else, when a new order notification is received.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
