### PR TITLE
Handle exception in case the device has no PDF reader app.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelFragment.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.shippinglabels
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.os.Bundle
 import android.os.Environment
@@ -145,13 +146,17 @@ class PrintShippingLabelFragment : BaseFragment(R.layout.fragment_print_shipping
             context, "${context.packageName}.provider", file
         )
 
-        val sendIntent = Intent(Intent.ACTION_VIEW)
-        sendIntent.setDataAndType(pdfUri, "application/pdf")
-        sendIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        sendIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-        startActivity(sendIntent)
+        try {
+            val sendIntent = Intent(Intent.ACTION_VIEW)
+            sendIntent.setDataAndType(pdfUri, "application/pdf")
+            sendIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            sendIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            startActivity(sendIntent)
 
-        viewModel.onPreviewLabelCompleted()
+            viewModel.onPreviewLabelCompleted()
+        } catch (exception: ActivityNotFoundException) {
+            displayError(R.string.shipping_label_preview_pdf_app_missing)
+        }
     }
 
     override fun onRequestAllowBackPress(): Boolean {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -365,6 +365,7 @@
     <string name="shipping_label_print_save_for_later">Save for later</string>
     <string name="shipping_label_print_screen_title">Print shipping label</string>
     <string name="shipping_label_preview_error">Error previewing shipping label</string>
+    <string name="shipping_label_preview_pdf_app_missing">Unable to preview shipping label. Please install a PDF viewer app and try again.</string>
     <string name="shipping_label_paper_size_legal">Legal (8.5 x 14 in)</string>
     <string name="shipping_label_paper_size_letter">Letter (8.5 x 11 in)</string>
     <string name="shipping_label_paper_size_label">Label (4 x 6 in)</string>


### PR DESCRIPTION
To fix #3854 

## Testing Instructions:

1. Have an Order with at least one Shipping Label already created for it.
2. Use a device or emulator that has no app that can open a PDF file. I found that it's easiest to just create a new AVD for this, which by default will have no PDF viewer app. I used an AVD with `Android 5.0 x86_64` for testing this.
3. Open that order, then tap "Reprint shipping label".
4. On the next screen, tap "Print shipping label".
5. The Loading pop-up will appear for a bit, and then the error message should show up at the bottom: "Unable to preview shipping label. Please install a PDF viewer app and try again."

<img src="https://user-images.githubusercontent.com/266376/115377932-4404e700-a1fa-11eb-85f8-52754773a6f0.png" width="42%" />


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
