### PR TITLE
Tracking - Card Reader Software Update

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -243,6 +243,12 @@ class AnalyticsTracker private constructor(private val context: Context) {
         CARD_READER_CONNECTION_SUCCESS,
         CARD_READER_DISCONNECT_TAPPED,
 
+        // -- Card Present Payments - software udpate
+        CARD_READER_SOFTWARE_UPDATE_TAPPED,
+        CARD_READER_SOFTWARE_UPDATE_SUCCESS,
+        CARD_READER_SOFTWARE_UPDATE_SKIP_TAPPED,
+        CARD_READER_SOFTWARE_UPDATE_FAILED,
+
         // -- Top-level navigation
         MAIN_MENU_SETTINGS_TAPPED,
         MAIN_MENU_CONTACT_SUPPORT_TAPPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModel.kt
@@ -4,9 +4,10 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_SOFTWARE_UPDATE_FAILED
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_SOFTWARE_UPDATE_SKIP_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_SOFTWARE_UPDATE_SUCCESS
+import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_SOFTWARE_UPDATE_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.SoftwareUpdateStatus.Failed
@@ -59,7 +60,7 @@ class CardReaderUpdateViewModel @Inject constructor(
     }
 
     private fun onUpdateClicked() {
-        tracker.track(Stat.CARD_READER_SOFTWARE_UPDATE_TAPPED)
+        tracker.track(CARD_READER_SOFTWARE_UPDATE_TAPPED)
         launch {
             cardReaderManager.updateSoftware().collect { status ->
                 when (status) {
@@ -98,7 +99,7 @@ class CardReaderUpdateViewModel @Inject constructor(
     }
 
     private fun onSkipClicked() {
-        tracker.track(Stat.CARD_READER_SOFTWARE_UPDATE_SKIP_TAPPED)
+        tracker.track(CARD_READER_SOFTWARE_UPDATE_SKIP_TAPPED)
         finishFlow(SKIPPED)
     }
 


### PR DESCRIPTION
Parent issue #3957

This PR adds Tracks events to the Card Reader Software Update flow.
*card_reader_software_update_tapped - user taps on "Update" button on the software update dialog
*card_reader_software_update_skip_tapped - user taps on "Skip/Cancel" button on the software update dialog
*card_reader_software_update_success - updating the reader completes successfully
*card_reader_software_update_failed - updating the reader fails

To test:
Make sure the events are being recorded - failure can be simulated by turning of the reader during an update. Consider if you want to finish updating your hw reader or test the successful flow on a simulated reader (like I did).

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
