### PR TITLE
Shipping Label Packages: fetch the correct weight of variations

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -97,6 +97,8 @@ data class Order(
     ) : Parcelable {
         @IgnoredOnParcel
         val uniqueId: Long = ProductHelper.productOrVariationId(productId, variationId)
+        @IgnoredOnParcel
+        val isVariation: Boolean = variationId != 0L
     }
 
     fun getBillingName(defaultValue: String): String {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -113,7 +113,7 @@ class EditShippingLabelPackagesViewModel @AssistedInject constructor(
         }
 
         order.items.forEach {
-            val result = if (it.variationId != 0L) {
+            val result = if (it.isVariation) {
                 fetchVariationIfNeeded(it.productId, it.variationId)
             } else {
                 fetchProductIfNeeded(it.productId)
@@ -162,7 +162,7 @@ class EditShippingLabelPackagesViewModel @AssistedInject constructor(
     }
 
     private fun Order.Item.toShippingItem(): ShippingLabelPackage.Item {
-        val weight = if (variationId != 0L) {
+        val weight = if (isVariation) {
             variationDetailRepository.getVariation(productId, variationId)!!.weight
         } else {
             productDetailRepository.getProduct(productId)!!.weight

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -97,17 +97,18 @@ class EditShippingLabelPackagesViewModel @AssistedInject constructor(
     }
 
     private suspend fun loadProductsWeightsIfNeeded(order: Order) {
-        suspend fun fetchVariationIfNeeded(productId: Long, variationId: Long): Boolean {
-            if (variationDetailRepository.getVariation(productId, variationId) == null) {
-                return variationDetailRepository.fetchVariation(productId, variationId) != null ||
-                    variationDetailRepository.lastFetchVariationErrorType == ProductErrorType.INVALID_PRODUCT_ID
-            }
-            return true
-        }
         suspend fun fetchProductIfNeeded(productId: Long): Boolean {
             if (productDetailRepository.getProduct(productId) == null) {
                 return productDetailRepository.fetchProduct(productId) != null ||
                     productDetailRepository.lastFetchProductErrorType == ProductErrorType.INVALID_PRODUCT_ID
+            }
+            return true
+        }
+        suspend fun fetchVariationIfNeeded(productId: Long, variationId: Long): Boolean {
+            if (!fetchProductIfNeeded(productId)) return false
+            if (variationDetailRepository.getVariation(productId, variationId) == null) {
+                return variationDetailRepository.fetchVariation(productId, variationId) != null ||
+                    variationDetailRepository.lastFetchVariationErrorType == ProductErrorType.INVALID_PRODUCT_ID
             }
             return true
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailRepository.kt
@@ -43,6 +43,7 @@ class VariationDetailRepository @Inject constructor(
     private var remoteVariationId: Long = 0L
 
     var lastUpdateVariationErrorType: ProductErrorType? = null
+    var lastFetchVariationErrorType: ProductErrorType? = null
 
     init {
         dispatcher.register(this)
@@ -53,6 +54,7 @@ class VariationDetailRepository @Inject constructor(
     }
 
     suspend fun fetchVariation(remoteProductId: Long, remoteVariationId: Long): ProductVariation? {
+        lastFetchVariationErrorType = null
         try {
             this.remoteProductId = remoteProductId
             this.remoteVariationId = remoteVariationId
@@ -114,6 +116,7 @@ class VariationDetailRepository @Inject constructor(
             event.remoteVariationId == remoteVariationId) {
             if (continuationFetchVariation?.isActive == true) {
                 if (event.isError) {
+                    lastFetchVariationErrorType = event.error?.type
                     continuationFetchVariation?.resume(false)
                 } else {
                     AnalyticsTracker.track(PRODUCT_VARIATION_LOADED)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.ProductDetailRepository
 import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.products.models.SiteParameters
+import com.woocommerce.android.ui.products.variations.VariationDetailRepository
 import com.woocommerce.android.util.CoroutineTestRule
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -66,6 +67,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
 
     private val orderDetailRepository: OrderDetailRepository = mock()
     private val productDetailRepository: ProductDetailRepository = mock()
+    private val variationDetailRepository: VariationDetailRepository = mock()
     private val shippingLabelRepository: ShippingLabelRepository = mock()
     private val parameterRepository: ParameterRepository = mock()
 
@@ -93,6 +95,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
             coroutinesTestRule.testDispatchers,
             productDetailRepository = productDetailRepository,
             orderDetailRepository = orderDetailRepository,
+            variationDetailRepository = variationDetailRepository,
             shippingLabelRepository = shippingLabelRepository,
             parameterRepository = parameterRepository
         )


### PR DESCRIPTION
Fixes #3779 by correctly fetching the variation weight if the item is a variation.

#### Testing
1. Modify a variable product by specifying different weight to one of its variations.
2. Create an order using this variation, and make sure it satisfies the SL creation conditions.
3. Open the order in the app.
4. Click on Create Shipping Label.
5. Pass the origin and shipping addresses steps.
6. Open the package details screen.
7. Confirm that the shown weight is the correct overridden weight of the variation.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
