### PR TITLE
Bintray shutdown fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ commands:
       parameters:
         jvmargs:
           type: string
-          default: "Xmx6g"
+          default: "Xmx1536m"
       steps:
         - run:
             name: Update memory setting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,9 +163,9 @@ jobs:
             echo "export FASTLANE_SKIP_UPDATE_CHECK=1" >> $BASH_ENV
             mv ~/.android/debug_a8c.keystore ~/.android/debug.keystore
             if [[ $APP_VERSION == *"-rc-"* ]]; then
-              bundle exec fastlane build_and_upload_beta skip_confirm:true create_release:true
+              bundle exec fastlane build_and_upload_beta skip_confirm:true skip_prechecks:true create_release:true
             else
-              bundle exec fastlane build_and_upload_release skip_confirm:true create_release:true
+              bundle exec fastlane build_and_upload_release skip_confirm:true skip_prechecks:true create_release:true
             fi
       - android/save-gradle-cache
       - slack/status:

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -20,18 +20,14 @@ apply plugin: 'io.sentry.android.gradle'
 apply plugin: 'androidx.navigation.safeargs.kotlin'
 
 repositories {
+    mavenCentral()
+    maven { url "https://jitpack.io" }
     maven { url 'https://zendesk.jfrog.io/zendesk/repo' }
+    maven { url 'https://a8c-libs.s3.amazonaws.com/android' }
 }
 
 allOpen {
     annotation("com.woocommerce.android.annotations.OpenClass")
-}
-
-repositories {
-    mavenCentral()
-    maven { url "https://jitpack.io" }
-    maven { url "https://dl.bintray.com/wordpress-mobile/maven" }
-    maven { url "http://dl.bintray.com/terl/lazysodium-maven" }
 }
 
 android {

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.16.0'
+    fluxCVersion = '1.16.1'
     daggerVersion = '2.33'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -243,7 +243,7 @@ platform :android do
       alpha: false,
       beta: false,
       final: true)
-    android_build_preflight()
+    android_build_preflight() unless options[:skip_prechecks]
 
     # Create the file names
     version = android_get_release_version()
@@ -286,7 +286,7 @@ platform :android do
   desc "Builds and uploads a new beta build to Google Play (without releasing it)"
   lane :build_and_upload_beta do | options |
     android_build_prechecks(skip_confirm: options[:skip_confirm], alpha: false, beta: true, final: false) unless (options[:skip_prechecks])
-    android_build_preflight() unless (options[:skip_prechecks])
+    android_build_preflight() unless options[:skip_prechecks]
 
     # Create the file names
     version = android_get_release_version()

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -9,7 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx6g
+org.gradle.jvmargs=-Xmx1536m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -21,10 +21,10 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-android-extensions'
 
 repositories {
+    mavenCentral()
     google()
     jcenter()
     maven { url "https://www.jitpack.io" }
-    maven { url "http://dl.bintray.com/terl/lazysodium-maven" }
 }
 
 android {


### PR DESCRIPTION
* Reverts 09611b526de6be0e795d714e6e1446b2192a3b56 which may result in out of memory error in CI
* Adds skip_prechecks flag for build and upload release CI commands 1cb1225c66ea4e51d63878aebd9c850cc38a5576 which in theory should fix the gradle properties issue from #3956
* Removes bintray repository for lazysodium and adds `mavenCentral` instead which is where the new version is hosted
* Updates FluxC to `1.16.1` https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1988 which fixes Bintray issues in FluxC library
* Combines `repositories` sections in `WordPress/build.gradle` file
* Adds `https://a8c-libs.s3.amazonaws.com/android` S3 repository where we now host the `libaddressinput` library

**To test:**
* Run `./gradlew bundleRelease --refresh-dependencies`
* Test address input feature to verify `libaddressinput` library is correctly published to S3 (I am trying to get more details on how to test this)