### PR TITLE
Shipping Labels: fix issue of incomplete addresses in the printed label

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Address.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Address.kt
@@ -83,6 +83,9 @@ data class Address(
 
     fun toShippingLabelModel(): ShippingLabelAddress {
         return ShippingLabelAddress(
+            company = company,
+            name = "$firstName $lastName",
+            phone = phone,
             address = address1,
             address2 = address2,
             city = city,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressValidator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressValidator.kt
@@ -6,13 +6,12 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
-import kotlinx.parcelize.Parcelize
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult
 import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult.InvalidAddress
 import org.wordpress.android.fluxc.model.shippinglabels.WCAddressVerificationResult.InvalidRequest
-import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress.Type
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
@@ -30,7 +29,7 @@ class ShippingLabelAddressValidator @Inject constructor(
             val result = withContext(Dispatchers.IO) {
                 shippingLabelStore.verifyAddress(
                     selectedSite.get(),
-                    address.toShippingLabelAddress(),
+                    address.toShippingLabelModel(),
                     type.toDataType()
                 )
             }
@@ -114,19 +113,5 @@ class ShippingLabelAddressValidator @Inject constructor(
                 DESTINATION -> Type.DESTINATION
             }
         }
-    }
-
-    private fun Address.toShippingLabelAddress(): ShippingLabelAddress {
-        return ShippingLabelAddress(
-            company = company,
-            name = "$firstName $lastName",
-            phone = phone,
-            country = country,
-            state = state,
-            address = address1,
-            address2 = address2,
-            city = city,
-            postcode = postcode
-        )
     }
 }


### PR DESCRIPTION
Fixes #3916, we weren't passing all the details to the network model when mapping from the business model, and it caused the printed labels to have incomplete data (missing name and compare)

#### Testing
1. Open an order that's eligible for shipping label creation.
2. Click on Create shipping label.
3. Keep track of the name and company values in the addresses.
4. Complete the form.
5. Click on buy shipping label.
6. Click on print label.
7. Make sure that the label has the name and company details.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
