### PR TITLE
Empty states design updates

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_login_jetpack_required.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_jetpack_required.xml
@@ -21,50 +21,39 @@
             android:layout_height="wrap_content"
             tools:context=".ui.login.LoginJetpackRequiredFragment">
 
-            <ImageView
-                android:id="@+id/imageView2"
+            <LinearLayout
+                android:id="@+id/msg_wrapper"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:importantForAccessibility="no"
-                android:layout_marginBottom="@dimen/major_200"
-                android:src="@drawable/img_login_jetpack_required"
-                app:layout_constraintBottom_toTopOf="@+id/jetpack_required_msg"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintVertical_bias="1.0" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/jetpack_required_msg"
-                style="@style/Woo.TextView.Body1"
-                android:textAlignment="center"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_150"
-                android:layout_marginEnd="@dimen/major_150"
-                android:textColor="@color/color_on_surface_high"
-                android:text="@string/login_jetpack_required_text"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintVertical_bias="0.48000002" />
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/btn_secondary_action"
-                style="@style/Woo.Button.TextButton"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/minor_100"
-                android:layout_marginStart="@dimen/major_300"
-                android:layout_marginEnd="@dimen/major_300"
-                android:text="@string/login_jetpack_what_is"
-                android:textAllCaps="false"
-                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/jetpack_required_msg"
-                app:layout_constraintVertical_bias="0.0" />
+                android:orientation="vertical">
+                    <ImageView
+                        android:id="@+id/imageView2"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:importantForAccessibility="no"
+                        android:layout_marginBottom="@dimen/major_200"
+                        android:src="@drawable/img_login_jetpack_required"
+                        android:layout_gravity="center_horizontal" />
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/jetpack_required_msg"
+                        style="@style/Woo.TextView.Body1"
+                        android:textAlignment="center"
+                        android:text="@string/login_jetpack_required_text"
+                        android:layout_height="wrap_content"
+                        android:layout_width="wrap_content" />
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/btn_secondary_action"
+                        style="@style/Woo.Button.TextButton"
+                        android:text="@string/login_jetpack_what_is"
+                        android:textAllCaps="false"
+                        android:layout_height="wrap_content"
+                        android:layout_width="wrap_content"
+                        android:layout_gravity="center_horizontal"/>
+            </LinearLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 

--- a/WooCommerce/src/main/res/layout/fragment_login_jetpack_required.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_jetpack_required.xml
@@ -21,39 +21,47 @@
             android:layout_height="wrap_content"
             tools:context=".ui.login.LoginJetpackRequiredFragment">
 
-            <LinearLayout
-                android:id="@+id/msg_wrapper"
+            <ImageView
+                android:id="@+id/imageView2"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
+                android:importantForAccessibility="no"
+                android:layout_marginBottom="@dimen/major_200"
+                android:src="@drawable/img_login_jetpack_required"
+                app:layout_constraintBottom_toTopOf="@+id/jetpack_required_msg"
                 app:layout_constraintEnd_toEndOf="parent"
-                android:orientation="vertical">
-                    <ImageView
-                        android:id="@+id/imageView2"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:importantForAccessibility="no"
-                        android:layout_marginBottom="@dimen/major_200"
-                        android:src="@drawable/img_login_jetpack_required"
-                        android:layout_gravity="center_horizontal" />
-                    <com.google.android.material.textview.MaterialTextView
-                        android:id="@+id/jetpack_required_msg"
-                        style="@style/Woo.TextView.Body1"
-                        android:textAlignment="center"
-                        android:text="@string/login_jetpack_required_text"
-                        android:layout_height="wrap_content"
-                        android:layout_width="wrap_content" />
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/btn_secondary_action"
-                        style="@style/Woo.Button.TextButton"
-                        android:text="@string/login_jetpack_what_is"
-                        android:textAllCaps="false"
-                        android:layout_height="wrap_content"
-                        android:layout_width="wrap_content"
-                        android:layout_gravity="center_horizontal"/>
-            </LinearLayout>
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintVertical_bias="1.0" />
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/jetpack_required_msg"
+                style="@style/Woo.TextView.Body1"
+                android:textAlignment="center"
+                android:text="@string/login_jetpack_required_text"
+                android:layout_height="wrap_content"
+                android:layout_width="wrap_content"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintVertical_bias="0.7"
+                />
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_secondary_action"
+                style="@style/Woo.Button.TextButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/minor_100"
+                android:layout_marginStart="@dimen/major_300"
+                android:layout_marginEnd="@dimen/major_300"
+                android:text="@string/login_jetpack_what_is"
+                android:textAllCaps="false"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/jetpack_required_msg"
+                app:layout_constraintVertical_bias="0.0" />
+
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 

