### PR TITLE
Add is_debug and build_type properties to Tracks events

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -504,14 +504,6 @@ class AnalyticsTracker private constructor(private val context: Context) {
     private var tracksClient: TracksClient? = TracksClient.getClient(context)
     private var username: String? = null
     private var anonymousID: String? = null
-    private val buildType: String by lazy {
-        when {
-            BuildConfig.DEBUG -> "dev"
-            BuildConfig.FLAVOR == "vanilla" && BuildConfig.VERSION_NAME.contains("rc") -> "beta"
-            BuildConfig.FLAVOR == "vanilla" -> "prod"
-            else -> "dev"
-        }
-    }
 
     private var site: SiteModel? = null
 
@@ -576,7 +568,6 @@ class AnalyticsTracker private constructor(private val context: Context) {
             }
         }
         finalProperties[IS_DEBUG] = BuildConfig.DEBUG
-        finalProperties[BUILD_TYPE] = buildType
 
         val propertiesJson = JSONObject(finalProperties)
         tracksClient?.track(EVENTS_PREFIX + eventName, propertiesJson, user, userType)
@@ -631,7 +622,6 @@ class AnalyticsTracker private constructor(private val context: Context) {
         private const val EVENTS_PREFIX = "woocommerceandroid_"
 
         const val IS_DEBUG = "is_debug"
-        const val BUILD_TYPE = "build_type"
         const val KEY_ALREADY_READ = "already_read"
         const val KEY_BLOG_ID = "blog_id"
         const val KEY_CONTEXT = "context"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import androidx.preference.PreferenceManager
 import com.automattic.android.tracks.TracksClient
+import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.BACK_PRESSED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.VIEW_SHOWN
 import com.woocommerce.android.util.WooLog
@@ -503,6 +504,14 @@ class AnalyticsTracker private constructor(private val context: Context) {
     private var tracksClient: TracksClient? = TracksClient.getClient(context)
     private var username: String? = null
     private var anonymousID: String? = null
+    private val buildType: String by lazy {
+        when {
+            BuildConfig.DEBUG -> "dev"
+            BuildConfig.FLAVOR == "vanilla" && BuildConfig.VERSION_NAME.contains("rc") -> "beta"
+            BuildConfig.FLAVOR == "vanilla" -> "prod"
+            else -> "dev"
+        }
+    }
 
     private var site: SiteModel? = null
 
@@ -566,6 +575,8 @@ class AnalyticsTracker private constructor(private val context: Context) {
                 finalProperties[KEY_IS_WPCOM_STORE] = it.isWpComStore
             }
         }
+        finalProperties[IS_DEBUG] = BuildConfig.DEBUG
+        finalProperties[BUILD_TYPE] = buildType
 
         val propertiesJson = JSONObject(finalProperties)
         tracksClient?.track(EVENTS_PREFIX + eventName, propertiesJson, user, userType)
@@ -619,6 +630,8 @@ class AnalyticsTracker private constructor(private val context: Context) {
         private const val TRACKS_ANON_ID = "nosara_tracks_anon_id"
         private const val EVENTS_PREFIX = "woocommerceandroid_"
 
+        const val IS_DEBUG = "is_debug"
+        const val BUILD_TYPE = "build_type"
         const val KEY_ALREADY_READ = "already_read"
         const val KEY_BLOG_ID = "blog_id"
         const val KEY_CONTEXT = "context"


### PR DESCRIPTION
We currently can't differentiate whether Tracks events were recorded by a developer/beta_tester/user. This PR adds two flags to all events recorded by the WCAndroid app:
- `is_debug` - true or false
- `build_type`- dev or beta or prod (we decided to remove this after all, more info [here](https://github.com/woocommerce/woocommerce-android/pull/4231#issuecomment-864267327))

I originally wanted to add these events to the Tracks library, but then decided against it. App's BuildConfig is not accessible from the library. Creating a callback which could be implemented by the apps felt like an overkill since we didn't need these events for 10 years - basically the only reason why we are introducing them is Card Present Payments project which will be released just to 5-10 merchants so we need to differentiate between events recorded by us(devs) vs merchants.

To Test:
1. Open the app
2. Close the app
3. Open the app
4. Wait for a few minutes and go to Tracks - Live Events -> search for you email/username -> find any of the events and check it contians `is_debug` and `build_type` properties.

cc @oguzkocer since we discussed this topic.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
