### PR TITLE
Issue/3725 refactor card reader manager step 2

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -31,7 +31,16 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
         </value>
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -31,16 +31,7 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
+          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
         </value>
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CardReaderSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CardReaderSettingsFragment.kt
@@ -89,7 +89,7 @@ class CardReaderSettingsFragment : Fragment(R.layout.fragment_settings_card_read
                 cardReaderManager.initialize(requireActivity().application)
             }
             lifecycleScope.launchWhenResumed {
-                cardReaderManager.startDiscovery(isSimulated = simulated).collect { event ->
+                cardReaderManager.discoverReaders(isSimulated = simulated).collect { event ->
                     AppLog.d(AppLog.T.MAIN, event.toString())
                     when (event) {
                         Started, Succeeded, is Failed -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CardReaderSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CardReaderSettingsFragment.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents.NotStarted
 import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents.Started
 import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents.Failed
 import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents.ReadersFound
+import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents.Succeeded
 import com.woocommerce.android.databinding.FragmentSettingsCardReaderBinding
 import kotlinx.coroutines.flow.collect
 import org.wordpress.android.util.AppLog
@@ -68,25 +69,6 @@ class CardReaderSettingsFragment : Fragment(R.layout.fragment_settings_card_read
         (requireActivity().application as? WooCommerce)?.let { application ->
             // TODO cardreader Move this into a VM
             lifecycleScope.launchWhenResumed {
-                application.cardReaderManager?.discoveryEvents?.collect { event ->
-                    AppLog.d(AppLog.T.MAIN, event.toString())
-                    when (event) {
-                        NotStarted, Started, is Failed -> {
-                            Snackbar.make(
-                                requireView(),
-                                event.javaClass.simpleName,
-                                BaseTransientBottomBar.LENGTH_SHORT
-                            ).show()
-                        }
-                        is ReadersFound -> {
-                            if (event.list.isNotEmpty()) {
-                                getCardReaderManager()?.connectToReader(event.list[0])
-                            }
-                        }
-                    }
-                }
-            }
-            lifecycleScope.launchWhenResumed {
                 application.cardReaderManager?.readerStatus?.collect { status ->
                     binding.connectionStatus.text = status.name
                 }
@@ -108,8 +90,23 @@ class CardReaderSettingsFragment : Fragment(R.layout.fragment_settings_card_read
                 cardReaderManager.initialize(requireActivity().application)
             }
             lifecycleScope.launchWhenResumed {
-                // TODO cardreader make sure to cancel the discovery when the user leaves the activity/app
-                cardReaderManager.startDiscovery(isSimulated = simulated)
+                cardReaderManager.startDiscovery(isSimulated = simulated).collect { event ->
+                    AppLog.d(AppLog.T.MAIN, event.toString())
+                    when (event) {
+                        NotStarted, Started, Succeeded, is Failed -> {
+                            Snackbar.make(
+                                requireView(),
+                                event.javaClass.simpleName,
+                                BaseTransientBottomBar.LENGTH_SHORT
+                            ).show()
+                        }
+                        is ReadersFound -> {
+                            if (event.list.isNotEmpty()) {
+                                getCardReaderManager()?.connectToReader(event.list[0])
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CardReaderSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CardReaderSettingsFragment.kt
@@ -14,12 +14,11 @@ import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.R
 import com.woocommerce.android.WooCommerce
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.cardreader.CardReaderManager
-import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents.NotStarted
-import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents.Started
 import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents.Failed
 import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents.ReadersFound
+import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents.Started
 import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents.Succeeded
+import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.databinding.FragmentSettingsCardReaderBinding
 import kotlinx.coroutines.flow.collect
 import org.wordpress.android.util.AppLog
@@ -93,7 +92,7 @@ class CardReaderSettingsFragment : Fragment(R.layout.fragment_settings_card_read
                 cardReaderManager.startDiscovery(isSimulated = simulated).collect { event ->
                     AppLog.d(AppLog.T.MAIN, event.toString())
                     when (event) {
-                        NotStarted, Started, Succeeded, is Failed -> {
+                        Started, Succeeded, is Failed -> {
                             Snackbar.make(
                                 requireView(),
                                 event.javaClass.simpleName,

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/CardReaderImpl.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/CardReaderImpl.kt
@@ -3,5 +3,5 @@ package com.woocommerce.android.cardreader
 import com.stripe.stripeterminal.model.external.Reader
 
 class CardReaderImpl(val cardReader: Reader) : CardReader {
-    override fun getId(): String = cardReader.serialNumber ?: "unknown id"
+    override fun getId(): String? = cardReader.serialNumber
 }

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/CardReaderImpl.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/CardReaderImpl.kt
@@ -1,0 +1,7 @@
+package com.woocommerce.android.cardreader
+
+import com.stripe.stripeterminal.model.external.Reader
+
+class CardReaderImpl(val cardReader: Reader) : CardReader {
+    override fun getId(): String = cardReader.serialNumber ?: "unknown id"
+}

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.cardreader
 import com.woocommerce.android.cardreader.internal.CardReaderManagerImpl
 import com.woocommerce.android.cardreader.internal.TokenProvider
 import com.woocommerce.android.cardreader.internal.connection.ConnectionManager
+import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction
 import com.woocommerce.android.cardreader.internal.payments.PaymentManager
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.CreatePaymentAction
@@ -25,7 +26,7 @@ object CardReaderManagerFactory {
                 CollectPaymentAction(terminal, logWrapper),
                 ProcessPaymentAction(terminal, logWrapper)
             ),
-            ConnectionManager(terminal, logWrapper)
+            ConnectionManager(terminal, logWrapper, DiscoverReadersAction(terminal))
         )
     }
 }

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -5,6 +5,7 @@ import android.content.ComponentCallbacks2
 import android.content.res.Configuration
 import com.stripe.stripeterminal.log.LogLevel
 import com.woocommerce.android.cardreader.CardPaymentStatus
+import com.woocommerce.android.cardreader.CardReader
 import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.CardReaderStatus
@@ -67,9 +68,9 @@ internal class CardReaderManagerImpl(
         return connectionManager.discoverReaders(isSimulated)
     }
 
-    override fun connectToReader(readerId: String) {
+    override fun connectToReader(cardReader: CardReader) {
         if (!terminal.isInitialized()) throw IllegalStateException("Terminal not initialized")
-        connectionManager.connectToReader(readerId)
+        connectionManager.connectToReader(cardReader)
     }
 
     override suspend fun collectPayment(amount: Int, currency: String): Flow<CardPaymentStatus> =

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -35,9 +35,6 @@ internal class CardReaderManagerImpl(
     override val isInitialized: Boolean
         get() { return terminal.isInitialized() }
 
-    @ExperimentalCoroutinesApi
-    override val discoveryEvents: MutableStateFlow<CardReaderDiscoveryEvents> = connectionManager.discoveryEvents
-
     override val readerStatus: MutableStateFlow<CardReaderStatus> = connectionManager.readerStatus
 
     override fun initialize(app: Application) {
@@ -67,9 +64,9 @@ internal class CardReaderManagerImpl(
         }
     }
 
-    override fun startDiscovery(isSimulated: Boolean) {
+    override fun startDiscovery(isSimulated: Boolean): Flow<CardReaderDiscoveryEvents> {
         if (!terminal.isInitialized()) throw IllegalStateException("Terminal not initialized")
-        connectionManager.startDiscovery(isSimulated)
+        return connectionManager.startDiscovery(isSimulated)
     }
 
     override fun connectToReader(readerId: String) {

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -62,9 +62,9 @@ internal class CardReaderManagerImpl(
         }
     }
 
-    override fun startDiscovery(isSimulated: Boolean): Flow<CardReaderDiscoveryEvents> {
+    override fun discoverReaders(isSimulated: Boolean): Flow<CardReaderDiscoveryEvents> {
         if (!terminal.isInitialized()) throw IllegalStateException("Terminal not initialized")
-        return connectionManager.startDiscovery(isSimulated)
+        return connectionManager.discoverReaders(isSimulated)
     }
 
     override fun connectToReader(readerId: String) {

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
@@ -1,59 +1,50 @@
 package com.woocommerce.android.cardreader.internal.connection
 
-import com.stripe.stripeterminal.callable.Callback
-import com.stripe.stripeterminal.callable.DiscoveryListener
 import com.stripe.stripeterminal.callable.ReaderCallback
 import com.stripe.stripeterminal.callable.TerminalListener
 import com.stripe.stripeterminal.model.external.ConnectionStatus
 import com.stripe.stripeterminal.model.external.ConnectionStatus.CONNECTED
 import com.stripe.stripeterminal.model.external.ConnectionStatus.CONNECTING
 import com.stripe.stripeterminal.model.external.ConnectionStatus.NOT_CONNECTED
-import com.stripe.stripeterminal.model.external.DeviceType.CHIPPER_2X
-import com.stripe.stripeterminal.model.external.DiscoveryConfiguration
 import com.stripe.stripeterminal.model.external.PaymentStatus
 import com.stripe.stripeterminal.model.external.Reader
 import com.stripe.stripeterminal.model.external.ReaderEvent
 import com.stripe.stripeterminal.model.external.TerminalException
 import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents
-import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents.NotStarted
 import com.woocommerce.android.cardreader.CardReaderStatus
+import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction
+import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus
 import com.woocommerce.android.cardreader.internal.wrappers.LogWrapper
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
 
 @ExperimentalCoroutinesApi
 internal class ConnectionManager(
     private val terminal: TerminalWrapper,
-    private val logWrapper: LogWrapper
+    private val logWrapper: LogWrapper,
+    private val discoverReadersAction: DiscoverReadersAction
 ) : TerminalListener {
-    private val foundReaders = mutableSetOf<Reader>()
-
-    val discoveryEvents: MutableStateFlow<CardReaderDiscoveryEvents> = MutableStateFlow(NotStarted)
-
     val readerStatus: MutableStateFlow<CardReaderStatus> = MutableStateFlow(CardReaderStatus.NOT_CONNECTED)
 
-    fun startDiscovery(isSimulated: Boolean) {
-        val config = DiscoveryConfiguration(0, CHIPPER_2X, isSimulated)
-        discoveryEvents.value = CardReaderDiscoveryEvents.Started
-        terminal.discoverReaders(config, object : DiscoveryListener {
-            override fun onUpdateDiscoveredReaders(readers: List<Reader>) {
-                foundReaders.addAll(readers)
-                discoveryEvents.value = CardReaderDiscoveryEvents.ReadersFound(readers.mapNotNull { it.serialNumber })
+    fun startDiscovery(isSimulated: Boolean) =
+        discoverReadersAction.discoverReaders(isSimulated).map { state ->
+            when (state) {
+                is DiscoverReadersStatus.Failure -> {
+                    CardReaderDiscoveryEvents.Failed(state.exception.toString())
+                }
+                is DiscoverReadersStatus.FoundReaders -> {
+                    CardReaderDiscoveryEvents.ReadersFound(state.readers.mapNotNull { it.serialNumber })
+                }
+                DiscoverReadersStatus.Success -> {
+                    CardReaderDiscoveryEvents.Succeeded
+                }
             }
-        }, object : Callback {
-            override fun onFailure(e: TerminalException) {
-                discoveryEvents.value = CardReaderDiscoveryEvents.Failed(e.toString())
-            }
-
-            override fun onSuccess() {
-                // It seems that StripeTerminalSDK never invokes this method
-            }
-        })
-    }
+        }
 
     fun connectToReader(readerId: String) {
-        foundReaders.find { it.serialNumber == readerId }?.let {
+        discoverReadersAction.foundReaders.find { it.serialNumber == readerId }?.let {
             terminal.connectToReader(it, object : ReaderCallback {
                 override fun onFailure(e: TerminalException) {
                     logWrapper.d("CardReader", "connecting to reader failed: ${e.errorMessage}")

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
@@ -29,6 +29,9 @@ internal class ConnectionManager(
     fun startDiscovery(isSimulated: Boolean) =
         discoverReadersAction.discoverReaders(isSimulated).map { state ->
             when (state) {
+                is DiscoverReadersStatus.Started -> {
+                    CardReaderDiscoveryEvents.Started
+                }
                 is DiscoverReadersStatus.Failure -> {
                     CardReaderDiscoveryEvents.Failed(state.exception.toString())
                 }

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
@@ -26,7 +26,7 @@ internal class ConnectionManager(
 ) : TerminalListener {
     val readerStatus: MutableStateFlow<CardReaderStatus> = MutableStateFlow(CardReaderStatus.NOT_CONNECTED)
 
-    fun startDiscovery(isSimulated: Boolean) =
+    fun discoverReaders(isSimulated: Boolean) =
         discoverReadersAction.discoverReaders(isSimulated).map { state ->
             when (state) {
                 is DiscoverReadersStatus.Started -> {

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersAction.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersAction.kt
@@ -28,9 +28,6 @@ internal class DiscoverReadersAction(private val terminal: TerminalWrapper) {
         data class FoundReaders(val readers: List<Reader>) : DiscoverReadersStatus()
         data class Failure(val exception: TerminalException) : DiscoverReadersStatus()
     }
-
-    val foundReaders = mutableSetOf<Reader>()
-
     fun discoverReaders(isSimulated: Boolean): Flow<DiscoverReadersStatus> {
         return callbackFlow {
             this.sendBlocking(Started)
@@ -39,7 +36,6 @@ internal class DiscoverReadersAction(private val terminal: TerminalWrapper) {
             try {
                 cancelable = terminal.discoverReaders(config, object : DiscoveryListener {
                     override fun onUpdateDiscoveredReaders(readers: List<Reader>) {
-                        foundReaders.addAll(readers)
                         this@callbackFlow.sendBlocking(FoundReaders(readers))
                     }
                 }, object : Callback {
@@ -55,7 +51,6 @@ internal class DiscoverReadersAction(private val terminal: TerminalWrapper) {
                 })
                 awaitClose()
             } finally {
-                foundReaders.clear()
                 cancelable?.takeIf { !it.isCompleted }?.cancel(noopCallback)
             }
         }

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersAction.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersAction.kt
@@ -9,6 +9,7 @@ import com.stripe.stripeterminal.model.external.Reader
 import com.stripe.stripeterminal.model.external.TerminalException
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Failure
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.FoundReaders
+import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Started
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Success
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -22,6 +23,7 @@ private const val DISCOVERY_TIMEOUT_IN_SECONDS = 60
 @ExperimentalCoroutinesApi
 internal class DiscoverReadersAction(private val terminal: TerminalWrapper) {
     sealed class DiscoverReadersStatus {
+        object Started: DiscoverReadersStatus()
         object Success : DiscoverReadersStatus()
         data class FoundReaders(val readers: List<Reader>) : DiscoverReadersStatus()
         data class Failure(val exception: TerminalException) : DiscoverReadersStatus()
@@ -31,6 +33,7 @@ internal class DiscoverReadersAction(private val terminal: TerminalWrapper) {
 
     fun discoverReaders(isSimulated: Boolean): Flow<DiscoverReadersStatus> {
         return callbackFlow {
+            this.sendBlocking(Started)
             val config = DiscoveryConfiguration(DISCOVERY_TIMEOUT_IN_SECONDS, CHIPPER_2X, isSimulated)
             var cancelable: Cancelable? = null
             try {

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersAction.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersAction.kt
@@ -1,0 +1,70 @@
+package com.woocommerce.android.cardreader.internal.connection.actions
+
+import com.stripe.stripeterminal.callable.Callback
+import com.stripe.stripeterminal.callable.Cancelable
+import com.stripe.stripeterminal.callable.DiscoveryListener
+import com.stripe.stripeterminal.model.external.DeviceType.CHIPPER_2X
+import com.stripe.stripeterminal.model.external.DiscoveryConfiguration
+import com.stripe.stripeterminal.model.external.Reader
+import com.stripe.stripeterminal.model.external.TerminalException
+import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Failure
+import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.FoundReaders
+import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Success
+import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.sendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+
+private const val DISCOVERY_TIMEOUT_IN_SECONDS = 60
+
+@ExperimentalCoroutinesApi
+internal class DiscoverReadersAction(private val terminal: TerminalWrapper) {
+    sealed class DiscoverReadersStatus {
+        object Success : DiscoverReadersStatus()
+        data class FoundReaders(val readers: List<Reader>) : DiscoverReadersStatus()
+        data class Failure(val exception: TerminalException) : DiscoverReadersStatus()
+    }
+
+    val foundReaders = mutableSetOf<Reader>()
+
+    fun discoverReaders(isSimulated: Boolean): Flow<DiscoverReadersStatus> {
+        return callbackFlow {
+            val config = DiscoveryConfiguration(DISCOVERY_TIMEOUT_IN_SECONDS, CHIPPER_2X, isSimulated)
+            var cancelable: Cancelable? = null
+            try {
+                cancelable = terminal.discoverReaders(config, object : DiscoveryListener {
+                    override fun onUpdateDiscoveredReaders(readers: List<Reader>) {
+                        foundReaders.addAll(readers)
+                        this@callbackFlow.sendBlocking(FoundReaders(readers))
+                    }
+                }, object : Callback {
+                    override fun onFailure(e: TerminalException) {
+                        this@callbackFlow.sendBlocking(Failure(e))
+                        this@callbackFlow.close()
+                    }
+
+                    override fun onSuccess() {
+                        this@callbackFlow.sendBlocking(Success)
+                        this@callbackFlow.close()
+                    }
+                })
+                awaitClose()
+            } finally {
+                foundReaders.clear()
+                cancelable?.takeIf { !it.isCompleted }?.cancel(noopCallback)
+            }
+        }
+    }
+}
+
+private val noopCallback = object : Callback {
+    override fun onFailure(e: TerminalException) {
+        println("Discovery cancellation failed")
+    }
+
+    override fun onSuccess() {
+        println("Discovery cancellation finished")
+    }
+}

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersAction.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersAction.kt
@@ -23,7 +23,7 @@ private const val DISCOVERY_TIMEOUT_IN_SECONDS = 60
 @ExperimentalCoroutinesApi
 internal class DiscoverReadersAction(private val terminal: TerminalWrapper) {
     sealed class DiscoverReadersStatus {
-        object Started: DiscoverReadersStatus()
+        object Started : DiscoverReadersStatus()
         object Success : DiscoverReadersStatus()
         data class FoundReaders(val readers: List<Reader>) : DiscoverReadersStatus()
         data class Failure(val exception: TerminalException) : DiscoverReadersStatus()
@@ -63,11 +63,7 @@ internal class DiscoverReadersAction(private val terminal: TerminalWrapper) {
 }
 
 private val noopCallback = object : Callback {
-    override fun onFailure(e: TerminalException) {
-        println("Discovery cancellation failed")
-    }
+    override fun onFailure(e: TerminalException) {}
 
-    override fun onSuccess() {
-        println("Discovery cancellation finished")
-    }
+    override fun onSuccess() {}
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReader.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReader.kt
@@ -1,0 +1,5 @@
+package com.woocommerce.android.cardreader
+
+interface CardReader {
+    fun getId(): String
+}

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReader.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReader.kt
@@ -1,5 +1,5 @@
 package com.woocommerce.android.cardreader
 
 interface CardReader {
-    fun getId(): String
+    fun getId(): String?
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderDiscoveryEvents.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderDiscoveryEvents.kt
@@ -2,7 +2,7 @@ package com.woocommerce.android.cardreader
 
 sealed class CardReaderDiscoveryEvents {
     object Started : CardReaderDiscoveryEvents()
-    data class ReadersFound(val list: List<String>) : CardReaderDiscoveryEvents()
+    data class ReadersFound(val list: List<CardReader>) : CardReaderDiscoveryEvents()
     data class Failed(val msg: String) : CardReaderDiscoveryEvents()
     object Succeeded : CardReaderDiscoveryEvents()
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderDiscoveryEvents.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderDiscoveryEvents.kt
@@ -5,4 +5,5 @@ sealed class CardReaderDiscoveryEvents {
     object Started : CardReaderDiscoveryEvents()
     data class ReadersFound(val list: List<String>) : CardReaderDiscoveryEvents()
     data class Failed(val msg: String) : CardReaderDiscoveryEvents()
+    object Succeeded : CardReaderDiscoveryEvents()
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderDiscoveryEvents.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderDiscoveryEvents.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.cardreader
 
 sealed class CardReaderDiscoveryEvents {
-    object NotStarted : CardReaderDiscoveryEvents()
     object Started : CardReaderDiscoveryEvents()
     data class ReadersFound(val list: List<String>) : CardReaderDiscoveryEvents()
     data class Failed(val msg: String) : CardReaderDiscoveryEvents()

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
@@ -12,7 +12,7 @@ interface CardReaderManager {
     val readerStatus: MutableStateFlow<CardReaderStatus>
     fun initialize(app: Application)
     fun discoverReaders(isSimulated: Boolean): Flow<CardReaderDiscoveryEvents>
-    fun connectToReader(readerId: String)
+    fun connectToReader(cardReader: CardReader)
 
     // TODO cardreader Stripe accepts only Int, is that ok?
     suspend fun collectPayment(amount: Int, currency: String): Flow<CardPaymentStatus>

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
@@ -11,10 +11,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 @ExperimentalCoroutinesApi
 interface CardReaderManager {
     val isInitialized: Boolean
-    val discoveryEvents: MutableStateFlow<CardReaderDiscoveryEvents>
     val readerStatus: MutableStateFlow<CardReaderStatus>
     fun initialize(app: Application)
-    fun startDiscovery(isSimulated: Boolean)
+    fun startDiscovery(isSimulated: Boolean): Flow<CardReaderDiscoveryEvents>
     fun connectToReader(readerId: String)
 
     // TODO cardreader Stripe accepts only Int, is that ok?

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
@@ -11,7 +11,7 @@ interface CardReaderManager {
     val isInitialized: Boolean
     val readerStatus: MutableStateFlow<CardReaderStatus>
     fun initialize(app: Application)
-    fun startDiscovery(isSimulated: Boolean): Flow<CardReaderDiscoveryEvents>
+    fun discoverReaders(isSimulated: Boolean): Flow<CardReaderDiscoveryEvents>
     fun connectToReader(readerId: String)
 
     // TODO cardreader Stripe accepts only Int, is that ok?

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
@@ -85,7 +85,7 @@ class CardReaderManagerImplTest {
     fun `given terminal not initialized, when reader discovery started, then exception is thrown`() {
         whenever(terminalWrapper.isInitialized()).thenReturn(false)
 
-        cardReaderManager.startDiscovery(true)
+        cardReaderManager.discoverReaders(true)
     }
 
     @Test(expected = IllegalStateException::class)

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
@@ -92,6 +92,6 @@ class CardReaderManagerImplTest {
     fun `given terminal not initialized, when connecting to reader started, then exception is thrown`() {
         whenever(terminalWrapper.isInitialized()).thenReturn(false)
 
-        cardReaderManager.connectToReader("")
+        cardReaderManager.connectToReader(mock())
     }
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
@@ -8,15 +8,7 @@ import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import com.stripe.stripeterminal.TerminalLifecycleObserver
-import com.stripe.stripeterminal.callable.Cancelable
-import com.stripe.stripeterminal.callable.DiscoveryListener
-import com.stripe.stripeterminal.callable.TerminalListener
-import com.stripe.stripeterminal.model.external.ConnectionStatus.CONNECTED
-import com.stripe.stripeterminal.model.external.ConnectionStatus.CONNECTING
-import com.stripe.stripeterminal.model.external.ConnectionStatus.NOT_CONNECTED
-import com.stripe.stripeterminal.model.external.Reader
-import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents
-import com.woocommerce.android.cardreader.CardReaderStatus
+import com.woocommerce.android.cardreader.internal.connection.ConnectionManager
 import com.woocommerce.android.cardreader.internal.wrappers.LogWrapper
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -35,10 +27,11 @@ class CardReaderManagerImplTest {
     private val lifecycleObserver: TerminalLifecycleObserver = mock()
     private val application: Application = mock()
     private val logWrapper: LogWrapper = mock()
+    private val connectionManager: ConnectionManager = mock()
 
     @Before
     fun setUp() {
-        cardReaderManager = CardReaderManagerImpl(terminalWrapper, tokenProvider, logWrapper, mock())
+        cardReaderManager = CardReaderManagerImpl(terminalWrapper, tokenProvider, logWrapper, mock(), connectionManager)
         whenever(terminalWrapper.getLifecycleObserver()).thenReturn(lifecycleObserver)
     }
 
@@ -100,89 +93,5 @@ class CardReaderManagerImplTest {
         whenever(terminalWrapper.isInitialized()).thenReturn(false)
 
         cardReaderManager.connectToReader("")
-    }
-
-    @Test
-    fun `when reader discovery started, then observers get notified`() {
-        whenever(terminalWrapper.isInitialized()).thenReturn(true)
-
-        cardReaderManager.startDiscovery(true)
-
-        assertThat(cardReaderManager.discoveryEvents.value).isEqualTo(CardReaderDiscoveryEvents.Started)
-    }
-
-    @Test
-    fun `when readers discovered, then observers get notified`() {
-        whenever(terminalWrapper.isInitialized()).thenReturn(true)
-        val dummyReaderId = "12345"
-        val discoveredReaders = listOf(mock<Reader>()
-            .apply { whenever(serialNumber).thenReturn(dummyReaderId) })
-        whenever(terminalWrapper.discoverReaders(any(), any(), any()))
-            .thenAnswer {
-                it.getArgument<DiscoveryListener>(1).onUpdateDiscoveredReaders(discoveredReaders)
-                mock<Cancelable>()
-            }
-
-        cardReaderManager.startDiscovery(true)
-
-        assertThat(cardReaderManager.discoveryEvents.value).isEqualTo(
-            CardReaderDiscoveryEvents.ReadersFound(listOf(dummyReaderId))
-        )
-    }
-
-    @Test
-    fun `when reader unexpectedly disconnected, then observers get notified`() {
-        whenever(terminalWrapper.initTerminal(any(), any(), any(), any()))
-            .thenAnswer {
-                it.getArgument<TerminalListener>(3).onUnexpectedReaderDisconnect(mock())
-            }
-
-        cardReaderManager.initialize(application)
-
-        assertThat(cardReaderManager.readerStatus.value).isEqualTo(
-            CardReaderStatus.NOT_CONNECTED
-        )
-    }
-
-    @Test
-    fun `when reader disconnected, then observers get notified`() {
-        whenever(terminalWrapper.initTerminal(any(), any(), any(), any()))
-            .thenAnswer {
-                it.getArgument<TerminalListener>(3).onConnectionStatusChange(NOT_CONNECTED)
-            }
-
-        cardReaderManager.initialize(application)
-
-        assertThat(cardReaderManager.readerStatus.value).isEqualTo(
-            CardReaderStatus.NOT_CONNECTED
-        )
-    }
-
-    @Test
-    fun `when connecting to reader, then observers get notified`() {
-        whenever(terminalWrapper.initTerminal(any(), any(), any(), any()))
-            .thenAnswer {
-                it.getArgument<TerminalListener>(3).onConnectionStatusChange(CONNECTING)
-            }
-
-        cardReaderManager.initialize(application)
-
-        assertThat(cardReaderManager.readerStatus.value).isEqualTo(
-            CardReaderStatus.CONNECTING
-        )
-    }
-
-    @Test
-    fun `when reader connection established, then observers get notified`() {
-        whenever(terminalWrapper.initTerminal(any(), any(), any(), any()))
-            .thenAnswer {
-                it.getArgument<TerminalListener>(3).onConnectionStatusChange(CONNECTED)
-            }
-
-        cardReaderManager.initialize(application)
-
-        assertThat(cardReaderManager.readerStatus.value).isEqualTo(
-            CardReaderStatus.CONNECTED
-        )
     }
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
@@ -1,0 +1,97 @@
+package com.woocommerce.android.cardreader.internal.connection
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import com.stripe.stripeterminal.callable.Cancelable
+import com.stripe.stripeterminal.callable.DiscoveryListener
+import com.stripe.stripeterminal.model.external.ConnectionStatus.CONNECTED
+import com.stripe.stripeterminal.model.external.ConnectionStatus.CONNECTING
+import com.stripe.stripeterminal.model.external.ConnectionStatus.NOT_CONNECTED
+import com.stripe.stripeterminal.model.external.Reader
+import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents
+import com.woocommerce.android.cardreader.CardReaderStatus
+import com.woocommerce.android.cardreader.internal.wrappers.LogWrapper
+import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class ConnectionManagerTest {
+    private val terminalWrapper: TerminalWrapper = mock()
+    private val logWrapper: LogWrapper = mock()
+
+    private lateinit var connectionManager: ConnectionManager
+
+    @Before
+    fun setUp() {
+        connectionManager = ConnectionManager(terminalWrapper, logWrapper)
+    }
+
+    @Test
+    fun `when reader discovery started, then observers get notified`() {
+        whenever(terminalWrapper.isInitialized()).thenReturn(true)
+
+        connectionManager.startDiscovery(true)
+
+        Assertions.assertThat(connectionManager.discoveryEvents.value).isEqualTo(CardReaderDiscoveryEvents.Started)
+    }
+
+    @Test
+    fun `when readers discovered, then observers get notified`() {
+        whenever(terminalWrapper.isInitialized()).thenReturn(true)
+        val dummyReaderId = "12345"
+        val discoveredReaders = listOf(
+            mock<Reader>()
+                .apply { whenever(serialNumber).thenReturn(dummyReaderId) })
+        whenever(terminalWrapper.discoverReaders(any(), any(), any()))
+            .thenAnswer {
+                it.getArgument<DiscoveryListener>(1).onUpdateDiscoveredReaders(discoveredReaders)
+                mock<Cancelable>()
+            }
+
+        connectionManager.startDiscovery(true)
+
+        Assertions.assertThat(connectionManager.discoveryEvents.value).isEqualTo(
+            CardReaderDiscoveryEvents.ReadersFound(listOf(dummyReaderId))
+        )
+    }
+
+    @Test
+    fun `when reader unexpectedly disconnected, then observers get notified`() {
+        connectionManager.onUnexpectedReaderDisconnect(mock())
+
+        Assertions.assertThat(connectionManager.readerStatus.value).isEqualTo(
+            CardReaderStatus.NOT_CONNECTED
+        )
+    }
+
+    @Test
+    fun `when reader disconnected, then observers get notified`() {
+        connectionManager.onConnectionStatusChange(NOT_CONNECTED)
+
+        Assertions.assertThat(connectionManager.readerStatus.value).isEqualTo(
+            CardReaderStatus.NOT_CONNECTED
+        )
+    }
+
+    @Test
+    fun `when connecting to reader, then observers get notified`() {
+        connectionManager.onConnectionStatusChange(CONNECTING)
+
+        Assertions.assertThat(connectionManager.readerStatus.value).isEqualTo(
+            CardReaderStatus.CONNECTING
+        )
+    }
+
+    @Test
+    fun `when reader connection established, then observers get notified`() {
+        connectionManager.onConnectionStatusChange(CONNECTED)
+
+        Assertions.assertThat(connectionManager.readerStatus.value).isEqualTo(
+            CardReaderStatus.CONNECTED
+        )
+    }
+}

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
@@ -49,7 +49,8 @@ class ConnectionManagerTest {
 
         val result = connectionManager.discoverReaders(true).toList()
 
-        Assertions.assertThat(result.first()).isEqualTo(ReadersFound(listOf(dummyReaderId)))
+        Assertions.assertThat((result.first() as ReadersFound).list.first().getId())
+            .isEqualTo(dummyReaderId)
     }
 
     @Test

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
@@ -10,7 +10,6 @@ import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents
 import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents.ReadersFound
 import com.woocommerce.android.cardreader.CardReaderStatus
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction
-import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Failure
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.FoundReaders
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Success

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
@@ -47,7 +47,7 @@ class ConnectionManagerTest {
         whenever(discoverReadersAction.discoverReaders(anyBoolean()))
             .thenReturn(flow { emit(FoundReaders(discoveredReaders)) })
 
-        val result = connectionManager.startDiscovery(true).toList()
+        val result = connectionManager.discoverReaders(true).toList()
 
         Assertions.assertThat(result.first()).isEqualTo(ReadersFound(listOf(dummyReaderId)))
     }
@@ -57,7 +57,7 @@ class ConnectionManagerTest {
         whenever(discoverReadersAction.discoverReaders(anyBoolean()))
             .thenReturn(flow { emit(Failure(mock())) })
 
-        val result = connectionManager.startDiscovery(true).single()
+        val result = connectionManager.discoverReaders(true).single()
 
         Assertions.assertThat(result).isInstanceOf(CardReaderDiscoveryEvents.Failed::class.java)
     }
@@ -67,7 +67,7 @@ class ConnectionManagerTest {
         whenever(discoverReadersAction.discoverReaders(anyBoolean()))
             .thenReturn(flow { emit(Success) })
 
-        val result = connectionManager.startDiscovery(true).single()
+        val result = connectionManager.discoverReaders(true).single()
 
         Assertions.assertThat(result).isInstanceOf(CardReaderDiscoveryEvents.Succeeded::class.java)
     }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
@@ -1,62 +1,76 @@
 package com.woocommerce.android.cardreader.internal.connection
 
-import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
-import com.stripe.stripeterminal.callable.Cancelable
-import com.stripe.stripeterminal.callable.DiscoveryListener
 import com.stripe.stripeterminal.model.external.ConnectionStatus.CONNECTED
 import com.stripe.stripeterminal.model.external.ConnectionStatus.CONNECTING
 import com.stripe.stripeterminal.model.external.ConnectionStatus.NOT_CONNECTED
 import com.stripe.stripeterminal.model.external.Reader
 import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents
+import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents.ReadersFound
 import com.woocommerce.android.cardreader.CardReaderStatus
+import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction
+import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus
+import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Failure
+import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.FoundReaders
+import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Success
 import com.woocommerce.android.cardreader.internal.wrappers.LogWrapper
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions
 import org.junit.Before
 import org.junit.Test
+import org.mockito.ArgumentMatchers.anyBoolean
 
 @ExperimentalCoroutinesApi
 class ConnectionManagerTest {
     private val terminalWrapper: TerminalWrapper = mock()
     private val logWrapper: LogWrapper = mock()
+    private val discoverReadersAction: DiscoverReadersAction = mock()
 
     private lateinit var connectionManager: ConnectionManager
 
     @Before
     fun setUp() {
-        connectionManager = ConnectionManager(terminalWrapper, logWrapper)
+        connectionManager = ConnectionManager(terminalWrapper, logWrapper, discoverReadersAction)
     }
 
     @Test
-    fun `when reader discovery started, then observers get notified`() {
-        whenever(terminalWrapper.isInitialized()).thenReturn(true)
-
-        connectionManager.startDiscovery(true)
-
-        Assertions.assertThat(connectionManager.discoveryEvents.value).isEqualTo(CardReaderDiscoveryEvents.Started)
-    }
-
-    @Test
-    fun `when readers discovered, then observers get notified`() {
-        whenever(terminalWrapper.isInitialized()).thenReturn(true)
+    fun `when readers discovered, then observers get notified`() = runBlockingTest {
         val dummyReaderId = "12345"
         val discoveredReaders = listOf(
             mock<Reader>()
                 .apply { whenever(serialNumber).thenReturn(dummyReaderId) })
-        whenever(terminalWrapper.discoverReaders(any(), any(), any()))
-            .thenAnswer {
-                it.getArgument<DiscoveryListener>(1).onUpdateDiscoveredReaders(discoveredReaders)
-                mock<Cancelable>()
-            }
+        whenever(discoverReadersAction.discoverReaders(anyBoolean()))
+            .thenReturn(flow { emit(FoundReaders(discoveredReaders)) })
 
-        connectionManager.startDiscovery(true)
+        val result = connectionManager.startDiscovery(true).toList()
 
-        Assertions.assertThat(connectionManager.discoveryEvents.value).isEqualTo(
-            CardReaderDiscoveryEvents.ReadersFound(listOf(dummyReaderId))
-        )
+        Assertions.assertThat(result.first()).isEqualTo(ReadersFound(listOf(dummyReaderId)))
+    }
+
+    @Test
+    fun `when discovery fails, then observers get notified`() = runBlockingTest {
+        whenever(discoverReadersAction.discoverReaders(anyBoolean()))
+            .thenReturn(flow { emit(Failure(mock())) })
+
+        val result = connectionManager.startDiscovery(true).single()
+
+        Assertions.assertThat(result).isInstanceOf(CardReaderDiscoveryEvents.Failed::class.java)
+    }
+
+    @Test
+    fun `when discovery succeeds, then observers get notified`() = runBlockingTest {
+        whenever(discoverReadersAction.discoverReaders(anyBoolean()))
+            .thenReturn(flow { emit(Success) })
+
+        val result = connectionManager.startDiscovery(true).single()
+
+        Assertions.assertThat(result).isInstanceOf(CardReaderDiscoveryEvents.Succeeded::class.java)
     }
 
     @Test

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersActionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersActionTest.kt
@@ -11,6 +11,7 @@ import com.stripe.stripeterminal.callable.DiscoveryListener
 import com.stripe.stripeterminal.model.external.Reader
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Failure
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.FoundReaders
+import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Started
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Success
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import kotlinx.coroutines.channels.ClosedSendChannelException
@@ -34,6 +35,17 @@ class DiscoverReadersActionTest {
     @Before
     fun setUp() {
         action = DiscoverReadersAction(terminal)
+    }
+
+    @Test
+    fun `when discovery started, then Started is emitted`() = runBlockingTest {
+        whenever(terminal.discoverReaders(any(), any(), any())).thenAnswer {
+            mock<Cancelable>()
+        }
+
+        val result = action.discoverReaders(false).first()
+
+        assertThat(result).isInstanceOf(Started::class.java)
     }
 
     @Test

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersActionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersActionTest.kt
@@ -1,0 +1,196 @@
+package com.woocommerce.android.cardreader.internal.connection.actions
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import com.stripe.stripeterminal.callable.Callback
+import com.stripe.stripeterminal.callable.Cancelable
+import com.stripe.stripeterminal.callable.DiscoveryListener
+import com.stripe.stripeterminal.model.external.Reader
+import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Failure
+import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.FoundReaders
+import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Success
+import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
+import kotlinx.coroutines.channels.ClosedSendChannelException
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runBlockingTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class DiscoverReadersActionTest {
+    private lateinit var action: DiscoverReadersAction
+    private val terminal: TerminalWrapper = mock()
+
+    @Before
+    fun setUp() {
+        action = DiscoverReadersAction(terminal)
+    }
+
+    @Test
+    fun `when nearby readers found, then FoundReaders is emitted`() = runBlockingTest {
+        whenever(terminal.discoverReaders(any(), any(), any())).thenAnswer {
+            onUpdateDiscoveredReaders(args = it.arguments, readers = listOf(mock()))
+            mock<Cancelable>()
+        }
+
+        val event = action.discoverReaders(false).first()
+
+        assertThat(event).isInstanceOf(FoundReaders::class.java)
+    }
+
+    @Test
+    fun `when reader discover succeeds, then Success is emitted`() = runBlockingTest {
+        whenever(terminal.discoverReaders(any(), any(), any())).thenAnswer {
+            onSuccess(args = it.arguments)
+            mock<Cancelable>()
+        }
+
+        val event = action.discoverReaders(false).first()
+
+        assertThat(event).isInstanceOf(Success::class.java)
+    }
+
+    @Test
+    fun `when reader discover fails, then Failure is emitted`() = runBlockingTest {
+        whenever(terminal.discoverReaders(any(), any(), any())).thenAnswer {
+            onFailure(it.arguments)
+            mock<Cancelable>()
+        }
+
+        val event = action.discoverReaders(false).first()
+
+        assertThat(event).isInstanceOf(Failure::class.java)
+    }
+
+    @Test
+    fun `when reader discover succeeds, then flow is terminated`() = runBlockingTest {
+        whenever(terminal.discoverReaders(any(), any(), any())).thenAnswer {
+            onSuccess(args = it.arguments)
+            mock<Cancelable>()
+        }
+
+        val event = action.discoverReaders(false).toList()
+
+        assertThat(event.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `when reader discover fails, then flow is terminated`() = runBlockingTest {
+        whenever(terminal.discoverReaders(any(), any(), any())).thenAnswer {
+            onFailure(it.arguments)
+            mock<Cancelable>()
+        }
+
+        val event = action.discoverReaders(false).toList()
+
+        assertThat(event.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `when readers discovered, then foundReaders is updated`() = runBlockingTest {
+        whenever(terminal.discoverReaders(any(), any(), any())).thenAnswer {
+            onUpdateDiscoveredReaders(args = it.arguments, readers = listOf(mock()))
+            mock<Cancelable>()
+        }
+
+        val job = launch {
+            action.discoverReaders(false).collect { }
+        }
+
+        assertThat(action.foundReaders.size).isNotEqualTo(0)
+        job.cancel()
+    }
+
+    @Test
+    fun `when flow terminates, then foundReaders collection is cleared`() = runBlockingTest {
+        whenever(terminal.discoverReaders(any(), any(), any())).thenAnswer {
+            onUpdateDiscoveredReaders(args = it.arguments, readers = listOf(mock()))
+            onSuccess(args = it.arguments)
+            mock<Cancelable>()
+        }
+        action.discoverReaders(false).toList()
+
+        assertThat(action.foundReaders.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `given flow not terminated, when job canceled, then reader discovery gets canceled`() = runBlockingTest {
+        val cancelable = mock<Cancelable>()
+        whenever(cancelable.isCompleted).thenReturn(false)
+        whenever(terminal.discoverReaders(any(), any(), any())).thenAnswer { cancelable }
+        val job = launch {
+            action.discoverReaders(false).collect { }
+        }
+
+        job.cancel()
+        joinAll(job)
+
+        verify(cancelable).cancel(any())
+    }
+
+    @Test
+    fun `given flow already terminated, when job canceled, then reader discovery not canceled`() = runBlockingTest {
+        val cancelable = mock<Cancelable>()
+        whenever(cancelable.isCompleted).thenReturn(true)
+        whenever(terminal.discoverReaders(any(), any(), any())).thenAnswer {
+            onSuccess(it.arguments)
+            cancelable
+        }
+        val job = launch {
+            action.discoverReaders(false).collect { }
+        }
+
+        job.cancel()
+        joinAll(job)
+
+        verify(cancelable, never()).cancel(any())
+    }
+
+    @Test
+    fun `given last event is terminal, when multiple events emitted, then flow terminates`() = runBlockingTest {
+        whenever(terminal.discoverReaders(any(), any(), any())).thenAnswer {
+            onUpdateDiscoveredReaders(args = it.arguments, readers = listOf(mock()))
+            onUpdateDiscoveredReaders(args = it.arguments, readers = listOf(mock()))
+            onFailure(it.arguments)
+            mock<Cancelable>()
+        }
+
+        val result = action.discoverReaders(false).toList()
+
+        assertThat(result.size).isEqualTo(3)
+    }
+
+    @Test(expected = ClosedSendChannelException::class)
+    fun `given more events emitted, when terminal event already processed, then exception is thrown`() =
+        runBlockingTest {
+            whenever(terminal.discoverReaders(any(), any(), any())).thenAnswer {
+                onSuccess(it.arguments)
+                onUpdateDiscoveredReaders(args = it.arguments, readers = listOf())
+                mock<Cancelable>()
+            }
+
+            action.discoverReaders(false).toList()
+        }
+
+    private fun onUpdateDiscoveredReaders(args: Array<Any>, readers: List<Reader>) {
+        args.filterIsInstance<DiscoveryListener>().first().onUpdateDiscoveredReaders(readers)
+    }
+
+    private fun onSuccess(args: Array<Any>) {
+        args.filterIsInstance<Callback>().first().onSuccess()
+    }
+
+    private fun onFailure(args: Array<Any>) {
+        args.filterIsInstance<Callback>().first().onFailure(mock())
+    }
+}

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersActionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersActionTest.kt
@@ -116,33 +116,6 @@ class DiscoverReadersActionTest {
     }
 
     @Test
-    fun `when readers discovered, then foundReaders is updated`() = runBlockingTest {
-        whenever(terminal.discoverReaders(any(), any(), any())).thenAnswer {
-            onUpdateDiscoveredReaders(args = it.arguments, readers = listOf(mock()))
-            mock<Cancelable>()
-        }
-
-        val job = launch {
-            action.discoverReaders(false).collect { }
-        }
-
-        assertThat(action.foundReaders.size).isNotEqualTo(0)
-        job.cancel()
-    }
-
-    @Test
-    fun `when flow terminates, then foundReaders collection is cleared`() = runBlockingTest {
-        whenever(terminal.discoverReaders(any(), any(), any())).thenAnswer {
-            onUpdateDiscoveredReaders(args = it.arguments, readers = listOf(mock()))
-            onSuccess(args = it.arguments)
-            mock<Cancelable>()
-        }
-        action.discoverReaders(false).toList()
-
-        assertThat(action.foundReaders.size).isEqualTo(0)
-    }
-
-    @Test
     fun `given flow not terminated, when job canceled, then reader discovery gets canceled`() = runBlockingTest {
         val cancelable = mock<Cancelable>()
         whenever(cancelable.isCompleted).thenReturn(false)

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersActionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersActionTest.kt
@@ -15,7 +15,9 @@ import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverRe
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Success
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import kotlinx.coroutines.channels.ClosedSendChannelException
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.joinAll
@@ -55,7 +57,8 @@ class DiscoverReadersActionTest {
             mock<Cancelable>()
         }
 
-        val event = action.discoverReaders(false).first()
+        val event = action.discoverReaders(false)
+            .ignoreStartedEvent().first()
 
         assertThat(event).isInstanceOf(FoundReaders::class.java)
     }
@@ -67,7 +70,8 @@ class DiscoverReadersActionTest {
             mock<Cancelable>()
         }
 
-        val event = action.discoverReaders(false).first()
+        val event = action.discoverReaders(false)
+            .ignoreStartedEvent().first()
 
         assertThat(event).isInstanceOf(Success::class.java)
     }
@@ -79,7 +83,8 @@ class DiscoverReadersActionTest {
             mock<Cancelable>()
         }
 
-        val event = action.discoverReaders(false).first()
+        val event = action.discoverReaders(false)
+            .ignoreStartedEvent().first()
 
         assertThat(event).isInstanceOf(Failure::class.java)
     }
@@ -91,7 +96,8 @@ class DiscoverReadersActionTest {
             mock<Cancelable>()
         }
 
-        val event = action.discoverReaders(false).toList()
+        val event = action.discoverReaders(false)
+            .ignoreStartedEvent().toList()
 
         assertThat(event.size).isEqualTo(1)
     }
@@ -103,7 +109,8 @@ class DiscoverReadersActionTest {
             mock<Cancelable>()
         }
 
-        val event = action.discoverReaders(false).toList()
+        val event = action.discoverReaders(false)
+            .ignoreStartedEvent().toList()
 
         assertThat(event.size).isEqualTo(1)
     }
@@ -177,7 +184,8 @@ class DiscoverReadersActionTest {
             mock<Cancelable>()
         }
 
-        val result = action.discoverReaders(false).toList()
+        val result = action.discoverReaders(false)
+            .ignoreStartedEvent().toList()
 
         assertThat(result.size).isEqualTo(3)
     }
@@ -205,4 +213,6 @@ class DiscoverReadersActionTest {
     private fun onFailure(args: Array<Any>) {
         args.filterIsInstance<Callback>().first().onFailure(mock())
     }
+
+    private fun <T> Flow<T>.ignoreStartedEvent(): Flow<T> = filterNot { it is Started }
 }


### PR DESCRIPTION
Parent issue #3725 

This PR
1. Renames "startDiscovery" to "discoverReaders"
2. Extracts logic related to reader discover into DiscoverReadersAction
3. "startDiscovery/discoverReaders" returns Flow now. It was a void method before and the consumer had to collect `discoveryEvents` MutableStateFlow. This change brings us two benefits - Firstly, it connects the producer with the consumer and secondly, we can easily cancel the discovery when the consumer stops collecting the flow.
4. Add tests

Note: CardReaderSettingsFragment is just a temporary class and doesn't need to be reviewed. It'll never be used in production.

To test - hw reader is NOT required
1. Open app settings
2. Click on "Manager card reader"
3. (optional) Check "use simulated card reader"
4. Tap on "Connect Card Reader"
5. Notice "Started" snackbar and notice state changes to "connecting/connected"

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
