### PR TITLE
Fix layout of Shipping Label format options screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 6.4
 -----
-
+- [*] Fixed a ui bug in the shipping label formats description screen. [https://github.com/woocommerce/woocommerce-android/pull/3791]
 
 6.3
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/LabelFormatOptionsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/LabelFormatOptionsFragment.kt
@@ -1,18 +1,10 @@
 package com.woocommerce.android.ui.orders.shippinglabels
 
-import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 
-class LabelFormatOptionsFragment : Fragment() {
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.fragment_label_format_options, container, false)
-    }
-
+class LabelFormatOptionsFragment : Fragment(R.layout.fragment_label_format_options) {
     override fun onResume() {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)

--- a/WooCommerce/src/main/res/layout/fragment_label_format_options.xml
+++ b/WooCommerce/src/main/res/layout/fragment_label_format_options.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?attr/colorSurface">
@@ -27,8 +28,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            tools:ignore="MissingConstraints">
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/labelFormatOption_legalTxt"
@@ -53,8 +53,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            tools:ignore="MissingConstraints">
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/labelFormatOption_letterTxt"
@@ -79,8 +78,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            tools:ignore="MissingConstraints">
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/labelFormatOption_labelTxt"


### PR DESCRIPTION
Fixes #3787, I think this was caused by the recent [update](https://github.com/woocommerce/woocommerce-android/pull/3686) to ConstraintLayout, the constraints defined on the views took precedence over Flow's constraints.

I removed the constraints from the views:
<img width=300 src="https://user-images.githubusercontent.com/1657201/113333421-51753280-931a-11eb-9c98-162e7f535112.png"/>
<img width=600 src="https://user-images.githubusercontent.com/1657201/113333425-52a65f80-931a-11eb-80d8-67c9ca91182b.png"/>

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
