### PR TITLE
issue/3929-tests-for-reordered-terms

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -30,12 +30,12 @@ import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.ui.products.tags.ProductTagsRepository
 import com.woocommerce.android.util.CoroutineTestRule
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.ProductUtils
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
-import com.woocommerce.android.util.ProductUtils
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
@@ -555,7 +555,6 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     fun `Re-ordering attribute terms is saved correctly`() {
         viewModel.productDetailViewStateData.observeForever { _, _ -> }
         val storedProduct = product.copy(
-            type = ProductType.VARIABLE.value.toLowerCase(),
             attributes = ProductTestUtils.generateProductAttributeList()
         )
         doReturn(storedProduct).whenever(productRepository).getProduct(any())

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -551,6 +551,33 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         assertThat(productsDraft?.saleEndDateGmt).isNull()
     }
 
+    @Test
+    fun `Re-ordering attribute terms is saved correctly`() {
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
+        val storedProduct = product.copy(
+            type = ProductType.VARIABLE.value.toLowerCase(),
+            attributes = ProductTestUtils.generateProductAttributeList()
+        )
+        doReturn(storedProduct).whenever(productRepository).getProduct(any())
+
+        val attribute = storedProduct.attributes[0]
+        val firstTerm = attribute.terms[0]
+        val secondTerm = attribute.terms[1]
+
+        viewModel.start()
+        viewModel.swapProductDraftAttributeTerms(
+            attribute.id,
+            attribute.name,
+            firstTerm,
+            secondTerm
+        )
+
+        val draftAttribute = viewModel.getProductDraftAttributes()[0]
+        val draftTerms = draftAttribute.terms
+        assertThat(draftTerms[0]).isEqualTo(secondTerm)
+        assertThat(draftTerms[1]).isEqualTo(firstTerm)
+    }
+
     private val productsDraft
         get() = viewModel.productDetailViewStateData.liveData.value?.productDraft
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products
 
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.model.ProductAttribute
 import com.woocommerce.android.model.ProductCategory
 import com.woocommerce.android.model.ProductTag
 import com.woocommerce.android.model.ProductVariation
@@ -121,4 +122,29 @@ object ProductTestUtils {
 
     fun generateProductImagesList() =
             (1L..10L).map { id -> generateProductImage(imageId = id) }
+
+    fun generateProductAttribute(id: Long): ProductAttribute {
+        return ProductAttribute(
+            id = id,
+            name = "attribute$id",
+            isVariation = true,
+            isVisible = true,
+            terms = ArrayList<String>().also {
+                it.add("one")
+                it.add("two")
+                it.add("three")
+            }
+        )
+    }
+
+    fun generateProductAttributeList(): List<ProductAttribute> {
+        with(ArrayList<ProductAttribute>()) {
+            add(generateProductAttribute(1))
+            add(generateProductAttribute(2))
+            add(generateProductAttribute(3))
+            add(generateProductAttribute(4))
+            add(generateProductAttribute(5))
+            return this
+        }
+    }
 }


### PR DESCRIPTION
Closes #3929 by adding a test for re-ordering product attribute terms.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
