### PR TITLE
Issue/3824 remove "kotlin extensions plugin"

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-parcelize'
 apply plugin: 'kotlin-allopen'
 apply plugin: 'se.bjurr.violations.violation-comments-to-github-gradle-plugin'
 apply plugin: 'io.sentry.android.gradle'
@@ -32,10 +32,6 @@ repositories {
     maven { url "https://jitpack.io" }
     maven { url "https://dl.bintray.com/wordpress-mobile/maven" }
     maven { url "http://dl.bintray.com/terl/lazysodium-maven" }
-}
-
-androidExtensions {
-    experimental = true
 }
 
 android {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundFragment.kt
@@ -12,20 +12,18 @@ import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.navGraphViewModels
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.base.UIMessageResolver
-import javax.inject.Inject
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.refunds.IssueRefundViewModel.IssueRefundEvent.ShowRefundSummary
 import com.woocommerce.android.ui.refunds.IssueRefundViewModel.RefundType
 import com.woocommerce.android.ui.refunds.IssueRefundViewModel.RefundType.AMOUNT
 import com.woocommerce.android.ui.refunds.IssueRefundViewModel.RefundType.ITEMS
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import dagger.Lazy
-import kotlinx.android.synthetic.main.fragment_refund_by_amount.*
-import org.wordpress.android.util.ActivityUtils
+import javax.inject.Inject
 
 class IssueRefundFragment : BaseFragment() {
     @Inject lateinit var viewModelFactory: Lazy<ViewModelFactory>
@@ -76,12 +74,13 @@ class IssueRefundFragment : BaseFragment() {
         viewModel.commonStateLiveData.observe(viewLifecycleOwner) { old, new ->
             new.screenTitle?.takeIfNotEqualTo(old?.screenTitle) { requireActivity().title = it }
 
-            if (new.refundType == AMOUNT) {
-                issueRefund_refundAmount.requestFocus()
-                ActivityUtils.showKeyboard(issueRefund_refundAmount)
-            } else {
-                ActivityUtils.hideKeyboard(requireActivity())
-            }
+            // As the tabs are hidden, this logic is not used for now
+//            if (new.refundType == AMOUNT) {
+//                issueRefund_refundAmount.requestFocus()
+//                ActivityUtils.showKeyboard(issueRefund_refundAmount)
+//            } else {
+//                ActivityUtils.hideKeyboard(requireActivity())
+//            }
         }
 
         viewModel.event.observe(viewLifecycleOwner, Observer { event ->


### PR DESCRIPTION
Fixes #3824, simply removes the "kotlin extensions" plugin and replaces it with "kotlin-parcelize"

#### Testing
I don't expect any behavior changes, smoke testing some parts, especially the refund screens would be enough.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
