### PR TITLE
Issue/3726 capture payment endpoint

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -31,7 +31,16 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
         </value>
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -31,16 +31,7 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
+          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
         </value>
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />

--- a/WooCommerce/src/debug/kotlin/com.woocommerce.android/WooCommerceDebug.kt
+++ b/WooCommerce/src/debug/kotlin/com.woocommerce.android/WooCommerceDebug.kt
@@ -21,10 +21,8 @@ class WooCommerceDebug : WooCommerce() {
             return result.model?.token.orEmpty()
         }
 
-        override suspend fun capturePaymentIntent(id: String): Boolean {
-            // TODO cardreader Invoke capturePayment on WCPayStore
-            delay(1000)
-            return true
+        override suspend fun capturePaymentIntent(orderId: Long, paymentId: String): Boolean {
+            return !payStore.capturePayment(selectedSite.get(), paymentId, orderId).isError
         }
     })
 

--- a/WooCommerce/src/debug/kotlin/com.woocommerce.android/WooCommerceDebug.kt
+++ b/WooCommerce/src/debug/kotlin/com.woocommerce.android/WooCommerceDebug.kt
@@ -12,7 +12,6 @@ import com.woocommerce.android.cardreader.CardReaderManagerFactory
 import com.woocommerce.android.cardreader.CardReaderStore
 import com.woocommerce.android.di.AppComponent
 import com.woocommerce.android.di.DaggerAppComponentDebug
