### PR TITLE
[Mobile Payments] Add Printing tutorial dialog to order detail screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -409,7 +409,8 @@ class MainActivity : AppUpgradeActivity(),
                 R.id.addOrderShipmentTrackingFragment,
                 R.id.addOrderNoteFragment,
                 R.id.printShippingLabelInfoFragment,
-                R.id.shippingLabelFormatOptionsFragment -> {
+                R.id.shippingLabelFormatOptionsFragment,
+                R.id.printingInstructionsFragment -> {
                     true
                 }
                 R.id.productDetailFragment -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
@@ -51,4 +51,5 @@ sealed class OrderNavigationTarget : Event() {
     data class StartShippingLabelCreationFlow(val orderIdentifier: String) : OrderNavigationTarget()
     object StartCardReaderConnectFlow : OrderNavigationTarget()
     data class StartCardReaderPaymentFlow(val orderIdentifier: String) : OrderNavigationTarget()
+    object ViewPrintingInstructions : OrderNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewCreateShippin
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderFulfillInfo
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewPrintShippingLabelInfo
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewPrintingInstructions
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewRefundedProducts
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewShipmentTrackingProviders
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewShippingLabelFormatOptions
@@ -128,6 +129,11 @@ class OrderNavigator @Inject constructor() {
             is StartCardReaderPaymentFlow -> {
                 val action = OrderDetailFragmentDirections
                     .actionOrderDetailFragmentToCardReaderPaymentDialog(target.orderIdentifier)
+                fragment.findNavController().navigateSafely(action)
+            }
+            is ViewPrintingInstructions -> {
+                val action = OrderDetailFragmentDirections
+                    .actionOrderDetailFragmentToPrintingInstructionsFragment()
                 fragment.findNavController().navigateSafely(action)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -260,9 +260,6 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
             onPrintingInstructionsClickListener = {
                 if (FeatureFlag.CARD_READER.isEnabled()) {
                     viewModel.onPrintingInstructionsClicked()
-//                    cardReaderManager.let {
-//                        viewModel.onAcceptCardPresentPaymentClicked(it)
-//                    }
                 }
             }
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -256,6 +256,14 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
                         viewModel.onAcceptCardPresentPaymentClicked(it)
                     }
                 }
+            },
+            onPrintingInstructionsClickListener = {
+                if (FeatureFlag.CARD_READER.isEnabled()) {
+                    viewModel.onPrintingInstructionsClicked()
+//                    cardReaderManager.let {
+//                        viewModel.onAcceptCardPresentPaymentClicked(it)
+//                    }
+                }
             }
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -43,6 +43,7 @@ import com.woocommerce.android.ui.orders.OrderNavigationTarget.StartShippingLabe
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewCreateShippingLabelInfo
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderFulfillInfo
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewPrintingInstructions
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewRefundedProducts
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository.OnProductImageChanged
 import com.woocommerce.android.util.WooLog
@@ -236,7 +237,7 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     fun onPrintingInstructionsClicked() {
-        TODO("Not yet implemented")
+        triggerEvent(ViewPrintingInstructions)
     }
 
     fun onConnectToReaderResultReceived(connected: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -235,6 +235,10 @@ class OrderDetailViewModel @Inject constructor(
         }
     }
 
+    fun onPrintingInstructionsClicked() {
+        TODO("Not yet implemented")
+    }
+
     fun onConnectToReaderResultReceived(connected: Boolean) {
         // TODO cardreader add tests for this functionality
         launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/PrintingInstructionsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/PrintingInstructionsFragment.kt
@@ -1,0 +1,12 @@
+package com.woocommerce.android.ui.orders.details
+
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class PrintingInstructionsFragment : BaseFragment(R.layout.fragment_printing_instructions) {
+    @Inject lateinit var uiMessageResolver: UIMessageResolver
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
@@ -31,7 +31,8 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
         isPaymentCollectableWithCardReader: Boolean,
         formatCurrencyForDisplay: (BigDecimal) -> String,
         onIssueRefundClickListener: (view: View) -> Unit,
-        onCollectCardPresentPaymentClickListener: (view: View) -> Unit
+        onCollectCardPresentPaymentClickListener: (view: View) -> Unit,
+        onPrintingInstructionsClickListener: (view: View) -> Unit
     ) {
         binding.paymentInfoProductsTotal.text = formatCurrencyForDisplay(order.productsTotal)
         binding.paymentInfoShippingTotal.text = formatCurrencyForDisplay(order.shippingTotal)
@@ -108,6 +109,15 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
             )
         } else {
             binding.paymentInfoCollectCardPresentPaymentButton.visibility = View.GONE
+        }
+
+        // TODO Cardreader update logic.
+        if (FeatureFlag.CARD_READER.isEnabled() && isPaymentCollectableWithCardReader) {
+            binding.paymentInfoPrintingInstructions.setOnClickListener(
+                onPrintingInstructionsClickListener
+            )
+        } else {
+            binding.paymentInfoPrintingInstructions.visibility = View.GONE
         }
     }
 

