### PR TITLE
Shipping Labels: pre-populate weight in packages step

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabelPackage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabelPackage.kt
@@ -15,6 +15,6 @@ data class ShippingLabelPackage(
         val productId: Long,
         val name: String,
         val attributesList: String,
-        val weight: String
+        val weight: Float
     ) : Parcelable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingPackage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingPackage.kt
@@ -11,7 +11,8 @@ data class ShippingPackage(
     val title: String,
     val isLetter: Boolean,
     val category: String,
-    val dimensions: PackageDimensions
+    val dimensions: PackageDimensions,
+    val boxWeight: Float
 ) : Parcelable {
     companion object {
         const val CUSTOM_PACKAGE_CATEGORY = "custom"
@@ -36,6 +37,7 @@ fun CustomPackage.toAppModel(): ShippingPackage {
             width = dimensionsParts[1].trim().toFloat(),
             height = dimensionsParts[2].trim().toFloat()
         ),
+        boxWeight = boxWeight,
         category = ShippingPackage.CUSTOM_PACKAGE_CATEGORY
     )
 }
@@ -52,6 +54,7 @@ fun PredefinedOption.toAppModel(): List<ShippingPackage> {
                 width = dimensionsParts[1].trim().toFloat(),
                 height = dimensionsParts[2].trim().toFloat()
             ),
+            boxWeight = it.boxWeight,
             category = this.title
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -65,6 +65,9 @@ class ShippingLabelPackagesAdapter(
             )
             binding.weightEditText.setOnTextChangedListener {
                 val weight = it?.toString()?.trim('.')?.ifEmpty { null }?.toFloat() ?: Float.NaN
+                // Return early if the weight wasn't changed
+                if (weight == shippingLabelPackages[adapterPosition].weight) return@setOnTextChangedListener
+
                 onWeightEdited(adapterPosition, weight)
 
                 if (weight <= 0.0) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -57,7 +57,7 @@ class ShippingLabelPackagesAdapter(
             with(binding.itemsList) {
                 layoutManager =
                     LinearLayoutManager(binding.root.context, LinearLayoutManager.VERTICAL, false)
-                adapter = PackageProductsAdapter()
+                adapter = PackageProductsAdapter(weightUnit)
             }
             binding.weightEditText.hint = binding.root.context.getString(
                 R.string.shipping_label_package_details_weight_hint,
@@ -136,7 +136,7 @@ class ShippingLabelPackagesAdapter(
     }
 }
 
-class PackageProductsAdapter() : RecyclerView.Adapter<PackageProductViewHolder>() {
+class PackageProductsAdapter(private val weightUnit: String) : RecyclerView.Adapter<PackageProductViewHolder>() {
     var items: List<ShippingLabelPackage.Item> = emptyList()
         set(value) {
             field = value
@@ -160,7 +160,7 @@ class PackageProductsAdapter() : RecyclerView.Adapter<PackageProductViewHolder>(
         fun bind(item: ShippingLabelPackage.Item) {
             binding.productName.text = item.name
             val attributes = item.attributesList.takeIf { it.isNotEmpty() }?.let { "$it \u2981 " } ?: StringUtils.EMPTY
-            val details = "$attributes${item.weight}"
+            val details = "$attributes${item.weight} $weightUnit"
             if (details.isEmpty()) {
                 binding.productDetails.isVisible = false
             } else {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelTestUtils.kt
@@ -29,7 +29,7 @@ object CreateShippingLabelTestUtils {
 
     fun generatePackage(id: String = "id", provider: String = "provider"): ShippingPackage {
         return ShippingPackage(
-            id, "title1", false, provider, PackageDimensions(1.0f, 1.0f, 1.0f)
+            id, "title1", false, provider, PackageDimensions(1.0f, 1.0f, 1.0f), 1f
         )
     }
 
@@ -42,7 +42,7 @@ object CreateShippingLabelTestUtils {
             id,
             selectedPackage ?: generatePackage(),
             weight,
-            listOf(Item(0L, "product", "", "10 kg"))
+            listOf(Item(0L, "product", "", 10f))
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
@@ -17,7 +17,6 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLab
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.ProductDetailRepository
 import com.woocommerce.android.ui.products.ProductTestUtils
-import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.ui.products.variations.VariationDetailRepository
 import com.woocommerce.android.util.CoroutineTestRule
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -80,9 +79,6 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
         whenever(shippingLabelRepository.getShippingPackages()).thenReturn(WooResult(availablePackages))
         whenever(orderDetailRepository.getOrder(ORDER_ID)).thenReturn(testOrder)
         whenever(productDetailRepository.getProduct(any())).thenReturn(testProduct)
-        whenever(parameterRepository.getParameters(any(), any())).thenReturn(
-            SiteParameters("", "kg", "", 0f)
-        )
         viewModel = EditShippingLabelPackagesViewModel(
             savedState,
             coroutinesTestRule.testDispatchers,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
@@ -124,10 +124,11 @@ class ShippingLabelsStateMachineTest {
                     "title",
                     false,
                     "provider",
-                    PackageDimensions(10.0f, 10.0f, 10.0f)
+                    PackageDimensions(10.0f, 10.0f, 10.0f),
+                    1f
                 ),
                 weight = 10.0f,
-                items = listOf(Item(10L, "item", "attributes", "10kgs"))
+                items = listOf(Item(10L, "item", "attributes", 10f))
             )
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackageSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackageSelectorViewModelTest.kt
@@ -28,10 +28,10 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 class ShippingPackageSelectorViewModelTest : BaseUnitTest() {
     private val availablePackages = listOf(
         ShippingPackage(
-            "id1", "title1", false, "provider1", PackageDimensions(1.0f, 1.0f, 1.0f)
+            "id1", "title1", false, "provider1", PackageDimensions(1.0f, 1.0f, 1.0f), 1f
         ),
         ShippingPackage(
-            "id2", "title2", false, "provider2", PackageDimensions(1.0f, 1.0f, 1.0f)
+            "id2", "title2", false, "provider2", PackageDimensions(1.0f, 1.0f, 1.0f), 1f
         )
     )
     private val parameterRepository: ParameterRepository = mock()

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'c1fe990ac6aaecb390c9e56af4dd1903a203883c'
+    fluxCVersion = 'da4336ac0a79a5673940bedeb692e37d7c223f35'
     daggerVersion = '2.33'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Fixes #3829, the implementation logic is similar to what the web client does:
1. Calculate the weight from the total weights of products + the weight of the box.
2. If the selected box is changed, update the weight unless it was edited manually by the user.

Depends on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1952

#### Testing
1. Create an order that satisfies shipping label creation.
2. Open the order details in the app.
3. Click on "create shipping label" button.
4. Pass the origin and destination addresses steps.
5. Open the packages step.
6. Confirm that the weight is pre-populated by the total weight of items and the box weight (if the total is 0, it will be ignored).
7. Select a different package.
8. Confirm that the weight has been updated.
9. Edit the weight manually.
10. Select a different package.
11. Confirm that the weight hasn't been changed.

Note: the `box_weight` of most (if not all) predefined packages is `0`, so to test this properly, please create some custom packages.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
