### PR TITLE
Issue/4159  Run detekt on pre-push hook

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,6 @@ subprojects {
     }
 }
 
-
 tasks.register("detektAll", io.gitlab.arturbosch.detekt.Detekt) {
     description = "Custom DETEKT build for all modules"
     parallel = true

--- a/tools/team-props/git-hooks/pre-push
+++ b/tools/team-props/git-hooks/pre-push
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo "Running detekt check..."
+OUTPUT="/tmp/detekt-$(date +%s)"
+./gradlew detektAll > $OUTPUT
+EXIT_CODE=$?
+if [ $EXIT_CODE -ne 0 ]; then
+  cat $OUTPUT
+  rm $OUTPUT
+  echo "***********************************************"
+  echo "              Detekt failed                    "
+  echo " Please fix the above issues before pushing    "
+  echo "***********************************************"
+  exit $EXIT_CODE
+fi
+rm $OUTPUT


### PR DESCRIPTION
Closes #4159

Added pre-push hook which runs detekt

**Do not merge before the target branch**

## If detekt doesn't pass but you need to push

#### Android studio:
 Just uncheck the flag `Run git hooks`
![image](https://user-images.githubusercontent.com/4923871/121496658-5a057b80-c9e3-11eb-8c32-f1e69eff2948.png)

#### Command line:
Use `--no-verify` flag

### How to test
Build the project. Try to format any file in a wrong way (so detekt doesn't pass) and see if you can push it