### PR TITLE
Hilt migration: migrate MainActivity

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -230,6 +230,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
         exclude group: 'com.android.support', module: 'support-core-utils'
     })
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
 
     // Dependencies for Espresso UI tests
     androidTestImplementation "androidx.test.ext:junit:$jUnitExtVersion"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ActivityBindingModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/ActivityBindingModule.kt
@@ -2,18 +2,9 @@ package com.woocommerce.android.di
 
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpModule
-import com.woocommerce.android.ui.aztec.AztecModule
 import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.MagicLinkInterceptActivity
 import com.woocommerce.android.ui.login.WooLoginFragmentModule
-import com.woocommerce.android.ui.main.MainActivity
-import com.woocommerce.android.ui.main.MainModule
-import com.woocommerce.android.ui.mystore.MyStoreModule
-import com.woocommerce.android.ui.orders.OrdersModule
-import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelsModule
-import com.woocommerce.android.ui.products.ProductsModule
-import com.woocommerce.android.ui.refunds.RefundsModule
-import com.woocommerce.android.ui.reviews.ReviewsModule
 import com.woocommerce.android.ui.sitepicker.SitePickerActivity
 import com.woocommerce.android.ui.sitepicker.SitePickerModule
 import dagger.Module
@@ -25,21 +16,6 @@ import org.wordpress.android.login.di.LoginFragmentModule
 @InstallIn(SingletonComponent::class)
 @Module
 abstract class ActivityBindingModule {
-    @ActivityScope
-    @ContributesAndroidInjector(
-            modules = [
-            MainModule::class,
-            MyStoreModule::class,
-            OrdersModule::class,
-            RefundsModule::class,
-            ProductsModule::class,
-            ReviewsModule::class,
-            SitePickerModule::class,
-            AztecModule::class,
-            ShippingLabelsModule::class
-    ])
-    abstract fun provideMainActivityInjector(): MainActivity
-
     @ActivityScope
     @ContributesAndroidInjector(modules = [
         LoginFragmentModule::class,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/MainActivityAggregatorModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/MainActivityAggregatorModule.kt
@@ -1,0 +1,32 @@
+package com.woocommerce.android.di
+
+import com.woocommerce.android.ui.aztec.AztecModule
+import com.woocommerce.android.ui.mystore.MyStoreModule
+import com.woocommerce.android.ui.orders.OrdersModule
+import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelsModule
+import com.woocommerce.android.ui.products.ProductsModule
+import com.woocommerce.android.ui.refunds.RefundsModule
+import com.woocommerce.android.ui.reviews.ReviewsModule
+import com.woocommerce.android.ui.sitepicker.SitePickerModule
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityComponent
+
+/**
+ * TODO A temporary class to allow injecting fragments relying on dagger.
+ * We should remove it after finishing the migration
+ */
+@InstallIn(ActivityComponent::class)
+@Module(
+    includes = [
+        MyStoreModule::class,
+        OrdersModule::class,
+        RefundsModule::class,
+        ProductsModule::class,
+        ReviewsModule::class,
+        SitePickerModule::class,
+        AztecModule::class,
+        ShippingLabelsModule::class
+    ]
+)
+interface MainActivityAggregatorModule

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -64,10 +64,10 @@ import com.woocommerce.android.widgets.WCPromoDialog
 import com.woocommerce.android.widgets.WCPromoDialog.PromoButton
 import com.woocommerce.android.widgets.WCPromoTooltip
 import com.woocommerce.android.widgets.WCPromoTooltip.Feature
-import dagger.android.AndroidInjection
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.login.LoginAnalyticsListener
 import org.wordpress.android.login.LoginMode
@@ -75,6 +75,7 @@ import org.wordpress.android.util.NetworkUtils
 import java.util.Locale
 import javax.inject.Inject
 
+@AndroidEntryPoint
 class MainActivity : AppUpgradeActivity(),
     MainContract.View,
     HasAndroidInjector,
@@ -181,7 +182,6 @@ class MainActivity : AppUpgradeActivity(),
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        AndroidInjection.inject(this)
         super.onCreate(savedInstanceState)
 
         binding = ActivityMainBinding.inflate(layoutInflater)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainModule.kt
@@ -1,17 +1,30 @@
 package com.woocommerce.android.ui.main
 
-import com.woocommerce.android.di.ActivityScope
+import android.app.Activity
 import com.woocommerce.android.ui.base.UIMessageResolver
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityComponent
+import dagger.hilt.android.scopes.ActivityScoped
 
+@InstallIn(ActivityComponent::class)
 @Module
 internal abstract class MainModule {
-    @ActivityScope
+    companion object {
+        // Hilt provides the current activity typed as Activity, this casts it to MainActivity
+        @Provides
+        fun provideMainActivity(activity: Activity): MainActivity {
+            return activity as MainActivity
+        }
+    }
+
+    @ActivityScoped
     @Binds
     abstract fun provideMainPresenter(mainActivityPresenter: MainPresenter): MainContract.Presenter
 
-    @ActivityScope
+    @ActivityScoped
     @Binds
     abstract fun provideUiMessageResolver(mainUIMessageResolver: MainUIMessageResolver): UIMessageResolver
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainUIMessageResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainUIMessageResolver.kt
@@ -2,12 +2,12 @@ package com.woocommerce.android.ui.main
 
 import android.view.ViewGroup
 import com.woocommerce.android.R
-import com.woocommerce.android.di.ActivityScope
 import com.woocommerce.android.ui.base.UIMessageResolver
+import dagger.hilt.android.scopes.ActivityScoped
 import javax.inject.Inject
 
-@ActivityScope
-class MainUIMessageResolver @Inject constructor(val activity: MainActivity) : UIMessageResolver {
+@ActivityScoped
+class MainUIMessageResolver @Inject constructor(activity: MainActivity) : UIMessageResolver {
     override val snackbarRoot: ViewGroup by lazy {
         activity.findViewById(R.id.snack_root) as ViewGroup
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenter.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.mystore
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
-import com.woocommerce.android.di.ActivityScope
 import com.woocommerce.android.network.ConnectionChangeReceiver
 import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
 import com.woocommerce.android.tools.NetworkStatus
@@ -12,6 +11,7 @@ import com.woocommerce.android.ui.mystore.MyStoreContract.Presenter
 import com.woocommerce.android.ui.mystore.MyStoreContract.View
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.DASHBOARD
+import dagger.hilt.android.scopes.ActivityScoped
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
@@ -38,7 +38,7 @@ import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
-@ActivityScope
+@ActivityScoped
 class MyStorePresenter @Inject constructor(
     private val dispatcher: Dispatcher,
     private val wooCommerceStore: WooCommerceStore, // Required to ensure the WooCommerceStore is initialized!

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/SavedStateHandleExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/SavedStateHandleExt.kt
@@ -1,0 +1,29 @@
+package com.woocommerce.android.viewmodel
+
+import android.os.Bundle
+import android.os.Parcelable
+import androidx.annotation.MainThread
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.NavArgs
+import androidx.navigation.NavArgsLazy
+import java.io.Serializable
+
+/**
+ * A temporary fix to allow extracting NavArgs from SavedStateHandle.
+ * Version 2.4.0 of the navigation component will contain a native way of extracting without
+ * having to pass by a Bundle.
+ * https://issuetracker.google.com/issues/136967621
+ */
+@MainThread
+inline fun <reified Args : NavArgs> SavedStateHandle.navArgs() = NavArgsLazy(Args::class) {
+    val bundle = Bundle()
+    keys().forEach {
+        val value = get<Any>(it)
+        if (value is Serializable) {
+            bundle.putSerializable(it, value)
+        } else if (value is Parcelable) {
+            bundle.putParcelable(it, value)
+        }
+    }
+    bundle
+}

--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ ext {
     materialVersion = '1.3.0'
     jUnitVersion = '4.12'
     jUnitExtVersion = '1.1.2'
+    robolectricVersion = '4.5.1'
 }
 
 tasks.getByPath('WooCommerce:preBuild').dependsOn installGitHooks


### PR DESCRIPTION
Part of #3936, this PR migrates MainActivity to Hilt, and allows migrating all its fragments incrementally.

It also adds the extension `navArgs` that allows extracting the fragments' `NavArgs` from `SavedStateHandle`, and adds Robolectric to allow testing this extension.
As explained in paqN3M-iM-p2, this is needed now until this enhancement https://issuetracker.google.com/issues/136967621 is released in the Navigation component. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.