### PR TITLE
Remove Extra Padding in Attribute Options Entry

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
@@ -264,11 +264,10 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
             layoutManagerGlobal!!.onRestoreInstanceState(it)
         }
 
-        binding.termEditText.setOnEditorActionListener { _, actionId, event ->
-            val termName = binding.termEditText.text?.toString() ?: ""
+        binding.termEditText.setOnEditorActionListener { termName ->
             if (termName.isNotBlank() && !assignedTermsAdapter.containsTerm(termName)) {
                 addTerm(termName)
-                binding.termEditText.text?.clear()
+                binding.termEditText.setText("")
             }
             true
         }

--- a/WooCommerce/src/main/res/layout/fragment_add_attribute_terms.xml
+++ b/WooCommerce/src/main/res/layout/fragment_add_attribute_terms.xml
@@ -20,31 +20,21 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/nameLayout"
-                style="@style/Woo.TextInputLayout"
+            <!-- Option EditText -->
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                android:id="@+id/termEditText"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/minor_100"
-                android:layout_marginBottom="@dimen/major_100"
-                android:hint="@string/product_new_attribute_term_name">
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/termEditText"
-                    style="@style/Woo.TextInputEditText"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:inputType="text" />
-
-            </com.google.android.material.textfield.TextInputLayout>
-
-
-            <com.google.android.material.textview.MaterialTextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:padding="@dimen/major_100"
-                android:text="@string/product_enter_attribute_term"
-                android:textAppearance="@style/TextAppearance.Woo.Caption" />
+                android:layout_marginTop="@dimen/major_75"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
+                android:paddingBottom="@dimen/major_75"
+                android:inputType="text"
+                android:hint="@string/product_new_attribute_term_name"
+                app:helperText="@string/product_enter_attribute_term"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/assignedTermList"


### PR DESCRIPTION
Closes #4140. 

⚠️ This is targetting the branch of https://github.com/woocommerce/woocommerce-android/pull/4102 and should not be merged until that PR is merged. 

## Design

Before | After 
--------|-------
<img src="https://user-images.githubusercontent.com/198826/121078389-2386f100-c796-11eb-8b49-3842af2bba82.png" width="300">        |    <img src="https://user-images.githubusercontent.com/198826/121078397-25e94b00-c796-11eb-8e49-ca06727bb9aa.png" width="300">   

## Changes

I changed the `TextInputLayout` + `MaterialTextView` UI elements to just `WCMaterialOutlinedEditTextView`. 

## Testing

1. Navigate to a variable product. 
2. Tap on Variations attributes
3. Pick an attribute
4. In the attribute options list, confirm that the padding between the _Option name_ text field and the “Add each option name...” helper text has been reduced.

## Author Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

