### PR TITLE
Update the plugin detection mechanism

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '8e95528367524778347ed7be9322a2dec233f85a'
+    fluxCVersion = 'df74cf6a0adf1b5453cb5ea852e8f2d6da0215ba'
     daggerVersion = '2.33'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'df74cf6a0adf1b5453cb5ea852e8f2d6da0215ba'
+    fluxCVersion = '1ff586bc287e4381d9dc3ff237a1a20d5c5b279e'
     daggerVersion = '2.33'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
This PR just updates the FluxC reference that uses a new mechanism to load active plugins, which allows for store managers to also create shipping labels.

**To test:**
1. Create/update a user and change the role to _Store manager_
2. Log in as that user
3. Go to Orders
4. Open an order that's eligible for SL creation
5. Verify that the `Create shipping label` button is displayed