### PR TITLE
issue/4114-auth-error-crash-fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -142,7 +142,9 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
             dispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(FetchSitesPayload()))
 
             // Update the user info for the currently logged in user
-            userEligibilityFetcher.fetchUserEligibility()
+            if (selectedSite.exists()) {
+                userEligibilityFetcher.fetchUserEligibility()
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #4114 by ensuring we check if the site exists before fetching the user role (since we need the site id). This fix should be fine because once a site is selected, we fetch the user role in `SitePickerActivity` anyway so this should not break any existing functionality.

### To test
@hichamboushaba was able to reproduce this crash.

- Logout from the app.
- Login.
- Don't select a store, kill the app.
- Re-open the app.
- Notice the crash.
- Pull the changes from this PR.
- Follow the same steps again and notice the app no longer crashes.

cc @AliSoftware this would require another beta release, once merged. Thank you 🙏 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
