### PR TITLE
Fix crash when deleting Attribute Terms

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListAdapter.kt
@@ -141,15 +141,17 @@ class AttributeTermsListAdapter(
         RecyclerView.ViewHolder(viewBinding.root) {
         init {
             viewBinding.root.setOnClickListener {
-                val item = termNames[adapterPosition]
-                onTermListener.onTermClick(item)
+                termNames.getOrNull(adapterPosition)?.let {
+                    onTermListener.onTermClick(it)
+                }
             }
 
             if (enableDeleting) {
                 viewBinding.termDelete.setOnClickListener {
-                    val item = termNames[adapterPosition]
-                    removeTerm(item)
-                    onTermListener.onTermDelete(item)
+                    termNames.getOrNull(adapterPosition)?.let {
+                        removeTerm(it)
+                        onTermListener.onTermDelete(it)
+                    }
                 }
             }
 


### PR DESCRIPTION
Summary
==========
Fixes #3949, when deleting the terms of a Local Attribute at a fast speed an `OutOfBoundsException` happens because of the invalid transitional state of the `adapterPosition` value, this fix blocks clicks interactions with the Term when the Adapter is currently at this state.

How to Test
==========
Steps to reproduce the behavior:
1. Go to a Variable Product
2. Click on 'Variations'
3. At the Variation List, go to the options button and select `Edit Attributes`
4. At the Attribute List, click on `Add Attribute`
5. Name the Attribute and start creating Terms
6. Create at least 4 new terms, and after it deletes them all really fast
7. No crash should happen.

Crash stacktrace
==========
```
2021-04-30 13:14:01.674 6311-6311/com.woocommerce.android E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.woocommerce.android, PID: 6311
    java.lang.ArrayIndexOutOfBoundsException: length=10; index=-1
        at java.util.ArrayList.get(ArrayList.java:439)
        at com.woocommerce.android.ui.products.variations.attributes.AttributeTermsListAdapter$TermViewHolder$2.onClick(AttributeTermsListAdapter.kt:150)
        at android.view.View.performClick(View.java:7161)
        at android.view.View.performClickInternal(View.java:7133)
        at android.view.View.access$3500(View.java:804)
        at android.view.View$PerformClick.run(View.java:27416)
        at android.os.Handler.handleCallback(Handler.java:883)
        at android.os.Handler.dispatchMessage(Handler.java:100)
        at android.os.Looper.loop(Looper.java:241)
        at android.app.ActivityThread.main(ActivityThread.java:7582)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:941)
```



Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
