### PR TITLE
Removed virtual option from product filters

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.R.string
 import com.woocommerce.android.di.ViewModelAssistedFactory
 import com.woocommerce.android.ui.products.ProductStockStatus.Companion.fromString
 import com.woocommerce.android.ui.products.ProductType.OTHER
+import com.woocommerce.android.ui.products.ProductType.VIRTUAL
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -38,15 +39,15 @@ class ProductFilterListViewModel @AssistedInject constructor(
     private val arguments: ProductFilterListFragmentArgs by savedState.navArgs()
 
     private val _filterListItems = MutableLiveData<List<FilterListItemUiModel>>()
-    final val filterListItems: LiveData<List<FilterListItemUiModel>> = _filterListItems
+    val filterListItems: LiveData<List<FilterListItemUiModel>> = _filterListItems
 
     private val _filterOptionListItems = MutableLiveData<List<FilterListOptionItemUiModel>>()
-    final val filterOptionListItems: LiveData<List<FilterListOptionItemUiModel>> = _filterOptionListItems
+    val filterOptionListItems: LiveData<List<FilterListOptionItemUiModel>> = _filterOptionListItems
 
-    final val productFilterListViewStateData = LiveDataDelegate(savedState, ProductFilterListViewState())
+    val productFilterListViewStateData = LiveDataDelegate(savedState, ProductFilterListViewState())
     private var productFilterListViewState by productFilterListViewStateData
 
-    final val productFilterOptionListViewStateData = LiveDataDelegate(savedState, ProductFilterOptionListViewState())
+    val productFilterOptionListViewStateData = LiveDataDelegate(savedState, ProductFilterOptionListViewState())
     private var productFilterOptionListViewState by productFilterOptionListViewStateData
 
     /**
@@ -55,7 +56,7 @@ class ProductFilterListViewModel @AssistedInject constructor(
      *
      * If no filters are previously selected, the map is empty.
      */
-    private final val productFilterOptions: MutableMap<ProductFilterOption, String> by lazy {
+    private val productFilterOptions: MutableMap<ProductFilterOption, String> by lazy {
         val params = savedState.get<MutableMap<ProductFilterOption, String>>(KEY_PRODUCT_FILTER_OPTIONS)
                 ?: mutableMapOf()
         arguments.selectedStockStatus?.let { params.put(STOCK_STATUS, it) }
@@ -183,7 +184,7 @@ class ProductFilterListViewModel @AssistedInject constructor(
                         TYPE,
                         resourceProvider.getString(string.product_type),
                         addDefaultFilterOption(
-                                ProductType.values().filterNot { it == OTHER }.map {
+                                ProductType.values().filterNot { it == OTHER || it == VIRTUAL }.map {
                                     FilterListOptionItemUiModel(
                                             resourceProvider.getString(it.stringResource),
                                             filterOptionItemValue = it.value,


### PR DESCRIPTION
Fixes #3937 by removing the virtual option when filtering products. This was not actually supported by the app but was introduced from the fix in #3900. 

### To test
- Click on the Products TAB.
- Click on the filters option. 
- Click on the Product type option.
- Notice that the Virtual option is not visible.
- Verify that you are able to select multiple filters without any issues.
- Note that the discard dialog will be displayed when clicking on the `X` icon, **only if there were any changes made to the filters**.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
