### PR TITLE
Inject `DateUtils` into DI graph

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -31,7 +31,16 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
         </value>
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -31,16 +31,7 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
+          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
         </value>
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/AppConfigModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/AppConfigModule.kt
@@ -1,12 +1,15 @@
 package com.woocommerce.android.di
 
 import android.content.Context
+import com.automattic.android.tracks.CrashLogging.CrashLoggingDataProvider
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig
+import com.woocommerce.android.util.CrashUtils
 import dagger.Module
 import dagger.Provides
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets
+import java.util.Locale
 
 @Module
 class AppConfigModule {
@@ -19,6 +22,12 @@ class AppConfigModule {
 
     @Provides
     fun provideUserAgent(appContext: Context) = UserAgent(appContext, USER_AGENT_APPNAME)
+
+    @Provides
+    fun provideDefaultLocale(): Locale = Locale.getDefault()
+
+    @Provides
+    fun provideCrashUtils(): CrashLoggingDataProvider = CrashUtils
 
     @Provides
     fun providesAppPrefs(appContext: Context): AppPrefs {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
@@ -74,7 +74,7 @@ fun Date.getTimeString(context: Context): String = DateFormat.getTimeFormat(cont
 
 fun Date.getMediumDate(context: Context): String = DateFormat.getMediumDateFormat(context).format(this)
 
-fun Date?.offsetGmtDate(gmtOffset: Float) = this?.let { DateUtils().offsetGmtDate(it, gmtOffset) }
+fun Date?.offsetGmtDate(gmtOffset: Float) = this?.let { DateUtils.offsetGmtDate(it, gmtOffset) }
 
 fun Date.formatToYYYYmmDDhhmmss(): String =
     SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault()).format(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreDateRangeView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreDateRangeView.kt
@@ -18,8 +18,11 @@ class MyStoreDateRangeView @JvmOverloads constructor(ctx: Context, attrs: Attrib
     : LinearLayout(ctx, attrs) {
     private val binding = MyStoreDateBarBinding.inflate(LayoutInflater.from(ctx), this)
 
-    fun initView() {
+    private lateinit var dateUtils: DateUtils
+
+    fun initView(dateUtils: DateUtils) {
         clearDateRangeValues()
+        this.dateUtils = dateUtils
     }
 
     /**
@@ -89,10 +92,10 @@ class MyStoreDateRangeView @JvmOverloads constructor(ctx: Context, attrs: Attrib
         activeGranularity: StatsGranularity
     ): String {
         return when (activeGranularity) {
-            StatsGranularity.DAYS -> DateUtils().getDayMonthDateString(dateString).orEmpty()
+            StatsGranularity.DAYS -> dateUtils.getDayMonthDateString(dateString).orEmpty()
             StatsGranularity.WEEKS -> dateString.formatToMonthDateOnly()
-            StatsGranularity.MONTHS -> DateUtils().getMonthString(dateString).orEmpty()
-            StatsGranularity.YEARS -> DateUtils().getYearString(dateString).orEmpty()
+            StatsGranularity.MONTHS -> dateUtils.getMonthString(dateString).orEmpty()
+            StatsGranularity.YEARS -> dateUtils.getYearString(dateString).orEmpty()
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -28,6 +28,7 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
@@ -59,6 +60,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store),
     @Inject lateinit var selectedSite: SelectedSite
     @Inject lateinit var currencyFormatter: CurrencyFormatter
     @Inject lateinit var uiMessageResolver: UIMessageResolver
+    @Inject lateinit var dateUtils: DateUtils
 
     private var _binding: FragmentMyStoreBinding? = null
     private val binding get() = _binding!!
@@ -149,13 +151,14 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store),
             }
         }
 
-        myStoreDateBar.initView()
+        myStoreDateBar.initView(dateUtils)
 
         binding.myStoreStats.initView(
             activeGranularity,
             listener = this,
             selectedSite = selectedSite,
-            formatCurrencyForDisplay = currencyFormatter::formatCurrencyRounded
+            formatCurrencyForDisplay = currencyFormatter::formatCurrencyRounded,
+            dateUtils = dateUtils
         )
 
         binding.myStoreTopPerformers.initView(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -63,6 +63,7 @@ class MyStoreStatsView @JvmOverloads constructor(
 
     private lateinit var selectedSite: SelectedSite
     private lateinit var formatCurrencyForDisplay: FormatCurrencyRounded
+    private lateinit var dateUtils: DateUtils
 
     private var revenueStatsModel: WCRevenueStatsModel? = null
     private var chartRevenueStats = mapOf<String, Double>()
@@ -113,12 +114,14 @@ class MyStoreStatsView @JvmOverloads constructor(
         period: StatsGranularity = DEFAULT_STATS_GRANULARITY,
         listener: MyStoreStatsListener,
         selectedSite: SelectedSite,
-        formatCurrencyForDisplay: FormatCurrencyRounded
+        formatCurrencyForDisplay: FormatCurrencyRounded,
+        dateUtils: DateUtils
     ) {
         this.listener = listener
         this.selectedSite = selectedSite
         this.activeGranularity = period
         this.formatCurrencyForDisplay = formatCurrencyForDisplay
+        this.dateUtils = dateUtils
 
         initChart()
 
@@ -513,10 +516,10 @@ class MyStoreStatsView @JvmOverloads constructor(
 
     private fun getEntryValue(dateString: String): String {
         return when (activeGranularity) {
-            StatsGranularity.DAYS -> DateUtils().getShortHourString(dateString).orEmpty()
+            StatsGranularity.DAYS -> dateUtils.getShortHourString(dateString).orEmpty()
             StatsGranularity.WEEKS -> dateString.formatToMonthDateOnly()
             StatsGranularity.MONTHS -> dateString.formatToMonthDateOnly()
-            StatsGranularity.YEARS -> DateUtils().getShortMonthString(dateString).orEmpty()
+            StatsGranularity.YEARS -> dateUtils.getShortMonthString(dateString).orEmpty()
         }
     }
 
@@ -588,10 +591,10 @@ class MyStoreStatsView @JvmOverloads constructor(
          */
         private fun getLabelValue(dateString: String): String {
             return when (activeGranularity) {
-                StatsGranularity.DAYS -> DateUtils().getShortHourString(dateString).orEmpty()
+                StatsGranularity.DAYS -> dateUtils.getShortHourString(dateString).orEmpty()
                 StatsGranularity.WEEKS -> getWeekLabelValue(dateString)
                 StatsGranularity.MONTHS -> dateString.formatToDateOnly()
-                StatsGranularity.YEARS -> DateUtils().getShortMonthString(dateString).orEmpty()
+                StatsGranularity.YEARS -> dateUtils.getShortMonthString(dateString).orEmpty()
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -51,6 +51,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRefundFragm
 import com.woocommerce.android.ui.orders.tracking.AddOrderShipmentTrackingFragment
 import com.woocommerce.android.ui.refunds.RefundSummaryFragment
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUndoSnackbar
@@ -71,6 +72,7 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
     @Inject lateinit var currencyFormatter: CurrencyFormatter
     @Inject lateinit var uiMessageResolver: UIMessageResolver
     @Inject lateinit var productImageMap: ProductImageMap
+    @Inject lateinit var dateUtils: DateUtils
 
     private var _binding: FragmentOrderDetailBinding? = null
     private val binding get() = _binding!!
@@ -320,9 +322,12 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
     private fun showShipmentTrackings(
         shipmentTrackings: List<OrderShipmentTracking>
     ) {
-        binding.orderDetailShipmentList.updateShipmentTrackingList(shipmentTrackings) {
-            viewModel.onDeleteShipmentTrackingClicked(it)
-        }
+        binding.orderDetailShipmentList.updateShipmentTrackingList(
+            shipmentTrackings = shipmentTrackings,
+            dateUtils = dateUtils,
+            onDeleteShipmentTrackingClicked = {
+                viewModel.onDeleteShipmentTrackingClicked(it)
+            })
     }
 
     private fun showShippingLabels(shippingLabels: List<ShippingLabel>, currency: String) {
@@ -377,7 +382,8 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
             FEATURE_FEEDBACK_BANNER, mapOf(
             AnalyticsTracker.KEY_FEEDBACK_CONTEXT to context,
             AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_GIVEN
-        ))
+        )
+        )
         registerFeedbackSetting(GIVEN)
         NavGraphMainDirections
             .actionGlobalFeedbackSurveyFragment(SurveyType.SHIPPING_LABELS)
@@ -394,7 +400,8 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
             FEATURE_FEEDBACK_BANNER, mapOf(
             AnalyticsTracker.KEY_FEEDBACK_CONTEXT to context,
             AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_DISMISSED
-        ))
+        )
+        )
         registerFeedbackSetting(DISMISSED)
         displayShippingLabelsWIPCard(false, isM1)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -382,8 +382,7 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
             FEATURE_FEEDBACK_BANNER, mapOf(
             AnalyticsTracker.KEY_FEEDBACK_CONTEXT to context,
             AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_GIVEN
-        )
-        )
+        ))
         registerFeedbackSetting(GIVEN)
         NavGraphMainDirections
             .actionGlobalFeedbackSurveyFragment(SurveyType.SHIPPING_LABELS)
@@ -400,8 +399,7 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
             FEATURE_FEEDBACK_BANNER, mapOf(
             AnalyticsTracker.KEY_FEEDBACK_CONTEXT to context,
             AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_DISMISSED
-        )
-        )
+        ))
         registerFeedbackSetting(DISMISSED)
         displayShippingLabelsWIPCard(false, isM1)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShipmentTrackingListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShipmentTrackingListAdapter.kt
