### PR TITLE
Shipping Labels: multiple bug fixes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -37,6 +37,7 @@ import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.model.order.toIdSet
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.LabelItem
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.AddOrderShipmentTrackingPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.DeleteOrderShipmentTrackingPayload
@@ -133,7 +134,7 @@ class OrderDetailRepository @Inject constructor(
         } else VALUE_API_SUCCESS
         AnalyticsTracker.track(Stat.SHIPPING_LABEL_API_REQUEST, mapOf(KEY_FEEDBACK_ACTION to action))
 
-        return result.model?.map { it.toAppModel() } ?: emptyList()
+        return result.model?.filter { it.status == LabelItem.STATUS_PURCHASED }?.map { it.toAppModel() } ?: emptyList()
     }
 
     suspend fun updateOrderStatus(
@@ -267,7 +268,9 @@ class OrderDetailRepository @Inject constructor(
         orderStore.getShipmentTrackingsForOrder(selectedSite.get(), localOrderId).map { it.toAppModel() }
 
     fun getOrderShippingLabels(remoteOrderId: Long) = shippingLabelStore
-        .getShippingLabelsForOrder(selectedSite.get(), remoteOrderId).map { it.toAppModel() }
+        .getShippingLabelsForOrder(selectedSite.get(), remoteOrderId)
+        .filter { it.status == LabelItem.STATUS_PURCHASED }
+        .map { it.toAppModel() }
 
     fun getWooServicesPluginInfo(): WooPlugin {
         val info = wooCommerceStore.getWooCommerceServicesPluginInfo(selectedSite.get())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
@@ -178,13 +178,19 @@ class ShippingLabelRepository @Inject constructor(
                 products = labelPackage.items.map { it.productId }
             )
         }
+        // Retrieve account settings, normally they should be cached at this point, and the response would be
+        // instantaneous
+        // We fallback to true as it's the default value in the plugin
+        val emailReceipts = getAccountSettings().model?.isEmailReceiptEnabled ?: true
+
         return shippingLabelStore.purchaseShippingLabels(
             site = selectedSite.get(),
             orderId = orderId,
             origin = origin.toShippingLabelModel(),
             destination = destination.toShippingLabelModel(),
             packagesData = packagesData,
-            customsData = null
+            customsData = null,
+            emailReceipts = emailReceipts
         ).let { result ->
             when {
                 result.isError -> WooResult(result.error)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesViewModel.kt
@@ -94,7 +94,7 @@ class ShippingCarrierRatesViewModel @Inject constructor(
 
             val banner = when {
                 arguments.order.shippingLines.isEmpty() -> null
-                arguments.order.shippingTotal == BigDecimal.ZERO -> resourceProvider.getString(
+                arguments.order.shippingTotal.isEqualTo(BigDecimal.ZERO) -> resourceProvider.getString(
                     R.string.shipping_label_shipping_carrier_shipping_method_banner_message,
                     arguments.order.shippingLines.first().methodTitle
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesViewModel.kt
@@ -92,9 +92,13 @@ class ShippingCarrierRatesViewModel @Inject constructor(
         } else {
             updateRates(generateRateModels(carrierRatesResult.model!!))
 
-            var banner: String? = null
-            if (arguments.order.shippingTotal > BigDecimal.ZERO && arguments.order.shippingLines.isNotEmpty()) {
-                banner = resourceProvider.getString(
+            val banner = when {
+                arguments.order.shippingLines.isEmpty() -> null
+                arguments.order.shippingTotal == BigDecimal.ZERO -> resourceProvider.getString(
+                    R.string.shipping_label_shipping_carrier_shipping_method_banner_message,
+                    arguments.order.shippingLines.first().methodTitle
+                )
+                else -> resourceProvider.getString(
                     R.string.shipping_label_shipping_carrier_flat_fee_banner_message,
                     arguments.order.shippingLines.first().methodTitle,
                     arguments.order.shippingTotal.format()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesViewModel.kt
@@ -8,7 +8,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.extensions.isEqualTo
-import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.ShippingRate
 import com.woocommerce.android.model.ShippingRate.Option
 import com.woocommerce.android.model.ShippingRate.Option.ADULT_SIGNATURE
@@ -53,15 +52,6 @@ class ShippingCarrierRatesViewModel @Inject constructor(
         private const val CARRIER_DHL_EXPRESS_KEY = "dhlexpress"
         private const val CARRIER_DHL_ECOMMERCE_KEY = "dhlecommerce"
         private const val CARRIER_DHL_ECOMMERCE_ASIA_KEY = "dhlecommerceasia"
-        private const val FLAT_RATE_KEY = "flat_rate"
-        private const val FREE_SHIPPING_KEY = "free_shipping"
-        private const val LOCAL_PICKUP_KEY = "local_pickup"
-        private const val SHIPPING_METHOD_USPS_TITLE = "USPS"
-        private const val SHIPPING_METHOD_DHL_TITLE = "DHL Express"
-        private const val SHIPPING_METHOD_FEDEX_TITLE = "Fedex"
-        private const val SHIPPING_METHOD_USPS_KEY = "wc_services_usps"
-        private const val SHIPPING_METHOD_DHL_KEY = "wc_services_dhlexpress"
-        private const val SHIPPING_METHOD_FEDEX_KEY = "wc_services_fedex"
     }
     private val arguments: ShippingCarrierRatesFragmentArgs by savedState.navArgs()
 
@@ -103,11 +93,11 @@ class ShippingCarrierRatesViewModel @Inject constructor(
             updateRates(generateRateModels(carrierRatesResult.model!!))
 
             var banner: String? = null
-            if (arguments.order.shippingTotal > BigDecimal.ZERO) {
+            if (arguments.order.shippingTotal > BigDecimal.ZERO && arguments.order.shippingLines.isNotEmpty()) {
                 banner = resourceProvider.getString(
                     R.string.shipping_label_shipping_carrier_flat_fee_banner_message,
-                    arguments.order.shippingTotal.format(),
-                    getShippingMethods(arguments.order).joinToString()
+                    arguments.order.shippingLines.first().methodTitle,
+                    arguments.order.shippingTotal.format()
                 )
             }
             viewState = viewState.copy(isEmptyViewVisible = false, bannerMessage = banner)
@@ -215,20 +205,6 @@ class ShippingCarrierRatesViewModel @Inject constructor(
                 itemCount = arguments.packages[i].items.size,
                 rateOptions = shippingRates
             )
-        }
-    }
-
-    private fun getShippingMethods(order: Order): List<String> {
-        return order.shippingMethods.map {
-            when (it.id) {
-                FLAT_RATE_KEY -> resourceProvider.getString(R.string.shipping_label_shipping_method_flat_rate)
-                FREE_SHIPPING_KEY -> resourceProvider.getString(R.string.shipping_label_shipping_method_free_shipping)
-                LOCAL_PICKUP_KEY -> resourceProvider.getString(R.string.shipping_label_shipping_method_local_pickup)
-                SHIPPING_METHOD_USPS_KEY -> SHIPPING_METHOD_USPS_TITLE
-                SHIPPING_METHOD_FEDEX_KEY -> SHIPPING_METHOD_FEDEX_TITLE
-                SHIPPING_METHOD_DHL_KEY -> SHIPPING_METHOD_DHL_TITLE
-                else -> resourceProvider.getString(R.string.other)
-            }
         }
     }
 

--- a/WooCommerce/src/main/res/layout/fragment_label_format_options.xml
+++ b/WooCommerce/src/main/res/layout/fragment_label_format_options.xml
@@ -97,6 +97,7 @@
                 android:layout_marginTop="@dimen/major_100"
                 android:layout_marginStart="@dimen/major_200"
                 android:layout_marginEnd="@dimen/major_200"
+                android:layout_marginBottom="@dimen/major_100"
                 android:importantForAccessibility="no"
                 android:src="@drawable/img_label_option_label" />
 

--- a/WooCommerce/src/main/res/layout/fragment_print_shipping_label.xml
+++ b/WooCommerce/src/main/res/layout/fragment_print_shipping_label.xml
@@ -152,6 +152,7 @@
             android:text="@string/shipping_label_paper_size_options_info"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toEndOf="@id/shippingLabelPrint_pagesIcon"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -502,9 +502,6 @@
     <string name="shipping_label_woo_discount_bottomsheet_message" formatted="false">When purchasing shipping labels with WooCommerce, you get 5% to 40% off compared to post office rates.</string>
     <string name="shipping_label_shipping_carrier_flat_fee_banner_message">Customer paid a %1$s of %2$s for shipping</string>
     <string name="shipping_label_shipping_carrier_shipping_method_banner_message">Your customer selected %1$s</string>
-    <string name="shipping_label_shipping_method_flat_rate">Flat rate</string>
-    <string name="shipping_label_shipping_method_local_pickup">Local pickup</string>
-    <string name="shipping_label_shipping_method_free_shipping">Free shipping</string>
     <string name="shipping_label_rate_option_signature_required">Signature required (%s)</string>
     <string name="shipping_label_rate_option_adult_signature_required">Adult signature required (%s)</string>
     <string name="shipping_label_rate_included_options">Includes %s</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -500,7 +500,7 @@
     <string name="shipping_label_shipping_carrier_rates_generic_error">There was an error loading shipping options</string>
     <string name="shipping_label_woo_discount_bottomsheet_title">What is WooCommerce  Services discount?</string>
     <string name="shipping_label_woo_discount_bottomsheet_message" formatted="false">When purchasing shipping labels with WooCommerce, you get 5% to 40% off compared to post office rates.</string>
-    <string name="shipping_label_shipping_carrier_flat_fee_banner_message">Customer paid %1$s (%2$s) for shipping</string>
+    <string name="shipping_label_shipping_carrier_flat_fee_banner_message">Customer paid a %1$s of %2$s for shipping</string>
     <string name="shipping_label_shipping_method_flat_rate">Flat rate</string>
     <string name="shipping_label_shipping_method_local_pickup">Local pickup</string>
     <string name="shipping_label_shipping_method_free_shipping">Free shipping</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -501,6 +501,7 @@
     <string name="shipping_label_woo_discount_bottomsheet_title">What is WooCommerce  Services discount?</string>
     <string name="shipping_label_woo_discount_bottomsheet_message" formatted="false">When purchasing shipping labels with WooCommerce, you get 5% to 40% off compared to post office rates.</string>
     <string name="shipping_label_shipping_carrier_flat_fee_banner_message">Customer paid a %1$s of %2$s for shipping</string>
+    <string name="shipping_label_shipping_carrier_shipping_method_banner_message">Your customer selected %1$s</string>
     <string name="shipping_label_shipping_method_flat_rate">Flat rate</string>
     <string name="shipping_label_shipping_method_local_pickup">Local pickup</string>
     <string name="shipping_label_shipping_method_free_shipping">Free shipping</string>

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.18.0'
+    fluxCVersion = '6dec6d01ddd922f148c4f0ceed324178fa4264fc'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'


### PR DESCRIPTION
This PR fixes multiple bugs related to the shipping labels feature, as they are small, I combined them in the same PR:

- a1c8f9e and 80234b2: Fixes #4050, this requires https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2014 to be merged first.
- a0fa894: Fixes #4072.
- 1d79907: Fixes #4073.
- dcadf55, 226545f, d4a2fe4 and 1b9c156: Fixes #4095.
- 268c77f: Fixes #4098.

#### Testing
All the fixes above are easy to test except the two last two ones. And please make sure you're using an order destined to US, as the customs form is not functional yet.
##### Confirming the fix of #4095 
1. Make sure you configured some shipping methods in your store.
2. Create an order eligible for shipping label creation, and with a shipping method selected.
3. Open the create shipping label form.
4. When you reach the step of rates, confirm that you see either:
      - if the shipping is free: "Your customer selected {shippingMethod}"
      - If the shipping has a cost: "Customer paid a {shippingMethod} of {cost} for shipping"

##### Confirming the fix of #4098 
This requires creating a failed shipping label, you need to do so using the API, or contact me to add you to my store to test it.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
