### PR TITLE
Update Products List Banner for Variations

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -716,7 +716,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_FEEDBACK_CANCELED = "canceled"
         const val VALUE_FEEDBACK_DISMISSED = "dismissed"
         const val VALUE_FEEDBACK_GIVEN = "gave_feedback"
-        const val VALUE_PRODUCT_M3_FEEDBACK = "products_m3"
+        const val VALUE_PRODUCTS_VARIATIONS_FEEDBACK = "products_variations"
         const val VALUE_SHIPPING_LABELS_M1_FEEDBACK = "shipping_labels_m1"
         const val VALUE_SHIPPING_LABELS_M2_FEEDBACK = "shipping_labels_m2"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
@@ -17,7 +17,6 @@ data class FeatureFeedbackSettings(
 
     enum class Feature(val description: String) {
         SHIPPING_LABELS_M1("shipping_labels_m1"),
-        PRODUCTS_M3("products_m3"),
         VARIATIONS("variations")
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
@@ -18,6 +18,5 @@ data class FeatureFeedbackSettings(
     enum class Feature(val description: String) {
         SHIPPING_LABELS_M1("shipping_labels_m1"),
         PRODUCTS_M3("products_m3"),
-        PRODUCTS_M2("products_m2")
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
@@ -18,5 +18,6 @@ data class FeatureFeedbackSettings(
     enum class Feature(val description: String) {
         SHIPPING_LABELS_M1("shipping_labels_m1"),
         PRODUCTS_M3("products_m3"),
+        VARIATIONS("variations")
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
@@ -17,6 +17,6 @@ data class FeatureFeedbackSettings(
 
     enum class Feature(val description: String) {
         SHIPPING_LABELS_M1("shipping_labels_m1"),
-        VARIATIONS("variations")
+        PRODUCTS_VARIATIONS("products_variations")
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -470,7 +470,7 @@ class ProductListFragment :
         AnalyticsTracker.track(
             FEATURE_FEEDBACK_BANNER,
             mapOf(
-                AnalyticsTracker.KEY_FEEDBACK_CONTEXT to AnalyticsTracker.VALUE_PRODUCT_M3_FEEDBACK,
+                AnalyticsTracker.KEY_FEEDBACK_CONTEXT to AnalyticsTracker.VALUE_PRODUCTS_VARIATIONS_FEEDBACK,
                 AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_GIVEN
             )
         )
@@ -484,7 +484,7 @@ class ProductListFragment :
         AnalyticsTracker.track(
             FEATURE_FEEDBACK_BANNER,
             mapOf(
-                AnalyticsTracker.KEY_FEEDBACK_CONTEXT to AnalyticsTracker.VALUE_PRODUCT_M3_FEEDBACK,
+                AnalyticsTracker.KEY_FEEDBACK_CONTEXT to AnalyticsTracker.VALUE_PRODUCTS_VARIATIONS_FEEDBACK,
                 AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_DISMISSED
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -26,7 +26,6 @@ import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.FeatureFeedbackSettings
-import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.VARIATIONS
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.DISMISSED
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.GIVEN
@@ -56,8 +55,10 @@ class ProductListFragment :
     OnLoadMoreListener,
     OnQueryTextListener,
     OnActionExpandListener {
+
     companion object {
         val TAG: String = ProductListFragment::class.java.simpleName
+        val CURRENT_WIP_NOTICE_FEATURE = FeatureFeedbackSettings.Feature.VARIATIONS
         val PRODUCT_FILTER_RESULT_KEY = "product_filter_result"
     }
 
@@ -81,7 +82,7 @@ class ProductListFragment :
     private val feedbackState: FeedbackState
         get() =
             FeedbackPrefs.getFeatureFeedbackSettings(TAG)
-                ?.takeIf { it.name == VARIATIONS.name }
+                ?.takeIf { it.name == CURRENT_WIP_NOTICE_FEATURE.name }
                 ?.state ?: UNANSWERED
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -492,7 +493,7 @@ class ProductListFragment :
     }
 
     private fun registerFeedbackSetting(state: FeedbackState) {
-        FeatureFeedbackSettings(VARIATIONS.name, state)
+        FeatureFeedbackSettings(CURRENT_WIP_NOTICE_FEATURE.name, state)
             .run { FeedbackPrefs.setFeatureFeedbackSettings(TAG, this) }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -58,7 +58,7 @@ class ProductListFragment :
 
     companion object {
         val TAG: String = ProductListFragment::class.java.simpleName
-        val CURRENT_WIP_NOTICE_FEATURE = FeatureFeedbackSettings.Feature.VARIATIONS
+        val CURRENT_WIP_NOTICE_FEATURE = FeatureFeedbackSettings.Feature.PRODUCTS_VARIATIONS
         val PRODUCT_FILTER_RESULT_KEY = "product_filter_result"
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -55,7 +55,6 @@ class ProductListFragment :
     OnLoadMoreListener,
     OnQueryTextListener,
     OnActionExpandListener {
-
     companion object {
         val TAG: String = ProductListFragment::class.java.simpleName
         val CURRENT_WIP_NOTICE_FEATURE = FeatureFeedbackSettings.Feature.PRODUCTS_VARIATIONS

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -376,7 +376,7 @@ class ProductListFragment :
     private fun showProductWIPNoticeCard(show: Boolean) {
         if (show && feedbackState != DISMISSED) {
             val wipCardTitleId = R.string.product_wip_title_m5
-            val wipCardMessageId = R.string.product_wip_message_m5
+            val wipCardMessageId = R.string.product_wip_message_variations
 
             binding.productsWipCard.visibility = View.VISIBLE
             binding.productsWipCard.initView(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -26,7 +26,7 @@ import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.FeatureFeedbackSettings
-import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.PRODUCTS_M3
+import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.VARIATIONS
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.DISMISSED
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.GIVEN
@@ -489,7 +489,7 @@ class ProductListFragment :
     }
 
     private fun registerFeedbackSetting(state: FeedbackState) {
-        FeatureFeedbackSettings(PRODUCTS_M3.name, state)
+        FeatureFeedbackSettings(VARIATIONS.name, state)
             .run { FeedbackPrefs.setFeatureFeedbackSettings(TAG, this) }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -78,8 +78,11 @@ class ProductListFragment :
     private var _binding: FragmentProductListBinding? = null
     private val binding get() = _binding!!
 
-    private val feedbackState
-        get() = FeedbackPrefs.getFeatureFeedbackSettings(TAG)?.state ?: UNANSWERED
+    private val feedbackState: FeedbackState
+        get() =
+            FeedbackPrefs.getFeatureFeedbackSettings(TAG)
+                ?.takeIf { it.name == VARIATIONS.name }
+                ?.state ?: UNANSWERED
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -904,7 +904,7 @@
     <string name="product_limited_editing_message">We\'ve added editing functionality to simple products. Keep an eye out for more options soon!</string>
     <string name="product_adding_wip_title">Create products from the app!</string>
     <string name="product_wip_message_m4">It\'s now possible to create new simple, linked and grouped products on the go from the Woo app. Not ready yet? Save them as a draft!</string>
-    <string name="product_wip_message_m5">You can now add downloadable files to a product and link upsell &amp; cross-sell products. No longer want a product? Trash it!</string>
+    <string name="product_wip_message_variations">You can now create and manage product variations!</string>
     <string name="product_wip_title">New editing options available</string>
     <string name="product_wip_title_m5">New features available!</string>
     <string name="product_wip_message_m2">We\'ve added more editing functionalities to products! You can now update images, see previews and share your products.</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -903,7 +903,6 @@
     <string name="product_limited_editing_title">Limited editing available</string>
     <string name="product_limited_editing_message">We\'ve added editing functionality to simple products. Keep an eye out for more options soon!</string>
     <string name="product_adding_wip_title">Create products from the app!</string>
-    <string name="product_wip_message_m4">It\'s now possible to create new simple, linked and grouped products on the go from the Woo app. Not ready yet? Save them as a draft!</string>
     <string name="product_wip_message_variations">You can now create and manage product variations!</string>
     <string name="product_wip_title">New editing options available</string>
     <string name="product_wip_title_m5">New features available!</string>


### PR DESCRIPTION
Closes #4243

## Design

Before | After 
--------|-------
<img src="https://user-images.githubusercontent.com/198826/123719872-dbf8ff80-d83f-11eb-99a0-0afdb4698f34.png" width="300">     |    <img src="https://user-images.githubusercontent.com/198826/123719878-df8c8680-d83f-11eb-9474-2a9477b97b3e.png" width="300">

## Changes

This updates the banner message in Products List to match iOS. I also fixed a bug that prevented the app from showing the banner again if the merchant has previously dismissed it.

## Testing

Best to delete the app to reset the state before doing following the steps.

1. Using the `develop` branch, navigate to the Product List. 
2. Dismiss the banner. 
3. Using this branch, navigate to the Product List. 
4. Confirm that the banner is displaying the new message. 
5. Confirm that you can still dismiss the banner. 

## Author Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

