### PR TITLE
Make installGitHooks task optional and use Task Configuration Avoidance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ task clean(type: Delete) {
  * Copies git-hooks from the `tools/team-props/git-hooks' directory to the `.git/hooks` folder
  * at the root of this project.
  */
-task installGitHooks(type: Copy) {
+tasks.register("installGitHooks", Copy) {
     println "Copying git-hooks scripts from tools/team-props/git-hooks to .git/hooks"
     from new File(rootProject.rootDir, 'tools/team-props/git-hooks')
     into { new File(rootProject.rootDir, '.git/hooks') }
@@ -116,8 +116,6 @@ ext {
     robolectricVersion = '4.5.1'
     hiltJetpackVersion = '1.0.0'
 }
-
-tasks.getByPath('WooCommerce:preBuild').dependsOn installGitHooks
 
 // Onboarding and dev env setup tasks
 task checkBundler(type:Exec) {


### PR DESCRIPTION
After internally discussing with the team, we have decided to make the `installGitHooks` task optional, so I've removed it from the `preBuild` task dependencies. I've also refactored the `installGitHooks` task to use [Task Configuration Avoidance](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) so it's not configured if it'll not be executed.

**To test: (optional)**
* Run ` ./gradlew tasks --all | grep installGitHooks` and verify that it returns `installGitHooks`. Alternatively, you can delete `.git/hook/pre-commit`, run `./gradlew installGitHooks` and verify the hook in `.git/hooks/pre-commit`.