--- a/WooCommerce/src/main/res/layout/fragment_printing_instructions.xml
+++ b/WooCommerce/src/main/res/layout/fragment_printing_instructions.xml
@@ -30,7 +30,7 @@
             android:layout_marginStart="@dimen/major_100"
             android:layout_marginTop="@dimen/major_200"
             android:layout_marginEnd="@dimen/major_100"
-            android:text="Step count 1"
+            android:text="1"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/imageView"
             app:shapeAppearanceOverlay="@style/Woo.Button.Colored.Circle" />

--- a/WooCommerce/src/main/res/layout/fragment_printing_instructions.xml
+++ b/WooCommerce/src/main/res/layout/fragment_printing_instructions.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingBottom="@dimen/major_100"
+        android:background="@color/color_surface">
+
+        <ImageView
+            android:id="@+id/imageView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/major_200"
+            android:importantForAccessibility="no"
+            android:src="@drawable/img_print_with_phone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="1.0" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/printingInstructionsLabelInfo_stepCount1"
+            style="@style/Woo.Button.Colored.Circle"
+            android:layout_width="@dimen/image_minor_100"
+            android:layout_height="@dimen/image_minor_100"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_200"
+            android:layout_marginEnd="@dimen/major_100"
+            android:text="Step count 1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/imageView"
+            app:shapeAppearanceOverlay="@style/Woo.Button.Colored.Circle" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/printingInstructionsLabelInfo_step1"
+            style="@style/Woo.TextView.Subtitle1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_200"
+            android:layout_marginEnd="@dimen/major_100"
+            android:text="@string/print_shipping_label_info_step_1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/printInstructionsLabelInfo_stepCount1"
+            app:layout_constraintTop_toBottomOf="@+id/imageView" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/printInstructionsLabelInfo_stepCount2"
+            style="@style/Woo.Button.Colored.Circle"
+            android:layout_width="@dimen/image_minor_100"
+            android:layout_height="@dimen/image_minor_100"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_200"
+            android:layout_marginEnd="@dimen/major_100"
+            android:text="@string/print_shipping_label_info_step_count_2"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/printingInstructionsLabelInfo_step1"
+            app:shapeAppearanceOverlay="@style/Woo.Button.Colored.Circle" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/printInstructionsLabelInfo_step2"
+            style="@style/Woo.TextView.Subtitle1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_200"
+            android:layout_marginEnd="@dimen/major_100"
+            android:text="@string/print_shipping_label_info_step_2"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/printingInstructionsLabelInfo_stepCount1"
+            app:layout_constraintTop_toBottomOf="@+id/printingInstructionsLabelInfo_step1" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/printInstructionsLabelInfo_stepCount3"
+            style="@style/Woo.Button.Colored.Circle"
+            android:layout_width="@dimen/image_minor_100"
+            android:layout_height="@dimen/image_minor_100"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_200"
+            android:layout_marginEnd="@dimen/major_100"
+            android:text="@string/print_shipping_label_info_step_count_3"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/printInstructionsLabelInfo_step2"
+            app:shapeAppearanceOverlay="@style/Woo.Button.Colored.Circle" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/printInstructionsLabelInfo_step3"
+            style="@style/Woo.TextView.Subtitle1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_200"
+            android:layout_marginEnd="@dimen/major_100"
+            android:text="@string/print_shipping_label_info_step_3"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/printInstructionsLabelInfo_stepCount3"
+            app:layout_constraintTop_toBottomOf="@+id/printInstructionsLabelInfo_step2" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/printInstructionsLabelInfo_stepCount4"
+            style="@style/Woo.Button.Colored.Circle"
+            android:layout_width="@dimen/image_minor_100"
+            android:layout_height="@dimen/image_minor_100"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_200"
+            android:layout_marginEnd="@dimen/major_100"
+            android:text="@string/print_shipping_label_info_step_count_4"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/printInstructionsLabelInfo_step3"
+            app:shapeAppearanceOverlay="@style/Woo.Button.Colored.Circle" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/printInstructionsLabelInfo_step4"
+            style="@style/Woo.TextView.Subtitle1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_200"
+            android:layout_marginEnd="@dimen/major_100"
+            android:text="@string/print_shipping_label_info_step_4"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/printInstructionsLabelInfo_stepCount4"
+            app:layout_constraintTop_toBottomOf="@+id/printInstructionsLabelInfo_step3" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/printInstructionsLabelInfo_stepCount5"
+            style="@style/Woo.Button.Colored.Circle"
+            android:layout_width="@dimen/image_minor_100"
+            android:layout_height="@dimen/image_minor_100"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_200"
+            android:layout_marginEnd="@dimen/major_100"
+            android:text="@string/print_shipping_label_info_step_count_5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/printInstructionsLabelInfo_step4"
+            app:shapeAppearanceOverlay="@style/Woo.Button.Colored.Circle" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/printInstructionsLabelInfo_step5"
+            style="@style/Woo.TextView.Subtitle1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_200"
+            android:layout_marginEnd="@dimen/major_100"
+            android:text="@string/print_shipping_label_info_step_5"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/printInstructionsLabelInfo_stepCount5"
+            app:layout_constraintTop_toBottomOf="@+id/printInstructionsLabelInfo_step4" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>

