### PR TITLE
Fix release version crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,14 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven {
+            url 'https://storage.googleapis.com/r8-releases/raw'
+        }
     }
     dependencies {
+        // Use updated version of r8 to fix this issue https://issuetracker.google.com/issues/178045782
+        // We should remove this after updating AGP
+        classpath 'com.android.tools:r8:2.2.64'
         classpath 'com.android.tools.build:gradle:4.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.automattic.android:fetchstyle:1.1'


### PR DESCRIPTION
While testing the app, @kidinov found out that the app crashes on release builds, after investigating we found out that the [root cause](https://issuetracker.google.com/issues/178045782) is a bug in r8, and we need to update it to fix it.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
