### PR TITLE
Add support for retry to PaymentManager

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -96,10 +96,10 @@ class CardReaderPaymentViewModel @AssistedInject constructor(
                 WaitingForInput -> {
                     // TODO cardreader prompt the user to tap/insert a card
                 }
-                CapturingPaymentFailed,
-                CollectingPaymentFailed,
+                is CapturingPaymentFailed,
+                is CollectingPaymentFailed,
                 InitializingPaymentFailed,
-                ProcessingPaymentFailed -> viewState.postValue(FailedPaymentState)
+                is ProcessingPaymentFailed -> viewState.postValue(FailedPaymentState)
                 is UnexpectedError -> {
                     logger.e(T.MAIN, paymentStatus.errorCause)
                     viewState.postValue(FailedPaymentState)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -180,7 +180,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `when collecting payment fails, then ui updated to failed state`() = runBlockingTest {
         whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
-            flow { emit(CollectingPaymentFailed) }
+            flow { emit(CollectingPaymentFailed(mock())) }
         }
 
         viewModel.start(cardReaderManager)
@@ -191,7 +191,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `when processing payment fails, then ui updated to failed state`() = runBlockingTest {
         whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
-            flow { emit(ProcessingPaymentFailed) }
+            flow { emit(ProcessingPaymentFailed(mock())) }
         }
 
         viewModel.start(cardReaderManager)
@@ -202,7 +202,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `when capturing payment fails, then ui updated to failed state`() = runBlockingTest {
         whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
-            flow { emit(CapturingPaymentFailed) }
+            flow { emit(CapturingPaymentFailed(mock())) }
         }
 
         viewModel.start(cardReaderManager)

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.cardreader.CardReader
 import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.CardReaderStatus
+import com.woocommerce.android.cardreader.PaymentData
 import com.woocommerce.android.cardreader.internal.connection.ConnectionManager
 import com.woocommerce.android.cardreader.internal.payments.PaymentManager
 import com.woocommerce.android.cardreader.internal.wrappers.LogWrapper
@@ -30,10 +31,13 @@ internal class CardReaderManagerImpl(
     companion object {
         private const val TAG = "CardReaderManager"
     }
+
     private lateinit var application: Application
 
     override val isInitialized: Boolean
-        get() { return terminal.isInitialized() }
+        get() {
+            return terminal.isInitialized()
+        }
 
     override val readerStatus: MutableStateFlow<CardReaderStatus> = connectionManager.readerStatus
 
@@ -76,6 +80,9 @@ internal class CardReaderManagerImpl(
 
     override suspend fun collectPayment(amount: BigDecimal, currency: String): Flow<CardPaymentStatus> =
         paymentManager.acceptPayment(amount, currency)
+
+    override suspend fun retryCollectPayment(paymentData: PaymentData): Flow<CardPaymentStatus> =
+        paymentManager.retry(paymentData)
 
     private fun initStripeTerminal(logLevel: LogLevel) {
         terminal.initTerminal(application, logLevel, tokenProvider, connectionManager)

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -82,7 +82,7 @@ internal class CardReaderManagerImpl(
         paymentManager.acceptPayment(amount, currency)
 
     override suspend fun retryCollectPayment(paymentData: PaymentData): Flow<CardPaymentStatus> =
-        paymentManager.retry(paymentData)
+        paymentManager.retryPayment(paymentData)
 
     private fun initStripeTerminal(logLevel: LogLevel) {
         terminal.initTerminal(application, logLevel, tokenProvider, connectionManager)

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -62,7 +62,7 @@ internal class PaymentManager(
         processPaymentIntent(paymentIntent).collect { emit(it) }
     }
 
-    fun retry(paymentData: PaymentData) = processPaymentIntent((paymentData as PaymentDataImpl).paymentIntent)
+    fun retryPayment(paymentData: PaymentData) = processPaymentIntent((paymentData as PaymentDataImpl).paymentIntent)
 
     private fun processPaymentIntent(data: PaymentIntent) = flow {
         var paymentIntent = data

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardPaymentStatus.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardPaymentStatus.kt
@@ -1,16 +1,19 @@
 package com.woocommerce.android.cardreader
 
+// TODO cardreader consider refactoring these states
 sealed class CardPaymentStatus {
     data class UnexpectedError(val errorCause: String) : CardPaymentStatus()
     object InitializingPayment : CardPaymentStatus()
     object InitializingPaymentFailed : CardPaymentStatus()
     object CollectingPayment : CardPaymentStatus()
-    object CollectingPaymentFailed : CardPaymentStatus()
+    data class CollectingPaymentFailed(val paymentData: PaymentData) : CardPaymentStatus()
     object WaitingForInput : CardPaymentStatus()
     object ShowAdditionalInfo : CardPaymentStatus()
     object ProcessingPayment : CardPaymentStatus()
-    object ProcessingPaymentFailed : CardPaymentStatus()
+    data class ProcessingPaymentFailed(val paymentData: PaymentData) : CardPaymentStatus()
     object CapturingPayment : CardPaymentStatus()
-    object CapturingPaymentFailed : CardPaymentStatus()
+    data class CapturingPaymentFailed(val paymentData: PaymentData) : CardPaymentStatus()
     object PaymentCompleted : CardPaymentStatus()
 }
+
+interface PaymentData

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
@@ -17,4 +17,5 @@ interface CardReaderManager {
 
     // TODO cardreader Stripe accepts only Int, is that ok?
     suspend fun collectPayment(amount: BigDecimal, currency: String): Flow<CardPaymentStatus>
+    suspend fun retryCollectPayment(paymentData: PaymentData): Flow<CardPaymentStatus>
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
@@ -373,7 +373,7 @@ class PaymentManagerTest {
             }
             val paymentData = PaymentDataImpl(paymentIntent)
 
-            val result = manager.retry(paymentData).first()
+            val result = manager.retryPayment(paymentData).first()
 
             assertThat(result).isInstanceOf(CollectingPayment::class.java)
         }
@@ -386,7 +386,7 @@ class PaymentManagerTest {
             }
             val paymentData = PaymentDataImpl(paymentIntent)
 
-            val result = manager.retry(paymentData).first()
+            val result = manager.retryPayment(paymentData).first()
 
             assertThat(result).isInstanceOf(ProcessingPayment::class.java)
         }
@@ -399,7 +399,7 @@ class PaymentManagerTest {
             }
             val paymentData = PaymentDataImpl(paymentIntent)
 
-            val result = manager.retry(paymentData).first()
+            val result = manager.retryPayment(paymentData).first()
 
             assertThat(result).isInstanceOf(CapturingPayment::class.java)
         }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
@@ -12,6 +12,7 @@ import com.stripe.stripeterminal.model.external.PaymentIntentStatus.CANCELED
 import com.stripe.stripeterminal.model.external.PaymentIntentStatus.REQUIRES_CAPTURE
 import com.stripe.stripeterminal.model.external.PaymentIntentStatus.REQUIRES_CONFIRMATION
 import com.stripe.stripeterminal.model.external.PaymentIntentStatus.REQUIRES_PAYMENT_METHOD
+import com.stripe.stripeterminal.model.external.TerminalException
 import com.woocommerce.android.cardreader.CardPaymentStatus
 import com.woocommerce.android.cardreader.CardPaymentStatus.CapturingPayment
 import com.woocommerce.android.cardreader.CardPaymentStatus.CapturingPaymentFailed
@@ -34,6 +35,7 @@ import com.woocommerce.android.cardreader.internal.payments.actions.ProcessPayme
 import com.woocommerce.android.cardreader.internal.payments.actions.ProcessPaymentAction.ProcessPaymentStatus
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -146,6 +148,7 @@ class PaymentManagerTest {
         verify(createPaymentAction).createPaymentIntent(captor.capture(), anyString())
         assertThat(captor.firstValue).isEqualTo(199)
     }
+
     // END - Arguments validation and conversion
     // BEGIN - Creating Payment intent
     @Test
@@ -221,6 +224,39 @@ class PaymentManagerTest {
     }
 
     @Test
+    fun `given exception contains PaymentIntent,when collecting payment fails, then PaymentData contain that intent`() =
+        runBlockingTest {
+            val paymentIntent = mock<PaymentIntent>()
+            val terminalException = mock<TerminalException>().also {
+                whenever(it.paymentIntent).thenReturn(paymentIntent)
+            }
+            whenever(collectPaymentAction.collectPayment(anyOrNull()))
+                .thenReturn(flow { emit(CollectPaymentStatus.Failure(terminalException)) })
+
+            val result = manager.acceptPayment(DUMMY_AMOUNT, USD_CURRENCY).toList()
+
+            assertThat((result.last() as CollectingPaymentFailed).paymentData)
+                .isEqualTo(PaymentDataImpl(paymentIntent))
+        }
+
+    @Test
+    fun `given exception doesn't contain PaymentIntent,when collecting payment fails, then data contain orig intent`() =
+        runBlockingTest {
+            val terminalException = mock<TerminalException>().also {
+                whenever(it.paymentIntent).thenReturn(null)
+            }
+            whenever(collectPaymentAction.collectPayment(anyOrNull()))
+                .thenReturn(flow { emit(CollectPaymentStatus.Failure(terminalException)) })
+
+            val result = manager.acceptPayment(DUMMY_AMOUNT, USD_CURRENCY).toList()
+
+            val captor = argumentCaptor<PaymentIntent>()
+            verify(collectPaymentAction).collectPayment(captor.capture())
+            assertThat((result.last() as CollectingPaymentFailed).paymentData)
+                .isEqualTo(PaymentDataImpl(captor.firstValue))
+        }
+
+    @Test
     fun `given status not REQUIRES_CONFIRMATION, when collecting payment finishes, then flow terminates`() =
         runBlockingTest {
             whenever(collectPaymentAction.collectPayment(anyOrNull()))
@@ -253,6 +289,38 @@ class PaymentManagerTest {
 
         assertThat(result.last()).isInstanceOf(ProcessingPaymentFailed::class.java)
     }
+
+    @Test
+    fun `given exception contains PaymentIntent,when processing payment fails, then PaymentData contain that intent`() =
+        runBlockingTest {
+            val paymentIntent = mock<PaymentIntent>()
+            val terminalException = mock<TerminalException>().also {
+                whenever(it.paymentIntent).thenReturn(paymentIntent)
+            }
+            whenever(processPaymentAction.processPayment(anyOrNull()))
+                .thenReturn(flow { emit(ProcessPaymentStatus.Failure(terminalException)) })
+
+            val result = manager.acceptPayment(DUMMY_AMOUNT, USD_CURRENCY).toList()
+
+            assertThat((result.last() as ProcessingPaymentFailed).paymentData).isEqualTo(PaymentDataImpl(paymentIntent))
+        }
+
+    @Test
+    fun `given exception doesn't contain PaymentIntent,when processing payment fails, then data contain orig intent`() =
+        runBlockingTest {
+            val terminalException = mock<TerminalException>().also {
+                whenever(it.paymentIntent).thenReturn(null)
+            }
+            whenever(processPaymentAction.processPayment(anyOrNull()))
+                .thenReturn(flow { emit(ProcessPaymentStatus.Failure(terminalException)) })
+
+            val result = manager.acceptPayment(DUMMY_AMOUNT, USD_CURRENCY).toList()
+
+            val captor = argumentCaptor<PaymentIntent>()
+            verify(processPaymentAction).processPayment(captor.capture())
+            assertThat((result.last() as ProcessingPaymentFailed).paymentData)
+                .isEqualTo(PaymentDataImpl(captor.firstValue))
+        }
 
     @Test
     fun `given status not REQUIRES_CAPTURE, when processing payment finishes, then flow terminates`() =
@@ -295,6 +363,47 @@ class PaymentManagerTest {
         assertThat(result.last()).isInstanceOf(CapturingPaymentFailed::class.java)
     }
     // END - Capturing Payment
+
+    // BEGIN - Retry
+    @Test
+    fun `given PaymentStatus REQUIRES_PAYMENT_METHOD, when retrying payment, then flow resumes on collectPayment`() =
+        runBlockingTest {
+            val paymentIntent = mock<PaymentIntent>().also {
+                whenever(it.status).thenReturn(REQUIRES_PAYMENT_METHOD)
+            }
+            val paymentData = PaymentDataImpl(paymentIntent)
+
+            val result = manager.retry(paymentData).first()
+
+            assertThat(result).isInstanceOf(CollectingPayment::class.java)
+        }
+
+    @Test
+    fun `given PaymentStatus REQUIRES_CONFIRMATION, when retrying payment, then flow resumes on processPayment`() =
+        runBlockingTest {
+            val paymentIntent = mock<PaymentIntent>().also {
+                whenever(it.status).thenReturn(REQUIRES_CONFIRMATION)
+            }
+            val paymentData = PaymentDataImpl(paymentIntent)
+
+            val result = manager.retry(paymentData).first()
+
+            assertThat(result).isInstanceOf(ProcessingPayment::class.java)
+        }
+
+    @Test
+    fun `given PaymentStatus REQUIRES_CAPTURE, when retrying payment, then flow resumes on capturePayment`() =
+        runBlockingTest {
+            val paymentIntent = mock<PaymentIntent>().also {
+                whenever(it.status).thenReturn(REQUIRES_CAPTURE)
+            }
+            val paymentData = PaymentDataImpl(paymentIntent)
+
+            val result = manager.retry(paymentData).first()
+
+            assertThat(result).isInstanceOf(CapturingPayment::class.java)
+        }
+    // END - Retry
 
     private fun createPaymentIntent(status: PaymentIntentStatus): PaymentIntent =
         mock<PaymentIntent>().also {


### PR DESCRIPTION
Parent issue #3726 

This PR adds support for retry to PaymentManager. 

Introduces PaymentData and PaymentDataImpl. PaymentDataImpl is actually just a wrapper for PaymentIntent which is a class provided by StripeTerminalSDK. We use this wrapper to hide technical details from the client (woo app).

PaymentData are added as parameter to error statuses so the client (woo app) can pass the data back when the user clicks on "retry". We could store the PaymentData within the PaymentManager but I thought it'd be better to keep it state-less to limit space for errors.

The actual payment flow will be quite straightforward:
1. Client invokes "collectPayment(..)"
2. The PaymentManager keeps informing the client about the current status (CardPaymentStatus)
3. If the payment fails, PaymentManager returns an error with PaymentData
4. The client can invoke `retryPayment()` and provide the PaymentData so the PaymentManager knows from which point to resume/retry the payment flow

More info about about the flow can be found on p91TBi-520-p2

To test
CircleCI tests should be enough.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
