### PR TITLE
issue/3651-product-price-update-bug-fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -10,7 +10,6 @@ import com.woocommerce.android.extensions.formatToString
 import com.woocommerce.android.extensions.formatToYYYYmmDDhhmmss
 import com.woocommerce.android.extensions.isEquivalentTo
 import com.woocommerce.android.extensions.isNotSet
-import com.woocommerce.android.extensions.roundError
 import com.woocommerce.android.ui.products.ProductBackorderStatus
 import com.woocommerce.android.ui.products.ProductStatus
 import com.woocommerce.android.ui.products.ProductStockStatus
@@ -469,8 +468,8 @@ fun WCProductModel.toAppModel(): Product {
         permalink = this.permalink,
         externalUrl = this.externalUrl,
         buttonText = this.buttonText,
-        salePrice = this.salePrice.toBigDecimalOrNull()?.roundError(),
-        regularPrice = this.regularPrice.toBigDecimalOrNull()?.roundError(),
+        salePrice = this.salePrice.toBigDecimalOrNull(),
+        regularPrice = this.regularPrice.toBigDecimalOrNull(),
         // In Core, if a tax class is empty it is considered as standard and we are following the same
         // procedure here
         taxClass = if (this.taxClass.isEmpty()) Product.TAX_CLASS_DEFAULT else this.taxClass,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
@@ -28,6 +28,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+import java.math.BigDecimal
 import java.util.Date
 
 class ProductPricingFragment
@@ -118,19 +119,21 @@ class ProductPricingFragment
         if (!isAdded) return
 
         with(binding.productRegularPrice) {
-            initView(currency, decimals, currencyFormatter)
-            pricingData.regularPrice?.let { setValue(it) }
-            getCurrencyEditText().value.observe(viewLifecycleOwner, Observer {
-                viewModel.onRegularPriceEntered(it)
-            })
+            prefixText = currency
+            pricingData.regularPrice?.let { setText(it.toString()) }
+            setOnTextChangedListener {
+                val price = it.toString().toBigDecimalOrNull() ?: BigDecimal.ZERO
+                viewModel.onRegularPriceEntered(price)
+            }
         }
 
         with(binding.productSalePrice) {
-            initView(currency, decimals, currencyFormatter)
-            pricingData.salePrice?.let { setValue(it) }
-            getCurrencyEditText().value.observe(viewLifecycleOwner, Observer {
-                viewModel.onSalePriceEntered(it)
-            })
+            prefixText = currency
+            pricingData.salePrice?.let { setText(it.toString()) }
+            setOnTextChangedListener {
+                val price = it.toString().toBigDecimalOrNull() ?: BigDecimal.ZERO
+                viewModel.onSalePriceEntered(price)
+            }
         }
 
         val scheduleSale = pricingData.isSaleScheduled == true

--- a/WooCommerce/src/main/res/layout/fragment_product_pricing.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_pricing.xml
@@ -26,7 +26,7 @@
                 app:layout_constraintTop_toTopOf="parent" />
 
             <!-- Product Regular Price -->
-            <com.woocommerce.android.widgets.WCMaterialOutlinedCurrencyEditTextView
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
                 android:id="@+id/product_regular_price"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -34,12 +34,13 @@
                 android:layout_marginTop="@dimen/major_75"
                 android:layout_marginEnd="@dimen/major_100"
                 android:hint="@string/product_regular_price"
+                android:inputType="numberDecimal"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/product_price_heading" />
 
             <!-- Product Sale Price -->
-            <com.woocommerce.android.widgets.WCMaterialOutlinedCurrencyEditTextView
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
                 android:id="@+id/product_sale_price"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -48,6 +49,7 @@
                 android:layout_marginEnd="@dimen/major_100"
                 android:layout_marginBottom="@dimen/minor_100"
                 android:hint="@string/product_sale_price"
+                android:inputType="numberDecimal"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/product_regular_price" />


### PR DESCRIPTION
Potentially fixes #3651. I was not able to reproduce the issue in #3651 but I noticed that we use the `CurrencyEditText` view class, which isn't really necessary for updating product price since we don't really validate any of the input using this class. I suspect the problem mentioned in this issue is related to a corner case from this class. 

I also noticed there is no way to add a decimal value when editing the price. For instance, if I want to add a price less than 0 (0.75), this is currently not possible in Android. iOS allows that though. 

In order to make it easier to edit, this PR just removes the reference to `CurrencyEditText` when updating regular and sale price, instead just adding an `inputType` as `numberDecimal`. 

### To test
- Click on a product and edit the regular price and sale price.
- Ensure that the existing functionality is not affected. For instance, 
	- the sale price should be less than the regular price. 
	- we should be able to update the price as 0 or less than 0.
- Verify that once the price is updated, it is reflected correctly in the product page of the store.  

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
