### PR TITLE
issue/4084-product-list-empty-view

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 6.8
 -----
+- [**] Fixed bug that caused a jumbled screen the very first time the product list is viewed. [https://github.com/woocommerce/woocommerce-android/pull/4090]
 
 
 6.7

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -187,7 +187,7 @@ class ProductListViewModel @AssistedInject constructor(
         _productList.value = products
 
         viewState = viewState.copy(
-            isEmptyViewVisible = products.isEmpty() && viewState.isLoading != true,
+            isEmptyViewVisible = products.isEmpty() && viewState.isSkeletonShown != true,
             displaySortAndFilterCard = products.isNotEmpty() || productFilterOptions.isNotEmpty()
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -179,7 +179,7 @@ class ProductListViewModel @AssistedInject constructor(
         refreshProducts()
     }
 
-    final fun reloadProductsFromDb(excludeProductId: Long? = null) {
+    fun reloadProductsFromDb(excludeProductId: Long? = null) {
         val excludedProductIds: List<Long>? = excludeProductId?.let { id ->
             ArrayList<Long>().also { it.add(id) }
         }
@@ -187,7 +187,7 @@ class ProductListViewModel @AssistedInject constructor(
         _productList.value = products
 
         viewState = viewState.copy(
-            isEmptyViewVisible = products.isEmpty(),
+            isEmptyViewVisible = products.isEmpty() && viewState.isLoading != true,
             displaySortAndFilterCard = products.isNotEmpty() || productFilterOptions.isNotEmpty()
         )
     }

--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -58,7 +58,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/products_wip_card"
+            app:layout_constraintTop_toTopOf="parent"
             tools:visibility="gone" />
 
         <ProgressBar

--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -58,8 +58,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:visibility="gone" />
+            app:layout_constraintTop_toTopOf="parent" />
 
         <ProgressBar
             android:id="@+id/loadMoreProgress"


### PR DESCRIPTION
Fixes #4084 - to test:

- Pull `develop`
- Login
- Switch to the product list
- Notice the "No products yet" empty view appears even though the loading skeleton is showing

Then:

- Pull this branch, repeat the steps, and notice the empty view no longer appears over the skeleton

I recommend testing this with a store that has no products to ensure the empty view does appear once the skeleton goes away.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
