### PR TITLE
Merge release/6.8 into develop – Release Notes

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,3 @@
 ---
 BUNDLE_PATH: "vendor/bundle"
+BUNDLE_JOBS: "16"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,7 +254,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (~> 2)
-  fastlane-plugin-wpmreleasetoolkit (~> 1.0)
+  fastlane-plugin-wpmreleasetoolkit (~> 1.1)
   nokogiri
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-wpmreleasetoolkit (1.0.1)
+    fastlane-plugin-wpmreleasetoolkit (1.1.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)
@@ -172,13 +172,13 @@ GEM
     memoist (0.16.2)
     mini_magick (4.11.0)
     mini_mime (1.1.0)
-    mini_portile2 (2.5.1)
+    mini_portile2 (2.5.3)
     minitest (5.14.4)
     multi_json (1.15.0)
     multipart-post (2.0.0)
     nanaimo (0.3.0)
     naturally (2.2.1)
-    nokogiri (1.11.5)
+    nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     octokit (4.21.0)
@@ -258,4 +258,4 @@ DEPENDENCIES
   nokogiri
 
 BUNDLED WITH
-   2.2.16
+   2.2.19

--- a/WooCommerce/metadata/PlayStoreStrings.pot
+++ b/WooCommerce/metadata/PlayStoreStrings.pot
@@ -11,19 +11,19 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_068"
+msgid ""
+"6.8:\n"
+"Back by popular demand, the order fulfill screen now displays when you click the "Mark order complete" button!\n"
+"\n"
+"In addition, we fixed a bug that was breaking the product list screen and added an error message for unauthorized users who attempt to access your store.\n"
+msgstr ""
+
 msgctxt "release_note_067"
 msgid ""
 "6.7:\n"
 "We have heard that orders may get fulfilled in multiple shipments. With this update, you can now print more than one label for an order. We also fixed a few other small things to make your experience better.\n"
 "\n"
-msgstr ""
-
-msgctxt "release_note_066"
-msgid ""
-"6.6:\n"
-"When editing a product, you can now create, delete, and update variations, attributes, and attribute options. You can also create and edit a virtual product from the product detail screen.\n"
-"It is now possible to refund a shipping line inside an order.\n"
-"We also fixed an issue that occurred when editing a product’s regular and sale prices.\n"
 msgstr ""
 
 #. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,5 +1,3 @@
-* [**] Due to popular demand, the Order fulfill is displayed once again when clicking on the Mark order complete button. [https://github.com/woocommerce/woocommerce-android/pull/4086]
-- [*] New descriptive error screen displayed for users without admin or shop manager access to the store. [https://github.com/woocommerce/woocommerce-android/pull/4074]
-- [**] Fixed bug that caused a jumbled screen the very first time the product list is viewed. [https://github.com/woocommerce/woocommerce-android/pull/4090]
+Back by popular demand, the order fulfill screen now displays when you click the "Mark order complete" button!
 
-
+In addition, we fixed a bug that was breaking the product list screen and added an error message for unauthorized users who attempt to access your store. 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,23 +5,9 @@ unless FastlaneCore::Helper.bundler?
   UI.user_error!('Please run fastlane via `bundle exec`')
 end
 
-def check_toolkit_update
-  plugin_name = 'fastlane-plugin-wpmreleasetoolkit'
-  UI.message('Checking for new version of the release toolkit...')
-  sh('bundle', 'outdated', plugin_name, '--porcelain') do |status, _, _|
-    break if status.success?
-
-    UI.important('The Release Toolkit you are using seems to be outdated. We suggest you to update to the latest version ASAP.')
-    if UI.interactive? && UI.confirm("Run \`bundle update #{plugin_name}\` now?")
-      sh('bundle', 'update', plugin_name)
-      UI.abort_with_message!("#{plugin_name} updated. Please restart your previous invocation of the \`#{lane_context[SharedValues::LANE_NAME]}\` lane to use the new toolkit.")
-    end
-  end
-end
-
 before_all do |lane|
   # Ensure we use the latest version of the toolkit
-  check_toolkit_update unless is_ci || ENV['FASTLANE_SKIP_TOOLKIT_UPDATE_CHECK']
+  check_for_toolkit_updates unless is_ci || ENV['FASTLANE_SKIP_TOOLKIT_UPDATE_CHECK']
 end
 
 ########################################################################

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 1.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 1.1'


### PR DESCRIPTION
* Just updated the release notes with the copy wrangled in concert with marketing – see p91TBi-5fe-p2#comment-4904
* Also took the occasion to update to latest release toolkit and its update-check feature

⚠️ Note: this needs to be merged before this weekend so those updated Release Notes are picked up when we send strings to our translation vendor.