### PR TITLE
Refresh order details after a shipping label refund

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -6,9 +6,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.snackbar.Snackbar.Callback
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedInject
-import dagger.assisted.AssistedFactory
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -48,6 +45,9 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUndoSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import kotlinx.android.parcel.Parcelize
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -248,6 +248,7 @@ class OrderDetailViewModel @AssistedInject constructor(
     fun onShippingLabelRefunded() {
         launch {
             fetchOrderShippingLabelsAsync().await()
+            displayOrderDetails()
         }
     }
 


### PR DESCRIPTION
Fixes #3788, a small fix that adds a missing call to refresh the order details after requesting a shipping label refund.

#### Testing
1. Create an order and a shipping label in wp-admin.
2. Open the order in the app.
3. Click on the overflow button on the shipping label card.
4. Click on Request refund.
5. Click on Refund label.
6. Make sure that the order details are refreshed after the label processing.

You can follow this guide: p91TBi-3xD-p2 for test steps, and make sure that the refund request is done withing 2 minutes of the creation, otherwise it will fail.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.