### PR TITLE
issue/3887-rename-attribute-confirm

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/RenameAttributeFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/RenameAttributeFragment.kt
@@ -49,15 +49,7 @@ class RenameAttributeFragment : Fragment(R.layout.fragment_rename_attribute), Ba
     override fun onResume() {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
-
-        binding.attributeName.editText?.let { editText ->
-            if (editText.requestFocus()) {
-                editText.selectAll()
-                editText.postDelayed({
-                    ActivityUtils.showKeyboard(editText)
-                }, 100)
-            }
-        }
+        binding.attributeName.showKeyboard(selectAll = true)
     }
 
     override fun onStop() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/RenameAttributeFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/RenameAttributeFragment.kt
@@ -33,9 +33,9 @@ class RenameAttributeFragment : Fragment(R.layout.fragment_rename_attribute), Ba
             binding.attributeName.setText(navArgs.attributeName)
         }
 
-        binding.attributeName.setOnEditorActionListener { termName: String ->
-            if (termName.isNotBlank()) {
-                navigateBack()
+        binding.attributeName.setOnEditorActionListener { attributeName: String ->
+            if (attributeName.isNotBlank()) {
+                navigateBack(attributeName)
             }
             true
         }
@@ -57,12 +57,12 @@ class RenameAttributeFragment : Fragment(R.layout.fragment_rename_attribute), Ba
     }
 
     override fun onRequestAllowBackPress(): Boolean {
-        navigateBack()
+        val attributeName = binding.attributeName.getText()
+        navigateBack(attributeName)
         return false
     }
 
-    private fun navigateBack() {
-        val attributeName = binding.attributeName.getText()
+    private fun navigateBack(attributeName: String) {
         if (attributeName.isNotEmpty() && !attributeName.equals(navArgs.attributeName)) {
             navigateBackWithResult(KEY_RENAME_ATTRIBUTE_RESULT, attributeName)
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/RenameAttributeFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/RenameAttributeFragment.kt
@@ -49,6 +49,15 @@ class RenameAttributeFragment : Fragment(R.layout.fragment_rename_attribute), Ba
     override fun onResume() {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
+
+        binding.attributeName.editText?.let { editText ->
+            if (editText.requestFocus()) {
+                editText.selectAll()
+                editText.postDelayed({
+                    ActivityUtils.showKeyboard(editText)
+                }, 100)
+            }
+        }
     }
 
     override fun onStop() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt
@@ -14,6 +14,7 @@ import androidx.core.widget.doAfterTextChanged
 import com.google.android.material.textfield.TextInputLayout
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.ViewMaterialOutlinedEdittextBinding
+import org.wordpress.android.util.ActivityUtils
 
 /**
  * Custom View that encapsulates a [TextInputLayout] and [TextInputEditText], and as such has the following
@@ -108,6 +109,17 @@ class WCMaterialOutlinedEditTextView @JvmOverloads constructor(
 
     fun setMaxLength(max: Int) {
         binding.editText.filters += InputFilter.LengthFilter(max)
+    }
+
+    fun showKeyboard(selectAll: Boolean = false) {
+        if (binding.editText.requestFocus()) {
+            if (selectAll) {
+                binding.editText.selectAll()
+            }
+            binding.editText.postDelayed({
+                ActivityUtils.showKeyboard(binding.editText)
+            }, 100)
+        }
     }
 
     override fun onSaveInstanceState(): Parcelable? {


### PR DESCRIPTION
Closes #3887 - previously when renaming a Product Attribute, hitting the Confirm button on the virtual keyboard dismisses the screen and loses the changes. The problem was due to us relying on the current string in the editor, but that's cleared by `WCMaterialOutlinedEditTextView` [when IME_ACTION_DONE](https://github.com/woocommerce/woocommerce-android/blob/293811f71f86f29b13f7ee813b8b8deaf16058f5/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedEditTextView.kt#L95) is received.

We may need to update `WCMaterialOutlinedEditTextView` so it doesn't do that, but since that's used in so many places I felt it safer to fix it in the rename screen. I've opened #3895 to address this issue globally.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
