### PR TITLE
Shipping Labels: update the logic of steps in the state machine

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -486,7 +486,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
     ) : Parcelable {
         @IgnoredOnParcel
         val isInternationalShipment
-            get() = stepsState.originAddressStep.data.country != stepsState.shippingAddressStep.data.country
+            get() = stepsState.isInternational
     }
 
     /**
@@ -540,63 +540,41 @@ class ShippingLabelsStateMachine @Inject constructor() {
         val customsStep: CustomsStep,
         val carrierStep: CarrierStep,
         val paymentsStep: PaymentsStep
-    ) : Parcelable {
+    ) : Parcelable, Iterable<Step<out Any?>> {
         @IgnoredOnParcel
         val isInternational
             get() = originAddressStep.data.country != shippingAddressStep.data.country
+
+        @IgnoredOnParcel
+        private val backingList = listOf(
+            originAddressStep,
+            shippingAddressStep,
+            packagingStep,
+            customsStep,
+            carrierStep,
+            paymentsStep
+        ).filter { it.isVisible }
+
         @Suppress("UNCHECKED_CAST")
         fun <T> updateStep(currentStep: Step<T>, newData: T): StepsState {
-            return if (currentStep.status == DONE) {
-                editStep(currentStep, newData)
-            } else {
-                completeStep(currentStep, newData)
-            }
-        }
-
-        private fun <T> completeStep(currentStep: Step<T>, newData: T): StepsState {
             return when (currentStep) {
                 is OriginAddressStep -> copy(
-                    originAddressStep = originAddressStep.copy(status = DONE, data = newData as Address),
-                    shippingAddressStep = shippingAddressStep.copy(status = READY),
-                    customsStep = customsStep.copy(
-                        isVisible = (newData as Address).country != shippingAddressStep.data.country
-                    )
+                    originAddressStep = originAddressStep.copy(status = DONE, data = newData as Address)
                 )
-                is ShippingAddressStep -> {
-                    val shipmentChangedToInternational = !isInternational &&
-                        (newData as Address).country != shippingAddressStep.data.country
-                    copy(
-                        shippingAddressStep = shippingAddressStep.copy(
-                            status = DONE,
-                            data = newData as Address
-                        ),
-                        packagingStep = packagingStep.copy(status = READY),
-                        customsStep = customsStep.copy(
-                            isVisible = (newData as Address).country != originAddressStep.data.country
-                        )
-                    ).invalidateOriginAddressIfNeeded(shipmentChangedToInternational)
-                }
-                is PackagingStep -> {
-                    val newPackagingStep = packagingStep.copy(
-                        status = DONE,
-                        data = newData as List<ShippingLabelPackage>
-                    )
-                    if (customsStep.isVisible) {
-                        copy(
-                            packagingStep = newPackagingStep,
-                            customsStep = customsStep.copy(status = READY)
-                        )
-                    } else {
-                        copy(
-                            packagingStep = newPackagingStep,
-                            carrierStep = carrierStep.copy(status = READY)
-                        )
-                    }
-                }
+                    .invalidateCarrierStep()
+                is ShippingAddressStep -> copy(
+                    shippingAddressStep = shippingAddressStep.copy(status = DONE, data = newData as Address)
+                )
+                    .invalidateCarrierStep()
+                is PackagingStep -> copy(
+                    packagingStep = packagingStep.copy(status = DONE, data = newData as List<ShippingLabelPackage>)
+                )
+                    .invalidateCustomsStep()
+                    .invalidateCarrierStep()
                 is CustomsStep -> copy(
-                    customsStep = customsStep.copy(status = DONE, data = newData as List<CustomsPackage>),
-                    carrierStep = carrierStep.copy(status = READY)
+                    customsStep = customsStep.copy(status = DONE, data = newData as List<CustomsPackage>)
                 )
+                    .invalidateCarrierStep()
                 is CarrierStep -> {
                     val paymentStatus = if (paymentsStep.data == null) READY else DONE
                     copy(
@@ -608,59 +586,70 @@ class ShippingLabelsStateMachine @Inject constructor() {
                     paymentsStep = paymentsStep.copy(status = DONE, data = newData as PaymentMethod)
                 )
             }
+                .updateForInternationalRequirements()
+                .calculateNextStep()
+                .fixStates()
         }
 
-        private fun <T> editStep(currentStep: Step<T>, newData: T): StepsState {
-            if (currentStep.data == newData) return this
-            return when (currentStep) {
-                is OriginAddressStep -> copy(originAddressStep = originAddressStep.copy(data = newData as Address))
-                    .invalidateCustomsStepIfNeeded()
-                    .invalidateCarrierStepIfNeeded()
-                is ShippingAddressStep -> {
-                    val shipmentChangedToInternational = !isInternational &&
-                        (newData as Address).country != shippingAddressStep.data.country
-                    copy(shippingAddressStep = shippingAddressStep.copy(data = newData as Address))
-                        .invalidateOriginAddressIfNeeded(shipmentChangedToInternational)
-                        .invalidateCustomsStepIfNeeded()
-                        .invalidateCarrierStepIfNeeded()
-                }
-                is PackagingStep ->
-                    copy(packagingStep = packagingStep.copy(data = newData as List<ShippingLabelPackage>))
-                        .invalidateCustomsStepIfNeeded()
-                        .invalidateCarrierStepIfNeeded()
-                is CustomsStep -> copy(customsStep = customsStep.copy(data = newData as List<CustomsPackage>))
-                    .invalidateCarrierStepIfNeeded()
-                is CarrierStep -> copy(carrierStep = carrierStep.copy(data = newData as List<ShippingRate>))
-                is PaymentsStep -> copy(paymentsStep = paymentsStep.copy(data = newData as PaymentMethod))
-            }
+        private fun updateForInternationalRequirements(): StepsState {
+            val originAddressStep = if (isInternational && !originAddressStep.data.phoneHas10Digits()) {
+                originAddressStep.copy(status = READY)
+            } else originAddressStep
+            val customsStep = customsStep.copy(
+                isVisible = isInternational,
+                data = if (isInternational) customsStep.data else null
+            )
+            return copy(
+                originAddressStep = originAddressStep,
+                customsStep = customsStep
+            )
         }
 
-        /**
-         * When a shipment becomes international, we need to check whether the origin address had a valid phone number
-         * or not, otherwise we need to invalidate it
-         */
-        private fun invalidateOriginAddressIfNeeded(shipmentChangedToInternational: Boolean): StepsState {
-            if (!shipmentChangedToInternational || originAddressStep.data.phoneHas10Digits()) return this
-            return copy(originAddressStep = originAddressStep.copy(status = READY))
-        }
-
-        private fun invalidateCarrierStepIfNeeded(): StepsState {
-            val carrierStep = if (carrierStep.status == DONE || carrierStep.status == READY) {
-                val newStatus = if (customsStep.isVisible && customsStep.status != DONE) NOT_READY else READY
-                carrierStep.copy(status = newStatus, data = emptyList())
-            } else {
-                val isReady = if (customsStep.isVisible) customsStep.status == DONE else packagingStep.status == DONE
-                carrierStep.copy(status = if (isReady) READY else NOT_READY)
-            }
+        private fun invalidateCarrierStep(): StepsState {
+            val carrierStep = carrierStep.copy(data = emptyList(), status = NOT_READY)
             return copy(carrierStep = carrierStep)
         }
 
-        private fun invalidateCustomsStepIfNeeded(): StepsState {
-            val customsStep = if (customsStep.status == DONE) {
-                customsStep.copy(status = READY, isVisible = isInternational, data = null)
-            } else customsStep.copy(isVisible = isInternational)
+        private fun invalidateCustomsStep(): StepsState {
+            val customsStep = customsStep.copy(data = null, status = NOT_READY)
             return copy(customsStep = customsStep)
         }
+
+        private fun calculateNextStep(): StepsState {
+            val nextStep = indexOfFirst { it.status != DONE }
+            return if (nextStep != -1) updateStepStatus(get(nextStep), READY) else this
+        }
+
+        /**
+         * Updates the steps so that only one step is READY at each time
+         */
+        private fun fixStates(): StepsState {
+            val indexOfReadyState = indexOfFirst { it.status == READY }
+            var updatedStates = this
+            for (i in indexOfReadyState + 1 until backingList.size) {
+                val step = get(i)
+                if (step.status == DONE) continue
+                updatedStates = updatedStates.updateStepStatus(step, NOT_READY)
+            }
+            return updatedStates
+        }
+
+        private fun <T> updateStepStatus(step: Step<T>, newStatus: StepStatus): StepsState {
+            return when (step) {
+                is OriginAddressStep -> copy(originAddressStep = originAddressStep.copy(status = newStatus))
+                is ShippingAddressStep -> copy(shippingAddressStep = shippingAddressStep.copy(status = newStatus))
+                is PackagingStep -> copy(packagingStep = packagingStep.copy(status = newStatus))
+                is CustomsStep -> copy(customsStep = customsStep.copy(status = newStatus))
+                is CarrierStep -> copy(carrierStep = carrierStep.copy(status = newStatus))
+                is PaymentsStep -> copy(paymentsStep = paymentsStep.copy(status = newStatus))
+            }
+        }
+
+        override fun iterator(): Iterator<Step<out Any?>> {
+            return backingList.iterator()
+        }
+
+        operator fun get(index: Int): Step<out Any?> = backingList[index]
     }
 
     enum class StepStatus {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
@@ -135,6 +135,10 @@ class ShippingLabelsStateMachineTest : BaseUnitTest() {
 
         stateMachine.start(order.toString())
         stateMachine.handleEvent(Event.DataLoaded(order, originAddress, shippingAddress, null))
+        stateMachine.handleEvent(Event.OriginAddressValidationStarted)
+        stateMachine.handleEvent(Event.AddressValidated(originAddress))
+        stateMachine.handleEvent(Event.ShippingAddressValidationStarted)
+        stateMachine.handleEvent(Event.AddressValidated(shippingAddress))
         stateMachine.handleEvent(Event.PackageSelectionStarted)
 
         assertThat(stateMachine.transitions.value.sideEffect).isEqualTo(SideEffect.ShowPackageOptions(emptyList()))
@@ -142,6 +146,8 @@ class ShippingLabelsStateMachineTest : BaseUnitTest() {
         stateMachine.handleEvent(Event.PackagesSelected(packagesList))
 
         val newStepsState = data.stepsState.copy(
+            originAddressStep = data.stepsState.originAddressStep.copy(status = DONE),
+            shippingAddressStep = data.stepsState.shippingAddressStep.copy(status = DONE),
             packagingStep = data.stepsState.packagingStep.copy(status = DONE, data = packagesList),
             carrierStep = data.stepsState.carrierStep.copy(status = READY)
         )


### PR DESCRIPTION
The current behavior of the state machine is that after finishing or editing each step, we will update the state of a pre-defined next state, this makes managing the changes of steps that may impact past "done" steps harder.
This PR updates this logic to the following steps:

1. There is no difference between finishing a step, or editing it, both will change the `status` to `Done`, and save the `newData`.
2. After updating a step, we invalidate the data of the other steps that depend on it, for example: changing the `packaging` step would require invalidating the `customs` and `carriers` steps.
3. We refresh the state of both `customs` and `originAddress` according to wether the shipment is international or not.
3. Then we calculate the next step to mark it as `Ready`, we find it by searching the first step in the list that's not `Done` yet, and we change its state to `Ready`.
4. The last thing to do is a bit of cleanup to make sure that only one step is `Ready` at each moment, so we iterate over the list, and check if there any steps that have the state `Ready` except the correct one, and fix them.

This implements what @Garance91540 suggested here:  p1622477175152100/1614252487.023600-slack-CGPNUU63E

Please don't merge until #4103 is merged.

#### Result
|Test|Screencast|
|----|-----------|
|Change destination country|<img width=400 src="https://user-images.githubusercontent.com/1657201/120357407-51cf8100-c2fd-11eb-867b-def626e0e146.gif"/>|
|Edit destination country after finishing packages step|<img width=400 src="https://user-images.githubusercontent.com/1657201/120357527-7297d680-c2fd-11eb-9b02-96a12081d5fb.gif"/>|
|Change shipment to national|<img width=400 src="https://user-images.githubusercontent.com/1657201/120357778-b8549f00-c2fd-11eb-93f9-5157aededd1b.gif"/>|
|Change packages for an international shipment|<img width=400 src="https://user-images.githubusercontent.com/1657201/120357912-d9b58b00-c2fd-11eb-8ddc-be8e7f5078a2.gif"/>|

#### Testing
I don't have exact specific steps to outline, just test different scenarios like the one described above, and confirm that the state is correct after them.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.