### PR TITLE
Don't hide the keyboard after submitting an order list search

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,13 +2,12 @@
 
 6.5
 -----
-
+- [*] Fixed bug that would cause the on-screen keyboard to disappear when searching the order list. [https://github.com/woocommerce/woocommerce-android/pull/3828]
 
 6.4
 -----
 * [*] Fixed bug where the app couldn't load products if there's decimal stock quantity. [https://github.com/woocommerce/woocommerce-android/pull/3782]
 - [*] Fixed a ui bug in the shipping label formats description screen. [https://github.com/woocommerce/woocommerce-android/pull/3791]
-- [*] Fixed bug that would cause the on-screen keyboard to disappear when searching the order list
 
 
 6.3

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,8 +7,9 @@
 6.4
 -----
 * [*] Fixed bug where the app couldn't load products if there's decimal stock quantity. [https://github.com/woocommerce/woocommerce-android/pull/3782]
-
 - [*] Fixed a ui bug in the shipping label formats description screen. [https://github.com/woocommerce/woocommerce-android/pull/3791]
+- [*] Fixed bug that would cause the on-screen keyboard to disappear when searching the order list
+
 
 6.3
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -379,10 +379,6 @@ class OrderListFragment : TopLevelFragment(R.layout.fragment_order_list),
 
     private fun updatePagedListData(pagedListData: PagedList<OrderListItemUIType>?) {
         binding.orderListView.submitPagedList(pagedListData)
-
-        if (pagedListData?.size != 0 && isSearching) {
-            WPActivityUtils.hideKeyboard(activity)
-        }
     }
 
     /**


### PR DESCRIPTION
Resolves #3616 - to test, try this in `develop`:

- Go to the order list
- Tap the search icon
- Pause for a second
- Note that the keyboard is hidden so you can't continue typing
- Switch to this branch and note that keyboard remains on-screen in this situation

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
