### PR TITLE
issue/3869-use-for-variations-true-take2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductAttribute.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductAttribute.kt
@@ -16,8 +16,8 @@ data class ProductAttribute(
     val isVariation: Boolean = DEFAULT_IS_VARIATION
 ) : Parcelable {
     companion object {
-        val DEFAULT_VISIBLE = true
-        val DEFAULT_IS_VARIATION = true
+        const val DEFAULT_VISIBLE = true
+        const val DEFAULT_IS_VARIATION = true
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductAttribute.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductAttribute.kt
@@ -17,7 +17,7 @@ data class ProductAttribute(
 ) : Parcelable {
     companion object {
         val DEFAULT_VISIBLE = true
-        val DEFAULT_IS_VARIATION = false
+        val DEFAULT_IS_VARIATION = true
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductGlobalAttribute.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductGlobalAttribute.kt
@@ -42,8 +42,8 @@ data class ProductGlobalAttribute(
             id = this.remoteId,
             name = this.name,
             terms = terms,
-            isVisible = DEFAULT_VISIBLE,
-            isVariation = DEFAULT_IS_VARIATION
+            isVisible = ProductAttribute.DEFAULT_VISIBLE,
+            isVariation = ProductAttribute.DEFAULT_IS_VARIATION
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductGlobalAttribute.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductGlobalAttribute.kt
@@ -42,7 +42,8 @@ data class ProductGlobalAttribute(
             id = this.remoteId,
             name = this.name,
             terms = terms,
-            isVisible = true
+            isVisible = DEFAULT_VISIBLE,
+            isVariation = DEFAULT_IS_VARIATION
         )
     }
 }


### PR DESCRIPTION
Closes #3869 - previously when an attribute was created, we set the "use for variations" value to False, which meant we couldn't use that attribute to generate a variation. This PR resolves this by setting it to True.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
