### PR TITLE
Custom settings for kotlin in editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,5 +9,10 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
 
+[*.{kt,kts}]
+max_line_length=120
+indent_style=space
+indent_size=4
+
 [*.yml]
 trim_trailing_whitespace=true


### PR DESCRIPTION
The initial idea that default idea settings will match our "old" settings was not correct, so we still need to have these 3 lines in order not set up IDEA manually.