--- a/WooCommerce/src/main/res/layout/fragment_login_site_check_error.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_site_check_error.xml
@@ -14,7 +14,7 @@
         android:layout_weight="1">
 
         <com.google.android.material.textview.MaterialTextView
-            style="@style/Woo.TextView.Subtitle1"
+            style="@style/TextAppearance.Woo.Body1"
             android:id="@+id/login_error_msg"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -23,7 +23,7 @@
             android:layout_marginEnd="@dimen/major_100"
             android:layout_marginBottom="@dimen/major_300"
             android:drawableTop="@drawable/img_woo_no_stores"
-            android:drawablePadding="@dimen/major_100"
+            android:drawablePadding="@dimen/major_300"
             android:gravity="center_horizontal"
             android:lineSpacingExtra="@dimen/line_spacing_extra_50"
             android:text="@string/login_not_wordpress_site"

--- a/WooCommerce/src/main/res/layout/fragment_login_site_check_error.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_site_check_error.xml
@@ -23,7 +23,7 @@
             android:layout_marginEnd="@dimen/major_100"
             android:layout_marginBottom="@dimen/major_300"
             android:drawableTop="@drawable/img_woo_no_stores"
-            android:drawablePadding="@dimen/major_300"
+            android:drawablePadding="@dimen/major_275"
             android:gravity="center_horizontal"
             android:lineSpacingExtra="@dimen/line_spacing_extra_50"
             android:text="@string/login_not_wordpress_site"

--- a/WooCommerce/src/main/res/layout/fragment_print_shipping_label_info.xml
+++ b/WooCommerce/src/main/res/layout/fragment_print_shipping_label_info.xml
@@ -7,7 +7,8 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingBottom="@dimen/major_100">
+        android:paddingBottom="@dimen/major_100"
+        android:background="@color/color_surface">
 
         <ImageView
             android:id="@+id/imageView"

--- a/WooCommerce/src/main/res/layout/wc_empty_view.xml
+++ b/WooCommerce/src/main/res/layout/wc_empty_view.xml
@@ -51,7 +51,9 @@
         <com.google.android.material.button.MaterialButton
             android:id="@+id/empty_view_button"
             style="@style/Woo.Button.Colored"
-            android:layout_width="@dimen/empty_state_button_width"
+            android:layout_marginStart="@dimen/major_300"
+            android:layout_marginEnd="@dimen/major_300"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="0dp"
             android:layout_marginBottom="@dimen/major_200"

--- a/WooCommerce/src/main/res/layout/wc_empty_view.xml
+++ b/WooCommerce/src/main/res/layout/wc_empty_view.xml
@@ -51,7 +51,7 @@
         <com.google.android.material.button.MaterialButton
             android:id="@+id/empty_view_button"
             style="@style/Woo.Button.Colored"
-            android:layout_width="@dimen/empty_states_button_width"
+            android:layout_width="@dimen/empty_state_button_width"
             android:layout_height="wrap_content"
             android:layout_marginTop="0dp"
             android:layout_marginBottom="@dimen/major_200"

--- a/WooCommerce/src/main/res/layout/wc_empty_view.xml
+++ b/WooCommerce/src/main/res/layout/wc_empty_view.xml
@@ -51,7 +51,7 @@
         <com.google.android.material.button.MaterialButton
             android:id="@+id/empty_view_button"
             style="@style/Woo.Button.Colored"
-            android:layout_width="@dimen/alert_dialog_max_width"
+            android:layout_width="@dimen/empty_states_button_width"
             android:layout_height="wrap_content"
             android:layout_marginTop="0dp"
             android:layout_marginBottom="@dimen/major_200"

--- a/WooCommerce/src/main/res/values/dimens_base.xml
+++ b/WooCommerce/src/main/res/values/dimens_base.xml
@@ -115,4 +115,5 @@ so that's the baseline as defined in `major_100`.
     <dimen name="top_performer_min_height">224dp</dimen>
     <dimen name="expanded_toolbar_height">108dp</dimen>
     <dimen name="toolbar_height">56dp</dimen>
