### PR TITLE
First iteration on the implementation of CardReaderPaymentViewModel

### DIFF
--- a/WooCommerce/src/debug/kotlin/com.woocommerce.android/WooCommerceDebug.kt
+++ b/WooCommerce/src/debug/kotlin/com.woocommerce.android/WooCommerceDebug.kt
@@ -21,7 +21,8 @@ class WooCommerceDebug : WooCommerce() {
         }
 
         override suspend fun capturePaymentIntent(id: String): Boolean {
-            return false
+            // TODO cardreader Invoke capturePayment on WCPayStore
+            return true
         }
     })
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
@@ -5,9 +5,13 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Observer
+import com.google.android.material.snackbar.BaseTransientBottomBar.LENGTH_SHORT
+import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.R
 import com.woocommerce.android.WooCommerce
 import com.woocommerce.android.databinding.FragmentCardReaderPaymentBinding
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
@@ -52,8 +52,16 @@ class CardReaderPaymentDialog : DialogFragment(R.layout.fragment_card_reader_pay
     }
 
     private fun initObservers() {
-        // TODO cardreader remove this
-        viewModel.foo()
+        viewModel.event.observe(viewLifecycleOwner, Observer { event ->
+            // TODO cardreader Replace debug Snackbar with proper UI updates
+            when (event) {
+                is ShowSnackbar -> Snackbar.make(
+                    requireView(),
+                    String.format(getString(event.message), *event.args),
+                    LENGTH_SHORT
+                ).show()
+            }
+        })
     }
 
     override fun androidInjector(): AndroidInjector<Any> = androidInjector

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
@@ -6,6 +6,7 @@ import android.view.View
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.R
+import com.woocommerce.android.WooCommerce
 import com.woocommerce.android.databinding.FragmentCardReaderPaymentBinding
 import com.woocommerce.android.viewmodel.ViewModelFactory
 import dagger.android.AndroidInjector
@@ -32,6 +33,13 @@ class CardReaderPaymentDialog : DialogFragment(R.layout.fragment_card_reader_pay
 
         initViews(binding)
         initObservers()
+        initViewModel()
+    }
+
+    private fun initViewModel() {
+        val manager = (requireActivity().application as WooCommerce).cardReaderManager
+        // TODO card reader: remove !! when cardReaderManager is changed to a nonnullable type in WooCommerce
+        viewModel.start(manager!!)
     }
 
     private fun initViews(binding: FragmentCardReaderPaymentBinding) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -1,22 +1,106 @@
 package com.woocommerce.android.ui.orders.cardreader
 
+import android.os.Parcelable
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.woocommerce.android.R
+import com.woocommerce.android.R.string
 import com.woocommerce.android.di.ViewModelAssistedFactory
+import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.CollectPaymentState
+import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.LoadingDataState
+import com.woocommerce.android.ui.orders.shippinglabels.PrintShippingLabelFragmentArgs
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingPackageSelectorViewModel.ViewState
 import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import kotlinx.android.parcel.Parcelize
