### PR TITLE
Run unit tests in CardReaderModule on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,8 +51,11 @@ jobs:
           cache-prefix: tests-cache-v1
       - <<: *copy_gradle_properties
       - run:
-          name: Unit tests
+          name: Unit tests WooCommerce
           command: ./gradlew --stacktrace testVanillaRelease
+      - run:
+          name: Unit tests CardReaderModule
+          command: ./gradlew --stacktrace lib:cardreader:testDebug
       - android/save-gradle-cache:
           cache-prefix: tests-cache-v1
       - android/save-test-results

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
@@ -38,7 +38,7 @@ class CardReaderManagerImplTest {
 
     @Before
     fun setUp() {
-        cardReaderManager = CardReaderManagerImpl(terminalWrapper, tokenProvider, logWrapper)
+        cardReaderManager = CardReaderManagerImpl(terminalWrapper, tokenProvider, logWrapper, mock())
         whenever(terminalWrapper.getLifecycleObserver()).thenReturn(lifecycleObserver)
     }
 


### PR DESCRIPTION
This PR updates the CI config so even unit tests located in CardReaderModule run on each build. We are intentional using "testDebug" and not "testRelease" since most of the classes in CardReaderModule are currently located in "debug" package. We'll move them to the release (main) package when the feature is ready for production. I've added a task to [this issue](https://github.com/woocommerce/woocommerce-android/issues/3724) to make sure we don't forget to udpate the command in the CI config.

Notice [the first run on CI failed](https://app.circleci.com/pipelines/github/woocommerce/woocommerce-android/10479/workflows/c4e6f329-8d7e-49f9-980e-3c5e0b3a4f0a/jobs/33216) due to an issue in `CardReaderManagerImplTest`.
Notice the second run on CI succeeded as d6874e3 fixed the issue.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
