### PR TITLE
Add timeout to collectPayment method

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -229,10 +229,12 @@ class OrderDetailViewModel @AssistedInject constructor(
             cardReaderManager?.collectPayment(999, "usd")?.collect {
                 when (it) {
                     CapturingPaymentFailed,
-                    CollectingPaymentFailed,
                     InitializingPaymentFailed,
                     ProcessingPaymentFailed -> triggerEvent(
                         ShowSnackbar(string.generic_string, arrayOf("Payment failed :("))
+                    )
+                    is CollectingPaymentFailed -> triggerEvent(
+                        ShowSnackbar(string.generic_string, arrayOf("Collecting payment failed:  ${it.error}"))
                     )
                     PaymentCompleted -> triggerEvent(
                         ShowSnackbar(string.generic_string, arrayOf("Payment completed successfully :))"))

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -14,10 +14,12 @@ import com.woocommerce.android.cardreader.CardPaymentStatus.ProcessingPaymentFai
 import com.woocommerce.android.cardreader.CardPaymentStatus.ShowAdditionalInfo
 import com.woocommerce.android.cardreader.CardPaymentStatus.WaitingForInput
 import com.woocommerce.android.cardreader.CardReaderStore
+import com.woocommerce.android.cardreader.CollectingPaymentError
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction.CollectPaymentStatus
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction.CollectPaymentStatus.DisplayMessageRequested
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction.CollectPaymentStatus.ReaderInputRequested
+import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction.CollectPaymentStatus.TimedOut
 import com.woocommerce.android.cardreader.internal.payments.actions.CreatePaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.CreatePaymentAction.CreatePaymentStatus.Failure
 import com.woocommerce.android.cardreader.internal.payments.actions.CreatePaymentAction.CreatePaymentStatus.Success
@@ -81,7 +83,8 @@ internal class PaymentManager(
             when (it) {
                 is DisplayMessageRequested -> emit(ShowAdditionalInfo)
                 is ReaderInputRequested -> emit(WaitingForInput)
-                is CollectPaymentStatus.Failure -> emit(CollectingPaymentFailed)
+                is CollectPaymentStatus.TerminalFailure -> emit(CollectingPaymentFailed(CollectingPaymentError.CARD_READER_ERROR))
+                TimedOut -> emit(CollectingPaymentFailed(CollectingPaymentError.TIMED_OUT))
                 is CollectPaymentStatus.Success -> result = it.paymentIntent
             }
         }

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/payments/actions/CollectPaymentAction.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/payments/actions/CollectPaymentAction.kt
@@ -59,7 +59,7 @@ internal class CollectPaymentAction(private val terminal: TerminalWrapper, priva
 
                     override fun onFailure(e: TerminalException) {
                         logWrapper.d("CardReader", "Payment collection failed")
-                        this@callbackFlow.sendBlocking(TerminalFailure(exception))
+                        this@callbackFlow.sendBlocking(TerminalFailure(e))
                         this@callbackFlow.close()
                     }
                 })

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/payments/actions/CollectPaymentAction.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/payments/actions/CollectPaymentAction.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.cardreader.internal.payments.actions
 
+import com.stripe.stripeterminal.callable.Callback
 import com.stripe.stripeterminal.callable.PaymentIntentCallback
 import com.stripe.stripeterminal.callable.ReaderDisplayListener
 import com.stripe.stripeterminal.model.external.PaymentIntent
@@ -7,27 +8,38 @@ import com.stripe.stripeterminal.model.external.ReaderDisplayMessage
 import com.stripe.stripeterminal.model.external.ReaderInputOptions
 import com.stripe.stripeterminal.model.external.TerminalException
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction.CollectPaymentStatus.DisplayMessageRequested
-import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction.CollectPaymentStatus.Failure
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction.CollectPaymentStatus.ReaderInputRequested
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction.CollectPaymentStatus.Success
+import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction.CollectPaymentStatus.TerminalFailure
+import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction.CollectPaymentStatus.TimedOut
 import com.woocommerce.android.cardreader.internal.wrappers.LogWrapper
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.sendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.withTimeout
 
+private const val TIMEOUT = 45000L
+
+@ExperimentalCoroutinesApi
 internal class CollectPaymentAction(private val terminal: TerminalWrapper, private val logWrapper: LogWrapper) {
     sealed class CollectPaymentStatus {
         data class DisplayMessageRequested(val msg: ReaderDisplayMessage) : CollectPaymentStatus()
         data class ReaderInputRequested(val options: ReaderInputOptions) : CollectPaymentStatus()
         data class Success(val paymentIntent: PaymentIntent) : CollectPaymentStatus()
-        data class Failure(val exception: TerminalException) : CollectPaymentStatus()
+        data class TerminalFailure(val exception: TerminalException) : CollectPaymentStatus()
+        object TimedOut : CollectPaymentStatus()
     }
 
     fun collectPayment(paymentIntent: PaymentIntent): Flow<CollectPaymentStatus> {
-        return callbackFlow {
-            terminal.collectPaymentMethod(paymentIntent, object : ReaderDisplayListener {
+        return callbackFlow<CollectPaymentStatus> {
+            val cancelable = terminal.collectPaymentMethod(paymentIntent, object : ReaderDisplayListener {
                 override fun onRequestReaderDisplayMessage(message: ReaderDisplayMessage) {
                     logWrapper.d("CardReader", message.toString())
                     this@callbackFlow.sendBlocking(DisplayMessageRequested(message))
@@ -45,14 +57,45 @@ internal class CollectPaymentAction(private val terminal: TerminalWrapper, priva
                         this@callbackFlow.close()
                     }
 
-                    override fun onFailure(exception: TerminalException) {
+                    override fun onFailure(e: TerminalException) {
                         logWrapper.d("CardReader", "Payment collection failed")
-                        this@callbackFlow.sendBlocking(Failure(exception))
+                        this@callbackFlow.sendBlocking(TerminalFailure(exception))
                         this@callbackFlow.close()
                     }
                 })
-            // TODO cardreader implement timeout
-            awaitClose()
+            awaitClose {
+                if (!cancelable.isCompleted) {
+                    cancelable.cancel(noopCallback)
+                }
+            }
+        }.timeout(TIMEOUT) {
+            it.sendBlocking(TimedOut)
         }
+    }
+
+    /**
+     * Wrapper for a coroutine which cancels the coroutine if it doesn't complete within `timeout`.
+     *
+     * `onTimeout` can be used to clean up resources or to inform the caller about the timeout.
+     */
+    private fun <T> Flow<T>.timeout(timeout: Long, onTimeout: suspend (ProducerScope<T>) -> Unit) =
+        channelFlow {
+            try {
+                withTimeout(timeout) {
+                    collect { send(it) }
+                }
+            } catch (e: TimeoutCancellationException) {
+                onTimeout(this)
+            }
+        }
+}
+
+private val noopCallback = object : Callback {
+    override fun onFailure(e: TerminalException) {
+        // no-op
+    }
+
+    override fun onSuccess() {
+        // no-op
     }
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardPaymentStatus.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardPaymentStatus.kt
@@ -4,7 +4,7 @@ sealed class CardPaymentStatus {
     object InitializingPayment : CardPaymentStatus()
     object InitializingPaymentFailed : CardPaymentStatus()
     object CollectingPayment : CardPaymentStatus()
-    object CollectingPaymentFailed : CardPaymentStatus()
+    data class CollectingPaymentFailed(val error: CollectingPaymentError) : CardPaymentStatus()
     object WaitingForInput : CardPaymentStatus()
     object ShowAdditionalInfo : CardPaymentStatus()
     object ProcessingPayment : CardPaymentStatus()
@@ -12,4 +12,8 @@ sealed class CardPaymentStatus {
     object CapturingPayment : CardPaymentStatus()
     object CapturingPaymentFailed : CardPaymentStatus()
     object PaymentCompleted : CardPaymentStatus()
+}
+
+enum class CollectingPaymentError {
+    CARD_READER_ERROR, TIMED_OUT
 }


### PR DESCRIPTION
This PR adds a timeout to "collectPayment" method. If the user doesn't tap/insert their card within 45s the flow times out.
This might not be an optimal solution, since StripeTerminalSDK can ask the user for additional info or "retry", but the timeout is not extended in such scenarios. StripeTerminalSDK has its own implementation of timing out, however, it crashes our app in some scenario - we are not able to reproduce such scenario anymore, but it was reported [here](https://github.com/woocommerce/woocommerce-android/pull/3795#issuecomment-812520209). Perhaps simply catching the exception might be a better solution than implementing the timeout ourselves.

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