+    <dimen name="empty_states_button_width">240dp</dimen>
 </resources>

--- a/WooCommerce/src/main/res/values/dimens_base.xml
+++ b/WooCommerce/src/main/res/values/dimens_base.xml
@@ -116,5 +116,4 @@ so that's the baseline as defined in `major_100`.
     <dimen name="top_performer_min_height">224dp</dimen>
     <dimen name="expanded_toolbar_height">108dp</dimen>
     <dimen name="toolbar_height">56dp</dimen>
-    <dimen name="empty_state_button_width">197dp</dimen>
 </resources>

--- a/WooCommerce/src/main/res/values/dimens_base.xml
+++ b/WooCommerce/src/main/res/values/dimens_base.xml
@@ -115,5 +115,5 @@ so that's the baseline as defined in `major_100`.
     <dimen name="top_performer_min_height">224dp</dimen>
     <dimen name="expanded_toolbar_height">108dp</dimen>
     <dimen name="toolbar_height">56dp</dimen>
-    <dimen name="empty_states_button_width">240dp</dimen>
+    <dimen name="empty_state_button_width">197dp</dimen>
 </resources>

--- a/WooCommerce/src/main/res/values/dimens_base.xml
+++ b/WooCommerce/src/main/res/values/dimens_base.xml
@@ -29,6 +29,7 @@ so that's the baseline as defined in `major_100`.
     <dimen name="major_175">28dp</dimen>
     <dimen name="major_200">32dp</dimen>
     <dimen name="major_250">40dp</dimen>
+    <dimen name="major_275">42dp</dimen>
     <dimen name="major_300">48dp</dimen>
     <dimen name="major_325">56dp</dimen>
     <dimen name="major_350">60dp</dimen>


### PR DESCRIPTION
This is to fix #3862

Here are the list of items being worked on in this PR. The items in parenthesis are the values used in the code.

### Empty State Screen in Light Mode
- [x] Background: Gray 0 (`@color/woo_gray_0` which translates to `#F6F7F7`)
- [x] Headline: Headline 6 (`@style/TextAppearance.Woo.Headline6`)
- [x] Body: Body 1 (`@style/TextAppearance.Woo.Body1`)
- [x] Button width: 197 x 36px (`@dimen/empty_states_button_width`)
### "Not a WordPress site" screen:
- [x] Vertical padding 42px (`@dimen/major_300`) 
- [x] Body: Body 1 (`@style/TextAppearance.Woo.Body1`)
### Site needs Jetpack screen:
- [x] Vertically center the main content.
### "Print with your device" screen
- [x] Set bg color to be white in light mode.

## Testing Instructions:

(please note that the "before" screenshots are from the `develop` version)

### Empty State Screen in Light Mode
|&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Changes&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|Before|After|
|-|-|-|
| Background color, headline styling, body text styling, button width. |![image](https://user-images.githubusercontent.com/266376/115839019-6f7b1200-a444-11eb-9bff-c13beea9c80f.png)| ![image](https://user-images.githubusercontent.com/266376/116066133-ebc65d00-a6b1-11eb-8c3e-0309c99b70c7.png) |


### "Not a WordPress site" screen
|&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Changes&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|Before|After|
|-|-|-|
| Spacing between image and text, body text styling |![image](https://user-images.githubusercontent.com/266376/115838244-aa307a80-a443-11eb-8f0a-f3da77746d4f.png) |![image](https://user-images.githubusercontent.com/266376/115837270-99333980-a442-11eb-9c9e-a9b10f08b39f.png)|


### "Site needs Jetpack" screen
|&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Changes&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|Before|After|
|-|-|-|
| Content now vertically centered. |![image](https://user-images.githubusercontent.com/266376/115838397-d64bfb80-a443-11eb-91cc-d22a40a4925a.png)|![image](https://user-images.githubusercontent.com/266376/115837217-8587d300-a442-11eb-918b-6d3061f9a2d8.png)|


### "Print with your device" screen in white background:
|&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Changes&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|Before|After|
|-|-|-|
| Background color now white |![image](https://user-images.githubusercontent.com/266376/115839252-a81aeb80-a444-11eb-9645-c35e058dadc2.png)|![image](https://user-images.githubusercontent.com/266376/115836737-0befe500-a442-11eb-89a4-bec5cffe2469.png)|

Update release notes:
 [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
