### PR TITLE
Enable leaving FetchingOrder dialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -256,7 +256,6 @@ class CardReaderPaymentViewModel @Inject constructor(
                 // show "data might be outdated" and exit the flow when the user presses back on FetchingOrder screen
                 launch {
                     triggerEvent(ShowSnackbar(R.string.card_reader_fetching_order_failed))
-                    delay(1) // needs to be here so both events are consumed
                     triggerEvent(Exit)
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -254,10 +254,8 @@ class CardReaderPaymentViewModel @Inject constructor(
                 viewState.value = FetchingOrderState
             } else {
                 // show "data might be outdated" and exit the flow when the user presses back on FetchingOrder screen
-                launch {
-                    triggerEvent(ShowSnackbar(R.string.card_reader_fetching_order_failed))
-                    triggerEvent(Exit)
-                }
+                triggerEvent(ShowSnackbar(R.string.card_reader_fetching_order_failed))
+                triggerEvent(Exit)
             }
         } else {
             triggerEvent(Exit)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -249,7 +249,7 @@ class CardReaderPaymentViewModel @Inject constructor(
     }
 
     fun onBackPressed() {
-        if (fetchOrderJob?.isActive == true ) {
+        if (fetchOrderJob?.isActive == true) {
             if (viewState.value != FetchingOrderState) {
                 viewState.value = FetchingOrderState
             } else {
@@ -261,7 +261,7 @@ class CardReaderPaymentViewModel @Inject constructor(
                 }
             }
         } else {
-                triggerEvent(Exit)
+            triggerEvent(Exit)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -210,17 +210,19 @@ class CardReaderPaymentViewModel @Inject constructor(
 
     private fun onSendReceiptClicked(receiptUrl: String, billingEmail: String) {
         launch {
-            triggerEvent(SendReceipt(
-                content = UiStringRes(
-                    R.string.card_reader_payment_receipt_email_content,
-                    listOf(UiStringText(receiptUrl))
-                ),
-                subject = UiStringRes(
-                    R.string.card_reader_payment_receipt_email_subject,
-                    listOf(UiStringText(selectedSite.get().name.orEmpty()))
-                ),
-                address = billingEmail
-            ))
+            triggerEvent(
+                SendReceipt(
+                    content = UiStringRes(
+                        R.string.card_reader_payment_receipt_email_content,
+                        listOf(UiStringText(receiptUrl))
+                    ),
+                    subject = UiStringRes(
+                        R.string.card_reader_payment_receipt_email_subject,
+                        listOf(UiStringText(selectedSite.get().name.orEmpty()))
+                    ),
+                    address = billingEmail
+                )
+            )
         }
     }
 
@@ -247,10 +249,19 @@ class CardReaderPaymentViewModel @Inject constructor(
     }
 
     fun onBackPressed() {
-        return if (fetchOrderJob?.isActive == true) {
-            viewState.value = FetchingOrderState
+        if (fetchOrderJob?.isActive == true ) {
+            if (viewState.value != FetchingOrderState) {
+                viewState.value = FetchingOrderState
+            } else {
+                // show "data might be outdated" and exit the flow when the user presses back on FetchingOrder screen
+                launch {
+                    triggerEvent(ShowSnackbar(R.string.card_reader_fetching_order_failed))
+                    delay(1) // needs to be here so both events are consumed
+                    triggerEvent(Exit)
+                }
+            }
         } else {
-            triggerEvent(Exit)
+                triggerEvent(Exit)
         }
     }
 


### PR DESCRIPTION
Parent issue #3726

This PR allows the user to leave "Fetching order dialog" during the payment flow. This dialog is shown only when the user leaves PaymentSuccessful screen before the order gets refetched. 
In other words, if the payment succeeds
- User presses back and refetching order finished - exit the payment flow
- User presses back and refetching order has not finished - show fetching order dialog
- User presses back when fetching order dialog is shown - exit the payment flow and show "data might be outdate" message

To test:
1. Open a detail of an order in US dollars
2. Go through the payment flow
3. Use charles to suspend re-fetch order request (or add a delay here)
4. Press back to dismiss PaymentSuccessful screen
5. Notice a progress dialog is shown
6. Press back again
7. Notice the payment flow is dismissed and a snackbar message is shown

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
