### PR TITLE
Issue/3725 more readers found

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -24,6 +24,8 @@ import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectView
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.OpenPermissionsSettings
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.RequestEnableBluetooth
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.RequestLocationPermissions
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ListItemViewState.ScanningInProgressListItem
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ListItemViewState.CardReaderListItem
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.BluetoothDisabledError
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.ConnectingFailedState
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.ConnectingState
@@ -32,6 +34,7 @@ import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectView
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.ReaderFoundState
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.ScanningFailedState
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.ScanningState
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.MultipleReadersFoundState
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -44,6 +47,8 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.util.AppLog.T
 import javax.inject.Inject
+
+private const val SHOW_LAST_N_DIGITS_OF_CARD_READERS_ID = 8
 
 @HiltViewModel
 class CardReaderConnectViewModel @Inject constructor(
@@ -62,7 +67,7 @@ class CardReaderConnectViewModel @Inject constructor(
      * Since this VM doesn't need to have support for MultiLiveEvent, it overrides _event from the parent
      * with SingleLiveEvent.
      */
-    protected override val _event = SingleLiveEvent<Event>()
+    override val _event = SingleLiveEvent<Event>()
     override val event: LiveData<Event> = _event
 
     private lateinit var cardReaderManager: CardReaderManager
@@ -184,18 +189,35 @@ class CardReaderConnectViewModel @Inject constructor(
     private fun onReadersFound(discoveryEvent: ReadersFound) {
         if (viewState.value is ConnectingState) return
         val availableReaders = discoveryEvent.list.filter { it.id != null }
-        if (availableReaders.isNotEmpty()) {
-            // TODO cardreader add support for showing multiple readers
-            val reader = availableReaders[0]
-            viewState.value = ReaderFoundState(
-                onPrimaryActionClicked = { onConnectToReaderClicked(reader) },
-                onSecondaryActionClicked = ::onCancelClicked,
-                readerId = reader.id.orEmpty()
-            )
-        } else {
-            viewState.value = ScanningState(::onCancelClicked)
+        viewState.value = when {
+            availableReaders.isEmpty() -> ScanningState(::onCancelClicked)
+            availableReaders.size == 1 -> buildSingleReaderFoundState(availableReaders[0])
+            availableReaders.size > 1 -> buildMultipleReadersFoundState(availableReaders)
+            else -> throw IllegalStateException("Unreachable code")
         }
     }
+
+    private fun buildSingleReaderFoundState(reader: CardReader) =
+        ReaderFoundState(
+            onPrimaryActionClicked = { onConnectToReaderClicked(reader) },
+            onSecondaryActionClicked = ::onCancelClicked,
+            readerId = reader.id.orEmpty()
+        )
+
+    private fun buildMultipleReadersFoundState(availableReaders: List<CardReader>): MultipleReadersFoundState {
+        val listItems: MutableList<ListItemViewState> = availableReaders
+            .map { mapReaderToListItem(it) }
+            .toMutableList()
+            .also { it.add(ScanningInProgressListItem) }
+        return MultipleReadersFoundState(listItems, ::onCancelClicked)
+    }
+
+    private fun mapReaderToListItem(reader: CardReader): ListItemViewState =
+        CardReaderListItem(
+            readerId = reader.id?.takeLast(SHOW_LAST_N_DIGITS_OF_CARD_READERS_ID).orEmpty(),
+            onConnectClicked = {
+                onConnectToReaderClicked(reader)
+            })
 
     private fun onConnectToReaderClicked(cardReader: CardReader) {
         viewState.value = ConnectingState(::onCancelClicked)
@@ -268,7 +290,8 @@ class CardReaderConnectViewModel @Inject constructor(
         @DrawableRes val illustration: Int? = null,
         @StringRes val hintLabel: Int? = null,
         val primaryActionLabel: Int? = null,
-        val secondaryActionLabel: Int? = null
+        val secondaryActionLabel: Int? = null,
+        open val listItems: List<ListItemViewState>? = null
     ) {
         open val onPrimaryActionClicked: (() -> Unit)? = null
         open val onSecondaryActionClicked: (() -> Unit)? = null
@@ -295,7 +318,13 @@ class CardReaderConnectViewModel @Inject constructor(
             secondaryActionLabel = R.string.cancel
         )
 
-        // TODO cardreader add multiple readers found state
+        data class MultipleReadersFoundState(
+            override val listItems: List<ListItemViewState>,
+            override val onSecondaryActionClicked: () -> Unit
+        ) : ViewState(
+            headerLabel = UiStringRes(R.string.card_reader_connect_multiple_readers_found_header),
+            secondaryActionLabel = R.string.cancel
+        )
 
         data class ConnectingState(override val onSecondaryActionClicked: (() -> Unit)) : ViewState(
             headerLabel = UiStringRes(R.string.card_reader_connect_connecting_header),
@@ -358,5 +387,19 @@ class CardReaderConnectViewModel @Inject constructor(
             primaryActionLabel = R.string.card_reader_connect_open_bluetooth_settings,
             secondaryActionLabel = R.string.cancel
         )
+    }
+
+    sealed class ListItemViewState {
+        object ScanningInProgressListItem : ListItemViewState() {
+            val label = UiStringRes(R.string.card_reader_connect_scanning_progress)
+            @DrawableRes val scanningIcon = R.drawable.ic_loop_24px
+        }
+
+        data class CardReaderListItem(
+            val readerId: String,
+            val onConnectClicked: () -> Unit
+        ) : ListItemViewState() {
+            val connectLabel: UiString = UiStringRes(R.string.card_reader_connect_connect_button)
+        }
     }
 }

--- a/WooCommerce/src/main/res/drawable/ic_loop_24px.xml
+++ b/WooCommerce/src/main/res/drawable/ic_loop_24px.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <group>
+    <clip-path
+        android:pathData="M12,1V4C16.42,4 20,7.58 20,12C20,13.57 19.54,15.03 18.76,16.26L17.3,14.8C17.75,13.97 18,13.01 18,12C18,8.69 15.31,6 12,6V9L8,5L12,1ZM6,12C6,15.31 8.69,18 12,18V15L16,19L12,23V20C7.58,20 4,16.42 4,12C4,10.43 4.46,8.97 5.24,7.74L6.7,9.2C6.25,10.03 6,10.99 6,12Z"
+        android:fillType="evenOdd"/>
+    <path
+        android:pathData="M0,0h24v24h-24z"
+        android:fillColor="?attr/colorOnSurface"
+        android:fillAlpha="0.38"/>
+  </group>
+</vector>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -711,9 +711,12 @@
             Card Reader Connection
         -->
     <string name="card_reader_connect_scanning_header">Scanning for readers</string>
+    <string name="card_reader_connect_scanning_progress" translatable="false">@string/card_reader_connect_scanning_header</string>
     <string name="card_reader_connect_scanning_hint">Press the power button of your reader until you see a flashing blue light</string>
     <string name="card_reader_connect_reader_found_header">Do you want to connect reader %s?</string>
+    <string name="card_reader_connect_multiple_readers_found_header">Several readers found</string>
     <string name="card_reader_connect_to_reader">Connect to reader</string>
+    <string name="card_reader_connect_connect_button">Connect</string>
     <string name="card_reader_connect_connecting_header">Connecting to reader</string>
     <string name="card_reader_connect_connecting_hint" translatable="false">@string/please_wait</string>
     <string name="card_reader_connect_failed_header">Connecting to reader failed</string>

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersActionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersActionTest.kt
@@ -64,6 +64,39 @@ class DiscoverReadersActionTest {
     }
 
     @Test
+    fun `when new readers found, then FoundReaders is emitted`() = runBlockingTest {
+        whenever(terminal.discoverReaders(any(), any(), any())).thenAnswer {
+            onUpdateDiscoveredReaders(args = it.arguments, readers = listOf(mock()))
+            onUpdateDiscoveredReaders(args = it.arguments, readers = listOf(mock(), mock()))
+            onSuccess(args = it.arguments)
+            mock<Cancelable>()
+        }
+
+        val events = action.discoverReaders(false)
+            .ignoreStartedEvent().toList()
+
+        assertThat(events[0]).isInstanceOf(FoundReaders::class.java)
+        assertThat(events[1]).isInstanceOf(FoundReaders::class.java)
+    }
+
+    @Test
+    fun `when already found readers found, then FoundReaders is NOT emitted`() = runBlockingTest {
+        whenever(terminal.discoverReaders(any(), any(), any())).thenAnswer {
+            val reader = mock<Reader>()
+            onUpdateDiscoveredReaders(args = it.arguments, readers = listOf(reader))
+            onUpdateDiscoveredReaders(args = it.arguments, readers = listOf(reader))
+            onSuccess(args = it.arguments)
+            mock<Cancelable>()
+        }
+
+        val events = action.discoverReaders(false)
+            .ignoreStartedEvent().toList()
+
+        assertThat(events[0]).isInstanceOf(FoundReaders::class.java)
+        assertThat(events[1]).isNotInstanceOf(FoundReaders::class.java)
+    }
+
+    @Test
     fun `when reader discover succeeds, then Success is emitted`() = runBlockingTest {
         whenever(terminal.discoverReaders(any(), any(), any())).thenAnswer {
             onSuccess(args = it.arguments)


### PR DESCRIPTION
Parent issue #3725 

This PR is a first step in handling state when StripeTerminalSDK returns multiple readers during a scan. The app displays a list of found readers (UI is not part of this PR).

This PR also updates DiscoverReadersAction to emit ReadersFound event only when it has changed since the last emission.


To test:
This PR doesn't contain the UI changes - run tests in [the follow-up PR](https://github.com/woocommerce/woocommerce-android/pull/4212).

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
