### PR TITLE
Fix selectable Attributes hint visibility

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeFragment.kt
@@ -185,7 +185,7 @@ class AddAttributeFragment : BaseProductFragment(R.layout.fragment_add_attribute
             }
         )
         binding.attributeSelectionHint.isVisible =
-            globalDraftAttributes.isNotEmpty() or localDraftAttributes.isNotEmpty()
+            globalAttributes.isNotEmpty() or localDraftAttributes.isNotEmpty()
     }
 
     private fun showSkeleton(show: Boolean) {


### PR DESCRIPTION
Summary
==========
Fixes issue #4290. When creating a new Variable Product, the Add Attributes view doesn't show the Global Attributes list hint. This happens due to a miscalculation of which global attributes list should be considered to present the hint or not.

Screenshots
==========
| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/5920403/123641564-c2809500-d7f8-11eb-9f15-63f8ddc29a42.png" width="280" height="585" /> | <img src="https://user-images.githubusercontent.com/5920403/123652534-c44f5600-d802-11eb-848a-90027f4389a4.png" width="280" height="585" /> |

How to Test
==========
Steps to reproduce the behavior:
1. Go to the Product List and hit the FAB to create a new `Variable Product`
2. Click on `Add Variation` and wait to enter the `Add Attributes` view
3. Once inside the `Add Attributes` view, verify that the hint suggesting to select a pre-defined Attribute is not visible

Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
