### PR TITLE
Fetch the correct image for variations in order details

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailProductListAdapter.kt
@@ -29,7 +29,7 @@ class OrderDetailProductListAdapter(
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val item = orderItems[position]
         val imageSize = holder.view.resources.getDimensionPixelSize(R.dimen.image_minor_100)
-        val productImage = PhotonUtils.getPhotonImageUrl(productImageMap.get(item.productId), imageSize, imageSize)
+        val productImage = PhotonUtils.getPhotonImageUrl(productImageMap.get(item.uniqueId), imageSize, imageSize)
         holder.view.initView(orderItems[position], productImage, formatCurrencyForDisplay)
         holder.view.setOnClickListener {
             if (item.isVariation) {


### PR DESCRIPTION
Fixes #3987, pass the correct id when fetching the product image, to correctly fetch the right image for variations.

### Testing
1. Create an order that has both regular products and variations.
2. Open order details.
3. Confirm that the correct image is fetched for all type of items.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
