### PR TITLE
Change Dependabot config to use up-to-date config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    default_labels:
-      - "bot: updated dependencies"
+    labels:
+      - "bot: dependencies update"
     reviewers:
       - "woocommerce/android-developers"
     ignore:


### PR DESCRIPTION
This is a follow-up to discussion started here: https://github.com/woocommerce/woocommerce-android/pull/3960#issuecomment-833330101

### Context

We use the legacy `default_labels` config field for `Dependabot`. This PR updates the config as well as the name of the label.

### Result
Please see my fork: https://github.com/wzieba/woocommerce-android/pulls

**No more `java` label 🎉😄**

<img width="750" alt="image" src="https://user-images.githubusercontent.com/5845095/122076300-0cca4500-cdfb-11eb-81d6-1f722295dac8.png">


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
