### PR TITLE
issue/fix-failing-test-in-develop

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -571,7 +571,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
             secondTerm
         )
 
-        val draftAttribute = viewModel.getProductDraftAttributes()[0]
+        val draftAttribute = viewModel.productDraftAttributes[0]
         val draftTerms = draftAttribute.terms
         assertThat(draftTerms[0]).isEqualTo(secondTerm)
         assertThat(draftTerms[1]).isEqualTo(firstTerm)


### PR DESCRIPTION
It looks like a failing test was pushed to `develop` when I merged #3912. This PR corrects it.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
