### PR TITLE
Fix `EditVariationAttributesViewModel` SavedState DI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesFragment.kt
@@ -2,7 +2,7 @@ package com.woocommerce.android.ui.products.variations.attributes.edit
 
 import android.os.Bundle
 import android.view.View
-import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
@@ -31,7 +31,7 @@ class EditVariationAttributesFragment :
 
     @Inject lateinit var viewModelFactory: ViewModelFactory
 
-    private val viewModel: EditVariationAttributesViewModel by activityViewModels { viewModelFactory }
+    private val viewModel: EditVariationAttributesViewModel by viewModels { viewModelFactory }
 
     private val navArgs: EditVariationAttributesFragmentArgs by navArgs()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesModule.kt
@@ -2,9 +2,7 @@ package com.woocommerce.android.ui.products.variations.attributes.edit
 
 import android.os.Bundle
 import androidx.lifecycle.ViewModel
-import androidx.navigation.fragment.findNavController
 import androidx.savedstate.SavedStateRegistryOwner
-import com.woocommerce.android.R
 import com.woocommerce.android.di.ViewModelAssistedFactory
 import com.woocommerce.android.ui.products.variations.attributes.edit.EditVariationAttributesViewModel.Factory
 import com.woocommerce.android.viewmodel.ViewModelKey
@@ -22,16 +20,13 @@ abstract class EditVariationAttributesModule {
         fun provideDefaultArgs(fragment: EditVariationAttributesFragment): Bundle? {
             return fragment.arguments
         }
-
-        @JvmStatic
-        @Provides
-        fun provideSavedStateRegistryOwner(fragment: EditVariationAttributesFragment): SavedStateRegistryOwner {
-            return fragment.findNavController().getBackStackEntry(R.id.nav_graph_products)
-        }
     }
 
     @Binds
     @IntoMap
     @ViewModelKey(EditVariationAttributesViewModel::class)
     abstract fun bindFactory(factory: Factory): ViewModelAssistedFactory<out ViewModel>
+
+    @Binds
+    abstract fun bindSavedStateRegistryOwner(fragment: EditVariationAttributesFragment): SavedStateRegistryOwner
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesViewModel.kt
@@ -12,7 +12,6 @@ import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
-import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.assisted.Assisted
@@ -26,8 +25,7 @@ class EditVariationAttributesViewModel @AssistedInject constructor(
     @Assisted savedState: SavedStateWithArgs,
     dispatchers: CoroutineDispatchers,
     private val productRepository: ProductDetailRepository,
-    private val variationRepository: VariationDetailRepository,
-    private val resources: ResourceProvider
+    private val variationRepository: VariationDetailRepository
 ) : ScopedViewModel(savedState, dispatchers) {
     private val _editableVariationAttributeList =
         MutableLiveData<List<VariationAttributeSelectionGroup>>()


### PR DESCRIPTION
Summary
==========
Fixes issue #3975  by adjusting how the `SavedStateWithArgs` is injected at `EditVariationAttributesModule`. The current injection method is incorrect since it tries to recover the ViewModel SavedState attached to the Product Nav args, which is the `ProductDetailViewModel`, not the expected one.

⚠️ I'm targeting this fix to the `release/6.6` branch since this will be an easy to reproduce crash situation and will be at Sentry in no time after the roll out.

How to Test
==========
1. Go to a Variation and select the Attributes section
2. Rotate the device UI from portrait to landscape
3. The fix should make the rotation works just fine, this is true for Activity background recovery too, without the fix, a crash should be verified with the following log: `Unable to start activity ComponentInfo{com.woocommerce.android/com.woocommerce.android.ui.main.MainActivity}: java.lang.IllegalArgumentException: No destination with ID 2131362794 is on the NavController's back stack. The current destination is null`

Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
