### PR TITLE
Issue/3725 extract is collectable method

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityChecker.kt
@@ -1,0 +1,20 @@
+package com.woocommerce.android.ui.orders.cardreader
+
+import com.woocommerce.android.extensions.CASH_ON_DELIVERY_PAYMENT_TYPE
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.orders.details.OrderDetailRepository
+import javax.inject.Inject
+
+class CardReaderPaymentCollectibilityChecker @Inject constructor() {
+    fun isCollectable(order: Order, orderDetailRepository: OrderDetailRepository): Boolean {
+        return with(order) {
+            currency.equals("USD", ignoreCase = true) &&
+                    (listOf(Order.Status.Pending, Order.Status.Processing, Order.Status.OnHold)).any { it == status } &&
+                    !isOrderPaid &&
+                    // Empty payment method explanation:
+                    // https://github.com/woocommerce/woocommerce/issues/29471
+                    (paymentMethod == CASH_ON_DELIVERY_PAYMENT_TYPE || paymentMethod.isEmpty()) &&
+                    !orderDetailRepository.hasSubscriptionProducts(order.getProductIds())
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityChecker.kt
@@ -6,17 +6,17 @@ import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import javax.inject.Inject
 
 class CardReaderPaymentCollectibilityChecker @Inject constructor(
-        private val orderDetailRepository: OrderDetailRepository
+    private val orderDetailRepository: OrderDetailRepository
 ) {
     fun isCollectable(order: Order): Boolean {
         return with(order) {
             currency.equals("USD", ignoreCase = true) &&
-                    (listOf(Order.Status.Pending, Order.Status.Processing, Order.Status.OnHold)).any { it == status } &&
-                    !isOrderPaid &&
-                    // Empty payment method explanation:
-                    // https://github.com/woocommerce/woocommerce/issues/29471
-                    (paymentMethod == CASH_ON_DELIVERY_PAYMENT_TYPE || paymentMethod.isEmpty()) &&
-                    !orderDetailRepository.hasSubscriptionProducts(order.getProductIds())
+                (listOf(Order.Status.Pending, Order.Status.Processing, Order.Status.OnHold)).any { it == status } &&
+                !isOrderPaid &&
+                // Empty payment method explanation:
+                // https://github.com/woocommerce/woocommerce/issues/29471
+                (paymentMethod == CASH_ON_DELIVERY_PAYMENT_TYPE || paymentMethod.isEmpty()) &&
+                !orderDetailRepository.hasSubscriptionProducts(order.getProductIds())
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityChecker.kt
@@ -5,8 +5,10 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import javax.inject.Inject
 
-class CardReaderPaymentCollectibilityChecker @Inject constructor() {
-    fun isCollectable(order: Order, orderDetailRepository: OrderDetailRepository): Boolean {
+class CardReaderPaymentCollectibilityChecker @Inject constructor(
+        private val orderDetailRepository: OrderDetailRepository
+) {
+    fun isCollectable(order: Order): Boolean {
         return with(order) {
             currency.equals("USD", ignoreCase = true) &&
                     (listOf(Order.Status.Pending, Order.Status.Processing, Order.Status.OnHold)).any { it == status } &&

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -14,16 +14,12 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_TRACKING_AD
 import com.woocommerce.android.annotations.OpenClassOnDebug
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.CardReaderStatus.Connected
-import com.woocommerce.android.extensions.CASH_ON_DELIVERY_PAYMENT_TYPE
 import com.woocommerce.android.extensions.isNotEqualTo
 import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.extensions.whenNotNullNorEmpty
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.model.Order.Status
-import com.woocommerce.android.model.Order.Status.OnHold
-import com.woocommerce.android.model.Order.Status.Pending
-import com.woocommerce.android.model.Order.Status.Processing
 import com.woocommerce.android.model.OrderNote
 import com.woocommerce.android.model.OrderShipmentTracking
 import com.woocommerce.android.model.Refund
@@ -46,6 +42,7 @@ import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSe
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewPrintCustomsForm
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewPrintingInstructions
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewRefundedProducts
+import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentCollectibilityChecker
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository.OnProductImageChanged
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
@@ -77,7 +74,8 @@ class OrderDetailViewModel @Inject constructor(
     private val appPrefs: AppPrefs,
     private val networkStatus: NetworkStatus,
     private val resourceProvider: ResourceProvider,
-    private val orderDetailRepository: OrderDetailRepository
+    private val orderDetailRepository: OrderDetailRepository,
+    private val paymentCollectibilityChecker: CardReaderPaymentCollectibilityChecker
 ) : ScopedViewModel(savedState) {
     companion object {
         // The required version to support shipping label creation
@@ -449,7 +447,11 @@ class OrderDetailViewModel @Inject constructor(
     private fun updateOrderState() {
         val orderStatus = orderDetailRepository.getOrderStatus(order.status.value)
         viewState = viewState.copy(
-            orderInfo = OrderInfo(order, isPaymentCollectableWithCardReader()),
+            orderInfo = OrderInfo(
+                    order = order,
+                    isPaymentCollectableWithCardReader = paymentCollectibilityChecker
+                            .isCollectable(order, orderDetailRepository)
+            ),
             orderStatus = orderStatus,
             toolbarTitle = resourceProvider.getString(
                 string.orderdetail_orderstatus_ordernum, order.number
@@ -570,18 +572,6 @@ class OrderDetailViewModel @Inject constructor(
             isProductListVisible = orderProducts.isVisible,
             areShippingLabelsVisible = shippingLabels.isVisible
         )
-    }
-
-    private fun isPaymentCollectableWithCardReader(): Boolean {
-        return with(order) {
-            currency.equals("USD", ignoreCase = true) &&
-                (listOf(Pending, Processing, OnHold)).any { it == status } &&
-                !isOrderPaid &&
-                // Empty payment method explanation:
-                // https://github.com/woocommerce/woocommerce/issues/29471
-                (paymentMethod == CASH_ON_DELIVERY_PAYMENT_TYPE || paymentMethod.isEmpty()) &&
-                !orderDetailRepository.hasSubscriptionProducts(order.getProductIds())
-        }
     }
 
     @SuppressWarnings("unused")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -450,7 +450,7 @@ class OrderDetailViewModel @Inject constructor(
             orderInfo = OrderInfo(
                     order = order,
                     isPaymentCollectableWithCardReader = paymentCollectibilityChecker
-                            .isCollectable(order, orderDetailRepository)
+                            .isCollectable(order)
             ),
             orderStatus = orderStatus,
             toolbarTitle = resourceProvider.getString(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -197,7 +197,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             // GIVEN
             doReturn(false).whenever(paymentCollectibilityChecker).isCollectable(any(), any())
             doReturn(order).whenever(repository).getOrder(any())
-            doReturn(order).whenever(repository).fetchOrder(any(), any())
+            doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
 
             // WHEN
@@ -213,7 +213,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             // GIVEN
             doReturn(true).whenever(paymentCollectibilityChecker).isCollectable(any(), any())
             doReturn(order).whenever(repository).getOrder(any())
-            doReturn(order).whenever(repository).fetchOrder(any(), any())
+            doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
 
             // WHEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -38,7 +38,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUndoSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -26,6 +26,7 @@ import com.woocommerce.android.model.ShippingLabel
 import com.woocommerce.android.model.WooPlugin
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentCollectibilityChecker
 import com.woocommerce.android.ui.orders.details.OrderDetailFragmentArgs
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.details.OrderDetailViewModel
@@ -37,6 +38,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUndoSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
+import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -45,7 +47,6 @@ import org.robolectric.RobolectricTestRunner
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.utils.DateUtils
 import java.math.BigDecimal
-import java.util.Date
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
@@ -63,6 +64,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     private val resources: ResourceProvider = mock {
         on(it.getString(any(), any())).thenAnswer { i -> i.arguments[0].toString() }
     }
+    private val paymentCollectibilityChecker: CardReaderPaymentCollectibilityChecker = mock()
 
     private val savedState = OrderDetailFragmentArgs(orderId = ORDER_IDENTIFIER).initSavedStateHandle()
 
@@ -103,7 +105,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                 appPrefsWrapper,
                 networkStatus,
                 resources,
-                repository
+                repository,
+                paymentCollectibilityChecker
             )
         )
 
@@ -190,23 +193,13 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when order not paid then show collect button`() =
+    fun `collect button hidden if payment is not collectable`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // GIVEN
-            initForCheckIfOrderCollectable(datePaid = Date())
-
-            // WHEN
-            viewModel.start()
-
-            // THEN
-            assertThat(currentViewStateValue!!.orderInfo!!.isPaymentCollectableWithCardReader).isTrue()
-        }
-
-    @Test
-    fun `when order is paid then hide collect button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
-            initForCheckIfOrderCollectable(datePaid = null, paymentMethodTitle = "")
+            doReturn(false).whenever(paymentCollectibilityChecker).isCollectable(any(), any())
+            doReturn(order).whenever(repository).getOrder(any())
+            doReturn(order).whenever(repository).fetchOrder(any(), any())
+            doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
 
             // WHEN
             viewModel.start()
@@ -216,185 +209,19 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when order in USD then show collect button`() =
+    fun `collect button shown if payment is collectable`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // GIVEN
-            initForCheckIfOrderCollectable(currency = "USD")
+            doReturn(true).whenever(paymentCollectibilityChecker).isCollectable(any(), any())
+            doReturn(order).whenever(repository).getOrder(any())
+            doReturn(order).whenever(repository).fetchOrder(any(), any())
+            doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
 
             // WHEN
             viewModel.start()
 
             // THEN
             assertThat(currentViewStateValue!!.orderInfo!!.isPaymentCollectableWithCardReader).isTrue()
-        }
-
-    @Test
-    fun `when order has subscriptions items then hide collect button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
-            initForCheckIfOrderCollectable(hasSubscriptionItems = true)
-
-            // WHEN
-            viewModel.start()
-
-            // THEN
-            assertThat(currentViewStateValue!!.orderInfo!!.isPaymentCollectableWithCardReader).isFalse()
-        }
-
-    @Test
-    fun `when order has no subscriptions items then show collect button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
-            initForCheckIfOrderCollectable(hasSubscriptionItems = false)
-
-            // WHEN
-            viewModel.start()
-
-            // THEN
-            assertThat(currentViewStateValue!!.orderInfo!!.isPaymentCollectableWithCardReader).isTrue()
-        }
-
-    @Test
-    fun `when order has code payment method then show collect button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
-            initForCheckIfOrderCollectable(paymentMethod = "cod")
-
-            // WHEN
-            viewModel.start()
-
-            // THEN
-            assertThat(currentViewStateValue!!.orderInfo!!.isPaymentCollectableWithCardReader).isTrue()
-        }
-
-    @Test
-    fun `when order has empty payment method then show collect button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
-            initForCheckIfOrderCollectable(paymentMethod = "")
-
-            // WHEN
-            viewModel.start()
-
-            // THEN
-            assertThat(currentViewStateValue!!.orderInfo!!.isPaymentCollectableWithCardReader).isTrue()
-        }
-
-    @Test
-    fun `when order has non code payment method then hide collect button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
-            initForCheckIfOrderCollectable(paymentMethod = "stripe")
-
-            // WHEN
-            viewModel.start()
-
-            // THEN
-            assertThat(currentViewStateValue!!.orderInfo!!.isPaymentCollectableWithCardReader).isFalse()
-        }
-
-    @Test
-    fun `when order has processing status then show collect button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
-            initForCheckIfOrderCollectable(paymentStatus = Order.Status.Processing)
-
-            // WHEN
-            viewModel.start()
-
-            // THEN
-            assertThat(currentViewStateValue!!.orderInfo!!.isPaymentCollectableWithCardReader).isTrue()
-        }
-
-    @Test
-    fun `when order has on hold status then show collect button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
-            initForCheckIfOrderCollectable(paymentStatus = Order.Status.OnHold)
-
-            // WHEN
-            viewModel.start()
-
-            // THEN
-            assertThat(currentViewStateValue!!.orderInfo!!.isPaymentCollectableWithCardReader).isTrue()
-        }
-
-    @Test
-    fun `when order has pending status then show collect button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
-            initForCheckIfOrderCollectable(paymentStatus = Order.Status.Pending)
-
-            // WHEN
-            viewModel.start()
-
-            // THEN
-            assertThat(currentViewStateValue!!.orderInfo!!.isPaymentCollectableWithCardReader).isTrue()
-        }
-
-    @Test
-    fun `when order has refunded status then hide collect button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
-            initForCheckIfOrderCollectable(paymentStatus = Order.Status.Refunded)
-
-            // WHEN
-            viewModel.start()
-
-            // THEN
-            assertThat(currentViewStateValue!!.orderInfo!!.isPaymentCollectableWithCardReader).isFalse()
-        }
-
-    @Test
-    fun `when order has custom status then hide collect button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
-            initForCheckIfOrderCollectable(paymentStatus = Order.Status.Custom("custom"))
-
-            // WHEN
-            viewModel.start()
-
-            // THEN
-            assertThat(currentViewStateValue!!.orderInfo!!.isPaymentCollectableWithCardReader).isFalse()
-        }
-
-    @Test
-    fun `when order has failed status then hide collect button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
-            initForCheckIfOrderCollectable(paymentStatus = Order.Status.Failed)
-
-            // WHEN
-            viewModel.start()
-
-            // THEN
-            assertThat(currentViewStateValue!!.orderInfo!!.isPaymentCollectableWithCardReader).isFalse()
-        }
-
-    @Test
-    fun `when order has completed status then hide collect button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
-            initForCheckIfOrderCollectable(paymentStatus = Order.Status.Completed)
-
-            // WHEN
-            viewModel.start()
-
-            // THEN
-            assertThat(currentViewStateValue!!.orderInfo!!.isPaymentCollectableWithCardReader).isFalse()
-        }
-
-    @Test
-    fun `when order has cancelled status then hide collect button`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
-            initForCheckIfOrderCollectable(paymentStatus = Order.Status.Cancelled)
-
-            // WHEN
-            viewModel.start()
-
-            // THEN
-            assertThat(currentViewStateValue!!.orderInfo!!.isPaymentCollectableWithCardReader).isFalse()
         }
 
     @Test
@@ -992,7 +819,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `re-fetch order when payment flow completes`() = coroutinesTestRule.testDispatcher.runBlockingTest {
-        initForCheckIfOrderCollectable()
         viewModel.start()
         val orderAfterPayment = order.copy(status = Status.fromDataModel(CoreOrderStatus.COMPLETED)!!)
         doReturn(orderAfterPayment).whenever(repository).getOrder(any())
@@ -1000,32 +826,5 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         viewModel.onCardReaderPaymentCompleted()
 
         assertThat(viewModel.order).isEqualTo(orderAfterPayment)
-    }
-
-    private suspend fun initForCheckIfOrderCollectable(
-        currency: String = "USD",
-        paymentStatus: Order.Status = Order.Status.Processing,
-        paymentMethod: String = "cod",
-        paymentMethodTitle: String = "title",
-        datePaid: Date? = null,
-        hasSubscriptionItems: Boolean = false
-    ) {
-        val nonPaidOrder = order.copy(
-            currency = currency,
-            paymentMethod = paymentMethod,
-            paymentMethodTitle = paymentMethodTitle,
-            datePaid = datePaid,
-            status = paymentStatus
-        )
-
-        doReturn(nonPaidOrder).whenever(repository).getOrder(any())
-        doReturn(nonPaidOrder).whenever(repository).fetchOrder(any())
-        doReturn(hasSubscriptionItems).whenever(repository).hasSubscriptionProducts(any())
-        doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
-        doReturn(testOrderNotes).whenever(repository).getOrderNotes(any())
-        doReturn(RequestResult.SUCCESS).whenever(repository).fetchOrderShipmentTrackingList(any(), any())
-        doReturn(testOrderShipmentTrackings).whenever(repository).getOrderShipmentTrackings(any())
-        doReturn(emptyList<ShippingLabel>()).whenever(repository).getOrderShippingLabels(any())
-        doReturn(emptyList<ShippingLabel>()).whenever(repository).fetchOrderShippingLabels(any())
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -195,7 +195,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     fun `collect button hidden if payment is not collectable`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // GIVEN
-            doReturn(false).whenever(paymentCollectibilityChecker).isCollectable(any(), any())
+            doReturn(false).whenever(paymentCollectibilityChecker).isCollectable(any())
             doReturn(order).whenever(repository).getOrder(any())
             doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
@@ -211,7 +211,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     fun `collect button shown if payment is collectable`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // GIVEN
-            doReturn(true).whenever(paymentCollectibilityChecker).isCollectable(any(), any())
+            doReturn(true).whenever(paymentCollectibilityChecker).isCollectable(any())
             doReturn(order).whenever(repository).getOrder(any())
             doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -9,7 +9,6 @@ import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.test.runBlockingTest
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -249,6 +249,5 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             datePaid = datePaid,
             status = paymentStatus
         )
-
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -16,8 +16,8 @@ import org.junit.Test
 import java.util.Date
 
 class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
-    private val checker: CardReaderPaymentCollectibilityChecker = CardReaderPaymentCollectibilityChecker()
     private val repository: OrderDetailRepository = mock()
+    private val checker: CardReaderPaymentCollectibilityChecker = CardReaderPaymentCollectibilityChecker(repository)
 
     private val generatedOrder = OrderTestUtils.generateTestOrder()
 
@@ -33,7 +33,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val order = getOrder(datePaid = null, paymentMethodTitle = "")
 
             // WHEN
-            val isCollectable = checker.isCollectable(order, repository)
+            val isCollectable = checker.isCollectable(order)
 
             // THEN
             assertThat(isCollectable).isFalse()
@@ -46,7 +46,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val order = getOrder(datePaid = Date())
 
             // WHEN
-            val isCollectable = checker.isCollectable(order, repository)
+            val isCollectable = checker.isCollectable(order)
 
             // THEN
             assertThat(isCollectable).isTrue()
@@ -59,7 +59,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val order = getOrder(paymentMethod = "")
 
             // WHEN
-            val isCollectable = checker.isCollectable(order, repository)
+            val isCollectable = checker.isCollectable(order)
 
             // THEN
             assertThat(isCollectable).isTrue()
@@ -72,7 +72,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val order = getOrder(currency = "USD")
 
             // WHEN
-            val isCollectable = checker.isCollectable(order, repository)
+            val isCollectable = checker.isCollectable(order)
 
             // THEN
             assertThat(isCollectable).isTrue()
@@ -86,7 +86,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             doReturn(false).whenever(repository).hasSubscriptionProducts(any())
 
             // WHEN
-            val isCollectable = checker.isCollectable(order, repository)
+            val isCollectable = checker.isCollectable(order)
 
             // THEN
             assertThat(isCollectable).isTrue()
@@ -100,7 +100,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             doReturn(true).whenever(repository).hasSubscriptionProducts(any())
 
             // WHEN
-            val isCollectable = checker.isCollectable(order, repository)
+            val isCollectable = checker.isCollectable(order)
 
             // THEN
             assertThat(isCollectable).isFalse()
@@ -113,7 +113,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val order = getOrder(paymentMethod = "cod")
 
             // WHEN
-            val isCollectable = checker.isCollectable(order, repository)
+            val isCollectable = checker.isCollectable(order)
 
             // THEN
             assertThat(isCollectable).isTrue()
@@ -126,7 +126,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val order = getOrder(paymentMethod = "stripe")
 
             // WHEN
-            val isCollectable = checker.isCollectable(order, repository)
+            val isCollectable = checker.isCollectable(order)
 
             // THEN
             assertThat(isCollectable).isFalse()
@@ -139,7 +139,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val order = getOrder(paymentStatus = Order.Status.Processing)
 
             // WHEN
-            val isCollectable = checker.isCollectable(order, repository)
+            val isCollectable = checker.isCollectable(order)
 
             // THEN
             assertThat(isCollectable).isTrue()
@@ -152,7 +152,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val order = getOrder(paymentStatus = Order.Status.OnHold)
 
             // WHEN
-            val isCollectable = checker.isCollectable(order, repository)
+            val isCollectable = checker.isCollectable(order)
 
             // THEN
             assertThat(isCollectable).isTrue()
@@ -165,7 +165,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val order = getOrder(paymentStatus = Order.Status.Pending)
 
             // WHEN
-            val isCollectable = checker.isCollectable(order, repository)
+            val isCollectable = checker.isCollectable(order)
 
             // THEN
             assertThat(isCollectable).isTrue()
@@ -178,7 +178,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val order = getOrder(paymentStatus = Order.Status.Refunded)
 
             // WHEN
-            val isCollectable = checker.isCollectable(order, repository)
+            val isCollectable = checker.isCollectable(order)
 
             // THEN
             assertThat(isCollectable).isFalse()
@@ -191,7 +191,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val order = getOrder(paymentStatus = Order.Status.Custom("custom"))
 
             // WHEN
-            val isCollectable = checker.isCollectable(order, repository)
+            val isCollectable = checker.isCollectable(order)
 
             // THEN
             assertThat(isCollectable).isFalse()
@@ -204,7 +204,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val order = getOrder(paymentStatus = Order.Status.Failed)
 
             // WHEN
-            val isCollectable = checker.isCollectable(order, repository)
+            val isCollectable = checker.isCollectable(order)
 
             // THEN
             assertThat(isCollectable).isFalse()
@@ -217,7 +217,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val order = getOrder(paymentStatus = Order.Status.Completed)
 
             // WHEN
-            val isCollectable = checker.isCollectable(order, repository)
+            val isCollectable = checker.isCollectable(order)
 
             // THEN
             assertThat(isCollectable).isFalse()
@@ -230,7 +230,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val order = getOrder(paymentStatus = Order.Status.Cancelled)
 
             // WHEN
-            val isCollectable = checker.isCollectable(order, repository)
+            val isCollectable = checker.isCollectable(order)
 
             // THEN
             assertThat(isCollectable).isFalse()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -1,0 +1,254 @@
+package com.woocommerce.android.ui.orders.cardreader
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.orders.OrderTestUtils
+import com.woocommerce.android.ui.orders.details.OrderDetailRepository
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.test.runBlockingTest
+import org.assertj.core.api.Assertions
+import org.junit.Before
+import org.junit.Test
+import java.util.Date
+
+class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
+    private val checker: CardReaderPaymentCollectibilityChecker = CardReaderPaymentCollectibilityChecker()
+    private val repository: OrderDetailRepository = mock()
+
+    private val generatedOrder = OrderTestUtils.generateTestOrder()
+
+    @Before
+    fun setUp() {
+        doReturn(false).whenever(repository).hasSubscriptionProducts(any())
+    }
+
+    @Test
+    fun `when order is paid then hide collect button`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val order = getOrder(datePaid = null, paymentMethodTitle = "")
+
+            // WHEN
+            val isCollectable = checker.isCollectable(order, repository)
+
+            // THEN
+            Assertions.assertThat(isCollectable).isFalse()
+        }
+
+    @Test
+    fun `when order not paid then show collect button`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val order = getOrder(datePaid = Date())
+
+            // WHEN
+            val isCollectable = checker.isCollectable(order, repository)
+
+            // THEN
+            Assertions.assertThat(isCollectable).isTrue()
+        }
+
+    @Test
+    fun `when order has empty payment method then it is not collectable`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val order = getOrder(paymentMethod = "")
+
+            // WHEN
+            val isCollectable = checker.isCollectable(order, repository)
+
+            // THEN
+            Assertions.assertThat(isCollectable).isTrue()
+        }
+
+    @Test
+    fun `when order in USD then it is collectable`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val order = getOrder(currency = "USD")
+
+            // WHEN
+            val isCollectable = checker.isCollectable(order, repository)
+
+            // THEN
+            Assertions.assertThat(isCollectable).isTrue()
+        }
+
+    @Test
+    fun `when order has no subscriptions items then is collectable`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val order = getOrder()
+            doReturn(false).whenever(repository).hasSubscriptionProducts(any())
+
+            // WHEN
+            val isCollectable = checker.isCollectable(order, repository)
+
+            // THEN
+            Assertions.assertThat(isCollectable).isTrue()
+        }
+
+    @Test
+    fun `when order has subscriptions items then hide collect button`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val order = getOrder()
+            doReturn(true).whenever(repository).hasSubscriptionProducts(any())
+
+            // WHEN
+            val isCollectable = checker.isCollectable(order, repository)
+
+            // THEN
+            Assertions.assertThat(isCollectable).isFalse()
+        }
+
+    @Test
+    fun `when order has code payment method then is collectable`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val order = getOrder(paymentMethod = "cod")
+
+            // WHEN
+            val isCollectable = checker.isCollectable(order, repository)
+
+            // THEN
+            Assertions.assertThat(isCollectable).isTrue()
+        }
+
+    @Test
+    fun `when order has non code payment method then it is not collectable`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val order = getOrder(paymentMethod = "stripe")
+
+            // WHEN
+            val isCollectable = checker.isCollectable(order, repository)
+
+            // THEN
+            Assertions.assertThat(isCollectable).isFalse()
+        }
+
+    @Test
+    fun `when order has processing status then is collectable`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val order = getOrder(paymentStatus = Order.Status.Processing)
+
+            // WHEN
+            val isCollectable = checker.isCollectable(order, repository)
+
+            // THEN
+            Assertions.assertThat(isCollectable).isTrue()
+        }
+
+    @Test
+    fun `when order has on hold status then is collectable`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val order = getOrder(paymentStatus = Order.Status.OnHold)
+
+            // WHEN
+            val isCollectable = checker.isCollectable(order, repository)
+
+            // THEN
+            Assertions.assertThat(isCollectable).isTrue()
+        }
+
+    @Test
+    fun `when order has pending status then is collectable`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val order = getOrder(paymentStatus = Order.Status.Pending)
+
+            // WHEN
+            val isCollectable = checker.isCollectable(order, repository)
+
+            // THEN
+            Assertions.assertThat(isCollectable).isTrue()
+        }
+
+    @Test
+    fun `when order has refunded status then is not collectable`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val order = getOrder(paymentStatus = Order.Status.Refunded)
+
+            // WHEN
+            val isCollectable = checker.isCollectable(order, repository)
+
+            // THEN
+            Assertions.assertThat(isCollectable).isFalse()
+        }
+
+    @Test
+    fun `when order has custom status then is not collectable`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val order = getOrder(paymentStatus = Order.Status.Custom("custom"))
+
+            // WHEN
+            val isCollectable = checker.isCollectable(order, repository)
+
+            // THEN
+            Assertions.assertThat(isCollectable).isFalse()
+        }
+
+    @Test
+    fun `when order has failed status then is not collectable`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val order = getOrder(paymentStatus = Order.Status.Failed)
+
+            // WHEN
+            val isCollectable = checker.isCollectable(order, repository)
+
+            // THEN
+            Assertions.assertThat(isCollectable).isFalse()
+        }
+
+    @Test
+    fun `when order has completed status then hide collect button`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val order = getOrder(paymentStatus = Order.Status.Completed)
+
+            // WHEN
+            val isCollectable = checker.isCollectable(order, repository)
+
+            // THEN
+            Assertions.assertThat(isCollectable).isFalse()
+        }
+
+    @Test
+    fun `when order has cancelled status then hide collect button`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val order = getOrder(paymentStatus = Order.Status.Cancelled)
+
+            // WHEN
+            val isCollectable = checker.isCollectable(order, repository)
+
+            // THEN
+            Assertions.assertThat(isCollectable).isFalse()
+        }
+
+    private fun getOrder(
+        currency: String = "USD",
+        paymentStatus: Order.Status = Order.Status.Processing,
+        paymentMethod: String = "cod",
+        paymentMethodTitle: String = "title",
+        datePaid: Date? = null
+    ): Order {
+        return generatedOrder.copy(
+            currency = currency,
+            paymentMethod = paymentMethod,
+            paymentMethodTitle = paymentMethodTitle,
+            datePaid = datePaid,
+            status = paymentStatus
+        )
+
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import java.util.Date
@@ -35,7 +36,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val isCollectable = checker.isCollectable(order, repository)
 
             // THEN
-            Assertions.assertThat(isCollectable).isFalse()
+            assertThat(isCollectable).isFalse()
         }
 
     @Test
@@ -48,7 +49,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val isCollectable = checker.isCollectable(order, repository)
 
             // THEN
-            Assertions.assertThat(isCollectable).isTrue()
+            assertThat(isCollectable).isTrue()
         }
 
     @Test
@@ -61,7 +62,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val isCollectable = checker.isCollectable(order, repository)
 
             // THEN
-            Assertions.assertThat(isCollectable).isTrue()
+            assertThat(isCollectable).isTrue()
         }
 
     @Test
@@ -74,7 +75,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val isCollectable = checker.isCollectable(order, repository)
 
             // THEN
-            Assertions.assertThat(isCollectable).isTrue()
+            assertThat(isCollectable).isTrue()
         }
 
     @Test
@@ -88,7 +89,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val isCollectable = checker.isCollectable(order, repository)
 
             // THEN
-            Assertions.assertThat(isCollectable).isTrue()
+            assertThat(isCollectable).isTrue()
         }
 
     @Test
@@ -102,7 +103,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val isCollectable = checker.isCollectable(order, repository)
 
             // THEN
-            Assertions.assertThat(isCollectable).isFalse()
+            assertThat(isCollectable).isFalse()
         }
 
     @Test
@@ -115,7 +116,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val isCollectable = checker.isCollectable(order, repository)
 
             // THEN
-            Assertions.assertThat(isCollectable).isTrue()
+            assertThat(isCollectable).isTrue()
         }
 
     @Test
@@ -128,7 +129,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val isCollectable = checker.isCollectable(order, repository)
 
             // THEN
-            Assertions.assertThat(isCollectable).isFalse()
+            assertThat(isCollectable).isFalse()
         }
 
     @Test
@@ -141,7 +142,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val isCollectable = checker.isCollectable(order, repository)
 
             // THEN
-            Assertions.assertThat(isCollectable).isTrue()
+            assertThat(isCollectable).isTrue()
         }
 
     @Test
@@ -154,7 +155,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val isCollectable = checker.isCollectable(order, repository)
 
             // THEN
-            Assertions.assertThat(isCollectable).isTrue()
+            assertThat(isCollectable).isTrue()
         }
 
     @Test
@@ -167,7 +168,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val isCollectable = checker.isCollectable(order, repository)
 
             // THEN
-            Assertions.assertThat(isCollectable).isTrue()
+            assertThat(isCollectable).isTrue()
         }
 
     @Test
@@ -180,7 +181,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val isCollectable = checker.isCollectable(order, repository)
 
             // THEN
-            Assertions.assertThat(isCollectable).isFalse()
+            assertThat(isCollectable).isFalse()
         }
 
     @Test
@@ -193,7 +194,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val isCollectable = checker.isCollectable(order, repository)
 
             // THEN
-            Assertions.assertThat(isCollectable).isFalse()
+            assertThat(isCollectable).isFalse()
         }
 
     @Test
@@ -206,7 +207,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val isCollectable = checker.isCollectable(order, repository)
 
             // THEN
-            Assertions.assertThat(isCollectable).isFalse()
+            assertThat(isCollectable).isFalse()
         }
 
     @Test
@@ -219,7 +220,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val isCollectable = checker.isCollectable(order, repository)
 
             // THEN
-            Assertions.assertThat(isCollectable).isFalse()
+            assertThat(isCollectable).isFalse()
         }
 
     @Test
@@ -232,7 +233,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             val isCollectable = checker.isCollectable(order, repository)
 
             // THEN
-            Assertions.assertThat(isCollectable).isFalse()
+            assertThat(isCollectable).isFalse()
         }
 
     private fun getOrder(


### PR DESCRIPTION
Parent issue #3726 

This PR extracts "isPaymentCollectableWithCardReader" method into a standalone class so it can be easily re-used. Most of the code was extracted using AS tools, copy-paste etc. 

To test:
Running CI tests should be enough

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
