### PR TITLE
Release variations feature

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 6.6
 -----
+- [***] Products: When editing a product, you can now create/delete/update product variations, product attributes and product attribute options. [https://github.com/woocommerce/woocommerce-android/pull/3946]
 - [*] Fixed a bug would not allow to edit the product price and sale price. [https://github.com/woocommerce/woocommerce-android/pull/3926]
 - [*] Added the option to create and edit a virtual product directly from the product detail screen. [https://github.com/woocommerce/woocommerce-android/pull/3900]
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -46,7 +46,6 @@ import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.PRIMA
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.SECONDARY
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.FeatureFlag.ADD_EDIT_VARIATIONS
 import com.woocommerce.android.util.PriceUtils
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -522,33 +521,18 @@ class ProductDetailCardBuilder(
         }
     }
 
-    private fun Product.emptyVariations(): ComplexProperty {
-        return if (ADD_EDIT_VARIATIONS.isEnabled()) {
-            ComplexProperty(
-                value = resources.getString(string.product_detail_add_variations),
-                icon = drawable.ic_gridicons_types,
-                showTitle = false,
-                onClick = {
-                    viewModel.onEditProductCardClicked(
-                        AddProductAttribute(isVariationCreation = true),
-                        PRODUCT_DETAIL_VIEW_PRODUCT_VARIANTS_TAPPED
-                    )
-                }
-            )
-        } else {
-            ComplexProperty(
-                title = string.product_variations,
-                value = resources.getString(string.product_detail_no_variations),
-                icon = drawable.ic_gridicons_types,
-                onClick = {
-                    viewModel.onEditProductCardClicked(
-                        ViewProductVariations(this.remoteId),
-                        PRODUCT_DETAIL_VIEW_PRODUCT_VARIANTS_TAPPED
-                    )
-                }
-            )
-        }
-    }
+    private fun Product.emptyVariations() =
+        ComplexProperty(
+            value = resources.getString(string.product_detail_add_variations),
+            icon = drawable.ic_gridicons_types,
+            showTitle = false,
+            onClick = {
+                viewModel.onEditProductCardClicked(
+                    AddProductAttribute(isVariationCreation = true),
+                    PRODUCT_DETAIL_VIEW_PRODUCT_VARIANTS_TAPPED
+                )
+            }
+        )
 
     private fun Product.categories(): ProductProperty? {
         return if (hasCategories) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
@@ -183,33 +183,30 @@ class VariationDetailCardBuilder(
     }
 
     private fun ProductVariation.attributes() =
-        takeIf { FeatureFlag.ADD_EDIT_VARIATIONS.isEnabled() }
-            ?.let {
-                PropertyGroup(
-                    title = string.product_attributes,
-                    properties = mutableMapOf<String, String>()
-                        .let { map ->
-                            attributes
-                                .filter { it.name != null && it.option != null }
-                                .map { Pair(it.name!!, it.option!!) }
-                                .let { map.apply { putAll(it) } }
-                        }.also { map ->
-                            parentProduct?.variationEnabledAttributes
-                                ?.filter { map.containsKey(it.name).not() }
-                                ?.map { Pair(it.name, resources.getString(string.product_any_attribute_hint)) }
-                                ?.let { map.apply { putAll(it) } }
-                        },
-                    icon = drawable.ic_gridicons_customize,
-                    onClick = {
-                        viewModel.onEditVariationCardClicked(
-                            ViewAttributes(
-                                remoteProductId,
-                                remoteVariationId
-                            )
-                        )
-                    }
+        PropertyGroup(
+            title = string.product_attributes,
+            properties = mutableMapOf<String, String>()
+                .let { map ->
+                    attributes
+                        .filter { it.name != null && it.option != null }
+                        .map { Pair(it.name!!, it.option!!) }
+                        .let { map.apply { putAll(it) } }
+                }.also { map ->
+                    parentProduct?.variationEnabledAttributes
+                        ?.filter { map.containsKey(it.name).not() }
+                        ?.map { Pair(it.name, resources.getString(string.product_any_attribute_hint)) }
+                        ?.let { map.apply { putAll(it) } }
+                },
+            icon = drawable.ic_gridicons_customize,
+            onClick = {
+                viewModel.onEditVariationCardClicked(
+                    ViewAttributes(
+                        remoteProductId,
+                        remoteVariationId
+                    )
                 )
             }
+        )
 
     private fun ProductVariation.shipping(): ProductProperty? {
         return if (!this.isVirtual) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
@@ -36,7 +36,6 @@ import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.
 import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.ViewPricing
 import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.ViewShipping
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.PriceUtils
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.ResourceProvider

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
@@ -38,8 +38,6 @@ import com.woocommerce.android.ui.products.variations.VariationDetailViewModel.D
 import com.woocommerce.android.ui.products.variations.VariationListViewModel.ShowAddAttributeView
 import com.woocommerce.android.ui.products.variations.VariationListViewModel.ShowAttributeList
 import com.woocommerce.android.ui.products.variations.VariationListViewModel.ShowVariationDetail
-import com.woocommerce.android.util.FeatureFlag
-import com.woocommerce.android.util.FeatureFlag.ADD_EDIT_VARIATIONS
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -116,19 +114,15 @@ class VariationListFragment : BaseFragment(R.layout.fragment_variation_list),
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         super.onCreateOptionsMenu(menu, inflater)
 
-        if (FeatureFlag.ADD_EDIT_VARIATIONS.isEnabled()) {
-            val mnuEditAttr = menu.add(Menu.NONE, ID_EDIT_ATTRIBUTES, Menu.NONE, R.string.product_variations_edit_attr)
-            mnuEditAttr.setShowAsAction(MenuItem.SHOW_AS_ACTION_NEVER)
-            mnuEditAttr.isVisible = false
-        }
+        val mnuEditAttr = menu.add(Menu.NONE, ID_EDIT_ATTRIBUTES, Menu.NONE, R.string.product_variations_edit_attr)
+        mnuEditAttr.setShowAsAction(MenuItem.SHOW_AS_ACTION_NEVER)
+        mnuEditAttr.isVisible = false
     }
 
     override fun onPrepareOptionsMenu(menu: Menu) {
         super.onPrepareOptionsMenu(menu)
 
-        if (FeatureFlag.ADD_EDIT_VARIATIONS.isEnabled()) {
-            menu.findItem(ID_EDIT_ATTRIBUTES)?.isVisible = !viewModel.isEmpty
-        }
+        menu.findItem(ID_EDIT_ATTRIBUTES)?.isVisible = !viewModel.isEmpty
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -274,17 +268,10 @@ class VariationListFragment : BaseFragment(R.layout.fragment_variation_list),
 
     private fun handleEmptyViewChanges(isEmptyViewVisible: Boolean) {
         binding.variationInfoContainer.visibility = if (isEmptyViewVisible) GONE else VISIBLE
-        if (ADD_EDIT_VARIATIONS.isEnabled()) {
-            binding.firstVariationView.updateVisibility(
-                shouldBeVisible = isEmptyViewVisible,
-                showButton = true
-            )
-        } else {
-            binding.emptyView.updateVisibility(
-                shouldBeVisible = isEmptyViewVisible,
-                showButton = false
-            )
-        }
+        binding.firstVariationView.updateVisibility(
+            shouldBeVisible = isEmptyViewVisible,
+            showButton = true
+        )
         requireActivity().invalidateOptionsMenu()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -7,14 +7,12 @@ import android.content.Context
  */
 enum class FeatureFlag {
     SHIPPING_LABELS_M4,
-    ADD_EDIT_VARIATIONS,
     DB_DOWNGRADE,
     ORDER_CREATION,
     CARD_READER;
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
             SHIPPING_LABELS_M4 -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
-            ADD_EDIT_VARIATIONS -> PackageUtils.isDebugBuild()
             DB_DOWNGRADE -> {
                 PackageUtils.isDebugBuild() || context != null && PackageUtils.isBetaBuild(context)
             }

--- a/WooCommerce/src/main/res/layout/fragment_variation_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_variation_list.xml
@@ -57,19 +57,6 @@
         </LinearLayout>
 
         <com.woocommerce.android.widgets.ActionableEmptyView
-            android:id="@+id/empty_view"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:visibility="gone"
-            tools:visibility="visible"
-            app:aevTitleAppearance="?attr/textAppearanceSubtitle1"
-            app:aevTitle="@string/product_variant_list_empty"
-            app:aevImage="@drawable/ic_empty_variations"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"/>
-
-        <com.woocommerce.android.widgets.ActionableEmptyView
             android:id="@+id/first_variation_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"


### PR DESCRIPTION
Summary
==========
Fixes issue #3945 by releasing the Variations / Attributes editing flows and features.

How to Test
==========
1. Enter the Product Detail View and verify that the `Add Variation` button is showing up and it's functional for Variable Products with no variations yet, and showing the Variations attributes data when there's Variations defined
2. Enter Variation List View, go to the options menu button and verify that the `Edit Attributes` is showing up and it's directing the user to the Attributes management views
3. Enter Variation Detail View and verify that the `Attributes` button is showing and it's functional for editing any Variations attributes available

Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
