### PR TITLE
Set up a `CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# All files in repository
+* @woocommerce/android-developers
+
+# Build tools
+/.bundle/           @woocommerce/android-developers @wordpress-mobile/platform-9
+/.circleci/         @woocommerce/android-developers @wordpress-mobile/platform-9
+/.configure-files/  @woocommerce/android-developers @wordpress-mobile/platform-9
+/.github/           @woocommerce/android-developers @wordpress-mobile/platform-9
+/fastlane/          @woocommerce/android-developers @wordpress-mobile/platform-9
+/gradle/            @woocommerce/android-developers @wordpress-mobile/platform-9
+/tools/             @woocommerce/android-developers @wordpress-mobile/platform-9
+.configure          @woocommerce/android-developers @wordpress-mobile/platform-9
+.ruby-version       @woocommerce/android-developers @wordpress-mobile/platform-9
+Gemfile             @woocommerce/android-developers @wordpress-mobile/platform-9
+Gemfile.lock        @woocommerce/android-developers @wordpress-mobile/platform-9
+*.gradle            @woocommerce/android-developers @wordpress-mobile/platform-9
+gradlew             @woocommerce/android-developers @wordpress-mobile/platform-9
+gradlew.bat         @woocommerce/android-developers @wordpress-mobile/platform-9
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,18 +2,17 @@
 * @woocommerce/android-developers
 
 # Build tools
-/.bundle/           @woocommerce/android-developers @wordpress-mobile/platform-9
-/.circleci/         @woocommerce/android-developers @wordpress-mobile/platform-9
-/.configure-files/  @woocommerce/android-developers @wordpress-mobile/platform-9
-/.github/           @woocommerce/android-developers @wordpress-mobile/platform-9
-/fastlane/          @woocommerce/android-developers @wordpress-mobile/platform-9
-/gradle/            @woocommerce/android-developers @wordpress-mobile/platform-9
-/tools/             @woocommerce/android-developers @wordpress-mobile/platform-9
-.configure          @woocommerce/android-developers @wordpress-mobile/platform-9
-.ruby-version       @woocommerce/android-developers @wordpress-mobile/platform-9
-Gemfile             @woocommerce/android-developers @wordpress-mobile/platform-9
-Gemfile.lock        @woocommerce/android-developers @wordpress-mobile/platform-9
-*.gradle            @woocommerce/android-developers @wordpress-mobile/platform-9
-gradlew             @woocommerce/android-developers @wordpress-mobile/platform-9
-gradlew.bat         @woocommerce/android-developers @wordpress-mobile/platform-9
-
+/.bundle/           @woocommerce/android-developers @woocommerce/platform-9
+/.circleci/         @woocommerce/android-developers @woocommerce/platform-9
+/.configure-files/  @woocommerce/android-developers @woocommerce/platform-9
+/.github/           @woocommerce/android-developers @woocommerce/platform-9
+/fastlane/          @woocommerce/android-developers @woocommerce/platform-9
+/gradle/            @woocommerce/android-developers @woocommerce/platform-9
+/tools/             @woocommerce/android-developers @woocommerce/platform-9
+.configure          @woocommerce/android-developers @woocommerce/platform-9
+.ruby-version       @woocommerce/android-developers @woocommerce/platform-9
+Gemfile             @woocommerce/android-developers @woocommerce/platform-9
+Gemfile.lock        @woocommerce/android-developers @woocommerce/platform-9
+*.gradle            @woocommerce/android-developers @woocommerce/platform-9
+gradlew             @woocommerce/android-developers @woocommerce/platform-9
+gradlew.bat         @woocommerce/android-developers @woocommerce/platform-9


### PR DESCRIPTION
Closes: #4270 

### How to verify

I've tried to do this [on a fork](https://github.com/wzieba/woocommerce-android/blob/develop/.github/CODEOWNERS) but this doesn't work because, as I later read in the docs:

> The people you choose as code owners must have write permissions for the repository. When the code owner is a team, that team must have write permissions

[Source](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners)

So then I've tried to verify this with this with [`codeowners-validator`](https://github.com/mszostok/codeowners-validator) tool and the result if following:

<img width="1018" alt="image" src="https://user-images.githubusercontent.com/5845095/123436912-6ab31580-d5cf-11eb-83b2-222b17df1b81.png">

It's true that Platform9 team is not part of `woocommerce` github organization but I can't find [in docs](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#about-code-owners) that it's a requirement.

I think it's worth a try and if needed - have some iterations on this.

### After merge action

Please check this checkbox under protected branch rules:

![image](https://user-images.githubusercontent.com/5845095/123437333-d9906e80-d5cf-11eb-8d38-47d2e7cd6d42.png)


Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
