### PR TITLE
Shipping Labels: international requirements for DHL

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Address.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Address.kt
@@ -91,7 +91,7 @@ data class Address(
      * Source: https://github.com/Automattic/woocommerce-services/issues/1351
      */
     fun hasValidPhoneNumber(addressType: AddressType): Boolean {
-        return when(addressType){
+        return when (addressType) {
             ORIGIN -> phone.replace(Regex("^1|[^\\d]"), "").length == 10
             DESTINATION -> phone.contains(Regex("\\d"))
         }
@@ -109,6 +109,18 @@ data class Address(
             state = state,
             country = country
         )
+    }
+
+    /**
+     * Compares this address's physical location to the other one
+     */
+    fun isSamePhysicalAddress(otherAddress: Address): Boolean {
+        return country == otherAddress.country &&
+            state == otherAddress.state &&
+            address1 == otherAddress.address1 &&
+            address2 == otherAddress.address2 &&
+            city == otherAddress.city &&
+            postcode == otherAddress.postcode
     }
 
     override fun toString(): String {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Address.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Address.kt
@@ -93,7 +93,7 @@ data class Address(
     fun hasValidPhoneNumber(addressType: AddressType): Boolean {
         return when(addressType){
             ORIGIN -> phone.replace(Regex("^1|[^\\d]"), "").length == 10
-            DESTINATION -> phone.contains("\\d")
+            DESTINATION -> phone.contains(Regex("\\d"))
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Address.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Address.kt
@@ -85,7 +85,11 @@ data class Address(
     }
 
     /**
-     * Checks whether the entered phone number contains 10 digits exactly after stripping an optional 1 as the area code.
+     * Checks whether the phone number is valid or not, depending on the [addressType], the check is:
+     * - [ORIGIN]: Checks whether the phone number contains 10 digits exactly after deleting an optional 1 as
+     *             the area code.
+     * - [DESTINATION]: Checks whether the phone has any digits.
+     *
      * As EasyPost is permissive for the presence of other characters, we delete all other characters before checking,
      * and that's similar to what the web client does.
      * Source: https://github.com/Automattic/woocommerce-services/issues/1351

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Address.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Address.kt
@@ -5,6 +5,9 @@ import com.google.i18n.addressinput.common.AddressData
 import com.google.i18n.addressinput.common.FormOptions
 import com.google.i18n.addressinput.common.FormatInterpreter
 import com.woocommerce.android.extensions.appendWithIfNotEmpty
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.DESTINATION
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.ORIGIN
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import kotlinx.parcelize.Parcelize
@@ -87,7 +90,12 @@ data class Address(
      * and that's similar to what the web client does.
      * Source: https://github.com/Automattic/woocommerce-services/issues/1351
      */
-    fun phoneHas10Digits() = phone.replace(Regex("^1|[^\\d]"), "").length == 10
+    fun hasValidPhoneNumber(addressType: AddressType): Boolean {
+        return when(addressType){
+            ORIGIN -> phone.replace(Regex("^1|[^\\d]"), "").length == 10
+            DESTINATION -> phone.contains("\\d")
+        }
+    }
 
     fun toShippingLabelModel(): ShippingLabelAddress {
         return ShippingLabelAddress(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/MetaData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/MetaData.kt
@@ -1,0 +1,65 @@
+package com.woocommerce.android.model
+
+import android.os.Parcel
+import android.os.Parcelable
+import android.os.Parcelable.Creator
+import org.wordpress.android.fluxc.model.WCMetaData
+import java.io.Serializable
+
+// we can's use Parcelize here for the generic type due to this bug: https://youtrack.jetbrains.com/issue/KT-42652
+data class MetaData<T : Any>(
+    val key: String,
+    val value: T
+) : Parcelable {
+    constructor(parcel: Parcel) : this(
+        parcel.readString()!!,
+        readValueFromParcel(parcel)
+    )
+
+    init {
+        if (value !is Parcelable && value !is Serializable) throw IllegalArgumentException()
+    }
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeString(key)
+        parcel.writeSerializable(value::class.java)
+        parcel.writeValue(value)
+    }
+
+    override fun describeContents(): Int {
+        return 0
+    }
+
+    companion object CREATOR : Creator<MetaData<*>> {
+        override fun createFromParcel(parcel: Parcel): MetaData<*> {
+            return MetaData<Any>(parcel)
+        }
+
+        override fun newArray(size: Int): Array<MetaData<*>?> {
+            return arrayOfNulls(size)
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        fun <T> readValueFromParcel(parcel: Parcel): T {
+            val classLoader = (parcel.readSerializable() as Class<*>).classLoader
+            return parcel.readValue(classLoader) as T
+        }
+    }
+}
+
+/**
+ * Try to convert [WCMetaData] to [MetaData]
+ * The function prefers [WCMetaData.displayKey] and [WCMetaData.displayValue] over the other variants,
+ * and tries to cast them to the generic type [T], or convert it using the optional [valueConverter]
+ * If it fails, it will return null
+ */
+@Suppress("UNCHECKED_CAST")
+fun <T : Any> WCMetaData.toAppModel(valueConverter: ((Any) -> T)? = null): MetaData<T>? {
+    val value = valueConverter?.let { converter ->
+        displayValue?.let(converter) ?: converter(value)
+    } ?: displayValue as? T ?: value as? T ?: return null
+    return MetaData(
+        key = displayKey ?: key,
+        value = value
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -55,7 +55,8 @@ data class Order(
     val shippingAddress: Address,
     val shippingMethods: List<ShippingMethod>,
     val items: List<Item>,
-    val shippingLines: List<ShippingLine>
+    val shippingLines: List<ShippingLine>,
+    val metaData: List<MetaData<String>>
 ) : Parcelable {
     @IgnoredOnParcel
     val isOrderPaid = paymentMethodTitle.isEmpty() && datePaid == null
@@ -279,7 +280,8 @@ fun WCOrderModel.toAppModel(): Order {
                     it.totalTax?.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
                     it.total?.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO
                 )
-            }
+            },
+            metaData = getMetaDataList().mapNotNull { it.toAppModel() }
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
@@ -17,7 +17,7 @@ sealed class CreateShippingLabelEvent : MultiLiveEvent.Event() {
         val address: Address,
         val type: AddressType,
         val validationResult: ValidationResult?,
-        val isInternational: Boolean
+        val requiresPhoneNumber: Boolean
     ) : CreateShippingLabelEvent()
 
     data class ShowSuggestedAddress(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -201,7 +201,7 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
                             address = event.address,
                             addressType = event.type,
                             validationResult = event.validationResult,
-                            requiresPhoneNumber = event.isInternational
+                            requiresPhoneNumber = event.requiresPhoneNumber
                         )
                     findNavController().navigateSafely(action)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -5,7 +5,6 @@ import android.view.View
 import androidx.annotation.StringRes
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.woocommerce.android.R
@@ -193,7 +192,7 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
             }
         }
 
-        viewModel.event.observe(viewLifecycleOwner, Observer { event ->
+        viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is ShowAddressEditor -> {
@@ -202,7 +201,7 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
                             address = event.address,
                             addressType = event.type,
                             validationResult = event.validationResult,
-                            isInternational = event.isInternational
+                            requiresPhoneNumber = event.isInternational
                         )
                     findNavController().navigateSafely(action)
                 }
@@ -268,7 +267,7 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
                 }
                 else -> event.isHandled = false
             }
-        })
+        }
     }
 
     private fun showProgressDialog(@StringRes title: Int, @StringRes message: Int) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -215,7 +215,7 @@ class CreateShippingLabelViewModel @Inject constructor(
                                 sideEffect.address,
                                 sideEffect.type,
                                 sideEffect.validationResult,
-                                sideEffect.isInternational
+                                sideEffect.requiresPhoneNumber
                             )
                         )
                         is SideEffect.ShowAddressSuggestion -> triggerEvent(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.extensions.sumByBigDecimal
 import com.woocommerce.android.extensions.sumByFloat
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.CustomsPackage
+import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.PaymentMethod
 import com.woocommerce.android.model.ShippingLabel
 import com.woocommerce.android.model.ShippingLabelPackage
@@ -409,7 +410,7 @@ class CreateShippingLabelViewModel @Inject constructor(
         return Event.DataLoaded(
             order = order,
             originAddress = getStoreAddress(),
-            shippingAddress = order.shippingAddress,
+            shippingAddress = getShippingAddress(order),
             currentPaymentMethod = accountSettings.paymentMethods.find { it.id == accountSettings.selectedPaymentId }
         )
     }
@@ -429,6 +430,11 @@ class CreateShippingLabelViewModel @Inject constructor(
             city = siteSettings?.city ?: "",
             postcode = siteSettings?.postalCode ?: ""
         )
+    }
+
+    private fun getShippingAddress(order: Order): Address {
+        val phoneNumber = order.metaData.firstOrNull { it.key == "_shipping_phone" }?.value.orEmpty()
+        return order.shippingAddress.copy(phone = phoneNumber)
     }
 
     private suspend fun validateAddress(address: Address, type: AddressType, isInternationalShipment: Boolean): Event {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingL
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowCountrySelector
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowStateSelector
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowSuggestedAddress
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.DESTINATION
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.ORIGIN
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.ValidationResult
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.ValidationResult.NameMissing
@@ -107,7 +108,11 @@ class EditShippingLabelAddressViewModel @Inject constructor(
         if (viewState.areAllRequiredFieldsValid) {
             launch {
                 viewState = viewState.copy(address = address, isValidationProgressDialogVisible = true)
-                val result = addressValidator.validateAddress(address, arguments.addressType, arguments.isInternational)
+                val result = addressValidator.validateAddress(
+                    address,
+                    arguments.addressType,
+                    arguments.requiresPhoneNumber
+                )
                 clearErrors()
                 handleValidationResult(address, result)
                 viewState = viewState.copy(isValidationProgressDialogVisible = false)
@@ -196,10 +201,14 @@ class EditShippingLabelAddressViewModel @Inject constructor(
     }
 
     private fun validatePhone(address: Address): Int? {
-        if (arguments.addressType != ORIGIN || !arguments.isInternational) return null
+        if (!arguments.requiresPhoneNumber) return null
+        val addressType = arguments.addressType
         return when {
             address.phone.isBlank() -> R.string.shipping_label_address_phone_required
-            !address.phoneHas10Digits() -> R.string.shipping_label_address_phone_invalid
+            addressType == ORIGIN && !address.hasValidPhoneNumber(addressType) ->
+                R.string.shipping_label_origin_address_phone_invalid
+            addressType == DESTINATION && !address.hasValidPhoneNumber(addressType) ->
+                R.string.shipping_label_destination_address_phone_invalid
             else -> null
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressValidator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressValidator.kt
@@ -6,7 +6,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.ORIGIN
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
@@ -26,11 +25,11 @@ class ShippingLabelAddressValidator @Inject constructor(
     suspend fun validateAddress(
         address: Address,
         type: AddressType,
-        isInternationalShipment: Boolean
+        requiresPhoneNumber: Boolean
     ): ValidationResult {
         if (isNameMissing(address)) {
             return ValidationResult.NameMissing
-        } else if (isInternationalShipment && type == ORIGIN && !address.phoneHas10Digits()) {
+        } else if (requiresPhoneNumber && !address.hasValidPhoneNumber(type)) {
             return ValidationResult.PhoneInvalid
         } else {
             val result = withContext(Dispatchers.IO) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressValidator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressValidator.kt
@@ -27,59 +27,63 @@ class ShippingLabelAddressValidator @Inject constructor(
         type: AddressType,
         requiresPhoneNumber: Boolean
     ): ValidationResult {
-        if (isNameMissing(address)) {
-            return ValidationResult.NameMissing
-        } else if (requiresPhoneNumber && !address.hasValidPhoneNumber(type)) {
-            return ValidationResult.PhoneInvalid
-        } else {
-            val result = withContext(Dispatchers.IO) {
-                shippingLabelStore.verifyAddress(
-                    selectedSite.get(),
-                    address.toShippingLabelModel(),
-                    type.toDataType()
-                )
-            }
+        return when {
+            isNameMissing(address) -> ValidationResult.NameMissing
+            requiresPhoneNumber && !address.hasValidPhoneNumber(type) -> ValidationResult.PhoneInvalid
+            else -> verifyAddress(address, type)
+        }
+    }
 
-            return if (result.isError) {
+    private suspend fun verifyAddress(address: Address, type: AddressType): ValidationResult {
+        val result = withContext(Dispatchers.IO) {
+            shippingLabelStore.verifyAddress(
+                selectedSite.get(),
+                address.toShippingLabelModel(),
+                type.toDataType()
+            )
+        }
+
+        if (result.isError) {
+            AnalyticsTracker.track(
+                Stat.SHIPPING_LABEL_ADDRESS_VALIDATION_FAILED,
+                mapOf("error" to result.error.type.name)
+            )
+
+            return ValidationResult.Error(result.error.type)
+        }
+        return when (result.model) {
+            null -> {
                 AnalyticsTracker.track(
                     Stat.SHIPPING_LABEL_ADDRESS_VALIDATION_FAILED,
-                    mapOf("error" to result.error.type.name)
+                    mapOf("error" to "response_model_null")
                 )
 
-                ValidationResult.Error(result.error.type)
-            } else when (result.model) {
-                null -> {
-                    AnalyticsTracker.track(
-                        Stat.SHIPPING_LABEL_ADDRESS_VALIDATION_FAILED,
-                        mapOf("error" to "response_model_null")
-                    )
+                ValidationResult.Error(GENERIC_ERROR)
+            }
+            is InvalidRequest -> {
+                AnalyticsTracker.track(
+                    Stat.SHIPPING_LABEL_ADDRESS_VALIDATION_FAILED,
+                    mapOf("error" to "address_not_found")
+                )
 
-                    ValidationResult.Error(GENERIC_ERROR)
-                }
-                is InvalidRequest -> {
-                    AnalyticsTracker.track(
-                        Stat.SHIPPING_LABEL_ADDRESS_VALIDATION_FAILED,
-                        mapOf("error" to "address_not_found")
-                    )
+                ValidationResult.NotFound((result.model as InvalidRequest).message)
+            }
+            is InvalidAddress -> {
+                AnalyticsTracker.track(
+                    Stat.SHIPPING_LABEL_ADDRESS_VALIDATION_FAILED,
+                    mapOf("error" to "invalid_address")
+                )
 
-                    ValidationResult.NotFound((result.model as InvalidRequest).message)
-                }
-                is InvalidAddress -> {
-                    AnalyticsTracker.track(
-                        Stat.SHIPPING_LABEL_ADDRESS_VALIDATION_FAILED,
-                        mapOf("error" to "invalid_address")
-                    )
-
-                    ValidationResult.Invalid((result.model as InvalidAddress).message)
-                }
-                is WCAddressVerificationResult.Valid -> {
-                    AnalyticsTracker.track(Stat.SHIPPING_LABEL_ADDRESS_VALIDATION_SUCCEEDED)
-                    val suggestion = (result.model as WCAddressVerificationResult.Valid).suggestedAddress.toAppModel()
-                    if (suggestion.toString() != address.toString()) {
-                        ValidationResult.SuggestedChanges(suggestion)
-                    } else {
-                        ValidationResult.Valid
-                    }
+                ValidationResult.Invalid((result.model as InvalidAddress).message)
+            }
+            is WCAddressVerificationResult.Valid -> {
+                AnalyticsTracker.track(Stat.SHIPPING_LABEL_ADDRESS_VALIDATION_SUCCEEDED)
+                val suggestion =
+                    (result.model as WCAddressVerificationResult.Valid).suggestedAddress.toAppModel()
+                if (suggestion.toString() != address.toString()) {
+                    ValidationResult.SuggestedChanges(suggestion)
+                } else {
+                    ValidationResult.Valid
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -592,7 +592,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         }
 
         private fun updateForInternationalRequirements(): StepsState {
-            val originAddressStep = if (isInternational && !originAddressStep.data.phoneHas10Digits()) {
+            val originAddressStep = if (isInternational && !originAddressStep.data.hasValidPhoneNumber()) {
                 originAddressStep.copy(status = READY)
             } else originAddressStep
             val customsStep = customsStep.copy(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -568,14 +568,22 @@ class ShippingLabelsStateMachine @Inject constructor() {
         @Suppress("UNCHECKED_CAST")
         fun <T> updateStep(currentStep: Step<T>, newData: T): StepsState {
             return when (currentStep) {
-                is OriginAddressStep -> copy(
-                    originAddressStep = originAddressStep.copy(status = DONE, data = newData as Address)
-                )
-                    .invalidateCarrierStep()
-                is ShippingAddressStep -> copy(
-                    shippingAddressStep = shippingAddressStep.copy(status = DONE, data = newData as Address)
-                )
-                    .invalidateCarrierStep()
+                is OriginAddressStep -> {
+                    val newAddress = newData as Address
+                    val isSamePhysicalAddress = newAddress.isSamePhysicalAddress(originAddressStep.data)
+                    val newState = copy(
+                        originAddressStep = originAddressStep.copy(status = DONE, data = newData as Address)
+                    )
+                    if (isSamePhysicalAddress) newState else newState.invalidateCarrierStep()
+                }
+                is ShippingAddressStep -> {
+                    val newAddress = newData as Address
+                    val isSamePhysicalAddress = newAddress.isSamePhysicalAddress(shippingAddressStep.data)
+                    val newState = copy(
+                        shippingAddressStep = shippingAddressStep.copy(status = DONE, data = newData as Address)
+                    )
+                    if (isSamePhysicalAddress) newState else newState.invalidateCarrierStep()
+                }
                 is PackagingStep -> copy(
                     packagingStep = packagingStep.copy(status = DONE, data = newData as List<ShippingLabelPackage>)
                 )

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -99,7 +99,7 @@
             app:argType="com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator$ValidationResult"
             app:nullable="true" />
         <argument
-            android:name="isInternational"
+            android:name="requiresPhoneNumber"
             app:argType="boolean" />
         <action
             android:id="@+id/action_editShippingLabelAddressFragment_to_itemSelectorDialog"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -477,7 +477,8 @@
     <string name="shipping_label_address_suggestion_entered_address">Entered address</string>
     <string name="shipping_label_address_suggestion_suggested_address">Suggested address</string>
     <string name="shipping_label_address_phone_required">A phone number is required because this shipment requires a customs form</string>
-    <string name="shipping_label_address_phone_invalid">Customs forms require a 10-digit phone number</string>
+    <string name="shipping_label_origin_address_phone_invalid">Customs forms require a 10-digit phone number</string>
+    <string name="shipping_label_destination_address_phone_invalid">Please enter a valid phone number</string>
     <string name="shipping_label_address_data_invalid_snackbar_message">Certain required fields are blank.</string>
     <string name="shipping_label_package_details_items_section_title">Items to fulfill</string>
     <string name="shipping_label_package_details_move_item">Move</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
@@ -291,7 +291,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
 
         stateFlow.value = Transition(State.OriginAddressValidation(data), null)
 
-        verify(addressValidator).validateAddress(originAddress, ORIGIN, isInternationalShipment = false)
+        verify(addressValidator).validateAddress(originAddress, ORIGIN, requiresPhoneNumber = false)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
@@ -91,7 +91,7 @@ class EditShippingLabelAddressViewModelTest : BaseUnitTest() {
             address = address,
             addressType = ORIGIN,
             validationResult = validationResult,
-            isInternational = false
+            requiresPhoneNumber = false
         ).initSavedStateHandle()
 
     private lateinit var viewModel: EditShippingLabelAddressViewModel

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = 'ef4072a5a419c779716589c5a23b621dff278644'
+    fluxCVersion = 'd2b388957aefc125808e5ac4da055b009d6ac7e3'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ task installGitHooks(type: Copy) {
 }
 
 ext {
-    fluxCVersion = '1.19.1'
+    fluxCVersion = 'ef4072a5a419c779716589c5a23b621dff278644'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'


### PR DESCRIPTION
Fixes #4195, this PR has two big changes:
1. Adds prefilling of the destination address phone number, the phone number is added by WCS, and it's part of the order's meta data.
2. Update the Shipping Label creation form to require a non-empty phone number when the shipment is international, and the carrier is DHL.

This depends on the PR https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2029, please don't merge until it's merged, and the FluxC's hash is updated.

#### Testing
1. Make sure your store is ready for WCS testing.
2. Create an **international** order eligible for shipping label creation and ensure that a phone number is entered in the shipping address.
3. Open the other details in the app*.
4. Click on "Create shipping label".
5. When getting to the destination address step, **confirm** that the phone number is prefilled.
6. Clear the phone number.
7. In the packaging step, please make sure to select a custom package or a DHL package.
8. Finish the customs step.
9. Make sure to select DHL at the carriers step.
10. Notice that the app will invalidate the destination address.
11. Open the destination address, and confirm that it asks you to enter a phone number.
12. Enter a phone number.
13. Continue the label purchase.
14. Confirm that it works without issues.

*. When getting to the step 3, if you decided to use an old order for testing, please make sure that you refresh it in the app, to make sure that the metadata is fetched.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
