### PR TITLE
issue/3923-disable-reordering-global-terms

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
@@ -222,14 +222,22 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
     }
 
     private fun initializeViews(savedInstanceState: Bundle?) {
-        layoutManagerAssigned = initializeRecycler(binding.assignedTermList, showIcons = true)
+        layoutManagerAssigned = initializeRecycler(
+            binding.assignedTermList,
+            enableDragAndDrop = !isGlobalAttribute,
+            enableDeleting = true
+        )
         assignedTermsAdapter = binding.assignedTermList.adapter as AttributeTermsListAdapter
         assignedTermsAdapter.setOnTermListener(assignedTermListener)
         savedInstanceState?.getParcelable<Parcelable>(LIST_STATE_KEY_ASSIGNED)?.let {
             layoutManagerAssigned!!.onRestoreInstanceState(it)
         }
 
-        layoutManagerGlobal = initializeRecycler(binding.globalTermList, showIcons = false)
+        layoutManagerGlobal = initializeRecycler(
+            binding.globalTermList,
+            enableDragAndDrop = false,
+            enableDeleting = false
+        )
         globalTermsAdapter = binding.globalTermList.adapter as AttributeTermsListAdapter
         globalTermsAdapter.setOnTermListener(globalTermListener)
         savedInstanceState?.getParcelable<Parcelable>(LIST_STATE_KEY_GLOBAL)?.let {
@@ -246,15 +254,19 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
         }
     }
 
-    private fun initializeRecycler(recycler: RecyclerView, showIcons: Boolean): LinearLayoutManager {
+    private fun initializeRecycler(
+        recycler: RecyclerView,
+        enableDragAndDrop: Boolean,
+        enableDeleting: Boolean
+    ): LinearLayoutManager {
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
         recycler.layoutManager = layoutManager
 
-        if (showIcons) {
-            recycler.adapter = AttributeTermsListAdapter(showIcons)
+        if (enableDragAndDrop) {
+            recycler.adapter = AttributeTermsListAdapter(enableDragAndDrop = true, enableDeleting = enableDeleting)
             itemTouchHelper.attachToRecyclerView(recycler)
         } else {
-            recycler.adapter = AttributeTermsListAdapter(showIcons)
+            recycler.adapter = AttributeTermsListAdapter(enableDragAndDrop = false, enableDeleting = enableDeleting)
         }
 
         recycler.addItemDecoration(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
@@ -15,7 +15,8 @@ import com.woocommerce.android.ui.products.variations.attributes.AttributeTermsL
  * Adapter which shows a simple list of attribute term names
  */
 class AttributeTermsListAdapter(
-    private val showIcons: Boolean,
+    private val enableDragAndDrop: Boolean,
+    private val enableDeleting: Boolean,
     private val dragHelper: ItemTouchHelper? = null
 ) : RecyclerView.Adapter<TermViewHolder>() {
     interface OnTermListener {
@@ -126,13 +127,15 @@ class AttributeTermsListAdapter(
                 onTermListener.onTermClick(item)
             }
 
-            if (showIcons) {
+            if (enableDeleting) {
                 viewBinding.termDelete.setOnClickListener {
                     val item = termNames[adapterPosition]
                     removeTerm(item)
                     onTermListener.onTermDelete(item)
                 }
+            }
 
+            if (enableDragAndDrop) {
                 viewBinding.termDragHandle.setOnClickListener {
                     dragHelper?.startDrag(this)
                 }
@@ -141,8 +144,8 @@ class AttributeTermsListAdapter(
 
         fun bind(termName: String) {
             viewBinding.termName.text = termName
-            viewBinding.termDragHandle.isVisible = showIcons
-            viewBinding.termDelete.isVisible = showIcons
+            viewBinding.termDragHandle.isVisible = enableDragAndDrop
+            viewBinding.termDelete.isVisible = enableDeleting
         }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -571,7 +571,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
             secondTerm
         )
 
-        val draftAttribute = viewModel.getProductDraftAttributes()[0]
+        val draftAttribute = viewModel.productDraftAttributes[0]
         val draftTerms = draftAttribute.terms
         assertThat(draftTerms[0]).isEqualTo(secondTerm)
         assertThat(draftTerms[1]).isEqualTo(firstTerm)


### PR DESCRIPTION
This PR simply removes the ability to re-order terms for a global attribute, since that's not supported by the backend and it's not available on either the web or iOS apps.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
