### PR TITLE
Issue/3725 Fix wrong battery display

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
@@ -133,7 +133,7 @@ class CardReaderDetailViewModel @Inject constructor(
         return currentBatteryLevel?.let {
             UiStringRes(
                 R.string.card_reader_detail_connected_battery_percentage,
-                listOf(UiStringText(it.roundToInt().toString()))
+                listOf(UiStringText((it * 100).roundToInt().toString()))
             )
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
@@ -72,7 +72,25 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
             verifyConnectedState(
                 viewModel,
                 UiStringText(READER_NAME),
-                UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("2"))),
+                UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("65"))),
+                updateAvailable = false
+            )
+        }
+
+    @Test
+    fun `when view model init with connected state and battery should emit correct values of connected state`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            initConnectedState(batteryLevel = 0.325f)
+
+            // WHEN
+            val viewModel = createViewModel()
+
+            // THEN
+            verifyConnectedState(
+                viewModel,
+                UiStringText(READER_NAME),
+                UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("33"))),
                 updateAvailable = false
             )
         }
@@ -162,7 +180,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
             verifyConnectedState(
                 viewModel,
                 UiStringText(READER_NAME),
-                UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("2"))),
+                UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("65"))),
                 updateAvailable = true
             )
         }
@@ -180,7 +198,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
             verifyConnectedState(
                 viewModel,
                 UiStringText(READER_NAME),
-                UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("2"))),
+                UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("65"))),
                 updateAvailable = false
             )
             assertThat(viewModel.event.value)
@@ -277,7 +295,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     private fun initConnectedState(
         readersName: String? = READER_NAME,
-        batteryLevel: Float? = 1.6F,
+        batteryLevel: Float? = 0.65F,
         updateAvailable: SoftwareUpdateAvailability = SoftwareUpdateAvailability.UpToDate
     ) = coroutinesTestRule.testDispatcher.runBlockingTest {
         val reader: CardReader = mock {


### PR DESCRIPTION
I was thinking that 1.0 it's 1% but that's wrong:

```
The reader's battery level, represented as a boxed float in the range [0, 1]. If the reader does not have a battery, or the battery level is unknown, this value is nil. (Chipper 2X and WisePad 3 only.)
```

Here is a fix for this bug.


### How to test
Just open "connected state" via settings

https://user-images.githubusercontent.com/4923871/119806193-a4b6cc00-beea-11eb-9512-2d91c9c9a141.mp4

