### PR TITLE
Updated Woo with FluxC changes

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/AppComponentTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/AppComponentTest.kt
@@ -7,9 +7,7 @@ import dagger.BindsInstance
 import dagger.Component
 import dagger.android.AndroidInjectionModule
 import org.wordpress.android.fluxc.module.DebugOkHttpClientModule
-import org.wordpress.android.fluxc.module.ReleaseBaseModule
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule
-import org.wordpress.android.fluxc.module.ReleaseWCNetworkModule
 import org.wordpress.android.login.di.LoginServiceModule
 import javax.inject.Singleton
 
@@ -19,9 +17,7 @@ import javax.inject.Singleton
         ThreadModule::class,
         ApplicationModule::class,
         AppConfigModule::class,
-        ReleaseBaseModule::class,
         ReleaseNetworkModule::class,
-        ReleaseWCNetworkModule::class,
         DebugOkHttpClientModule::class,
         InterceptorModuleTest::class,
         ActivityBindingModule::class,

--- a/WooCommerce/src/debug/kotlin/com.woocommerce.android/di/AppComponentDebug.kt
+++ b/WooCommerce/src/debug/kotlin/com.woocommerce.android/di/AppComponentDebug.kt
@@ -8,9 +8,7 @@ import dagger.BindsInstance
 import dagger.Component
 import dagger.android.AndroidInjectionModule
 import org.wordpress.android.fluxc.module.DebugOkHttpClientModule
-import org.wordpress.android.fluxc.module.ReleaseBaseModule
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule
-import org.wordpress.android.fluxc.module.ReleaseWCNetworkModule
 import org.wordpress.android.login.di.LoginServiceModule
 import javax.inject.Singleton
 
@@ -19,9 +17,7 @@ import javax.inject.Singleton
         AndroidInjectionModule::class,
         ApplicationModule::class,
         AppConfigModule::class,
-        ReleaseBaseModule::class,
         ReleaseNetworkModule::class,
-        ReleaseWCNetworkModule::class,
         DebugOkHttpClientModule::class,
         SelectedSiteModule::class,
         InterceptorModule::class,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/AppComponent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/AppComponent.kt
@@ -9,10 +9,8 @@ import dagger.BindsInstance
 import dagger.Component
 import dagger.android.AndroidInjectionModule
 import dagger.android.AndroidInjector
-import org.wordpress.android.fluxc.module.ReleaseBaseModule
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule
 import org.wordpress.android.fluxc.module.ReleaseOkHttpClientModule
-import org.wordpress.android.fluxc.module.ReleaseWCNetworkModule
 import org.wordpress.android.login.di.LoginServiceModule
 import javax.inject.Singleton
 
@@ -21,9 +19,7 @@ import javax.inject.Singleton
         AndroidInjectionModule::class,
         ApplicationModule::class,
         AppConfigModule::class,
-        ReleaseBaseModule::class,
         ReleaseNetworkModule::class,
-        ReleaseWCNetworkModule::class,
         ReleaseOkHttpClientModule::class,
         SelectedSiteModule::class,
         ThreadModule::class,

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '28d010b1f5c0e59849fefe9ec757794696aa593e'
+    fluxCVersion = 'a659f89db021d0793d77ed405ff0fbcb1e3a93de'
     daggerVersion = '2.33'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
This PR just updates FluxC hash to the latest one. It looks like there were some changes made in [#1946](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1946) in FluxC that removed some of the classes we were using in `AppComponent` and `AppComponentDebug`. 

This is causing the build to fail. This PR just fixes that. 

### To test
- Make sure the app builds.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
