### PR TITLE
issue/3941-single-term-drag-and-drop

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
@@ -8,8 +8,10 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.DiffUtil.Callback
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
+import kotlin.concurrent.schedule
 import com.woocommerce.android.databinding.AttributeTermListItemBinding
 import com.woocommerce.android.ui.products.variations.attributes.AttributeTermsListAdapter.TermViewHolder
+import java.util.Timer
 
 /**
  * Adapter which shows a simple list of attribute term names
@@ -80,12 +82,10 @@ class AttributeTermsListAdapter(
     fun addTerm(termName: String) {
         if (!containsTerm(termName)) {
             termNames.add(0, termName)
-            // if there's now two terms, we must refresh the whole list since we only show the drag handle
-            // when there's more than one term
+            notifyItemInserted(0)
+            // if there's now two terms, we must refresh the whole list
             if (itemCount == 2) {
-                notifyDataSetChanged()
-            } else {
-                notifyItemInserted(0)
+                delayedChangeNotification()
             }
         }
     }
@@ -94,11 +94,21 @@ class AttributeTermsListAdapter(
         val index = termNames.indexOf(term)
         if (index >= 0) {
             termNames.remove(term)
+            notifyItemRemoved(index)
             if (itemCount == 1) {
-                notifyDataSetChanged()
-            } else {
-                notifyItemRemoved(index)
+                delayedChangeNotification()
             }
+        }
+    }
+
+    /**
+     * When the list of terms changes from/to a single item we must refresh all the views since we only show the
+     * drag handle when there's more than one term, but we delay the refresh to give the added/removed term time
+     * to animate
+     */
+    private fun delayedChangeNotification() {
+        Timer().schedule(250) {
+            notifyDataSetChanged()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
@@ -135,7 +135,7 @@ class AttributeTermsListAdapter(
                 }
             }
 
-            if (enableDragAndDrop) {
+            if (enableDragAndDrop && termNames.size > 1) {
                 viewBinding.termDragHandle.setOnClickListener {
                     dragHelper?.startDrag(this)
                 }
@@ -144,7 +144,7 @@ class AttributeTermsListAdapter(
 
         fun bind(termName: String) {
             viewBinding.termName.text = termName
-            viewBinding.termDragHandle.isVisible = enableDragAndDrop
+            viewBinding.termDragHandle.isVisible = enableDragAndDrop && termNames.size > 1
             viewBinding.termDelete.isVisible = enableDeleting
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products.variations.attributes
 
 import android.annotation.SuppressLint
+import android.os.Handler
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.view.isVisible
@@ -8,10 +9,8 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.DiffUtil.Callback
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
-import kotlin.concurrent.schedule
 import com.woocommerce.android.databinding.AttributeTermListItemBinding
 import com.woocommerce.android.ui.products.variations.attributes.AttributeTermsListAdapter.TermViewHolder
-import java.util.Timer
 
 /**
  * Adapter which shows a simple list of attribute term names
@@ -83,7 +82,6 @@ class AttributeTermsListAdapter(
         if (!containsTerm(termName)) {
             termNames.add(0, termName)
             notifyItemInserted(0)
-            // if there's now two terms, we must refresh the whole list
             if (itemCount == 2) {
                 delayedChangeNotification()
             }
@@ -102,14 +100,14 @@ class AttributeTermsListAdapter(
     }
 
     /**
-     * When the list of terms changes from/to a single item we must refresh all the views since we only show the
-     * drag handle when there's more than one term, but we delay the refresh to give the added/removed term time
+     * When the listchanges from/to a single term we must refresh all the views since we only show the drag
+     * handle when there's more than one term, but we delay the refresh to give the added/removed term time
      * to animate
      */
     private fun delayedChangeNotification() {
-        Timer().schedule(250) {
+        Handler().postDelayed({
             notifyDataSetChanged()
-        }
+        }, 300)
     }
 
     fun swapItems(from: Int, to: Int) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
@@ -80,7 +80,25 @@ class AttributeTermsListAdapter(
     fun addTerm(termName: String) {
         if (!containsTerm(termName)) {
             termNames.add(0, termName)
-            notifyItemInserted(0)
+            // if there's now two terms, we must refresh the whole list since we only show the drag handle
+            // when there's more than one term
+            if (itemCount == 2) {
+                notifyDataSetChanged()
+            } else {
+                notifyItemInserted(0)
+            }
+        }
+    }
+
+    fun removeTerm(term: String) {
+        val index = termNames.indexOf(term)
+        if (index >= 0) {
+            termNames.remove(term)
+            if (itemCount == 1) {
+                notifyDataSetChanged()
+            } else {
+                notifyItemRemoved(index)
+            }
         }
     }
 
@@ -93,14 +111,6 @@ class AttributeTermsListAdapter(
         notifyItemMoved(from, to)
 
         onTermListener.onTermMoved(fromValue, toValue)
-    }
-
-    fun removeTerm(term: String) {
-        val index = termNames.indexOf(term)
-        if (index >= 0) {
-            termNames.remove(term)
-            notifyItemRemoved(index)
-        }
     }
 
     private class TermItemDiffUtil(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
@@ -100,7 +100,7 @@ class AttributeTermsListAdapter(
     }
 
     /**
-     * When the listchanges from/to a single term we must refresh all the views since we only show the drag
+     * When the list changes from/to a single term we must refresh all the views since we only show the drag
      * handle when there's more than one term, but we delay the refresh to give the added/removed term time
      * to animate
      */


### PR DESCRIPTION
Fixes #3941 - Previously we continued to show the drag handle on the list of attribute terms even when there was a single term. To test:

- View the list of attribute terms
- Ensure the drag handle doesn't appear when there's one term
- Ensure it does appear when there's more than one term

![Screenshot_20210429_163941](https://user-images.githubusercontent.com/3903757/116615707-ad2adf80-a909-11eb-95af-b8ae1f50322e.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
