### PR TITLE
Use value capture instead of nullability bang at class field reference

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -371,7 +371,7 @@ class IssueRefundViewModel @AssistedInject constructor(
                         return@async when (commonState.refundType) {
                             ITEMS -> {
                                 val allItems = mutableListOf<WCRefundItem>()
-                                refundItems.value.takeIf { it.isNullOrEmpty().not() }?.let {
+                                refundItems.value?.let {
                                     it.forEach { item -> allItems.add(item.toDataModel()) }
                                 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -376,7 +376,9 @@ class IssueRefundViewModel @AssistedInject constructor(
                                 }
 
                                 val selectedShipping = refundShippingLines.value?.filter {
-                                    refundByItemsState.selectedShippingLines!!.contains(it.shippingLine.itemId)
+                                    refundByItemsState.selectedShippingLines
+                                        ?.contains(it.shippingLine.itemId)
+                                        ?: false
                                 }
                                 selectedShipping?.forEach { allItems.add(it.toDataModel()) }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -371,8 +371,8 @@ class IssueRefundViewModel @AssistedInject constructor(
                         return@async when (commonState.refundType) {
                             ITEMS -> {
                                 val allItems = mutableListOf<WCRefundItem>()
-                                if (! refundItems.value.isNullOrEmpty()) {
-                                    refundItems.value!!.forEach { allItems.add(it.toDataModel()) }
+                                refundItems.value.takeIf { it.isNullOrEmpty().not() }?.let {
+                                    it.forEach { item -> allItems.add(item.toDataModel()) }
                                 }
 
                                 val selectedShipping = refundShippingLines.value?.filter {


### PR DESCRIPTION
Summary
==========
Fixes issue #3982. A `NullPointerException` is happening as reported by Sentry at `IssueRefundViewModel`
```
com.woocommerce.android.ui.refunds.IssueRefundViewModel$onRefundConfirmed$1$resultCall$1 in invokeSuspend at line 376
```

We can see at the referred code from the stacktrace that we're using double bangs access at a nullable class field reference:

``` kotlin
if (!refundItems.value.isNullOrEmpty()) {
   refundItems.value!!.forEach { allItems.add(it.toDataModel()) }
}
```
This is a specially difficult issue to reproduce since it needs a race condition between the async coroutine running the `if` check and the double bang access, with the `refundItems.value` becoming null between those two operations in another thread. So I'm tackling this problem by capturing the value with a `let` enclosure to make sure we got the non-null value and avoid accessing the class field reference.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
