### PR TITLE
Import strings from binary deps

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -364,20 +364,15 @@ platform :android do
   desc "Merge libraries strings files into the main app one"
   lane :localize_libs do | options |
     binary_imported_libraries = [
-    {
-      name: "Login Library",
-      import_key: "wordPressLoginVersion",
-      repository: "wordpress-mobile/WordPress-Login-Flow-Android",
-      strings_file_path: "WordPressLoginFlow/src/main/res/values/strings.xml",
-      github_release_prefix: "",
-      exclusions: ["default_web_client_id"]
-    },
-  ]
-
-    if (an_localize_libs(app_strings_path: main_strings_path, libs_strings_path: libraries_strings_path)) then
-      UI.important("Your #{main_strings_path} has changed.")
-      UI.input("Please, review the changes, commit them and press return to continue.")
-    end
+      {
+        name: "Login Library",
+        import_key: "wordPressLoginVersion",
+        repository: "wordpress-mobile/WordPress-Login-Flow-Android",
+        strings_file_path: "WordPressLoginFlow/src/main/res/values/strings.xml",
+        github_release_prefix: "",
+        exclusions: ["default_web_client_id"]
+      },
+    ]
 
     binary_imported_libraries.each do  | lib |
       download_path = android_download_file_by_version(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -363,13 +363,50 @@ platform :android do
   #####################################################################################
   desc "Merge libraries strings files into the main app one"
   lane :localize_libs do | options |
-    libraries_strings_path = [
-      {library: "Login Library", strings_path: "./libs/login/WordPressLoginFlow/src/main/res/values/strings.xml", exclusions: ["default_web_client_id"]}
-    ]
+    binary_imported_libraries = [
+    {
+      name: "Login Library",
+      import_key: "wordPressLoginVersion",
+      repository: "wordpress-mobile/WordPress-Login-Flow-Android",
+      strings_file_path: "WordPressLoginFlow/src/main/res/values/strings.xml",
+      github_release_prefix: "",
+      exclusions: ["default_web_client_id"]
+    },
+  ]
 
     if (an_localize_libs(app_strings_path: main_strings_path, libs_strings_path: libraries_strings_path)) then
       UI.important("Your #{main_strings_path} has changed.")
       UI.input("Please, review the changes, commit them and press return to continue.")
+    end
+
+    binary_imported_libraries.each do  | lib |
+      download_path = android_download_file_by_version(
+        library_name: lib[:name],
+        import_key: lib[:import_key],
+        repository: lib[:repository],
+        file_path: lib[:strings_file_path],
+        github_release_prefix: lib[:github_release_prefix])
+
+      if download_path.nil?
+        error_message = "Can't download strings file for #{lib[:name]}.\r\n"
+        error_message += "Strings for this library won't get translated.\r\n"
+        error_message += "Do you want to continue anyway?"
+        UI.user_error! "Abort." unless UI.confirm(error_message)
+      else
+        UI.message("Strings.xml file for #{lib[:name]} downloaded to #{download_path}.")
+        lib_to_merge = [ {
+          library: lib[:name], 
+          strings_path: download_path, 
+          exclusions: lib[:exclusions]
+        }]
+        an_localize_libs(app_strings_path: main_strings_path, libs_strings_path: lib_to_merge)
+        File.delete(download_path) if File.exist?(download_path)
+      end
+    end
+
+    is_repo_clean = ("git status --porcelain").empty?
+    unless is_repo_clean then
+      commit_strings(options)
     end
   end
 


### PR DESCRIPTION
This PR updates `Fastfile` to handle importing strings from binary dependencies (currently, only the Login Library in WooCommerce Android). 

## To test:

_**Verify that the strings from the library are imported**_
1. Comment out the [commit step here](https://github.com/woocommerce/woocommerce-android/blob/81fb9bb24255744cc2604c802f17879efa2c362e/fastlane/Fastfile#L404) to avoid unintended commits during testing.
2. Delete a string which belongs to the Login Library from strings.xml (for example: `invalid_verification_code`).
3. Update the version of the `LoginLibrary` to the released one (`v0.0.1`) (Currently, the `release-toolkit `doesn't support downloading a file from a commit hash referenced in the way we do in `build.gradle`)
4. Run `bundle exec fastlane localize_libs`.
5. Verify that the removed string has been re-added (it looks like there's also another string that is changed in the Login Library and which gets updated).
6. Revert all the changes.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
