### PR TITLE
Update Error Message if the Site is not WP 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -672,7 +672,7 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
             // The url entered is not a WordPress site.
             val protocolRegex = Regex("^(http[s]?://)", IGNORE_CASE)
             val siteAddressClean = siteInfo.url.replaceFirst(protocolRegex, "")
-            val errorMessage = getString(R.string.login_not_wordpress_site, siteAddressClean)
+            val errorMessage = getString(R.string.login_not_wordpress_site)
 
             // hide the keyboard
             org.wordpress.android.util.ActivityUtils.hideKeyboard(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -672,7 +672,7 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
             // The url entered is not a WordPress site.
             val protocolRegex = Regex("^(http[s]?://)", IGNORE_CASE)
             val siteAddressClean = siteInfo.url.replaceFirst(protocolRegex, "")
-            val errorMessage = getString(R.string.login_not_wordpress_site)
+            val errorMessage = getString(R.string.login_not_wordpress_site_v2)
 
             // hide the keyboard
             org.wordpress.android.util.ActivityUtils.hideKeyboard(this)

--- a/WooCommerce/src/main/res/layout-land/fragment_login_site_check_error.xml
+++ b/WooCommerce/src/main/res/layout-land/fragment_login_site_check_error.xml
@@ -27,7 +27,7 @@
             android:layout_marginBottom="0dp"
             android:gravity="center"
             android:lineSpacingExtra="@dimen/line_spacing_extra_50"
-            android:text="@string/login_not_wordpress_site"
+            android:text="@string/login_not_wordpress_site_v2"
             android:textStyle="bold"
             android:visibility="visible"/>
     </ScrollView>

--- a/WooCommerce/src/main/res/layout/fragment_login_site_check_error.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_site_check_error.xml
@@ -26,7 +26,7 @@
             android:drawablePadding="@dimen/major_100"
             android:gravity="center_horizontal"
             android:lineSpacingExtra="@dimen/line_spacing_extra_50"
-            android:text="@string/login_not_wordpress_site"
+            android:text="@string/login_not_wordpress_site_v2"
             android:textStyle="bold"
             android:layout_gravity="center"
             android:visibility="visible"/>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -170,7 +170,7 @@
     <string name="login_not_woo_store">It looks like %1$s is not a WooCommerce site. Install the WooCommerce plugin on your site and then %2$s</string>
     <string name="login_not_connected_jetpack">To use this app for %1$s you\'ll need to have the Jetpack plugin setup and connected to this account. \n\nOnce setup, %2$s</string>
     <string name="login_no_jetpack">To use this app for %1$s you\'ll need to have the Jetpack plugin setup and connected to a WordPress.com account</string>
-    <string name="login_not_wordpress_site">We were not able to detect a WordPress site at the address you entered. Please make sure WordPress is installed and that you are running the latest available version.</string>
+    <string name="login_not_wordpress_site_v2">We were not able to detect a WordPress site at the address you entered. Please make sure WordPress is installed and that you are running the latest available version.</string>
     <string name="login_refresh_app">refresh the app</string>
     <string name="login_refresh_app_continue">refresh the app to continue</string>
     <string name="login_refresh_app_progress">Checking for WooCommerce…</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -170,7 +170,7 @@
     <string name="login_not_woo_store">It looks like %1$s is not a WooCommerce site. Install the WooCommerce plugin on your site and then %2$s</string>
     <string name="login_not_connected_jetpack">To use this app for %1$s you\'ll need to have the Jetpack plugin setup and connected to this account. \n\nOnce setup, %2$s</string>
     <string name="login_no_jetpack">To use this app for %1$s you\'ll need to have the Jetpack plugin setup and connected to a WordPress.com account</string>
-    <string name="login_not_wordpress_site">The website %1$s is not a WordPress site. For us to connect to it, the site must have WordPress installed.</string>
+    <string name="login_not_wordpress_site">We were not able to detect a WordPress site at the address you entered. Please make sure WordPress is installed and that you are running the latest available version.</string>
     <string name="login_refresh_app">refresh the app</string>
     <string name="login_refresh_app_continue">refresh the app to continue</string>
     <string name="login_refresh_app_progress">Checking for WooCommerce…</string>


### PR DESCRIPTION
This changes the error message to match iOS (https://github.com/woocommerce/woocommerce-ios/pull/4046) and is to address https://github.com/woocommerce/woocommerce-ios/issues/3392. 

## Design

Before | After 
--------|-------
<img src="https://user-images.githubusercontent.com/198826/116298402-a5c4d400-a759-11eb-866e-53f6eceec221.png" width="300">|<img src="https://user-images.githubusercontent.com/198826/116298408-a78e9780-a759-11eb-97fe-33e252f7aec0.png" width="300">


## Testing

1. Log out. 
2. Tap “Enter Your Store Address”. 
3. Enter a URL of a site that is not WordPress. 
4. Tap Continue. 
5. Confirm the error message “We were not able to detect...” is shown. 

## Author Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

