### PR TITLE
Re-fetch order after payment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
@@ -10,11 +10,13 @@ import androidx.fragment.app.viewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentCardReaderPaymentBinding
 import com.woocommerce.android.extensions.navigateBackWithNotice
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.CardReaderPaymentEvent.PrintReceipt
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.CardReaderPaymentEvent.SendReceipt
 import com.woocommerce.android.util.PrintHtmlHelper
 import com.woocommerce.android.util.UiHelpers
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -22,6 +24,7 @@ import javax.inject.Inject
 class CardReaderPaymentDialog : DialogFragment(R.layout.fragment_card_reader_payment) {
     val viewModel: CardReaderPaymentViewModel by viewModels()
     @Inject lateinit var printHtmlHelper: PrintHtmlHelper
+    @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         dialog!!.setCanceledOnTouchOutside(false)
@@ -60,6 +63,7 @@ class CardReaderPaymentDialog : DialogFragment(R.layout.fragment_card_reader_pay
                 is SendReceipt -> {
                     // TODO cardreader implement
                 }
+                is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 else -> event.isHandled = false
             }
         })

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.cardreader
 
+import android.app.Dialog
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -8,7 +9,10 @@ import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentCardReaderPaymentBinding
+import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.util.UiHelpers
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -18,6 +22,14 @@ class CardReaderPaymentDialog : DialogFragment(R.layout.fragment_card_reader_pay
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         dialog!!.setCanceledOnTouchOutside(false)
         return super.onCreateView(inflater, container, savedInstanceState)
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return object : Dialog(requireContext(), theme) {
+            override fun onBackPressed() {
+                viewModel.onBackPressed()
+            }
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -50,5 +62,17 @@ class CardReaderPaymentDialog : DialogFragment(R.layout.fragment_card_reader_pay
                 viewState.onSecondaryActionClicked?.invoke()
             }
         })
