### PR TITLE
Issue/3725 Disconnect from a reader

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
@@ -31,12 +31,15 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.utils.AppLogWrapper
+import org.wordpress.android.util.AppLog.T
 import javax.inject.Inject
 import kotlin.math.roundToInt
 
 @HiltViewModel
 class CardReaderDetailViewModel @Inject constructor(
     val cardReaderManager: CardReaderManager,
+    private val appLogWrapper: AppLogWrapper,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
     private val viewState = MutableLiveData<ViewState>(Loading)
@@ -115,7 +118,10 @@ class CardReaderDetailViewModel @Inject constructor(
     private fun onDisconnectClicked() {
         launch {
             val disconnectionResult = cardReaderManager.disconnectReader()
-            if (!disconnectionResult) showNotConnectedState()
+            if (!disconnectionResult) {
+                appLogWrapper.e(T.MAIN, "Disconnection from reader has failed")
+                showNotConnectedState()
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
@@ -47,10 +47,14 @@ class CardReaderDetailViewModel @Inject constructor(
             cardReaderManager.readerStatus.collect { status ->
                 when (status) {
                     is Connected -> checkForUpdates()
-                    else -> viewState.value = NotConnectedState(onPrimaryActionClicked = ::onConnectBtnClicked)
+                    else -> showNotConnectedState()
                 }
             }.exhaustive
         }
+    }
+
+    private fun showNotConnectedState() {
+        viewState.value = NotConnectedState(onPrimaryActionClicked = ::onConnectBtnClicked)
     }
 
     private suspend fun checkForUpdates() {
@@ -109,7 +113,10 @@ class CardReaderDetailViewModel @Inject constructor(
     }
 
     private fun onDisconnectClicked() {
-        // TODO cardreader implement disconnect functionality
+        launch {
+            val disconnectionResult = cardReaderManager.disconnectReader()
+            if (!disconnectionResult) showNotConnectedState()
+        }
     }
 
     fun onUpdateResult(updateResult: UpdateResult) {

--- a/WooCommerce/src/release/kotlin/com/woocommerce/android/di/CardReaderModule.kt
+++ b/WooCommerce/src/release/kotlin/com/woocommerce/android/di/CardReaderModule.kt
@@ -35,6 +35,7 @@ class CardReaderModule {
         override fun discoverReaders(isSimulated: Boolean): Flow<CardReaderDiscoveryEvents> = flow {}
 
         override suspend fun connectToReader(cardReader: CardReader): Boolean = false
+        override suspend fun disconnectReader(): Boolean = false
 
         override suspend fun collectPayment(
             orderId: Long,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
@@ -236,6 +236,36 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
         assertThat(viewModel.event.value).isNull()
     }
 
+    @Test
+    fun `when on disconnect button clicked with success should do nothing`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            initConnectedState()
+            whenever(cardReaderManager.disconnectReader()).thenReturn(true)
+            val viewModel = createViewModel()
+
+            // WHEN
+            (viewModel.viewStateData.value as ConnectedState).primaryButtonState!!.onActionClicked()
+
+            // THEN
+            assertThat(viewModel.viewStateData.value).isInstanceOf(ConnectedState::class.java)
+        }
+
+    @Test
+    fun `when on disconnect button clicked with fail should change to not connected state`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            initConnectedState()
+            whenever(cardReaderManager.disconnectReader()).thenReturn(false)
+            val viewModel = createViewModel()
+
+            // WHEN
+            (viewModel.viewStateData.value as ConnectedState).primaryButtonState!!.onActionClicked()
+
+            // THEN
+            assertThat(viewModel.viewStateData.value).isInstanceOf(NotConnectedState::class.java)
+        }
+
     private fun verifyNotConnectedState(viewModel: CardReaderDetailViewModel) {
         val state = viewModel.viewStateData.value as NotConnectedState
         assertThat(state.headerLabel)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
@@ -321,6 +321,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     private fun createViewModel() = CardReaderDetailViewModel(
         cardReaderManager,
+        mock(),
         SavedStateHandle()
     )
 

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -81,6 +81,12 @@ internal class CardReaderManagerImpl(
         return connectionManager.connectToReader(cardReader)
     }
 
+    override suspend fun disconnectReader(): Boolean {
+        if (!terminal.isInitialized()) throw IllegalStateException("Terminal not initialized")
+        if (terminal.getConnectedReader() == null) return false
+        return connectionManager.disconnectReader()
+    }
+
     override suspend fun collectPayment(orderId: Long, amount: BigDecimal, currency: String): Flow<CardPaymentStatus> =
         paymentManager.acceptPayment(orderId, amount, currency)
 

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.cardreader.internal.connection
 
+import com.stripe.stripeterminal.callable.Callback
 import com.stripe.stripeterminal.callable.ReaderCallback
 import com.stripe.stripeterminal.callable.TerminalListener
 import com.stripe.stripeterminal.model.external.ConnectionStatus
@@ -60,6 +61,18 @@ internal class ConnectionManager(
                 }
             })
         }
+    }
+
+    suspend fun disconnectReader() = suspendCoroutine<Boolean> { continuation ->
+        terminal.disconnectReader(object : Callback {
+            override fun onFailure(e: TerminalException) {
+                continuation.resume(false)
+            }
+
+            override fun onSuccess() {
+                continuation.resume(true)
+            }
+        })
     }
 
     override fun onUnexpectedReaderDisconnect(reader: Reader) {

--- a/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/wrappers/TerminalWrapper.kt
+++ b/libs/cardreader/src/debug/java/com/woocommerce/android/cardreader/internal/wrappers/TerminalWrapper.kt
@@ -44,6 +44,9 @@ internal class TerminalWrapper {
     fun connectToReader(reader: Reader, callback: ReaderCallback) =
         Terminal.getInstance().connectReader(reader, callback)
 
+    fun disconnectReader(callback: Callback) =
+        Terminal.getInstance().disconnectReader(callback)
+
     fun createPaymentIntent(params: PaymentIntentParameters, callback: PaymentIntentCallback) =
         Terminal.getInstance().createPaymentIntent(params, callback)
 

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
@@ -14,6 +14,7 @@ interface CardReaderManager {
     fun initialize(app: Application)
     fun discoverReaders(isSimulated: Boolean): Flow<CardReaderDiscoveryEvents>
     suspend fun connectToReader(cardReader: CardReader): Boolean
+    suspend fun disconnectReader(): Boolean
 
     // TODO cardreader Stripe accepts only Int, is that ok?
     suspend fun collectPayment(orderId: Long, amount: BigDecimal, currency: String): Flow<CardPaymentStatus>

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -112,4 +113,44 @@ class CardReaderManagerImplTest {
 
         verify(softwareUpdateManager).softwareUpdateStatus()
     }
+
+    @Test
+    fun `given terminal not initialized when disconnect from reader, then exception is thrown`() {
+        whenever(terminalWrapper.isInitialized()).thenReturn(false)
+
+        assertThatIllegalStateException().isThrownBy {
+            runBlockingTest {
+                cardReaderManager.disconnectReader()
+            }
+        }
+    }
+
+    @Test
+    fun `given terminal initialized and no connected reader when disconnect from reader then return false`() =
+        runBlockingTest {
+            whenever(terminalWrapper.isInitialized()).thenReturn(true)
+            whenever(terminalWrapper.getConnectedReader()).thenReturn(null)
+
+            assertThat(cardReaderManager.disconnectReader()).isFalse()
+        }
+
+    @Test
+    fun `given terminal initialized and connected reader and success when disconnect from reader then return true`() =
+        runBlockingTest {
+            whenever(terminalWrapper.isInitialized()).thenReturn(true)
+            whenever(terminalWrapper.getConnectedReader()).thenReturn(mock())
+            whenever(connectionManager.disconnectReader()).thenReturn(true)
+
+            assertThat(cardReaderManager.disconnectReader()).isTrue()
+        }
+
+    @Test
+    fun `given terminal initialized and connected reader and fail when disconnect from reader then return false`() =
+        runBlockingTest {
+            whenever(terminalWrapper.isInitialized()).thenReturn(true)
+            whenever(terminalWrapper.getConnectedReader()).thenReturn(mock())
+            whenever(connectionManager.disconnectReader()).thenReturn(false)
+
+            assertThat(cardReaderManager.disconnectReader()).isFalse()
+        }
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.cardreader.internal.connection
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
+import com.stripe.stripeterminal.callable.Callback
 import com.stripe.stripeterminal.callable.ReaderCallback
 import com.stripe.stripeterminal.model.external.ConnectionStatus.CONNECTED
 import com.stripe.stripeterminal.model.external.ConnectionStatus.CONNECTING
@@ -130,6 +131,28 @@ class ConnectionManagerTest {
         }
 
         val result = connectionManager.connectToReader(CardReaderImpl(mock()))
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `when disconnect succeeds, then true is returned`() = runBlockingTest {
+        whenever(terminalWrapper.disconnectReader(any())).thenAnswer {
+            (it.arguments[0] as Callback).onSuccess()
+        }
+
+        val result = connectionManager.disconnectReader()
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `when disconnect fails, then false is returned`() = runBlockingTest {
+        whenever(terminalWrapper.disconnectReader(any())).thenAnswer {
+            (it.arguments[0] as Callback).onFailure(mock())
+        }
+
+        val result = connectionManager.disconnectReader()
 
         assertThat(result).isFalse()
     }


### PR DESCRIPTION
Parent issue #3725 

merge after https://github.com/woocommerce/woocommerce-android/pull/4082

PR implements disconnection from a reader functionality.

### How to test
Connect to a reader via settings -> click the disconnect button

https://user-images.githubusercontent.com/4923871/119793400-391b3180-bedf-11eb-8296-6bea34907172.mp4

