### PR TITLE
issue/4235-payments-cutoff-label

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_card_reader_connect.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_connect.xml
@@ -38,13 +38,13 @@
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/hint_label"
             style="@style/Woo.Card.Body.High"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/margin_extra_extra_medium_large"
             android:layout_marginEnd="@dimen/margin_extra_extra_medium_large"
             android:layout_marginBottom="@dimen/margin_extra_medium_large"
             android:gravity="center"
-            tools:text="Want to keep looking for readers?" />
+            tools:text="Please wait" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/primary_action_btn"

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_connect.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_connect.xml
@@ -40,11 +40,11 @@
             style="@style/Woo.Card.Body.High"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingStart="@dimen/margin_extra_extra_medium_large"
-            android:paddingEnd="@dimen/margin_extra_extra_medium_large"
+            android:layout_marginStart="@dimen/margin_extra_extra_medium_large"
+            android:layout_marginEnd="@dimen/margin_extra_extra_medium_large"
             android:layout_marginBottom="@dimen/margin_extra_medium_large"
             android:gravity="center"
-            tools:text="Please wait" />
+            tools:text="Want to keep looking for readers?" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/primary_action_btn"

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_connect.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_connect.xml
@@ -40,8 +40,8 @@
             style="@style/Woo.Card.Body.High"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/margin_extra_extra_medium_large"
-            android:layout_marginEnd="@dimen/margin_extra_extra_medium_large"
+            android:paddingStart="@dimen/margin_extra_extra_medium_large"
+            android:paddingEnd="@dimen/margin_extra_extra_medium_large"
             android:layout_marginBottom="@dimen/margin_extra_medium_large"
             android:gravity="center"
             tools:text="Please wait" />


### PR DESCRIPTION
Fixes #4235 - Previously the "Want to keep looking for readers?" label was cut off, like this:

![clipped](https://user-images.githubusercontent.com/3903757/122817091-83f15480-d2a5-11eb-87ab-84a60a9fb754.png)

This simple PR fixes the problem.

![failed](https://user-images.githubusercontent.com/3903757/122817849-738da980-d2a6-11eb-8170-b578068a04d8.png)


To test:

* Power off your card reader
* Settings > Manage card reader
* Redirect to the card reader detail fragment
* Tap "Connect card reader"
* Wait for it to timeout

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
