### PR TITLE
Provide `debug` release variant for `debug` builds in Sentry

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/BuildConfigWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/BuildConfigWrapper.kt
@@ -1,0 +1,11 @@
+package com.woocommerce.android.util
+
+import com.woocommerce.android.BuildConfig
+import dagger.Reusable
+import javax.inject.Inject
+
+@Reusable
+class BuildConfigWrapper @Inject constructor() {
+    val debug = BuildConfig.DEBUG
+    val versionName = BuildConfig.VERSION_NAME
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProvider.kt
@@ -7,6 +7,7 @@ import com.automattic.android.tracks.crashlogging.ExtraKnownKey
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.util.locale.LocaleProvider
 import org.wordpress.android.fluxc.store.AccountStore
 import java.util.Locale
@@ -18,7 +19,8 @@ class WCCrashLoggingDataProvider @Inject constructor(
     private val selectedSite: SelectedSite,
     private val appPrefs: AppPrefs,
     private val enqueueSendingEncryptedLogs: EnqueueSendingEncryptedLogs,
-    private val uuidGenerator: UuidGenerator
+    private val uuidGenerator: UuidGenerator,
+    buildConfig: BuildConfigWrapper,
 ) : CrashLoggingDataProvider {
     override val buildType: String = BuildConfig.BUILD_TYPE
 
@@ -27,7 +29,11 @@ class WCCrashLoggingDataProvider @Inject constructor(
     override val locale: Locale?
         get() = localeProvider.provideLocale()
 
-    override val releaseName: String = BuildConfig.VERSION_NAME
+    override val releaseName: String = if (buildConfig.debug) {
+        DEBUG_RELEASE_NAME
+    } else {
+        buildConfig.versionName
+    }
 
     override val sentryDSN: String = BuildConfig.SENTRY_DSN
 
@@ -86,5 +92,6 @@ class WCCrashLoggingDataProvider @Inject constructor(
         const val SITE_ID_KEY = "site_id"
         const val SITE_URL_KEY = "site_url"
         const val EXTRA_UUID = "uuid"
+        const val DEBUG_RELEASE_NAME = "debug"
     }
 }


### PR DESCRIPTION
Closes #4292 

For context and reasons for this change please check the issue.

| Before | After |
| ---- | ---- |
| <img width="508" alt="Screenshot 2021-06-28 at 17 31 42" src="https://user-images.githubusercontent.com/5845095/123670737-d13d6b00-d83d-11eb-9f0a-d438dea74279.png"> | <img width="529" alt="image" src="https://user-images.githubusercontent.com/5845095/123672264-67be5c00-d83f-11eb-82a0-7522680c328d.png"> |


## How to test

### TC1 Debug variant 
1. Apply the attached `Patch` available at the bottom
2. Build debug variant and run the app
3. Go to `releases` on the Sentry dashboard
4. **Make sure there's `debug` release**
5. Go to `issues` on the Sentry dashboard
6. Select "This is test" issue
7. **Make sure it has `debug` release attached**
8. **Remove the issue**

### TC2 Release variant
1. Apply the attached `Patch` available at the bottom
2. Build release variant and run the app
3. Go to `issues` on the Sentry dashboard
4. Select "This is test" issue
5. **Make sure it has `6.9-rc-2` release attached**
6. **Remove the issue**

### TC3 Installable build
1. Run the app built by CI (link should be available in PRs comments)
2. Go to `releases` on the Sentry dashboard
3. Make sure there's no new release matching `pr-####-build-#####` schema

#### Patch

```
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProvider.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
--- WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProvider.kt	(revision ea3a2b5bfac457a545a1ea99ff2745ab6bc7be56)
+++ WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProvider.kt	(date 1624897863226)
@@ -47,7 +47,7 @@
     }
 
     override fun crashLoggingEnabled(): Boolean {
-        return appPrefs.isCrashReportingEnabled()
+        return true
     }
 
     override fun extraKnownKeys(): List<ExtraKnownKey> {
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
--- WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt	(revision ea3a2b5bfac457a545a1ea99ff2745ab6bc7be56)
+++ WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt	(date 1624897863222)
@@ -176,6 +176,8 @@
         tabLayout.addOnTabSelectedListener(tabSelectedListener)
 
         refreshMyStoreStats(forced = this.isRefreshPending)
+
+        crashLogging.sendReport(message = "This is test")
     }
 
     private fun initTabLayout() {
```

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
