### PR TITLE
Disable shipping label creation if the order is not eligible

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -508,10 +508,12 @@ class OrderDetailViewModel @Inject constructor(
             _shipmentTrackings.value = shipmentTracking.list
         }
 
+        val isOrderEligibleForSLCreation = isShippingPluginReady &&
+            orderDetailRepository.isOrderEligibleForSLCreation(order.remoteId)
+
         viewState = viewState.copy(
-            isCreateShippingLabelButtonVisible = isShippingPluginReady &&
-                orderDetailRepository.isOrderEligibleForSLCreation(order.remoteId) &&
-                ! shippingLabels.isVisible,
+            isCreateShippingLabelButtonVisible = isOrderEligibleForSLCreation && !shippingLabels.isVisible,
+            isProductListMenuVisible = isOrderEligibleForSLCreation && shippingLabels.isVisible,
             isShipmentTrackingAvailable = shipmentTracking.isVisible,
             isProductListVisible = orderProducts.isVisible,
             areShippingLabelsVisible = shippingLabels.isVisible
@@ -535,7 +537,8 @@ class OrderDetailViewModel @Inject constructor(
         val refreshedProductId: Long? = null,
         val isCreateShippingLabelButtonVisible: Boolean? = null,
         val isProductListVisible: Boolean? = null,
-        val areShippingLabelsVisible: Boolean? = null
+        val areShippingLabelsVisible: Boolean? = null,
+        val isProductListMenuVisible: Boolean? = null
     ) : Parcelable {
         val isMarkOrderCompleteButtonVisible: Boolean?
             get() = if (orderStatus != null) orderStatus.statusKey == CoreOrderStatus.PROCESSING.value else null
@@ -545,9 +548,6 @@ class OrderDetailViewModel @Inject constructor(
 
         val isReprintShippingLabelBannerVisible: Boolean
             get() = !isCreateShippingLabelBannerVisible && areShippingLabelsVisible == true
-
-        val isProductListMenuVisible: Boolean?
-            get() = areShippingLabelsVisible
     }
 
     data class ListInfo<T>(val isVisible: Boolean = true, val list: List<T> = emptyList())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -318,7 +318,8 @@ class EditShippingLabelAddressFragment
             viewModel.onUseAddressAsIsButtonClicked()
         }
         binding.countrySpinner.onClick {
-            viewModel.onCountrySpinnerTapped()
+            // TODO enable this only for M4
+            // viewModel.onCountrySpinnerTapped()
         }
         binding.stateSpinner.onClick {
             viewModel.onStateSpinnerTapped()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -81,7 +81,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         isShipmentTrackingAvailable = true,
         isCreateShippingLabelButtonVisible = false,
         isProductListVisible = true,
-        areShippingLabelsVisible = false
+        areShippingLabelsVisible = false,
+        isProductListMenuVisible = false
     )
 
     private val mixedProducts = listOf(


### PR DESCRIPTION
Fixes #4052, instead of depending only on the visibility of other shipping labels for showing the "re-create shipping label" button, we will check if order is eligible too.

The PR fixes also another issue that I noticed, in the address screen, we are allowing country selection, but as we are supporting only the US, this will just confuse users (it won't cause a real issue as the purchase will fail later), I disabled the click listener on the spinner temporarily, until we have an M4 feature flag.

#### Testing

1. Create an order with an international shipping address.
2. Create a shipping label in the web client.
3. Open the order details in the app.
4. Confirm that the menu icon in the products section is invisible.
5. Go back to the web client, and update the shipping address to a US one.
6. Open the order details in the app.
7. Confirm that the menu icon is visible.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
