### PR TITLE
Shipping Labels Purchase: unit tests

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelTestUtils.kt
@@ -1,6 +1,14 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation
 
 import com.woocommerce.android.model.Address
+import com.woocommerce.android.model.PackageDimensions
+import com.woocommerce.android.model.PaymentMethod
+import com.woocommerce.android.model.ShippingLabelPackage
+import com.woocommerce.android.model.ShippingLabelPackage.Item
+import com.woocommerce.android.model.ShippingPackage
+import com.woocommerce.android.model.ShippingRate
+import java.math.BigDecimal
+import java.util.Date
 
 object CreateShippingLabelTestUtils {
     fun generateAddress(): Address {
@@ -16,6 +24,45 @@ object CreateShippingLabelTestUtils {
             city = "Lexington",
             postcode = "11222",
             email = "boss@kfc.com"
+        )
+    }
+
+    fun generatePackage(id: String = "id", provider: String = "provider"): ShippingPackage {
+        return ShippingPackage(
+            id, "title1", false, provider, PackageDimensions(1.0f, 1.0f, 1.0f)
+        )
+    }
+
+    fun generateShippingLabelPackage(
+        id: String = "package1",
+        weight: Float = 10f,
+        selectedPackage: ShippingPackage? = null
+    ): ShippingLabelPackage {
+        return ShippingLabelPackage(
+            id,
+            selectedPackage ?: generatePackage(),
+            weight,
+            listOf(Item(0L, "product", "", "10 kg"))
+        )
+    }
+
+    fun generatePaymentMethod(id: Int = 1, cardType: String = "visa"): PaymentMethod {
+        return PaymentMethod(id, "Jhon Doe", cardType, "1234", Date(2030, 11, 31))
+    }
+
+    fun generateRate(packageId: String = "package1"): ShippingRate {
+        return ShippingRate(
+            packageId = packageId,
+            shipmentId = "shipmentId",
+            rateId = "rateId",
+            serviceId = "serviceId",
+            carrierId = "carrier",
+            serviceName = "service",
+            deliveryDays = 10,
+            price = BigDecimal.TEN,
+            discount = BigDecimal.ZERO,
+            formattedFee = "10 $",
+            option = ShippingRate.Option.DEFAULT
         )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
@@ -7,11 +7,8 @@ import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import com.woocommerce.android.model.PackageDimensions
 import com.woocommerce.android.model.ShippingAccountSettings
 import com.woocommerce.android.model.ShippingLabelPackage
-import com.woocommerce.android.model.ShippingLabelPackage.Item
-import com.woocommerce.android.model.ShippingPackage
 import com.woocommerce.android.model.StoreOwnerDetails
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
@@ -41,12 +38,8 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
     }
 
     private val availablePackages = listOf(
-        ShippingPackage(
-            "id1", "title1", false, "provider1", PackageDimensions(1.0f, 1.0f, 1.0f)
-        ),
-        ShippingPackage(
-            "id2", "title2", false, "provider2", PackageDimensions(1.0f, 1.0f, 1.0f)
-        )
+        CreateShippingLabelTestUtils.generatePackage("id1", "provider1"),
+        CreateShippingLabelTestUtils.generatePackage("id2", "provider2")
     )
 
     private val shippingAccountSettings = ShippingAccountSettings(
@@ -115,11 +108,8 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
     @Test
     fun `test edit flow`() = coroutinesTestRule.testDispatcher.runBlockingTest {
         val currentShippingPackages = arrayOf(
-            ShippingLabelPackage(
-                "package1",
-                availablePackages.first(),
-                10.0f,
-                listOf(Item(0L, "product", "", "10 kg"))
+            CreateShippingLabelTestUtils.generateShippingLabelPackage(
+                selectedPackage = availablePackages[0]
             )
         )
         setup(currentShippingPackages)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentViewModelTest.kt
@@ -7,7 +7,6 @@ import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import com.woocommerce.android.R
-import com.woocommerce.android.model.PaymentMethod
 import com.woocommerce.android.model.ShippingAccountSettings
 import com.woocommerce.android.model.StoreOwnerDetails
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRepository
@@ -28,16 +27,15 @@ import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.API_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
-import java.util.Date
 
 @ExperimentalCoroutinesApi
 class EditShippingLabelPaymentViewModelTest : BaseUnitTest() {
     private val shippingLabelRepository: ShippingLabelRepository = mock()
 
     @Suppress("DEPRECATION")
-    private val paymentMethods = listOf<PaymentMethod>(
-        PaymentMethod(1, "Jhon Doe", "visa", "1234", Date(2030, 11, 31)),
-        PaymentMethod(2, "Jhon Doe", "mastercard", "1234", Date(2030, 11, 31))
+    private val paymentMethods = listOf(
+        CreateShippingLabelTestUtils.generatePaymentMethod(id = 1, cardType = "visa"),
+        CreateShippingLabelTestUtils.generatePaymentMethod(id = 2, cardType = "mastercard")
     )
 
     private val shippingAccountSettings = ShippingAccountSettings(


### PR DESCRIPTION
This just adds unit tests of the shipping labels purchase feature, and closes #3698.

Shouldn't be merged until #3765 is merged.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
