### PR TITLE
Fix `VariationAttributeSelectionGroup` serialization crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesFragment.kt
@@ -9,6 +9,7 @@ import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.R
+import com.woocommerce.android.R.string
 import com.woocommerce.android.databinding.FragmentEditVariationAttributesBinding
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.takeIfNotEqualTo
@@ -59,7 +60,7 @@ class EditVariationAttributesFragment :
         _binding = FragmentEditVariationAttributesBinding.bind(view)
         setupObservers()
         setupViews()
-        viewModel.start(navArgs.remoteProductId, navArgs.remoteVariationId)
+        viewModel.start(navArgs.remoteProductId, navArgs.remoteVariationId, getString(string.product_any_attribute_hint))
     }
 
     override fun onDestroyView() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesFragment.kt
@@ -60,7 +60,7 @@ class EditVariationAttributesFragment :
         _binding = FragmentEditVariationAttributesBinding.bind(view)
         setupObservers()
         setupViews()
-        viewModel.start(navArgs.remoteProductId, navArgs.remoteVariationId, getString(string.product_any_attribute_hint))
+        viewModel.start(navArgs.remoteProductId, navArgs.remoteVariationId)
     }
 
     override fun onDestroyView() {
@@ -112,6 +112,7 @@ class EditVariationAttributesFragment :
             ?: binding.attributeSelectionGroupList.apply {
                 adapter = VariationAttributesAdapter(
                     selectableOptions,
+                    getString(string.product_any_attribute_hint),
                     ::displaySelectionDialog
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesViewModel.kt
@@ -51,12 +51,12 @@ class EditVariationAttributesViewModel @AssistedInject constructor(
             ?.contentDeepEquals(viewState.updatedAttributeSelection.toTypedArray())
             ?: false
 
-    fun start(productId: Long, variationId: Long) {
+    fun start(productId: Long, variationId: Long, anyAttributeResourceText: String) {
         viewState = viewState.copy(
             parentProductID = productId,
             editableVariationID = variationId
         )
-        loadProductAttributes()
+        loadProductAttributes(anyAttributeResourceText)
     }
 
     fun exit() {
@@ -72,13 +72,13 @@ class EditVariationAttributesViewModel @AssistedInject constructor(
         viewState = viewState.copy(updatedAttributeSelection = attributeSelection)
     }
 
-    private fun loadProductAttributes() =
+    private fun loadProductAttributes(anyAttributeResourceText: String) =
         viewState.copy(isSkeletonShown = true).let { viewState = it }.also {
             launch(context = dispatchers.computation) {
                 parentProduct?.variationEnabledAttributes
                     ?.pairAttributeWithSelectedOption()
                     ?.pairAttributeWithUnselectedOption()
-                    ?.mapToAttributeSelectionGroupList()
+                    ?.mapToAttributeSelectionGroupList(anyAttributeResourceText)
                     ?.dispatchListResult()
                     ?: updateSkeletonVisibility(visible = false)
             }
@@ -99,7 +99,7 @@ class EditVariationAttributesViewModel @AssistedInject constructor(
                 ?.let { toMutableList().apply { addAll(it) } }
         }
 
-    private fun List<Pair<ProductAttribute, VariantOption>>.mapToAttributeSelectionGroupList() =
+    private fun List<Pair<ProductAttribute, VariantOption>>.mapToAttributeSelectionGroupList(anyAttributeResourceText: String) =
         pairMap { productAttribute, selectedOption ->
             VariationAttributeSelectionGroup(
                 id = productAttribute.id,
@@ -107,7 +107,7 @@ class EditVariationAttributesViewModel @AssistedInject constructor(
                 options = productAttribute.terms,
                 selectedOptionIndex = productAttribute.terms.indexOf(selectedOption.option),
                 noOptionSelected = selectedOption.option.isNullOrEmpty(),
-                resourceCreator = { resources.getString(it) }
+                anyAttributeResourceText = anyAttributeResourceText
             )
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesViewModel.kt
@@ -51,12 +51,12 @@ class EditVariationAttributesViewModel @AssistedInject constructor(
             ?.contentDeepEquals(viewState.updatedAttributeSelection.toTypedArray())
             ?: false
 
-    fun start(productId: Long, variationId: Long, anyAttributeResourceText: String) {
+    fun start(productId: Long, variationId: Long) {
         viewState = viewState.copy(
             parentProductID = productId,
             editableVariationID = variationId
         )
-        loadProductAttributes(anyAttributeResourceText)
+        loadProductAttributes()
     }
 
     fun exit() {
@@ -72,13 +72,13 @@ class EditVariationAttributesViewModel @AssistedInject constructor(
         viewState = viewState.copy(updatedAttributeSelection = attributeSelection)
     }
 
-    private fun loadProductAttributes(anyAttributeResourceText: String) =
+    private fun loadProductAttributes() =
         viewState.copy(isSkeletonShown = true).let { viewState = it }.also {
             launch(context = dispatchers.computation) {
                 parentProduct?.variationEnabledAttributes
                     ?.pairAttributeWithSelectedOption()
                     ?.pairAttributeWithUnselectedOption()
-                    ?.mapToAttributeSelectionGroupList(anyAttributeResourceText)
+                    ?.mapToAttributeSelectionGroupList()
                     ?.dispatchListResult()
                     ?: updateSkeletonVisibility(visible = false)
             }
@@ -99,15 +99,14 @@ class EditVariationAttributesViewModel @AssistedInject constructor(
                 ?.let { toMutableList().apply { addAll(it) } }
         }
 
-    private fun List<Pair<ProductAttribute, VariantOption>>.mapToAttributeSelectionGroupList(anyAttributeResourceText: String) =
+    private fun List<Pair<ProductAttribute, VariantOption>>.mapToAttributeSelectionGroupList() =
         pairMap { productAttribute, selectedOption ->
             VariationAttributeSelectionGroup(
                 id = productAttribute.id,
                 attributeName = productAttribute.name,
                 options = productAttribute.terms,
                 selectedOptionIndex = productAttribute.terms.indexOf(selectedOption.option),
-                noOptionSelected = selectedOption.option.isNullOrEmpty(),
-                anyAttributeResourceText = anyAttributeResourceText
+                noOptionSelected = selectedOption.option.isNullOrEmpty()
             )
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/VariationAttributeSelectionGroup.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/VariationAttributeSelectionGroup.kt
@@ -9,7 +9,6 @@ data class VariationAttributeSelectionGroup(
     private val id: Long,
     private var options: List<String>,
     private var noOptionSelected: Boolean = false,
-    private val anyAttributeResourceText: String,
     val attributeName: String,
     var selectedOptionIndex: Int
 ) : Parcelable {
@@ -20,9 +19,9 @@ data class VariationAttributeSelectionGroup(
         get() = options
 
     private val anySelectionOption
-        get() = "$anyAttributeResourceText $attributeName"
+        get() = "Any"
 
-    private val isAnyOptionSelected
+    val isAnyOptionSelected
         get() = options.getOrNull(selectedOptionIndex) == anySelectionOption
 
     init {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/VariationAttributeSelectionGroup.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/VariationAttributeSelectionGroup.kt
@@ -12,14 +12,15 @@ data class VariationAttributeSelectionGroup(
     val attributeName: String,
     var selectedOptionIndex: Int
 ) : Parcelable {
+    companion object {
+        const val anySelectionOption = "Any"
+    }
+
     val selectedOption
         get() = options.getOrNull(selectedOptionIndex) ?: ""
 
     val attributeOptions
         get() = options
-
-    private val anySelectionOption
-        get() = "Any"
 
     val isAnyOptionSelected
         get() = options.getOrNull(selectedOptionIndex) == anySelectionOption

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/VariationAttributeSelectionGroup.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/VariationAttributeSelectionGroup.kt
@@ -1,19 +1,15 @@
 package com.woocommerce.android.ui.products.variations.attributes.edit
 
 import android.os.Parcelable
-import com.woocommerce.android.R.string
 import com.woocommerce.android.model.VariantOption
 import kotlinx.parcelize.Parcelize
-import kotlinx.parcelize.RawValue
-
-typealias StringResourceCreator = (Int) -> String
 
 @Parcelize
 data class VariationAttributeSelectionGroup(
     private val id: Long,
     private var options: List<String>,
     private var noOptionSelected: Boolean = false,
-    private val resourceCreator: @RawValue StringResourceCreator,
+    private val anyAttributeResourceText: String,
     val attributeName: String,
     var selectedOptionIndex: Int
 ) : Parcelable {
@@ -24,7 +20,7 @@ data class VariationAttributeSelectionGroup(
         get() = options
 
     private val anySelectionOption
-        get() = "${resourceCreator(string.product_any_attribute_hint)} $attributeName"
+        get() = "$anyAttributeResourceText $attributeName"
 
     private val isAnyOptionSelected
         get() = options.getOrNull(selectedOptionIndex) == anySelectionOption

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/VariationAttributesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/VariationAttributesAdapter.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.ui.products.variations.attributes.edit.VariationA
 
 class VariationAttributesAdapter(
     var sourceData: MutableList<VariationAttributeSelectionGroup>,
+    private val anyAttributeResourceText: String,
     private val onGroupClickListener: (VariationAttributeSelectionGroup) -> Unit
 ) : RecyclerView.Adapter<VariationAttributeSelectionViewHolder>() {
     override fun getItemCount() = sourceData.size
@@ -45,9 +46,16 @@ class VariationAttributesAdapter(
         fun bind(item: VariationAttributeSelectionGroup) {
             viewBinding.attributeOptionsSpinner.apply {
                 hint = item.attributeName
-                setText(item.selectedOption)
+                setText(item.selectedOptionDisplayText())
                 setClickListener { onGroupClickListener(item) }
             }
         }
+
+        private fun VariationAttributeSelectionGroup.selectedOptionDisplayText() =
+            if (isAnyOptionSelected) {
+                "$anyAttributeResourceText $attributeName"
+            } else {
+                selectedOption
+            }
     }
 }


### PR DESCRIPTION
Summary
==========
Fixes issue #3966 reported by Sentry. I didn't manage to reproduce the problem, but looking at the stack trace, it suggests that when the `EditVariationAttributesViewModel` tries to restore his `ViewState`, the `updatedAttributeSelection: List<VariationAttributeSelectionGroup>` field fails to be serialized. 

Looking at the `VariationAttributeSelectionGroup` data class, the only property there that could suffer to be serialized is the `resourceCreator`, which is a function reference covered by a `typealias` to suppress compiler issues, I decided to remove the need for this function object to be injected into the class, since it's a business entity, and this function object is a string resource builder, and I think it's most likely that this will solve the crash issue.

⚠️  Since this issue was raised at `6.6-rc1`, I'm placing the branch target to `release/6.6` as a fix for beta.

Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
