### PR TITLE
Add wildcard ignore for .configure-files folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,8 @@ sentry.properties
 .markdownlint.json
 
 local-builds.gradle
+
+# All secrets should be stored under .configure-files
+# Everything without a .enc extension is ignored
+.configure-files/*
+!.configure-files/*.enc


### PR DESCRIPTION
Makes sure that all the non-encrypted files in the `.configure-files` folder are ignored, for future proofing.

To test, add a file the folder and verify it doesn't appear in the `git status` output.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
