### PR TITLE
Turn connectToReader into a suspendable function

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CardReaderSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CardReaderSettingsFragment.kt
@@ -92,16 +92,24 @@ class CardReaderSettingsFragment : Fragment(R.layout.fragment_settings_card_read
                 cardReaderManager.discoverReaders(isSimulated = simulated).collect { event ->
                     AppLog.d(AppLog.T.MAIN, event.toString())
                     when (event) {
-                        Started, Succeeded, is Failed -> {
+                        Started -> {
                             Snackbar.make(
                                 requireView(),
                                 event.javaClass.simpleName,
                                 BaseTransientBottomBar.LENGTH_SHORT
                             ).show()
                         }
+                        Succeeded, is Failed -> {
+                            // no-op
+                        }
                         is ReadersFound -> {
                             if (event.list.isNotEmpty()) {
-                                getCardReaderManager()?.connectToReader(event.list[0])
+                                val success = getCardReaderManager()?.connectToReader(event.list[0]) ?: false
+                                Snackbar.make(
+                                    requireView(),
+                                    "Connecting to reader ${if (success) "succeeded" else "failed"}",
+                                    BaseTransientBottomBar.LENGTH_SHORT
+                                ).show()
                             }
                         }
                     }

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -68,9 +68,9 @@ internal class CardReaderManagerImpl(
         return connectionManager.discoverReaders(isSimulated)
     }
 
-    override fun connectToReader(cardReader: CardReader) {
+    override suspend fun connectToReader(cardReader: CardReader): Boolean {
         if (!terminal.isInitialized()) throw IllegalStateException("Terminal not initialized")
-        connectionManager.connectToReader(cardReader)
+        return connectionManager.connectToReader(cardReader)
     }
 
     override suspend fun collectPayment(amount: Int, currency: String): Flow<CardPaymentStatus> =

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
@@ -12,7 +12,7 @@ interface CardReaderManager {
     val readerStatus: MutableStateFlow<CardReaderStatus>
     fun initialize(app: Application)
     fun discoverReaders(isSimulated: Boolean): Flow<CardReaderDiscoveryEvents>
-    fun connectToReader(cardReader: CardReader)
+    suspend fun connectToReader(cardReader: CardReader): Boolean
 
     // TODO cardreader Stripe accepts only Int, is that ok?
     suspend fun collectPayment(amount: Int, currency: String): Flow<CardPaymentStatus>

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.cardreader.internal.connection.ConnectionManager
 import com.woocommerce.android.cardreader.internal.wrappers.LogWrapper
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -89,9 +90,10 @@ class CardReaderManagerImplTest {
     }
 
     @Test(expected = IllegalStateException::class)
-    fun `given terminal not initialized, when connecting to reader started, then exception is thrown`() {
-        whenever(terminalWrapper.isInitialized()).thenReturn(false)
+    fun `given terminal not initialized, when connecting to reader started, then exception is thrown`() =
+        runBlockingTest {
+            whenever(terminalWrapper.isInitialized()).thenReturn(false)
 
-        cardReaderManager.connectToReader(mock())
-    }
+            cardReaderManager.connectToReader(mock())
+        }
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
@@ -52,7 +52,7 @@ class ConnectionManagerTest {
 
         val result = connectionManager.discoverReaders(true).toList()
 
-       assertThat((result.first() as ReadersFound).list.first().getId())
+        assertThat((result.first() as ReadersFound).list.first().getId())
             .isEqualTo(dummyReaderId)
     }
 
@@ -63,7 +63,7 @@ class ConnectionManagerTest {
 
         val result = connectionManager.discoverReaders(true).single()
 
-       assertThat(result).isInstanceOf(CardReaderDiscoveryEvents.Failed::class.java)
+        assertThat(result).isInstanceOf(CardReaderDiscoveryEvents.Failed::class.java)
     }
 
     @Test
@@ -73,14 +73,14 @@ class ConnectionManagerTest {
 
         val result = connectionManager.discoverReaders(true).single()
 
-       assertThat(result).isInstanceOf(CardReaderDiscoveryEvents.Succeeded::class.java)
+        assertThat(result).isInstanceOf(CardReaderDiscoveryEvents.Succeeded::class.java)
     }
 
     @Test
     fun `when reader unexpectedly disconnected, then observers get notified`() {
         connectionManager.onUnexpectedReaderDisconnect(mock())
 
-       assertThat(connectionManager.readerStatus.value).isEqualTo(
+        assertThat(connectionManager.readerStatus.value).isEqualTo(
             CardReaderStatus.NOT_CONNECTED
         )
     }
@@ -89,7 +89,7 @@ class ConnectionManagerTest {
     fun `when reader disconnected, then observers get notified`() {
         connectionManager.onConnectionStatusChange(NOT_CONNECTED)
 
-       assertThat(connectionManager.readerStatus.value).isEqualTo(
+        assertThat(connectionManager.readerStatus.value).isEqualTo(
             CardReaderStatus.NOT_CONNECTED
         )
     }
@@ -98,7 +98,7 @@ class ConnectionManagerTest {
     fun `when connecting to reader, then observers get notified`() {
         connectionManager.onConnectionStatusChange(CONNECTING)
 
-       assertThat(connectionManager.readerStatus.value).isEqualTo(
+        assertThat(connectionManager.readerStatus.value).isEqualTo(
             CardReaderStatus.CONNECTING
         )
     }
@@ -107,7 +107,7 @@ class ConnectionManagerTest {
     fun `when reader connection established, then observers get notified`() {
         connectionManager.onConnectionStatusChange(CONNECTED)
 
-       assertThat(connectionManager.readerStatus.value).isEqualTo(
+        assertThat(connectionManager.readerStatus.value).isEqualTo(
             CardReaderStatus.CONNECTED
         )
     }


### PR DESCRIPTION
Parent issue #3726 

Merge instructions:
~1. Make sure https://github.com/woocommerce/woocommerce-android/pull/3820 is merged~
~2. Remove "Not ready for merge" label~
3. Merge this PR

This PR transforms "connectToReader" method into a suspendable function.

To test - hw reader is NOT required
1. Open app settings
2. Tap on Manage card reader
3. (optional) Check "Use simulated card reader"
4. Turn on airplane mode
4. Tap on "Connect Card Reader"
5. Notice "Connection to reader failed" message
6. Turn off airplane mode and wait for 10s
7. Tap on "Connect Card Reader"
8. Notice "Connection to reader succeeded" message


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
