### PR TITLE
Extract code related to reader connection to ConnectionManager

### DIFF
--- a/libs/cardreader/build.gradle
+++ b/libs/cardreader/build.gradle
@@ -25,6 +25,9 @@ android {
     }
     kotlinOptions {
         jvmTarget = '1.8'
+        freeCompilerArgs += [
+                "-Xuse-experimental=kotlinx.coroutines.ExperimentalCoroutinesApi"
+        ]
     }
 }
 

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
@@ -3,13 +3,16 @@ package com.woocommerce.android.cardreader
 import com.woocommerce.android.cardreader.internal.CardReaderManagerImpl
 import com.woocommerce.android.cardreader.internal.payments.PaymentManager
 import com.woocommerce.android.cardreader.internal.TokenProvider
+import com.woocommerce.android.cardreader.internal.connection.ConnectionManager
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.CreatePaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.ProcessPaymentAction
 import com.woocommerce.android.cardreader.internal.wrappers.LogWrapper
 import com.woocommerce.android.cardreader.internal.wrappers.PaymentIntentParametersFactory
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 
+@ExperimentalCoroutinesApi
 object CardReaderManagerFactory {
     fun createCardReaderManager(cardReaderStore: CardReaderStore): CardReaderManager {
         val terminal = TerminalWrapper()
@@ -23,7 +26,8 @@ object CardReaderManagerFactory {
                 CreatePaymentAction(PaymentIntentParametersFactory(), terminal, logWrapper),
                 CollectPaymentAction(terminal, logWrapper),
                 ProcessPaymentAction(terminal, logWrapper)
-            )
+            ),
+            ConnectionManager(terminal, logWrapper)
         )
     }
 }

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
@@ -1,18 +1,16 @@
 package com.woocommerce.android.cardreader
 
 import com.woocommerce.android.cardreader.internal.CardReaderManagerImpl
-import com.woocommerce.android.cardreader.internal.payments.PaymentManager
 import com.woocommerce.android.cardreader.internal.TokenProvider
 import com.woocommerce.android.cardreader.internal.connection.ConnectionManager
