### PR TITLE
Issue 3957. Check software update status after successful update

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
@@ -132,7 +132,10 @@ class CardReaderDetailViewModel @Inject constructor(
 
     fun onUpdateReaderResult(updateResult: UpdateResult) {
         when (updateResult) {
-            SUCCESS -> triggerEvent(Event.ShowSnackbar(R.string.card_reader_detail_connected_update_success))
+            SUCCESS -> {
+                launch { checkForUpdates() }
+                triggerEvent(Event.ShowSnackbar(R.string.card_reader_detail_connected_update_success))
+            }
             FAILED -> triggerEvent(Event.ShowSnackbar(R.string.card_reader_detail_connected_update_failed))
             SKIPPED -> {
             }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
@@ -235,16 +235,71 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when on update result with success then software update status checked`() {
+    fun `given up to date software, when on update result successful, then connected state without update emitted`() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // GIVEN
             val viewModel = createViewModel()
+            initConnectedState()
 
             // WHEN
             viewModel.onUpdateReaderResult(UpdateResult.SUCCESS)
 
             // THEN
             verify(cardReaderManager).softwareUpdateAvailability()
+            verifyConnectedState(
+                viewModel,
+                UiStringText(READER_NAME),
+                UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("65"))),
+                updateAvailable = false
+            )
+        }
+    }
+
+    @Test
+    fun `given software update available, when on update result successful, then connected with update emitted`() {
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val viewModel = createViewModel()
+            initConnectedState(updateAvailable = SoftwareUpdateAvailability.UpdateAvailable)
+
+            // WHEN
+            viewModel.onUpdateReaderResult(UpdateResult.SUCCESS)
+
+            // THEN
+            verify(cardReaderManager).softwareUpdateAvailability()
+            verifyConnectedState(
+                viewModel,
+                UiStringText(READER_NAME),
+                UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("65"))),
+                updateAvailable = true
+            )
+        }
+    }
+
+    @Test
+    fun `given software update check failed, when on update result successful, then connected state with snackbar`() {
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val viewModel = createViewModel()
+            initConnectedState(updateAvailable = SoftwareUpdateAvailability.CheckForUpdatesFailed)
+
+            // WHEN
+            val events = mutableListOf<Event>()
+            viewModel.event.observeForever { events.add(it) }
+            viewModel.onUpdateReaderResult(UpdateResult.SUCCESS)
+
+            // THEN
+            verify(cardReaderManager).softwareUpdateAvailability()
+            verifyConnectedState(
+                viewModel,
+                UiStringText(READER_NAME),
+                UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("65"))),
+                updateAvailable = false
+            )
+            assertThat(events[0])
+                .isEqualTo(Event.ShowSnackbar(R.string.card_reader_detail_connected_update_check_failed))
+            assertThat(events[1])
+                .isEqualTo(Event.ShowSnackbar(R.string.card_reader_detail_connected_update_success))
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
@@ -235,6 +235,20 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when on update result with success then software update status checked`() {
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val viewModel = createViewModel()
+
+            // WHEN
+            viewModel.onUpdateReaderResult(UpdateResult.SUCCESS)
+
+            // THEN
+            verify(cardReaderManager).softwareUpdateAvailability()
+        }
+    }
+
+    @Test
     fun `when on update result with failed should send snackbar event with failed text`() {
         // GIVEN
         val viewModel = createViewModel()


### PR DESCRIPTION
Parent issue: #3957 

The PR adds check software update status after the successful update was performed. It's needed in order to make sure that we show relevant "connected, no update available OR update available" depends on what is the current situation with a reader.

### How to test
My physical reader is up to date so the only way how to test it was to modify the code in `SoftwareUpdateManager::softwareUpdateStatus` like the following:

```
    suspend fun softwareUpdateStatus() = flow {
        emit(Initializing)

        if (Math.random() > 0.5) {
            emit(SoftwareUpdateAvailability.UpToDate)
            return@flow
        }

        when (checkUpdatesAction.checkUpdates()) {
            CheckSoftwareUpdates.UpToDate -> emit(SoftwareUpdateAvailability.UpToDate)
            is CheckSoftwareUpdates.Failed -> emit(SoftwareUpdateAvailability.CheckForUpdatesFailed)
            is CheckSoftwareUpdates.UpdateAvailable -> emit(SoftwareUpdateAvailability.UpdateAvailable)
        }
    }
```