### PR TITLE
issue/4181-overlapping-no-price-message

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListFragment.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.ui.products.variations
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.View
-import android.view.View.GONE
+import android.view.View.INVISIBLE
 import android.view.View.VISIBLE
 import androidx.annotation.StringRes
 import androidx.core.view.isVisible
@@ -223,7 +223,7 @@ class VariationListFragment : BaseFragment(R.layout.fragment_variation_list),
     }
 
     private fun handleEmptyViewChanges(isEmptyViewVisible: Boolean) {
-        binding.variationInfoContainer.visibility = if (isEmptyViewVisible) GONE else VISIBLE
+        binding.variationInfoContainer.visibility = if (isEmptyViewVisible) INVISIBLE else VISIBLE
         binding.firstVariationView.updateVisibility(
             shouldBeVisible = isEmptyViewVisible,
             showButton = true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
@@ -58,12 +58,16 @@ class VariationListViewModel @Inject constructor(
 
     private val _variationList = MutableLiveData<List<ProductVariation>>()
     val variationList: LiveData<List<ProductVariation>> = Transformations.map(_variationList) { variations ->
+        val isEmpty = viewState.parentProduct?.variationEnabledAttributes?.isEmpty() == true
         variations.apply {
-            viewState = viewState.parentProduct
-                ?.takeIf { it.variationEnabledAttributes.isEmpty() }
-                ?.let { viewState.copy(isEmptyViewVisible = true) }
-                ?: any { it.isVisible && it.regularPrice.isNotSet() && it.salePrice.isNotSet() }
-                    .let { viewState.copy(isWarningVisible = it) }
+            viewState = viewState.copy(
+                isEmptyViewVisible = isEmpty,
+                isWarningVisible = !isEmpty && any { variation ->
+                    variation.isVisible &&
+                        variation.regularPrice.isNotSet() &&
+                        variation.salePrice.isNotSet()
+                }
+            )
         }
     }
 


### PR DESCRIPTION
Fixes #4181 - sets the variation list container view to invisible rather than gone so the warning banner can be correctly aligned to the top. 

![fix](https://user-images.githubusercontent.com/3903757/121744964-afb85180-cad1-11eb-8440-1a3a318fe249.png)

Note, though, that the issue shows another problem in that the warning banner should never be shown when the empty view is showing. I wasn't able to reproduce this, but I believe I fixed it by simplifying the logic for showing these views in bf07f3e.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
