### PR TITLE
Merge release/6.6 into develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ commands:
       parameters:
         jvmargs:
           type: string
-          default: "Xmx1536m"
+          default: "Xmx6g"
       steps:
         - run:
             name: Update memory setting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ commands:
       parameters:
         jvmargs:
           type: string
-          default: "Xmx6g"
+          default: "Xmx1536m"
       steps:
         - run:
             name: Update memory setting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,9 +163,9 @@ jobs:
             echo "export FASTLANE_SKIP_UPDATE_CHECK=1" >> $BASH_ENV
             mv ~/.android/debug_a8c.keystore ~/.android/debug.keystore
             if [[ $APP_VERSION == *"-rc-"* ]]; then
-              bundle exec fastlane build_and_upload_beta skip_confirm:true create_release:true
+              bundle exec fastlane build_and_upload_beta skip_confirm:true skip_prechecks:true create_release:true
             else
-              bundle exec fastlane build_and_upload_release skip_confirm:true create_release:true
+              bundle exec fastlane build_and_upload_release skip_confirm:true skip_prechecks:true create_release:true
             fi
       - android/save-gradle-cache
       - slack/status:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+6.7
+-----
+
+
 6.6
 -----
 - [***] Products: When editing a product, you can now create/delete/update product variations, product attributes and product attribute options. [https://github.com/woocommerce/woocommerce-android/pull/3946]

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -44,9 +44,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "6.5"
+            versionName "6.6-rc-1"
         }
