### PR TITLE
issue/3869-use-for-variations-true

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductAttribute.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductAttribute.kt
@@ -12,11 +12,11 @@ data class ProductAttribute(
     val id: Long,
     val name: String,
     val terms: List<String>,
-    val isVisible: Boolean = DEFAULT_VISIBLE,
+    val isVisible: Boolean = DEFAULT_IS_VISIBLE,
     val isVariation: Boolean = DEFAULT_IS_VARIATION
 ) : Parcelable {
     companion object {
-        val DEFAULT_VISIBLE = true
+        val DEFAULT_IS_VISIBLE = true
         val DEFAULT_IS_VARIATION = true
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductAttribute.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductAttribute.kt
@@ -17,7 +17,7 @@ data class ProductAttribute(
 ) : Parcelable {
     companion object {
         val DEFAULT_VISIBLE = true
-        val DEFAULT_IS_VARIATION = false
+        val DEFAULT_IS_VARIATION = true
     }
 
     /**
@@ -33,8 +33,8 @@ data class ProductAttribute(
         WCProductModel.ProductAttribute(
             id = id,
             name = name,
-            visible = isVisible,
             options = terms.toMutableList(),
+            visible = isVisible,
             variation = isVariation
         )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductGlobalAttribute.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductGlobalAttribute.kt
@@ -42,7 +42,7 @@ data class ProductGlobalAttribute(
             id = this.remoteId,
             name = this.name,
             terms = terms,
-            isVisible = ProductAttribute.DEFAULT_VISIBLE,
+            isVisible = ProductAttribute.DEFAULT_IS_VISIBLE,
             isVariation = ProductAttribute.DEFAULT_IS_VARIATION
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductGlobalAttribute.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductGlobalAttribute.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.model
 
 import android.os.Parcelable
-import com.woocommerce.android.model.ProductAttribute.Companion
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.attribute.WCGlobalAttributeModel
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductGlobalAttribute.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductGlobalAttribute.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.model
 
 import android.os.Parcelable
+import com.woocommerce.android.model.ProductAttribute.Companion
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.attribute.WCGlobalAttributeModel
 
@@ -42,7 +43,8 @@ data class ProductGlobalAttribute(
             id = this.remoteId,
             name = this.name,
             terms = terms,
-            isVisible = true
+            isVisible = ProductAttribute.DEFAULT_VISIBLE,
+            isVariation = ProductAttribute.DEFAULT_IS_VARIATION
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -43,7 +43,6 @@ import com.woocommerce.android.model.ProductGlobalAttribute
 import com.woocommerce.android.model.ProductTag
 import com.woocommerce.android.model.addTags
 import com.woocommerce.android.model.sortCategories
-import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.products.ProductDetailBottomSheetBuilder.ProductDetailBottomSheetUiItem
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitExternalLink
@@ -1067,7 +1066,7 @@ class ProductDetailViewModel @AssistedInject constructor(
      */
     fun addAttributeTermToDraft(attributeId: Long, attributeName: String, termName: String) {
         val updatedTerms = ArrayList<String>()
-        var isVisible = ProductAttribute.DEFAULT_VISIBLE
+        var isVisible = ProductAttribute.DEFAULT_IS_VISIBLE
         var isVariation = ProductAttribute.DEFAULT_IS_VARIATION
 
         // find this attribute in the draft attributes
@@ -1254,7 +1253,7 @@ class ProductDetailViewModel @AssistedInject constructor(
                 id = 0L,
                 name = attributeName,
                 terms = emptyList(),
-                isVisible = ProductAttribute.DEFAULT_VISIBLE,
+                isVisible = ProductAttribute.DEFAULT_IS_VISIBLE,
                 isVariation = ProductAttribute.DEFAULT_IS_VARIATION
             )
         )


### PR DESCRIPTION
Closes #3869 - previously when an attribute was created, we set the "use for variations" value to False, which meant we couldn't use that attribute to generate a variation. This PR resolves this by setting it to True.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
