### PR TITLE
Shipping Labels: Customs screen UI part 1

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -26,4 +26,8 @@ object AppUrls {
     const val CROWDSIGNAL_PRODUCT_SURVEY = "https://automattic.survey.fm/woo-app-feature-feedback-products"
     const val CROWDSIGNAL_SHIPPING_LABELS_SURVEY =
         "https://automattic.survey.fm/woo-app-feature-feedback-shipping-labels"
+
+    const val SHIPPING_LABEL_CUSTOMS_ITN = "https://pe.usps.com/text/imm/immc5_010.htm"
+    const val SHIPPING_LABEL_CUSTOMS_HS_TARIFF_NUMBER =
+        "https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#section-29"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringExt.kt
@@ -1,12 +1,11 @@
 package com.woocommerce.android.extensions
 
 import android.text.Spannable
-import android.text.SpannableString
 import android.text.method.LinkMovementMethod
 import android.widget.TextView
+import androidx.core.text.buildSpannedString
 import com.woocommerce.android.widgets.WooClickableSpan
 import org.apache.commons.text.StringEscapeUtils
-import java.lang.NumberFormatException
 
 /**
  * Checks if a given string is a number (supports positive or negative numbers)
@@ -73,27 +72,20 @@ fun String.configureStringClick(
     clickAction: WooClickableSpan,
     textField: TextView
 ) {
-    SpannableString(this)
-        .buildClickableUrlSpan(clickableContent, this, clickAction)
-        .let {
-            textField.apply {
-                setText(it, TextView.BufferType.SPANNABLE)
-                movementMethod = LinkMovementMethod.getInstance()
-            }
+    buildSpannedString {
+        append(this@configureStringClick)
+        setSpan(
+            clickAction,
+            indexOf(clickableContent),
+            indexOf(clickableContent) + clickableContent.length,
+            Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+    }.let {
+        textField.apply {
+            setText(it, TextView.BufferType.SPANNABLE)
+            movementMethod = LinkMovementMethod.getInstance()
         }
-}
-
-private fun SpannableString.buildClickableUrlSpan(
-    clickableContent: String,
-    fullContent: String,
-    clickAction: WooClickableSpan
-) = apply {
-    setSpan(
-        clickAction,
-        (fullContent.length - clickableContent.length),
-        fullContent.length,
-        Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-    )
+    }
 }
 
 fun String.semverCompareTo(otherVersion: String): Int {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringExt.kt
@@ -1,10 +1,5 @@
 package com.woocommerce.android.extensions
 
-import android.text.Spannable
-import android.text.method.LinkMovementMethod
-import android.widget.TextView
-import androidx.core.text.buildSpannedString
-import com.woocommerce.android.widgets.WooClickableSpan
 import org.apache.commons.text.StringEscapeUtils
 
 /**
@@ -62,30 +57,6 @@ fun String.fastStripHtml(): String {
 
     // use regex to strip tags, then convert entities in the result
     return htmlString.substring(start)
-}
-
-/**
- * Makes any text range inside a TextView clickable with a special color and a URL redirection
- */
-fun String.configureStringClick(
-    clickableContent: String,
-    clickAction: WooClickableSpan,
-    textField: TextView
-) {
-    buildSpannedString {
-        append(this@configureStringClick)
-        setSpan(
-            clickAction,
-            indexOf(clickableContent),
-            indexOf(clickableContent) + clickableContent.length,
-            Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-        )
-    }.let {
-        textField.apply {
-            setText(it, TextView.BufferType.SPANNABLE)
-            movementMethod = LinkMovementMethod.getInstance()
-        }
-    }
 }
 
 fun String.semverCompareTo(otherVersion: String): Int {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/TextViewExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/TextViewExt.kt
@@ -4,12 +4,16 @@ import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
 import android.os.Build
 import android.text.Html
+import android.text.Spannable
+import android.text.SpannableString
 import android.text.SpannableStringBuilder
+import android.text.method.LinkMovementMethod
 import android.text.style.ClickableSpan
 import android.view.View
 import android.widget.TextView
 import androidx.annotation.ColorRes
 import androidx.core.content.ContextCompat
+import com.woocommerce.android.widgets.WooClickableSpan
 
 typealias OnLinkClicked = (ClickableSpan) -> Unit
 
@@ -60,5 +64,26 @@ private fun addLinkListener(strBuilder: SpannableStringBuilder, span: ClickableS
 fun TextView.setDrawableColor(@ColorRes colorRes: Int) {
     compoundDrawables.filterNotNull().forEach {
         it.colorFilter = PorterDuffColorFilter(ContextCompat.getColor(context, colorRes), PorterDuff.Mode.SRC_IN)
+    }
+}
+
+/**
+ * Makes any text range inside a TextView clickable with a special color and a URL redirection
+ */
+fun TextView.setClickableText(
+    content: String,
+    clickableContent: String,
+    clickAction: WooClickableSpan,
+) {
+    SpannableString(content).apply {
+        setSpan(
+            clickAction,
+            indexOf(clickableContent),
+            indexOf(clickableContent) + clickableContent.length,
+            Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+    }.let {
+        setText(it, TextView.BufferType.SPANNABLE)
+        movementMethod = LinkMovementMethod.getInstance()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/TextViewExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/TextViewExt.kt
@@ -73,7 +73,7 @@ fun TextView.setDrawableColor(@ColorRes colorRes: Int) {
 fun TextView.setClickableText(
     content: String,
     clickableContent: String,
-    clickAction: WooClickableSpan,
+    clickAction: WooClickableSpan
 ) {
     SpannableString(content).apply {
         setSpan(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/CustomsPackage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/CustomsPackage.kt
@@ -1,0 +1,40 @@
+package com.woocommerce.android.model
+
+import android.os.Parcelable
+import androidx.annotation.StringRes
+import com.woocommerce.android.R
+import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
+
+@Parcelize
+data class CustomsPackage(
+    val returnToSender: Boolean,
+    val contentsType: ContentsType,
+    val restrictionType: RestrictionType,
+    val itn: String,
+    val lines: List<CustomsLine>
+) : Parcelable
+
+@Parcelize
+data class CustomsLine(
+    val itemDescription: String,
+    val hsTariffNumber: String,
+    val weight: Float,
+    val value: BigDecimal,
+    val originCountry: String
+) : Parcelable
+
+enum class ContentsType(@StringRes title: Int) {
+    Merchandise(R.string.shipping_label_customs_contents_type_merchandise),
+    Documents(R.string.shipping_label_customs_contents_type_documents),
+    Gift(R.string.shipping_label_customs_contents_type_gifts),
+    Sample(R.string.shipping_label_customs_contents_type_sample),
+    Other(R.string.shipping_label_customs_contents_type_other);
+}
+
+enum class RestrictionType(@StringRes title: Int) {
+    None(R.string.shipping_label_customs_restriction_type_none),
+    Quarantine(R.string.shipping_label_customs_restriction_type_quarantine),
+    SanitaryInspection(R.string.shipping_label_customs_restriction_type_sanitary_inspection),
+    Other(R.string.shipping_label_customs_restriction_type_other);
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/CustomsPackage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/CustomsPackage.kt
@@ -8,6 +8,8 @@ import java.math.BigDecimal
 
 @Parcelize
 data class CustomsPackage(
+    val id: String,
+    val box: ShippingPackage,
     val returnToSender: Boolean,
     val contentsType: ContentsType,
     val restrictionType: RestrictionType,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/CustomsPackage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/CustomsPackage.kt
@@ -24,7 +24,7 @@ data class CustomsLine(
     val originCountry: String
 ) : Parcelable
 
-enum class ContentsType(@StringRes title: Int) {
+enum class ContentsType(@StringRes val title: Int) {
     Merchandise(R.string.shipping_label_customs_contents_type_merchandise),
     Documents(R.string.shipping_label_customs_contents_type_documents),
     Gift(R.string.shipping_label_customs_contents_type_gifts),
@@ -32,7 +32,7 @@ enum class ContentsType(@StringRes title: Int) {
     Other(R.string.shipping_label_customs_contents_type_other);
 }
 
-enum class RestrictionType(@StringRes title: Int) {
+enum class RestrictionType(@StringRes val title: Int) {
     None(R.string.shipping_label_customs_restriction_type_none),
     Quarantine(R.string.shipping_label_customs_restriction_type_quarantine),
     SanitaryInspection(R.string.shipping_label_customs_restriction_type_sanitary_inspection),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
@@ -40,7 +40,7 @@ class FeedbackCompletedFragment : androidx.fragment.app.Fragment(R.layout.fragme
         binding.completionHelpGuide.setClickableText(
             content = getString(R.string.feedback_completed_description, contactUsText),
             clickableContent = contactUsText,
-            clickAction = WooClickableSpan { activity?.startHelpActivity(FEEDBACK_SURVEY) },
+            clickAction = WooClickableSpan { activity?.startHelpActivity(FEEDBACK_SURVEY) }
         )
         binding.btnBackToStore.setOnClickListener { activity?.onBackPressed() }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
@@ -13,7 +13,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBA
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_PRODUCT_M3_CONTEXT
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SURVEY_SCREEN
 import com.woocommerce.android.databinding.FragmentFeedbackCompletedBinding
-import com.woocommerce.android.extensions.configureStringClick
+import com.woocommerce.android.extensions.setClickableText
 import com.woocommerce.android.extensions.startHelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin.FEEDBACK_SURVEY
 import com.woocommerce.android.ui.feedback.SurveyType.MAIN
@@ -37,12 +37,11 @@ class FeedbackCompletedFragment : androidx.fragment.app.Fragment(R.layout.fragme
 
         val binding = FragmentFeedbackCompletedBinding.bind(view)
         val contactUsText = getString(R.string.feedback_completed_contact_us)
-        getString(R.string.feedback_completed_description, contactUsText)
-            .configureStringClick(
-                clickableContent = contactUsText,
-                clickAction = WooClickableSpan { activity?.startHelpActivity(FEEDBACK_SURVEY) },
-                textField = binding.completionHelpGuide
-            )
+        binding.completionHelpGuide.setClickableText(
+            content = getString(R.string.feedback_completed_description, contactUsText),
+            clickableContent = contactUsText,
+            clickAction = WooClickableSpan { activity?.startHelpActivity(FEEDBACK_SURVEY) },
+        )
         binding.btnBackToStore.setOnClickListener { activity?.onBackPressed() }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -20,7 +20,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.databinding.FragmentMyStoreBinding
-import com.woocommerce.android.extensions.configureStringClick
+import com.woocommerce.android.extensions.setClickableText
 import com.woocommerce.android.extensions.startHelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
 import com.woocommerce.android.tools.SelectedSite
@@ -171,12 +171,11 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store),
         )
 
         val contactUsText = getString(R.string.my_store_stats_availability_contact_us)
-        getString(R.string.my_store_stats_availability_description, contactUsText)
-            .configureStringClick(
-                clickableContent = contactUsText,
-                clickAction = WooClickableSpan { activity?.startHelpActivity(Origin.MY_STORE) },
-                textField = binding.myStoreStatsAvailabilityMessage
-            )
+        binding.myStoreStatsAvailabilityMessage.setClickableText(
+            content = getString(R.string.my_store_stats_availability_description, contactUsText),
+            clickableContent = contactUsText,
+            clickAction = WooClickableSpan { activity?.startHelpActivity(Origin.MY_STORE) },
+        )
 
         tabLayout.addOnTabSelectedListener(tabSelectedListener)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -174,7 +174,7 @@ class MyStoreFragment : TopLevelFragment(R.layout.fragment_my_store),
         binding.myStoreStatsAvailabilityMessage.setClickableText(
             content = getString(R.string.my_store_stats_availability_description, contactUsText),
             clickableContent = contactUsText,
-            clickAction = WooClickableSpan { activity?.startHelpActivity(Origin.MY_STORE) },
+            clickAction = WooClickableSpan { activity?.startHelpActivity(Origin.MY_STORE) }
         )
 
         tabLayout.addOnTabSelectedListener(tabSelectedListener)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
@@ -51,6 +51,8 @@ sealed class CreateShippingLabelEvent : MultiLiveEvent.Event() {
         val shippingLabelPackages: List<ShippingLabelPackage>
     ) : CreateShippingLabelEvent()
 
+    object ShowCustomsForm : CreateShippingLabelEvent()
+
     data class ShowShippingRates(
         val order: Order,
         val originAddress: Address,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -23,6 +23,7 @@ import com.woocommerce.android.model.ShippingRate
 import com.woocommerce.android.ui.base.BaseDaggerFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowAddressEditor
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowCustomsForm
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowPackageDetails
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowPaymentDetails
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowPrintShippingLabels
@@ -242,6 +243,11 @@ class CreateShippingLabelFragment : BaseDaggerFragment(R.layout.fragment_create_
                             shippingLabelId = event.labels.first().id,
                             isReprint = false
                         )
+                    findNavController().navigateSafely(action)
+                }
+                is ShowCustomsForm -> {
+                    val action = CreateShippingLabelFragmentDirections
+                        .actionCreateShippingLabelFragmentToShippingCustomsFragment()
                     findNavController().navigateSafely(action)
                 }
                 else -> event.isHandled = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -49,6 +49,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLab
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPaymentFragment.Companion.EDIT_PAYMENTS_RESULT
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrierRatesFragment.Companion.SHIPPING_CARRIERS_CLOSED
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrierRatesFragment.Companion.SHIPPING_CARRIERS_RESULT
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustomsFragment.Companion.EDIT_CUSTOMS_RESULT
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SELECTED_ADDRESS_ACCEPTED
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SELECTED_ADDRESS_TO_BE_EDITED
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SUGGESTED_ADDRESS_DISCARDED
@@ -127,6 +128,9 @@ class CreateShippingLabelFragment : BaseDaggerFragment(R.layout.fragment_create_
         }
         handleResult<List<ShippingRate>>(SHIPPING_CARRIERS_RESULT) {
             viewModel.onShippingCarriersSelected(it)
+        }
+        handleNotice(EDIT_CUSTOMS_RESULT) {
+            viewModel.onCustomsFilledOut()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -59,6 +59,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.AddressInvalid
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.AddressValidated
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.AddressValidationFailed
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.CustomsFormFilledOut
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.EditAddressRequested
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.EditPackagingCanceled
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.EditPaymentCanceled
@@ -593,6 +594,10 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
     fun onShippingCarrierSelectionCanceled() {
         AnalyticsTracker.track(Stat.SHIPPING_LABEL_SHIPPING_CARRIER_SELECTION_CANCELED)
         stateMachine.handleEvent(ShippingCarrierSelectionCanceled)
+    }
+
+    fun onCustomsFilledOut() {
+        stateMachine.handleEvent(CustomsFormFilledOut)
     }
 
     fun onWooDiscountInfoClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -34,6 +34,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRepository
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowAddressEditor
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowCustomsForm
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowPackageDetails
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowPaymentDetails
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowPrintShippingLabels
@@ -89,11 +90,11 @@ import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.PriceUtils
+import com.woocommerce.android.viewmodel.DaggerScopedViewModel
 import com.woocommerce.android.viewmodel.LiveDataDelegateWithArgs
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.SavedStateWithArgs
-import com.woocommerce.android.viewmodel.DaggerScopedViewModel
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -214,7 +215,7 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                             )
                         )
                         is SideEffect.ShowPackageOptions -> openPackagesDetails(sideEffect.shippingPackages)
-                        is SideEffect.ShowCustomsForm -> handleResult { Event.CustomsFormFilledOut }
+                        is SideEffect.ShowCustomsForm -> openCustomsForm()
                         is SideEffect.ShowCarrierOptions -> openShippingCarrierRates(sideEffect.data)
                         is SideEffect.ShowPaymentOptions -> openPaymentDetails()
                         is SideEffect.ShowLabelsPrint -> openPrintLabelsScreen(sideEffect.orderId, sideEffect.labels)
@@ -293,6 +294,10 @@ class CreateShippingLabelViewModel @AssistedInject constructor(
                 shippingLabelPackages = currentShippingPackages
             )
         )
+    }
+
+    private fun openCustomsForm() {
+        triggerEvent(ShowCustomsForm)
     }
 
     private fun openPaymentDetails() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
@@ -1,16 +1,24 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation
 
+import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
+import com.woocommerce.android.AppUrls
+import com.woocommerce.android.R
 import com.woocommerce.android.databinding.ShippingCustomsLineListItemBinding
 import com.woocommerce.android.databinding.ShippingCustomsListItemBinding
+import com.woocommerce.android.extensions.collapse
+import com.woocommerce.android.extensions.configureStringClick
+import com.woocommerce.android.extensions.expand
 import com.woocommerce.android.model.CustomsLine
 import com.woocommerce.android.model.CustomsPackage
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustomsAdapter.PackageCustomsViewHolder
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustomsLineAdapter.CustomsLineViewHolder
+import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.widgets.WooClickableSpan
 
 class ShippingCustomsAdapter : RecyclerView.Adapter<PackageCustomsViewHolder>() {
     var customsPackages: List<CustomsPackage> = emptyList()
@@ -32,15 +40,32 @@ class ShippingCustomsAdapter : RecyclerView.Adapter<PackageCustomsViewHolder>() 
 
     class PackageCustomsViewHolder(val binding: ShippingCustomsListItemBinding) : ViewHolder(binding.root) {
         private val linesAdapter: ShippingCustomsLineAdapter by lazy { ShippingCustomsLineAdapter() }
+        private val context
+            get() = binding.root.context
 
         init {
             binding.itemsList.apply {
+                itemAnimator = null
                 layoutManager = LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false)
                 adapter = linesAdapter
             }
+
+            val learnMoreText = context.getString(R.string.learn_more)
+            context.getString(R.string.shipping_label_customs_learn_more_itn, learnMoreText)
+                .configureStringClick(
+                    learnMoreText,
+                    WooClickableSpan { ChromeCustomTabUtils.launchUrl(context, AppUrls.SHIPPING_LABEL_CUSTOMS_ITN) },
+                    binding.itnDescription
+                )
         }
 
+        @SuppressLint("SetTextI18n")
         fun bind(customsPackage: CustomsPackage) {
+            binding.packageId.text = context.getString(
+                R.string.orderdetail_shipping_label_item_header,
+                adapterPosition + 1
+            )
+            binding.packageName.text = "- ${customsPackage.box.title}"
             binding.contentsTypeSpinner.setText(customsPackage.contentsType.title)
             binding.restrictionTypeSpinner.setText(customsPackage.restrictionType.title)
             binding.itnEditText.setText(customsPackage.itn)
@@ -68,7 +93,31 @@ class ShippingCustomsLineAdapter : RecyclerView.Adapter<CustomsLineViewHolder>()
     override fun getItemCount(): Int = customsLines.size
 
     class CustomsLineViewHolder(val binding: ShippingCustomsLineListItemBinding) : ViewHolder(binding.root) {
+        private val context
+            get() = binding.root.context
+
+        init {
+            binding.expandIcon.setOnClickListener {
+                if (binding.expandIcon.rotation == 0f) {
+                    binding.expandIcon.rotation = 180f
+                    // binding.expandIcon.animate().rotation(180f).start()
+                    binding.detailsLayout.expand()
+                } else {
+                    binding.expandIcon.rotation = 0f
+                    // binding.expandIcon.animate().rotation(0f).start()
+                    binding.detailsLayout.collapse()
+                }
+            }
+            val learnMoreText = context.getString(R.string.learn_more)
+            context.getString(R.string.shipping_label_customs_learn_more_hs_tariff_number, learnMoreText)
+                .configureStringClick(
+                    learnMoreText,
+                    WooClickableSpan { ChromeCustomTabUtils.launchUrl(context, AppUrls.SHIPPING_LABEL_CUSTOMS_HS_TARIFF_NUMBER) },
+                    binding.hsTariffNumberInfos
+                )
+        }
         fun bind(customsPackage: CustomsLine) {
+            binding.lineTitle.text = context.getString(R.string.shipping_label_customs_line_item, adapterPosition + 1)
             binding.itemDescriptionEditText.setText(customsPackage.itemDescription)
             binding.hsTariffNumberEditText.setText(customsPackage.hsTariffNumber)
             binding.weightEditText.setText(customsPackage.weight.toString())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
@@ -1,0 +1,79 @@
+package com.woocommerce.android.ui.orders.shippinglabels.creation
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.ViewHolder
+import com.woocommerce.android.databinding.ShippingCustomsLineListItemBinding
+import com.woocommerce.android.databinding.ShippingCustomsListItemBinding
+import com.woocommerce.android.model.CustomsLine
+import com.woocommerce.android.model.CustomsPackage
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustomsAdapter.PackageCustomsViewHolder
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustomsLineAdapter.CustomsLineViewHolder
+
+class ShippingCustomsAdapter : RecyclerView.Adapter<PackageCustomsViewHolder>() {
+    var customsPackages: List<CustomsPackage> = emptyList()
+        set(value) {
+            field = value
+            notifyDataSetChanged()
+        }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PackageCustomsViewHolder {
+        val binding = ShippingCustomsListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return PackageCustomsViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: PackageCustomsViewHolder, position: Int) {
+        holder.bind(customsPackages[position])
+    }
+
+    override fun getItemCount(): Int = customsPackages.size
+
+    class PackageCustomsViewHolder(val binding: ShippingCustomsListItemBinding) : ViewHolder(binding.root) {
+        private val linesAdapter: ShippingCustomsLineAdapter by lazy { ShippingCustomsLineAdapter() }
+
+        init {
+            binding.itemsList.apply {
+                layoutManager = LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false)
+                adapter = linesAdapter
+            }
+        }
+
+        fun bind(customsPackage: CustomsPackage) {
+            binding.contentsTypeSpinner.setText(customsPackage.contentsType.title)
+            binding.restrictionTypeSpinner.setText(customsPackage.restrictionType.title)
+            binding.itnEditText.setText(customsPackage.itn)
+            linesAdapter.customsLines = customsPackage.lines
+        }
+    }
+}
+
+class ShippingCustomsLineAdapter : RecyclerView.Adapter<CustomsLineViewHolder>() {
+    var customsLines: List<CustomsLine> = emptyList()
+        set(value) {
+            field = value
+            notifyDataSetChanged()
+        }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CustomsLineViewHolder {
+        val binding = ShippingCustomsLineListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return CustomsLineViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: CustomsLineViewHolder, position: Int) {
+        holder.bind(customsLines[position])
+    }
+
+    override fun getItemCount(): Int = customsLines.size
+
+    class CustomsLineViewHolder(val binding: ShippingCustomsLineListItemBinding) : ViewHolder(binding.root) {
+        fun bind(customsPackage: CustomsLine) {
+            binding.itemDescriptionEditText.setText(customsPackage.itemDescription)
+            binding.hsTariffNumberEditText.setText(customsPackage.hsTariffNumber)
+            binding.weightEditText.setText(customsPackage.weight.toString())
+            binding.valueEditText.setText(customsPackage.value.toPlainString())
+            binding.countrySpinner.setText(customsPackage.originCountry)
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
@@ -11,8 +11,8 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.ShippingCustomsLineListItemBinding
 import com.woocommerce.android.databinding.ShippingCustomsListItemBinding
 import com.woocommerce.android.extensions.collapse
-import com.woocommerce.android.extensions.configureStringClick
 import com.woocommerce.android.extensions.expand
+import com.woocommerce.android.extensions.setClickableText
 import com.woocommerce.android.model.CustomsLine
 import com.woocommerce.android.model.CustomsPackage
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustomsAdapter.PackageCustomsViewHolder
@@ -51,12 +51,16 @@ class ShippingCustomsAdapter : RecyclerView.Adapter<PackageCustomsViewHolder>() 
             }
 
             val learnMoreText = context.getString(R.string.learn_more)
-            context.getString(R.string.shipping_label_customs_learn_more_itn, learnMoreText)
-                .configureStringClick(
-                    learnMoreText,
-                    WooClickableSpan { ChromeCustomTabUtils.launchUrl(context, AppUrls.SHIPPING_LABEL_CUSTOMS_ITN) },
-                    binding.itnDescription
-                )
+            binding.itnDescription.setClickableText(
+                content = context.getString(R.string.shipping_label_customs_learn_more_itn, learnMoreText),
+                clickableContent = learnMoreText,
+                clickAction = WooClickableSpan {
+                    ChromeCustomTabUtils.launchUrl(
+                        context,
+                        AppUrls.SHIPPING_LABEL_CUSTOMS_ITN
+                    )
+                }
+            )
         }
 
         @SuppressLint("SetTextI18n")
@@ -109,13 +113,18 @@ class ShippingCustomsLineAdapter : RecyclerView.Adapter<CustomsLineViewHolder>()
                 }
             }
             val learnMoreText = context.getString(R.string.learn_more)
-            context.getString(R.string.shipping_label_customs_learn_more_hs_tariff_number, learnMoreText)
-                .configureStringClick(
-                    learnMoreText,
-                    WooClickableSpan { ChromeCustomTabUtils.launchUrl(context, AppUrls.SHIPPING_LABEL_CUSTOMS_HS_TARIFF_NUMBER) },
-                    binding.hsTariffNumberInfos
-                )
+            binding.hsTariffNumberInfos.setClickableText(
+                content = context.getString(R.string.shipping_label_customs_learn_more_hs_tariff_number, learnMoreText),
+                clickableContent = learnMoreText,
+                clickAction = WooClickableSpan {
+                    ChromeCustomTabUtils.launchUrl(
+                        context,
+                        AppUrls.SHIPPING_LABEL_CUSTOMS_HS_TARIFF_NUMBER
+                    )
+                }
+            )
         }
+
         fun bind(customsPackage: CustomsLine) {
             binding.lineTitle.text = context.getString(R.string.shipping_label_customs_line_item, adapterPosition + 1)
             binding.itemDescriptionEditText.setText(customsPackage.itemDescription)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
@@ -1,0 +1,11 @@
+package com.woocommerce.android.ui.orders.shippinglabels.creation
+
+import androidx.fragment.app.viewModels
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.base.BaseFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class ShippingCustomsFragment : BaseFragment(R.layout.fragment_shipping_customs) {
+    private val viewModel: ShippingCustomsViewModel by viewModels()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
@@ -1,11 +1,37 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation
 
+import android.os.Bundle
+import android.view.View
 import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
+import com.woocommerce.android.databinding.FragmentShippingCustomsBinding
+import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class ShippingCustomsFragment : BaseFragment(R.layout.fragment_shipping_customs) {
     private val viewModel: ShippingCustomsViewModel by viewModels()
+
+    private val customsAdapter: ShippingCustomsAdapter by lazy { ShippingCustomsAdapter() }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val binding = FragmentShippingCustomsBinding.bind(view)
+        binding.packagesList.apply {
+            this.adapter = customsAdapter
+            layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
+        }
+
+        setupObservers(binding)
+    }
+
+    private fun setupObservers(binding: FragmentShippingCustomsBinding) {
+        viewModel.viewStateData.observe(viewLifecycleOwner, { old, new ->
+            new.customsPackages.takeIfNotEqualTo(old?.customsPackages) { customsPackages ->
+                customsAdapter.customsPackages = customsPackages
+            }
+        })
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
@@ -1,23 +1,55 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation
 
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentShippingCustomsBinding
+import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class ShippingCustomsFragment : BaseFragment(R.layout.fragment_shipping_customs) {
+class ShippingCustomsFragment : BaseFragment(R.layout.fragment_shipping_customs), BackPressListener {
+    companion object {
+        const val EDIT_CUSTOMS_CLOSED = "edit_customs_closed"
+        const val EDIT_CUSTOMS_RESULT = "edit_customs_result"
+    }
+
     private val viewModel: ShippingCustomsViewModel by viewModels()
 
     private val customsAdapter: ShippingCustomsAdapter by lazy { ShippingCustomsAdapter() }
 
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        super.onCreateOptionsMenu(menu, inflater)
+
+        inflater.inflate(R.menu.menu_done, menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.menu_done -> {
+                viewModel.onDoneButtonClicked()
+                true
+            }
+            else -> {
+                super.onOptionsItemSelected(item)
+            }
+        }
+    }
+
+    override fun getFragmentTitle(): String = getString(R.string.shipping_label_create_customs)
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setHasOptionsMenu(true)
         val binding = FragmentShippingCustomsBinding.bind(view)
         binding.packagesList.apply {
             this.adapter = customsAdapter
@@ -33,5 +65,18 @@ class ShippingCustomsFragment : BaseFragment(R.layout.fragment_shipping_customs)
                 customsAdapter.customsPackages = customsPackages
             }
         })
+        viewModel.event.observe(viewLifecycleOwner, { event ->
+            when (event) {
+                // TODO use EDIT_CUSTOMS_CLOSED for ExitWIthResult event, and EDIT_CUSTOMS_CLOSED for Exit
+                is Exit -> navigateBackWithNotice(EDIT_CUSTOMS_RESULT)
+                else -> event.isHandled = false
+            }
+        })
+    }
+
+    override fun onRequestAllowBackPress(): Boolean {
+        // TODO pass this to the ViewModel
+        navigateBackWithNotice(EDIT_CUSTOMS_RESULT)
+        return false
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
@@ -1,9 +1,17 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation
 
+import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.model.ContentsType
+import com.woocommerce.android.model.CustomsLine
+import com.woocommerce.android.model.CustomsPackage
+import com.woocommerce.android.model.RestrictionType
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRepository
+import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
 import javax.inject.Inject
 
 @HiltViewModel
@@ -11,4 +19,34 @@ class ShippingCustomsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     shippingLabelRepository: ShippingLabelRepository
 ) : ScopedViewModel(savedStateHandle) {
+    val viewStateData = LiveDataDelegate(savedState, ViewState())
+    private var viewState by viewStateData
+
+    init {
+        // TODO fake data
+        viewState = ViewState(
+            customsPackages = listOf(
+                CustomsPackage(
+                    returnToSender = true,
+                    contentsType = ContentsType.Merchandise,
+                    restrictionType = RestrictionType.None,
+                    itn = "",
+                    lines = listOf(
+                        CustomsLine(
+                            itemDescription = "Water bottle",
+                            hsTariffNumber = "",
+                            weight = 1.5f,
+                            value = BigDecimal.valueOf(15),
+                            originCountry = "United States"
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    @Parcelize
+    data class ViewState(
+        val customsPackages: List<CustomsPackage> = emptyList()
+    ) : Parcelable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.model.RestrictionType
 import com.woocommerce.android.model.ShippingPackage
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRepository
 import com.woocommerce.android.viewmodel.LiveDataDelegate
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.parcelize.Parcelize
@@ -61,6 +62,10 @@ class ShippingCustomsViewModel @Inject constructor(
                 )
             )
         )
+    }
+
+    fun onDoneButtonClicked() {
+        triggerEvent(Exit)
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
@@ -1,0 +1,14 @@
+package com.woocommerce.android.ui.orders.shippinglabels.creation
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRepository
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class ShippingCustomsViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    shippingLabelRepository: ShippingLabelRepository
+) : ScopedViewModel(savedStateHandle) {
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
@@ -5,7 +5,9 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.model.ContentsType
 import com.woocommerce.android.model.CustomsLine
 import com.woocommerce.android.model.CustomsPackage
+import com.woocommerce.android.model.PackageDimensions
 import com.woocommerce.android.model.RestrictionType
+import com.woocommerce.android.model.ShippingPackage
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRepository
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -27,6 +29,15 @@ class ShippingCustomsViewModel @Inject constructor(
         viewState = ViewState(
             customsPackages = listOf(
                 CustomsPackage(
+                    id = "default_package",
+                    box = ShippingPackage(
+                        id = "small_package",
+                        title = "Small Box",
+                        dimensions = PackageDimensions(10f, 10f, 2f),
+                        boxWeight = 0f,
+                        category = "USPS",
+                        isLetter = false
+                    ),
                     returnToSender = true,
                     contentsType = ContentsType.Merchandise,
                     restrictionType = RestrictionType.None,
@@ -34,6 +45,13 @@ class ShippingCustomsViewModel @Inject constructor(
                     lines = listOf(
                         CustomsLine(
                             itemDescription = "Water bottle",
+                            hsTariffNumber = "",
+                            weight = 1.5f,
+                            value = BigDecimal.valueOf(15),
+                            originCountry = "United States"
+                        ),
+                        CustomsLine(
+                            itemDescription = "Water bottle 2",
                             hsTariffNumber = "",
                             weight = 1.5f,
                             value = BigDecimal.valueOf(15),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.NOT_READY
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.READY
 import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.PackageUtils
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -469,7 +470,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         @Parcelize
         data class CustomsStep(
             override val status: StepStatus,
-            override val isVisible: Boolean = FeatureFlag.SHIPPING_LABELS_M4.isEnabled(),
+            override val isVisible: Boolean = FeatureFlag.SHIPPING_LABELS_M4.isEnabled() && !PackageUtils.isTesting(),
             override val data: Unit = Unit
         ) : Step<Unit>()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -26,12 +26,13 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.DONE
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.NOT_READY
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.READY
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
-import kotlinx.parcelize.Parcelize
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 /*
@@ -468,7 +469,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         @Parcelize
         data class CustomsStep(
             override val status: StepStatus,
-            override val isVisible: Boolean = false,
+            override val isVisible: Boolean = FeatureFlag.SHIPPING_LABELS_M4.isEnabled(),
             override val data: Unit = Unit
         ) : Step<Unit>()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedSpinnerView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCMaterialOutlinedSpinnerView.kt
@@ -8,6 +8,7 @@ import android.util.SparseArray
 import android.view.LayoutInflater
 import android.view.View
 import androidx.annotation.AttrRes
+import androidx.annotation.StringRes
 import com.google.android.material.textfield.TextInputLayout
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.ViewMaterialOutlinedSpinnerBinding
@@ -51,6 +52,10 @@ class WCMaterialOutlinedSpinnerView @JvmOverloads constructor(
 
     fun setText(selectedText: String) {
         binding.spinnerEditText.setText(selectedText)
+    }
+
+    fun setText(@StringRes selectedTextRes: Int) {
+        binding.spinnerEditText.setText(selectedTextRes)
     }
 
     fun setHtmlText(selectedText: String) {

--- a/WooCommerce/src/main/res/layout/fragment_shipping_customs.xml
+++ b/WooCommerce/src/main/res/layout/fragment_shipping_customs.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/packages_list"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:itemCount="2"
+        tools:listitem="@layout/shipping_customs_list_item" />
+
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/shipping_customs_content_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_customs_content_list_item.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/start_guideline"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        app:layout_constraintGuide_begin="@dimen/major_100" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/end_guideline"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        app:layout_constraintGuide_end="@dimen/major_100" />
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/content_icon"
+        android:layout_width="@dimen/image_minor_50"
+        android:layout_height="@dimen/image_minor_50"
+        android:layout_marginTop="@dimen/major_100"
+        app:layout_constraintBottom_toTopOf="@id/item_description_edit_text"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_gridicons_list_checkmark" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/line_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/major_200"
+        android:textAppearance="?attr/textAppearanceSubtitle1"
+        android:textColor="@color/color_on_surface_high"
+        app:layout_constraintBottom_toBottomOf="@id/content_icon"
+        app:layout_constraintStart_toEndOf="@id/content_icon"
+        app:layout_constraintTop_toTopOf="@id/content_icon"
+        tools:text="Custom Line 1" />
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/expand_icon"
+        android:layout_width="@dimen/image_minor_50"
+        android:layout_height="@dimen/image_minor_50"
+        android:src="@drawable/ic_arrow_down"
+        android:tint="@color/color_on_surface_high"
+        app:layout_constraintBottom_toBottomOf="@id/content_icon"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintTop_toTopOf="@id/content_icon" />
+
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/barrier"
+        android:layout_width="0dp"
+        android:layout_height="@dimen/major_100"
+        app:barrierDirection="bottom"
+        app:barrierMargin="@dimen/major_100"
+        app:constraint_referenced_ids="content_icon, expand_icon, line_title" />
+
+    <androidx.constraintlayout.widget.Group
+        android:id="@+id/details_group"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:visibility="gone"
+        app:constraint_referenced_ids="item_description_edit_text, hs_tariff_number_edit_text, hs_tariff_number_infos, weight_edit_text, value_edit_text, country_spinner, country_description" />
+
+    <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+        android:id="@+id/item_description_edit_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:hint="@string/shipping_label_customs_item_description_hint"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/barrier" />
+
+    <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+        android:id="@+id/hs_tariff_number_edit_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_100"
+        android:hint="@string/shipping_label_customs_hs_tariff_hint"
+        android:inputType="number"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/item_description_edit_text" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/hs_tariff_number_infos"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceBody2"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/hs_tariff_number_edit_text"
+        tools:text="Learn more about HS Tariff number" />
+
+    <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+        android:id="@+id/weight_edit_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_100"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/hs_tariff_number_infos"
+        tools:hint="Weight (oz per unit)" />
+
+    <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+        android:id="@+id/value_edit_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_100"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/weight_edit_text"
+        tools:hint="Value ($ per unit)" />
+
+    <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+        android:id="@+id/country_spinner"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_100"
+        android:hint="@string/shipping_label_customs_origin_country_hint"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/value_edit_text" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/country_description"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginEnd="@dimen/major_100"
+        android:gravity="start"
+        android:text="@string/shipping_label_customs_origin_country_explanation"
+        android:textAppearance="?attr/textAppearanceCaption"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/country_spinner" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/shipping_customs_line_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_customs_line_list_item.xml
@@ -67,12 +67,14 @@
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="@id/end_guideline"
         app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/barrier">
+        app:layout_constraintTop_toBottomOf="@id/barrier"
+        tools:visibility="visible">
 
         <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
             android:id="@+id/item_description_edit_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/major_100"
             android:hint="@string/shipping_label_customs_item_description_hint" />
 
         <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView

--- a/WooCommerce/src/main/res/layout/shipping_customs_line_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_customs_line_list_item.xml
@@ -23,8 +23,7 @@
         android:id="@+id/content_icon"
         android:layout_width="@dimen/image_minor_50"
         android:layout_height="@dimen/image_minor_50"
-        android:layout_marginTop="@dimen/major_100"
-        app:layout_constraintBottom_toTopOf="@id/item_description_edit_text"
+        app:layout_constraintBottom_toBottomOf="@id/barrier"
         app:layout_constraintStart_toStartOf="@id/start_guideline"
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/ic_gridicons_list_checkmark" />
@@ -43,101 +42,84 @@
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/expand_icon"
-        android:layout_width="@dimen/image_minor_50"
-        android:layout_height="@dimen/image_minor_50"
+        android:layout_width="@dimen/image_major_50"
+        android:layout_height="@dimen/image_major_50"
+        android:background="@drawable/ripple_grey_oval"
+        android:padding="@dimen/major_75"
         android:src="@drawable/ic_arrow_down"
         android:tint="@color/color_on_surface_high"
         app:layout_constraintBottom_toBottomOf="@id/content_icon"
-        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@id/content_icon" />
 
     <androidx.constraintlayout.widget.Barrier
         android:id="@+id/barrier"
         android:layout_width="0dp"
-        android:layout_height="@dimen/major_100"
+        android:layout_height="0dp"
         app:barrierDirection="bottom"
-        app:barrierMargin="@dimen/major_100"
         app:constraint_referenced_ids="content_icon, expand_icon, line_title" />
 
-    <androidx.constraintlayout.widget.Group
-        android:id="@+id/details_group"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:visibility="visible"
-        app:constraint_referenced_ids="item_description_edit_text, hs_tariff_number_edit_text, hs_tariff_number_infos, weight_edit_text, value_edit_text, country_spinner, country_description" />
-
-    <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-        android:id="@+id/item_description_edit_text"
+    <LinearLayout
+        android:id="@+id/details_layout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:hint="@string/shipping_label_customs_item_description_hint"
+        android:orientation="vertical"
+        android:visibility="gone"
         app:layout_constraintEnd_toEndOf="@id/end_guideline"
         app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/barrier" />
+        app:layout_constraintTop_toBottomOf="@id/barrier">
 
-    <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-        android:id="@+id/hs_tariff_number_edit_text"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/major_100"
-        android:hint="@string/shipping_label_customs_hs_tariff_hint"
-        android:inputType="number"
-        app:layout_constraintEnd_toEndOf="@id/end_guideline"
-        app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/item_description_edit_text" />
+        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+            android:id="@+id/item_description_edit_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/shipping_label_customs_item_description_hint" />
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/hs_tariff_number_infos"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textAppearance="?attr/textAppearanceBody2"
-        app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/hs_tariff_number_edit_text"
-        tools:text="Learn more about HS Tariff number" />
+        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+            android:id="@+id/hs_tariff_number_edit_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/major_100"
+            android:hint="@string/shipping_label_customs_hs_tariff_hint"
+            android:inputType="number" />
 
-    <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-        android:id="@+id/weight_edit_text"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/major_100"
-        app:layout_constraintEnd_toEndOf="@id/end_guideline"
-        app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/hs_tariff_number_infos"
-        tools:hint="Weight (oz per unit)" />
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/hs_tariff_number_infos"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceBody2"
+            tools:text="Learn more about HS Tariff number" />
 
-    <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-        android:id="@+id/value_edit_text"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/major_100"
-        app:layout_constraintEnd_toEndOf="@id/end_guideline"
-        app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/weight_edit_text"
-        tools:hint="Value ($ per unit)" />
+        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+            android:id="@+id/weight_edit_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/major_100"
+            tools:hint="Weight (oz per unit)" />
 
-    <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-        android:id="@+id/country_spinner"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/major_100"
-        android:hint="@string/shipping_label_customs_origin_country_hint"
-        app:layout_constraintEnd_toEndOf="@id/end_guideline"
-        app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/value_edit_text" />
+        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+            android:id="@+id/value_edit_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/major_100"
+            tools:hint="Value ($ per unit)" />
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/country_description"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/major_100"
-        android:layout_marginEnd="@dimen/major_100"
-        android:layout_marginBottom="@dimen/major_100"
-        android:gravity="start"
-        android:text="@string/shipping_label_customs_origin_country_explanation"
-        android:textAppearance="?attr/textAppearanceCaption"
-        app:layout_constraintEnd_toEndOf="@id/end_guideline"
-        app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/country_spinner"
-        app:layout_constraintBottom_toBottomOf="parent"/>
+        <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+            android:id="@+id/country_spinner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/major_100"
+            android:hint="@string/shipping_label_customs_origin_country_hint" />
 
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/country_description"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginEnd="@dimen/major_100"
+            android:layout_marginBottom="@dimen/major_100"
+            android:gravity="start"
+            android:text="@string/shipping_label_customs_origin_country_explanation"
+            android:textAppearance="?attr/textAppearanceCaption" />
+    </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/shipping_customs_line_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_customs_line_list_item.xml
@@ -63,7 +63,7 @@
         android:id="@+id/details_group"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:visibility="gone"
+        android:visibility="visible"
         app:constraint_referenced_ids="item_description_edit_text, hs_tariff_number_edit_text, hs_tariff_number_infos, weight_edit_text, value_edit_text, country_spinner, country_description" />
 
     <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
@@ -131,11 +131,13 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/major_100"
         android:layout_marginEnd="@dimen/major_100"
+        android:layout_marginBottom="@dimen/major_100"
         android:gravity="start"
         android:text="@string/shipping_label_customs_origin_country_explanation"
         android:textAppearance="?attr/textAppearanceCaption"
         app:layout_constraintEnd_toEndOf="@id/end_guideline"
         app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/country_spinner" />
+        app:layout_constraintTop_toBottomOf="@id/country_spinner"
+        app:layout_constraintBottom_toBottomOf="parent"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/shipping_customs_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_customs_list_item.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.woocommerce.android.widgets.WCElevatedConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/start_guideline"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        app:layout_constraintGuide_begin="@dimen/major_100" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/end_guideline"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        app:layout_constraintGuide_end="@dimen/major_100" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/package_id"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_75"
+        android:textAppearance="?attr/textAppearanceSubtitle1"
+        android:textColor="@color/color_on_surface_high"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Package 1" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/package_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/minor_50"
+        android:textAppearance="@style/TextAppearance.Woo.Body1"
+        app:layout_constraintBaseline_toBaselineOf="@id/package_id"
+        app:layout_constraintStart_toEndOf="@id/package_id"
+        tools:text="- Small Package" />
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:layout_width="@dimen/image_minor_50"
+        android:layout_height="@dimen/image_minor_50"
+        android:src="@drawable/ic_arrow_down"
+        android:tint="@color/color_on_surface_high"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@id/package_id"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintTop_toTopOf="@id/package_id"
+        tools:visibility="visible" />
+
+    <View
+        android:id="@+id/divider_1"
+        style="@style/Woo.Divider"
+        android:layout_marginTop="@dimen/major_75"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/package_name" />
+
+    <com.google.android.material.checkbox.MaterialCheckBox
+        android:id="@+id/return_checkbox"
+        style="@style/Woo.CheckBox"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/shipping_label_customs_return_to_sender"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/divider_1" />
+
+    <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+        android:id="@+id/contents_type_spinner"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_100"
+        android:hint="@string/shipping_label_customs_contents_type_hint"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/return_checkbox" />
+
+    <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+        android:id="@+id/contents_type_description"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_100"
+        android:hint="@string/shipping_label_customs_contents_type_other_hint"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/contents_type_spinner" />
+
+    <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+        android:id="@+id/restriction_type_spinner"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_100"
+        android:hint="@string/shipping_label_customs_restriction_type_hint"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/contents_type_description" />
+
+    <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+        android:id="@+id/restriction_type_description"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_100"
+        android:hint="@string/shipping_label_customs_restriction_type_other_hint"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/restriction_type_spinner" />
+
+    <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+        android:id="@+id/itn_edit_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_100"
+        android:hint="@string/shipping_label_customs_itn_hint"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/restriction_type_description" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/itn_description"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_100"
+        android:textAppearance="?attr/textAppearanceBody2"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/itn_edit_text"
+        tools:text="Learn more about Internal Transaction Number" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/content_section_title"
+        android:layout_width="0dp"
+        android:layout_height="@dimen/major_300"
+        android:layout_marginTop="@dimen/major_100"
+        android:background="@color/default_window_background"
+        android:gravity="center_vertical"
+        android:paddingStart="@dimen/major_100"
+        android:paddingEnd="@dimen/major_100"
+        android:text="@string/shipping_label_customs_package_content"
+        android:textAppearance="?attr/textAppearanceSubtitle2"
+        android:textColor="@color/color_on_surface_disabled"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/itn_description" />
+
+    <View
+        android:id="@+id/divider_2"
+        style="@style/Woo.Divider"
+        android:layout_marginStart="@dimen/major_100"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/content_section_title" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/items_list"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/divider_2"
+        tools:itemCount="1"
+        tools:listitem="@layout/shipping_customs_content_list_item" />
+
+</com.woocommerce.android.widgets.WCElevatedConstraintLayout>

--- a/WooCommerce/src/main/res/layout/shipping_customs_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_customs_list_item.xml
@@ -161,6 +161,6 @@
         android:layout_height="wrap_content"
         app:layout_constraintTop_toBottomOf="@id/divider_2"
         tools:itemCount="1"
-        tools:listitem="@layout/shipping_customs_content_list_item" />
+        tools:listitem="@layout/shipping_customs_line_list_item" />
 
 </com.woocommerce.android.widgets.WCElevatedConstraintLayout>

--- a/WooCommerce/src/main/res/layout/shipping_customs_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_customs_list_item.xml
@@ -64,6 +64,7 @@
         style="@style/Woo.CheckBox"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/minor_100"
         android:text="@string/shipping_label_customs_return_to_sender"
         app:layout_constraintEnd_toEndOf="@id/end_guideline"
         app:layout_constraintStart_toStartOf="@id/start_guideline"

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -288,7 +288,14 @@
             app:enterAnim="@anim/activity_slide_in_from_right"
             app:exitAnim="@anim/activity_slide_out_to_left"
             app:popEnterAnim="@anim/activity_slide_in_from_left"
-            app:popExitAnim="@anim/activity_slide_out_to_right"/>
+            app:popExitAnim="@anim/activity_slide_out_to_right" />
+        <action
+            android:id="@+id/action_createShippingLabelFragment_to_shippingCustomsFragment"
+            app:destination="@id/shippingCustomsFragment"
+            app:enterAnim="@anim/activity_slide_in_from_right"
+            app:exitAnim="@anim/activity_slide_out_to_left"
+            app:popEnterAnim="@anim/activity_slide_in_from_left"
+            app:popExitAnim="@anim/activity_slide_out_to_right" />
     </fragment>
     <fragment
         android:id="@+id/shippingLabelAddressSuggestionFragment"
@@ -347,7 +354,7 @@
             app:enterAnim="@anim/activity_slide_in_from_right"
             app:exitAnim="@anim/activity_slide_out_to_left"
             app:popEnterAnim="@anim/activity_slide_in_from_left"
-            app:popExitAnim="@anim/activity_slide_out_to_right"/>
+            app:popExitAnim="@anim/activity_slide_out_to_right" />
     </fragment>
     <fragment
         android:id="@+id/shippingPackageSelectorFragment"
@@ -362,7 +369,7 @@
         android:id="@+id/editShippingLabelPaymentFragment"
         android:name="com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPaymentFragment"
         android:label="EditShippingLabelPaymentFragment"
-        tools:layout="@layout/fragment_edit_shipping_label_payment"/>
+        tools:layout="@layout/fragment_edit_shipping_label_payment" />
     <fragment
         android:id="@+id/shippingCarrierRatesFragment"
         android:name="com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrierRatesFragment"
@@ -395,6 +402,10 @@
     <dialog
         android:id="@+id/cardReaderConnectDialog"
         android:name="com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectFragment"
-        android:label="CardReaderConnectDialog">
-    </dialog>
+        android:label="CardReaderConnectDialog"></dialog>
+    <fragment
+        android:id="@+id/shippingCustomsFragment"
+        android:name="com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustomsFragment"
+        android:label="ShippingCustomsFragment"
+        tools:layout="@layout/fragment_shipping_customs" />
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -501,6 +501,17 @@
     <string name="shipping_label_rate_included_options_signature_required_free">Eligible for free signature requirement</string>
     <string name="shipping_label_selected_rates_description">%s rates selected</string>
     <string name="shipping_label_selected_rates_total_description">%s total</string>
+    <string name="shipping_label_customs_return_to_sender">Return to sender if package is unabled to be delivered</string>
+    <string name="shipping_label_customs_contents_type_hint">Contents type</string>
+    <string name="shipping_label_customs_restriction_type_hint">Restriction type</string>
+    <string name="shipping_label_customs_contents_type_other_hint">Contents details</string>
+    <string name="shipping_label_customs_restriction_type_other_hint">Restriction details</string>
+    <string name="shipping_label_customs_itn_hint" translatable="false">ITN</string>
+    <string name="shipping_label_customs_package_content">Package content</string>
+    <string name="shipping_label_customs_item_description_hint">Description</string>
+    <string name="shipping_label_customs_hs_tariff_hint">HS Tariff number (Optional)</string>
+    <string name="shipping_label_customs_origin_country_hint">Origin country</string>
+    <string name="shipping_label_customs_origin_country_explanation">Country where the product was manufactured or assembled</string>
     <!--
             Refunds
         -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -512,6 +512,15 @@
     <string name="shipping_label_customs_hs_tariff_hint">HS Tariff number (Optional)</string>
     <string name="shipping_label_customs_origin_country_hint">Origin country</string>
     <string name="shipping_label_customs_origin_country_explanation">Country where the product was manufactured or assembled</string>
+    <string name="shipping_label_customs_contents_type_merchandise">Merchandise</string>
+    <string name="shipping_label_customs_contents_type_documents">Documents</string>
+    <string name="shipping_label_customs_contents_type_gifts">Gifts</string>
+    <string name="shipping_label_customs_contents_type_sample">Sample</string>
+    <string name="shipping_label_customs_contents_type_other">Other</string>
+    <string name="shipping_label_customs_restriction_type_none">None</string>
+    <string name="shipping_label_customs_restriction_type_quarantine">Quarantine</string>
+    <string name="shipping_label_customs_restriction_type_sanitary_inspection">Sanitary / Phytosanitary inspection</string>
+    <string name="shipping_label_customs_restriction_type_other">Other</string>
     <!--
             Refunds
         -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -521,6 +521,9 @@
     <string name="shipping_label_customs_restriction_type_quarantine">Quarantine</string>
     <string name="shipping_label_customs_restriction_type_sanitary_inspection">Sanitary / Phytosanitary inspection</string>
     <string name="shipping_label_customs_restriction_type_other">Other</string>
+    <string name="shipping_label_customs_line_item">Custom Line %1$d</string>
+    <string name="shipping_label_customs_learn_more_itn">%1$s about Internal Transaction Number</string>
+    <string name="shipping_label_customs_learn_more_hs_tariff_number">%1$s about HS Tariff number</string>
     <!--
             Refunds
         -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -47,7 +47,7 @@
     <string name="cancel">Cancel</string>
     <string name="keep_editing">Keep editing</string>
     <string name="keep_changes">Keep changes</string>
-    <string name="learn_more">Learn More</string>
+    <string name="learn_more">Learn more</string>
     <string name="try_it_now">Try it now</string>
     <string name="offline_message">Offline \u2014 using cached data</string>
     <string name="offline_error">Your network is unavailable. Check your data or wifi connection.</string>


### PR DESCRIPTION
Part 2 of #3526, this adds the UI implementation for the customs screen, this doesn't implement any interaction with the UI, nor loading real data, those will be handled in a separate PR, as this one is already big.

|  |  |
|----|-----|
|![Screenshot_1621617535](https://user-images.githubusercontent.com/1657201/119174908-12817480-ba61-11eb-8d64-84ccc9feb42c.png)|![Screenshot_1621617651](https://user-images.githubusercontent.com/1657201/119175058-49f02100-ba61-11eb-91b0-811f8ac36bbe.png)|

#### Testing
1. Open order details of an order that's eligible for shipping label creation.
2. Click on Create shipping label.
3. Notice that the customs step is visible on debug builds.
4. Pass the first step.
5. Click on Continue in the customs step.
6. Check the UI (all data is fake for now).
7. Confirm that there is no regression in the other parts of the shipping labels form is enough (for this step, please note that the order has to be destined to US for the purchase to work)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
