### PR TITLE
Fix Flaky Variations Number Problem

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -366,7 +366,12 @@ class ProductDetailViewModel @Inject constructor(
         launch {
             viewState.productDraft?.let { draft ->
                 variationRepository.createEmptyVariation(draft)
-                    ?.let { updateProductDraft(numVariation = draft.numVariations + 1) }
+                    ?.let {
+                        val fetchedProduct = productRepository.fetchProduct(draft.remoteId)
+                        if (fetchedProduct != null) {
+                            updateProductState(productToUpdateFrom = fetchedProduct)
+                        }
+                    }
                     ?.let { triggerEvent(ExitProductAttributeList(variationCreated = true)) }
                     ?: triggerEvent(ExitProductAttributeList())
             }.also {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -371,13 +371,10 @@ class ProductDetailViewModel @Inject constructor(
             viewState.productDraft?.let { draft ->
                 variationRepository.createEmptyVariation(draft)
                     ?.let {
-                        val fetchedProduct = productRepository.fetchProduct(draft.remoteId)
-                        if (fetchedProduct != null) {
-                            updateProductState(productToUpdateFrom = fetchedProduct)
-                        }
-                    }
-                    ?.let { triggerEvent(ExitProductAttributeList(variationCreated = true)) }
-                    ?: triggerEvent(ExitProductAttributeList())
+                        productRepository.fetchProduct(draft.remoteId)
+                                ?.also { updateProductState(productToUpdateFrom = it) }
+                        triggerEvent(ExitProductAttributeList(variationCreated = true))
+                    } ?: triggerEvent(ExitProductAttributeList())
             }.also {
                 attributeListViewState = attributeListViewState.copy(isCreatingVariationDialogShown = false)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -360,6 +360,10 @@ class ProductDetailViewModel @Inject constructor(
         updateProductBeforeEnteringFragment()
     }
 
+    /**
+     * Called during the Add _first_ Variation flow. Uploads the pending attribute changes and generates the first
+     * variation for the variable product.
+     */
     fun onAttributeListDoneButtonClicked() {
         saveAttributeChanges()
         attributeListViewState = attributeListViewState.copy(isCreatingVariationDialogShown = true)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -579,7 +579,8 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `When generating a variation, the latest Product should be fetched from the site`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `When generating a variation, the latest Product should be fetched from the site`() =
+            coroutinesTestRule.testDispatcher.runBlockingTest {
         // Given
         doReturn(product).whenever(productRepository).getProduct(any())
 


### PR DESCRIPTION
Fixes #4210. 

## Findings

Here is the video of the bug again for reference: 

https://user-images.githubusercontent.com/198826/122105756-5eaca400-cdd6-11eb-9fe8-798439a0e35c.mov

I'm not ashamed to say that it took me more than a day to figure this out. 😆 Even then, I'm still not very confident that I understood the problem correctly. 

Anyway, what I can deduce is that this is a race condition. 

Currently, `VariationsListViewModel` [can dictate](https://github.com/woocommerce/woocommerce-android/blob/7fb7ebf3f3be3b6d6e4bf61893ef2354fe8e8995/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt#L127-L129) the number of variations to display in the Product Detail page. This can become a problem if `VariationsListViewModel` has [an outdated `Product`](https://github.com/woocommerce/woocommerce-android/blob/7fb7ebf3f3be3b6d6e4bf61893ef2354fe8e8995/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt#L83-L86).

The reason why it works _sometimes_ is that after the user generates a variation, we do 2 things. Call `saveAttributeChanges` and `variationRepository.createEmptyVariation`:

https://github.com/woocommerce/woocommerce-android/blob/7fb7ebf3f3be3b6d6e4bf61893ef2354fe8e8995/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt#L363-L376

It's not clear which one should go first. I don't think it matters(?). What's important to know is that `saveAttributeChanges` can eventually [update the product to the site and save the result in the local database](https://github.com/woocommerce/woocommerce-android/blob/7fb7ebf3f3be3b6d6e4bf61893ef2354fe8e8995/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt#L238-L248), which is a `Product`. That latest `Product` can sometimes have the correct  [`numVariations`](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/2dc146171e0ffa7537ded242a6a5a8376359909b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt#L389-L407). Sometimes it doesn't. This all depends on whether `createEmptyVariation` finishes first before `saveAttributesChanges`. 

![image](https://user-images.githubusercontent.com/198826/122615545-eea45500-d045-11eb-8f24-94a459909662.png)

If `createEmptyVariation` finishes first, the site's `numVariations` will be correct. And so we'll present the correct number all the time.

## Solution

I considered whether `createEmptyVariation` should be executed first and then we'll wait before calling `saveAttributeChanges`. But that seems incorrect since modifying attributes has the potential to wreak havoc in the number of variations (p91TBi-3Oc-p2#comment-2369).

But it might still be worth it to implement a sequencing of `saveAttributeChanges → wait → createEmptyVariation`. I'll let @ThomazFB chime in on that. 

I ended up adding an API fetch of the most recent `Product` instead so we'll have the most accurate number of variations. And it'll be saved locally in the database. 

https://github.com/woocommerce/woocommerce-android/blob/98ae08c78b0bf0999290917dacbbb42e355a506d/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt#L372-L379

Please do let me know if there's a better way to do this. I'm missing a lot of context of how `ProductDetailViewModel` works. Not to mention it's been a while since I've written Kotlin/Android. 😅 

## Testing

1. Tap on Products tab → Big plus button. 
2. Choose Variable product. 
3. Add a variation. 
4. Add a global attribute and select multiple options. 
5. Add a local attribute and add multiple options. 
4. Follow the flow until one variation is generated. 
4. When you're navigated back to the Product List, tap on “Variations (1 variation)”.
5. Navigate back. 
8. Confirm that the Variations row is still showing 1 variation. 
9. Tap on “Variations (1 variation)“ again. 
10. Generate a new variation. 
11. Navigate back. 
12. The Variations row should show a total of 2 variations. 
13. Tap on the Variations row again. 
14. Delete a variation. 
15. Navigate back.
15. The Variations row should show a total of 1 variation. 

## Author Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.