### PR TITLE
Update google-services plugin to 4.3.8

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -1,10 +1,11 @@
 buildscript {
     repositories {
+        google()
         jcenter()
         maven { url 'https://plugins.gradle.org/m2/' }
     }
     dependencies {
-        classpath 'com.google.gms:google-services:3.2.0'
+        classpath 'com.google.gms:google-services:4.3.8'
         classpath 'se.bjurr.violations:violation-comments-to-github-gradle-plugin:1.51'
         classpath 'io.sentry:sentry-android-gradle-plugin:1.7.28'
     }

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -142,8 +142,8 @@ dependencies {
         exclude group: "com.google.guava", module: "guava"
     }
 
-    implementation 'com.google.firebase:firebase-messaging:17.0.0'
-    implementation 'com.google.android.gms:play-services-auth:15.0.1'
+    implementation 'com.google.firebase:firebase-messaging:21.0.0'
+    implementation 'com.google.android.gms:play-services-auth:19.0.0'
 
     // Support library
     implementation "androidx.legacy:legacy-support-v4:1.0.0"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/FCMMessageService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/FCMMessageService.kt
@@ -10,41 +10,39 @@ import dagger.android.AndroidInjection
 import org.wordpress.android.fluxc.store.AccountStore
 import javax.inject.Inject
 
+private const val PUSH_TYPE_ZENDESK = "zendesk"
+private const val PUSH_ARG_ZENDESK_REQUEST_ID = "zendesk_sdk_request_id"
+
 class FCMMessageService : FirebaseMessagingService() {
     @Inject lateinit var accountStore: AccountStore
     @Inject lateinit var zendeskHelper: ZendeskHelper
     @Inject lateinit var notificationHandler: NotificationHandler
-
-    private val PUSH_TYPE_ZENDESK = "zendesk"
-    private val PUSH_ARG_ZENDESK_REQUEST_ID = "zendesk_sdk_request_id"
 
     override fun onCreate() {
         AndroidInjection.inject(this)
         super.onCreate()
     }
 
-    override fun onMessageReceived(message: RemoteMessage?) {
+    override fun onMessageReceived(message: RemoteMessage) {
         WooLog.v(T.NOTIFS, "Received message from Firebase")
 
         if (!accountStore.hasAccessToken()) return
 
-        message?.data?.let {
-            if (PUSH_TYPE_ZENDESK == it["type"]) {
-                val zendeskRequestId = it[PUSH_ARG_ZENDESK_REQUEST_ID]
+        if (PUSH_TYPE_ZENDESK == message.data["type"]) {
+            val zendeskRequestId = message.data[PUSH_ARG_ZENDESK_REQUEST_ID]
 
-                // Try to refresh the Zendesk request page if it's currently being displayed;
-                // otherwise show a notification
-                if (!zendeskHelper.refreshRequest(this, zendeskRequestId)) {
-                    notificationHandler.handleZendeskNotification(this.applicationContext)
-                }
-            } else {
-                notificationHandler.buildAndShowNotificationFromNoteData(
-                        this.applicationContext,
-                        convertMapToBundle(it),
-                        accountStore.account
-                )
+            // Try to refresh the Zendesk request page if it's currently being displayed;
+            // otherwise show a notification
+            if (!zendeskHelper.refreshRequest(this, zendeskRequestId)) {
+                notificationHandler.handleZendeskNotification(this.applicationContext)
             }
-        } ?: WooLog.d(T.NOTIFS, "No notification message content received. Aborting.")
+        } else {
+            notificationHandler.buildAndShowNotificationFromNoteData(
+                    this.applicationContext,
+                    convertMapToBundle(message.data),
+                    accountStore.account
+            )
+        }
     }
 
     private fun convertMapToBundle(data: Map<String, String>): Bundle {


### PR DESCRIPTION
Details in WPAndroid counterpart: https://github.com/wordpress-mobile/WordPress-Android/pull/14788

Unfortunately updating google-services plugin in isolation did not work, as you can see from the failed CI build. So, I've also updated [firebase messaging](https://firebase.google.com/support/release-notes/android) and [play services auth](https://developers.google.com/android/guides/setup) dependencies as well.

Note that latest version of firebase messaging `22.0.0` has a lot of breaking changes, so I opted to go with `21.0.0` instead which had only one. I've fixed the breaking change and I can see the deprecated warnings, so it'll be easier to fix them in isolation.

**To test:**
* Test Google Login
* If we can test it, it'd be good to test push notifications as well - cc @jkmassel  

_P.S: It might help to enable `Hide whitespace changes` while reviewing the PR._

**Update release notes:**

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
