### PR TITLE
Fixe rare crash when fetching store's plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'c2633ee2117c9b6104fc2c18be1309f04b059f82'
+    fluxCVersion = '7894de85cbaefd2d35eed46a19b7a88041444216'
     daggerVersion = '2.33'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
Fixes #3925, updates FluxC to import the fix https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1981.

### Testing
Open an order that's eligible for shipping labels creation, and confirm that you can see the Create shipping label button.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
