### PR TITLE
Update Dagger components to use `OkHttClientModule`

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/AppComponentTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/AppComponentTest.kt
@@ -7,7 +7,7 @@ import com.woocommerce.android.util.crashlogging.CrashLoggingModule
 import dagger.BindsInstance
 import dagger.Component
 import dagger.android.AndroidInjectionModule
-import org.wordpress.android.fluxc.module.DebugOkHttpClientModule
+import org.wordpress.android.fluxc.module.OkHttpClientModule
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule
 import org.wordpress.android.login.di.LoginServiceModule
 import javax.inject.Singleton
@@ -19,7 +19,7 @@ import javax.inject.Singleton
         ApplicationModule::class,
         AppConfigModule::class,
         ReleaseNetworkModule::class,
-        DebugOkHttpClientModule::class,
+        OkHttpClientModule::class,
         InterceptorModuleTest::class,
         ActivityBindingModule::class,
         SelectedSiteModule::class,

--- a/WooCommerce/src/debug/kotlin/com.woocommerce.android/di/AppComponentDebug.kt
+++ b/WooCommerce/src/debug/kotlin/com.woocommerce.android/di/AppComponentDebug.kt
@@ -8,7 +8,7 @@ import com.woocommerce.android.util.crashlogging.CrashLoggingModule
 import dagger.BindsInstance
 import dagger.Component
 import dagger.android.AndroidInjectionModule
-import org.wordpress.android.fluxc.module.DebugOkHttpClientModule
+import org.wordpress.android.fluxc.module.OkHttpClientModule
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule
 import org.wordpress.android.login.di.LoginServiceModule
 import javax.inject.Singleton
@@ -20,7 +20,7 @@ import javax.inject.Singleton
         ApplicationModule::class,
         AppConfigModule::class,
         ReleaseNetworkModule::class,
-        DebugOkHttpClientModule::class,
+        OkHttpClientModule::class,
         SelectedSiteModule::class,
         InterceptorModule::class,
         ActivityBindingModule::class,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/AppComponent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/AppComponent.kt
@@ -10,8 +10,8 @@ import dagger.BindsInstance
 import dagger.Component
 import dagger.android.AndroidInjectionModule
 import dagger.android.AndroidInjector
+import org.wordpress.android.fluxc.module.OkHttpClientModule
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule
-import org.wordpress.android.fluxc.module.ReleaseOkHttpClientModule
 import org.wordpress.android.login.di.LoginServiceModule
 import javax.inject.Singleton
 
@@ -22,7 +22,7 @@ import javax.inject.Singleton
         ApplicationModule::class,
         AppConfigModule::class,
         ReleaseNetworkModule::class,
-        ReleaseOkHttpClientModule::class,
+        OkHttpClientModule::class,
         SelectedSiteModule::class,
         ThreadModule::class,
         ActivityBindingModule::class,

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '107d9653e7fa8b1c178ada2c516394ba88279ac7'
+    fluxCVersion = '76920ced2ce731b8050fbc0ed9c09e6cf1f82f96'
     daggerVersion = '2.33'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
### Context

This PR is about syncing with changes introduced in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1976

Testing is not required.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
