### PR TITLE
Replace FAB with empty state button on Empty Product screen.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -253,7 +253,12 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
                             )
                         }
                         new.filterCount?.compareTo(0) == 1 -> binding.emptyView.show(EmptyViewType.FILTER_RESULTS)
-                        else -> binding.emptyView.show(EmptyViewType.PRODUCT_LIST)
+                        else -> {
+                            viewModel.hideAddProductButton() /* Hide FAB and use empty state view's button */
+                            binding.emptyView.show(EmptyViewType.PRODUCT_LIST) {
+                                showAddProductBottomSheet()
+                            }
+                        }
                     }
                 } else {
                     binding.emptyView.hide()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -254,7 +254,6 @@ class ProductListFragment : TopLevelFragment(R.layout.fragment_product_list),
                         }
                         new.filterCount?.compareTo(0) == 1 -> binding.emptyView.show(EmptyViewType.FILTER_RESULTS)
                         else -> {
-                            viewModel.hideAddProductButton() /* Hide FAB and use empty state view's button */
                             binding.emptyView.show(EmptyViewType.PRODUCT_LIST) {
                                 showAddProductBottomSheet()
                             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -188,6 +188,8 @@ class ProductListViewModel @AssistedInject constructor(
 
         viewState = viewState.copy(
             isEmptyViewVisible = products.isEmpty(),
+            /* if there are no products, hide Add Product button and use the empty view's button instead. */
+            isAddProductButtonVisible = products.isNotEmpty(),
             displaySortAndFilterCard = products.isNotEmpty() || productFilterOptions.isNotEmpty()
         )
     }
@@ -269,16 +271,11 @@ class ProductListViewModel @AssistedInject constructor(
             isLoading = false,
             isLoadingMore = false,
             isRefreshing = false,
-            isAddProductButtonVisible = true,
             canLoadMore = productRepository.canLoadMoreProducts,
             isEmptyViewVisible = _productList.value?.isEmpty() == true,
+            /* if there are no products, hide Add Product button and use the empty view's button instead. */
+            isAddProductButtonVisible = _productList.value?.isEmpty() == false,
             displaySortAndFilterCard = productFilterOptions.isNotEmpty() || _productList.value?.isNotEmpty() == true
-        )
-    }
-
-    fun hideAddProductButton() {
-        viewState = viewState.copy(
-            isAddProductButtonVisible = false
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -266,11 +266,12 @@ class ProductListViewModel @AssistedInject constructor(
      * Resets the view state following a refresh
      */
     private fun resetViewState() {
-        // - If there are no products in default view, app shows empty view with its own add button, so hide
-        //   Add Product FAB.
-        //   - However, if there are no products as a result of searching or filtering, the empty view has no button,
-        //     so show Add Product FAB
-        // - Else If there's at least one product, show Add Product FAB.
+        // Conditionals for showing / hiding the Add Product FAB:
+        // If there are no products:
+        // - in default view, hide the Add Product FAB, because the empty view has its own add button.
+        // - in search/filter result view, show the Add Product FAB, because the empty view doesn't have add button.
+        //
+        // If there is at least one product in default or search/filter result view, show the Add Product FAB.
         val shouldShowAddProductButton =
             if (_productList.value?.isEmpty() == true) {
                 when {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -267,12 +267,16 @@ class ProductListViewModel @AssistedInject constructor(
     private fun resetViewState() {
         // - If there are no products in default view, app shows empty view with its own add button, so hide
         //   Add Product FAB.
-        //   - However, if there are no products as a result of searching, the empty view has no add button, so show
-        //   Add Product FAB.
+        //   - However, if there are no products as a result of searching or filtering, the empty view has no button,
+        //     so show Add Product FAB
         // - Else If there's at least one product, show Add Product FAB.
         val shouldShowAddProductButton =
             if(_productList.value?.isEmpty() == true) {
-                viewState.query != null
+                when {
+                    viewState.query != null -> { true }
+                    viewState.filterCount?.compareTo(0) == 1 -> { true }
+                    else -> { false }
+                }
             } else {
                 true
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -87,7 +87,7 @@ class ProductListViewModel @AssistedInject constructor(
     fun getSearchQuery() = viewState.query
 
     fun onSearchQueryChanged(query: String) {
-        viewState = viewState.copy(query = query, isEmptyViewVisible = false)
+        viewState = viewState.copy(query = query, isEmptyViewVisible = false, isAddProductButtonVisible = true)
 
         if (query.length > 2) {
             onSearchRequested()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -292,11 +292,6 @@ class ProductListViewModel @AssistedInject constructor(
             isAddProductButtonVisible = shouldShowAddProductButton,
             displaySortAndFilterCard = productFilterOptions.isNotEmpty() || _productList.value?.isNotEmpty() == true
         )
-
-        /* When search result returns zero, the app will show empty state screen. Make sure FAB shows up in this case. */
-        if (viewState.query != null) {
-            viewState = viewState.copy(isAddProductButtonVisible = true)
-        }
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -258,14 +258,25 @@ class ProductListViewModel @AssistedInject constructor(
                     )
                     fetchProductList(loadMore = loadMore, scrollToTop = scrollToTop)
                 }
-            }
-        }
+            }}
     }
 
     /**
      * Resets the view state following a refresh
      */
     private fun resetViewState() {
+        // - If there are no products in default view, app shows empty view with its own add button, so hide
+        //   Add Product FAB.
+        //   - However, if there are no products as a result of searching, the empty view has no add button, so show
+        //   Add Product FAB.
+        // - Else If there's at least one product, show Add Product FAB.
+        val shouldShowAddProductButton =
+            if(_productList.value?.isEmpty() == true) {
+                viewState.query != null
+            } else {
+                true
+            }
+
         viewState = viewState.copy(
             isSkeletonShown = false,
             isLoading = false,
@@ -273,10 +284,14 @@ class ProductListViewModel @AssistedInject constructor(
             isRefreshing = false,
             canLoadMore = productRepository.canLoadMoreProducts,
             isEmptyViewVisible = _productList.value?.isEmpty() == true,
-            /* if there are no products, hide Add Product button and use the empty view's button instead. */
-            isAddProductButtonVisible = _productList.value?.isEmpty() == false,
+            isAddProductButtonVisible = shouldShowAddProductButton,
             displaySortAndFilterCard = productFilterOptions.isNotEmpty() || _productList.value?.isNotEmpty() == true
         )
+
+        /* When search result returns zero, the app will show empty state screen. Make sure FAB shows up in this case. */
+        if(viewState.query != null) {
+            viewState = viewState.copy(isAddProductButtonVisible = true)
+        }
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -275,9 +275,9 @@ class ProductListViewModel @AssistedInject constructor(
         val shouldShowAddProductButton =
             if (_productList.value?.isEmpty() == true) {
                 when {
-                    viewState.query != null -> { true }
-                    productFilterOptions.isNotEmpty() -> { true }
-                    else -> { false }
+                    viewState.query != null -> true
+                    productFilterOptions.isNotEmpty() -> true
+                    else -> false
                 }
             } else {
                 true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -276,6 +276,12 @@ class ProductListViewModel @AssistedInject constructor(
         )
     }
 
+    fun hideAddProductButton() {
+        viewState = viewState.copy(
+            isAddProductButtonVisible = false
+        )
+    }
+
     /**
      * If products are already being fetched, wait for the existing job to finish
      */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -258,7 +258,8 @@ class ProductListViewModel @AssistedInject constructor(
                     )
                     fetchProductList(loadMore = loadMore, scrollToTop = scrollToTop)
                 }
-            }}
+            }
+        }
     }
 
     /**
@@ -271,10 +272,10 @@ class ProductListViewModel @AssistedInject constructor(
         //     so show Add Product FAB
         // - Else If there's at least one product, show Add Product FAB.
         val shouldShowAddProductButton =
-            if(_productList.value?.isEmpty() == true) {
+            if (_productList.value?.isEmpty() == true) {
                 when {
                     viewState.query != null -> { true }
-                    viewState.filterCount?.compareTo(0) == 1 -> { true }
+                    productFilterOptions.isNotEmpty() -> { true }
                     else -> { false }
                 }
             } else {
@@ -293,7 +294,7 @@ class ProductListViewModel @AssistedInject constructor(
         )
 
         /* When search result returns zero, the app will show empty state screen. Make sure FAB shows up in this case. */
-        if(viewState.query != null) {
+        if (viewState.query != null) {
             viewState = viewState.copy(isAddProductButtonVisible = true)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -87,7 +87,7 @@ class ProductListViewModel @AssistedInject constructor(
     fun getSearchQuery() = viewState.query
 
     fun onSearchQueryChanged(query: String) {
-        viewState = viewState.copy(query = query, isEmptyViewVisible = false, isAddProductButtonVisible = true)
+        viewState = viewState.copy(query = query, isEmptyViewVisible = false)
 
         if (query.length > 2) {
             onSearchRequested()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCEmptyView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCEmptyView.kt
@@ -119,19 +119,18 @@ class WCEmptyView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? =
                 isTitleBold = false
                 val fmtArgs = "<strong>$searchQueryOrFilter</strong>"
                 title = String.format(
-                        context.getString(R.string.orders_empty_message_with_order_status_filter),
-                        fmtArgs
+                    context.getString(R.string.orders_empty_message_with_order_status_filter),
+                    fmtArgs
                 )
                 message = null
                 buttonText = null
                 drawableId = R.drawable.img_empty_search
             }
             PRODUCT_LIST -> {
-                // TODO: once adding products is supported, this needs to be updated to match designs
                 isTitleBold = true
                 title = context.getString(R.string.product_list_empty)
-                message = null
-                buttonText = null
+                message = context.getString(R.string.empty_product_message)
+                buttonText = context.getString(R.string.empty_product_add_product_button)
                 drawableId = R.drawable.img_empty_products
             }
             FILTER_RESULTS -> {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -827,6 +827,8 @@
     <string name="cross_sells_desc">Products promoted in the cart when current product is selected</string>
     <string name="add_products_button">Add products</string>
     <string name="edit_products_button">Edit products</string>
+    <string name="empty_product_add_product_button">Add product</string>
+    <string name="empty_product_message">Start selling today by adding your first product to the store.</string>
 
     <plurals name="product_count">
         <item quantity="one">%d product</item>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
@@ -126,7 +126,7 @@ class ProductListViewModelTest : BaseUnitTest() {
     @Test
     fun `Shows and hides add product button correctly when loading list of products`() = test {
         // when
-        doReturn(emptyList<Product>()).whenever(productRepository).fetchProductList()
+        doReturn(productList).whenever(productRepository).fetchProductList(productFilterOptions = emptyMap())
 
         createViewModel()
 
@@ -141,6 +141,27 @@ class ProductListViewModelTest : BaseUnitTest() {
 
         // then
         assertThat(isAddProductButtonVisible).containsExactly(true, false, true)
+    }
+
+    @Test
+    /* We hide the Add Product FAB and use the empty view's button instead. */
+    fun `Hides add product button when list of products is empty`() = test {
+        // when
+        doReturn(emptyList<Product>()).whenever(productRepository).fetchProductList()
+
+        createViewModel()
+
+        val isAddProductButtonVisible = ArrayList<Boolean>()
+        viewModel.viewStateLiveData.observeForever { old, new ->
+            new.isAddProductButtonVisible?.takeIfNotEqualTo(old?.isAddProductButtonVisible) {
+                isAddProductButtonVisible.add(it)
+            }
+        }
+
+        viewModel.loadProducts()
+
+        // then
+        assertThat(isAddProductButtonVisible).containsExactly(false)
     }
 
     @Test


### PR DESCRIPTION
To fix #3712

## What this PR does:
Replaces the FAB on empty product screen with the default button that the empty view layout has.

|Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/266376/115538734-649a7300-a2c6-11eb-96c1-1095d92345c5.png) | ![image](https://user-images.githubusercontent.com/266376/115538121-c1e1f480-a2c5-11eb-9b0d-74f50ce9e4b0.png) |

## Testing instruction:
1. Use a site with zero products in it.
2. Go to "Products" tab in the app.
3. Make sure that you're seeing layout similar to the "After" screenshot above.
4. Tap the "Add product" button and make sure adding products work normally as before.

## Testing instruction part 2:
As it turns out, this change also affects product search result view, so this PR has additional changes to tackle that. Here are the testing instructions: 

**Site with no products:**
| Steps | Screenshot |
|-|-|
| 1. Use a site with zero products in it. <br> 2. Go to "Products" tab in the app. <br> 3. Do a search that will result in **no products**. Make sure the empty `"We're sorry, we couldn't find results for..."` screen **and** the Add Product floating button are shown. | <img src="https://user-images.githubusercontent.com/266376/116525012-481fbb80-a902-11eb-9678-ac1acbc8410a.png" width="50%" /> |

**Site with existing products:**
1. Use that has products in it.
2. Do a search that will result in **some products**. Make sure that screen has the Add Product floating button.
3. Do a search that will result in **no products**. Make sure the empty `"We're sorry, we couldn't find results for..."` screen **and** the Add Product floating button are shown.
4. Press back to go to the default Products list screen.
5. Tap "Filters" at the top and select a filter that will result in **some products**. Make sure that screen has the Add Product floating button.
6. Clear the filter.
7. Tap "Filters" at the top and select a filter that will result in **no products**. Make sure the empty `"No products found"` screen **and** the Add Product floating button are shown.

Screenshots below for the different cases:

| Search resulting in some products | Search resulting in no products | Filter resulting in some products  | Filter resulting in no products | 
|-|-|-|-|
| ![image](https://user-images.githubusercontent.com/266376/116524766-f414d700-a901-11eb-8564-1295a0073580.png) | ![image](https://user-images.githubusercontent.com/266376/116524645-d0ea2780-a901-11eb-82ca-e0faab76de6c.png) | ![image](https://user-images.githubusercontent.com/266376/116524517-ad26e180-a901-11eb-9aa1-39fa78647927.png) | ![image](https://user-images.githubusercontent.com/266376/116524308-705aea80-a901-11eb-9b70-f14b69f17e40.png) |

Update release notes:

[x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
