### PR TITLE
issue/4279-payment-errors-in-red

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectFragment.kt
@@ -12,6 +12,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -103,6 +104,14 @@ class CardReaderConnectFragment : DialogFragment(R.layout.fragment_card_reader_c
             binding.secondaryActionBtn.setOnClickListener {
                 viewState.onSecondaryActionClicked?.invoke()
             }
+
+            binding.headerLabel.setTextColor(
+                if (viewState.isError) {
+                    ContextCompat.getColor(requireActivity(), R.color.color_error)
+                } else {
+                    ContextCompat.getColor(requireActivity(), R.color.color_on_surface_medium)
+                }
+            )
 
             with(binding.illustration.layoutParams as ViewGroup.MarginLayoutParams) {
                 topMargin = resources.getDimensionPixelSize(viewState.illustrationTopMargin)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -312,7 +312,8 @@ class CardReaderConnectViewModel @Inject constructor(
         val primaryActionLabel: Int? = null,
         val secondaryActionLabel: Int? = null,
         @DimenRes val illustrationTopMargin: Int = R.dimen.major_200,
-        open val listItems: List<ListItemViewState>? = null
+        open val listItems: List<ListItemViewState>? = null,
+        val isError: Boolean = false,
     ) {
         open val onPrimaryActionClicked: (() -> Unit)? = null
         open val onSecondaryActionClicked: (() -> Unit)? = null
@@ -364,7 +365,8 @@ class CardReaderConnectViewModel @Inject constructor(
             illustration = R.drawable.img_products_error,
             primaryActionLabel = R.string.try_again,
             secondaryActionLabel = R.string.cancel,
-            illustrationTopMargin = R.dimen.major_150
+            illustrationTopMargin = R.dimen.major_150,
+            isError = true
         )
 
         data class ConnectingFailedState(
@@ -375,7 +377,8 @@ class CardReaderConnectViewModel @Inject constructor(
             illustration = R.drawable.img_products_error,
             primaryActionLabel = R.string.try_again,
             secondaryActionLabel = R.string.cancel,
-            illustrationTopMargin = R.dimen.major_150
+            illustrationTopMargin = R.dimen.major_150,
+            isError = true
         )
 
         data class MissingPermissionsError(
@@ -386,7 +389,8 @@ class CardReaderConnectViewModel @Inject constructor(
             illustration = R.drawable.img_products_error,
             primaryActionLabel = R.string.card_reader_connect_open_permission_settings,
             secondaryActionLabel = R.string.cancel,
-            illustrationTopMargin = R.dimen.major_150
+            illustrationTopMargin = R.dimen.major_150,
+            isError = true
         )
 
         data class LocationDisabledError(
@@ -397,7 +401,8 @@ class CardReaderConnectViewModel @Inject constructor(
             illustration = R.drawable.img_products_error,
             primaryActionLabel = R.string.card_reader_connect_open_location_settings,
             secondaryActionLabel = R.string.cancel,
-            illustrationTopMargin = R.dimen.major_150
+            illustrationTopMargin = R.dimen.major_150,
+            isError = true
         )
 
         data class BluetoothDisabledError(
@@ -408,7 +413,8 @@ class CardReaderConnectViewModel @Inject constructor(
             illustration = R.drawable.img_products_error,
             primaryActionLabel = R.string.card_reader_connect_open_bluetooth_settings,
             secondaryActionLabel = R.string.cancel,
-            illustrationTopMargin = R.dimen.major_150
+            illustrationTopMargin = R.dimen.major_150,
+            isError = true
         )
     }
 


### PR DESCRIPTION
Closes #4279 - Previously error messages in the header of the payment dialogs were the same color as success messages, and I recommend we change them to red. This PR implements that change, but I've marked it `do not merge` because it needs design approval first.

![light](https://user-images.githubusercontent.com/3903757/123682571-274be780-d819-11eb-826e-f0896dd1bb1a.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
