### PR TITLE
Issue/3725 check location provider enabled

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectFragment.kt
@@ -2,8 +2,10 @@ package com.woocommerce.android.ui.prefs.cardreader.connect
 
 import android.app.Activity.RESULT_OK
 import android.bluetooth.BluetoothAdapter
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.os.Bundle
+import android.provider.Settings
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
@@ -14,19 +16,26 @@ import com.woocommerce.android.R
 import com.woocommerce.android.WooCommerce
 import com.woocommerce.android.databinding.FragmentCardReaderConnectBinding
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.CheckBluetoothEnabled
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.CheckLocationEnabled
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.CheckLocationPermissions
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.InitializeCardReaderManager
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.OpenLocationSettings
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.OpenPermissionsSettings
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.RequestEnableBluetooth
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.RequestLocationPermissions
+import com.woocommerce.android.util.LocationUtils
 import com.woocommerce.android.util.UiHelpers
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooPermissionUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class CardReaderConnectFragment : DialogFragment(R.layout.fragment_card_reader_connect) {
     val viewModel: CardReaderConnectViewModel by viewModels()
+
+    @Inject lateinit var locationUtils: LocationUtils
 
     private val requestPermissionLauncher = registerForActivityResult(RequestPermission()) { isGranted: Boolean ->
         (viewModel.event.value as? RequestLocationPermissions)?.let {
@@ -37,6 +46,12 @@ class CardReaderConnectFragment : DialogFragment(R.layout.fragment_card_reader_c
     private val requestEnableBluetoothLauncher = registerForActivityResult(StartActivityForResult()) { activityResult ->
         (viewModel.event.value as? RequestEnableBluetooth)?.let {
             it.onEnableBluetoothRequestResult.invoke(activityResult.resultCode == RESULT_OK)
+        }
+    }
+
+    private val requestEnableLocationProviderLauncher = registerForActivityResult(StartActivityForResult()) { _ ->
+        (viewModel.event.value as? OpenLocationSettings)?.let {
+            it.onLocationSettingsClosed.invoke()
         }
     }
 
@@ -58,6 +73,12 @@ class CardReaderConnectFragment : DialogFragment(R.layout.fragment_card_reader_c
                 }
                 is OpenPermissionsSettings -> {
                     WooPermissionUtils.showAppSettings(requireContext())
+                }
+                is CheckLocationEnabled -> {
+                    event.onLocationEnabledCheckResult(locationUtils.isLocationEnabled())
+                }
+                is OpenLocationSettings -> {
+                    openLocationSettings()
                 }
                 is CheckBluetoothEnabled -> {
                     val btAdapter = BluetoothAdapter.getDefaultAdapter()
@@ -90,6 +111,15 @@ class CardReaderConnectFragment : DialogFragment(R.layout.fragment_card_reader_c
             binding.secondaryActionBtn.setOnClickListener {
                 viewState.onSecondaryActionClicked?.invoke()
             }
+        }
+    }
+
+    private fun openLocationSettings() {
+        try {
+            val enableLocationIntent = Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
+            requestEnableLocationProviderLauncher.launch(enableLocationIntent)
+        } catch (e: ActivityNotFoundException) {
+            WooLog.e(WooLog.T.CARD_READER, "Location settings activity not found.")
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectFragment.kt
@@ -72,7 +72,7 @@ class CardReaderConnectFragment : DialogFragment(R.layout.fragment_card_reader_c
                     WooPermissionUtils.requestFineLocationPermission(requestPermissionLauncher)
                 }
                 is OpenPermissionsSettings -> {
-                    WooPermissionUtils.showAppSettings(requireContext())
+                    WooPermissionUtils.showAppSettings(requireContext(), openInNewStack = false)
                 }
                 is CheckLocationEnabled -> {
                     event.onLocationEnabledCheckResult(locationUtils.isLocationEnabled())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/LocationUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/LocationUtils.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.util
 import android.content.Context
 import android.location.LocationManager
 import androidx.core.location.LocationManagerCompat
-import dagger.Reusable
 import javax.inject.Inject
 
 class LocationUtils @Inject constructor(private val appContext: Context) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/LocationUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/LocationUtils.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.util
+
+import android.content.Context
+import android.location.LocationManager
+import androidx.core.location.LocationManagerCompat
+import dagger.Reusable
+import javax.inject.Inject
+
+class LocationUtils @Inject constructor(private val appContext: Context) {
+    fun isLocationEnabled(): Boolean {
+        return (appContext.getSystemService(Context.LOCATION_SERVICE) as? LocationManager)?.let {
+            return LocationManagerCompat.isLocationEnabled(it)
+        } ?: false
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -33,7 +33,8 @@ object WooLog {
         NOTIFICATIONS,
         LOGIN,
         REVIEWS,
-        MEDIA
+        MEDIA,
+        CARD_READER
     }
 
     // Breaking convention to be consistent with org.wordpress.android.util.AppLog

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooPermissionUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooPermissionUtils.kt
@@ -163,12 +163,14 @@ object WooPermissionUtils {
     /*
      * open the device's settings page for this app so the user can edit permissions
      */
-    fun showAppSettings(context: Context) {
+    fun showAppSettings(context: Context, openInNewStack: Boolean = true) {
         val intent = Intent()
         intent.action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
         val uri = Uri.fromParts("package", context.packageName, null)
         intent.data = uri
-        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        if (openInNewStack) {
+            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }
         context.startActivity(intent)
     }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -631,8 +631,10 @@
     <string name="card_reader_connect_connecting_hint" translatable="false">@string/please_wait</string>
     <string name="card_reader_connect_failed_header">Connecting to reader failed</string>
     <string name="card_reader_connect_missing_permissions_hint">Missing required location permission</string>
+    <string name="card_reader_connect_location_provider_disabled_hint">Location is disabled</string>
     <string name="card_reader_connect_bluetooth_disabled_hint">Bluetooth is disabled</string>
     <string name="card_reader_connect_open_permission_settings">Open settings</string>
+    <string name="card_reader_connect_open_location_settings">Open settings</string>
 
     <!--
         Notifications

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -187,7 +187,6 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
             assertThat(viewModel.event.value).isInstanceOf(CheckLocationEnabled::class.java)
         }
 
-
     @Test
     fun `given bluetooth disabled, when connection flow started, then enable-bluetooth request emitted`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {


### PR DESCRIPTION
Parent issue #3725 

Merge instructions:
1. Make sure https://github.com/woocommerce/woocommerce-android/pull/4009 is merged
2. Remove "do not merge" label
3. Merge this PR

Checks if location provider is enabled when the user enters "connect reader" flow. StripeTerminalSDK requires "gps/network" provider. Fixes issue reported [here](https://github.com/woocommerce/woocommerce-android/pull/4007#issuecomment-838526923).

Logic summary
- user has location enabled, start the scan
- user has location disabled, show "Location disabled" error
- user clicks on "Open settings" button, open settings and re-check state when the user returns back to the app

To test
1. Disable Location in OS settings (Note: Location provider is not the same thing as location permission)
2. Tap on "Manage card reader
3. Tap on "Redirect to CardReaderDetailFragment"
4. Tap on "Connect"
5. Notice the "Location disabled" error is shown
8. Tap on "Open App settings"
9. Enable "Location" and go back to the app
10. Notice the connection flow is resumed automatically

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
