### PR TITLE
issue/3790-jumbled-epilogue

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -363,10 +363,8 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
             return
         }
 
-        binding.noStoresView.noStoresViewText.visibility = View.GONE
-        binding.noStoresView.btnSecondaryAction.visibility = View.GONE
+        binding.noStoresView.noStoresView.visibility = View.GONE
         binding.siteListContainer.visibility = View.VISIBLE
-        binding.noStoresView.btnSecondaryAction.visibility = View.GONE
 
         binding.siteListLabel.text = when {
             wcSites.size == 1 -> getString(R.string.login_connected_store)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -327,7 +327,12 @@ class SitePickerActivity : AppCompatActivity(), SitePickerContract.View, OnSiteC
                 binding.loginEpilogueButtonBar.buttonSecondary.visibility = View.GONE
             }
 
-            loginSiteUrl?.let { processLoginSite(it) }
+            loginSiteUrl?.let {
+                // hide the site list and validate the url if we already know the connected store, which will happen
+                // if the user logged in by entering their store address
+                binding.siteListContainer.visibility = View.GONE
+                processLoginSite(it)
+            }
             return
         }
 

--- a/WooCommerce/src/main/res/layout/activity_site_picker.xml
+++ b/WooCommerce/src/main/res/layout/activity_site_picker.xml
@@ -84,7 +84,9 @@
 
             <include
                 android:id="@+id/no_stores_view"
-                layout="@layout/view_login_no_stores" />
+                layout="@layout/view_login_no_stores"
+                android:visibility="gone"
+                tools:visibility="visible" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
Fixes #3445 - prior to this PR, this jumbled epilogue screen would briefly appear if you logged in using your site address:

![before](https://user-images.githubusercontent.com/3903757/113342324-59be7500-92fc-11eb-9b4b-efa624c17ac3.png)

This PR resolves this by hiding the empty view and store list in this situation:

![epilogue](https://user-images.githubusercontent.com/3903757/113342297-51fed080-92fc-11eb-85d5-b0b90e638faa.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
