### PR TITLE
Update WordPressUtils dependency to 1.40.0

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -150,7 +150,7 @@ dependencies {
     implementation "androidx.navigation:navigation-fragment-ktx:$navigationVersion"
     implementation "androidx.navigation:navigation-ui-ktx:$navigationVersion"
 
-    implementation('org.wordpress:utils:1.26') {
+    implementation('org.wordpress:utils:1.40.0') {
         exclude group: "com.mcxiaoke.volley"
         exclude group: "com.android.support"
     }


### PR DESCRIPTION
[As promised](https://github.com/woocommerce/woocommerce-android/pull/3892#issuecomment-830509668), this PR updates [WordPress-Utils-Android](https://github.com/wordpress-mobile/wordpress-utils-android) to the latest version which is now served through S3.

**To test:**

I think it should be enough to test if logs are showing up since [AppLog](https://github.com/wordpress-mobile/WordPress-Utils-Android/blob/develop/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java) is part of the utils library. Hopefully there are no logical changes in the library that might break the client. 🤞 