### PR TITLE
Fix supports for multiple observers in MultiLiveEvent

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
@@ -34,8 +34,8 @@ open class MultiLiveEvent<T : Event> : MutableLiveData<T>() {
         super.observe(owner, Observer { t ->
             if (pending.get()) {
                 t.isHandled = true
-                pending.compareAndSet(t.isHandled, false)
                 observer.onChanged(t)
+                pending.compareAndSet(t.isHandled, false)
             }
         })
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/ScopedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/ScopedViewModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.viewmodel
 
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -17,8 +18,8 @@ import kotlin.coroutines.CoroutineContext
 abstract class ScopedViewModel(
     protected val savedState: SavedStateHandle
 ) : ViewModel(), CoroutineScope {
-    private val _event = MultiLiveEvent<Event>()
-    val event: LiveData<Event> = _event
+    protected open val _event: MutableLiveData<Event> = MultiLiveEvent<Event>()
+    open val event: LiveData<Event> = _event
 
     override val coroutineContext: CoroutineContext
         get() = viewModelScope.coroutineContext


### PR DESCRIPTION
This PR reverts 2b376b0533a57c835dbd5694aad0ec338f50e32c as it introduced a critical bug -> several our flows which are depending on MultiLiveEvent are not working anymore. The commit breaks handling of an event by multiple observables since it always sets `pending` field to false no matter if the observer decided to handle the event or not. It technically turns MultiLiveEvent into a SingleLiveEvent.

Props to @ThomazFB for finding the bug and also for pinning down the commit which introduced it!

To test
<img src="https://user-images.githubusercontent.com/2261188/118294603-8095cc80-b4a0-11eb-8540-dbddb4ce28c1.gif" width="150px" />

1. Open a detail of a variation product which doesn't have any variations
2. Tap on Add variations
3. Press back and notice it works as expected



Second part of this PR fixes issue which I originally tried to fix in 2b376b0533a57c835dbd5694aad0ec338f50e32c. 
When multiple events are send synchronously to MultiLiveEvent only the first one gets handled as `MultiLiveEvent.pending` field gets set to false when the first events is handled hence all the other events are ignored.
Example: Imagine VM sends CheckPermissions event -> the view layer synchronously checks the permissions and invokes vm.permissionChecked(true), the vm sends CheckBluetoothEvent, but this event is never observed by the view layer, since `MultiLiveEvent.pending` was set to false by the previous event.

There are several possible solutions for this issue, but I opted for the solution which requires minimal changes. I plan to consider completely refactoring all our usages of MultiLiveEvent, but that's work for 3+ days.
I opted for simply overriding MultiLiveEvent with SingleLiveEvent in CardReaderConnectViewModel since the view layer doesn't have multiple observers anyway.

To test:
<img src="https://user-images.githubusercontent.com/2261188/118294806-bb980000-b4a0-11eb-8ecd-47c01a19d7e0.gif" width="150px" />

- hw reader is NOT required
- WCpay account is NOT required
1. Open app settings
2. Tap on "Manage Card reader"
3. Tap on "Redirect to cardreaderdetailfragment"
4. Tap on "Connect"
5. Notice scanning starts (you might get asked for permissions) and a reader is found
That's it, the rest of the flow requires WCPay, but it's not necessary to test this part.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

cc @AliSoftware This PR needs to be merged before the codefreeze. 
