### PR TITLE
issue/3835-dont-update-attributes-unless-changed

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -556,6 +556,6 @@ fun WCProductModel.ProductAttribute.toJson(): JsonObject {
         json.addProperty("id", id)
         json.addProperty("name", name)
         json.addProperty("visible", visible)
-        json.addProperty("options", options.joinToString())
+        json.addProperty("options", "[${options.joinToString()}]")
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -547,4 +547,3 @@ fun MediaModel.toAppModel(): Product.Image {
  */
 fun WCProductModel.toProductReviewProductModel() =
     ProductReviewProduct(this.remoteProductId, this.name, this.permalink)
-}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -547,15 +547,4 @@ fun MediaModel.toAppModel(): Product.Image {
  */
 fun WCProductModel.toProductReviewProductModel() =
     ProductReviewProduct(this.remoteProductId, this.name, this.permalink)
-
-/**
- * TODO: move to FluxC model
- */
-fun WCProductModel.ProductAttribute.toJson(): JsonObject {
-    return JsonObject().also { json ->
-        json.addProperty("id", id)
-        json.addProperty("name", name)
-        json.addProperty("visible", visible)
-        json.addProperty("options", "[${options.joinToString()}]")
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
@@ -127,7 +127,8 @@ class ProductDetailRepository @Inject constructor(
             suspendCoroutineWithTimeout<Boolean>(AppConstants.REQUEST_TIMEOUT) {
                 continuationUpdateProduct = it
 
-                val product = updatedProduct.toDataModel(getCachedWCProductModel(updatedProduct.remoteId))
+                val cachedProduct = getCachedWCProductModel(updatedProduct.remoteId)
+                val product = updatedProduct.toDataModel(cachedProduct)
                 val payload = WCProductStore.UpdateProductPayload(selectedSite.get(), product)
                 dispatcher.dispatch(WCProductActionBuilder.newUpdateProductAction(payload))
             } ?: false // request timed out

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'c1fe990ac6aaecb390c9e56af4dd1903a203883c'
+    fluxCVersion = 'c7539d9ae4ca1eae2264f261f5b4dcc484d17448'
     daggerVersion = '2.33'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'd6fb9743fd3cd1bf4bf520c1d8c28fbe4299deaa'
+    fluxCVersion = 'caf960b8207181fdd099390de655dbb512e7ca2e'
     daggerVersion = '2.33'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '0ba99902b56869a924db4a204a895160304e6ddd'
+    fluxCVersion = 'fb28e2e93cbdfa0263f21788b91c1a45c19cb40a'
     daggerVersion = '2.33'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'da4336ac0a79a5673940bedeb692e37d7c223f35'
+    fluxCVersion = '0ba99902b56869a924db4a204a895160304e6ddd'
     daggerVersion = '2.33'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'c7539d9ae4ca1eae2264f261f5b4dcc484d17448'
+    fluxCVersion = 'd6fb9743fd3cd1bf4bf520c1d8c28fbe4299deaa'
     daggerVersion = '2.33'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Resolves #3835 - previously when a product is updated the list of attributes was always sent with any other changes, even when the attributes haven't changed. This PR corrects this by only passing the attributes when they've changed.

Note that the logic for this occurs in [this FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1957), which has been merged already.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
