### PR TITLE
Use line_item id as unique identifier when displaying products

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] Various design tweaks on empty state screen [https://github.com/woocommerce/woocommerce-android/pull/3879]
 - [*] Removed trash option from product status in Product Settings [https://github.com/woocommerce/woocommerce-android/pull/4148]
 - [*] Fixed an issue where the app would crash when loading refunds [https://github.com/woocommerce/woocommerce-android/pull/4166]
+- [*] Fixed a rare bug that would display incorrect order quantities for variable products [https://github.com/woocommerce/woocommerce-android/pull/4193]
 
 6.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
@@ -33,7 +33,8 @@ data class Refund(
         val total: BigDecimal = BigDecimal.ZERO,
         val totalTax: BigDecimal = BigDecimal.ZERO,
         val sku: String = "",
-        val price: BigDecimal = BigDecimal.ZERO
+        val price: BigDecimal = BigDecimal.ZERO,
+        val refundId: Long = 0
     ) : Parcelable {
         @IgnoredOnParcel
         val uniqueId: Long = ProductHelper.productOrVariationId(productId, variationId)
@@ -83,51 +84,20 @@ fun WCRefundItem.toAppModel(): Refund.Item {
             -(total ?: BigDecimal.ZERO).roundError(), // WCRefundItem.total is NEGATIVE
             -totalTax.roundError(), // WCRefundItem.totalTax is NEGATIVE
             sku ?: "",
-            price?.roundError() ?: BigDecimal.ZERO
+            price?.roundError() ?: BigDecimal.ZERO,
+        metaData?.get(0)?.value?.toString()?.toLongOrNull() ?: -1
     )
 }
 
 fun WCRefundShippingLine.toAppModel(): Refund.ShippingLine {
     return Refund.ShippingLine(
-        itemId = getRefundedShippingLineId(),
+        itemId = metaData?.get(0)?.value?.toString()?.toLongOrNull() ?: -1,
         methodId = methodId ?: "",
         methodTitle = methodTitle ?: "",
         totalTax = -totalTax.roundError(),      // WCRefundShippineLine.totalTax is NEGATIVE
         total = (total).roundError()            // WCREfundShippingLine.total is NEGATIVE
     )
 }
-
-/**
- * In a "WCRefundShippingLine" object, the id of the refunded shipping line is buried in "metaData" property like so:
- *
- * -------------------------------------------
- *
- * meta_data: [
- *     0: {
- *         display_key: "_refunded_item_id"
- *         display_value: "72"
- *         id: 591                         <-- Not what we want. This is the metadata id.
- *         key: "_refunded_item_id"
- *         value: "72"                     <-- This is the specific shipping line id that we want.
- *         }
- *    ]
- *
- * -------------------------------------------
- *
- * This method extracts that `value` property and returns it, or returns -1 if it can't find it.
- */
-fun WCRefundShippingLine.getRefundedShippingLineId(): Long {
-    if (this.metaData != null) {
-        val resultJson = this.metaData!!.get(0).asJsonObject
-        if (resultJson.has("value") && resultJson.get("value").isJsonPrimitive) {
-            return resultJson.get("value").asLong
-        }
-    }
-    return -1
-}
-
-fun List<Refund>.hasNonRefundedProducts(products: List<Order.Item>) =
-    getMaxRefundQuantities(products).values.any { it > 0 }
 
 fun List<Refund>.getNonRefundedProducts(
     products: List<Order.Item>
@@ -157,7 +127,7 @@ fun List<Refund>.getMaxRefundQuantities(
     products: List<Order.Item>
 ): Map<Long, Int> {
     val map = mutableMapOf<Long, Int>()
-    val groupedRefunds = this.flatMap { it.items }.groupBy { it.id }
+    val groupedRefunds = this.flatMap { it.items }.groupBy { it.refundId }
     products.map { item ->
         map[item.itemId] = item.quantity - (groupedRefunds[item.itemId]?.sumBy { it.quantity } ?: 0)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
@@ -34,7 +34,7 @@ data class Refund(
         val totalTax: BigDecimal = BigDecimal.ZERO,
         val sku: String = "",
         val price: BigDecimal = BigDecimal.ZERO,
-        val refundId: Long = 0
+        val orderItemId: Long = 0
     ) : Parcelable {
         @IgnoredOnParcel
         val uniqueId: Long = ProductHelper.productOrVariationId(productId, variationId)
@@ -127,7 +127,7 @@ fun List<Refund>.getMaxRefundQuantities(
     products: List<Order.Item>
 ): Map<Long, Int> {
     val map = mutableMapOf<Long, Int>()
-    val groupedRefunds = this.flatMap { it.items }.groupBy { it.refundId }
+    val groupedRefunds = this.flatMap { it.items }.groupBy { it.orderItemId }
     products.map { item ->
         map[item.itemId] = item.quantity - (groupedRefunds[item.itemId]?.sumBy { it.quantity } ?: 0)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
@@ -134,9 +134,9 @@ fun List<Refund>.getNonRefundedProducts(
 ): List<Order.Item> {
     val leftoverProducts = getMaxRefundQuantities(products).filter { it.value > 0 }
     return products
-        .filter { leftoverProducts.contains(it.uniqueId) }
+        .filter { leftoverProducts.contains(it.itemId) }
         .map {
-            val newQuantity = leftoverProducts[it.uniqueId]
+            val newQuantity = leftoverProducts[it.itemId]
             val quantity = it.quantity.toBigDecimal()
             val totalTax = if (quantity > BigDecimal.ZERO) {
                 it.totalTax.divide(quantity, 2, HALF_UP)
@@ -157,9 +157,9 @@ fun List<Refund>.getMaxRefundQuantities(
     products: List<Order.Item>
 ): Map<Long, Int> {
     val map = mutableMapOf<Long, Int>()
-    val groupedRefunds = this.flatMap { it.items }.groupBy { it.uniqueId }
+    val groupedRefunds = this.flatMap { it.items }.groupBy { it.id }
     products.map { item ->
-        map[item.uniqueId] = item.quantity - (groupedRefunds[item.uniqueId]?.sumBy { it.quantity } ?: 0)
+        map[item.itemId] = item.quantity - (groupedRefunds[item.itemId].sumBy { it.quantity } ?: 0)
     }
     return map
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
@@ -159,7 +159,7 @@ fun List<Refund>.getMaxRefundQuantities(
     val map = mutableMapOf<Long, Int>()
     val groupedRefunds = this.flatMap { it.items }.groupBy { it.id }
     products.map { item ->
-        map[item.itemId] = item.quantity - (groupedRefunds[item.itemId].sumBy { it.quantity } ?: 0)
+        map[item.itemId] = item.quantity - (groupedRefunds[item.itemId]?.sumBy { it.quantity } ?: 0)
     }
     return map
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
@@ -125,7 +125,7 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
         binding.paymentInfoRefundTotalSection.hide()
 
         var availableRefundQuantity = order.availableRefundQuantity
-        refunds.flatMap { it.items }.groupBy { it.uniqueId }.forEach { productRefunds ->
+        refunds.flatMap { it.items }.groupBy { it.refundId }.forEach { productRefunds ->
             val refundedCount = productRefunds.value.sumBy { it.quantity }
             availableRefundQuantity -= refundedCount
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
@@ -125,7 +125,7 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
         binding.paymentInfoRefundTotalSection.hide()
 
         var availableRefundQuantity = order.availableRefundQuantity
-        refunds.flatMap { it.items }.groupBy { it.refundId }.forEach { productRefunds ->
+        refunds.flatMap { it.items }.groupBy { it.orderItemId }.forEach { productRefunds ->
             val refundedCount = productRefunds.value.sumBy { it.quantity }
             availableRefundQuantity -= refundedCount
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/IssueRefundViewModel.kt
@@ -93,7 +93,7 @@ class IssueRefundViewModel @Inject constructor(
     }
 
     private val _refundItems = MutableLiveData<List<ProductRefundListItem>>()
-    final val refundItems: LiveData<List<ProductRefundListItem>> = _refundItems
+    val refundItems: LiveData<List<ProductRefundListItem>> = _refundItems
 
     private val _refundShippingLines = MutableLiveData<List<ShippingRefundListItem>>()
     val refundShippingLines: LiveData<List<ShippingRefundListItem>> = _refundShippingLines
@@ -114,7 +114,7 @@ class IssueRefundViewModel @Inject constructor(
             updateRefundTotal(new.enteredAmount)
         }
     )
-    final val productsRefundLiveData = LiveDataDelegate(savedState, ProductsRefundViewState())
+    val productsRefundLiveData = LiveDataDelegate(savedState, ProductsRefundViewState())
 
     private var commonState by commonStateLiveData
     private var refundByAmountState by refundByAmountStateLiveData
@@ -140,7 +140,7 @@ class IssueRefundViewModel @Inject constructor(
     }
 
     private var refundJob: Job? = null
-    final val isRefundInProgress: Boolean
+    val isRefundInProgress: Boolean
         get() = refundJob?.isActive ?: false
 
     init {
@@ -236,8 +236,8 @@ class IssueRefundViewModel @Inject constructor(
         }
 
         val items = order.items.map {
-            val maxQuantity = maxQuantities[it.uniqueId] ?: 0
-            val selectedQuantity = min(selectedQuantities[it.uniqueId] ?: 0, maxQuantity)
+            val maxQuantity = maxQuantities[it.itemId] ?: 0
+            val selectedQuantity = min(selectedQuantities[it.itemId] ?: 0, maxQuantity)
             ProductRefundListItem(it, maxQuantity, selectedQuantity)
         }
         updateRefundItems(items)
@@ -460,7 +460,7 @@ class IssueRefundViewModel @Inject constructor(
     }
 
     fun onRefundQuantityTapped(uniqueId: Long) {
-        _refundItems.value?.firstOrNull { it.orderItem.uniqueId == uniqueId }?.let {
+        _refundItems.value?.firstOrNull { it.orderItem.itemId == uniqueId }?.let {
             triggerEvent(ShowNumberPicker(it))
         }
 
@@ -527,7 +527,7 @@ class IssueRefundViewModel @Inject constructor(
     private fun getUpdatedItemList(uniqueId: Long, newQuantity: Int): MutableList<ProductRefundListItem> {
         val newItems = mutableListOf<ProductRefundListItem>()
         _refundItems.value?.forEach {
-            if (it.orderItem.uniqueId == uniqueId) {
+            if (it.orderItem.itemId == uniqueId) {
                 newItems.add(
                         it.copy(
                                 quantity = newQuantity,
@@ -544,11 +544,11 @@ class IssueRefundViewModel @Inject constructor(
     fun onSelectButtonTapped() {
         if (areAllItemsSelected) {
             _refundItems.value?.forEach {
-                onRefundQuantityChanged(it.orderItem.uniqueId, 0)
+                onRefundQuantityChanged(it.orderItem.itemId, 0)
             }
         } else {
             _refundItems.value?.forEach {
-                onRefundQuantityChanged(it.orderItem.uniqueId, it.maxQuantity)
+                onRefundQuantityChanged(it.orderItem.itemId, it.maxQuantity)
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByItemsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundByItemsFragment.kt
@@ -140,7 +140,7 @@ class RefundByItemsFragment : BaseFragment(R.layout.fragment_refund_by_items),
             new.selectButtonTitle?.takeIfNotEqualTo(old?.selectButtonTitle) {
                 binding.issueRefundSelectButton.text = it
             }
-            new.isShippingMainSwitchChecked?.takeIfNotEqualTo(old?.isShippingMainSwitchChecked) { checked ->
+            new.isShippingMainSwitchChecked.takeIfNotEqualTo(old?.isShippingMainSwitchChecked) { checked ->
                 binding.issueRefundShippingMainSwitch.isChecked = checked
             }
             new.selectedShippingLines?.takeIfNotEqualTo(old?.selectedShippingLines) { shippingLines ->
@@ -192,7 +192,7 @@ class RefundByItemsFragment : BaseFragment(R.layout.fragment_refund_by_items),
                 is ShowNumberPicker -> {
                     val action = IssueRefundFragmentDirections.actionIssueRefundFragmentToRefundItemsPickerDialog(
                             getString(R.string.order_refunds_select_quantity),
-                            event.refundItem.orderItem.uniqueId,
+                            event.refundItem.orderItem.itemId,
                             event.refundItem.maxQuantity,
                             event.refundItem.quantity
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundDetailViewModel.kt
@@ -61,7 +61,7 @@ class RefundDetailViewModel @Inject constructor(
     }
 
     private fun displayRefundedProducts(order: Order, refunds: List<Refund>) {
-        val groupedRefunds = refunds.flatMap { it.items }.groupBy { it.refundId }
+        val groupedRefunds = refunds.flatMap { it.items }.groupBy { it.orderItemId }
         val refundedProducts = groupedRefunds.keys.mapNotNull { id ->
             order.items.firstOrNull { it.itemId == id }?.let { item ->
                 groupedRefunds[id]?.sumBy { it.quantity }?.let { quantity ->
@@ -84,7 +84,7 @@ class RefundDetailViewModel @Inject constructor(
         if (refund.items.isNotEmpty()) {
             val items = refund.items.map { refundItem ->
                 ProductRefundListItem(
-                    order.items.first { it.itemId == refundItem.refundId },
+                    order.items.first { it.itemId == refundItem.orderItemId },
                     quantity = refundItem.quantity
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundDetailViewModel.kt
@@ -61,9 +61,9 @@ class RefundDetailViewModel @Inject constructor(
     }
 
     private fun displayRefundedProducts(order: Order, refunds: List<Refund>) {
-        val groupedRefunds = refunds.flatMap { it.items }.groupBy { it.uniqueId }
+        val groupedRefunds = refunds.flatMap { it.items }.groupBy { it.refundId }
         val refundedProducts = groupedRefunds.keys.mapNotNull { id ->
-            order.items.firstOrNull { it.uniqueId == id }?.let { item ->
+            order.items.firstOrNull { it.itemId == id }?.let { item ->
                 groupedRefunds[id]?.sumBy { it.quantity }?.let { quantity ->
                     ProductRefundListItem(item, quantity = quantity)
                 }
@@ -84,7 +84,7 @@ class RefundDetailViewModel @Inject constructor(
         if (refund.items.isNotEmpty()) {
             val items = refund.items.map { refundItem ->
                 ProductRefundListItem(
-                    order.items.first { it.uniqueId == refundItem.uniqueId },
+                    order.items.first { it.itemId == refundItem.refundId },
                     quantity = refundItem.quantity
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/refunds/RefundProductListAdapter.kt
@@ -127,7 +127,7 @@ class RefundProductListAdapter(
 
             quantityTextView.text = item.quantity.toString()
             quantityTextView.setOnClickListener {
-                onItemClicked(item.orderItem.uniqueId)
+                onItemClicked(item.orderItem.itemId)
             }
 
             imageMap.get(item.orderItem.productId)?.let {
@@ -163,7 +163,7 @@ class RefundProductListAdapter(
         private val newList: List<ProductRefundListItem>
     ) : Callback() {
         override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-            return oldList[oldItemPosition].orderItem.uniqueId == newList[newItemPosition].orderItem.uniqueId
+            return oldList[oldItemPosition].orderItem.itemId == newList[newItemPosition].orderItem.itemId
         }
 
         override fun getOldListSize(): Int = oldList.size

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderTestUtils.kt
@@ -217,7 +217,8 @@ object OrderTestUtils {
                         subtotal = BigDecimal.valueOf(10.00),
                         total = BigDecimal.valueOf(10.00),
                         totalTax = BigDecimal.ZERO,
-                        price = BigDecimal.valueOf(10.00)
+                        price = BigDecimal.valueOf(10.00),
+                        orderItemId = 1L
                     )
                 ),
                 shippingLines = listOf(

--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'e1fc3eb87caa0a824d512dc5c902a6ed9e0d09a2'
+    fluxCVersion = '9ce563feb91904567a66acd9255486282f1ef8dd'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '60acf539471e6e4494f4d01a57af689c2edac528'
+    fluxCVersion = 'e1fc3eb87caa0a824d512dc5c902a6ed9e0d09a2'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'


### PR DESCRIPTION
Fixes #3811. There have been a few complaints from some merchants that the quantity displayed in the Order detail screen for variable products is incorrect. I was not able to reproduce this issue from my own test site but had to SSP into another site to reproduce it.

It seems that for a particular order, there are two variable products with quantity 2 and 1 respectively. But the app is displaying both products are 1. This was because the `variation_id` of both the products were the same. This was causing the incorrect quantity issue when we [were fetching non refunded products for display](https://github.com/woocommerce/woocommerce-android/blob/98b122bfe96ce34babf3d47f36d47483bec7d7a4/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt#L146).

I updated the logic to use the `line_item.id` instead of the `line_item.unique_id` since it looks like the `variation_id` is not unique. I didn't face any issues when testing the order detail screen for different scenarios so I assume everything is working correctly. But would like to get some feedback from reviewers to verify that everything is working fine. 

#### To test the original issue
- SSP into this [site](https://github.com/woocommerce/woocommerce-android/issues/3811#issuecomment-846451639). Please DM me for more details.
- Click on the Orders TAB and search for order number 2269.
- Notice that the product list displays the correct quantity (as sent from the API).

#### Smoke Testing
Since this change modifies the unique identifier we use in the app, it would be nice to test the following features. **Please perform these sites from your own test site.**:
- Try refunding an entire order and verify that the product list is not displayed. 
- Try refunding a product from an order that contains atleast 2 products. Verify that the product list displays the correct details.
- Try refunding orders that contain variable products, physical products and virtual products.

cc @nbradbury @hichamboushaba I assigned the PR to both of you because I thought you might have more context around order details and refunds in general :) 

I think this fix might be worth including in the new beta releasing today. cc @jkmassel since you will be taking care of the beta release this sprint 😄 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