-        versionCode 214
+        versionCode 215
 
         minSdkVersion 21
         targetSdkVersion 30

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -20,18 +20,14 @@ apply plugin: 'io.sentry.android.gradle'
 apply plugin: 'androidx.navigation.safeargs.kotlin'
 
 repositories {
+    mavenCentral()
+    maven { url "https://jitpack.io" }
     maven { url 'https://zendesk.jfrog.io/zendesk/repo' }
+    maven { url 'https://a8c-libs.s3.amazonaws.com/android' }
 }
 
 allOpen {
     annotation("com.woocommerce.android.annotations.OpenClass")
-}
-
-repositories {
-    mavenCentral()
-    maven { url "https://jitpack.io" }
-    maven { url "https://dl.bintray.com/wordpress-mobile/maven" }
-    maven { url "http://dl.bintray.com/terl/lazysodium-maven" }
 }
 
 android {

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,1 +1,5 @@
-We have a shiny new feature available for beta testing! US-based merchants can create shipping labels for physical orders right from the app (for US destinations only). We've also fixed some bugs: expired shipping labels now display more accurate information, and the on-screen keyboard won't disappear when searching your order list.
+- [***] Products: When editing a product, you can now create/delete/update product variations, product attributes and product attribute options. [https://github.com/woocommerce/woocommerce-android/pull/3946]
+- [**] Refunds: Refunding a shipping line inside an order is now possible. [https://github.com/woocommerce/woocommerce-android/pull/3935/]
+- [*] Fixed a bug would not allow to edit the product price and sale price. [https://github.com/woocommerce/woocommerce-android/pull/3926]
+- [*] Added the option to create and edit a virtual product directly from the product detail screen. [https://github.com/woocommerce/woocommerce-android/pull/3900]
+

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '7894de85cbaefd2d35eed46a19b7a88041444216'
+    fluxCVersion = '1.16.0'
     daggerVersion = '2.33'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.16.0'
+    fluxCVersion = '1.16.1'
     daggerVersion = '2.33'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -243,7 +243,7 @@ platform :android do
       alpha: false,
       beta: false,
       final: true)
-    android_build_preflight()
+    android_build_preflight() unless options[:skip_prechecks]
 
     # Create the file names
     version = android_get_release_version()
@@ -286,7 +286,7 @@ platform :android do
   desc "Builds and uploads a new beta build to Google Play (without releasing it)"
   lane :build_and_upload_beta do | options |
     android_build_prechecks(skip_confirm: options[:skip_confirm], alpha: false, beta: true, final: false) unless (options[:skip_prechecks])
-    android_build_preflight() unless (options[:skip_prechecks])
+    android_build_preflight() unless options[:skip_prechecks]
 
     # Create the file names
     version = android_get_release_version()

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="currency_total_negative">-%1$s%2$s</string>
     <string name="order_total">Order total</string>
     <string name="shipping">Shipping</string>
+    <string name="multiple_shipping">multiple shipping lines</string>
     <string name="edit">Edit</string>
     <string name="payment">Payment</string>
     <string name="taxes">Taxes</string>
@@ -170,7 +171,7 @@
     <string name="login_not_woo_store">It looks like %1$s is not a WooCommerce site. Install the WooCommerce plugin on your site and then %2$s</string>
     <string name="login_not_connected_jetpack">To use this app for %1$s you\'ll need to have the Jetpack plugin setup and connected to this account. \n\nOnce setup, %2$s</string>
     <string name="login_no_jetpack">To use this app for %1$s you\'ll need to have the Jetpack plugin setup and connected to a WordPress.com account</string>
-    <string name="login_not_wordpress_site">The website %1$s is not a WordPress site. For us to connect to it, the site must have WordPress installed.</string>
+    <string name="login_not_wordpress_site_v2">We were not able to detect a WordPress site at the address you entered. Please make sure WordPress is installed and that you are running the latest available version.</string>
     <string name="login_refresh_app">refresh the app</string>
     <string name="login_refresh_app_continue">refresh the app to continue</string>
     <string name="login_refresh_app_progress">Checking for WooCommerce…</string>
@@ -365,6 +366,7 @@
     <string name="shipping_label_print_save_for_later">Save for later</string>
     <string name="shipping_label_print_screen_title">Print shipping label</string>
     <string name="shipping_label_preview_error">Error previewing shipping label</string>
+    <string name="shipping_label_preview_pdf_app_missing">Unable to preview shipping label. Please install a PDF viewer app and try again.</string>
     <string name="shipping_label_paper_size_legal">Legal (8.5 x 14 in)</string>
     <string name="shipping_label_paper_size_letter">Letter (8.5 x 11 in)</string>
     <string name="shipping_label_paper_size_label">Label (4 x 6 in)</string>
@@ -594,6 +596,29 @@
     <string name="order_shipment_tracking_progress_message">Please wait</string>
 
     <!--
+        Card Reader Payments
+    -->
+    <string name="card_reader_tap_or_insert">Tap or insert to pay</string>
+    <string name="card_reader_payment_collect_payment_hint" translatable="false">@string/card_reader_tap_or_insert</string>
+    <string name="card_reader_payment_processing_payment_hint" translatable="false">@string/please_wait</string>
+    <string name="card_reader_payment_capturing_payment_hint" translatable="false">@string/please_wait</string>
+
+    <string name="card_reader_collect_payment">Collect payment</string>
+    <string name="card_reader_payment_collect_payment_header" translatable="false">@string/card_reader_collect_payment</string>
+    <string name="card_reader_payment_processing_payment_header" translatable="false">@string/card_reader_collect_payment</string>
+    <string name="card_reader_payment_capturing_payment_header" translatable="false">@string/card_reader_collect_payment</string>
+    <string name="card_reader_payment_completed_payment_header">Payment successful</string>
+    <string name="card_reader_payment_payment_failed_header">Payment failed</string>
+
+    <string name="card_reader_payment_collect_payment_state">Reader is ready</string>
+    <string name="card_reader_payment_processing_payment_state">Processing payment</string>
+    <string name="card_reader_payment_capturing_payment_state">Capturing payment</string>
+    <string name="card_reader_payment_failed_unexpected_error_state">Payment failed. Please try again.</string>
+
+    <string name="card_reader_payment_print_receipt">Print receipt</string>
+    <string name="card_reader_payment_send_receipt">Send receipt</string>
+
+    <!--
         Notifications
     -->
     <string name="new_notifications">%d new notifications</string>
@@ -742,6 +767,7 @@
     <string name="product_short_description">Short description</string>
     <string name="product_short_description_empty">Brief summary about the product</string>
     <string name="product_update_dialog_title">Updating product</string>
+    <string name="product_delete_dialog_title">Deleting product</string>
     <string name="product_update_dialog_message">Please wait…</string>
     <string name="product_detail_update_product_error">Error updating product</string>
     <string name="product_detail_update_product_success">Product updated</string>
@@ -861,6 +887,8 @@
     <string name="variation_detail_price_warning">Variations without price won\'t be shown in your store</string>
     <string name="variation_detail_price_warning_title">Some variations do not have prices</string>
     <string name="variation_detail_image_add">Add a variation image</string>
+    <string name="variation_create_dialog_title">Creating variation</string>
+    <string name="variation_confirm_delete">Do you want to delete this Variation?</string>
 
     <!--
         Product images
@@ -1186,11 +1214,13 @@
 
     <!-- New Product bottom sheet -->
     <string name="product_add_type_list_header" translatable="false">@string/product_type_list_header</string>
-    <string name="product_add_type_simple">Simple product</string>
+    <string name="product_add_type_simple">Simple physical product</string>
+    <string name="product_add_type_virtual">Simple virtual product</string>
     <string name="product_add_type_variable">Variable product</string>
     <string name="product_add_type_grouped">Grouped product</string>
     <string name="product_add_type_external">External product</string>
     <string name="product_add_type_simple_desc">A unique item to sell</string>
+    <string name="product_add_type_virtual_desc">A unique digital product</string>
     <string name="product_add_type_variable_desc">A product with variations like color or size</string>
     <string name="product_add_type_grouped_desc" translatable="false">@string/product_type_grouped_desc</string>
     <string name="product_add_type_external_desc" translatable="false">@string/product_type_external_desc</string>

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -9,7 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx6g
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -9,7 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx6g
+org.gradle.jvmargs=-Xmx1536m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -21,10 +21,10 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-android-extensions'
 
 repositories {
+    mavenCentral()
     google()
     jcenter()
     maven { url "https://www.jitpack.io" }
-    maven { url "http://dl.bintray.com/terl/lazysodium-maven" }
 }
 
 android {


### PR DESCRIPTION
First beta after code freeze.

<details><summary>Old notes from before the CI + bintray fix</summary>

Note: I had to update the `build.gradle-example` and `.circleci/config.yml` files (see diff) to align the `jvmargs` memory settings to what was now set in the mobile-secrets (6g), as otherwise I hit [this error on CI](https://app.circleci.com/pipelines/github/woocommerce/woocommerce-android/11115/workflows/3ecd56f5-e0e8-45f8-8d76-45bcee61780c/jobs/35744).

```
[13:59:03]: gradle.properties has changes that need to be merged. Would you like to see a diff?
```

---

⚠️ Keeping this as Draft for now because 🚨 [build is failing, due to FluxC 1.16.0 not being able to be found](https://app.circleci.com/pipelines/github/woocommerce/woocommerce-android/11120/workflows/f3b73702-e905-4cd2-840b-9141342417a6/jobs/35761). It seems it failed to be published to bintray, but I have no idea how to check why nor how to force-retry a publication 🤔  Any help appreciated to solve that blocker.

[EDIT] [Jitpack build log](https://jitpack.io/com/github/wordpress-mobile/WordPress-FluxC-Android/1.16.0/build.log) shows that it's due to `configure:0.5.0` which had itself failed to publish on last bump.

</details>

Note: the bintray, FluxC and configure issues mentioned in the spoiler block above have all been addressed and fixed in #3959 so this should be good to go now.