### PR TITLE
Fix typo in Product Type Selector

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1323,7 +1323,7 @@
 
     <!-- Product type bottom sheets -->
     <string name="product_type_list_header">Select a product type</string>
-    <string name="product_type_simple_title">Simple physical productt</string>
+    <string name="product_type_simple_title">Simple physical product</string>
     <string name="product_type_simple_desc">A unique physical product that you may have to ship to the customer</string>
     <string name="product_type_virtual_title">Simple virtual product</string>
     <string name="product_type_virtual_desc">A unique digital product like services, downloadable books, music or videos</string>


### PR DESCRIPTION
The string `product_type_simple_title` (which was introduced in https://github.com/woocommerce/woocommerce-android/pull/3999) contains a typo of `Simple physical productt` (instead of `product`)

Just fixing this real quick while I stumbled upon it while playing with the app.

<img src="https://user-images.githubusercontent.com/216089/120684109-9e05f700-c49e-11eb-8a67-d597152ee437.jpg" width="30%" />

---

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. _(it does not)_
