### PR TITLE
Modified inflation logic for FeedbackRequestCard

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackRequestCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackRequestCard.kt
@@ -17,7 +17,7 @@ class FeedbackRequestCard @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : WCElevatedConstraintLayout(ctx, attrs, defStyleAttr) {
-    private val binding = FeedbackRequestCardBinding.inflate(LayoutInflater.from(ctx))
+    private val binding = FeedbackRequestCardBinding.inflate(LayoutInflater.from(ctx), this, true)
 
     /**
      * Sets the click listeners for the buttons on this card


### PR DESCRIPTION
Fixes #3990 by modifying the inflation logic for `FeedbackRequestCard`.

### To test
- Replace [this method](https://github.com/woocommerce/woocommerce-android/blob/d7833a7e3c6fbda92bd380fd31a88dfac21b577e/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt#L363) with this one: `private fun handleFeedbackRequestCardState() = setupFeedbackRequestCard()`.
- Open the app and verify that the feedback card is displayed.
- As a sanity check, please follow this testing guide in `p91TBi-3dX` to verify that the conditional logic is also working fine.

cc @AliSoftware, sorry for the late call but this one would also need to be included in the next beta release. Thank you!!

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
