### PR TITLE
Introduce CardReaderPaymentDialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ActivityBindingModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ActivityBindingModule.kt
@@ -38,7 +38,8 @@ abstract class ActivityBindingModule {
             ReviewsModule::class,
             SitePickerModule::class,
             AztecModule::class,
-            ShippingLabelsModule::class
+            ShippingLabelsModule::class,
+            CardReaderModule::class
     ])
     abstract fun provideMainActivityInjector(): MainActivity
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
@@ -48,5 +48,5 @@ sealed class OrderNavigationTarget : Event() {
     object ViewPrintShippingLabelInfo : OrderNavigationTarget()
     object ViewShippingLabelFormatOptions : OrderNavigationTarget()
     data class StartShippingLabelCreationFlow(val orderIdentifier: String) : OrderNavigationTarget()
-    data class StartCardReaderPaymentFlow(val orderIdentifier: String): OrderNavigationTarget()
+    data class StartCardReaderPaymentFlow(val orderIdentifier: String) : OrderNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
@@ -48,4 +48,5 @@ sealed class OrderNavigationTarget : Event() {
     object ViewPrintShippingLabelInfo : OrderNavigationTarget()
     object ViewShippingLabelFormatOptions : OrderNavigationTarget()
     data class StartShippingLabelCreationFlow(val orderIdentifier: String) : OrderNavigationTarget()
+    data class StartCardReaderPaymentFlow(val orderIdentifier: String): OrderNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.ui.orders.OrderNavigationTarget.AddOrderShipmentT
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.IssueOrderRefund
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.PrintShippingLabel
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.RefundShippingLabel
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.StartCardReaderPaymentFlow
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.StartShippingLabelCreationFlow
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewCreateShippingLabelInfo
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
@@ -110,6 +111,11 @@ class OrderNavigator @Inject constructor() {
             is StartShippingLabelCreationFlow -> {
                 val action = OrderDetailFragmentDirections
                     .actionOrderDetailFragmentToCreateShippingLabelFragment(target.orderIdentifier)
+                fragment.findNavController().navigateSafely(action)
+            }
+            is StartCardReaderPaymentFlow -> {
+                val action = OrderDetailFragmentDirections
+                    .actionOrderDetailFragmentToCardReaderPaymentDialog(target.orderIdentifier)
                 fragment.findNavController().navigateSafely(action)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
@@ -1,0 +1,62 @@
+package com.woocommerce.android.ui.orders.cardreader
+
+import android.app.Dialog
+import android.content.Context
+import android.os.Bundle
+import android.view.View
+import android.view.Window
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.R
+import com.woocommerce.android.databinding.FragmentCardReaderPaymentBinding
+import com.woocommerce.android.databinding.FragmentSettingsCardReaderConnectBinding
+import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.NavigationTarget.CardReaderScanScreen
+import com.woocommerce.android.viewmodel.ViewModelFactory
+import dagger.android.AndroidInjector
+import dagger.android.DispatchingAndroidInjector
+import dagger.android.HasAndroidInjector
+import dagger.android.support.AndroidSupportInjection
+import javax.inject.Inject
+
+class CardReaderPaymentDialog : DialogFragment(R.layout.fragment_card_reader_payment), HasAndroidInjector {
+    @Inject lateinit var viewModelFactory: ViewModelFactory
+    @Inject internal lateinit var androidInjector: DispatchingAndroidInjector<Any>
+
+    val viewModel: CardReaderPaymentViewModel by viewModels { viewModelFactory }
+
+    override fun onAttach(context: Context) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = super.onCreateDialog(savedInstanceState)
+        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
+        return dialog
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val binding = FragmentCardReaderPaymentBinding.bind(view)
+
+        initViews(binding)
+        initObservers()
+    }
+
+    private fun initViews(binding: FragmentCardReaderPaymentBinding) {
+        // TODO cardreader remove this
+        binding.testingText.setText("Hardcoded: Card Reader Payment Fragment")
+    }
+
+    private fun initObservers() {
+        // TODO cardreader remove this
+        viewModel.foo()
+    }
+
+    override fun androidInjector(): AndroidInjector<Any> = androidInjector
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
@@ -1,10 +1,8 @@
 package com.woocommerce.android.ui.orders.cardreader
 
-import android.app.Dialog
 import android.content.Context
 import android.os.Bundle
 import android.view.View
-import android.view.Window
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.R

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
@@ -27,12 +27,6 @@ class CardReaderPaymentDialog : DialogFragment(R.layout.fragment_card_reader_pay
         super.onAttach(context)
     }
 
-    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val dialog = super.onCreateDialog(savedInstanceState)
-        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
-        return dialog
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
@@ -7,14 +7,8 @@ import android.view.View
 import android.view.Window
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
-import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentCardReaderPaymentBinding
-import com.woocommerce.android.databinding.FragmentSettingsCardReaderConnectBinding
-import com.woocommerce.android.extensions.navigateSafely
-import com.woocommerce.android.ui.base.BaseFragment
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.NavigationTarget.CardReaderScanScreen
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -1,0 +1,26 @@
+package com.woocommerce.android.ui.orders.cardreader
+
+import com.woocommerce.android.di.ViewModelAssistedFactory
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel
+import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+import com.woocommerce.android.viewmodel.SavedStateWithArgs
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import org.wordpress.android.fluxc.utils.AppLogWrapper
+import org.wordpress.android.util.AppLog.T
+
+class CardReaderPaymentViewModel @AssistedInject constructor(
+    @Assisted savedState: SavedStateWithArgs,
+    dispatchers: CoroutineDispatchers,
+    private val logger: AppLogWrapper
+) : ScopedViewModel(savedState, dispatchers) {
+    fun foo() {
+        logger.d(T.MAIN, "Testing foo()")
+    }
+
+    @AssistedFactory
+    interface Factory : ViewModelAssistedFactory<CardReaderPaymentViewModel>
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -1,9 +1,7 @@
 package com.woocommerce.android.ui.orders.cardreader
 
 import com.woocommerce.android.di.ViewModelAssistedFactory
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel
 import com.woocommerce.android.util.CoroutineDispatchers
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.assisted.Assisted

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/di/CardReaderPaymentModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/di/CardReaderPaymentModule.kt
@@ -1,0 +1,33 @@
+package com.woocommerce.android.ui.orders.cardreader.di
+
+import android.os.Bundle
+import androidx.lifecycle.ViewModel
+import androidx.savedstate.SavedStateRegistryOwner
+import com.woocommerce.android.di.ViewModelAssistedFactory
+import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentDialog
+import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel
+import com.woocommerce.android.viewmodel.ViewModelKey
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.multibindings.IntoMap
+
+@Module
+abstract class CardReaderPaymentModule {
+    @Module
+    companion object {
+        @JvmStatic
+        @Provides
+        fun provideDefaultArgs(fragment: CardReaderPaymentDialog): Bundle? {
+            return fragment.arguments
+        }
+    }
+
+    @Binds
+    abstract fun bindSavedStateRegistryOwner(fragment: CardReaderPaymentDialog): SavedStateRegistryOwner
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(CardReaderPaymentViewModel::class)
+    abstract fun bindFactory(factory: CardReaderPaymentViewModel.Factory): ViewModelAssistedFactory<out ViewModel>
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -40,11 +40,13 @@ import com.woocommerce.android.model.getNonRefundedProducts
 import com.woocommerce.android.model.getNonRefundedShippingLabelProducts
 import com.woocommerce.android.model.loadProducts
 import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.ui.orders.OrderNavigationTarget
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.AddOrderNote
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.AddOrderShipmentTracking
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.IssueOrderRefund
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.PrintShippingLabel
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.RefundShippingLabel
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.StartCardReaderPaymentFlow
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.StartShippingLabelCreationFlow
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewCreateShippingLabelInfo
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
@@ -226,37 +228,7 @@ class OrderDetailViewModel @AssistedInject constructor(
     }
 
     fun onAcceptCardPresentPaymentClicked(cardReaderManager: CardReaderManager?) {
-        launch {
-            // TODO cardreader use the correct currency or hide the button
-            cardReaderManager?.collectPayment(999, "usd")?.collect {
-                when (it) {
-                    CapturingPaymentFailed,
-                    CollectingPaymentFailed,
-                    InitializingPaymentFailed,
-                    ProcessingPaymentFailed -> triggerEvent(
-                        ShowSnackbar(string.generic_string, arrayOf("Payment failed :("))
-                    )
-                    PaymentCompleted -> triggerEvent(
-                        ShowSnackbar(string.generic_string, arrayOf("Payment completed successfully :))"))
-                    )
-                    CollectingPayment -> {
-                    }
-                    InitializingPayment -> triggerEvent(
-                        ShowSnackbar(string.generic_string, arrayOf("Payment flow started."))
-                    )
-                    CapturingPayment -> {
-                    }
-                    ProcessingPayment -> triggerEvent(
-                        ShowSnackbar(string.generic_string, arrayOf("Processing payment."))
-                    )
-                    ShowAdditionalInfo -> {
-                    }
-                    WaitingForInput -> triggerEvent(
-                        ShowSnackbar(string.generic_string, arrayOf("Tap your card"))
-                    )
-                }
-            }
-        }
+        triggerEvent(StartCardReaderPaymentFlow(order.identifier))
     }
 
     fun onViewRefundedProductsClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -12,17 +12,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_TRACKING_ADD
 import com.woocommerce.android.annotations.OpenClassOnDebug
-import com.woocommerce.android.cardreader.CardPaymentStatus.CapturingPayment
-import com.woocommerce.android.cardreader.CardPaymentStatus.CapturingPaymentFailed
-import com.woocommerce.android.cardreader.CardPaymentStatus.CollectingPayment
-import com.woocommerce.android.cardreader.CardPaymentStatus.CollectingPaymentFailed
-import com.woocommerce.android.cardreader.CardPaymentStatus.InitializingPayment
-import com.woocommerce.android.cardreader.CardPaymentStatus.InitializingPaymentFailed
-import com.woocommerce.android.cardreader.CardPaymentStatus.PaymentCompleted
-import com.woocommerce.android.cardreader.CardPaymentStatus.ProcessingPayment
-import com.woocommerce.android.cardreader.CardPaymentStatus.ProcessingPaymentFailed
-import com.woocommerce.android.cardreader.CardPaymentStatus.ShowAdditionalInfo
-import com.woocommerce.android.cardreader.CardPaymentStatus.WaitingForInput
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.di.ViewModelAssistedFactory
 import com.woocommerce.android.extensions.isNotEqualTo
@@ -40,7 +29,6 @@ import com.woocommerce.android.model.getNonRefundedProducts
 import com.woocommerce.android.model.getNonRefundedShippingLabelProducts
 import com.woocommerce.android.model.loadProducts
 import com.woocommerce.android.tools.NetworkStatus
-import com.woocommerce.android.ui.orders.OrderNavigationTarget
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.AddOrderNote
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.AddOrderShipmentTracking
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.IssueOrderRefund
@@ -64,7 +52,6 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.greenrobot.eventbus.EventBus

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/CardReaderModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/CardReaderModule.kt
@@ -1,7 +1,10 @@
 package com.woocommerce.android.ui.prefs.cardreader
 
 import com.woocommerce.android.di.FragmentScope
+import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentDialog
+import com.woocommerce.android.ui.orders.cardreader.di.CardReaderPaymentModule
 import com.woocommerce.android.ui.prefs.cardreader.CardReaderModule.CardReaderConnectFragmentModule
+import com.woocommerce.android.ui.prefs.cardreader.CardReaderModule.CardReaderPaymentFragmentModule
 import com.woocommerce.android.ui.prefs.cardreader.CardReaderModule.CardReaderScanFragmentModule
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectFragment
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectModule
@@ -13,7 +16,8 @@ import dagger.android.ContributesAndroidInjector
 @Module(
     includes = [
         CardReaderConnectFragmentModule::class,
-        CardReaderScanFragmentModule::class
+        CardReaderScanFragmentModule::class,
+        CardReaderPaymentFragmentModule::class
     ]
 )
 object CardReaderModule {
@@ -29,5 +33,12 @@ object CardReaderModule {
         @FragmentScope
         @ContributesAndroidInjector(modules = [CardReaderScanModule::class])
         abstract fun cardReaderScanFragment(): CardReaderScanFragment
+    }
+
+    @Module
+    abstract class CardReaderPaymentFragmentModule {
+        @FragmentScope
+        @ContributesAndroidInjector(modules = [CardReaderPaymentModule::class])
+        abstract fun cardReaderPaymentFragment(): CardReaderPaymentDialog
     }
 }

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_payment.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_payment.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/testing_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -207,6 +207,15 @@
             app:exitAnim="@anim/activity_slide_out_to_left"
             app:popEnterAnim="@anim/activity_slide_in_from_left"
             app:popExitAnim="@anim/activity_slide_out_to_right" />
+        <action
+            android:id="@+id/action_orderDetailFragment_to_cardReaderPaymentDialog"
+            app:destination="@id/cardReaderPaymentDialog"
+            app:enterAnim="@anim/activity_fade_in"
+            app:popExitAnim="@anim/activity_fade_out">
+            <argument
+                android:name="orderIdentifier"
+                app:argType="string" />
+        </action>
     </fragment>
     <dialog
         android:id="@+id/orderStatusSelectorDialog"
@@ -372,4 +381,8 @@
             android:name="selectedRates"
             app:argType="com.woocommerce.android.model.ShippingRate[]" />
     </fragment>
+    <dialog
+        android:id="@+id/cardReaderPaymentDialog"
+        android:name="com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentDialog"
+        android:label="CardReaderPaymentDialog" />
 </navigation>


### PR DESCRIPTION
Parent issue #3726 

This PR introduces CardReaderPaymentDialog which will be used to display the following payment flow:
<img width="935" alt="Screenshot 2021-04-20 at 13 56 32" src="https://user-images.githubusercontent.com/2261188/115449282-422e2a00-a1e0-11eb-8c10-54933b874637.png">

The fragment currently contains just a dummy UI. However, the structure of the code should be reviewed as if it was ready for production. 

Note/Question: I wasn't sure if it is ok to add the new fragment into CardReaderModule (dagger) which currently contains CardReaderScan and CardReaderConnect fragments which are part of the AppSettingsActivity whereas the newly added CardReaderPaymentDialog is part of MainActivity. I decided to add it there and update ActivityBindingModule in c582c92260fce19f7935d8c7cf605ccfdb84303a. Let me know if you think it's ok or think another approach would be better.

To Test:
1. Open a detail of an order
2. Tap on "Collect Payment"
3. Notice a dummy dialog with "Hardcoded: Card Reader Payment fragment" text is shown.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
