### PR TITLE
Smaller bottom padding to compensate bottom inset

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_card_reader_connect.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_connect.xml
@@ -13,7 +13,7 @@
         android:gravity="center_horizontal"
         android:orientation="vertical"
         android:paddingTop="@dimen/major_200"
-        android:paddingBottom="26dp">
+        android:paddingBottom="@dimen/payments_dialog_bottom_padding">
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/header_label"

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_connect.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_connect.xml
@@ -13,7 +13,7 @@
         android:gravity="center_horizontal"
         android:orientation="vertical"
         android:paddingTop="@dimen/major_200"
-        android:paddingBottom="@dimen/major_200">
+        android:paddingBottom="26dp">
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/header_label"

--- a/WooCommerce/src/main/res/values/dimens_payments.xml
+++ b/WooCommerce/src/main/res/values/dimens_payments.xml
@@ -2,4 +2,5 @@
 <resources>
     <dimen name="payments_dialog_width">280dp</dimen>
     <dimen name="payments_dialog_height">388dp</dimen>
+    <dimen name="payments_dialog_bottom_padding">26dp</dimen>
 </resources>


### PR DESCRIPTION
Following the @Garance91540 [advice](https://github.com/woocommerce/woocommerce-android/pull/4247#issuecomment-870567401) the only way I found to make bottom padding 32dp actually making it 26dp. Our styles of the buttons have 6dp bottom and top inset, so in order to compensate that I had to change the bottom padding of the layout.

I don't like the solution, but having a button visually closer to the left and right border than to the bottom looks bad as well. @nbradbury  if we go this way, then probably for the collecting flow we have to do the same

![screen](https://user-images.githubusercontent.com/4923871/123807480-8d5b6c00-d8f8-11eb-800f-7922f2f2f75e.png)


