### PR TITLE
issue/3549-unanchored-wip

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -33,7 +33,6 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/minor_00"
             android:visibility="gone"
-            app:layout_constraintBottom_toTopOf="@id/productsRecycler"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/products_wip_card"
@@ -49,8 +48,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/products_sort_filter_card"
             tools:itemCount="5"
-            tools:listitem="@layout/product_list_item"
-            tools:visibility="visible" />
+            tools:listitem="@layout/product_list_item" />
 
         <com.woocommerce.android.widgets.WCEmptyView
             android:id="@+id/empty_view"


### PR DESCRIPTION
Closes #3549 - To test, pull `develop` and replace [this line](https://github.com/woocommerce/woocommerce-android/blob/0821552ebc66e4f352c00e8046382979731e72d2/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt#L276) with:

```
showSkeleton(true)
```

Then go to the product list and notice how the WIP and filter views appear untethered. 

![wip](https://user-images.githubusercontent.com/3903757/119364194-a67b5800-bc7c-11eb-93be-afb7c6d69f51.png)

Next, pull this branch, make the same change, and notice those two views appear correctly.

![wip2](https://user-images.githubusercontent.com/3903757/119364629-17227480-bc7d-11eb-9256-2af9ba1e6962.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
