### PR TITLE
Fix failing develop

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -297,7 +297,7 @@ class CardReaderConnectViewModel @Inject constructor(
             override val onPrimaryActionClicked: () -> Unit,
             override val onSecondaryActionClicked: () -> Unit
         ) : ViewState(
-            headerLabel = R.string.card_reader_connect_failed_header,
+            headerLabel = UiStringRes(R.string.card_reader_connect_failed_header),
             illustration = R.drawable.img_card_reader_scanning,
             hintLabel = R.string.card_reader_connect_location_provider_disabled_hint,
             primaryActionLabel = R.string.card_reader_connect_open_location_settings,


### PR DESCRIPTION
LocationDisabledError was introduced in one PR but `headerLabel` was updated from Int to UIString in another PR. These two PRs got merged one after another and develop is broken now. This PR fixes this issue.

To test:
CI build is enough