### PR TITLE
Attempt to fix some image upload issues

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesUtils.kt
@@ -79,7 +79,7 @@ object ProductImagesUtils {
 
         media.fileName = filename
         media.title = filename
-        media.filePath = fetchedUri.path
+        media.filePath = path
         media.localSiteId = localSiteId
         media.fileExtension = fileExtension
         media.mimeType = mimeType

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesUtils.kt
@@ -47,9 +47,13 @@ object ProductImagesUtils {
 
         // optimize the image if the setting is enabled
         if (AppPrefs.getImageOptimizationEnabled()) {
-            getOptimizedImagePath(context, path)?.let {
-                path = it
-            } ?: WooLog.w(T.MEDIA, "mediaModelFromLocalUri > failed to optimize image")
+            try {
+                getOptimizedImagePath(context, path)?.let {
+                    path = it
+                } ?: WooLog.w(T.MEDIA, "mediaModelFromLocalUri > failed to optimize image")
+            } catch (e: Exception) {
+                WooLog.e(T.MEDIA, "mediaModelFromLocalUri > failed to optimize image", e)
+            }
         }
 
         val file = File(path)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesUtils.kt
@@ -46,6 +46,7 @@ object ProductImagesUtils {
         }
 
         // optimize the image if the setting is enabled
+        @Suppress("TooGenericExceptionCaught")
         if (AppPrefs.getImageOptimizationEnabled()) {
             try {
                 getOptimizedImagePath(context, path)?.let {


### PR DESCRIPTION
This PR is an attempt to fix some image upload issues, it contains two fixes:
1. Ignore image optimization errors instead of crashing the app (closes #3437)
2. Use the resolved file path for the upload instead of the Uri path, which hopefully would fix the issue discussed in p1624426777374300-slack-CGPNUU63E and would make the optimization useful, as its result wasn't used before.

#### Testing
I couldn't reproduce any of the original issues, but I was able to confirm that with the change 2, we are uploading the optimized image (https://d.pr/i/9SOEmG), to confirm it:

1. Use the app without these changes.
2. Upload a big image to your store (I used sample images from [here](https://effigis.com/en/solutions/satellite-images/satellite-image-samples/) to test)
3. Go to the media section in wp-admin, and check the image size (by clicking on "edit" button)
4. Apply this PR changes.
5. Re-upload the same image.
6. Go to the store and confirm that the image is optimized, and smaller than the original one.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.