### PR TITLE
Open TOS from the login screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -28,6 +28,7 @@ import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step.ENTER_SITE_ADDR
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.UrlUtils
 import dagger.android.AndroidInjection
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
@@ -70,6 +71,7 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
     @Inject internal lateinit var loginAnalyticsListener: LoginAnalyticsListener
     @Inject internal lateinit var unifiedLoginTracker: UnifiedLoginTracker
     @Inject internal lateinit var zendeskHelper: ZendeskHelper
+    @Inject internal lateinit var urlUtils: UrlUtils
 
     private var loginMode: LoginMode? = null
 
@@ -554,7 +556,7 @@ class LoginActivity : AppCompatActivity(), LoginListener, GoogleListener, Prolog
     }
 
     override fun onTermsOfServiceClicked() {
-        // TODO: Signup
+        ChromeCustomTabUtils.launchUrl(this, urlUtils.tosUrlWithLocale)
     }
 
     //  -- END: LoginListener implementation methods

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UrlUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UrlUtils.kt
@@ -1,0 +1,16 @@
+package com.woocommerce.android.util
+
+import android.content.Context
+import com.woocommerce.android.AppUrls
+import org.wordpress.android.util.LanguageUtils
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UrlUtils @Inject constructor(
+    private val context: Context
+) {
+    val tosUrlWithLocale by lazy {
+        "${AppUrls.AUTOMATTIC_TOS}?locale=${LanguageUtils.getPatchedCurrentDeviceLanguage(context)}"
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UrlUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UrlUtils.kt
@@ -2,11 +2,11 @@ package com.woocommerce.android.util
 
 import android.content.Context
 import com.woocommerce.android.AppUrls
+import dagger.Reusable
 import org.wordpress.android.util.LanguageUtils
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
+@Reusable
 class UrlUtils @Inject constructor(
     private val context: Context
 ) {


### PR DESCRIPTION
Implemented functionality of the opening TOS in chrome tab from the login screen. #3871 

It looks like that we started to show the TOSes links in [this commit](https://github.com/woocommerce/woocommerce-android/commit/88851bcd449f8792c5ee7b34552da154a30bdde7), but we forgot to implement the click listener. 

This PR implements it.

### How to test:
Login screen -> Continue with Wordpress -> Click on TOS link under email address
or
Login screen -> Continue with Wordpress -> Click on TOS link under continue with google

### Video

* [Debug build](https://d.pr/v/RfKYAw)
* [Release build](https://d.pr/v/mOvvt7)

Closes: #3871