-import kotlinx.coroutines.delay
 
 class WooCommerceDebug : WooCommerce() {
     override val cardReaderManager = CardReaderManagerFactory.createCardReaderManager(object : CardReaderStore {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -76,7 +76,7 @@ class CardReaderPaymentViewModel @AssistedInject constructor(
                 loadOrderFromDB()?.let { order ->
                     order.total.toBigDecimalOrNull()?.let { amount ->
                         // TODO cardreader don't hardcode currency symbol ($)
-                        collectPaymentFlow(cardReaderManager, amount, order.currency, "$$amount")
+                        collectPaymentFlow(cardReaderManager, order.remoteOrderId, amount, order.currency, "$$amount")
                     } ?: throw IllegalStateException("Converting order.total to BigDecimal failed")
                 } ?: throw IllegalStateException("Null order is not expected at this point")
             } catch (e: IllegalStateException) {
@@ -90,28 +90,30 @@ class CardReaderPaymentViewModel @AssistedInject constructor(
         }
     }
 
-    fun retry(paymentData: PaymentData, amountLabel: String) {
+    fun retry(orderId: Long, paymentData: PaymentData, amountLabel: String) {
         paymentFlowJob = launch {
             viewState.postValue((LoadingDataState))
             delay(ARTIFICIAL_RETRY_DELAY)
-            cardReaderManager.retryCollectPayment(paymentData).collect { paymentStatus ->
-                onPaymentStatusChanged(paymentStatus, amountLabel)
+            cardReaderManager.retryCollectPayment(orderId, paymentData).collect { paymentStatus ->
+                onPaymentStatusChanged(orderId, paymentStatus, amountLabel)
             }
         }
     }
 
     private suspend fun collectPaymentFlow(
         cardReaderManager: CardReaderManager,
+        orderId: Long,
         amount: BigDecimal,
         currency: String,
         amountLabel: String
     ) {
-        cardReaderManager.collectPayment(amount, currency).collect { paymentStatus ->
-            onPaymentStatusChanged(paymentStatus, amountLabel)
+        cardReaderManager.collectPayment(orderId, amount, currency).collect { paymentStatus ->
+            onPaymentStatusChanged(orderId, paymentStatus, amountLabel)
         }
     }
 
     private fun onPaymentStatusChanged(
+        orderId: Long,
         paymentStatus: CardPaymentStatus,
         amountLabel: String
     ) {
@@ -127,20 +129,20 @@ class CardReaderPaymentViewModel @AssistedInject constructor(
             WaitingForInput -> {
                 // TODO cardreader prompt the user to tap/insert a card
             }
-            InitializingPaymentFailed -> emitFailedPaymentState(null, amountLabel)
-            is CollectingPaymentFailed -> emitFailedPaymentState(paymentStatus.paymentData, amountLabel)
-            is ProcessingPaymentFailed -> emitFailedPaymentState(paymentStatus.paymentData, amountLabel)
-            is CapturingPaymentFailed -> emitFailedPaymentState(paymentStatus.paymentData, amountLabel)
+            InitializingPaymentFailed -> emitFailedPaymentState(orderId, null, amountLabel)
+            is CollectingPaymentFailed -> emitFailedPaymentState(orderId, paymentStatus.paymentData, amountLabel)
+            is ProcessingPaymentFailed -> emitFailedPaymentState(orderId, paymentStatus.paymentData, amountLabel)
+            is CapturingPaymentFailed -> emitFailedPaymentState(orderId, paymentStatus.paymentData, amountLabel)
             is UnexpectedError -> {
                 logger.e(MAIN, paymentStatus.errorCause)
-                emitFailedPaymentState(null, amountLabel)
+                emitFailedPaymentState(orderId, null, amountLabel)
             }
         }
     }
 
-    private fun emitFailedPaymentState(paymentData: PaymentData?, amountLabel: String) {
+    private fun emitFailedPaymentState(orderId: Long, paymentData: PaymentData?, amountLabel: String) {
         val onRetryClicked = if (paymentData != null) {
-            { retry(paymentData, amountLabel) }
+            { retry(orderId, paymentData, amountLabel) }
         } else {
             { initPaymentFlow() }
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.clearInvocations
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.times
@@ -85,10 +86,10 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         whenever(mockedOrder.total).thenReturn(DUMMY_TOTAL)
         whenever(mockedOrder.currency).thenReturn("USD")
         whenever(orderStore.getOrderByIdentifier(ORDER_IDENTIFIER)).thenReturn(mockedOrder)
-        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+        whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
             flow<CardPaymentStatus> { }
         }
-        whenever(cardReaderManager.retryCollectPayment(any())).thenAnswer {
+        whenever(cardReaderManager.retryCollectPayment(any(), any())).thenAnswer {
             flow<CardPaymentStatus> { }
         }
     }
@@ -122,7 +123,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when initializing payment, then ui updated to initializing payment state `() = runBlockingTest {
-        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+        whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
             flow { emit(InitializingPayment) }
         }
 
@@ -133,7 +134,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when collecting payment, then ui updated to collecting payment state`() = runBlockingTest {
-        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+        whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
             flow { emit(CollectingPayment) }
         }
 
@@ -144,7 +145,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when processing payment, then ui updated to processing payment state`() = runBlockingTest {
-        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+        whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
             flow { emit(ProcessingPayment) }
         }
 
@@ -155,7 +156,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when capturing payment, then ui updated to capturing payment state`() = runBlockingTest {
-        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+        whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
             flow { emit(CapturingPayment) }
         }
 
@@ -166,7 +167,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment completed, then ui updated to payment successful state`() = runBlockingTest {
-        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+        whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
             flow { emit(PaymentCompleted) }
         }
 
@@ -177,7 +178,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when initializing payment fails, then ui updated to failed state`() = runBlockingTest {
-        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+        whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
             flow { emit(InitializingPaymentFailed) }
         }
 
@@ -188,7 +189,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when collecting payment fails, then ui updated to failed state`() = runBlockingTest {
-        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+        whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
             flow { emit(CollectingPaymentFailed(mock())) }
         }
 
@@ -199,7 +200,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when processing payment fails, then ui updated to failed state`() = runBlockingTest {
-        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+        whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
             flow { emit(ProcessingPaymentFailed(mock())) }
         }
 
@@ -210,7 +211,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when capturing payment fails, then ui updated to failed state`() = runBlockingTest {
-        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+        whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
             flow { emit(CapturingPaymentFailed(mock())) }
         }
 
@@ -221,7 +222,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when unexpected error occurs during payment flow, then ui updated to failed state`() = runBlockingTest {
-        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+        whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
             flow { emit(UnexpectedError("")) }
         }
 
@@ -233,7 +234,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given user clicks on retry, when payment initialization fails, then flow restarted from scratch`() =
         runBlockingTest {
-            whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+            whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
                 flow { emit(CardPaymentStatus.InitializingPaymentFailed) }
             }
             viewModel.start(cardReaderManager)
@@ -241,88 +242,88 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
             (viewModel.viewStateData.value as FailedPaymentState).onPrimaryActionClicked.invoke()
 
-            verify(cardReaderManager).collectPayment(any(), anyString())
+            verify(cardReaderManager).collectPayment(any(), any(), anyString())
         }
 
     @Test
     fun `given user clicks on retry, when payment collection fails, then retryCollectPayment invoked`() =
         runBlockingTest {
-            whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+            whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
                 flow { emit(CardPaymentStatus.CollectingPaymentFailed(mock())) }
             }
             viewModel.start(cardReaderManager)
 
             (viewModel.viewStateData.value as FailedPaymentState).onPrimaryActionClicked.invoke()
 
-            verify(cardReaderManager).retryCollectPayment(any())
+            verify(cardReaderManager).retryCollectPayment(any(), any())
         }
 
     @Test
     fun `given user clicks on retry, when payment collection fails, then flow retried with provided PaymentData`() =
         runBlockingTest {
             val paymentData = mock<PaymentData>()
-            whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+            whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
                 flow { emit(CardPaymentStatus.CollectingPaymentFailed(paymentData)) }
             }
             viewModel.start(cardReaderManager)
 
             (viewModel.viewStateData.value as FailedPaymentState).onPrimaryActionClicked.invoke()
 
-            verify(cardReaderManager).retryCollectPayment(paymentData)
+            verify(cardReaderManager).retryCollectPayment(any(), eq(paymentData))
         }
 
     @Test
     fun `given user clicks on retry, when payment processing fails, then retryCollectPayment invoked`() =
         runBlockingTest {
-            whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+            whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
                 flow { emit(CardPaymentStatus.ProcessingPaymentFailed(mock())) }
             }
             viewModel.start(cardReaderManager)
 
             (viewModel.viewStateData.value as FailedPaymentState).onPrimaryActionClicked.invoke()
 
-            verify(cardReaderManager).retryCollectPayment(any())
+            verify(cardReaderManager).retryCollectPayment(any(), any())
         }
 
     @Test
     fun `given user clicks on retry, when payment processing fails, then flow retried with provided PaymentData`() =
         runBlockingTest {
             val paymentData = mock<PaymentData>()
-            whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+            whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
                 flow { emit(CardPaymentStatus.ProcessingPaymentFailed(paymentData)) }
             }
             viewModel.start(cardReaderManager)
 
             (viewModel.viewStateData.value as FailedPaymentState).onPrimaryActionClicked.invoke()
 
-            verify(cardReaderManager).retryCollectPayment(paymentData)
+            verify(cardReaderManager).retryCollectPayment(any(), eq(paymentData))
         }
 
     @Test
     fun `given user clicks on retry, when capturing payment fails, then retryCollectPayment invoked`() =
         runBlockingTest {
-            whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+            whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
                 flow { emit(CardPaymentStatus.CapturingPaymentFailed(mock())) }
             }
             viewModel.start(cardReaderManager)
 
             (viewModel.viewStateData.value as FailedPaymentState).onPrimaryActionClicked.invoke()
 
-            verify(cardReaderManager).retryCollectPayment(any())
+            verify(cardReaderManager).retryCollectPayment(any(), any())
         }
 
     @Test
     fun `given user clicks on retry, when capturing payment fails then flow retried with provided PaymentData`() =
         runBlockingTest {
             val paymentData = mock<PaymentData>()
-            whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+            whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
                 flow { emit(CardPaymentStatus.CapturingPaymentFailed(paymentData)) }
             }
             viewModel.start(cardReaderManager)
 
             (viewModel.viewStateData.value as FailedPaymentState).onPrimaryActionClicked.invoke()
 
-            verify(cardReaderManager).retryCollectPayment(paymentData)
+            verify(cardReaderManager).retryCollectPayment(any(), eq(paymentData))
         }
 
     @Test
@@ -342,7 +343,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when collecting payment, then progress and buttons are hidden`() = runBlockingTest {
-        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+        whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
             flow { emit(CollectingPayment) }
         }
 
@@ -356,7 +357,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when collecting payment, then correct labels and illustration is shown`() = runBlockingTest {
-        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+        whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
             flow { emit(CollectingPayment) }
         }
 
@@ -372,7 +373,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when processing payment, then progress and buttons are hidden`() = runBlockingTest {
-        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+        whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
             flow { emit(ProcessingPayment) }
         }
 
@@ -386,7 +387,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when processing payment, then correct labels and illustration is shown`() = runBlockingTest {
-        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+        whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
             flow { emit(ProcessingPayment) }
         }
 
@@ -402,7 +403,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when capturing payment, then progress and buttons are hidden`() = runBlockingTest {
-        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+        whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
             flow { emit(CapturingPayment) }
         }
 
@@ -416,7 +417,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when capturing payment, then correct labels and illustration is shown`() = runBlockingTest {
-        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+        whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
             flow { emit(CapturingPayment) }
         }
 
@@ -432,7 +433,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment fails, then progress and secondary button are hidden`() = runBlockingTest {
-        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+        whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
             flow { emit(CollectingPaymentFailed(mock())) }
         }
 
@@ -445,7 +446,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment fails, then correct labels, illustration and button are shown`() = runBlockingTest {
-        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+        whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
             flow { emit(CollectingPaymentFailed(mock())) }
         }
 
@@ -462,7 +463,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when payment succeeds, then correct labels, illustration and buttons are shown`() = runBlockingTest {
-        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer {
+        whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer {
             flow { emit(PaymentCompleted) }
         }
 
@@ -480,13 +481,13 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given payment flow already started, when start() is invoked, then flow is not restarted`() = runBlockingTest {
-        whenever(cardReaderManager.collectPayment(any(), anyString())).thenAnswer { flow<CardPaymentStatus> {} }
+        whenever(cardReaderManager.collectPayment(any(), any(), anyString())).thenAnswer { flow<CardPaymentStatus> {} }
 
         viewModel.start(cardReaderManager)
         viewModel.start(cardReaderManager)
         viewModel.start(cardReaderManager)
         viewModel.start(cardReaderManager)
 
-        verify(cardReaderManager, times(1)).collectPayment(anyOrNull(), anyString())
+        verify(cardReaderManager, times(1)).collectPayment(anyOrNull(), anyOrNull(), anyString())
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '14dccfc36e810ebbfcc4b2379396b1a6a6db28bf'
+    fluxCVersion = 'c2633ee2117c9b6104fc2c18be1309f04b059f82'
     daggerVersion = '2.33'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'b49a012d5ff4c533bebc1a96cc66be4939759aa6'
+    fluxCVersion = '14dccfc36e810ebbfcc4b2379396b1a6a6db28bf'
     daggerVersion = '2.33'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '107d9653e7fa8b1c178ada2c516394ba88279ac7'
+    fluxCVersion = 'b49a012d5ff4c533bebc1a96cc66be4939759aa6'
     daggerVersion = '2.33'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -78,11 +78,11 @@ internal class CardReaderManagerImpl(
         return connectionManager.connectToReader(cardReader)
     }
 
-    override suspend fun collectPayment(amount: BigDecimal, currency: String): Flow<CardPaymentStatus> =
-        paymentManager.acceptPayment(amount, currency)
+    override suspend fun collectPayment(orderId: Long, amount: BigDecimal, currency: String): Flow<CardPaymentStatus> =
+        paymentManager.acceptPayment(orderId, amount, currency)
 
-    override suspend fun retryCollectPayment(paymentData: PaymentData): Flow<CardPaymentStatus> =
-        paymentManager.retryPayment(paymentData)
+    override suspend fun retryCollectPayment(orderId: Long, paymentData: PaymentData): Flow<CardPaymentStatus> =
+        paymentManager.retryPayment(orderId, paymentData)
 
     private fun initStripeTerminal(logLevel: LogLevel) {
         terminal.initTerminal(application, logLevel, tokenProvider, connectionManager)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
@@ -16,6 +16,6 @@ interface CardReaderManager {
     suspend fun connectToReader(cardReader: CardReader): Boolean
 
     // TODO cardreader Stripe accepts only Int, is that ok?
-    suspend fun collectPayment(orderId:Long, amount: BigDecimal, currency: String): Flow<CardPaymentStatus>
+    suspend fun collectPayment(orderId: Long, amount: BigDecimal, currency: String): Flow<CardPaymentStatus>
     suspend fun retryCollectPayment(orderId: Long, paymentData: PaymentData): Flow<CardPaymentStatus>
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
@@ -16,6 +16,6 @@ interface CardReaderManager {
     suspend fun connectToReader(cardReader: CardReader): Boolean
 
     // TODO cardreader Stripe accepts only Int, is that ok?
-    suspend fun collectPayment(amount: BigDecimal, currency: String): Flow<CardPaymentStatus>
-    suspend fun retryCollectPayment(paymentData: PaymentData): Flow<CardPaymentStatus>
+    suspend fun collectPayment(orderId:Long, amount: BigDecimal, currency: String): Flow<CardPaymentStatus>
+    suspend fun retryCollectPayment(orderId: Long, paymentData: PaymentData): Flow<CardPaymentStatus>
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderStore.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderStore.kt
@@ -3,5 +3,5 @@ package com.woocommerce.android.cardreader
 interface CardReaderStore {
     suspend fun getConnectionToken(): String
 
-    suspend fun capturePaymentIntent(id: String): Boolean
+    suspend fun capturePaymentIntent(orderId: Long, paymentId: String): Boolean
 }


### PR DESCRIPTION
Parent issue #3726

Merge instructions:
1. Make sure FluxC's PR is merged first - https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1980
2. Merge this PR

This PR 
- Updates FluxC hash.
- Updates "capturePayment" method so it uses WCPayStore.capturePayment.
- Propagates "orderId" to "capturePayment".

To test:
Note: Since the backend code is not in production yet, this PR needs to be tested against a development version of WCPay plugin. There are four options:
1. Build https://github.com/Automattic/woocommerce-payments/pull/1689 locally and upload the plugin to your testing site
2. DM me and I can send you the zip with the build
3. DM me and I can invite you to my testing site
4. Ask iOS folks to test this PR since they have the setup ready

Instructions:
- Make sure to test these changes with a site with WCPay in devmode (or live mode, but only hw reader is supported in live mode) and with development version of WCPay as mentioned above
- HW reader is required to test this PR
1. Open app settings
2. Tap on "Manage card reader"
4. Tap on "Connect card reader"
5. Go back - open a detail of an order in **USD currency**
6. Tap on "Collect payment"
7. Check that the flow works and the payment succeeds
8. Dismiss the dialog -> pull to refresh the order detail -> notice the order is "Paid"

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
