### PR TITLE
issue/4296-payment-scanning-description-padding 

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_card_reader_connect.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_connect.xml
@@ -48,14 +48,14 @@
             style="@style/Woo.Card.Body.High"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_125"
-            android:layout_marginEnd="@dimen/major_125"
+            android:paddingStart="@dimen/major_125"
+            android:paddingEnd="@dimen/major_125"
             android:gravity="center"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/illustration"
             app:layout_constraintBottom_toTopOf="@id/secondary_action_btn"
-            tools:text="Please wait" />
+            tools:text="@string/card_reader_connect_scanning_hint" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/multiple_card_readers_found_rv"


### PR DESCRIPTION
Fixes #4296 by changing margin to padding. Before and after shots below.

![before](https://user-images.githubusercontent.com/3903757/123692084-65023d80-d824-11eb-995f-53dbad1e9e93.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
