### PR TITLE
Shipping Labels: disable shipping label creation if WCS version is lower than 1.25.11 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringExt.kt
@@ -6,6 +6,7 @@ import android.text.method.LinkMovementMethod
 import android.widget.TextView
 import com.woocommerce.android.widgets.WooClickableSpan
 import org.apache.commons.text.StringEscapeUtils
+import java.lang.NumberFormatException
 
 /**
  * Checks if a given string is a number (supports positive or negative numbers)
@@ -93,4 +94,23 @@ private fun SpannableString.buildClickableUrlSpan(
         fullContent.length,
         Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
     )
+}
+
+fun String.semverCompareTo(otherVersion: String): Int {
+    try {
+        val thisVersionTokens = substringBefore("-").split(".").map { Integer.parseInt(it) }
+        val otherVersionTokens = otherVersion.substringBefore("-").split(".").map { Integer.parseInt(it) }
+
+        thisVersionTokens.forEachIndexed { index, token ->
+            if (token > otherVersionTokens[index]) {
+                return 1
+            } else if (token < otherVersionTokens[index]) {
+                return -1
+            }
+        }
+        return 0
+    } catch (e: NumberFormatException) {
+        // if the parsing fails, consider this version lower than the other one
+        return -1
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/WooPlugin.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/WooPlugin.kt
@@ -2,5 +2,6 @@ package com.woocommerce.android.model
 
 data class WooPlugin(
     val isInstalled: Boolean,
-    val isActive: Boolean
+    val isActive: Boolean,
+    val version: String?
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -297,7 +297,7 @@ class OrderDetailRepository @Inject constructor(
 
     fun getWooServicesPluginInfo(): WooPlugin {
         val info = wooCommerceStore.getWooCommerceServicesPluginInfo(selectedSite.get())
-        return WooPlugin(info != null, info?.active ?: false)
+        return WooPlugin(info != null, info?.active ?: false, info?.version)
     }
 
     fun getStoreCountryCode(): String? {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -26,6 +26,7 @@ import com.woocommerce.android.cardreader.CardPaymentStatus.WaitingForInput
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.di.ViewModelAssistedFactory
 import com.woocommerce.android.extensions.isNotEqualTo
+import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.extensions.whenNotNullNorEmpty
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.OrderStatus
@@ -81,6 +82,9 @@ class OrderDetailViewModel @AssistedInject constructor(
     private val resourceProvider: ResourceProvider,
     private val orderDetailRepository: OrderDetailRepository
 ) : ScopedViewModel(savedState, dispatchers) {
+    companion object {
+        private const val SUPPORTED_WCS_VERSION = "1.25.11"
+    }
     private val navArgs: OrderDetailFragmentArgs by savedState.navArgs()
 
     private val orderIdSet: OrderIdSet
@@ -117,7 +121,8 @@ class OrderDetailViewModel @AssistedInject constructor(
 
     private val isShippingPluginReady: Boolean by lazy {
         val pluginInfo = orderDetailRepository.getWooServicesPluginInfo()
-        pluginInfo.isInstalled && pluginInfo.isActive
+        pluginInfo.isInstalled && pluginInfo.isActive &&
+            (pluginInfo.version ?: "0.0.0").semverCompareTo(SUPPORTED_WCS_VERSION) >= 0
     }
 
     override fun onCleared() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -83,7 +83,8 @@ class OrderDetailViewModel @AssistedInject constructor(
     private val orderDetailRepository: OrderDetailRepository
 ) : ScopedViewModel(savedState, dispatchers) {
     companion object {
-        private const val SUPPORTED_WCS_VERSION = "1.25.11"
+        // The required version to support shipping label creation
+        const val SUPPORTED_WCS_VERSION = "1.25.11"
     }
     private val navArgs: OrderDetailFragmentArgs by savedState.navArgs()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -109,7 +109,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             .whenever(savedState).getLiveData<ViewState>(any(), any())
         doReturn(true).whenever(networkStatus).isConnected()
 
-        doReturn(WooPlugin(true, true, version = OrderDetailViewModel.SUPPORTED_WCS_VERSION)).whenever(repository).getWooServicesPluginInfo()
+        doReturn(WooPlugin(true, true, version = OrderDetailViewModel.SUPPORTED_WCS_VERSION))
+            .whenever(repository).getWooServicesPluginInfo()
 
         viewModel = spy(OrderDetailViewModel(
             savedState,
@@ -591,7 +592,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         doReturn(order).whenever(repository).getOrder(any())
         doReturn(order).whenever(repository).fetchOrder(any())
 
-        doReturn(WooPlugin(isInstalled = true, isActive = true, version = OrderDetailViewModel.SUPPORTED_WCS_VERSION)).whenever(repository).getWooServicesPluginInfo()
+        doReturn(WooPlugin(isInstalled = true, isActive = true, version = OrderDetailViewModel.SUPPORTED_WCS_VERSION))
+            .whenever(repository).getWooServicesPluginInfo()
         doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.remoteId)
         doReturn(true).whenever(repository).isOrderEligibleForSLCreation(order.remoteId)
 
@@ -612,29 +614,31 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `hide shipping label creation if wcs is older than supported version`() = coroutinesTestRule.testDispatcher.runBlockingTest {
-        doReturn(order).whenever(repository).getOrder(any())
-        doReturn(order).whenever(repository).fetchOrder(any())
+    fun `hide shipping label creation if wcs is older than supported version`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            doReturn(order).whenever(repository).getOrder(any())
+            doReturn(order).whenever(repository).fetchOrder(any())
 
-        doReturn(WooPlugin(isInstalled = true, isActive = true, version = "1.25.10")).whenever(repository).getWooServicesPluginInfo()
+            doReturn(WooPlugin(isInstalled = true, isActive = true, version = "1.25.10")).whenever(repository)
+                .getWooServicesPluginInfo()
 
-        doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
-        doReturn(RequestResult.SUCCESS).whenever(repository).fetchOrderShipmentTrackingList(any(), any())
-        doReturn(emptyList<ShippingLabel>()).whenever(repository).fetchOrderShippingLabels(any())
-        doReturn(emptyList<Refund>()).whenever(repository).fetchOrderRefunds(any())
-        doReturn(emptyList<Product>()).whenever(repository).fetchProductsByRemoteIds(any())
+            doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
+            doReturn(RequestResult.SUCCESS).whenever(repository).fetchOrderShipmentTrackingList(any(), any())
+            doReturn(emptyList<ShippingLabel>()).whenever(repository).fetchOrderShippingLabels(any())
+            doReturn(emptyList<Refund>()).whenever(repository).fetchOrderRefunds(any())
+            doReturn(emptyList<Product>()).whenever(repository).fetchProductsByRemoteIds(any())
 
-        var isCreateShippingLabelButtonVisible: Boolean? = null
-        viewModel.viewStateData.observeForever { _, new ->
-            isCreateShippingLabelButtonVisible = new.isCreateShippingLabelButtonVisible
+            var isCreateShippingLabelButtonVisible: Boolean? = null
+            viewModel.viewStateData.observeForever { _, new ->
+                isCreateShippingLabelButtonVisible = new.isCreateShippingLabelButtonVisible
+            }
+
+            viewModel.start()
+
+            verify(repository, never()).fetchSLCreationEligibility(any())
+            verify(repository, never()).isOrderEligibleForSLCreation(any())
+            assertThat(isCreateShippingLabelButtonVisible).isFalse()
         }
-
-        viewModel.start()
-
-        verify(repository, never()).fetchSLCreationEligibility(any())
-        verify(repository, never()).isOrderEligibleForSLCreation(any())
-        assertThat(isCreateShippingLabelButtonVisible).isFalse()
-    }
 
     @Test
     fun `hide shipping label creation if the order is not eligible`() =
@@ -642,7 +646,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         doReturn(order).whenever(repository).getOrder(any())
         doReturn(order).whenever(repository).fetchOrder(any())
 
-        doReturn(WooPlugin(isInstalled = true, isActive = true, version = OrderDetailViewModel.SUPPORTED_WCS_VERSION)).whenever(repository).getWooServicesPluginInfo()
+        doReturn(WooPlugin(isInstalled = true, isActive = true, version = OrderDetailViewModel.SUPPORTED_WCS_VERSION))
+            .whenever(repository).getWooServicesPluginInfo()
         doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.remoteId)
         doReturn(false).whenever(repository).isOrderEligibleForSLCreation(order.remoteId)
 
@@ -663,28 +668,32 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `hide shipping label creation if wcs plugin is not installed`() = coroutinesTestRule.testDispatcher.runBlockingTest {
-        doReturn(order).whenever(repository).getOrder(any())
-        doReturn(order).whenever(repository).fetchOrder(any())
+    fun `hide shipping label creation if wcs plugin is not installed`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            doReturn(order).whenever(repository).getOrder(any())
+            doReturn(order).whenever(repository).fetchOrder(any())
 
-        doReturn(WooPlugin(isInstalled = false, isActive = false, version = OrderDetailViewModel.SUPPORTED_WCS_VERSION)).whenever(repository)
-            .getWooServicesPluginInfo()
+            doReturn(
+                WooPlugin(
+                    isInstalled = false, isActive = false, version = OrderDetailViewModel.SUPPORTED_WCS_VERSION
+                )
+            ).whenever(repository).getWooServicesPluginInfo()
 
-        doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
-        doReturn(RequestResult.SUCCESS).whenever(repository).fetchOrderShipmentTrackingList(any(), any())
-        doReturn(emptyList<ShippingLabel>()).whenever(repository).fetchOrderShippingLabels(any())
-        doReturn(emptyList<Refund>()).whenever(repository).fetchOrderRefunds(any())
-        doReturn(emptyList<Product>()).whenever(repository).fetchProductsByRemoteIds(any())
+            doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
+            doReturn(RequestResult.SUCCESS).whenever(repository).fetchOrderShipmentTrackingList(any(), any())
+            doReturn(emptyList<ShippingLabel>()).whenever(repository).fetchOrderShippingLabels(any())
+            doReturn(emptyList<Refund>()).whenever(repository).fetchOrderRefunds(any())
+            doReturn(emptyList<Product>()).whenever(repository).fetchProductsByRemoteIds(any())
 
-        var isCreateShippingLabelButtonVisible: Boolean? = null
-        viewModel.viewStateData.observeForever { _, new ->
-            isCreateShippingLabelButtonVisible = new.isCreateShippingLabelButtonVisible
+            var isCreateShippingLabelButtonVisible: Boolean? = null
+            viewModel.viewStateData.observeForever { _, new ->
+                isCreateShippingLabelButtonVisible = new.isCreateShippingLabelButtonVisible
+            }
+
+            viewModel.start()
+
+            verify(repository, never()).fetchSLCreationEligibility(any())
+            verify(repository, never()).isOrderEligibleForSLCreation(any())
+            assertThat(isCreateShippingLabelButtonVisible).isFalse()
         }
-
-        viewModel.start()
-
-        verify(repository, never()).fetchSLCreationEligibility(any())
-        verify(repository, never()).isOrderEligibleForSLCreation(any())
-        assertThat(isCreateShippingLabelButtonVisible).isFalse()
-    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -109,7 +109,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             .whenever(savedState).getLiveData<ViewState>(any(), any())
         doReturn(true).whenever(networkStatus).isConnected()
 
-        doReturn(WooPlugin(true, true)).whenever(repository).getWooServicesPluginInfo()
+        doReturn(WooPlugin(true, true, version = OrderDetailViewModel.SUPPORTED_WCS_VERSION)).whenever(repository).getWooServicesPluginInfo()
 
         viewModel = spy(OrderDetailViewModel(
             savedState,
@@ -591,7 +591,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         doReturn(order).whenever(repository).getOrder(any())
         doReturn(order).whenever(repository).fetchOrder(any())
 
-        doReturn(WooPlugin(isInstalled = true, isActive = true)).whenever(repository).getWooServicesPluginInfo()
+        doReturn(WooPlugin(isInstalled = true, isActive = true, version = OrderDetailViewModel.SUPPORTED_WCS_VERSION)).whenever(repository).getWooServicesPluginInfo()
         doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.remoteId)
         doReturn(true).whenever(repository).isOrderEligibleForSLCreation(order.remoteId)
 
@@ -612,12 +612,37 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `hide shipping label creation if wcs is older than supported version`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+        doReturn(order).whenever(repository).getOrder(any())
+        doReturn(order).whenever(repository).fetchOrder(any())
+
+        doReturn(WooPlugin(isInstalled = true, isActive = true, version = "1.25.10")).whenever(repository).getWooServicesPluginInfo()
+
+        doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
+        doReturn(RequestResult.SUCCESS).whenever(repository).fetchOrderShipmentTrackingList(any(), any())
+        doReturn(emptyList<ShippingLabel>()).whenever(repository).fetchOrderShippingLabels(any())
+        doReturn(emptyList<Refund>()).whenever(repository).fetchOrderRefunds(any())
+        doReturn(emptyList<Product>()).whenever(repository).fetchProductsByRemoteIds(any())
+
+        var isCreateShippingLabelButtonVisible: Boolean? = null
+        viewModel.viewStateData.observeForever { _, new ->
+            isCreateShippingLabelButtonVisible = new.isCreateShippingLabelButtonVisible
+        }
+
+        viewModel.start()
+
+        verify(repository, never()).fetchSLCreationEligibility(any())
+        verify(repository, never()).isOrderEligibleForSLCreation(any())
+        assertThat(isCreateShippingLabelButtonVisible).isFalse()
+    }
+
+    @Test
     fun `hide shipping label creation if the order is not eligible`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
         doReturn(order).whenever(repository).getOrder(any())
         doReturn(order).whenever(repository).fetchOrder(any())
 
-        doReturn(WooPlugin(isInstalled = true, isActive = true)).whenever(repository).getWooServicesPluginInfo()
+        doReturn(WooPlugin(isInstalled = true, isActive = true, version = OrderDetailViewModel.SUPPORTED_WCS_VERSION)).whenever(repository).getWooServicesPluginInfo()
         doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.remoteId)
         doReturn(false).whenever(repository).isOrderEligibleForSLCreation(order.remoteId)
 
@@ -638,12 +663,12 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `hide shipping label creation if wcs plugin is not installed`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `hide shipping label creation if wcs plugin is not installed`() = coroutinesTestRule.testDispatcher.runBlockingTest {
         doReturn(order).whenever(repository).getOrder(any())
         doReturn(order).whenever(repository).fetchOrder(any())
 
-        doReturn(WooPlugin(isInstalled = false, isActive = false)).whenever(repository).getWooServicesPluginInfo()
+        doReturn(WooPlugin(isInstalled = false, isActive = false, version = OrderDetailViewModel.SUPPORTED_WCS_VERSION)).whenever(repository)
+            .getWooServicesPluginInfo()
 
         doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
         doReturn(RequestResult.SUCCESS).whenever(repository).fetchOrderShipmentTrackingList(any(), any())
@@ -658,6 +683,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         viewModel.start()
 
+        verify(repository, never()).fetchSLCreationEligibility(any())
+        verify(repository, never()).isOrderEligibleForSLCreation(any())
         assertThat(isCreateShippingLabelButtonVisible).isFalse()
     }
 }


### PR DESCRIPTION
Shipping labels purchase needs the new [status endpoint](https://github.com/Automattic/woocommerce-services/pull/2390), this was released as part of the version 1.25.11, so the feature shouldn't be enabled unless the store has a newer version.

#### Testing
1. Install version 1.25.10 of WCS in your store.
2. Open an order that's eligible for shipping creation.
3. Confirm that "Create shipping label" button is hidden.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
