### PR TITLE
Added logic to fetch site and user info only if user is logged in

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -211,8 +211,9 @@ open class WooCommerce : MultiDexApplication(), HasAndroidInjector, ApplicationL
     }
 
     override fun onFirstActivityResumed() {
-        // Update the WP.com account details, settings, and site list every time the app is completely restarted
-        if (networkStatus.isConnected()) {
+        // Update the WP.com account details, settings, and site list every time the app is completely restarted,
+        // only if the logged in
+        if (networkStatus.isConnected() && accountStore.hasAccessToken()) {
             dispatcher.dispatch(AccountActionBuilder.newFetchAccountAction())
             dispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction())
             dispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(FetchSitesPayload()))


### PR DESCRIPTION
Fixes #3927  .

This PR just adds a check to `WooCommerce` class that fetches the site and user information only if the user is logged in to the app i.e. the `accountStore.getAccessToken()` is not null.


/rest/v1.1/me/settings/ | Fetches the user settings | 426.5
-- | -- | --
/rest/v1.1/me/sites/ | Fetches the sites for the logged in user. | 468.5
/rest/v1.1/me/ | Fetches the meta data about the current user. | 448


#### To test
- Open the app and notice that if you are logged in, the above APIs are called from the app.
- Logout of the app, close it completely and open it again. Notice the above APIs are not called.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