--- a/WooCommerce/src/main/res/layout/fragment_printing_instructions.xml
+++ b/WooCommerce/src/main/res/layout/fragment_printing_instructions.xml
@@ -45,7 +45,7 @@
             android:layout_marginEnd="@dimen/major_100"
             android:text="@string/print_shipping_label_info_step_1"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/printInstructionsLabelInfo_stepCount1"
+            app:layout_constraintStart_toEndOf="@+id/printingInstructionsLabelInfo_stepCount1"
             app:layout_constraintTop_toBottomOf="@+id/imageView" />
 
         <com.google.android.material.button.MaterialButton

--- a/WooCommerce/src/main/res/layout/fragment_printing_instructions.xml
+++ b/WooCommerce/src/main/res/layout/fragment_printing_instructions.xml
@@ -30,7 +30,7 @@
             android:layout_marginStart="@dimen/major_100"
             android:layout_marginTop="@dimen/major_200"
             android:layout_marginEnd="@dimen/major_100"
-            android:text="1"
+            android:text="@string/print_receipt_label_info_step_count_1"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/imageView"
             app:shapeAppearanceOverlay="@style/Woo.Button.Colored.Circle" />
@@ -43,7 +43,7 @@
             android:layout_marginStart="@dimen/major_100"
             android:layout_marginTop="@dimen/major_200"
             android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/print_shipping_label_info_step_1"
+            android:text="@string/print_receipt_label_info_step_1"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@+id/printingInstructionsLabelInfo_stepCount1"
             app:layout_constraintTop_toBottomOf="@+id/imageView" />
@@ -56,7 +56,7 @@
             android:layout_marginStart="@dimen/major_100"
             android:layout_marginTop="@dimen/major_200"
             android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/print_shipping_label_info_step_count_2"
+            android:text="@string/print_receipt_label_info_step_count_2"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/printingInstructionsLabelInfo_step1"
             app:shapeAppearanceOverlay="@style/Woo.Button.Colored.Circle" />
@@ -69,7 +69,7 @@
             android:layout_marginStart="@dimen/major_100"
             android:layout_marginTop="@dimen/major_200"
             android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/print_shipping_label_info_step_2"
+            android:text="@string/print_receipt_label_info_step_2"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@+id/printingInstructionsLabelInfo_stepCount1"
             app:layout_constraintTop_toBottomOf="@+id/printingInstructionsLabelInfo_step1" />
@@ -82,7 +82,7 @@
             android:layout_marginStart="@dimen/major_100"
             android:layout_marginTop="@dimen/major_200"
             android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/print_shipping_label_info_step_count_3"
+            android:text="@string/print_receipt_label_info_step_count_3"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/printInstructionsLabelInfo_step2"
             app:shapeAppearanceOverlay="@style/Woo.Button.Colored.Circle" />
@@ -95,7 +95,7 @@
             android:layout_marginStart="@dimen/major_100"
             android:layout_marginTop="@dimen/major_200"
             android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/print_shipping_label_info_step_3"
+            android:text="@string/print_receipt_label_info_step_3"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@+id/printInstructionsLabelInfo_stepCount3"
             app:layout_constraintTop_toBottomOf="@+id/printInstructionsLabelInfo_step2" />
@@ -108,7 +108,7 @@
             android:layout_marginStart="@dimen/major_100"
             android:layout_marginTop="@dimen/major_200"
             android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/print_shipping_label_info_step_count_4"
