### PR TITLE
issue/4200-save-as-draft-6.9

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -613,8 +613,7 @@ class ProductDetailViewModel @Inject constructor(
      * Called when the "Save as draft" button is clicked in Product detail screen
      */
     fun onSaveAsDraftButtonClicked() {
-        updateProductDraft(productStatus = DRAFT)
-        startPublishProduct()
+        startPublishProduct(productStatus = DRAFT)
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -568,8 +568,7 @@ class ProductDetailViewModel @Inject constructor(
             val neutralAction = if (isProductUnderCreation) {
                 neutralBtnId = string.product_detail_save_as_draft
                 DialogInterface.OnClickListener { _, _ ->
-                    updateProductDraft(productStatus = DRAFT)
-                    startPublishProduct(exitWhenDone = true)
+                    startPublishProduct(productStatus = DRAFT, exitWhenDone = true)
                 }
             } else {
                 neutralBtnId = null
@@ -654,8 +653,8 @@ class ProductDetailViewModel @Inject constructor(
         }
     }
 
-    private fun startPublishProduct(exitWhenDone: Boolean = false) {
-        updateProductDraft(productStatus = PUBLISH)
+    private fun startPublishProduct(productStatus: ProductStatus = PUBLISH, exitWhenDone: Boolean = false) {
+        updateProductDraft(productStatus = productStatus)
 
         viewState.productDraft?.let {
             trackPublishing(it)


### PR DESCRIPTION
Fixes #4200 - Note that this targets `release/6.9`. To test:

- In the product list, tap to create a product
- Start typing a title
- Hit the back button
- When the dialog below appears, choose "Save as draft"
- Verify that the product is saved as a draft rather than published

![Screenshot_20210615_130945](https://user-images.githubusercontent.com/3903757/122095153-01672180-cddb-11eb-8d61-09f9e0d0857e.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
