### PR TITLE
Issue/3725 connect errors

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -290,7 +290,7 @@ class CardReaderConnectViewModel @Inject constructor(
             override val onSecondaryActionClicked: () -> Unit
         ) : ViewState(
             headerLabel = UiStringRes(R.string.card_reader_connect_failed_header),
-            illustration = R.drawable.img_card_reader_scanning,
+            illustration = R.drawable.img_products_error,
             hintLabel = R.string.card_reader_connect_scanning_failed_hint,
             primaryActionLabel = R.string.retry,
             secondaryActionLabel = R.string.cancel
@@ -301,7 +301,7 @@ class CardReaderConnectViewModel @Inject constructor(
             override val onSecondaryActionClicked: () -> Unit
         ) : ViewState(
             headerLabel = UiStringRes(R.string.card_reader_connect_failed_header),
-            illustration = R.drawable.img_card_reader_connecting,
+            illustration = R.drawable.img_products_error,
             hintLabel = R.string.card_reader_connect_connecting_failed_hint,
             primaryActionLabel = R.string.retry,
             secondaryActionLabel = R.string.cancel
@@ -312,7 +312,7 @@ class CardReaderConnectViewModel @Inject constructor(
             override val onSecondaryActionClicked: () -> Unit
         ) : ViewState(
             headerLabel = UiStringRes(R.string.card_reader_connect_failed_header),
-            illustration = R.drawable.img_card_reader_scanning,
+            illustration = R.drawable.img_products_error,
             hintLabel = R.string.card_reader_connect_missing_permissions_hint,
             primaryActionLabel = R.string.card_reader_connect_open_permission_settings,
             secondaryActionLabel = R.string.cancel
@@ -323,7 +323,7 @@ class CardReaderConnectViewModel @Inject constructor(
             override val onSecondaryActionClicked: () -> Unit
         ) : ViewState(
             headerLabel = UiStringRes(R.string.card_reader_connect_failed_header),
-            illustration = R.drawable.img_card_reader_scanning,
+            illustration = R.drawable.img_products_error,
             hintLabel = R.string.card_reader_connect_location_provider_disabled_hint,
             primaryActionLabel = R.string.card_reader_connect_open_location_settings,
             secondaryActionLabel = R.string.cancel
@@ -334,7 +334,7 @@ class CardReaderConnectViewModel @Inject constructor(
             override val onSecondaryActionClicked: () -> Unit
         ) : ViewState(
             headerLabel = UiStringRes(R.string.card_reader_connect_failed_header),
-            illustration = R.drawable.img_card_reader_scanning,
+            illustration = R.drawable.img_products_error,
             hintLabel = R.string.card_reader_connect_bluetooth_disabled_hint,
             primaryActionLabel = R.string.card_reader_connect_open_bluetooth_settings,
             secondaryActionLabel = R.string.cancel

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -113,7 +113,6 @@ class CardReaderConnectViewModel @Inject constructor(
 
     private fun onCardReaderManagerInitialized(cardReaderManager: CardReaderManager) {
         this.cardReaderManager = cardReaderManager
-        // TODO cardreader check location permissions
         launch {
             startScanning()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -289,7 +289,7 @@ class CardReaderConnectViewModel @Inject constructor(
             override val onPrimaryActionClicked: () -> Unit,
             override val onSecondaryActionClicked: () -> Unit
         ) : ViewState(
-            headerLabel = UiStringRes(R.string.card_reader_scanning_failed_header),
+            headerLabel = UiStringRes(R.string.card_reader_connect_failed_header),
             illustration = R.drawable.img_card_reader_scanning,
             hintLabel = R.string.card_reader_connect_scanning_failed_hint,
             primaryActionLabel = R.string.retry,
@@ -300,14 +300,13 @@ class CardReaderConnectViewModel @Inject constructor(
             override val onPrimaryActionClicked: () -> Unit,
             override val onSecondaryActionClicked: () -> Unit
         ) : ViewState(
-            headerLabel = UiStringRes(R.string.card_reader_connecting_failed_header),
+            headerLabel = UiStringRes(R.string.card_reader_connect_failed_header),
             illustration = R.drawable.img_card_reader_connecting,
             hintLabel = R.string.card_reader_connect_connecting_failed_hint,
             primaryActionLabel = R.string.retry,
             secondaryActionLabel = R.string.cancel
         )
 
-        // TODO cardreader add error state
         data class MissingPermissionsError(
             override val onPrimaryActionClicked: () -> Unit,
             override val onSecondaryActionClicked: () -> Unit
@@ -337,7 +336,7 @@ class CardReaderConnectViewModel @Inject constructor(
             headerLabel = UiStringRes(R.string.card_reader_connect_failed_header),
             illustration = R.drawable.img_card_reader_scanning,
             hintLabel = R.string.card_reader_connect_bluetooth_disabled_hint,
-            primaryActionLabel = R.string.card_reader_connect_open_permission_settings,
+            primaryActionLabel = R.string.card_reader_connect_open_bluetooth_settings,
             secondaryActionLabel = R.string.cancel
         )
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -630,6 +630,10 @@
     <string name="card_reader_connect_connecting_header">Connecting to reader</string>
     <string name="card_reader_connect_connecting_hint" translatable="false">@string/please_wait</string>
     <string name="card_reader_connect_failed_header">Connecting to reader failed</string>
+    <string name="card_reader_scanning_failed_header">Scanning failed</string>
+    <string name="card_reader_connect_scanning_failed_hint">We couldn\'t find any card readers.</string>
+    <string name="card_reader_connecting_failed_header">Connecting to reader failed</string>
+    <string name="card_reader_connect_connecting_failed_hint">We couldn\'t connect to the reader.</string>
     <string name="card_reader_connect_missing_permissions_hint">Missing required location permission</string>
     <string name="card_reader_connect_location_provider_disabled_hint">Location is disabled</string>
     <string name="card_reader_connect_bluetooth_disabled_hint">Bluetooth is disabled</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -630,7 +630,7 @@
     <string name="card_reader_connect_connecting_header">Connecting to reader</string>
     <string name="card_reader_connect_connecting_hint" translatable="false">@string/please_wait</string>
     <string name="card_reader_connect_failed_header">Connecting to reader failed</string>
-    <string name="card_reader_connect_scanning_failed_hint">We couldn\'t find any card readers.</string>
+    <string name="card_reader_connect_scanning_failed_hint">We couldn\'t find any readers.</string>
     <string name="card_reader_connect_connecting_failed_hint">We couldn\'t connect to the reader.</string>
     <string name="card_reader_connect_missing_permissions_hint">Missing required location permission</string>
     <string name="card_reader_connect_location_provider_disabled_hint">Location is disabled</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -630,15 +630,14 @@
     <string name="card_reader_connect_connecting_header">Connecting to reader</string>
     <string name="card_reader_connect_connecting_hint" translatable="false">@string/please_wait</string>
     <string name="card_reader_connect_failed_header">Connecting to reader failed</string>
-    <string name="card_reader_scanning_failed_header">Scanning failed</string>
     <string name="card_reader_connect_scanning_failed_hint">We couldn\'t find any card readers.</string>
-    <string name="card_reader_connecting_failed_header">Connecting to reader failed</string>
     <string name="card_reader_connect_connecting_failed_hint">We couldn\'t connect to the reader.</string>
     <string name="card_reader_connect_missing_permissions_hint">Missing required location permission</string>
     <string name="card_reader_connect_location_provider_disabled_hint">Location is disabled</string>
     <string name="card_reader_connect_bluetooth_disabled_hint">Bluetooth is disabled</string>
     <string name="card_reader_connect_open_permission_settings">Open settings</string>
     <string name="card_reader_connect_open_location_settings">Open settings</string>
+    <string name="card_reader_connect_open_bluetooth_settings">Open settings</string>
 
     <!--
         Notifications

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -507,7 +507,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
                 .isEqualTo(R.string.cancel)
             assertThat(viewModel.viewStateData.value!!.illustration)
                 .describedAs("Check illustration")
-                .isEqualTo(R.drawable.img_card_reader_scanning)
+                .isEqualTo(R.drawable.img_products_error)
         }
 
     @Test
@@ -532,7 +532,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
                 .isEqualTo(R.string.cancel)
             assertThat(viewModel.viewStateData.value!!.illustration)
                 .describedAs("Check illustration")
-                .isEqualTo(R.drawable.img_card_reader_connecting)
+                .isEqualTo(R.drawable.img_products_error)
         }
 
     @Test
@@ -556,7 +556,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
                 .isEqualTo(R.string.cancel)
             assertThat(viewModel.viewStateData.value!!.illustration)
                 .describedAs("Check illustration")
-                .isEqualTo(R.drawable.img_card_reader_scanning)
+                .isEqualTo(R.drawable.img_products_error)
         }
 
     @Test
@@ -580,7 +580,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
                 .isEqualTo(R.string.cancel)
             assertThat(viewModel.viewStateData.value!!.illustration)
                 .describedAs("Check illustration")
-                .isEqualTo(R.drawable.img_card_reader_scanning)
+                .isEqualTo(R.drawable.img_products_error)
         }
 
     @Test
@@ -606,7 +606,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
                 .isEqualTo(R.string.cancel)
             assertThat(viewModel.viewStateData.value!!.illustration)
                 .describedAs("Check illustration")
-                .isEqualTo(R.drawable.img_card_reader_scanning)
+                .isEqualTo(R.drawable.img_products_error)
         }
 
     private suspend fun init(scanState: ScanResult = READER_FOUND, connectingSucceeds: Boolean = true) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -396,7 +396,6 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
             (viewModel.event.value as InitializeCardReaderManager).onCardManagerInitialized(cardReaderManager)
 
             (viewModel.viewStateData.value as ScanningFailedState).onSecondaryActionClicked.invoke()
-
         }
 
     @Test


### PR DESCRIPTION
Parent issue #3725 

Goal of this PR is to wrap up error handling for "reader connection" flow. It introduces two new view states - ScanningFailed and ConnectingFailed.

To test:
- Unfortunately, I'm not sure how to simulate failing connection or failing scan without modifying the code.
1. Replace [this line](https://github.com/woocommerce/woocommerce-android/blob/e98aa3454fc46a06006fccd10b8f5317d92e77e8/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt#L43) with `CardReaderDiscoveryEvents.Failed("")`
2. Build the app
3. Open app settings
4. Tap on "Manage card reader"
5. Tap on "Redirect to CardReaderDetailFragment 
6. Tap on "Connect"
7. Notice "Scanning failed" error is shown
8. Tap on "Retry" and notice the flow is restarted (it fails again)
9. Revert changes made in `1`
10. Return "false" on [this line](https://github.com/woocommerce/woocommerce-android/blob/e98aa3454fc46a06006fccd10b8f5317d92e77e8/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt#L59)
11. Repeat steps 2-6 
12. Tap on "Connect"
13. Notice "Connecting failed" state is shown (note: It's just a simulation so the connection actually succeeds -> "retry" won't work. If you want to run some additional test you'll need to restart the app to disconnect from the reader. )

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