+import kotlinx.coroutines.launch
+import kotlinx.parcelize.IgnoredOnParcel
+import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.util.AppLog.T
 
 class CardReaderPaymentViewModel @AssistedInject constructor(
     @Assisted savedState: SavedStateWithArgs,
     dispatchers: CoroutineDispatchers,
-    private val logger: AppLogWrapper
+    private val logger: AppLogWrapper,
+    private val orderStore: WCOrderStore
 ) : ScopedViewModel(savedState, dispatchers) {
+    private val arguments: CardReaderPaymentDialogArgs by savedState.navArgs()
+
+    // The app shouldn't store the state as payment flow gets canceled when the vm dies
+    private val viewState = MutableLiveData<ViewState>(LoadingDataState)
+    val viewStateData: LiveData<ViewState> = viewState
+
+    init {
+        start()
+    }
+
+    final fun start() {
+        launch {
+            val order = orderStore.getOrderByIdentifier(arguments.orderIdentifier)
+            logger.d(T.MAIN, "CardReader: Order: $order")
+        }
+    }
+
     fun foo() {
         logger.d(T.MAIN, "Testing foo()")
+    }
+
+    sealed class ViewState(
+        val hintLabel: Int?,
+        val headerLabel: Int?,
+        val paymentStateLabel: Int?,
+        val illustration: Int?
+    ) {
+        abstract val amountWithCurrencyLabel: String?
+
+        // TODO cardreader Update LoadingDataState
+        object LoadingDataState: ViewState(
+            hintLabel = null,
+            headerLabel = null,
+            paymentStateLabel = null,
+            illustration = null
+        ) {
+            override val amountWithCurrencyLabel = null
+        }
+
+        data class CollectPaymentState(override val amountWithCurrencyLabel: String) : ViewState(
+            hintLabel = R.string.card_reader_payment_collect_payment_hint,
+            headerLabel = R.string.card_reader_payment_collect_payment_header,
+            paymentStateLabel = R.string.card_reader_payment_collect_payment_state,
+            illustration = R.drawable.common_full_open_on_phone
+        )
+
+        data class ProcessingPaymentState(override val amountWithCurrencyLabel: String) :
+            ViewState(
+                hintLabel = R.string.card_reader_payment_processing_payment_hint,
+                headerLabel = R.string.card_reader_payment_processing_payment_header,
+                paymentStateLabel = R.string.card_reader_payment_processing_payment_state,
+                illustration = R.drawable.common_full_open_on_phone
+            )
+
+        data class CapturingPaymentState(override val amountWithCurrencyLabel: String) :
+            ViewState(
+                hintLabel = R.string.card_reader_payment_collect_payment_hint,
+                headerLabel = R.string.card_reader_payment_capturing_payment_header,
+                paymentStateLabel = R.string.card_reader_payment_capturing_payment_state,
+                illustration = R.drawable.common_full_open_on_phone
+            )
+
+        data class PaymentSuccessfulState(override val amountWithCurrencyLabel: String) :
+            ViewState(
+                hintLabel = null,
+                headerLabel = R.string.card_reader_payment_completed_payment_header,
+                paymentStateLabel = null,
+                illustration = R.drawable.common_full_open_on_phone
+            )
     }
 
     @AssistedFactory

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -67,22 +67,18 @@ class CardReaderPaymentViewModel @AssistedInject constructor(
     private fun loadOrderFromDB() = orderStore.getOrderByIdentifier(arguments.orderIdentifier)
 
     sealed class ViewState(
-        val hintLabel: Int?,
-        val headerLabel: Int?,
-        val paymentStateLabel: Int?,
-        val illustration: Int?
+        val hintLabel: Int? = null,
+        val headerLabel: Int? = null,
+        val paymentStateLabel: Int? = null,
+        val illustration: Int? = null
     ) {
-        abstract val amountWithCurrencyLabel: String?
+        open val amountWithCurrencyLabel: String? = ""
 
         // TODO cardreader Update LoadingDataState
-        object LoadingDataState: ViewState(
-            hintLabel = null,
-            headerLabel = null,
-            paymentStateLabel = null,
-            illustration = null
-        ) {
-            override val amountWithCurrencyLabel = null
-        }
+        object LoadingDataState : ViewState()
+
+        // TODO cardreader Update FailedPaymentState
+        object FailedPaymentState : ViewState()
 
         data class CollectPaymentState(override val amountWithCurrencyLabel: String) : ViewState(
             hintLabel = R.string.card_reader_payment_collect_payment_hint,
@@ -109,9 +105,7 @@ class CardReaderPaymentViewModel @AssistedInject constructor(
 
         data class PaymentSuccessfulState(override val amountWithCurrencyLabel: String) :
             ViewState(
-                hintLabel = null,
                 headerLabel = R.string.card_reader_payment_completed_payment_header,
-                paymentStateLabel = null,
                 illustration = R.drawable.common_full_open_on_phone
             )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -62,7 +62,7 @@ class CardReaderPaymentViewModel @AssistedInject constructor(
                     order.total.toBigDecimalOrNull()?.let { amount ->
                         // TODO cardreader don't hardcode currency symbol ($)
                         collectPaymentFlow(cardReaderManager, amount, order.currency, "$$amount")
-                    } ?: IllegalStateException("Converting order.total to BigDecimal failed")
+                    } ?: throw IllegalStateException("Converting order.total to BigDecimal failed")
                 } ?: throw IllegalStateException("Null order is not expected at this point")
             } catch (e: IllegalStateException) {
                 logger.e(T.MAIN, e.stackTraceToString())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -61,7 +61,7 @@ class CardReaderPaymentViewModel @AssistedInject constructor(
                 loadOrderFromDB()?.let { order ->
                     order.total.toBigDecimalOrNull()?.let { amount ->
                         // TODO cardreader don't hardcode currency symbol ($)
-                        collectPaymentFlow(cardReaderManager, amount, order.currency, "$${amount}")
+                        collectPaymentFlow(cardReaderManager, amount, order.currency, "$$amount")
                     } ?: IllegalStateException("Converting order.total to BigDecimal failed")
                 } ?: throw IllegalStateException("Null order is not expected at this point")
             } catch (e: IllegalStateException) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -3,10 +3,26 @@ package com.woocommerce.android.ui.orders.cardreader
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.woocommerce.android.R
+import com.woocommerce.android.cardreader.CardPaymentStatus.CapturingPayment
+import com.woocommerce.android.cardreader.CardPaymentStatus.CapturingPaymentFailed
+import com.woocommerce.android.cardreader.CardPaymentStatus.CollectingPayment
+import com.woocommerce.android.cardreader.CardPaymentStatus.CollectingPaymentFailed
+import com.woocommerce.android.cardreader.CardPaymentStatus.InitializingPayment
+import com.woocommerce.android.cardreader.CardPaymentStatus.InitializingPaymentFailed
+import com.woocommerce.android.cardreader.CardPaymentStatus.PaymentCompleted
+import com.woocommerce.android.cardreader.CardPaymentStatus.ProcessingPayment
+import com.woocommerce.android.cardreader.CardPaymentStatus.ProcessingPaymentFailed
+import com.woocommerce.android.cardreader.CardPaymentStatus.ShowAdditionalInfo
+import com.woocommerce.android.cardreader.CardPaymentStatus.UnexpectedError
+import com.woocommerce.android.cardreader.CardPaymentStatus.WaitingForInput
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.di.ViewModelAssistedFactory
+import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.CapturingPaymentState
+import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.CollectPaymentState
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.FailedPaymentState
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.LoadingDataState
+import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.PaymentSuccessfulState
+import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.ProcessingPaymentState
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
@@ -44,7 +60,8 @@ class CardReaderPaymentViewModel @AssistedInject constructor(
             try {
                 loadOrderFromDB()?.let { order ->
                     order.total.toBigDecimalOrNull()?.let { amount ->
-                        collectPaymentFlow(cardReaderManager, amount, order.currency)
+                        // TODO cardreader don't hardcode currency symbol ($)
+                        collectPaymentFlow(cardReaderManager, amount, order.currency, "$${amount}")
                     } ?: IllegalStateException("Converting order.total to BigDecimal failed")
                 } ?: throw IllegalStateException("Null order is not expected at this point")
             } catch (e: IllegalStateException) {
@@ -57,9 +74,29 @@ class CardReaderPaymentViewModel @AssistedInject constructor(
     private suspend fun collectPaymentFlow(
         cardReaderManager: CardReaderManager,
         amount: BigDecimal,
-        currency: String
+        currency: String,
+        amountLabel: String
     ) {
         cardReaderManager.collectPayment(amount, currency).collect { paymentStatus ->
+            when (paymentStatus) {
+                InitializingPayment -> viewState.postValue(LoadingDataState)
+                CollectingPayment -> viewState.postValue(CollectPaymentState(amountLabel))
+                CapturingPayment -> viewState.postValue(CapturingPaymentState(amountLabel))
+                ProcessingPayment -> viewState.postValue(ProcessingPaymentState(amountLabel))
+                PaymentCompleted -> viewState.postValue(PaymentSuccessfulState(amountLabel))
+                ShowAdditionalInfo -> {
+                    // TODO cardreader prompt the user to take certain action eg. Remove card
+                }
+                WaitingForInput -> {
+                    // TODO cardreader prompt the user to tap/insert a card
+                }
+                CapturingPaymentFailed,
+                CollectingPaymentFailed,
+                InitializingPaymentFailed,
+                ProcessingPaymentFailed,
+                is UnexpectedError -> viewState.postValue(FailedPaymentState)
+            }
+            // TODO cardreader remove this line which is used only for debug purposes
             triggerEvent(ShowSnackbar(R.string.generic_string, arrayOf(paymentStatus.javaClass.simpleName)))
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -62,7 +62,7 @@ class CardReaderPaymentViewModel @AssistedInject constructor(
                     order.total.toBigDecimalOrNull()?.let { amount ->
                         // TODO cardreader don't hardcode currency symbol ($)
                         collectPaymentFlow(cardReaderManager, amount, order.currency, "$${amount}")
-                    } ?: IllegalStateException("Converting order.total to BigDecimal failed")
+                    } ?: throw IllegalStateException("Converting order.total to BigDecimal failed")
                 } ?: throw IllegalStateException("Null order is not expected at this point")
             } catch (e: IllegalStateException) {
                 logger.e(T.MAIN, e.stackTraceToString())
@@ -81,8 +81,8 @@ class CardReaderPaymentViewModel @AssistedInject constructor(
             when (paymentStatus) {
                 InitializingPayment -> viewState.postValue(LoadingDataState)
                 CollectingPayment -> viewState.postValue(CollectPaymentState(amountLabel))
-                CapturingPayment -> viewState.postValue(CapturingPaymentState(amountLabel))
                 ProcessingPayment -> viewState.postValue(ProcessingPaymentState(amountLabel))
+                CapturingPayment -> viewState.postValue(CapturingPaymentState(amountLabel))
                 PaymentCompleted -> viewState.postValue(PaymentSuccessfulState(amountLabel))
                 ShowAdditionalInfo -> {
                     // TODO cardreader prompt the user to take certain action eg. Remove card

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -226,8 +226,7 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
             onIssueRefundClickListener = { viewModel.onIssueOrderRefundClicked() },
             onCollectCardPresentPaymentClickListener = {
                 if (FeatureFlag.CARD_READER.isEnabled()) {
-                    val manager = (requireActivity().application as? WooCommerce)?.cardReaderManager
-                    viewModel.onAcceptCardPresentPaymentClicked(cardReaderManager = manager)
+                    viewModel.onAcceptCardPresentPaymentClicked()
                 }
             }
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -11,7 +11,6 @@ import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.FeedbackPrefs
 import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
-import com.woocommerce.android.WooCommerce
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.FEATURE_FEEDBACK_BANNER
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_DETAIL_PRODUCT_TAPPED

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -214,7 +214,7 @@ class OrderDetailViewModel @AssistedInject constructor(
         triggerEvent(IssueOrderRefund(remoteOrderId = order.remoteId))
     }
 
-    fun onAcceptCardPresentPaymentClicked(cardReaderManager: CardReaderManager?) {
+    fun onAcceptCardPresentPaymentClicked() {
         triggerEvent(StartCardReaderPaymentFlow(order.identifier))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -12,7 +12,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_TRACKING_ADD
 import com.woocommerce.android.annotations.OpenClassOnDebug
-import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.di.ViewModelAssistedFactory
 import com.woocommerce.android.extensions.isNotEqualTo
 import com.woocommerce.android.extensions.semverCompareTo

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -211,11 +211,7 @@
             android:id="@+id/action_orderDetailFragment_to_cardReaderPaymentDialog"
             app:destination="@id/cardReaderPaymentDialog"
             app:enterAnim="@anim/activity_fade_in"
-            app:popExitAnim="@anim/activity_fade_out">
-            <argument
-                android:name="orderIdentifier"
-                app:argType="string" />
-        </action>
+            app:popExitAnim="@anim/activity_fade_out" />
     </fragment>
     <dialog
         android:id="@+id/orderStatusSelectorDialog"
@@ -384,5 +380,9 @@
     <dialog
         android:id="@+id/cardReaderPaymentDialog"
         android:name="com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentDialog"
-        android:label="CardReaderPaymentDialog" />
+        android:label="CardReaderPaymentDialog">
+        <argument
+            android:name="orderIdentifier"
+            app:argType="string" />
+    </dialog>
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -595,6 +595,24 @@
     <string name="order_shipment_tracking_progress_message">Please wait</string>
 
     <!--
+        Card Reader Payments
+    -->
+    <string name="card_reader_tap_or_insert">Tap or insert to pay</string>
+    <string name="card_reader_payment_collect_payment_hint" translatable="false">@string/card_reader_tap_or_insert</string>
+    <string name="card_reader_payment_processing_payment_hint" translatable="false">@string/card_reader_tap_or_insert</string>
+    <string name="card_reader_payment_capturing_payment_hint" translatable="false">@string/card_reader_tap_or_insert</string>
+
+    <string name="card_reader_collect_payment">Collect payment</string>
+    <string name="card_reader_payment_collect_payment_header" translatable="false">@string/card_reader_collect_payment</string>
+    <string name="card_reader_payment_processing_payment_header" translatable="false">@string/card_reader_collect_payment</string>
+    <string name="card_reader_payment_capturing_payment_header" translatable="false">@string/card_reader_collect_payment</string>
+    <string name="card_reader_payment_completed_payment_header">Payment successful</string>
+
+    <string name="card_reader_payment_collect_payment_state">Reader is ready</string>
+    <string name="card_reader_payment_processing_payment_state">Processing payment</string>
+    <string name="card_reader_payment_capturing_payment_state">Capturing payment</string>
+
+    <!--
         Notifications
     -->
     <string name="new_notifications">%d new notifications</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -1,0 +1,219 @@
+package com.woocommerce.android.ui.orders.cardreader
+
+import androidx.lifecycle.SavedStateHandle
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.spy
+import com.nhaarman.mockitokotlin2.whenever
+import com.woocommerce.android.cardreader.CardPaymentStatus
+import com.woocommerce.android.cardreader.CardPaymentStatus.CapturingPayment
+import com.woocommerce.android.cardreader.CardPaymentStatus.CapturingPaymentFailed
+import com.woocommerce.android.cardreader.CardPaymentStatus.CollectingPayment
+import com.woocommerce.android.cardreader.CardPaymentStatus.CollectingPaymentFailed
+import com.woocommerce.android.cardreader.CardPaymentStatus.InitializingPayment
+import com.woocommerce.android.cardreader.CardPaymentStatus.InitializingPaymentFailed
+import com.woocommerce.android.cardreader.CardPaymentStatus.PaymentCompleted
+import com.woocommerce.android.cardreader.CardPaymentStatus.ProcessingPayment
+import com.woocommerce.android.cardreader.CardPaymentStatus.ProcessingPaymentFailed
+import com.woocommerce.android.cardreader.CardPaymentStatus.UnexpectedError
+import com.woocommerce.android.cardreader.CardReaderManager
+import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.CapturingPaymentState
+import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.CollectPaymentState
+import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.FailedPaymentState
+import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.LoadingDataState
+import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.PaymentSuccessfulState
+import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.ProcessingPaymentState
+import com.woocommerce.android.util.CoroutineTestRule
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.SavedStateWithArgs
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runBlockingTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyString
+import org.wordpress.android.fluxc.model.WCOrderModel
+import org.wordpress.android.fluxc.store.WCOrderStore
+import org.wordpress.android.fluxc.utils.AppLogWrapper
+
+@ExperimentalCoroutinesApi
+class CardReaderPaymentViewModelTest : BaseUnitTest() {
+    companion object {
+        private const val ORDER_IDENTIFIER = "1-1-1"
+    }
+
+    @get:Rule
+    var coroutinesTestRule = CoroutineTestRule()
+
+    private lateinit var viewModel: CardReaderPaymentViewModel
+    private val loggerWrapper: AppLogWrapper = mock()
+    private val orderStore: WCOrderStore = mock()
+    private val cardReaderManager: CardReaderManager = mock()
+
+    private val savedState: SavedStateWithArgs = spy(
+        SavedStateWithArgs(
+            SavedStateHandle(),
+            null,
+            CardReaderPaymentDialogArgs(orderIdentifier = CardReaderPaymentViewModelTest.ORDER_IDENTIFIER)
+        )
+    )
+
+    @Before
+    fun setUp() = runBlockingTest {
+        viewModel = CardReaderPaymentViewModel(
+            savedState,
+            dispatchers = coroutinesTestRule.testDispatchers,
+            logger = loggerWrapper,
+            orderStore = orderStore
+        )
+
+        val mockedOrder = mock<WCOrderModel>()
+        whenever(mockedOrder.total).thenReturn("10.12")
+        whenever(mockedOrder.currency).thenReturn("USD")
+        whenever(orderStore.getOrderByIdentifier(ORDER_IDENTIFIER)).thenReturn(mockedOrder)
+        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+            flow<CardPaymentStatus> { }
+        }
+    }
+
+    @Test
+    fun `given Order contains invalid total, when payment screen shown, then FailedPayment state is shown`() {
+        val mockedOrder = mock<WCOrderModel>()
+        whenever(mockedOrder.total).thenReturn("invalid big decimal")
+        whenever(orderStore.getOrderByIdentifier(ORDER_IDENTIFIER)).thenReturn(mockedOrder)
+
+        viewModel.start(cardReaderManager)
+
+        assertThat(viewModel.viewStateData.value).isInstanceOf(FailedPaymentState::class.java)
+    }
+
+    @Test
+    fun `given Order not found in database, when payment screen shown, then FailedPayment state is shown`() {
+        whenever(orderStore.getOrderByIdentifier(ORDER_IDENTIFIER)).thenReturn(null)
+
+        viewModel.start(cardReaderManager)
+
+        assertThat(viewModel.viewStateData.value).isInstanceOf(FailedPaymentState::class.java)
+    }
+
+    @Test
+    fun `when payment screen shown, then loading data state is shown`() {
+        viewModel.start(cardReaderManager)
+
+        assertThat(viewModel.viewStateData.value).isInstanceOf(LoadingDataState::class.java)
+    }
+
+    @Test
+    fun `when initializing payment, then ui updated to initializing payment state `() = runBlockingTest {
+        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+            flow { emit(InitializingPayment) }
+        }
+
+        viewModel.start(cardReaderManager)
+
+        assertThat(viewModel.viewStateData.value).isInstanceOf(LoadingDataState::class.java)
+    }
+
+    @Test
+    fun `when collecting payment, then ui updated to collecting payment state`() = runBlockingTest {
+        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+            flow { emit(CollectingPayment) }
+        }
+
+        viewModel.start(cardReaderManager)
+
+        assertThat(viewModel.viewStateData.value).isInstanceOf(CollectPaymentState::class.java)
+    }
+
+    @Test
+    fun `when processing payment, then ui updated to processing payment state`() = runBlockingTest {
+        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+            flow { emit(ProcessingPayment) }
+        }
+
+        viewModel.start(cardReaderManager)
+
+        assertThat(viewModel.viewStateData.value).isInstanceOf(ProcessingPaymentState::class.java)
+    }
+
+    @Test
+    fun `when capturing payment, then ui updated to capturing payment state`() = runBlockingTest {
+        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+            flow { emit(CapturingPayment) }
+        }
+
+        viewModel.start(cardReaderManager)
+
+        assertThat(viewModel.viewStateData.value).isInstanceOf(CapturingPaymentState::class.java)
+    }
+
+    @Test
+    fun `when payment completed, then ui updated to payment successful state`() = runBlockingTest {
+        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+            flow { emit(PaymentCompleted) }
+        }
+
+        viewModel.start(cardReaderManager)
+
+        assertThat(viewModel.viewStateData.value).isInstanceOf(PaymentSuccessfulState::class.java)
+    }
+
+    @Test
+    fun `when initializing payment fails, then ui updated to failed state`() = runBlockingTest {
+        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+            flow { emit(InitializingPaymentFailed) }
+        }
+
+        viewModel.start(cardReaderManager)
+
+        assertThat(viewModel.viewStateData.value).isInstanceOf(FailedPaymentState::class.java)
+    }
+
+    @Test
+    fun `when collecting payment fails, then ui updated to failed state`() = runBlockingTest {
+        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+            flow { emit(CollectingPaymentFailed) }
+        }
+
+        viewModel.start(cardReaderManager)
+
+        assertThat(viewModel.viewStateData.value).isInstanceOf(FailedPaymentState::class.java)
+    }
+
+    @Test
+    fun `when processing payment fails, then ui updated to failed state`() = runBlockingTest {
+        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+            flow { emit(ProcessingPaymentFailed) }
+        }
+
+        viewModel.start(cardReaderManager)
+
+        assertThat(viewModel.viewStateData.value).isInstanceOf(FailedPaymentState::class.java)
+    }
+
+    @Test
+    fun `when capturing payment fails, then ui updated to failed state`() = runBlockingTest {
+        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+            flow { emit(CapturingPaymentFailed) }
+        }
+
+        viewModel.start(cardReaderManager)
+
+        assertThat(viewModel.viewStateData.value).isInstanceOf(FailedPaymentState::class.java)
+    }
+
+    @Test
+    fun `when unexpected error occurs during payment flow, then ui updated to failed state`() = runBlockingTest {
+        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+            flow { emit(UnexpectedError("")) }
+        }
+
+        viewModel.start(cardReaderManager)
+
+        assertThat(viewModel.viewStateData.value).isInstanceOf(FailedPaymentState::class.java)
+    }
+
+    // TODO cardreader add tests for ViewState fields when they are final
+}

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.cardreader.internal.wrappers.LogWrapper
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import java.math.BigDecimal
 
 /**
  * Implementation of CardReaderManager using StripeTerminalSDK.
@@ -73,7 +74,7 @@ internal class CardReaderManagerImpl(
         return connectionManager.connectToReader(cardReader)
     }
 
-    override suspend fun collectPayment(amount: Int, currency: String): Flow<CardPaymentStatus> =
+    override suspend fun collectPayment(amount: BigDecimal, currency: String): Flow<CardPaymentStatus> =
         paymentManager.acceptPayment(amount, currency)
 
     private fun initStripeTerminal(logLevel: LogLevel) {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardPaymentStatus.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardPaymentStatus.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.cardreader
 
 sealed class CardPaymentStatus {
+    data class UnexpectedError(val errorCause: String) : CardPaymentStatus()
     object InitializingPayment : CardPaymentStatus()
     object InitializingPaymentFailed : CardPaymentStatus()
     object CollectingPayment : CardPaymentStatus()

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.cardreader
 import android.app.Application
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import java.math.BigDecimal
 
 /**
  * Interface for consumers who want to start accepting POC card payments.
@@ -15,5 +16,5 @@ interface CardReaderManager {
     suspend fun connectToReader(cardReader: CardReader): Boolean
 
     // TODO cardreader Stripe accepts only Int, is that ok?
-    suspend fun collectPayment(amount: Int, currency: String): Flow<CardPaymentStatus>
+    suspend fun collectPayment(amount: BigDecimal, currency: String): Flow<CardPaymentStatus>
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.cardreader.internal.payments
 
-import com.nhaarman.mockitokotlin2.KArgumentCaptor
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.mock

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
@@ -47,8 +47,11 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.junit.MockitoJUnitRunner
+import java.math.BigDecimal
 
 private const val TIMEOUT = 1000L
+private val DUMMY_AMOUNT = BigDecimal(0)
+private val USD_CURRENCY = "USD"
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
@@ -87,7 +90,7 @@ class PaymentManagerTest {
     // BEGIN - Creating Payment intent
     @Test
     fun `when creating payment intent starts, then InitializingPayment is emitted`() = runBlockingTest {
-        val result = manager.acceptPayment(0, "")
+        val result = manager.acceptPayment(DUMMY_AMOUNT, USD_CURRENCY)
             .takeUntil(InitializingPayment).toList()
 
         assertThat(result.last()).isInstanceOf(InitializingPayment::class.java)
@@ -98,7 +101,7 @@ class PaymentManagerTest {
         whenever(createPaymentAction.createPaymentIntent(anyInt(), anyString()))
             .thenReturn(flow { emit(CreatePaymentStatus.Failure(mock())) })
 
-        val result = manager.acceptPayment(0, "").toList()
+        val result = manager.acceptPayment(DUMMY_AMOUNT, USD_CURRENCY).toList()
 
         assertThat(result.last()).isInstanceOf(InitializingPaymentFailed::class.java)
     }
@@ -110,7 +113,7 @@ class PaymentManagerTest {
                 .thenReturn(flow { emit(CreatePaymentStatus.Success(createPaymentIntent(CANCELED))) })
 
             val result = withTimeoutOrNull(TIMEOUT) {
-                manager.acceptPayment(0, "").toList()
+                manager.acceptPayment(DUMMY_AMOUNT, USD_CURRENCY).toList()
             }
 
             assertThat(result).isNotNull // verify the flow did not timeout
@@ -121,7 +124,7 @@ class PaymentManagerTest {
     // BEGIN - Collecting Payment
     @Test
     fun `when collecting payment starts, then CollectingPayment is emitted`() = runBlockingTest {
-        val result = manager.acceptPayment(0, "")
+        val result = manager.acceptPayment(DUMMY_AMOUNT, USD_CURRENCY)
             .takeUntil(CollectingPayment).toList()
 
         assertThat(result.last()).isInstanceOf(CollectingPayment::class.java)
@@ -132,7 +135,7 @@ class PaymentManagerTest {
         whenever(collectPaymentAction.collectPayment(anyOrNull()))
             .thenReturn(flow { emit(CollectPaymentStatus.ReaderInputRequested(mock())) })
 
-        val result = manager.acceptPayment(0, "").toList()
+        val result = manager.acceptPayment(DUMMY_AMOUNT, USD_CURRENCY).toList()
 
         assertThat(result.last()).isInstanceOf(WaitingForInput::class.java)
     }
@@ -142,7 +145,7 @@ class PaymentManagerTest {
         whenever(collectPaymentAction.collectPayment(anyOrNull()))
             .thenReturn(flow { emit(CollectPaymentStatus.DisplayMessageRequested(mock())) })
 
-        val result = manager.acceptPayment(0, "").toList()
+        val result = manager.acceptPayment(DUMMY_AMOUNT, USD_CURRENCY).toList()
 
         assertThat(result.last()).isInstanceOf(ShowAdditionalInfo::class.java)
     }
@@ -152,7 +155,7 @@ class PaymentManagerTest {
         whenever(collectPaymentAction.collectPayment(anyOrNull()))
             .thenReturn(flow { emit(CollectPaymentStatus.Failure(mock())) })
 
-        val result = manager.acceptPayment(0, "").toList()
+        val result = manager.acceptPayment(DUMMY_AMOUNT, USD_CURRENCY).toList()
 
         assertThat(result.last()).isInstanceOf(CollectingPaymentFailed::class.java)
     }
@@ -164,7 +167,7 @@ class PaymentManagerTest {
                 .thenReturn(flow { emit(CollectPaymentStatus.Success(createPaymentIntent(CANCELED))) })
 
             val result = withTimeoutOrNull(TIMEOUT) {
-                manager.acceptPayment(0, "").toList()
+                manager.acceptPayment(DUMMY_AMOUNT, USD_CURRENCY).toList()
             }
 
             assertThat(result).isNotNull // verify the flow did not timeout
@@ -175,7 +178,7 @@ class PaymentManagerTest {
     // BEGIN - Processing Payment
     @Test
     fun `when processing payment starts, then ProcessingPayment is emitted`() = runBlockingTest {
-        val result = manager.acceptPayment(0, "")
+        val result = manager.acceptPayment(DUMMY_AMOUNT, USD_CURRENCY)
             .takeUntil(ProcessingPayment).toList()
 
         assertThat(result.last()).isInstanceOf(ProcessingPayment::class.java)
@@ -186,7 +189,7 @@ class PaymentManagerTest {
         whenever(processPaymentAction.processPayment(anyOrNull()))
             .thenReturn(flow { emit(ProcessPaymentStatus.Failure(mock())) })
 
-        val result = manager.acceptPayment(0, "").toList()
+        val result = manager.acceptPayment(DUMMY_AMOUNT, USD_CURRENCY).toList()
 
         assertThat(result.last()).isInstanceOf(ProcessingPaymentFailed::class.java)
     }
@@ -198,7 +201,7 @@ class PaymentManagerTest {
                 .thenReturn(flow { emit(ProcessPaymentStatus.Success(createPaymentIntent(CANCELED))) })
 
             val result = withTimeoutOrNull(TIMEOUT) {
-                manager.acceptPayment(0, "").toList()
+                manager.acceptPayment(DUMMY_AMOUNT, USD_CURRENCY).toList()
             }
 
             assertThat(result).isNotNull // verify the flow did not timeout
@@ -209,7 +212,7 @@ class PaymentManagerTest {
     // BEGIN - Capturing Payment
     @Test
     fun `when capturing payment starts, then CapturingPayment is emitted`() = runBlockingTest {
-        val result = manager.acceptPayment(0, "")
+        val result = manager.acceptPayment(DUMMY_AMOUNT, USD_CURRENCY)
             .takeUntil(CapturingPayment).toList()
 
         assertThat(result.last()).isInstanceOf(CapturingPayment::class.java)
@@ -217,7 +220,7 @@ class PaymentManagerTest {
 
     @Test
     fun `when capturing payment succeeds, then PaymentCompleted is emitted`() = runBlockingTest {
-        val result = manager.acceptPayment(0, "")
+        val result = manager.acceptPayment(DUMMY_AMOUNT, USD_CURRENCY)
             .takeUntil(PaymentCompleted).toList()
 
         assertThat(result.last()).isInstanceOf(PaymentCompleted::class.java)
@@ -227,7 +230,7 @@ class PaymentManagerTest {
     fun `when capturing payment fails, then CapturingPaymentFailed is emitted`() = runBlockingTest {
         whenever(cardReaderStore.capturePaymentIntent(anyString())).thenReturn(false)
 
-        val result = manager.acceptPayment(0, "").toList()
+        val result = manager.acceptPayment(DUMMY_AMOUNT, USD_CURRENCY).toList()
 
         assertThat(result.last()).isInstanceOf(CapturingPaymentFailed::class.java)
     }


### PR DESCRIPTION
Parent issue #3726 

Note: Half of the changes are unit tests which imo help with the review so I'm ignoring the "changes > 500" peril check. Having said that, let me know if you think I should still split it into multiple PRs.

This PR implements a first iteration of logic in CardReaderPaymentViewModel. The ViewModel is responsible for starting the "payment" flow and updating ViewState based on the events received from CardReaderManager. The view layer doesn't listen to ViewState events yet. I've also added a temporary ShowSnackBar events which display the received events in a snackbar - just for testing purposes.

There is also an update in the PaymentManager - the received amount is converted from dollars to cents, since the StripeTerminalSDK accepts only currency smallest unit. (I should have made this change in a separate PR, just let me know and I can split it)

Note: The current implementation doesn't work with other currency but USD.

To Test
- Store with working WCPay is required to test these changes
1. Open app settings
2. Tap on "Manager card reader"
3. (optional) Check "use simulated card reader"
4. Tap "Connect to reader"
4. Go back to homepage
5. Open detail of an order with USD currency
6. Tap on "Collect payment" button
7. Notice a snackbar with current state is shown (tap your card if you are using hw reader)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
