### PR TITLE
Shipping Labels: Select the suggested address by default

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressSuggestionFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressSuggestionFragment.kt
@@ -81,6 +81,10 @@ class ShippingLabelAddressSuggestionFragment
             new.suggestedAddress?.takeIfNotEqualTo(old?.suggestedAddress) {
                 binding.suggestedAddressText.setHtmlText(it.toStringMarkingDifferences(new.enteredAddress))
             }
+            new.selectedAddress?.takeIfNotEqualTo(old?.selectedAddress) { address ->
+                binding.suggestedAddressOption.isChecked = new.suggestedAddress == address
+                binding.enteredAddressOption.isChecked = new.enteredAddress == address
+            }
             new.areButtonsEnabled.takeIfNotEqualTo(old?.areButtonsEnabled) {
                 binding.editAddressButton.isEnabled = it
                 binding.useSuggestedAddressButton.isEnabled = it

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressSuggestionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressSuggestionViewModel.kt
@@ -2,9 +2,6 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation
 
 import android.os.Parcelable
 import androidx.annotation.StringRes
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedInject
-import dagger.assisted.AssistedFactory
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SHIPPING_LABEL_ADDRESS_SUGGESTIONS_EDIT_SELECTED_ADDRESS_BUTTON_TAPPED
@@ -19,6 +16,9 @@ import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import kotlinx.parcelize.Parcelize
 
 class ShippingLabelAddressSuggestionViewModel @AssistedInject constructor(
@@ -27,7 +27,14 @@ class ShippingLabelAddressSuggestionViewModel @AssistedInject constructor(
 ) : ScopedViewModel(savedState, dispatchers) {
     private val arguments: ShippingLabelAddressSuggestionFragmentArgs by savedState.navArgs()
 
-    val viewStateData = LiveDataDelegate(savedState, ViewState(arguments.enteredAddress, arguments.suggestedAddress))
+    val viewStateData = LiveDataDelegate(
+        savedState,
+        ViewState(
+            enteredAddress = arguments.enteredAddress,
+            suggestedAddress = arguments.suggestedAddress,
+            selectedAddress = arguments.suggestedAddress
+        )
+    )
     private var viewState by viewStateData
 
     init {

--- a/WooCommerce/src/main/res/layout/fragment_shipping_label_address_suggestion.xml
+++ b/WooCommerce/src/main/res/layout/fragment_shipping_label_address_suggestion.xml
@@ -106,6 +106,7 @@
                 android:layout_marginTop="@dimen/minor_50"
                 android:paddingStart="@dimen/major_175"
                 android:paddingEnd="@dimen/major_150"
+                android:checked="true"
                 android:text="@string/shipping_label_address_suggestion_suggested_address" />
 
             <com.google.android.material.textview.MaterialTextView

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressSuggestionViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressSuggestionViewModelTest.kt
@@ -28,7 +28,7 @@ class ShippingLabelAddressSuggestionViewModelTest : BaseUnitTest() {
     private val initialViewState = ViewState(
         enteredAddress,
         suggestedAddress,
-        null,
+        suggestedAddress,
         R.string.orderdetail_shipping_label_item_shipfrom
     )
 
@@ -63,8 +63,6 @@ class ShippingLabelAddressSuggestionViewModelTest : BaseUnitTest() {
     fun `Updates the selected address`() = coroutinesTestRule.testDispatcher.runBlockingTest {
         var viewState: ViewState? = null
         viewModel.viewStateData.observeForever { _, new -> viewState = new }
-
-        assertThat(viewState?.areButtonsEnabled).isFalse()
 
         viewModel.onSelectedAddressChanged(false)
         assertThat(viewState).isEqualTo(initialViewState.copy(selectedAddress = enteredAddress))


### PR DESCRIPTION
Fixes #3915 , currently when an address change is suggested, none of the options is selected.
With this PR, the suggested address will be selected by default, this is matching what the web client does.

### Testing
1. Open an order that's eligible for shipping labels creation.
2. Click on Create shipping label.
3. Edit the shipping address, and make small changes so that the backend will validate it and suggest a change.
4. Make sure that the suggested address is selected by default.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
