### PR TITLE
Remove trash option from Product Status

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Updated empty state illustrations. [https://github.com/woocommerce/woocommerce-android/pull/3678]
 - [*] Various design tweaks on empty state screen [https://github.com/woocommerce/woocommerce-android/pull/3879]
+- [*] Removed trash option from product status in Product Settings [https://github.com/woocommerce/woocommerce-android/pull/4148]
 
 
 6.8

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductStatus.kt
@@ -13,8 +13,7 @@ enum class ProductStatus(@StringRes val stringResource: Int = 0, val value: Stri
     PUBLISH(R.string.product_status_published, CoreProductStatus.PUBLISH.value),
     DRAFT(R.string.product_status_draft, CoreProductStatus.DRAFT.value),
     PENDING(R.string.product_status_pending, CoreProductStatus.PENDING.value),
-    PRIVATE(R.string.product_status_private, CoreProductStatus.PRIVATE.value),
-    TRASH(R.string.product_status_trashed, CoreProductStatus.TRASH.value);
+    PRIVATE(R.string.product_status_private, CoreProductStatus.PRIVATE.value);
 
     /**
      * Returns a localized string used when displaying the status in the UI. The "long" parameter
@@ -27,7 +26,6 @@ enum class ProductStatus(@StringRes val stringResource: Int = 0, val value: Stri
             DRAFT -> R.string.product_status_draft
             PENDING -> R.string.product_status_pending
             PRIVATE -> if (long) R.string.product_status_privately_published else R.string.product_status_private
-            TRASH -> R.string.product_status_trashed
         }
         return context.getString(resId)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductStatusFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductStatusFragment.kt
@@ -14,7 +14,6 @@ import com.woocommerce.android.ui.products.ProductStatus.DRAFT
 import com.woocommerce.android.ui.products.ProductStatus.PENDING
 import com.woocommerce.android.ui.products.ProductStatus.PRIVATE
 import com.woocommerce.android.ui.products.ProductStatus.PUBLISH
-import com.woocommerce.android.ui.products.ProductStatus.TRASH
 
 /**
  * Settings screen which enables choosing a product status
@@ -44,7 +43,6 @@ class ProductStatusFragment : BaseProductSettingsFragment(R.layout.fragment_prod
         binding.btnPublishedPrivately.setOnClickListener(this)
         binding.btnDraft.setOnClickListener(this)
         binding.btnPending.setOnClickListener(this)
-        binding.btnTrashed.setOnClickListener(this)
 
         getButtonForStatus(selectedStatus)?.isChecked = true
 
@@ -75,7 +73,6 @@ class ProductStatusFragment : BaseProductSettingsFragment(R.layout.fragment_prod
             binding.btnPublishedPrivately.isChecked = it == binding.btnPublishedPrivately
             binding.btnDraft.isChecked = it == binding.btnDraft
             binding.btnPending.isChecked = it == binding.btnPending
-            binding.btnTrashed.isChecked = it == binding.btnTrashed
             selectedStatus = getStatusForButtonId(it.id)
         }
     }
@@ -99,7 +96,6 @@ class ProductStatusFragment : BaseProductSettingsFragment(R.layout.fragment_prod
             DRAFT -> binding.btnDraft
             PENDING -> binding.btnPending
             PRIVATE -> binding.btnPublishedPrivately
-            TRASH -> binding.btnTrashed
             else -> null
         }
     }
@@ -110,7 +106,6 @@ class ProductStatusFragment : BaseProductSettingsFragment(R.layout.fragment_prod
             R.id.btnDraft -> DRAFT.toString()
             R.id.btnPending -> PENDING.toString()
             R.id.btnPublishedPrivately -> PRIVATE.toString()
-            R.id.btnTrashed -> TRASH.toString()
             else -> throw IllegalArgumentException()
         }
     }

--- a/WooCommerce/src/main/res/layout/fragment_product_status.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_status.xml
@@ -43,13 +43,4 @@
         android:text="@string/product_status_pending" />
 
     <View style="@style/Woo.Divider" />
-
-    <CheckedTextView
-        android:id="@+id/btnTrashed"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/product_status_trashed" />
-
-    <View style="@style/Woo.Divider" />
-
 </LinearLayout>


### PR DESCRIPTION
Fixes #3047 

Removed trash radio button from Product Settings -> Status
TODO: update RELEASE-NOTES.txt if all good

<img width=320 src=https://user-images.githubusercontent.com/990349/121270849-cf9b1a00-c905-11eb-855a-493ece5d09cb.png>


Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