+            android:text="@string/print_receipt_label_info_step_count_4"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/printInstructionsLabelInfo_step3"
             app:shapeAppearanceOverlay="@style/Woo.Button.Colored.Circle" />
@@ -121,7 +121,7 @@
             android:layout_marginStart="@dimen/major_100"
             android:layout_marginTop="@dimen/major_200"
             android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/print_shipping_label_info_step_4"
+            android:text="@string/print_receipt_label_info_step_4"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@+id/printInstructionsLabelInfo_stepCount4"
             app:layout_constraintTop_toBottomOf="@+id/printInstructionsLabelInfo_step3" />
@@ -134,7 +134,7 @@
             android:layout_marginStart="@dimen/major_100"
             android:layout_marginTop="@dimen/major_200"
             android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/print_shipping_label_info_step_count_5"
+            android:text="@string/print_receipt_label_info_step_count_5"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/printInstructionsLabelInfo_step4"
             app:shapeAppearanceOverlay="@style/Woo.Button.Colored.Circle" />
@@ -147,10 +147,62 @@
             android:layout_marginStart="@dimen/major_100"
             android:layout_marginTop="@dimen/major_200"
             android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/print_shipping_label_info_step_5"
+            android:text="@string/print_receipt_label_info_step_5"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@+id/printInstructionsLabelInfo_stepCount5"
             app:layout_constraintTop_toBottomOf="@+id/printInstructionsLabelInfo_step4" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/printInstructionsLabelInfo_stepCount6"
+            style="@style/Woo.Button.Colored.Circle"
+            android:layout_width="@dimen/image_minor_100"
+            android:layout_height="@dimen/image_minor_100"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_200"
+            android:layout_marginEnd="@dimen/major_100"
+            android:text="@string/print_receipt_label_info_step_count_6"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/printInstructionsLabelInfo_step5"
+            app:shapeAppearanceOverlay="@style/Woo.Button.Colored.Circle" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/printInstructionsLabelInfo_step6"
+            style="@style/Woo.TextView.Subtitle1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_200"
+            android:layout_marginEnd="@dimen/major_100"
+            android:text="@string/print_receipt_label_info_step_6"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/printInstructionsLabelInfo_stepCount6"
+            app:layout_constraintTop_toBottomOf="@+id/printInstructionsLabelInfo_step5" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/printInstructionsLabelInfo_stepCount7"
+            style="@style/Woo.Button.Colored.Circle"
+            android:layout_width="@dimen/image_minor_100"
+            android:layout_height="@dimen/image_minor_100"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_200"
+            android:layout_marginEnd="@dimen/major_100"
+            android:text="@string/print_receipt_label_info_step_count_7"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/printInstructionsLabelInfo_step6"
+            app:shapeAppearanceOverlay="@style/Woo.Button.Colored.Circle" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/printInstructionsLabelInfo_step7"
+            style="@style/Woo.TextView.Subtitle1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_200"
+            android:layout_marginEnd="@dimen/major_100"
+            android:text="@string/print_receipt_label_info_step_7"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/printInstructionsLabelInfo_stepCount7"
+            app:layout_constraintTop_toBottomOf="@+id/printInstructionsLabelInfo_step6" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/WooCommerce/src/main/res/layout/fragment_printing_instructions.xml
+++ b/WooCommerce/src/main/res/layout/fragment_printing_instructions.xml
@@ -14,7 +14,7 @@
             android:id="@+id/imageView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/major_200"
+            android:layout_marginTop="@dimen/major_100"
             android:importantForAccessibility="no"
             android:src="@drawable/img_print_with_phone"
             app:layout_constraintEnd_toEndOf="parent"

--- a/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
@@ -367,6 +367,15 @@
                 android:layout_marginEnd="@dimen/minor_00"
                 android:text="@string/orderdetail_collect_payment_button"/>
 
+            <!-- Show Printing Instructions button -->
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/paymentInfo_printingInstructions"
+                style="@style/Woo.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end|center_vertical"
+                android:layout_marginEnd="@dimen/minor_00"
+                android:text="@string/orderdetail_printing_instructions_button"/>
         </LinearLayout>
     </LinearLayout>
 </merge>

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -226,6 +226,13 @@
             app:destination="@id/cardReaderConnectDialog"
             app:enterAnim="@anim/activity_fade_in"
             app:popExitAnim="@anim/activity_fade_out" />
