### PR TITLE
Use hw card reader by default

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -67,7 +67,7 @@ android {
         // TODO remove this once the hilt migration is complete
         javaCompileOptions.annotationProcessorOptions.arguments['dagger.hilt.disableModulesHaveInstallInCheck'] = 'true'
 
-        buildConfigField "boolean", "USE_SIMULATED_READER", useSimulatedReader
+        buildConfigField "boolean", "USE_SIMULATED_READER", project.hasProperty("useSimulatedReader").toString()
     }
 
     buildFeatures {

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -66,6 +66,8 @@ android {
         testInstrumentationRunner 'com.woocommerce.android.WooCommerceTestRunner'
         // TODO remove this once the hilt migration is complete
         javaCompileOptions.annotationProcessorOptions.arguments['dagger.hilt.disableModulesHaveInstallInCheck'] = 'true'
+
+        buildConfigField "boolean", "USE_SIMULATED_READER", useSimulatedReader
     }
 
     buildFeatures {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -5,6 +5,7 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.R
 import com.woocommerce.android.cardreader.CardReader
 import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents
@@ -159,7 +160,7 @@ class CardReaderConnectViewModel @Inject constructor(
 
     private suspend fun startScanning() {
         cardReaderManager
-            .discoverReaders(isSimulated = false)
+            .discoverReaders(isSimulated = BuildConfig.USE_SIMULATED_READER)
             // TODO cardreader should we move flowOn to CardReaderModule?
             .flowOn(dispatchers.io)
             .collect { discoveryEvent ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -159,8 +159,7 @@ class CardReaderConnectViewModel @Inject constructor(
 
     private suspend fun startScanning() {
         cardReaderManager
-            // TODO cardreader set isSimulated to false or add a temporary checkbox to the UI
-            .discoverReaders(isSimulated = true)
+            .discoverReaders(isSimulated = false)
             // TODO cardreader should we move flowOn to CardReaderModule?
             .flowOn(dispatchers.io)
             .collect { discoveryEvent ->

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -44,3 +44,6 @@ wc.in_app_update_type = 0
 
 # Necessary for gradle 5
 kapt.incremental.apt=false
+
+# Use simulated vs hw card reader for card present payments
+useSimulatedReader = false

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -44,6 +44,3 @@ wc.in_app_update_type = 0
 
 # Necessary for gradle 5
 kapt.incremental.apt=false
-
-# Use simulated vs hw card reader for card present payments
-useSimulatedReader = false


### PR DESCRIPTION
Parent issue #3725 

This PR changes the default card reader from simulated to a hw reader. Since we have implemented the vital flows, using a real hw reader might be preferred so we can notice some edge case issues. 

To test:
Try to connect to a hw reader.

@nbradbury @kidinov I'm explicitly requesting your review to make sure you both know about this change in the default behavior.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
