### PR TITLE
Update fluxC to point to 1.16.2 which contains the latest fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.16.1'
+    fluxCVersion = '1.16.2'
     daggerVersion = '2.33'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'


### PR DESCRIPTION
To fix #3973

## What this PR does:
In https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1948 , I introduced changes into the value stored in the data column of the `WCRefund` table. Specifically, I'm adding `shipping_lines` key-data pair from API responses into the table. The data then gets used by FluxC and Woo Android to display and process refunds properly.

**The problem**: If the app already has existing Refund data in `WCRefund` table prior to this change, then that data will not contain the `shipping_lines` key-data pair yet. This will then crash the app in Order Details view, because FluxC expects them to exist, yet they don't.

**The solution**: This requires FluxC fix which is already done and approved on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1991 . In this PR we're just making the app to use that fix.

## Testing instructions:

**To replicate the issue:**

1. This might be a bit tricky to get, but first you need a site with an Order with some already refunded item in it, and make sure this Order is already opened in the app at least once.
2. Switch to `release/6.6` branch and run the app. Open the same Order again, and check that now the app crashes. Log will say something like this:
```
NullPointerException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkNotNullParameter, parameter shippingLineItems
    at com.woocommerce.android.ui.orders.details.OrderDetailRepository.getOrderRefunds(OrderDetailRepository.kt:280)
    at com.woocommerce.android.ui.orders.details.OrderDetailViewModel.checkIfFetchNeeded(OrderDetailViewModel.kt:185)
    at com.woocommerce.android.ui.orders.details.OrderDetailViewModel.start(OrderDetailViewModel.kt:131)
    at com.woocommerce.android.ui.orders.details.OrderDetailViewModel.<init>(OrderDetailViewModel.kt:124)
    at com.woocommerce.android.ui.orders.details.OrderDetailViewModel_Factory.newInstance(OrderDetailViewModel_Factory.java:55)
```

For step 1, in case you have an Order with Refund but it doesn't cause a crash, it likely means that its data is already correct. To make it broken, you can use Flipper app to edit the data in WCRefund table. Specifically, edit the "Data" column value in WCRefunds table and delete the `shipping_lines:[]` part in it. Then continue to step 2.

**To test the fix:**

1. Switch to this PR's branch (`use-fluxc-16-2`) and run the app.
2. Open the same Order again (make sure internet is connected), check that now the Order Details is opening correctly without crash.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
