### PR TITLE
Set `platform-9` team as the code owner for config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,17 +2,17 @@
 * @woocommerce/android-developers
 
 # Build tools
-/.bundle/           @woocommerce/android-developers @woocommerce/platform-9
-/.circleci/         @woocommerce/android-developers @woocommerce/platform-9
-/.configure-files/  @woocommerce/android-developers @woocommerce/platform-9
-/.github/           @woocommerce/android-developers @woocommerce/platform-9
-/fastlane/          @woocommerce/android-developers @woocommerce/platform-9
-/gradle/            @woocommerce/android-developers @woocommerce/platform-9
-/tools/             @woocommerce/android-developers @woocommerce/platform-9
-.configure          @woocommerce/android-developers @woocommerce/platform-9
-.ruby-version       @woocommerce/android-developers @woocommerce/platform-9
-Gemfile             @woocommerce/android-developers @woocommerce/platform-9
-Gemfile.lock        @woocommerce/android-developers @woocommerce/platform-9
-*.gradle            @woocommerce/android-developers @woocommerce/platform-9
-gradlew             @woocommerce/android-developers @woocommerce/platform-9
-gradlew.bat         @woocommerce/android-developers @woocommerce/platform-9
+/.bundle/           @woocommerce/platform-9
+/.circleci/         @woocommerce/platform-9
+/.configure-files/  @woocommerce/platform-9
+/.github/           @woocommerce/platform-9
+/fastlane/          @woocommerce/platform-9
+/gradle/            @woocommerce/platform-9
+/tools/             @woocommerce/platform-9
+.configure          @woocommerce/platform-9
+.ruby-version       @woocommerce/platform-9
+Gemfile             @woocommerce/platform-9
+Gemfile.lock        @woocommerce/platform-9
+settings.gradle     @woocommerce/platform-9
+gradlew             @woocommerce/platform-9
+gradlew.bat         @woocommerce/platform-9

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,17 +2,17 @@
 * @woocommerce/android-developers
 
 # Build tools
-/.bundle/           @woocommerce/platform-9
-/.circleci/         @woocommerce/platform-9
-/.configure-files/  @woocommerce/platform-9
-/.github/           @woocommerce/platform-9
-/fastlane/          @woocommerce/platform-9
-/gradle/            @woocommerce/platform-9
-/tools/             @woocommerce/platform-9
-.configure          @woocommerce/platform-9
-.ruby-version       @woocommerce/platform-9
-Gemfile             @woocommerce/platform-9
-Gemfile.lock        @woocommerce/platform-9
-settings.gradle     @woocommerce/platform-9
-gradlew             @woocommerce/platform-9
-gradlew.bat         @woocommerce/platform-9
+/.bundle/           @woocommerce/owl-team
+/.circleci/         @woocommerce/owl-team
+/.configure-files/  @woocommerce/owl-team
+/.github/           @woocommerce/owl-team
+/fastlane/          @woocommerce/owl-team
+/gradle/            @woocommerce/owl-team
+/tools/             @woocommerce/owl-team
+.configure          @woocommerce/owl-team
+.ruby-version       @woocommerce/owl-team
+Gemfile             @woocommerce/owl-team
+Gemfile.lock        @woocommerce/owl-team
+settings.gradle     @woocommerce/owl-team
+gradlew             @woocommerce/owl-team
+gradlew.bat         @woocommerce/owl-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,7 @@
 * @woocommerce/android-developers
 
 # Build tools
+/.buildkite/        @woocommerce/owl-team
 /.bundle/           @woocommerce/owl-team
 /.circleci/         @woocommerce/owl-team
 /.configure-files/  @woocommerce/owl-team


### PR DESCRIPTION
According to [documentation](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file):

> #Order is important; the last matching pattern takes the most
#precedence. When someone opens a pull request that only
#modifies JS files, only @js-owner and not the global
#owner(s) will be requested for a review.
*.js    @js-owner

and this seems to be our case

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