+
+        viewModel.event.observe(viewLifecycleOwner, { event ->
+            when (event) {
+                Exit -> {
+                    navigateBackWithNotice(KEY_CARD_PAYMENT_RESULT)
+                }
+            }
+        })
+    }
+
+    companion object {
+        const val KEY_CARD_PAYMENT_RESULT = "key_card_payment_result"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -24,6 +24,7 @@ import com.woocommerce.android.cardreader.CardPaymentStatus.WaitingForInput
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.PaymentData
 import com.woocommerce.android.cardreader.receipts.ReceiptCreator
+import com.woocommerce.android.cardreader.receipts.ReceiptPaymentInfo
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.CardReaderPaymentEvent.PrintReceipt
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.CardReaderPaymentEvent.SendReceipt
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.CapturingPaymentState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.cardreader
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
@@ -63,7 +64,7 @@ class CardReaderPaymentViewModel @Inject constructor(
     val viewStateData: LiveData<ViewState> = viewState
 
     private var paymentFlowJob: Job? = null
-    private var fetchOrderJob: Job? = null
+    @VisibleForTesting var fetchOrderJob: Job? = null
 
     fun start() {
         // TODO cardreader Check if the payment was already processed and cancel this flow
@@ -140,9 +141,13 @@ class CardReaderPaymentViewModel @Inject constructor(
 
     private fun onPaymentCompleted(amountLabel: String) {
         viewState.postValue(PaymentSuccessfulState(amountLabel))
+        reFetchOrder()
+    }
+
+    @VisibleForTesting
+    fun reFetchOrder() {
         fetchOrderJob = launch {
             orderRepository.fetchOrder(arguments.orderIdentifier)
-            delay(5000)
             if (viewState.value == FetchingOrderState) {
                 triggerEvent(Exit)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -166,6 +166,7 @@ class CardReaderPaymentViewModel @Inject constructor(
     fun reFetchOrder() {
         fetchOrderJob = launch {
             orderRepository.fetchOrder(arguments.orderIdentifier)
+                ?: triggerEvent(Event.ShowSnackbar(R.string.card_reader_fetching_order_failed))
             if (viewState.value == FetchingOrderState) {
                 triggerEvent(Exit)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -140,6 +140,7 @@ class CardReaderPaymentViewModel @Inject constructor(
             CollectingPayment -> viewState.postValue(CollectPaymentState(amountLabel))
             ProcessingPayment -> viewState.postValue(ProcessingPaymentState(amountLabel))
             CapturingPayment -> viewState.postValue(CapturingPaymentState(amountLabel))
+            // TODO cardreader store receipt data into a persistent storage
             is PaymentCompleted -> onPaymentCompleted(paymentStatus, amountLabel)
             ShowAdditionalInfo -> {
                 // TODO cardreader prompt the user to take certain action eg. Remove card

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -43,6 +43,7 @@ import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.ui.orders.OrderNavigationTarget
 import com.woocommerce.android.ui.orders.OrderNavigator
 import com.woocommerce.android.ui.orders.OrderProductActionListener
+import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentDialog
 import com.woocommerce.android.ui.orders.details.adapter.OrderDetailShippingLabelsAdapter.OnShippingLabelClickListener
 import com.woocommerce.android.ui.orders.fulfill.OrderFulfillViewModel
 import com.woocommerce.android.ui.orders.notes.AddOrderNoteFragment
@@ -222,6 +223,11 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
         handleResult<Boolean>(CardReaderConnectFragment.KEY_CONNECT_TO_READER_RESULT) { connected ->
             if (FeatureFlag.CARD_READER.isEnabled()) {
                 viewModel.onConnectToReaderResultReceived(connected)
+            }
+        }
+        handleNotice(CardReaderPaymentDialog.KEY_CARD_PAYMENT_RESULT) {
+            if (FeatureFlag.CARD_READER.isEnabled()) {
+                viewModel.onCardReaderPaymentCompleted()
             }
         }
         handleNotice(RefundSummaryFragment.REFUND_ORDER_NOTICE_KEY) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -576,6 +576,19 @@ class OrderDetailViewModel @Inject constructor(
         viewState = viewState.copy(refreshedProductId = event.remoteProductId)
     }
 
+    fun onCardReaderPaymentCompleted() {
+        reloadOrderDetails()
+    }
+
+    private fun reloadOrderDetails() {
+        launch {
+            orderDetailRepository.getOrder(navArgs.orderId)?.let {
+                order = it
+            }
+            displayOrderDetails()
+        }
+    }
+
     @Parcelize
     data class ViewState(
         val orderInfo: OrderInfo? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -45,6 +45,8 @@ import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderFulfillI
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewRefundedProducts
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository.OnProductImageChanged
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUndoSnackbar
@@ -584,7 +586,7 @@ class OrderDetailViewModel @Inject constructor(
         launch {
             orderDetailRepository.getOrder(navArgs.orderId)?.let {
                 order = it
-            }
+            } ?: WooLog.w(T.ORDERS, "Order ${navArgs.orderId} not found in the database.")
             displayOrderDetails()
         }
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -692,6 +692,8 @@
     <string name="card_reader_receipt_summary_title">Summary</string>
     <string name="card_reader_receipt_aid_title">AID</string>
 
+    <string name="card_reader_fetching_order_failed">Error fetching order. Order state in the app might be outdated.</string>
+
     <!--
             Card Reader Connection
         -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -661,6 +661,10 @@
     <string name="card_reader_payment_collect_payment_loading_header">Getting ready to collect payment</string>
     <string name="card_reader_payment_collect_payment_loading_payment_state">Connecting to reader</string>
 
+    <string name="card_reader_payment_fetch_order_loading_hint" translatable="false">@string/please_wait</string>
+    <string name="card_reader_payment_fetch_order_loading_header">Updating the app state</string>
+    <string name="card_reader_payment_fetch_order_loading_payment_state">Refreshing order</string>
+
     <string name="card_reader_collect_payment">Collect payment</string>
     <string name="card_reader_payment_collect_payment_header" translatable="false">@string/card_reader_collect_payment</string>
     <string name="card_reader_payment_processing_payment_header" translatable="false">@string/card_reader_collect_payment</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.OrderStatus
+import com.woocommerce.android.model.Order.Status
 import com.woocommerce.android.model.OrderNote
 import com.woocommerce.android.model.OrderShipmentTracking
 import com.woocommerce.android.model.Product
@@ -96,13 +97,15 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         doReturn(WooPlugin(true, true, version = OrderDetailViewModel.SUPPORTED_WCS_VERSION))
             .whenever(repository).getWooServicesPluginInfo()
 
-        viewModel = spy(OrderDetailViewModel(
-            savedState,
-            appPrefsWrapper,
-            networkStatus,
-            resources,
-            repository
-        ))
+        viewModel = spy(
+            OrderDetailViewModel(
+                savedState,
+                appPrefsWrapper,
+                networkStatus,
+                resources,
+                repository
+            )
+        )
 
         clearInvocations(
             viewModel,
@@ -581,10 +584,12 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
             doReturn(orderShippingLabels).whenever(repository).getOrderShippingLabels(any())
 
-            doReturn(WooPlugin(
-                isInstalled = true,
-                isActive = true,
-                version = OrderDetailViewModel.SUPPORTED_WCS_VERSION)
+            doReturn(
+                WooPlugin(
+                    isInstalled = true,
+                    isActive = true,
+                    version = OrderDetailViewModel.SUPPORTED_WCS_VERSION
+                )
             ).whenever(repository).getWooServicesPluginInfo()
             doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.remoteId)
             doReturn(true).whenever(repository).isOrderEligibleForSLCreation(order.remoteId)
@@ -625,10 +630,12 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
             doReturn(emptyList<ShippingLabel>()).whenever(repository).getOrderShippingLabels(any())
 
-            doReturn(WooPlugin(
-                isInstalled = true,
-                isActive = true,
-                version = OrderDetailViewModel.SUPPORTED_WCS_VERSION)
+            doReturn(
+                WooPlugin(
+                    isInstalled = true,
+                    isActive = true,
+                    version = OrderDetailViewModel.SUPPORTED_WCS_VERSION
+                )
             ).whenever(repository).getWooServicesPluginInfo()
 
             doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.remoteId)
@@ -923,29 +930,35 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `hide shipping label creation if the order is not eligible`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-        doReturn(order).whenever(repository).getOrder(any())
-        doReturn(order).whenever(repository).fetchOrder(any())
+            doReturn(order).whenever(repository).getOrder(any())
+            doReturn(order).whenever(repository).fetchOrder(any())
 
-        doReturn(WooPlugin(isInstalled = true, isActive = true, version = OrderDetailViewModel.SUPPORTED_WCS_VERSION))
-            .whenever(repository).getWooServicesPluginInfo()
-        doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.remoteId)
-        doReturn(false).whenever(repository).isOrderEligibleForSLCreation(order.remoteId)
+            doReturn(
+                WooPlugin(
+                    isInstalled = true,
+                    isActive = true,
+                    version = OrderDetailViewModel.SUPPORTED_WCS_VERSION
+                )
+            )
+                .whenever(repository).getWooServicesPluginInfo()
+            doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.remoteId)
+            doReturn(false).whenever(repository).isOrderEligibleForSLCreation(order.remoteId)
 
-        doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
-        doReturn(RequestResult.SUCCESS).whenever(repository).fetchOrderShipmentTrackingList(any(), any())
-        doReturn(emptyList<ShippingLabel>()).whenever(repository).fetchOrderShippingLabels(any())
-        doReturn(emptyList<Refund>()).whenever(repository).fetchOrderRefunds(any())
-        doReturn(emptyList<Product>()).whenever(repository).fetchProductsByRemoteIds(any())
+            doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
+            doReturn(RequestResult.SUCCESS).whenever(repository).fetchOrderShipmentTrackingList(any(), any())
+            doReturn(emptyList<ShippingLabel>()).whenever(repository).fetchOrderShippingLabels(any())
+            doReturn(emptyList<Refund>()).whenever(repository).fetchOrderRefunds(any())
+            doReturn(emptyList<Product>()).whenever(repository).fetchProductsByRemoteIds(any())
 
-        var isCreateShippingLabelButtonVisible: Boolean? = null
-        viewModel.viewStateData.observeForever { _, new ->
-            isCreateShippingLabelButtonVisible = new.isCreateShippingLabelButtonVisible
+            var isCreateShippingLabelButtonVisible: Boolean? = null
+            viewModel.viewStateData.observeForever { _, new ->
+                isCreateShippingLabelButtonVisible = new.isCreateShippingLabelButtonVisible
+            }
+
+            viewModel.start()
+
+            assertThat(isCreateShippingLabelButtonVisible).isFalse()
         }
-
-        viewModel.start()
-
-        assertThat(isCreateShippingLabelButtonVisible).isFalse()
-    }
 
     @Test
     fun `hide shipping label creation if wcs plugin is not installed`() =
@@ -976,6 +989,18 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             verify(repository, never()).isOrderEligibleForSLCreation(any())
             assertThat(isCreateShippingLabelButtonVisible).isFalse()
         }
+
+    @Test
+    fun `re-fetch order when payment flow completes`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+        initForCheckIfOrderCollectable()
+        viewModel.start()
+        val orderAfterPayment = order.copy(status = Status.fromDataModel(CoreOrderStatus.COMPLETED)!!)
+        doReturn(orderAfterPayment).whenever(repository).getOrder(any())
+
+        viewModel.onCardReaderPaymentCompleted()
+
+        assertThat(viewModel.order).isEqualTo(orderAfterPayment)
+    }
 
     private suspend fun initForCheckIfOrderCollectable(
         currency: String = "USD",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -37,6 +37,7 @@ import com.woocommerce.android.util.receipts.ReceiptDataMapper
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -560,5 +561,15 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             viewModel.reFetchOrder()
 
             assertThat(viewModel.event.value).isNotEqualTo(Exit)
+        }
+
+    @Test
+    fun `when re-fetching order fails, then SnackBar shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(orderRepository.fetchOrder(any())).thenReturn(null)
+
+            viewModel.reFetchOrder()
+
+            assertThat(viewModel.event.value).isInstanceOf(ShowSnackbar::class.java)
         }
 }


### PR DESCRIPTION
Parent issue #3726 

The app automatically re-fetches order when the payment flow completes and refreshes state of the order detail screen. This is needed so the order status and "paid state" gets refreshed.

The logic is following
1. When the payment completes -> PaymentSuccessful screen is shown
2. The app automatically starts fetching the order
3a. If the user leaves PaymentSuccessful screen before the re-fetch completes a progress dialog is shown
3b. If the user leaves PaymentSuccessful screen after the re-fetch completes the progress dialog is NOT shown

Note: I don't like the unit tests at all. Especially the usage of @VisibleForTesting annotation. However, I'm not sure if there is any other way how to test this, since we need to simulate that "re-fetch" takes some time. Let me know if you have any better suggestions ;).

To Test:
1. Open a detail of an order in US dollars 
2. Go through the payment flow
3. Use charles to suspend re-fetch order request (or add a delay [here](https://github.com/woocommerce/woocommerce-android/blob/3beacefb0494cccbd667b6410cd1bc6c921a5b89/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt#L150))
4. Press back to dismiss PaymentSuccessful screen
5. Notice a progress dialog is shown
6. Resume re-fetch order request
7. Notice the progress gets dismissed and order detail gets updated = it is "Paid"
-------------------------
Run the same test again, but dismiss PaymentSuccessful screen after the request completes -> the progress should not be shown at all.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
