### PR TITLE
Updates callsites for get_prs_list

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -61,6 +61,10 @@ platform :android do
 
     android_bump_version_release()
     new_version = android_get_app_version()
+
+    # Get PRs list before the frozen tag is set
+    get_prs_list(repository: GHHELPER_REPO, milestone:"#{new_version}", report_path:"#{File.expand_path('~')}/wcandroid_prs_list_#{old_version}_#{new_version}.txt")
+
     extract_release_notes_for_version(version: new_version,
       release_notes_file_path:"#{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt",
       extracted_notes_file_path:release_notes_path)
@@ -70,7 +74,6 @@ platform :android do
 
     localize_libs()
     send_strings_for_translation()
-    get_prs_list(repository: GHHELPER_REPO, start_tag:"#{old_version}", report_path:"#{File.expand_path('~')}/wcandroid_prs_list_#{old_version}_#{new_version}.txt")
   end
 
   #####################################################################################
@@ -213,9 +216,9 @@ platform :android do
   # bundle exec fastlane build_and_upload_release [skip_confirm:<skip confirm>] [create_release:<Create release on GH> ]
   #
   # Example:
-  # bundle exec fastlane build_and_upload_release 
-  # bundle exec fastlane build_and_upload_release skip_confirm:true 
-  # bundle exec fastlane build_and_upload_release create_release:true 
+  # bundle exec fastlane build_and_upload_release
+  # bundle exec fastlane build_and_upload_release skip_confirm:true
+  # bundle exec fastlane build_and_upload_release create_release:true
   #####################################################################################
   desc "Builds and uploads release for distribution"
   lane :build_and_upload_release do | options |
@@ -259,9 +262,9 @@ platform :android do
   # bundle exec fastlane build_and_upload_beta [skip_confirm:<skip confirm>] [create_release:<Create release on GH> ]
   #
   # Example:
-  # bundle exec fastlane build_and_upload_beta 
-  # bundle exec fastlane build_and_upload_beta skip_confirm:true 
-  # bundle exec fastlane build_and_upload_beta create_release:true 
+  # bundle exec fastlane build_and_upload_beta
+  # bundle exec fastlane build_and_upload_beta skip_confirm:true
+  # bundle exec fastlane build_and_upload_beta create_release:true
   #####################################################################################
   desc "Builds and uploads a new beta build to Google Play (without releasing it)"
   lane :build_and_upload_beta do | options |
@@ -374,7 +377,7 @@ platform :android do
   ########################################################################
   desc "Get a list of pull request from `start_tag` to the current state"
   lane :get_pullrequests_list do | options |
-    get_prs_list(repository:GHHELPER_REPO, start_tag:"#{options[:start_tag]}", report_path:"#{File.expand_path('~')}/wcandroid_prs_list.txt")
+    get_prs_list(repository:GHHELPER_REPO, milestone:"#{options[:mileston]}", report_path:"#{File.expand_path('~')}/wcandroid_prs_list.txt")
   end
 
   #####################################################################################
@@ -471,7 +474,7 @@ platform :android do
     prerelease = options[:prerelease] || false
 
     project_root = File.dirname(File.expand_path(File.dirname(__FILE__)))
-    
+
     # APKs built on CI are not signed with master key, which means Google Sign-In won't work with those.
     # So don't attach them to the release, as this ends up being confusing for beta-testers.
     apk_file_path = File.join(project_root, 'artifacts', universal_apk_name(version)) unless is_ci

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -377,7 +377,7 @@ platform :android do
   ########################################################################
   desc "Get a list of pull request from `start_tag` to the current state"
   lane :get_pullrequests_list do | options |
-    get_prs_list(repository:GHHELPER_REPO, milestone:"#{options[:mileston]}", report_path:"#{File.expand_path('~')}/wcandroid_prs_list.txt")
+    get_prs_list(repository:GHHELPER_REPO, milestone:"#{options[:milestone]}", report_path:"#{File.expand_path('~')}/wcandroid_prs_list.txt")
   end
 
   #####################################################################################


### PR DESCRIPTION
Updates callsites for get_prs_list to use new implementation

To test: 

1. Run `bundle exec fastlane get_pullrequests_list milestone:<milstone>` to generate a PRs list file and validate the contents
2. Run `bundle exec fastlane code_freeze` and validate the contents of the prs list file generated