### PR TITLE
Shipping Labels: fix crash when address validation fails

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -237,7 +237,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
                 )
             }
             on<Event.AddressValidationFailed> {
-                transitionTo(State.OriginAddressValidationFailure, SideEffect.ShowError(AddressValidationError))
+                transitionTo(State.WaitingForInput(data), SideEffect.ShowError(AddressValidationError))
             }
         }
 
@@ -296,7 +296,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
                 )
             }
             on<Event.AddressValidationFailed> {
-                transitionTo(State.ShippingAddressValidationFailure, SideEffect.ShowError(AddressValidationError))
+                transitionTo(State.WaitingForInput(data), SideEffect.ShowError(AddressValidationError))
             }
         }
 
@@ -610,9 +610,6 @@ class ShippingLabelsStateMachine @Inject constructor() {
         data class OriginAddressEditing(val data: StateMachineData) : State()
 
         @Parcelize
-        object OriginAddressValidationFailure : State()
-
-        @Parcelize
         data class ShippingAddressValidation(val data: StateMachineData) : State()
 
         @Parcelize
@@ -620,9 +617,6 @@ class ShippingLabelsStateMachine @Inject constructor() {
 
         @Parcelize
         data class ShippingAddressEditing(val data: StateMachineData) : State()
-
-        @Parcelize
-        object ShippingAddressValidationFailure : State()
 
         @Parcelize
         data class PackageSelection(val data: StateMachineData) : State()


### PR DESCRIPTION
Fixes #3899, the cause of the issue is that we try update the state machine by undefined state if the address validation fails.
Actually we don't need a specific state for address validation, as the error message is displayed by a SideEffect, and the new state need to allow the user to retry, which is the common state `WaitingForInput`.

### Testing
1. Open an order eligible for shipping label creation.
2. Click on "Create shipping label"
3. After the UI is loaded, put your device in airplane mode.
4. Click on "continue"
5. Confirm that you get an error message, and that the app doesn't crash.
6. Repeat 3->5 for shipping address.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
