### PR TITLE
Color fix for "Package Details" icon.

### DIFF
--- a/WooCommerce/src/main/res/drawable/ic_gridicons_customize.xml
+++ b/WooCommerce/src/main/res/drawable/ic_gridicons_customize.xml
@@ -9,7 +9,6 @@
         android:fillType="evenOdd"/>
     <path
         android:pathData="M0,0.998h24v24h-24z"
-        android:fillColor="#000000"
-        android:fillAlpha="0.6"/>
+        android:fillColor="@color/color_icon" />
   </group>
 </vector>


### PR DESCRIPTION
To fix #3832

## Testing Instructions

(copied from the original issue)
1. Install the WooCommerce Shipping & Tax plugin.
2. On the web, purchase a shipping label for any order.
3. On your device, turn on Dark Theme or Dark Mode.
4. In the app, go to the order from step 2 and tap the "show shipment details" option.
5. Check to see that the icons look correct. The icon should look correct both in Dark and Light mode:

| Shipment Details screen  | Light mode | Dark mode |
|-|-|-|
| Before | ![image](https://user-images.githubusercontent.com/266376/115360709-1617a680-a1ea-11eb-8160-23f3a7a162b4.png) | ![115360783-2891e000-a1ea-11eb-95db-155e76d6dfe8](https://user-images.githubusercontent.com/266376/115361712-08165580-a1eb-11eb-85c8-d68729aacf27.png)  |
| After | ![image](https://user-images.githubusercontent.com/266376/115360450-d486fb80-a1e9-11eb-9694-ad827c110fa7.png) |![image](https://user-images.githubusercontent.com/266376/115360319-b8835a00-a1e9-11eb-82dd-32034f42a3c1.png)|

This icon is also used in **Products** > [_Select a variation product_] > **Variations** > [_Select a Variation_], in the **"Attributes"** card. 

This update fixes the icon color there so that it is now similar to the other icons in the same area. Screenshots below:

| Variation details screen  | Light mode | Dark mode |
|-|-|-|
| Before | ![image](https://user-images.githubusercontent.com/266376/115360992-5aa34200-a1ea-11eb-8288-379d06a690a3.png) | ![115360914-452e1800-a1ea-11eb-9e6f-7b9c5e8f7c2e](https://user-images.githubusercontent.com/266376/115361845-2c723200-a1eb-11eb-9f56-2965f703381d.png) |
| After | ![image](https://user-images.githubusercontent.com/266376/115359540-f9c73a00-a1e8-11eb-808c-d098541c9dbe.png) | ![image](https://user-images.githubusercontent.com/266376/115359611-0c417380-a1e9-11eb-9299-aea45c8267b6.png) |


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
