### PR TITLE
Update `Dependabot` to limit 5 opened PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "gradle"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
As agreed, for some time we'll limit it to 5 instead of 3.

p1624609329113200-slack-C6H8C3G23


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.