### PR TITLE
Update ReviewDetailViewModel.kt

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModel.kt
@@ -108,6 +108,7 @@ class ReviewDetailViewModel @AssistedInject constructor(
                         }
                     }
                     ERROR -> triggerEvent(ShowSnackbar(R.string.wc_load_review_error))
+                    else -> triggerEvent(ShowSnackbar(R.string.wc_load_review_error))
                 }
             }
         } else {


### PR DESCRIPTION
Fixes #2386 

When battery saver is on Revew notification fails to load review detail due to potential network issues


Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
