### PR TITLE
issue/3841-phoneno-format-nullpointer-fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/PhoneUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/PhoneUtils.kt
@@ -17,7 +17,7 @@ object PhoneUtils {
                 @Suppress("DEPRECATION")
                 PhoneNumberUtils.formatNumber(number)
             }
-        } catch (e: IllegalStateException) {
+        } catch (e: Exception) {
             WooLog.d(T.UTILS, "Unable to format phone number: $number")
             number
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/PhoneUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/PhoneUtils.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.util
 
-import android.os.Build
 import android.telephony.PhoneNumberUtils
 import com.woocommerce.android.util.WooLog.T
 import java.util.Locale
@@ -11,14 +10,9 @@ object PhoneUtils {
      */
     fun formatPhone(number: String): String {
         return try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                PhoneNumberUtils.formatNumber(number, Locale.getDefault().country)
-            } else {
-                @Suppress("DEPRECATION")
-                PhoneNumberUtils.formatNumber(number)
-            }
+            PhoneNumberUtils.formatNumber(number, Locale.getDefault().country)
         } catch (e: Exception) {
-            WooLog.d(T.UTILS, "Unable to format phone number: $number")
+            WooLog.e(T.UTILS, "Unable to format phone number: $number", e)
             number
         }
     }


### PR DESCRIPTION
Fixes #3841. It looks like the method [PhoneNumberUtils.formatNumber(number,Locale.getDefault().country)](https://github.com/woocommerce/woocommerce-android/blob/714bc66bf8c77a450f0971ef336e39aeb4c51c18/WooCommerce/src/main/kotlin/com/woocommerce/android/util/PhoneUtils.kt#L15) returns a null value when the given phone number is not valid. This PR just updates the method to return the default phone number regardless of the exception that is thrown. 

#### To test
- Open an order from `wp-admin` of your test store.
- Enter a random phone number for the billing address. Sample: `85301473669909094861`.
- Open the order in the app and notice that the app no longer crashes.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
