### PR TITLE
issue/4225-manage-readers-overlap

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_card_reader_detail_disconnected_state.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_detail_disconnected_state.xml
@@ -133,9 +133,10 @@
             layout="@layout/fragment_card_reader_detail_learn_more"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintBottom_toBottomOf="parent"
+            android:layout_marginTop="@dimen/major_200"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/card_reader_detail_connect_btn" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </ScrollView>

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_detail_disconnected_state.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_detail_disconnected_state.xml
@@ -31,6 +31,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/major_200"
+            android:importantForAccessibility="no"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/card_reader_detail_connect_header_label"

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_detail_disconnected_state.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_detail_disconnected_state.xml
@@ -55,7 +55,7 @@
             style="@style/Woo.TextView.Body1"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_150"
+            android:layout_marginStart="@dimen/major_125"
             android:textColor="@color/color_on_surface"
             app:layout_constraintBottom_toBottomOf="@id/card_reader_detail_first_hint_number_label"
             app:layout_constraintStart_toEndOf="@id/card_reader_detail_first_hint_number_label"

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_detail_disconnected_state.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_detail_disconnected_state.xml
@@ -59,6 +59,7 @@
             android:layout_marginStart="@dimen/major_125"
             android:textColor="@color/color_on_surface"
             app:layout_constraintBottom_toBottomOf="@id/card_reader_detail_first_hint_number_label"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/card_reader_detail_first_hint_number_label"
             app:layout_constraintTop_toTopOf="@id/card_reader_detail_first_hint_number_label"
             tools:text="Make sure card reader is charged" />


### PR DESCRIPTION
This PR resolves #4225 by:

1. Using the same indentation for the first numbered label as the other two
2. Positioning the "learn more" text below the connect button so it doesn't overlap the button

![reader](https://user-images.githubusercontent.com/3903757/122402065-267aa200-cf4b-11eb-9ce1-d4b10d3f8464.png)


Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
