### PR TITLE
issue/4274-payment-wording-tweaks

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -34,4 +34,5 @@ object AppUrls {
         "https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#section-29"
 
     const val WPCOM_ADD_PAYMENT_METHOD = "https://wordpress.com/me/purchases/add-payment-method"
+    const val WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS = "https://woocommerce.com/payments/"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -334,7 +334,7 @@ class CardReaderPaymentViewModel
             headerLabel = R.string.card_reader_payment_payment_failed_header,
             paymentStateLabel = errorType.message,
             paymentStateLabelTopMargin = R.dimen.major_100,
-            primaryActionLabel = R.string.card_reader_payment_failed_retry,
+            primaryActionLabel = R.string.try_again,
             // TODO cardreader optimize all newly added vector drawables
             illustration = R.drawable.img_products_error
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailFragment.kt
@@ -7,6 +7,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
+import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.R.color
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -24,6 +25,7 @@ import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewMo
 import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewModel.ViewState.NotConnectedState
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateDialogFragment
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.UpdateResult
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.UiHelpers
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -36,6 +38,12 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
         super.onViewCreated(view, savedInstanceState)
 
         val binding = FragmentCardReaderDetailBinding.bind(view)
+
+        val learnMoreListener = View.OnClickListener {
+            ChromeCustomTabUtils.launchUrl(requireActivity(), AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS)
+        }
+        binding.readerConnectedState.cardReaderDetailLearnMoreTv.learnMore.setOnClickListener(learnMoreListener)
+        binding.readerDisconnectedState.cardReaderDetailLearnMoreTv.learnMore.setOnClickListener(learnMoreListener)
 
         observeEvents(binding)
         observeViewState(binding)

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_detail_learn_more.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_detail_learn_more.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.textview.MaterialTextView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    style="@style/Woo.TextView.Caption"
     android:id="@+id/learnMore"
+    style="@style/Woo.TextView.Caption"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
     android:drawableStart="@drawable/ic_info_outline_20dp"
     android:drawablePadding="@dimen/major_100"
     android:text="@string/card_reader_detail_learn_more"

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_detail_learn_more.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_detail_learn_more.xml
@@ -2,6 +2,7 @@
 <com.google.android.material.textview.MaterialTextView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     style="@style/Woo.TextView.Caption"
+    android:id="@+id/learnMore"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:drawableStart="@drawable/ic_info_outline_20dp"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -755,9 +755,9 @@
     <string name="card_reader_detail_connected_enforced_update_software">Please update your reader software to keep accepting payments</string>
     <string name="card_reader_detail_connected_disconnect_reader">Disconnect reader</string>
     <string name="card_reader_detail_connected_reader_unknown">UNKNOWN CARD READER\'s NAME</string>
-    <string name="card_reader_detail_connected_update_check_failed">Software version update check has failed. Please try again later</string>
+    <string name="card_reader_detail_connected_update_check_failed">Software version update check has failed</string>
     <string name="card_reader_detail_connected_update_success">Reader\’s software updated</string>
-    <string name="card_reader_detail_connected_update_failed">Reader\'s software update has failed. Please try again later</string>
+    <string name="card_reader_detail_connected_update_failed">Reader\'s software update has failed</string>
 
     <!--
         Card Reader Software update

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -706,14 +706,14 @@
     <string name="card_reader_payment_failed_no_network_state" translatable="false">@string/error_generic_network</string>
     <string name="card_reader_payment_failed_card_declined_state">Card declined</string>
     <string name="card_reader_payment_failed_collecting_payment_timed_out_state">Card declined</string>
-    <string name="card_reader_payment_failed_unexpected_error_state">Payment failed. Please try again.</string>
+    <string name="card_reader_payment_failed_unexpected_error_state">The payment did not succeed</string>
 
     <string name="card_reader_payment_print_receipt">Print receipt</string>
     <string name="card_reader_payment_send_receipt">Send receipt</string>
 
     <string name="card_reader_payment_description">Online payment for order %s for %s</string>
     <string name="card_reader_payment_receipt_email_subject">Your receipt from %s</string>
-    <string name="card_reader_payment_receipt_email_content">Thank you for your purchase! You can find the receipt for your payment at the following link: %s</string>
+    <string name="card_reader_payment_receipt_email_content">Thank you for your purchase! Click the link below for your payment receipt.\n\n%s</string>
     <string name="card_reader_payment_email_client_not_found">Can\'t detect your email client app</string>
     <string name="card_reader_refetching_order_failed">Error fetching order. Order state in the app might be outdated.</string>
     <string name="card_reader_payment_order_paid_payment_cancelled">The order is already paid</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -707,7 +707,6 @@
     <string name="card_reader_payment_failed_card_declined_state">Card declined</string>
     <string name="card_reader_payment_failed_collecting_payment_timed_out_state">Card declined</string>
     <string name="card_reader_payment_failed_unexpected_error_state">Payment failed. Please try again.</string>
-    <string name="card_reader_payment_failed_retry">Try collecting payment again</string>
 
     <string name="card_reader_payment_print_receipt">Print receipt</string>
     <string name="card_reader_payment_send_receipt">Send receipt</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -743,7 +743,7 @@
         Card Reader Detail
     -->
     <string name="card_reader_detail_not_connected_header">Connect your card reader</string>
-    <string name="card_reader_detail_learn_more">&lt;a href="https://woocommerce.com/payments/"&gt;Learn more&lt;/a&gt; about accepting payments with your mobile device and ordering card readers</string>
+    <string name="card_reader_detail_learn_more">&lt;a href=\'\'&gt;Learn more&lt;/a&gt; about accepting mobile payments and ordering card readers</string>
     <string name="card_reader_detail_not_connected_first_hint_label">Make sure card reader is charged</string>
     <string name="card_reader_detail_not_connected_second_hint_label">Turn card reader on and place it next to mobile device</string>
     <string name="card_reader_detail_not_connected_third_hint_label">Turn mobile device bluetooth on</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -506,7 +506,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
                 .isEqualTo(R.dimen.major_100)
             assertThat(viewState.hintLabel).describedAs("hintLabel").isNull()
             assertThat(viewState.primaryActionLabel).describedAs("primaryActionLabel")
-                .isEqualTo(R.string.card_reader_payment_failed_retry)
+                .isEqualTo(R.string.try_again)
         }
 
     @Test


### PR DESCRIPTION
Closes #4274 and closes #4253.

- Shortened "Try collecting payment again" button text to simply "Try again"

![failed](https://user-images.githubusercontent.com/3903757/123470122-f625aa00-d5c1-11eb-81cc-7ea457c7224c.png)

- Updated the receipt email text and added space above the link

![email](https://user-images.githubusercontent.com/3903757/123470175-0a69a700-d5c2-11eb-9bef-9371ade0c328.png)

- Updated the "learn more" text, made the entire view tappable, and moved the hardcoded URL to `AppUrls`

![learn-more](https://user-images.githubusercontent.com/3903757/123470355-4997f800-d5c2-11eb-9858-0924ebfc90c1.png)

- Removed unnecessary "Please try again later" from two strings


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
