### PR TITLE
Add payload to fetch sites action

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -50,6 +50,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.OnJetpack
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.SiteStore.FetchSitesPayload
 import org.wordpress.android.fluxc.store.WCPayStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.utils.ErrorUtils.OnUnexpectedError
@@ -214,7 +215,7 @@ open class WooCommerce : MultiDexApplication(), HasAndroidInjector, ApplicationL
         if (networkStatus.isConnected()) {
             dispatcher.dispatch(AccountActionBuilder.newFetchAccountAction())
             dispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction())
-            dispatcher.dispatch(SiteActionBuilder.newFetchSitesAction())
+            dispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(FetchSitesPayload()))
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/MagicLinkInterceptRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/MagicLinkInterceptRepository.kt
@@ -26,6 +26,7 @@ import org.wordpress.android.fluxc.store.AccountStore.AccountErrorType
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged
 import org.wordpress.android.fluxc.store.AccountStore.UpdateTokenPayload
+import org.wordpress.android.fluxc.store.SiteStore.FetchSitesPayload
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.login.LoginAnalyticsListener
 import javax.inject.Inject
@@ -181,7 +182,7 @@ class MagicLinkInterceptRepository @Inject constructor(
             suspendCoroutineWithTimeout<Boolean>(AppConstants.REQUEST_TIMEOUT) {
                 continuationFetchSites = it
 
-                dispatcher.dispatch(SiteActionBuilder.newFetchSitesAction())
+                dispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(FetchSitesPayload()))
             } ?: false // request timed out
         } catch (e: CancellationException) {
             WooLog.e(LOGIN, "Exception encountered while fetching sites", e)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
@@ -33,6 +33,7 @@ import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged
 import org.wordpress.android.fluxc.store.AccountStore.UpdateTokenPayload
 import org.wordpress.android.fluxc.store.NotificationStore
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.SiteStore.FetchSitesPayload
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountPayload
@@ -105,7 +106,7 @@ class MainPresenter @Inject constructor(
     override fun fetchSitesAfterDowngrade() {
         isFetchingSitesAfterDowngrade = true
         mainView?.showProgressDialog(R.string.loading_stores)
-        dispatcher.dispatch(SiteActionBuilder.newFetchSitesAction())
+        dispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(FetchSitesPayload()))
     }
 
     @Suppress("unused")
@@ -143,7 +144,7 @@ class MainPresenter @Inject constructor(
                 dispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction())
             } else if (event.causeOfChange == AccountAction.FETCH_SETTINGS) {
                 // The user's account settings have also been fetched and stored - now we can fetch the user's sites
-                dispatcher.dispatch(SiteActionBuilder.newFetchSitesAction())
+                dispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(FetchSitesPayload()))
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.SiteStore.FetchSitesPayload
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.store.WooCommerceStore.OnApiVersionFetched
@@ -66,7 +67,7 @@ class SitePickerPresenter @Inject constructor(
     }
 
     override fun fetchSitesFromAPI() {
-        dispatcher.dispatch(SiteActionBuilder.newFetchSitesAction())
+        dispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(FetchSitesPayload()))
     }
 
     override fun fetchUpdatedSiteFromAPI(site: SiteModel) {

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '07d58c173950028b50ffbb92eb54ac0cfbdc94bf'
+    fluxCVersion = '8e95528367524778347ed7be9322a2dec233f85a'
     daggerVersion = '2.33'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
@@ -37,6 +37,7 @@ import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.AccountErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.SiteStore.FetchSitesPayload;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 import org.wordpress.android.util.AppLog;
@@ -332,7 +333,7 @@ public abstract class LoginBaseFormFragment<LoginListenerType> extends Fragment 
             mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
         } else if (event.causeOfChange == AccountAction.FETCH_SETTINGS) {
             // The user's account settings have also been fetched and stored - now we can fetch the user's sites
-            mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
+            mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(new FetchSitesPayload()));
             mDispatcher.dispatch(AccountActionBuilder.newFetchSubscriptionsAction());
         }
     }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginWpcomService.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginWpcomService.java
@@ -22,6 +22,7 @@ import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnSocialChanged;
 import org.wordpress.android.fluxc.store.AccountStore.PushSocialPayload;
+import org.wordpress.android.fluxc.store.SiteStore.FetchSitesPayload;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 import org.wordpress.android.login.LoginWpcomService.LoginState;
@@ -375,7 +376,7 @@ public class LoginWpcomService extends AutoForeground<LoginState> {
         } else if (event.causeOfChange == AccountAction.FETCH_SETTINGS) {
             setState(LoginStep.FETCHING_SITES);
             // The user's account settings have also been fetched and stored - now we can fetch the user's sites
-            mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
+            mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(new FetchSitesPayload()));
         }
     }
 


### PR DESCRIPTION
This PR adds an empty `FetchSitesPayload` to `newFetchSitesAction` as part of the Jetpack app filters support in the fetch sites API. It doesn't alter any user-facing functionality in `WCAndroid`.

Related Issue:
https://github.com/wordpress-mobile/WordPress-Android/issues/14299
Related PR:
wordpress-mobile/WordPress-FluxC-Android#1936

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