+import com.woocommerce.android.cardreader.internal.payments.PaymentManager
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.CreatePaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.ProcessPaymentAction
 import com.woocommerce.android.cardreader.internal.wrappers.LogWrapper
 import com.woocommerce.android.cardreader.internal.wrappers.PaymentIntentParametersFactory
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 
-@ExperimentalCoroutinesApi
 object CardReaderManagerFactory {
     fun createCardReaderManager(cardReaderStore: CardReaderStore): CardReaderManager {
         val terminal = TerminalWrapper()

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -3,25 +3,12 @@ package com.woocommerce.android.cardreader.internal
 import android.app.Application
 import android.content.ComponentCallbacks2
 import android.content.res.Configuration
-import com.stripe.stripeterminal.callable.Callback
-import com.stripe.stripeterminal.callable.DiscoveryListener
-import com.stripe.stripeterminal.callable.ReaderCallback
-import com.stripe.stripeterminal.callable.TerminalListener
 import com.stripe.stripeterminal.log.LogLevel
-import com.stripe.stripeterminal.model.external.ConnectionStatus
-import com.stripe.stripeterminal.model.external.ConnectionStatus.CONNECTED
-import com.stripe.stripeterminal.model.external.ConnectionStatus.CONNECTING
-import com.stripe.stripeterminal.model.external.ConnectionStatus.NOT_CONNECTED
-import com.stripe.stripeterminal.model.external.DeviceType
-import com.stripe.stripeterminal.model.external.DiscoveryConfiguration
-import com.stripe.stripeterminal.model.external.PaymentStatus
-import com.stripe.stripeterminal.model.external.Reader
-import com.stripe.stripeterminal.model.external.ReaderEvent
-import com.stripe.stripeterminal.model.external.TerminalException
 import com.woocommerce.android.cardreader.CardPaymentStatus
 import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.CardReaderStatus
+import com.woocommerce.android.cardreader.internal.connection.ConnectionManager
 import com.woocommerce.android.cardreader.internal.payments.PaymentManager
 import com.woocommerce.android.cardreader.internal.wrappers.LogWrapper
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
@@ -37,7 +24,8 @@ internal class CardReaderManagerImpl(
     private val terminal: TerminalWrapper,
     private val tokenProvider: TokenProvider,
     private val logWrapper: LogWrapper,
-    private val paymentManager: PaymentManager
+    private val paymentManager: PaymentManager,
+    private val connectionManager: ConnectionManager
 ) : CardReaderManager {
     companion object {
         private const val TAG = "CardReaderManager"
@@ -48,12 +36,9 @@ internal class CardReaderManagerImpl(
         get() { return terminal.isInitialized() }
 
     @ExperimentalCoroutinesApi
-    override val discoveryEvents: MutableStateFlow<CardReaderDiscoveryEvents> = MutableStateFlow(
-        CardReaderDiscoveryEvents.NotStarted
-    )
+    override val discoveryEvents: MutableStateFlow<CardReaderDiscoveryEvents> = connectionManager.discoveryEvents
 
-    override val readerStatus: MutableStateFlow<CardReaderStatus> = MutableStateFlow(CardReaderStatus.NOT_CONNECTED)
-    private val foundReaders = mutableSetOf<Reader>()
+    override val readerStatus: MutableStateFlow<CardReaderStatus> = connectionManager.readerStatus
 
     override fun initialize(app: Application) {
         if (!terminal.isInitialized()) {
@@ -84,75 +69,18 @@ internal class CardReaderManagerImpl(
 
     override fun startDiscovery(isSimulated: Boolean) {
         if (!terminal.isInitialized()) throw IllegalStateException("Terminal not initialized")
-        val config = DiscoveryConfiguration(0, DeviceType.CHIPPER_2X, isSimulated)
-        discoveryEvents.value = CardReaderDiscoveryEvents.Started
-        terminal.discoverReaders(config, object : DiscoveryListener {
-            override fun onUpdateDiscoveredReaders(readers: List<Reader>) {
-                foundReaders.addAll(readers)
-                discoveryEvents.value = CardReaderDiscoveryEvents.ReadersFound(readers.mapNotNull { it.serialNumber })
-            }
-        }, object : Callback {
-            override fun onFailure(e: TerminalException) {
-                discoveryEvents.value = CardReaderDiscoveryEvents.Failed(e.toString())
-            }
-
-            override fun onSuccess() {}
-        })
+        connectionManager.startDiscovery(isSimulated)
     }
 
     override fun connectToReader(readerId: String) {
         if (!terminal.isInitialized()) throw IllegalStateException("Terminal not initialized")
-        foundReaders.find { it.serialNumber == readerId }?.let {
-            terminal.connectToReader(it, object : ReaderCallback {
-                override fun onFailure(e: TerminalException) {
-                    logWrapper.d("CardReader", "connecting to reader failed: ${e.errorMessage}")
-                }
-
-                override fun onSuccess(reader: Reader) {
-                    logWrapper.d("CardReader", "connecting to reader succeeded")
-                }
-            })
-        } ?: logWrapper.e("CardReader", "Connecting to reader failed: reader not found")
+        connectionManager.connectToReader(readerId)
     }
 
     override suspend fun collectPayment(amount: Int, currency: String): Flow<CardPaymentStatus> =
         paymentManager.acceptPayment(amount, currency)
 
     private fun initStripeTerminal(logLevel: LogLevel) {
-        val listener = object : TerminalListener {
-            override fun onUnexpectedReaderDisconnect(reader: Reader) {
-                readerStatus.value = CardReaderStatus.NOT_CONNECTED
-                logWrapper.d("CardReader", "onUnexpectedReaderDisconnect")
-            }
-
-            override fun onConnectionStatusChange(status: ConnectionStatus) {
-                super.onConnectionStatusChange(status)
-                readerStatus.value = when (status) {
-                    NOT_CONNECTED -> CardReaderStatus.NOT_CONNECTED
-                    CONNECTING -> CardReaderStatus.CONNECTING
-                    CONNECTED -> CardReaderStatus.CONNECTED
-                }
-                logWrapper.d("CardReader", "onConnectionStatusChange: ${status.name}")
-            }
-
-            override fun onPaymentStatusChange(status: PaymentStatus) {
-                super.onPaymentStatusChange(status)
-                // TODO cardreader: Not Implemented
-                logWrapper.d("CardReader", "onPaymentStatusChange: ${status.name}")
-            }
-
-            override fun onReportLowBatteryWarning() {
-                super.onReportLowBatteryWarning()
-                // TODO cardreader: Not Implemented
-                logWrapper.d("CardReader", "onReportLowBatteryWarning")
-            }
-
-            override fun onReportReaderEvent(event: ReaderEvent) {
-                super.onReportReaderEvent(event)
-                // TODO cardreader: Not Implemented
-                logWrapper.d("CardReader", "onReportReaderEvent: $event.name")
-            }
-        }
-        terminal.initTerminal(application, logLevel, tokenProvider, listener)
+        terminal.initTerminal(application, logLevel, tokenProvider, connectionManager)
     }
 }

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -12,14 +12,12 @@ import com.woocommerce.android.cardreader.internal.connection.ConnectionManager
 import com.woocommerce.android.cardreader.internal.payments.PaymentManager
 import com.woocommerce.android.cardreader.internal.wrappers.LogWrapper
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 
 /**
  * Implementation of CardReaderManager using StripeTerminalSDK.
  */
-@ExperimentalCoroutinesApi
 internal class CardReaderManagerImpl(
     private val terminal: TerminalWrapper,
     private val tokenProvider: TokenProvider,
@@ -35,7 +33,6 @@ internal class CardReaderManagerImpl(
     override val isInitialized: Boolean
         get() { return terminal.isInitialized() }
 
-    @ExperimentalCoroutinesApi
     override val discoveryEvents: MutableStateFlow<CardReaderDiscoveryEvents> = connectionManager.discoveryEvents
 
     override val readerStatus: MutableStateFlow<CardReaderStatus> = connectionManager.readerStatus

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
@@ -1,0 +1,101 @@
+package com.woocommerce.android.cardreader.internal.connection
+
+import com.stripe.stripeterminal.callable.Callback
+import com.stripe.stripeterminal.callable.DiscoveryListener
+import com.stripe.stripeterminal.callable.ReaderCallback
+import com.stripe.stripeterminal.callable.TerminalListener
+import com.stripe.stripeterminal.model.external.ConnectionStatus
+import com.stripe.stripeterminal.model.external.ConnectionStatus.CONNECTED
+import com.stripe.stripeterminal.model.external.ConnectionStatus.CONNECTING
+import com.stripe.stripeterminal.model.external.ConnectionStatus.NOT_CONNECTED
+import com.stripe.stripeterminal.model.external.DeviceType.CHIPPER_2X
+import com.stripe.stripeterminal.model.external.DiscoveryConfiguration
+import com.stripe.stripeterminal.model.external.PaymentStatus
+import com.stripe.stripeterminal.model.external.Reader
+import com.stripe.stripeterminal.model.external.ReaderEvent
+import com.stripe.stripeterminal.model.external.TerminalException
+import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents
+import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents.NotStarted
+import com.woocommerce.android.cardreader.CardReaderStatus
+import com.woocommerce.android.cardreader.internal.wrappers.LogWrapper
+import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+
+@ExperimentalCoroutinesApi
+internal class ConnectionManager(
+    private val terminal: TerminalWrapper,
+    private val logWrapper: LogWrapper
+) : TerminalListener {
+    private val foundReaders = mutableSetOf<Reader>()
+
+    val discoveryEvents: MutableStateFlow<CardReaderDiscoveryEvents> = MutableStateFlow(NotStarted)
+
+    val readerStatus: MutableStateFlow<CardReaderStatus> = MutableStateFlow(CardReaderStatus.NOT_CONNECTED)
+
+    fun startDiscovery(isSimulated: Boolean) {
+        val config = DiscoveryConfiguration(0, CHIPPER_2X, isSimulated)
+        discoveryEvents.value = CardReaderDiscoveryEvents.Started
+        terminal.discoverReaders(config, object : DiscoveryListener {
+            override fun onUpdateDiscoveredReaders(readers: List<Reader>) {
+                foundReaders.addAll(readers)
+                discoveryEvents.value = CardReaderDiscoveryEvents.ReadersFound(readers.mapNotNull { it.serialNumber })
+            }
+        }, object : Callback {
+            override fun onFailure(e: TerminalException) {
+                discoveryEvents.value = CardReaderDiscoveryEvents.Failed(e.toString())
+            }
+
+            override fun onSuccess() {
+                // It seems that StripeTerminalSDK never invokes this method
+            }
+        })
+    }
+
+    fun connectToReader(readerId: String) {
+        foundReaders.find { it.serialNumber == readerId }?.let {
+            terminal.connectToReader(it, object : ReaderCallback {
+                override fun onFailure(e: TerminalException) {
+                    logWrapper.d("CardReader", "connecting to reader failed: ${e.errorMessage}")
+                }
+
+                override fun onSuccess(reader: Reader) {
+                    logWrapper.d("CardReader", "connecting to reader succeeded")
+                }
+            })
+        } ?: logWrapper.e("CardReader", "Connecting to reader failed: reader not found")
+    }
+
+    override fun onUnexpectedReaderDisconnect(reader: Reader) {
+        readerStatus.value = CardReaderStatus.NOT_CONNECTED
+        logWrapper.d("CardReader", "onUnexpectedReaderDisconnect")
+    }
+
+    override fun onConnectionStatusChange(status: ConnectionStatus) {
+        super.onConnectionStatusChange(status)
+        readerStatus.value = when (status) {
+            NOT_CONNECTED -> CardReaderStatus.NOT_CONNECTED
+            CONNECTING -> CardReaderStatus.CONNECTING
+            CONNECTED -> CardReaderStatus.CONNECTED
+        }
+        logWrapper.d("CardReader", "onConnectionStatusChange: ${status.name}")
+    }
+
+    override fun onPaymentStatusChange(status: PaymentStatus) {
+        super.onPaymentStatusChange(status)
+        // TODO cardreader: Not Implemented
+        logWrapper.d("CardReader", "onPaymentStatusChange: ${status.name}")
+    }
+
+    override fun onReportLowBatteryWarning() {
+        super.onReportLowBatteryWarning()
+        // TODO cardreader: Not Implemented
+        logWrapper.d("CardReader", "onReportLowBatteryWarning")
+    }
+
+    override fun onReportReaderEvent(event: ReaderEvent) {
+        super.onReportReaderEvent(event)
+        // TODO cardreader: Not Implemented
+        logWrapper.d("CardReader", "onReportReaderEvent: $event.name")
+    }
+}

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
@@ -19,10 +19,8 @@ import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents.NotStarted
 import com.woocommerce.android.cardreader.CardReaderStatus
 import com.woocommerce.android.cardreader.internal.wrappers.LogWrapper
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 
-@ExperimentalCoroutinesApi
 internal class ConnectionManager(
     private val terminal: TerminalWrapper,
     private val logWrapper: LogWrapper

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -24,14 +24,12 @@ import com.woocommerce.android.cardreader.internal.payments.actions.CreatePaymen
 import com.woocommerce.android.cardreader.internal.payments.actions.ProcessPaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.ProcessPaymentAction.ProcessPaymentStatus
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
 
-@ExperimentalCoroutinesApi
 internal class PaymentManager(
     private val cardReaderStore: CardReaderStore,
     private val createPaymentAction: CreatePaymentAction,

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentAction.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentAction.kt
@@ -9,13 +9,11 @@ import com.woocommerce.android.cardreader.internal.payments.actions.CreatePaymen
 import com.woocommerce.android.cardreader.internal.wrappers.LogWrapper
 import com.woocommerce.android.cardreader.internal.wrappers.PaymentIntentParametersFactory
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.sendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 
-@ExperimentalCoroutinesApi
 internal class CreatePaymentAction(
     private val paymentIntentParametersFactory: PaymentIntentParametersFactory,
     private val terminal: TerminalWrapper,
@@ -35,9 +33,9 @@ internal class CreatePaymentAction(
                     this@callbackFlow.close()
                 }
 
-                override fun onFailure(exception: TerminalException) {
+                override fun onFailure(e: TerminalException) {
                     logWrapper.d("CardReader", "Creating payment intent failed")
-                    this@callbackFlow.sendBlocking(Failure(exception))
+                    this@callbackFlow.sendBlocking(Failure(e))
                     this@callbackFlow.close()
                 }
             })

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
@@ -1,14 +1,12 @@
 package com.woocommerce.android.cardreader
 
 import android.app.Application
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 
 /**
  * Interface for consumers who want to start accepting POC card payments.
  */
-@ExperimentalCoroutinesApi
 interface CardReaderManager {
     val isInitialized: Boolean
     val discoveryEvents: MutableStateFlow<CardReaderDiscoveryEvents>

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
@@ -8,15 +8,7 @@ import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import com.stripe.stripeterminal.TerminalLifecycleObserver
-import com.stripe.stripeterminal.callable.Cancelable
-import com.stripe.stripeterminal.callable.DiscoveryListener
-import com.stripe.stripeterminal.callable.TerminalListener
-import com.stripe.stripeterminal.model.external.ConnectionStatus.CONNECTED
-import com.stripe.stripeterminal.model.external.ConnectionStatus.CONNECTING
-import com.stripe.stripeterminal.model.external.ConnectionStatus.NOT_CONNECTED
-import com.stripe.stripeterminal.model.external.Reader
-import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents
-import com.woocommerce.android.cardreader.CardReaderStatus
+import com.woocommerce.android.cardreader.internal.connection.ConnectionManager
 import com.woocommerce.android.cardreader.internal.wrappers.LogWrapper
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -35,10 +27,11 @@ class CardReaderManagerImplTest {
     private val lifecycleObserver: TerminalLifecycleObserver = mock()
     private val application: Application = mock()
     private val logWrapper: LogWrapper = mock()
+    private val connectionManager: ConnectionManager = mock()
 
     @Before
     fun setUp() {
-        cardReaderManager = CardReaderManagerImpl(terminalWrapper, tokenProvider, logWrapper, mock())
+        cardReaderManager = CardReaderManagerImpl(terminalWrapper, tokenProvider, logWrapper, mock(), connectionManager)
         whenever(terminalWrapper.getLifecycleObserver()).thenReturn(lifecycleObserver)
     }
 
@@ -100,89 +93,5 @@ class CardReaderManagerImplTest {
         whenever(terminalWrapper.isInitialized()).thenReturn(false)
 
         cardReaderManager.connectToReader("")
-    }
-
-    @Test
-    fun `when reader discovery started, then observers get notified`() {
-        whenever(terminalWrapper.isInitialized()).thenReturn(true)
-
-        cardReaderManager.startDiscovery(true)
-
-        assertThat(cardReaderManager.discoveryEvents.value).isEqualTo(CardReaderDiscoveryEvents.Started)
-    }
-
-    @Test
-    fun `when readers discovered, then observers get notified`() {
-        whenever(terminalWrapper.isInitialized()).thenReturn(true)
-        val dummyReaderId = "12345"
-        val discoveredReaders = listOf(mock<Reader>()
-            .apply { whenever(serialNumber).thenReturn(dummyReaderId) })
-        whenever(terminalWrapper.discoverReaders(any(), any(), any()))
-            .thenAnswer {
-                it.getArgument<DiscoveryListener>(1).onUpdateDiscoveredReaders(discoveredReaders)
-                mock<Cancelable>()
-            }
-
-        cardReaderManager.startDiscovery(true)
-
-        assertThat(cardReaderManager.discoveryEvents.value).isEqualTo(
-            CardReaderDiscoveryEvents.ReadersFound(listOf(dummyReaderId))
-        )
-    }
-
-    @Test
-    fun `when reader unexpectedly disconnected, then observers get notified`() {
-        whenever(terminalWrapper.initTerminal(any(), any(), any(), any()))
-            .thenAnswer {
-                it.getArgument<TerminalListener>(3).onUnexpectedReaderDisconnect(mock())
-            }
-
-        cardReaderManager.initialize(application)
-
-        assertThat(cardReaderManager.readerStatus.value).isEqualTo(
-            CardReaderStatus.NOT_CONNECTED
-        )
-    }
-
-    @Test
-    fun `when reader disconnected, then observers get notified`() {
-        whenever(terminalWrapper.initTerminal(any(), any(), any(), any()))
-            .thenAnswer {
-                it.getArgument<TerminalListener>(3).onConnectionStatusChange(NOT_CONNECTED)
-            }
-
-        cardReaderManager.initialize(application)
-
-        assertThat(cardReaderManager.readerStatus.value).isEqualTo(
-            CardReaderStatus.NOT_CONNECTED
-        )
-    }
-
-    @Test
-    fun `when connecting to reader, then observers get notified`() {
-        whenever(terminalWrapper.initTerminal(any(), any(), any(), any()))
-            .thenAnswer {
-                it.getArgument<TerminalListener>(3).onConnectionStatusChange(CONNECTING)
-            }
-
-        cardReaderManager.initialize(application)
-
-        assertThat(cardReaderManager.readerStatus.value).isEqualTo(
-            CardReaderStatus.CONNECTING
-        )
-    }
-
-    @Test
-    fun `when reader connection established, then observers get notified`() {
-        whenever(terminalWrapper.initTerminal(any(), any(), any(), any()))
-            .thenAnswer {
-                it.getArgument<TerminalListener>(3).onConnectionStatusChange(CONNECTED)
-            }
-
-        cardReaderManager.initialize(application)
-
-        assertThat(cardReaderManager.readerStatus.value).isEqualTo(
-            CardReaderStatus.CONNECTED
-        )
     }
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
@@ -1,0 +1,97 @@
+package com.woocommerce.android.cardreader.internal.connection
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import com.stripe.stripeterminal.callable.Cancelable
+import com.stripe.stripeterminal.callable.DiscoveryListener
+import com.stripe.stripeterminal.model.external.ConnectionStatus.CONNECTED
+import com.stripe.stripeterminal.model.external.ConnectionStatus.CONNECTING
+import com.stripe.stripeterminal.model.external.ConnectionStatus.NOT_CONNECTED
+import com.stripe.stripeterminal.model.external.Reader
+import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents
+import com.woocommerce.android.cardreader.CardReaderStatus
+import com.woocommerce.android.cardreader.internal.wrappers.LogWrapper
+import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class ConnectionManagerTest {
+    private val terminalWrapper: TerminalWrapper = mock()
+    private val logWrapper: LogWrapper = mock()
+
+    private lateinit var connectionManager: ConnectionManager
+
+    @Before
+    fun setUp() {
+        connectionManager = ConnectionManager(terminalWrapper, logWrapper)
+    }
+
+    @Test
+    fun `when reader discovery started, then observers get notified`() {
+        whenever(terminalWrapper.isInitialized()).thenReturn(true)
+
+        connectionManager.startDiscovery(true)
+
+        Assertions.assertThat(connectionManager.discoveryEvents.value).isEqualTo(CardReaderDiscoveryEvents.Started)
+    }
+
+    @Test
+    fun `when readers discovered, then observers get notified`() {
+        whenever(terminalWrapper.isInitialized()).thenReturn(true)
+        val dummyReaderId = "12345"
+        val discoveredReaders = listOf(
+            mock<Reader>()
+                .apply { whenever(serialNumber).thenReturn(dummyReaderId) })
+        whenever(terminalWrapper.discoverReaders(any(), any(), any()))
+            .thenAnswer {
+                it.getArgument<DiscoveryListener>(1).onUpdateDiscoveredReaders(discoveredReaders)
+                mock<Cancelable>()
+            }
+
+        connectionManager.startDiscovery(true)
+
+        Assertions.assertThat(connectionManager.discoveryEvents.value).isEqualTo(
+            CardReaderDiscoveryEvents.ReadersFound(listOf(dummyReaderId))
+        )
+    }
+
+    @Test
+    fun `when reader unexpectedly disconnected, then observers get notified`() {
+        connectionManager.onUnexpectedReaderDisconnect(mock())
+
+        Assertions.assertThat(connectionManager.readerStatus.value).isEqualTo(
+            CardReaderStatus.NOT_CONNECTED
+        )
+    }
+
+    @Test
+    fun `when reader disconnected, then observers get notified`() {
+        connectionManager.onConnectionStatusChange(NOT_CONNECTED)
+
+        Assertions.assertThat(connectionManager.readerStatus.value).isEqualTo(
+            CardReaderStatus.NOT_CONNECTED
+        )
+    }
+
+    @Test
+    fun `when connecting to reader, then observers get notified`() {
+        connectionManager.onConnectionStatusChange(CONNECTING)
+
+        Assertions.assertThat(connectionManager.readerStatus.value).isEqualTo(
+            CardReaderStatus.CONNECTING
+        )
+    }
+
+    @Test
+    fun `when reader connection established, then observers get notified`() {
+        connectionManager.onConnectionStatusChange(CONNECTED)
+
+        Assertions.assertThat(connectionManager.readerStatus.value).isEqualTo(
+            CardReaderStatus.CONNECTED
+        )
+    }
+}


### PR DESCRIPTION
This PR extracts code related to reader connection from CardReaderManager into a newly introduced ConnectionManager. There are no other changes. We plan to do some more refactoring in follow up PRs - this PR was created to make the follow up PRs focused.

To test:
I personally think that this PR doesn't need to be tested. We'll touch most of the code in the follow up PRs anyway and none of it is used in production. However, if you want to test it, follow the instructions below.

- Testing this PR requires a hw card reader.
1. Connect to a store which has an active and working WCPay (in dev/test mode)
2. Open app settings (tap on gear icon in the top right corner)
3. Tap on "Manage card readers" (Make sure bluetooth is on)
4. Leave the "simulated card reader" unchecked
5. Tap on "Connect card reader"
6. Notice "Started" snackbar
7. Turn on the card reader
8. Notice a textview below the "Connect card reader" button changes to "Connecting/Connected" (it might take up to 20s)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