+        <action
+            android:id="@+id/action_orderDetailFragment_to_printingInstructionsFragment"
+            app:destination="@id/printingInstructionsFragment"
+            app:enterAnim="@anim/activity_slide_in_from_right"
+            app:exitAnim="@anim/activity_slide_out_to_left"
+            app:popEnterAnim="@anim/activity_slide_in_from_left"
+            app:popExitAnim="@anim/activity_slide_out_to_right" />
     </fragment>
     <dialog
         android:id="@+id/orderStatusSelectorDialog"
@@ -413,6 +420,12 @@
         android:name="com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectFragment"
         android:label="CardReaderConnectDialog">
     </dialog>
+    <fragment
+        android:id="@+id/printingInstructionsFragment"
+        android:name="com.woocommerce.android.ui.orders.details.PrintingInstructionsFragment"
+        android:label="PrintingInstructionsFragment"
+        tools:layout="@layout/fragment_printing_instructions">
+    </fragment>
     <fragment
         android:id="@+id/shippingCustomsFragment"
         android:name="com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustomsFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -391,6 +391,20 @@
     <string name="shipping_label_paper_size_legal">Legal (8.5 x 14 in)</string>
     <string name="shipping_label_paper_size_letter">Letter (8.5 x 11 in)</string>
     <string name="shipping_label_paper_size_label">Label (4 x 6 in)</string>
+    <string name="print_receipt_label_info_step_count_1" translatable="false">1</string>
+    <string name="print_receipt_label_info_step_count_2" translatable="false">2</string>
+    <string name="print_receipt_label_info_step_count_3" translatable="false">3</string>
+    <string name="print_receipt_label_info_step_count_4" translatable="false">4</string>
+    <string name="print_receipt_label_info_step_count_5" translatable="false">5</string>
+    <string name="print_receipt_label_info_step_count_6" translatable="false">6</string>
+    <string name="print_receipt_label_info_step_count_7" translatable="false">7</string>
+    <string name="print_receipt_label_info_step_1">Make sure the Print Service Plugin for yor printer is installed.</string>
+    <string name="print_receipt_label_info_step_2">Enable bluetooth or Wifi connection on your printer.</string>
+    <string name="print_receipt_label_info_step_3">When selecting "Print receipt" after accepting payment, replace "Save as PDF" with "All printers", and search for new printer.</string>
+    <string name="print_receipt_label_info_step_4">Pair and connect the printer to your mobile when prompted.</string>
+    <string name="print_receipt_label_info_step_5">Adjust paper size as needed, and select "Print" when ready to print the receipt.</string>
+    <string name="print_receipt_label_info_step_6">If printing is not available, you can always save your receipt as PDF and send it by email to print it from another device.</string>
+    <string name="print_receipt_label_info_step_7">If you are experiencing issues printing from your device, contact customer support for your printer.</string>
     <string name="print_shipping_label_info_title">Print with your device</string>
     <string name="print_shipping_label_format_options_title">Label format options</string>
     <string name="print_shipping_label_info_step_count_1" translatable="false">1</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -313,6 +313,7 @@
     <string name="orderdetail_shipping_notice">This order is using extensions to calculate shipping. The shipping methods shown might be incomplete.</string>
     <string name="orderdetail_issue_refund_button">Issue refund</string>
     <string name="orderdetail_collect_payment_button">Collect Payment</string>
+    <string name="orderdetail_printing_instructions_button">How to print</string>
     <string name="orderdetail_products_recreate_shipping_label_menu">Create new shipping label</string>
     <string name="orderdetail_shipping_label_item_header">Package %d</string>
     <string name="orderdetail_shipping_label_item_menu">Refund shipping label</string>


### PR DESCRIPTION
Implements part of #4039 

Video:

https://user-images.githubusercontent.com/2722505/121600219-24c45200-ca12-11eb-9f38-ffc4b8ce26bb.mov

Screenshots:

Order details:
<img src="https://user-images.githubusercontent.com/2722505/121600264-33126e00-ca12-11eb-9335-522c54ace5f5.png" width="350"/>

Printing tutorial:

| | |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/2722505/121600394-6523d000-ca12-11eb-88e3-f2bec48c7257.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/121600409-68b75700-ca12-11eb-9189-541a2cccac39.png" width="350"/> |

## Changes
* Added PrintingInstructionsFragment. For context: p91TBi-5gp#comment-4895
* Added "How to print" button to order details
* Add navigation to the new fragment

## How to test
* On a store gated into Card Present Payments, navigate to an legible order
* Notice the "How to print" button. Tap the button, and it should navigate to the new fragment
* The "How to print" button should only be visible on eligible orders.

Please be nice, newbie here! 😊 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
