### PR TITLE
Issue/3725 Battery reader level and name

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -14,7 +14,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_TRACKING_AD
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.extensions.CASH_ON_DELIVERY_PAYMENT_TYPE
 import com.woocommerce.android.cardreader.CardReaderManager
-import com.woocommerce.android.cardreader.CardReaderStatus.CONNECTED
+import com.woocommerce.android.cardreader.CardReaderStatus.Connected
 import com.woocommerce.android.extensions.isNotEqualTo
 import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.extensions.whenNotNullNorEmpty
@@ -225,7 +225,7 @@ class OrderDetailViewModel @Inject constructor(
 
     fun onAcceptCardPresentPaymentClicked(cardReaderManager: CardReaderManager) {
         // TODO cardreader add tests for this functionality
-        if (cardReaderManager.readerStatus.value == CONNECTED) {
+        if (cardReaderManager.readerStatus.value is Connected) {
             triggerEvent(StartCardReaderPaymentFlow(order.identifier))
         } else {
             triggerEvent(StartCardReaderConnectFlow)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CardReaderSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CardReaderSettingsFragment.kt
@@ -21,11 +21,12 @@ import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents.ReadersFound
 import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents.Started
 import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents.Succeeded
 import com.woocommerce.android.cardreader.CardReaderManager
-import com.woocommerce.android.cardreader.CardReaderStatus.CONNECTED
-import com.woocommerce.android.cardreader.CardReaderStatus.CONNECTING
-import com.woocommerce.android.cardreader.CardReaderStatus.NOT_CONNECTED
+import com.woocommerce.android.cardreader.CardReaderStatus.Connected
+import com.woocommerce.android.cardreader.CardReaderStatus.Connecting
+import com.woocommerce.android.cardreader.CardReaderStatus.NotConnected
 import com.woocommerce.android.cardreader.SoftwareUpdateStatus.Installing
 import com.woocommerce.android.databinding.FragmentSettingsCardReaderBinding
+import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.extensions.navigateSafely
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CancellationException
@@ -106,15 +107,15 @@ class CardReaderSettingsFragment : Fragment(R.layout.fragment_settings_card_read
     }
 
     private fun startObserving(binding: FragmentSettingsCardReaderBinding) {
-        (requireActivity().application as? WooCommerce)?.let { application ->
+        (requireActivity().application as? WooCommerce)?.let {
             // TODO cardreader Move this into a VM
             lifecycleScope.launchWhenResumed {
                 cardReaderManager?.readerStatus?.collect { status ->
-                    binding.connectionStatus.text = status.name
+                    binding.connectionStatus.text = status::class.simpleName!!.toUpperCase()
                     when (status) {
-                        CONNECTING, NOT_CONNECTED -> binding.updateReaderSoftware.isEnabled = false
-                        CONNECTED -> binding.updateReaderSoftware.isEnabled = true
-                    }
+                        Connecting, NotConnected -> binding.updateReaderSoftware.isEnabled = false
+                        is Connected -> binding.updateReaderSoftware.isEnabled = true
+                    }.exhaustive
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -183,14 +183,14 @@ class CardReaderConnectViewModel @Inject constructor(
 
     private fun onReadersFound(discoveryEvent: ReadersFound) {
         if (viewState.value is ConnectingState) return
-        val availableReaders = discoveryEvent.list.filter { it.getId() != null }
+        val availableReaders = discoveryEvent.list.filter { it.id != null }
         if (availableReaders.isNotEmpty()) {
             // TODO cardreader add support for showing multiple readers
             val reader = availableReaders[0]
             viewState.value = ReaderFoundState(
                 onPrimaryActionClicked = { onConnectToReaderClicked(reader) },
                 onSecondaryActionClicked = ::onCancelClicked,
-                readerId = reader.getId().orEmpty()
+                readerId = reader.id.orEmpty()
             )
         } else {
             viewState.value = ScanningState(::onCancelClicked)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
@@ -9,7 +9,6 @@ import com.woocommerce.android.cardreader.CardReader
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.CardReaderStatus.Connected
 import com.woocommerce.android.extensions.exhaustive
-import com.woocommerce.android.extensions.formatToString
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
@@ -23,6 +22,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.math.roundToInt
 
 @HiltViewModel
 class CardReaderDetailViewModel @Inject constructor(
@@ -81,7 +81,7 @@ class CardReaderDetailViewModel @Inject constructor(
         return currentBatteryLevel?.let {
             UiStringRes(
                 R.string.card_reader_detail_connected_battery_percentage,
-                listOf(UiStringText(it.formatToString()))
+                listOf(UiStringText(it.roundToInt().toString()))
             )
         }
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -659,6 +659,7 @@
     <string name="card_reader_detail_connected_update_software">Update reader\'s software</string>
     <string name="card_reader_detail_connected_enforced_update_software">Please update your reader software to keep accepting payments</string>
     <string name="card_reader_detail_connected_disconnect_reader">Disconnect reader</string>
+    <string name="card_reader_detail_connected_reader_unknown">UNKNOWN CARD READER\'s NAME</string>
 
     <!--
         Notifications

--- a/WooCommerce/src/release/kotlin/com/woocommerce/android/di/CardReaderModule.kt
+++ b/WooCommerce/src/release/kotlin/com/woocommerce/android/di/CardReaderModule.kt
@@ -26,7 +26,7 @@ class CardReaderModule {
     @Singleton
     fun provideCardReaderManager(): CardReaderManager = object : CardReaderManager {
         override val isInitialized: Boolean = false
-        override val readerStatus: StateFlow<CardReaderStatus> = MutableStateFlow(CardReaderStatus.NOT_CONNECTED)
+        override val readerStatus: StateFlow<CardReaderStatus> = MutableStateFlow(CardReaderStatus.NotConnected)
 
         override fun initialize(app: Application) {}
 

--- a/WooCommerce/src/release/kotlin/com/woocommerce/android/di/CardReaderModule.kt
+++ b/WooCommerce/src/release/kotlin/com/woocommerce/android/di/CardReaderModule.kt
@@ -1,22 +1,33 @@
 package com.woocommerce.android.di
 
+import android.app.Application
+import com.woocommerce.android.cardreader.CardPaymentStatus
+import com.woocommerce.android.cardreader.CardReader
+import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents
 import com.woocommerce.android.cardreader.CardReaderManager
+import com.woocommerce.android.cardreader.CardReaderStatus
+import com.woocommerce.android.cardreader.CardReaderStatus.NotConnected
+import com.woocommerce.android.cardreader.PaymentData
+import com.woocommerce.android.cardreader.SoftwareUpdateStatus
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import javax.annotation.Nullable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flow
+import java.math.BigDecimal
 import javax.inject.Singleton
 
 @InstallIn(SingletonComponent::class)
 @Module
 class CardReaderModule {
     @Provides
-    @Nullable
     @Singleton
     fun provideCardReaderManager(): CardReaderManager = object : CardReaderManager {
         override val isInitialized: Boolean = false
-        override val readerStatus: StateFlow<CardReaderStatus> = MutableStateFlow(CardReaderStatus.NotConnected)
+        override val readerStatus: StateFlow<CardReaderStatus> = MutableStateFlow(NotConnected)
 
         override fun initialize(app: Application) {}
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -31,7 +31,6 @@ import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectView
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModelTest.ScanResult.FAILED
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModelTest.ScanResult.READER_FOUND
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModelTest.ScanResult.SCANNING
-import com.woocommerce.android.util.LocationUtils
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -52,8 +51,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: CardReaderConnectViewModel
 
     private val cardReaderManager: CardReaderManager = mock()
-    private val locationUtils: LocationUtils = mock()
-    private val reader = mock<CardReader>().also { whenever(it.getId()).thenReturn("dummy id") }
+    private val reader = mock<CardReader>().also { whenever(it.id).thenReturn("dummy id") }
 
     @Before
     fun setUp() = coroutinesTestRule.testDispatcher.runBlockingTest {
@@ -294,7 +292,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
     @Test
     fun `given reader id is null, when reader found, then reader is ignored`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            whenever(reader.getId()).thenReturn(null)
+            whenever(reader.id).thenReturn(null)
 
             init(scanState = READER_FOUND)
 
@@ -444,7 +442,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
                 .isEqualTo(
                     UiStringRes(
                         R.string.card_reader_connect_reader_found_header,
-                        listOf(UiStringText("<b>${reader.getId()}</b>")),
+                        listOf(UiStringText("<b>${reader.id}</b>")),
                         true
                     )
                 )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
@@ -23,6 +23,19 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `when view model init with connected state should emit connected view state`() {
         // GIVEN
+        val status = MutableStateFlow(CardReaderStatus.Connected(mock()))
+        whenever(cardReaderManager.readerStatus).thenReturn(status)
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        assertThat(viewModel.viewStateData.value).isInstanceOf(ConnectedState::class.java)
+    }
+
+    @Test
+    fun `when view model init with connected state should emit correct values of connected state`() {
+        // GIVEN
         val batteryLevel = 1.6F
         val readerName = "CH3231H"
         val reader: CardReader = mock {
@@ -36,23 +49,10 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
         val viewModel = createViewModel()
 
         // THEN
-        assertThat(viewModel.viewStateData.value).isInstanceOf(ConnectedState::class.java)
-    }
-
-    @Test
-    fun `when view model init with connected state should emit correct values of connected state`() {
-        // GIVEN
-        val status = MutableStateFlow(CardReaderStatus.CONNECTED)
-        whenever(cardReaderManager.readerStatus).thenReturn(status)
-
-        // WHEN
-        val viewModel = createViewModel()
-
-        // THEN
         verifyConnectedState(
             viewModel,
             UiStringText(readerName),
-            UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("1.6")))
+            UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("2")))
         )
     }
 
@@ -93,7 +93,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `when view model init with not connected state should emit correct values not connected state`() {
         // GIVEN
-        val status = MutableStateFlow(CardReaderStatus.NOT_CONNECTED)
+        val status = MutableStateFlow(CardReaderStatus.NotConnected)
         whenever(cardReaderManager.readerStatus).thenReturn(status)
 
         // WHEN
@@ -106,7 +106,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `when view model init with connecting state should emit not connected view state`() {
         // GIVEN
-        val status = MutableStateFlow(CardReaderStatus.CONNECTING)
+        val status = MutableStateFlow(CardReaderStatus.Connecting)
         whenever(cardReaderManager.readerStatus).thenReturn(status)
 
         // WHEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
@@ -4,43 +4,70 @@ import androidx.lifecycle.SavedStateHandle
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import com.woocommerce.android.R
+import com.woocommerce.android.cardreader.CardReader
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.CardReaderStatus
+import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
+import com.woocommerce.android.model.UiString.UiStringText
 import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewModel.ViewState.ConnectedState
 import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewModel.ViewState.NotConnectedState
 import com.woocommerce.android.viewmodel.BaseUnitTest
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
-@ExperimentalCoroutinesApi
 class CardReaderDetailViewModelTest : BaseUnitTest() {
     private val cardReaderManager: CardReaderManager = mock()
 
     @Test
     fun `when view model init with connected state should emit connected view state`() {
         // GIVEN
-        val status = MutableStateFlow(CardReaderStatus.CONNECTED)
+        val batteryLevel = 1.6F
+        val readerName = "CH3231H"
+        val reader: CardReader = mock {
+            on { id }.thenReturn(readerName)
+            on { currentBatteryLevel }.thenReturn(batteryLevel)
+        }
+        val status = MutableStateFlow(CardReaderStatus.Connected(reader))
         whenever(cardReaderManager.readerStatus).thenReturn(status)
 
         // WHEN
         val viewModel = createViewModel()
 
         // THEN
-        val state = viewModel.viewStateData.value as ConnectedState
-        assertThat(state.enforceReaderUpdate)
-            .isEqualTo(UiStringRes(R.string.card_reader_detail_connected_enforced_update_software))
-        assertThat(state.primaryButtonState?.text).isNull()
-        assertThat(state.secondaryButtonState?.text)
-            .isEqualTo(UiStringRes(R.string.card_reader_detail_connected_disconnect_reader))
+        verifyConnectedState(
+            viewModel,
+            UiStringText(readerName),
+            UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("1.6")))
+        )
+    }
+
+    @Test
+    fun `when view model init with connected state and empty name should emit connected view state with fallbacks`() {
+        // GIVEN
+        val reader: CardReader = mock {
+            on { id }.thenReturn(null)
+            on { currentBatteryLevel }.thenReturn(null)
+        }
+        val status = MutableStateFlow(CardReaderStatus.Connected(reader))
+        whenever(cardReaderManager.readerStatus).thenReturn(status)
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        verifyConnectedState(
+            viewModel,
+            UiStringRes(R.string.card_reader_detail_connected_reader_unknown),
+            null
+        )
     }
 
     @Test
     fun `when view model init with not connected state should emit not connected view state`() {
         // GIVEN
-        val status = MutableStateFlow(CardReaderStatus.NOT_CONNECTED)
+        val status = MutableStateFlow(CardReaderStatus.NotConnected)
         whenever(cardReaderManager.readerStatus).thenReturn(status)
 
         // WHEN
@@ -53,7 +80,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `when view model init with connection state should emit not connected view state`() {
         // GIVEN
-        val status = MutableStateFlow(CardReaderStatus.CONNECTING)
+        val status = MutableStateFlow(CardReaderStatus.Connecting)
         whenever(cardReaderManager.readerStatus).thenReturn(status)
 
         // WHEN
@@ -66,15 +93,30 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
     private fun verifyNotConnectedState(viewModel: CardReaderDetailViewModel) {
         val state = viewModel.viewStateData.value as NotConnectedState
         assertThat(state.headerLabel)
-                .isEqualTo(UiStringRes(R.string.card_reader_detail_not_connected_header))
+            .isEqualTo(UiStringRes(R.string.card_reader_detail_not_connected_header))
         assertThat(state.illustration)
-                .isEqualTo(R.drawable.img_card_reader_not_connected)
+            .isEqualTo(R.drawable.img_card_reader_not_connected)
         assertThat(state.firstHintLabel)
-                .isEqualTo(UiStringRes(R.string.card_reader_detail_not_connected_first_hint_label))
+            .isEqualTo(UiStringRes(R.string.card_reader_detail_not_connected_first_hint_label))
         assertThat(state.secondHintLabel)
-                .isEqualTo(UiStringRes(R.string.card_reader_detail_not_connected_second_hint_label))
+            .isEqualTo(UiStringRes(R.string.card_reader_detail_not_connected_second_hint_label))
         assertThat(state.connectBtnLabel)
-                .isEqualTo(UiStringRes(R.string.card_reader_details_not_connected_connect_button_label))
+            .isEqualTo(UiStringRes(R.string.card_reader_details_not_connected_connect_button_label))
+    }
+
+    private fun verifyConnectedState(
+        viewModel: CardReaderDetailViewModel,
+        readerName: UiString,
+        batteryLevel: UiString?
+    ) {
+        val state = viewModel.viewStateData.value as ConnectedState
+        assertThat(state.enforceReaderUpdate)
+            .isEqualTo(UiStringRes(R.string.card_reader_detail_connected_enforced_update_software))
+        assertThat(state.readerName).isEqualTo(readerName)
+        assertThat(state.readerBattery).isEqualTo(batteryLevel)
+        assertThat(state.primaryButtonState?.text).isNull()
+        assertThat(state.secondaryButtonState?.text)
+            .isEqualTo(UiStringRes(R.string.card_reader_detail_connected_disconnect_reader))
     }
 
     private fun createViewModel() = CardReaderDetailViewModel(

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/CardReaderImpl.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/CardReaderImpl.kt
@@ -3,5 +3,8 @@ package com.woocommerce.android.cardreader
 import com.stripe.stripeterminal.model.external.Reader
 
 class CardReaderImpl(val cardReader: Reader) : CardReader {
-    override fun getId(): String? = cardReader.serialNumber
+    override val id: String?
+        get() = cardReader.serialNumber
+    override val currentBatteryLevel: Float?
+        get() = cardReader.batteryLevel
 }

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
@@ -28,7 +28,7 @@ internal class ConnectionManager(
     private val logWrapper: LogWrapper,
     private val discoverReadersAction: DiscoverReadersAction
 ) : TerminalListener {
-    val readerStatus: MutableStateFlow<CardReaderStatus> = MutableStateFlow(CardReaderStatus.NOT_CONNECTED)
+    val readerStatus: MutableStateFlow<CardReaderStatus> = MutableStateFlow(CardReaderStatus.NotConnected)
 
     fun discoverReaders(isSimulated: Boolean) =
         discoverReadersAction.discoverReaders(isSimulated).map { state ->
@@ -63,16 +63,16 @@ internal class ConnectionManager(
     }
 
     override fun onUnexpectedReaderDisconnect(reader: Reader) {
-        readerStatus.value = CardReaderStatus.NOT_CONNECTED
+        readerStatus.value = CardReaderStatus.NotConnected
         logWrapper.d("CardReader", "onUnexpectedReaderDisconnect")
     }
 
     override fun onConnectionStatusChange(status: ConnectionStatus) {
         super.onConnectionStatusChange(status)
         readerStatus.value = when (status) {
-            NOT_CONNECTED -> CardReaderStatus.NOT_CONNECTED
-            CONNECTING -> CardReaderStatus.CONNECTING
-            CONNECTED -> CardReaderStatus.CONNECTED
+            NOT_CONNECTED -> CardReaderStatus.NotConnected
+            CONNECTING -> CardReaderStatus.Connecting
+            CONNECTED -> CardReaderStatus.Connected(terminal.getConnectedReader()!!)
         }
         logWrapper.d("CardReader", "onConnectionStatusChange: ${status.name}")
     }

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/wrappers/TerminalWrapper.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/wrappers/TerminalWrapper.kt
@@ -18,6 +18,8 @@ import com.stripe.stripeterminal.model.external.PaymentIntent
 import com.stripe.stripeterminal.model.external.PaymentIntentParameters
 import com.stripe.stripeterminal.model.external.Reader
 import com.stripe.stripeterminal.model.external.ReaderSoftwareUpdate
+import com.woocommerce.android.cardreader.CardReader
+import com.woocommerce.android.cardreader.CardReaderImpl
 import com.woocommerce.android.cardreader.internal.TokenProvider
 
 /**
@@ -60,4 +62,6 @@ internal class TerminalWrapper {
         listener: ReaderSoftwareUpdateListener,
         callback: Callback
     ) = Terminal.getInstance().installUpdate(updateData, listener, callback)
+
+    fun getConnectedReader(): CardReader? = Terminal.getInstance().connectedReader?.let { CardReaderImpl(it) }
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReader.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReader.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.cardreader
 
 interface CardReader {
-    fun getId(): String?
+    val id: String?
+    val currentBatteryLevel: Float?
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderStatus.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderStatus.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.cardreader
 
-enum class CardReaderStatus {
-    NOT_CONNECTED,
-    CONNECTED,
-    CONNECTING
+sealed class CardReaderStatus {
+    object NotConnected : CardReaderStatus()
+    data class Connected(val cardReader: CardReader) : CardReaderStatus()
+    object Connecting : CardReaderStatus()
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
@@ -52,7 +52,7 @@ class ConnectionManagerTest {
 
         val result = connectionManager.discoverReaders(true).toList()
 
-        assertThat((result.first() as ReadersFound).list.first().getId())
+        assertThat((result.first() as ReadersFound).list.first().id)
             .isEqualTo(dummyReaderId)
     }
 
@@ -81,7 +81,7 @@ class ConnectionManagerTest {
         connectionManager.onUnexpectedReaderDisconnect(mock())
 
         assertThat(connectionManager.readerStatus.value).isEqualTo(
-            CardReaderStatus.NOT_CONNECTED
+            CardReaderStatus.NotConnected
         )
     }
 
@@ -90,7 +90,7 @@ class ConnectionManagerTest {
         connectionManager.onConnectionStatusChange(NOT_CONNECTED)
 
         assertThat(connectionManager.readerStatus.value).isEqualTo(
-            CardReaderStatus.NOT_CONNECTED
+            CardReaderStatus.NotConnected
         )
     }
 
@@ -99,17 +99,17 @@ class ConnectionManagerTest {
         connectionManager.onConnectionStatusChange(CONNECTING)
 
         assertThat(connectionManager.readerStatus.value).isEqualTo(
-            CardReaderStatus.CONNECTING
+            CardReaderStatus.Connecting
         )
     }
 
     @Test
     fun `when reader connection established, then observers get notified`() {
+        val cardReader = CardReaderImpl(mock())
+        whenever(terminalWrapper.getConnectedReader()).thenReturn(cardReader)
         connectionManager.onConnectionStatusChange(CONNECTED)
 
-        assertThat(connectionManager.readerStatus.value).isEqualTo(
-            CardReaderStatus.CONNECTED
-        )
+        assertThat(connectionManager.readerStatus.value).isEqualTo(CardReaderStatus.Connected(cardReader))
     }
 
     @Test


### PR DESCRIPTION
Parent issue #3725 

Passing batter level and name inside connected state. Passed data used to be shown on the Connected reader screen

### How to test
Settings -> Manger readers -> Redirect -> Connect. Check readers name and batter

https://user-images.githubusercontent.com/4923871/119107387-dbdb3800-ba27-11eb-8813-98cc5a196fa2.mp4

![image](https://user-images.githubusercontent.com/4923871/119107871-54da8f80-ba28-11eb-832a-11d119353b40.png)

