### PR TITLE
Issue 3724. Removed usage of AppLogWrapper

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -40,6 +40,7 @@ import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectView
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.ScanningFailedState
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.ScanningState
 import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -48,16 +49,13 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
-import org.wordpress.android.fluxc.utils.AppLogWrapper
-import org.wordpress.android.util.AppLog.T
 import javax.inject.Inject
 
 @HiltViewModel
 class CardReaderConnectViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val dispatchers: CoroutineDispatchers,
-    private val tracker: AnalyticsTrackerWrapper,
-    private val appLogWrapper: AppLogWrapper
+    private val tracker: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedState) {
     /**
      * This is a workaround for a bug in MultiLiveEvent, which can't be fixed without vital changes.
@@ -194,7 +192,7 @@ class CardReaderConnectViewModel @Inject constructor(
                     null,
                     discoveryEvent.msg
                 )
-                appLogWrapper.e(T.MAIN, "Scanning failed: ${discoveryEvent.msg}")
+                WooLog.e(WooLog.T.CARD_READER, "Scanning failed: ${discoveryEvent.msg}")
                 viewState.value = ScanningFailedState(::startFlow, ::onCancelClicked)
             }
         }
@@ -245,7 +243,7 @@ class CardReaderConnectViewModel @Inject constructor(
                 onReaderConnected()
             } else {
                 tracker.track(AnalyticsTracker.Stat.CARD_READER_CONNECTION_FAILED)
-                appLogWrapper.e(T.MAIN, "Connecting to reader failed.")
+                WooLog.e(WooLog.T.CARD_READER, "Connecting to reader failed.")
                 viewState.value = ConnectingFailedState({ onConnectToReaderClicked(cardReader) }, ::onCancelClicked)
             }
         }
@@ -264,12 +262,12 @@ class CardReaderConnectViewModel @Inject constructor(
     }
 
     private fun onCancelClicked() {
-        appLogWrapper.e(T.MAIN, "Connection flow interrupted by the user.")
+        WooLog.e(WooLog.T.CARD_READER, "Connection flow interrupted by the user.")
         exitFlow(connected = false)
     }
 
     private fun onReaderConnected() {
-        appLogWrapper.e(T.MAIN, "Connecting to reader succeeded.")
+        WooLog.e(WooLog.T.CARD_READER, "Connecting to reader succeeded.")
         exitFlow(connected = true)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
@@ -28,13 +28,12 @@ import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewMo
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.UpdateResult.FAILED
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.UpdateResult.SKIPPED
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.UpdateResult.SUCCESS
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
-import org.wordpress.android.fluxc.utils.AppLogWrapper
-import org.wordpress.android.util.AppLog.T
 import javax.inject.Inject
 import kotlin.math.roundToInt
 
@@ -42,7 +41,6 @@ import kotlin.math.roundToInt
 class CardReaderDetailViewModel @Inject constructor(
     val cardReaderManager: CardReaderManager,
     private val tracker: AnalyticsTrackerWrapper,
-    private val appLogWrapper: AppLogWrapper,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
     private val viewState = MutableLiveData<ViewState>(Loading)
@@ -124,7 +122,7 @@ class CardReaderDetailViewModel @Inject constructor(
         launch {
             val disconnectionResult = cardReaderManager.disconnectReader()
             if (!disconnectionResult) {
-                appLogWrapper.e(T.MAIN, "Disconnection from reader has failed")
+                WooLog.e(WooLog.T.CARD_READER, "Disconnection from reader has failed")
                 showNotConnectedState()
             }
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -69,8 +69,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
         viewModel = CardReaderConnectViewModel(
             SavedStateHandle(),
             coroutinesTestRule.testDispatchers,
-            tracker,
-            mock()
+            tracker
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
@@ -451,7 +451,6 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
     private fun createViewModel() = CardReaderDetailViewModel(
         cardReaderManager,
         tracker,
-        mock(),
         SavedStateHandle()
     )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -19,7 +19,8 @@ object WooLog {
     enum class T {
         DASHBOARD,
         ORDERS,
-        UTILS
+        UTILS,
+        CARD_READER
     }
 
     // Breaking convention to be consistent with org.wordpress.android.util.AppLog


### PR DESCRIPTION
Parent issue #3724 

Removes usage of AppLog in favor of WooLog

### How To Test
Run the app. Open settings and connect to a reader. Check the logs