### PR TITLE
Improve how s3 repository is defined and define which dependencies it serves

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -21,10 +21,21 @@ apply plugin: 'io.sentry.android.gradle'
 apply plugin: 'androidx.navigation.safeargs.kotlin'
 
 repositories {
+    maven {
+        url 'https://a8c-libs.s3.amazonaws.com/android'
+        content {
+            includeGroup "org.wordpress"
+        }
+    }
+    maven {
+        url 'https://zendesk.jfrog.io/zendesk/repo'
+        content {
+            includeGroup "com.zendesk"
+            includeGroup "com.zendesk.belvedere2"
+        }
+    }
     mavenCentral()
     maven { url "https://jitpack.io" }
-    maven { url 'https://zendesk.jfrog.io/zendesk/repo' }
-    maven { url 'https://a8c-libs.s3.amazonaws.com/android' }
 }
 
 allOpen {


### PR DESCRIPTION
This PR tells Gradle which dependencies to check in the custom maven repos which speeds up the dependency resolution. By moving the custom repositories to the top, it also makes it more secure as it'll be the first place Gradle will look. The performance gain is somewhat negligible in WCAndroid, but you can checkout https://github.com/wordpress-mobile/WordPress-Android/pull/14775 for how impactful it's for WPAndroid.

**Update release notes:**

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
