### PR TITLE
Update dependabot config default labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    default_labels:
+      - "bot: updated dependencies"
     reviewers:
       - "woocommerce/android-developers"
     ignore:


### PR DESCRIPTION
### Description

This PR updates the `Dependabot`config to use `bot: updated dependencies` as the default label instead of `dependencies` following this documentation:  https://dependabot.com/docs/config-file/#default_labels.

<sup>(internal reference: paaHJt-244-p2)</sup>

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.