### PR TITLE
Fix typo in product selector

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1312,7 +1312,7 @@
 
     <!-- Product type bottom sheets -->
     <string name="product_type_list_header">Select a product type</string>
-    <string name="product_type_simple_title">Simple physical productt</string>
+    <string name="product_type_simple_title">Simple physical product</string>
     <string name="product_type_simple_desc">A unique physical product that you may have to ship to the customer</string>
     <string name="product_type_virtual_title">Simple virtual product</string>
     <string name="product_type_virtual_desc">A unique digital product like services, downloadable books, music or videos</string>


### PR DESCRIPTION
Pulls in the commit by @AliSoftware from https://github.com/woocommerce/woocommerce-android/pull/4128 to fix a typo in the product selector. Fixes #4191. 

**🚑 ⚠️ This targets the `release/6.8` branch.** 

Before | After 
--------|-------
![image](https://user-images.githubusercontent.com/198826/121755534-ae3c5880-cad4-11eb-9a61-d18891ec55f7.png)  |       ![2021-06-11 16 43 15](https://user-images.githubusercontent.com/198826/121755567-beecce80-cad4-11eb-89ae-ea1a4b7ba934.png)

## Testing 

1. Navigate to Products
2. Tap on the big plus button. You won't miss it.


