### PR TITLE
issue/3833-update-product-attributes-bug-fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -557,5 +557,6 @@ fun WCProductModel.ProductAttribute.toJson(): JsonObject {
         json.addProperty("name", name)
         json.addProperty("visible", visible)
         json.addProperty("options", options.joinToString())
+        json.addProperty("variation", variation)
     }
 }


### PR DESCRIPTION
Fixes #3833. I've been looking into #3833 and it turns out there are two separate issues. 

1. We seem to be sending the `attributes` object in the API request when updating the product, even though the attributes section has not been updated. **We should not be sending the `attributes` object in the API request when it has not changed.**
2. When we are sending the `attributes` object in the API request when updating the product, we fail to add the `variation` field. This flag is what determines whether the attributes can be used for variations. **We accidentally fail to send this field so the attributes/variations disappear from the product store.**

**Solution**
I have opened a PR here to fix Issue 2. So the `variation` field in now included in the API request when updating a product. This will ensure the attributes/variations will not disappear from the store. 

In order to fix Issue 1, we need to include the `position` field in the `ProductAttribute` model in FluxC and update the `ProductAttribute` in Woo to include those changes. I tried to fix that but it seems to be a lot more changes than I expected and I'm not sure why this was excluded in the first place. and since work is being done at the moment for variations by @ThomazFB and @nbradbury I would like to leave it up to them to decide if this field needs to be included. 

Since this issue feels important I thought it best to target the release branch instead of `develop`. cc @AliSoftware this might need a new beta to be released please! Thank you!!

### To test
- Go to Products tab, select a variable product to edit.
- Change the "Short description" of the product and tap "UPDATE".
- Tap three dots > `View product on the store` and notice the product variations are removed.
- Pull the changes from this PR and notice that the product variations are no longer removed from the product page in the store.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
