### PR TITLE
Remove newly created Attribute when no Terms is defined

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsFragment.kt
@@ -213,6 +213,9 @@ class AddAttributeTermsFragment : BaseProductFragment(R.layout.fragment_add_attr
     }
 
     override fun onRequestAllowBackPress(): Boolean {
+        if (navArgs.isNewAttribute and assignedTermsAdapter.isEmpty()) {
+            viewModel.removeAttributeFromDraft(navArgs.attributeId, attributeName)
+        }
         saveChangesAndReturn()
         return false
     }


### PR DESCRIPTION
Summary
==========
Fixes issue #4221. If I add a new attribute to a product (new or existing), that attribute is saved and added to the product even if I don't add any attribute options. This PR solves this problem by removing from the Product Draft any incomplete Attribute creation.

Screenshots
==========
| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/8658164/122381896-4ae17900-cf61-11eb-8b8d-989285e2b508.gif" width="300px"> | <img src="https://user-images.githubusercontent.com/5920403/123671543-ca4e3280-d814-11eb-9400-89faf6ee0e33.gif" width="300px"> |

How to Test
==========
1. Open an existing variable product.
2. Tap the "Variations attributes" section.
3. Select "Add Attribute."
4. Enter a new attribute name and tap enter.
5. Tap the back button without adding any options. Notice the new attribute name is *NOT* in the attribute list.
6. Tap the back button again and notice the new attribute is *NOT* in the list of product attributes.
7. Tap the back button again and notice the new attribute is *NOT* listed in the "Variations attributes" section
8. Select "Variations" and verify the new attribute is *NOT* listed on the product variations

Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