@@ -13,7 +13,8 @@ import com.woocommerce.android.ui.orders.details.adapter.OrderDetailShipmentTrac
 import com.woocommerce.android.util.DateUtils
 
 class OrderDetailShipmentTrackingListAdapter(
-    private val onDeleteShipmentTrackingClicked: (trackingNumber: String) -> Unit
+    private val onDeleteShipmentTrackingClicked: (trackingNumber: String) -> Unit,
+    private val dateUtils: DateUtils
 ) : RecyclerView.Adapter<OrderDetailShipmentTrackingViewHolder>() {
     var shipmentTrackingList: List<OrderShipmentTracking> = ArrayList()
         set(value) {
@@ -33,7 +34,7 @@ class OrderDetailShipmentTrackingListAdapter(
             parent,
             false
         )
-        return OrderDetailShipmentTrackingViewHolder(viewBinding, onDeleteShipmentTrackingClicked)
+        return OrderDetailShipmentTrackingViewHolder(viewBinding, onDeleteShipmentTrackingClicked, dateUtils)
     }
 
     override fun onBindViewHolder(holder: OrderDetailShipmentTrackingViewHolder, position: Int) {
@@ -44,7 +45,8 @@ class OrderDetailShipmentTrackingListAdapter(
 
     class OrderDetailShipmentTrackingViewHolder(
         private val viewBinding: OrderDetailShipmentTrackingListItemBinding,
-        private val onDeleteShipmentTrackingClicked: (trackingNumber: String) -> Unit
+        private val onDeleteShipmentTrackingClicked: (trackingNumber: String) -> Unit,
+        private val dateUtils: DateUtils
     ) : RecyclerView.ViewHolder(
         viewBinding.root
     ) {
@@ -52,7 +54,7 @@ class OrderDetailShipmentTrackingListAdapter(
             with(viewBinding.trackingType) { text = shipmentTracking.trackingProvider }
             with(viewBinding.trackingNumber) { text = shipmentTracking.trackingNumber }
             with(viewBinding.trackingDateShipped) {
-                text = DateUtils().getLocalizedLongDateString(context, shipmentTracking.dateShipped).orEmpty()
+                text = dateUtils.getLocalizedLongDateString(context, shipmentTracking.dateShipped).orEmpty()
             }
             with(viewBinding.trackingBtnTrack) {
                 isVisible = true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailShipmentTrackingListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailShipmentTrackingListView.kt
@@ -10,6 +10,7 @@ import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.databinding.OrderDetailShipmentTrackingListBinding
 import com.woocommerce.android.model.OrderShipmentTracking
 import com.woocommerce.android.ui.orders.details.adapter.OrderDetailShipmentTrackingListAdapter
+import com.woocommerce.android.util.DateUtils
 
 class OrderDetailShipmentTrackingListView @JvmOverloads constructor(
     ctx: Context,
@@ -20,11 +21,12 @@ class OrderDetailShipmentTrackingListView @JvmOverloads constructor(
 
     fun updateShipmentTrackingList(
         shipmentTrackings: List<OrderShipmentTracking>,
-        onDeleteShipmentTrackingClicked: (trackingNumber: String) -> Unit
+        onDeleteShipmentTrackingClicked: (trackingNumber: String) -> Unit,
+        dateUtils: DateUtils
     ) {
         val shipmentTrackingAdapter =
             binding.shipmentTrackItems.adapter as? OrderDetailShipmentTrackingListAdapter
-                ?: OrderDetailShipmentTrackingListAdapter(onDeleteShipmentTrackingClicked)
+                ?: OrderDetailShipmentTrackingListAdapter(onDeleteShipmentTrackingClicked, dateUtils)
 
         binding.shipmentTrackItems.apply {
             setHasFixedSize(true)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemDataSource.kt
@@ -123,7 +123,7 @@ class OrderListItemDataSource(
             // Check if future-dated orders should be excluded from the results list.
             if (listDescriptor.excludeFutureOrders) {
                 val currentDate = Date()
-                if (DateUtils().isAfterDate(currentDate, date)) {
+                if (DateUtils.isAfterDate(currentDate, date)) {
                     // This order is dated for the future so skip adding it to the list
                     return@forEach
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
@@ -34,7 +34,8 @@ import kotlinx.android.parcel.Parcelize
 import java.util.Date
 
 class ShippingCarrierRatesAdapter(
-    private val onRateSelected: (ShippingRate) -> Unit
+    private val onRateSelected: (ShippingRate) -> Unit,
+    private val dateUtils: DateUtils
 ) : RecyclerView.Adapter<RateListViewHolder>() {
     var items: List<PackageRateListItem> = emptyList()
         set(value) {
@@ -119,7 +120,6 @@ class ShippingCarrierRatesAdapter(
                     binding.carrierServiceName.text = rateItem.title
 
                     if (rateItem.deliveryDate != null) {
-                        val dateUtils = DateUtils()
                         binding.deliveryTime.text = dateUtils.getShortMonthDayString(
                             dateUtils.getYearMonthDayStringFromDate(rateItem.deliveryDate)
                         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesFragment.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
+import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -36,9 +37,11 @@ class ShippingCarrierRatesFragment : BaseFragment(R.layout.fragment_shipping_car
         const val SHIPPING_CARRIERS_CLOSED = "shipping_carriers_closed"
         const val SHIPPING_CARRIERS_RESULT = "shipping_carriers_result"
     }
+
     @Inject lateinit var uiMessageResolver: UIMessageResolver
     @Inject lateinit var viewModelFactory: ViewModelFactory
     @Inject lateinit var resourceProvider: ResourceProvider
+    @Inject lateinit var dateUtils: DateUtils
 
     private var doneMenuItem: MenuItem? = null
 
@@ -87,7 +90,10 @@ class ShippingCarrierRatesFragment : BaseFragment(R.layout.fragment_shipping_car
 
     private fun initializeViews() {
         binding.carrierRates.apply {
-            adapter = binding.carrierRates.adapter ?: ShippingCarrierRatesAdapter(viewModel::onShippingRateSelected)
+            adapter = binding.carrierRates.adapter ?: ShippingCarrierRatesAdapter(
+                onRateSelected = viewModel::onShippingRateSelected,
+                dateUtils = dateUtils
+            )
             layoutManager = LinearLayoutManager(context)
             itemAnimator = DefaultItemAnimator().apply {
                 supportsChangeAnimations = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingFragment.kt
@@ -49,6 +49,7 @@ class AddOrderShipmentTrackingFragment : BaseFragment(R.layout.fragment_add_ship
     @Inject lateinit var uiMessageResolver: UIMessageResolver
     @Inject lateinit var viewModelFactory: ViewModelFactory
     @Inject lateinit var navigator: OrderNavigator
+    @Inject lateinit var dateUtils: DateUtils
 
     private val viewModel: AddOrderShipmentTrackingViewModel by viewModels { viewModelFactory }
 
@@ -115,7 +116,7 @@ class AddOrderShipmentTrackingFragment : BaseFragment(R.layout.fragment_add_ship
             }
 
             new.date.takeIfNotEqualTo(old?.date) {
-                DateUtils().getLocalizedLongDateString(requireActivity(), it)
+                dateUtils.getLocalizedLongDateString(requireActivity(), it)
                     .let { localizedString ->
                         binding.date.setText(localizedString.orEmpty())
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
@@ -29,6 +29,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
 import java.util.Date
+import javax.inject.Inject
 
 class ProductPricingFragment
     : BaseProductEditorFragment(R.layout.fragment_product_pricing), ProductItemSelectorDialogListener {
@@ -45,6 +46,8 @@ class ProductPricingFragment
 
     private var _binding: FragmentProductPricingBinding? = null
     private val binding get() = _binding!!
+
+    @Inject lateinit var dateUtils: DateUtils
 
     override fun onPause() {
         super.onPause()
@@ -150,7 +153,7 @@ class ProductPricingFragment
             setClickListener {
                 startDatePickerDialog = displayDatePickerDialog(binding.scheduleSaleStartDate, OnDateSetListener {
                     _, selectedYear, selectedMonth, dayOfMonth ->
-                    val selectedDate = DateUtils().localDateToGmt(
+                    val selectedDate = dateUtils.localDateToGmt(
                             selectedYear, selectedMonth, dayOfMonth, gmtOffset, true
                     )
 
@@ -164,7 +167,7 @@ class ProductPricingFragment
             setClickListener {
                 endDatePickerDialog = displayDatePickerDialog(binding.scheduleSaleEndDate, OnDateSetListener {
                     _, selectedYear, selectedMonth, dayOfMonth ->
-                    val selectedDate = DateUtils().localDateToGmt(
+                    val selectedDate = dateUtils.localDateToGmt(
                             selectedYear, selectedMonth, dayOfMonth, gmtOffset, false
                     )
 
@@ -268,9 +271,9 @@ class ProductPricingFragment
         dateSetListener: OnDateSetListener
     ): DatePickerDialog {
         val dateString = if (spinnerEditText.getText().isNotBlank())
-            DateUtils().formatToYYYYmmDD(spinnerEditText.getText())
+            dateUtils.formatToYYYYmmDD(spinnerEditText.getText())
         else
-            DateUtils().formatToYYYYmmDD(Date().formatToMMMddYYYY())
+            dateUtils.formatToYYYYmmDD(Date().formatToMMMddYYYY())
         val (year, month, day) = dateString?.split("-").orEmpty()
         val datePicker = DatePickerDialog(
                 requireActivity(), dateSetListener, year.toInt(), month.toInt() - 1, day.toInt()
@@ -287,7 +290,7 @@ class ProductPricingFragment
      * If given [date] is null, current date is used
      */
     private fun formatSaleDateForDisplay(date: Date?, gmtOffset: Float): String {
-        val currentDate = DateUtils().offsetGmtDate(Date(), gmtOffset)
+        val currentDate = DateUtils.offsetGmtDate(Date(), gmtOffset)
         val dateOnSaleFrom = date?.offsetGmtDate(gmtOffset) ?: currentDate
         return dateOnSaleFrom.formatToMMMddYYYY()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -3,9 +3,7 @@ package com.woocommerce.android.util
 import android.content.Context
 import android.text.format.DateFormat
 import com.automattic.android.tracks.CrashLogging.CrashLoggingDataProvider
-import com.woocommerce.android.R
 import com.woocommerce.android.extensions.formatToYYYYmmDD
-import com.woocommerce.android.model.TimeGroup
 import com.woocommerce.android.util.WooLog.T.UTILS
 import org.apache.commons.lang3.time.DateUtils
 import java.text.DateFormatSymbols

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -14,12 +14,13 @@ import java.util.Calendar
 import java.util.Date
 import java.util.GregorianCalendar
 import java.util.Locale
+import javax.inject.Inject
 
-class DateUtils(
-    val locale: Locale = Locale.getDefault(),
-    val crashLogger: CrashLoggingDataProvider = CrashUtils
+class DateUtils @Inject constructor(
+    private val locale: Locale,
+    private val crashLogger: CrashLoggingDataProvider
 ) {
-    val friendlyMonthDayFormat: SimpleDateFormat = SimpleDateFormat("MMM d", locale)
+    private val friendlyMonthDayFormat: SimpleDateFormat = SimpleDateFormat("MMM d", locale)
 
     private val weekOfYearStartingMondayFormat: SimpleDateFormat = SimpleDateFormat("yyyy-'W'ww", locale).apply {
         calendar = Calendar.getInstance().apply {
@@ -263,44 +264,6 @@ class DateUtils(
         }
     }
 
-    fun getDayOfWeekWithMonthAndDayFromDate(date: Date): String {
-        val dateFormat = SimpleDateFormat("EEEE, MMM dd", Locale.US)
-        return dateFormat.format(date)
-    }
-
-    /**
-     * Compares two dates to determine if [date2] is after [date1]. Note that
-     * this method strips the time information from the comparison and is only comparing
-     * the dates.
-     *
-     * @param date1 the base date for comparison
-     * @param date2 the date to determine if after [date1]
-     */
-    fun isAfterDate(date1: Date, date2: Date): Boolean {
-        val dateOnly1 = DateUtils.round(date1, Calendar.DATE)
-        val dateOnly2 = DateUtils.round(date2, Calendar.DATE)
-        return dateOnly2.after(dateOnly1)
-    }
-
-    /**
-     * Returns a date with the passed GMT offset applied - note that this assumes the passed date is GMT
-     *
-     * The [operator] can either be [Int::plus] or [Int::minus]
-     * [Int::plus] is passed when formatting gmtDate to local date
-     * [Int::minus] is passed when formatting local date to gmt
-     */
-    fun offsetGmtDate(dateGmt: Date, gmtOffset: Float, operator: (Int, Int) -> Int = Int::plus): Date {
-        if (gmtOffset == 0f) {
-            return dateGmt
-        }
-
-        val secondsOffset = (3600 * gmtOffset).toInt() // 3600 is the number of seconds in an hour
-        val calendar = Calendar.getInstance()
-        calendar.time = dateGmt
-        calendar.set(Calendar.SECOND, operator(calendar.get(Calendar.SECOND), secondsOffset))
-        return calendar.time
-    }
-
     /**
      * Converts the given [year] [month] [day] to a [Date] object
      * and applies the passed [gmtOffset] to the date
@@ -368,5 +331,45 @@ class DateUtils(
     private fun String.reportAsError(e: Exception) {
         WooLog.e(UTILS, this)
         (crashLogger as? CrashUtils)?.logException(e)
+    }
+
+    companion object {
+        /**
+         * Returns a date with the passed GMT offset applied - note that this assumes the passed date is GMT
+         *
+         * The [operator] can either be [Int::plus] or [Int::minus]
+         * [Int::plus] is passed when formatting gmtDate to local date
+         * [Int::minus] is passed when formatting local date to gmt
+         */
+        fun offsetGmtDate(dateGmt: Date, gmtOffset: Float, operator: (Int, Int) -> Int = Int::plus): Date {
+            if (gmtOffset == 0f) {
+                return dateGmt
+            }
+
+            val secondsOffset = (3600 * gmtOffset).toInt() // 3600 is the number of seconds in an hour
+            val calendar = Calendar.getInstance()
+            calendar.time = dateGmt
+            calendar.set(Calendar.SECOND, operator(calendar.get(Calendar.SECOND), secondsOffset))
+            return calendar.time
+        }
+
+        /**
+         * Compares two dates to determine if [date2] is after [date1]. Note that
+         * this method strips the time information from the comparison and is only comparing
+         * the dates.
+         *
+         * @param date1 the base date for comparison
+         * @param date2 the date to determine if after [date1]
+         */
+        fun isAfterDate(date1: Date, date2: Date): Boolean {
+            val dateOnly1 = DateUtils.round(date1, Calendar.DATE)
+            val dateOnly2 = DateUtils.round(date2, Calendar.DATE)
+            return dateOnly2.after(dateOnly1)
+        }
+
+        fun getDayOfWeekWithMonthAndDayFromDate(date: Date): String {
+            val dateFormat = SimpleDateFormat("EEEE, MMM dd", Locale.US)
+            return dateFormat.format(date)
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -37,25 +37,6 @@ class DateUtils @Inject constructor(
     private val yyyyMMddFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US)
 
     /**
-     * Returns a string in the format of {date} at {time}.
-     */
-    fun getFriendlyShortDateAtTimeString(context: Context, date: Date): String {
-        val dateLabel = when (TimeGroup.getTimeGroupForDate(date)) {
-            TimeGroup.GROUP_TODAY -> {
-                context.getString(R.string.date_timeframe_today).toLowerCase(locale)
-            }
-            TimeGroup.GROUP_YESTERDAY -> {
-                context.getString(R.string.date_timeframe_yesterday).toLowerCase(locale)
-            }
-            else -> {
-                DateFormat.getDateFormat(context).format(date)
-            }
-        }
-        val timeString = DateFormat.getTimeFormat(context).format(date.time)
-        return context.getString(R.string.date_at_time, dateLabel, timeString)
-    }
-
-    /**
      * Given an ISO8601 date of format YYYY-MM-DD, returns the number of days in the given month.
      *
      * return null if the argument is not a valid iso8601 date string.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCEmptyStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCEmptyStatsView.kt
@@ -31,7 +31,7 @@ class WCEmptyStatsView @JvmOverloads constructor(
 
     fun updateVisitorCount(visits: Int) {
         visitorValue.text = visits.toString()
-        emptyStatsViewDateTitle.text = DateUtils().getDayOfWeekWithMonthAndDayFromDate(Date())
+        emptyStatsViewDateTitle.text = DateUtils.getDayOfWeekWithMonthAndDayFromDate(Date())
 
         // The empty view is only shown when there are no orders, which means the revenue is also 0
         ordersValue.text = "0"

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -242,7 +242,8 @@
     <fragment
         android:id="@+id/createShippingLabelFragment"
         android:name="com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelFragment"
-        android:label="CreateShippingLabelFragment">
+        android:label="CreateShippingLabelFragment"
+        tools:layout="@layout/fragment_create_shipping_label">
         <argument
             android:name="orderIdentifier"
             app:argType="string" />
@@ -355,7 +356,8 @@
     <fragment
         android:id="@+id/shippingCarrierRatesFragment"
         android:name="com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrierRatesFragment"
-        android:label="ShippingCarrierRatesFragment">
+        android:label="ShippingCarrierRatesFragment"
+        tools:layout="@layout/fragment_shipping_carrier_rates">
         <argument
             android:name="originAddress"
             app:argType="com.woocommerce.android.model.Address" />


### PR DESCRIPTION
Resolves: #3857 

### Context
Please check attached ticket for reasons for this change.

### How to test
This PR doesn't add any features. It builds fine, the only possible issue I can see is runtime crash caused by not injecting `DateUtils` to some of the fragments. It doesn't happen to me when I smoke test.

Only one suggestion to testing would be to open each fragment edited in this PR and check if it doesn't crash. I didn't open  `ShippingCarrierRatesFragment` yet - I'm looking for a way how to do this :)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
