### PR TITLE
Shipping Labels: add ability to move items to new packages

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/CustomsPackage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/CustomsPackage.kt
@@ -14,7 +14,7 @@ import java.math.BigDecimal
 @Parcelize
 data class CustomsPackage(
     val id: String,
-    val box: ShippingPackage,
+    val labelPackage: ShippingLabelPackage,
     val returnToSender: Boolean,
     val contentsType: ContentsType,
     val contentsDescription: String? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabelPackage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabelPackage.kt
@@ -1,16 +1,31 @@
 package com.woocommerce.android.model
 
 import android.os.Parcelable
+import com.woocommerce.android.R
+import com.woocommerce.android.model.UiString.UiStringRes
+import com.woocommerce.android.model.UiString.UiStringText
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import java.math.BigDecimal
 
 @Parcelize
 data class ShippingLabelPackage(
-    val packageId: String,
+    val position: Int,
     val selectedPackage: ShippingPackage?,
     val weight: Float,
     val items: List<Item>
 ) : Parcelable {
+    @IgnoredOnParcel
+    val packageId: String
+        get() = "package$position"
+
+    @IgnoredOnParcel
+    val title: UiString
+        get() = UiStringRes(
+            R.string.shipping_label_package_details_title_template,
+            listOf(UiStringText(position.toString()))
+        )
+
     @Parcelize
     data class Item(
         val productId: Long,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabelPackage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabelPackage.kt
@@ -1,9 +1,8 @@
 package com.woocommerce.android.model
 
+import android.content.Context
 import android.os.Parcelable
 import com.woocommerce.android.R
-import com.woocommerce.android.model.UiString.UiStringRes
-import com.woocommerce.android.model.UiString.UiStringText
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import java.math.BigDecimal
@@ -19,13 +18,6 @@ data class ShippingLabelPackage(
     val packageId: String
         get() = "package$position"
 
-    @IgnoredOnParcel
-    val title: UiString
-        get() = UiStringRes(
-            R.string.shipping_label_package_details_title_template,
-            listOf(UiStringText(position.toString()))
-        )
-
     @Parcelize
     data class Item(
         val productId: Long,
@@ -36,3 +28,6 @@ data class ShippingLabelPackage(
         val value: BigDecimal
     ) : Parcelable
 }
+
+fun ShippingLabelPackage.getTitle(context: Context) =
+    context.getString(R.string.shipping_label_package_details_title_template, position)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
+import com.woocommerce.android.model.ShippingLabelPackage
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
@@ -100,6 +101,9 @@ class EditShippingLabelPackagesFragment :
         handleResult<ShippingPackageSelectorResult>(ShippingPackageSelectorFragment.SELECTED_PACKAGE_RESULT) { result ->
             viewModel.onPackageSelected(result.position, result.selectedPackage)
         }
+        handleResult<List<ShippingLabelPackage>>(MoveShippingItemDialog.MOVE_ITEM_RESULT) { packagesList ->
+            viewModel.updatePackagesList(packagesList)
+        }
     }
 
     private fun setupObservers(binding: FragmentEditShippingLabelPackagesBinding) {
@@ -132,7 +136,8 @@ class EditShippingLabelPackagesFragment :
                     val action = EditShippingLabelPackagesFragmentDirections
                         .actionEditShippingLabelPackagesFragmentToMoveShippingItemDialog(
                             item = event.item,
-                            currentPackage = event.currentPackage
+                            currentPackage = event.currentPackage,
+                            packagesList = event.packagesList.toTypedArray()
                         )
 
                     findNavController().navigateSafely(action)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -5,11 +5,9 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DefaultItemAnimator
-import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentEditShippingLabelPackagesBinding
@@ -49,6 +47,7 @@ class EditShippingLabelPackagesFragment :
         ShippingLabelPackagesAdapter(
             viewModel.weightUnit,
             viewModel::onWeightEdited,
+            viewModel::onExpandedChanged,
             viewModel::onPackageSpinnerClicked,
             viewModel::onMoveButtonClicked
         )
@@ -110,7 +109,7 @@ class EditShippingLabelPackagesFragment :
 
     private fun setupObservers(binding: FragmentEditShippingLabelPackagesBinding) {
         viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
-            new.shippingLabelPackages.takeIfNotEqualTo(old?.shippingLabelPackages) {
+            new.packagesUiModels.takeIfNotEqualTo(old?.packagesUiModels) {
                 packagesAdapter.shippingLabelPackages = it
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -22,6 +22,7 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPackagesViewModel.OpenPackageSelectorEvent
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPackagesViewModel.ShowMoveItemDialog
+import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.MoveItemResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -102,8 +103,8 @@ class EditShippingLabelPackagesFragment :
         handleResult<ShippingPackageSelectorResult>(ShippingPackageSelectorFragment.SELECTED_PACKAGE_RESULT) { result ->
             viewModel.onPackageSelected(result.position, result.selectedPackage)
         }
-        handleResult<List<ShippingLabelPackage>>(MoveShippingItemDialog.MOVE_ITEM_RESULT) { packagesList ->
-            viewModel.updatePackagesList(packagesList)
+        handleResult<MoveItemResult>(MoveShippingItemDialog.MOVE_ITEM_RESULT) { result ->
+            viewModel.handleMoveItemResult(result)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -8,6 +8,7 @@ import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.observe
 import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentEditShippingLabelPackagesBinding
@@ -84,6 +85,10 @@ class EditShippingLabelPackagesFragment :
         with(binding.packagesList) {
             layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
             adapter = packagesAdapter
+            itemAnimator = DefaultItemAnimator().apply {
+                // Disable change animations to avoid duplicating viewholders
+                supportsChangeAnimations = false
+            }
         }
 
         setupObservers(binding)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -6,7 +6,6 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.observe
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -21,6 +20,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPackagesViewModel.OpenPackageSelectorEvent
+import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPackagesViewModel.ShowMoveItemDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -46,7 +46,8 @@ class EditShippingLabelPackagesFragment :
         ShippingLabelPackagesAdapter(
             viewModel.weightUnit,
             viewModel::onWeightEdited,
-            viewModel::onPackageSpinnerClicked
+            viewModel::onPackageSpinnerClicked,
+            viewModel::onMoveButtonClicked
         )
     }
 
@@ -123,6 +124,15 @@ class EditShippingLabelPackagesFragment :
                     val action = EditShippingLabelPackagesFragmentDirections
                         .actionEditShippingLabelPackagesFragmentToShippingPackageSelectorFragment(
                             position = event.position
+                        )
+
+                    findNavController().navigateSafely(action)
+                }
+                is ShowMoveItemDialog -> {
+                    val action = EditShippingLabelPackagesFragmentDirections
+                        .actionEditShippingLabelPackagesFragmentToMoveShippingItemDialog(
+                            item = event.item,
+                            currentPackage = event.currentPackage
                         )
 
                     findNavController().navigateSafely(action)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -5,9 +5,11 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DefaultItemAnimator
+import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentEditShippingLabelPackagesBinding

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -16,7 +16,6 @@ import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
-import com.woocommerce.android.model.ShippingLabelPackage
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
@@ -111,7 +110,7 @@ class EditShippingLabelPackagesFragment :
     private fun setupObservers(binding: FragmentEditShippingLabelPackagesBinding) {
         viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
             new.packagesUiModels.takeIfNotEqualTo(old?.packagesUiModels) {
-                packagesAdapter.shippingLabelPackages = it
+                packagesAdapter.uiModels = it
             }
 
             new.showSkeletonView.takeIfNotEqualTo(old?.showSkeletonView) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -11,6 +11,10 @@ import com.woocommerce.android.model.ShippingPackage
 import com.woocommerce.android.model.getNonRefundedProducts
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRepository
+import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage
+import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage.ExistingPackage
+import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage.NewPackage
+import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage.OriginalPackage
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.ProductDetailRepository
 import com.woocommerce.android.ui.products.variations.VariationDetailRepository
@@ -160,7 +164,11 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
     }
 
     fun onMoveButtonClicked(item: ShippingLabelPackage.Item, shippingPackage: ShippingLabelPackage) {
-        triggerEvent(ShowMoveItemDialog(item, shippingPackage))
+        triggerEvent(ShowMoveItemDialog(item, shippingPackage, viewState.shippingLabelPackages))
+    }
+
+    fun updatePackagesList(packages: List<ShippingLabelPackage>) {
+        viewState = viewState.copy(shippingLabelPackages = packages)
     }
 
     fun onDoneButtonClicked() {
@@ -216,6 +224,7 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
 
     data class ShowMoveItemDialog(
         val item: ShippingLabelPackage.Item,
-        val currentPackage: ShippingLabelPackage
+        val currentPackage: ShippingLabelPackage,
+        val packagesList: List<ShippingLabelPackage>
     ) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -159,6 +159,10 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
         viewState = viewState.copy(shippingLabelPackages = packages)
     }
 
+    fun onMoveButtonClicked(item: ShippingLabelPackage.Item, shippingPackage: ShippingLabelPackage) {
+        triggerEvent(ShowMoveItemDialog(item, shippingPackage))
+    }
+
     fun onDoneButtonClicked() {
         triggerEvent(ExitWithResult(viewState.shippingLabelPackages))
     }
@@ -209,4 +213,9 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
     }
 
     data class OpenPackageSelectorEvent(val position: Int) : MultiLiveEvent.Event()
+
+    data class ShowMoveItemDialog(
+        val item: ShippingLabelPackage.Item,
+        val currentPackage: ShippingLabelPackage
+    ) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.order.toIdSet
 import org.wordpress.android.fluxc.store.WCProductStore.ProductErrorType
@@ -174,7 +175,7 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
     }
 
     fun onMoveButtonClicked(item: ShippingLabelPackage.Item, shippingPackage: ShippingLabelPackage) {
-        triggerEvent(ShowMoveItemDialog(item, shippingPackage, viewState.packagesUiModels.map { it.data }))
+        triggerEvent(ShowMoveItemDialog(item, shippingPackage, viewState.packages))
     }
 
     fun handleMoveItemResult(result: MoveItemResult) {
@@ -231,7 +232,7 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
     }
 
     fun onDoneButtonClicked() {
-        triggerEvent(ExitWithResult(viewState.packagesUiModels.map { it.data }))
+        triggerEvent(ExitWithResult(viewState.packages))
     }
 
     fun onBackButtonClicked() {
@@ -272,6 +273,9 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
         val showSkeletonView: Boolean = false,
         val packagesWithEditedWeight: Set<String> = setOf()
     ) : Parcelable {
+        @IgnoredOnParcel
+        val packages: List<ShippingLabelPackage>
+            get() = packagesUiModels.map { it.data }
         val isDataValid: Boolean
             get() = packagesUiModels.isNotEmpty() &&
                 packagesUiModels.all {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -32,6 +32,7 @@ import javax.inject.Inject
 import kotlin.math.ceil
 
 @HiltViewModel
+@Suppress("TooManyFunctions")
 class EditShippingLabelPackagesViewModel @Inject constructor(
     savedState: SavedStateHandle,
     parameterRepository: ParameterRepository,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -92,7 +92,7 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
         val totalWeight = items.sumByFloat { it.weight * it.quantity } + (lastUsedPackage?.boxWeight ?: 0f)
         return listOf(
             ShippingLabelPackage(
-                packageId = "package1",
+                position = 1,
                 selectedPackage = lastUsedPackage,
                 weight = if (totalWeight != 0f) totalWeight else Float.NaN,
                 items = items

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -231,7 +231,7 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
     }
 
     fun onDoneButtonClicked() {
-        triggerEvent(ExitWithResult(viewState.packagesUiModels))
+        triggerEvent(ExitWithResult(viewState.packagesUiModels.map { it.data }))
     }
 
     fun onBackButtonClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemDialog.kt
@@ -1,0 +1,9 @@
+package com.woocommerce.android.ui.orders.shippinglabels.creation
+
+import androidx.fragment.app.DialogFragment
+import com.woocommerce.android.R
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class MoveShippingItemDialog : DialogFragment(R.layout.dialog_move_shipping_item) {
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemDialog.kt
@@ -52,14 +52,14 @@ class MoveShippingItemDialog : DialogFragment(R.layout.dialog_move_shipping_item
     }
 
     private fun setupObservers(binding: DialogMoveShippingItemBinding) {
-        viewModel.viewStateData.observe(viewLifecycleOwner, { old, new ->
+        viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
             new.selectedDestination?.takeIfNotEqualTo(old?.selectedDestination) { selectedItem ->
                 binding.optionsGroup.children.firstOrNull { it.tag == selectedItem }?.isSelected = true
             }
             new.isMoveButtonEnabled.takeIfNotEqualTo(old?.isMoveButtonEnabled) {
                 binding.moveButton.isEnabled = it
             }
-        })
+        }
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is ExitWithResult<*> -> navigateBackWithResult(MOVE_ITEM_RESULT, event.data)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemDialog.kt
@@ -38,7 +38,7 @@ class MoveShippingItemDialog : DialogFragment(R.layout.dialog_move_shipping_item
 
     private fun initUi(binding: DialogMoveShippingItemBinding) {
         val packageDescription = viewModel.currentPackage.getTitle(requireContext()) +
-            viewModel.currentPackage.selectedPackage?.let { ": ${it.title}" }
+            (viewModel.currentPackage.selectedPackage?.let { ": ${it.title}" } ?: "")
         binding.dialogDescription.text =
             getString(string.shipping_label_move_item_dialog_description, packageDescription)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemDialog.kt
@@ -6,6 +6,7 @@ import android.widget.RadioButton
 import androidx.core.view.children
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.R.string
 import com.woocommerce.android.databinding.DialogMoveShippingItemBinding
@@ -16,6 +17,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingIte
 import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage.ExistingPackage
 import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage.NewPackage
 import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage.OriginalPackage
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -49,6 +51,9 @@ class MoveShippingItemDialog : DialogFragment(R.layout.dialog_move_shipping_item
         binding.moveButton.setOnClickListener {
             viewModel.onMoveButtonClicked()
         }
+        binding.cancelButton.setOnClickListener {
+            viewModel.onCancelButtonClicked()
+        }
     }
 
     private fun setupObservers(binding: DialogMoveShippingItemBinding) {
@@ -63,6 +68,7 @@ class MoveShippingItemDialog : DialogFragment(R.layout.dialog_move_shipping_item
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is ExitWithResult<*> -> navigateBackWithResult(MOVE_ITEM_RESULT, event.data)
+                is Exit -> findNavController().navigateUp()
                 else -> event.isHandled = false
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemDialog.kt
@@ -22,7 +22,7 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class MoveShippingItemDialog : DialogFragment(R.layout.dialog_move_shipping_item) {
     companion object {
-        const val SELECTED_DESTINATION_PACKAGE_RESULT = "selected_destination_package_result"
+        const val MOVE_ITEM_RESULT = "move-item-result"
     }
 
     private val viewModel: MoveShippingItemViewModel by viewModels()
@@ -62,7 +62,7 @@ class MoveShippingItemDialog : DialogFragment(R.layout.dialog_move_shipping_item
         })
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
-                is ExitWithResult<*> -> navigateBackWithResult(SELECTED_DESTINATION_PACKAGE_RESULT, event.data)
+                is ExitWithResult<*> -> navigateBackWithResult(MOVE_ITEM_RESULT, event.data)
                 else -> event.isHandled = false
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemDialog.kt
@@ -1,9 +1,67 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation
 
+import android.os.Bundle
+import android.view.View
+import android.widget.RadioButton
+import androidx.core.view.children
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
 import com.woocommerce.android.R
+import com.woocommerce.android.R.string
+import com.woocommerce.android.databinding.DialogMoveShippingItemBinding
+import com.woocommerce.android.extensions.takeIfNotEqualTo
+import com.woocommerce.android.model.getTitle
+import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationItem
+import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationItem.ExistingPackage
+import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationItem.NewPackage
+import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationItem.OriginalPackage
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MoveShippingItemDialog : DialogFragment(R.layout.dialog_move_shipping_item) {
+    private val viewModel: MoveShippingItemViewModel by viewModels()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val binding = DialogMoveShippingItemBinding.bind(view)
+        initUi(binding)
+        setupObservers(binding)
+    }
+
+    private fun initUi(binding: DialogMoveShippingItemBinding) {
+        val packageDescription = viewModel.currentPackage.getTitle(requireContext()) +
+            viewModel.currentPackage.selectedPackage?.let { ": ${it.title}" }
+        binding.dialogDescription.text =
+            getString(string.shipping_label_move_item_dialog_description, packageDescription)
+
+        with(viewModel.availableDestinations) {
+            forEach {
+                binding.optionsGroup.addView(it.generateRadioButton())
+            }
+        }
+    }
+
+    private fun setupObservers(binding: DialogMoveShippingItemBinding) {
+        viewModel.viewStateData.observe(viewLifecycleOwner, { old, new ->
+            new.selectedDestination?.takeIfNotEqualTo(old?.selectedDestination) { selectedItem ->
+                binding.optionsGroup.children.firstOrNull { it.tag == selectedItem }?.isSelected = true
+            }
+            new.isMoveButtonEnabled.takeIfNotEqualTo(old?.isMoveButtonEnabled) {
+                binding.moveButton.isEnabled = it
+            }
+        })
+    }
+
+    private fun DestinationItem.generateRadioButton(): RadioButton {
+        return RadioButton(requireContext()).apply {
+            setText(
+                when (this@generateRadioButton) {
+                    is ExistingPackage -> TODO()
+                    NewPackage -> R.string.shipping_label_move_item_dialog_new_package_option
+                    OriginalPackage -> R.string.shipping_label_move_item_dialog_original_packaging_option
+                }
+            )
+            tag = this@generateRadioButton
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
@@ -38,46 +38,8 @@ class MoveShippingItemViewModel @Inject constructor(
 
     fun onMoveButtonClicked() {
         viewState.selectedDestination?.let {
-            moveItem(it)
+            triggerEvent(ExitWithResult(MoveItemResult(navArgs.item, navArgs.currentPackage, it)))
         } ?: throw IllegalStateException("move button listener invoked while no package is selected")
-    }
-
-    private fun moveItem(destination: DestinationPackage) {
-        val packages = navArgs.packagesList.toMutableList()
-        val item = navArgs.item
-        val currentPackage = navArgs.currentPackage
-
-        fun moveItemToNewPackage(): List<ShippingLabelPackage> {
-            val updatedItems = if (item.quantity > 1) {
-                // if the item quantity is more than one, subtract 1 from it
-                val mutableItems = currentPackage.items.toMutableList()
-                val updatedItem = item.copy(quantity = item.quantity - 1)
-                mutableItems[mutableItems.indexOf(item)] = updatedItem
-                mutableItems
-            } else {
-                currentPackage.items - item
-            }
-            packages[packages.indexOf(currentPackage)] = currentPackage.copy(items = updatedItems)
-            packages.add(
-                ShippingLabelPackage(
-                    position = packages.size + 1,
-                    selectedPackage = currentPackage.selectedPackage,
-                    weight = item.weight + (currentPackage.selectedPackage?.boxWeight ?: 0f),
-                    items = listOf(item.copy(quantity = 1))
-                )
-            )
-            return packages
-        }
-
-        triggerEvent(
-            ExitWithResult(
-                when (destination) {
-                    is ExistingPackage -> TODO()
-                    NewPackage -> moveItemToNewPackage()
-                    OriginalPackage -> TODO()
-                }
-            )
-        )
     }
 
     @Parcelize
@@ -88,6 +50,13 @@ class MoveShippingItemViewModel @Inject constructor(
         val isMoveButtonEnabled
             get() = selectedDestination != null
     }
+
+    @Parcelize
+    data class MoveItemResult(
+        val item: ShippingLabelPackage.Item,
+        val currentPackage: ShippingLabelPackage,
+        val destination: DestinationPackage
+    ) : Parcelable
 
     sealed class DestinationPackage : Parcelable {
         @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.model.ShippingLabelPackage
 import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage.NewPackage
 import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage.OriginalPackage
 import com.woocommerce.android.viewmodel.LiveDataDelegate
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
@@ -39,6 +40,10 @@ class MoveShippingItemViewModel @Inject constructor(
         viewState.selectedDestination?.let {
             triggerEvent(ExitWithResult(MoveItemResult(navArgs.item, navArgs.currentPackage, it)))
         } ?: throw IllegalStateException("move button listener invoked while no package is selected")
+    }
+
+    fun onCancelButtonClicked() {
+        triggerEvent(Exit)
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.model.ShippingLabelPackage
-import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage.ExistingPackage
 import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage.NewPackage
 import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage.OriginalPackage
 import com.woocommerce.android.viewmodel.LiveDataDelegate

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
@@ -1,12 +1,52 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation
 
+import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.model.ShippingLabelPackage
+import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationItem.NewPackage
+import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationItem.OriginalPackage
+import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 @HiltViewModel
 class MoveShippingItemViewModel @Inject constructor(
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
+    private val navArgs: MoveShippingItemDialogArgs by savedState.navArgs()
+
+    val viewStateData = LiveDataDelegate(savedState, ViewState())
+    private var viewState by viewStateData
+
+    val availableDestinations: List<DestinationItem>
+    val currentPackage = navArgs.currentPackage
+
+    init {
+        // TODO
+        availableDestinations = listOf(NewPackage, OriginalPackage)
+    }
+
+    @Parcelize
+    data class ViewState(
+        val selectedDestination: DestinationItem? = null
+    ) : Parcelable {
+        @IgnoredOnParcel
+        val isMoveButtonEnabled
+            get() = selectedDestination != null
+    }
+
+    sealed class DestinationItem : Parcelable {
+        @Parcelize
+        object NewPackage : DestinationItem()
+
+        @Parcelize
+        class ExistingPackage(val destinationPackage: ShippingLabelPackage) : DestinationItem()
+
+        @Parcelize
+        object OriginalPackage : DestinationItem()
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.model.ShippingLabelPackage
+import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage.ExistingPackage
 import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage.NewPackage
 import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage.OriginalPackage
 import com.woocommerce.android.viewmodel.LiveDataDelegate
@@ -36,8 +37,47 @@ class MoveShippingItemViewModel @Inject constructor(
     }
 
     fun onMoveButtonClicked() {
-        requireNotNull(viewState.selectedDestination, { "move button listener invoked while no package is selected" })
-        triggerEvent(ExitWithResult(viewState.selectedDestination))
+        viewState.selectedDestination?.let {
+            moveItem(it)
+        } ?: throw IllegalStateException("move button listener invoked while no package is selected")
+    }
+
+    private fun moveItem(destination: DestinationPackage) {
+        val packages = navArgs.packagesList.toMutableList()
+        val item = navArgs.item
+        val currentPackage = navArgs.currentPackage
+
+        fun moveItemToNewPackage(): List<ShippingLabelPackage> {
+            val updatedItems = if (item.quantity > 1) {
+                // if the item quantity is more than one, subtract 1 from it
+                val mutableItems = currentPackage.items.toMutableList()
+                val updatedItem = item.copy(quantity = item.quantity - 1)
+                mutableItems[mutableItems.indexOf(item)] = updatedItem
+                mutableItems
+            } else {
+                currentPackage.items - item
+            }
+            packages[packages.indexOf(currentPackage)] = currentPackage.copy(items = updatedItems)
+            packages.add(
+                ShippingLabelPackage(
+                    position = packages.size + 1,
+                    selectedPackage = currentPackage.selectedPackage,
+                    weight = item.weight + (currentPackage.selectedPackage?.boxWeight ?: 0f),
+                    items = listOf(item.copy(quantity = 1))
+                )
+            )
+            return packages
+        }
+
+        triggerEvent(
+            ExitWithResult(
+                when (destination) {
+                    is ExistingPackage -> TODO()
+                    NewPackage -> moveItemToNewPackage()
+                    OriginalPackage -> TODO()
+                }
+            )
+        )
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
@@ -3,9 +3,10 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.model.ShippingLabelPackage
-import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationItem.NewPackage
-import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationItem.OriginalPackage
+import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage.NewPackage
+import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage.OriginalPackage
 import com.woocommerce.android.viewmodel.LiveDataDelegate
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -22,7 +23,7 @@ class MoveShippingItemViewModel @Inject constructor(
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 
-    val availableDestinations: List<DestinationItem>
+    val availableDestinations: List<DestinationPackage>
     val currentPackage = navArgs.currentPackage
 
     init {
@@ -30,23 +31,32 @@ class MoveShippingItemViewModel @Inject constructor(
         availableDestinations = listOf(NewPackage, OriginalPackage)
     }
 
+    fun onDestinationPackageSelected(destinationPackage: DestinationPackage) {
+        viewState = viewState.copy(selectedDestination = destinationPackage)
+    }
+
+    fun onMoveButtonClicked() {
+        requireNotNull(viewState.selectedDestination, { "move button listener invoked while no package is selected" })
+        triggerEvent(ExitWithResult(viewState.selectedDestination))
+    }
+
     @Parcelize
     data class ViewState(
-        val selectedDestination: DestinationItem? = null
+        val selectedDestination: DestinationPackage? = null
     ) : Parcelable {
         @IgnoredOnParcel
         val isMoveButtonEnabled
             get() = selectedDestination != null
     }
 
-    sealed class DestinationItem : Parcelable {
+    sealed class DestinationPackage : Parcelable {
         @Parcelize
-        object NewPackage : DestinationItem()
+        object NewPackage : DestinationPackage()
 
         @Parcelize
-        class ExistingPackage(val destinationPackage: ShippingLabelPackage) : DestinationItem()
+        class ExistingPackage(val destinationPackage: ShippingLabelPackage) : DestinationPackage()
 
         @Parcelize
-        object OriginalPackage : DestinationItem()
+        object OriginalPackage : DestinationPackage()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
@@ -1,0 +1,12 @@
+package com.woocommerce.android.ui.orders.shippinglabels.creation
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class MoveShippingItemViewModel @Inject constructor(
+    savedState: SavedStateHandle
+) : ScopedViewModel(savedState) {
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.databinding.ShippingRateListItemBinding
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.isEqualTo
 import com.woocommerce.android.extensions.show
+import com.woocommerce.android.model.ShippingLabelPackage
 import com.woocommerce.android.model.ShippingRate
 import com.woocommerce.android.model.ShippingRate.Option
 import com.woocommerce.android.model.ShippingRate.Option.ADULT_SIGNATURE
@@ -31,6 +32,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrier
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrierRatesAdapter.ShippingRateItem.ShippingCarrier.UPS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrierRatesAdapter.ShippingRateItem.ShippingCarrier.USPS
 import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.util.UiHelpers
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import java.util.Date
@@ -55,7 +57,7 @@ class ShippingCarrierRatesAdapter(
     }
 
     override fun onBindViewHolder(holder: RateListViewHolder, position: Int) {
-        holder.bind(items[position], position)
+        holder.bind(items[position])
     }
 
     inner class RateListViewHolder(private val binding: ShippingRateListBinding) : ViewHolder(binding.root) {
@@ -66,11 +68,8 @@ class ShippingCarrierRatesAdapter(
             }
         }
         @SuppressLint("SetTextI18n")
-        fun bind(rateList: PackageRateListItem, position: Int) {
-            binding.packageName.text = binding.root.resources.getString(
-                R.string.shipping_label_package_details_title_template,
-                position + 1
-            )
+        fun bind(rateList: PackageRateListItem) {
+            binding.packageName.text = UiHelpers.getTextOfUiString(binding.root.context, rateList.shippingPackage.title)
 
             binding.packageItemsCount.text = "- ${binding.root.resources.getQuantityString(
                 R.plurals.shipping_label_package_details_items_count,
@@ -298,9 +297,14 @@ class ShippingCarrierRatesAdapter(
     @Parcelize
     data class PackageRateListItem(
         val id: String,
-        val itemCount: Int,
+        val shippingPackage: ShippingLabelPackage,
         val rateOptions: List<ShippingRateItem>
     ) : Parcelable {
+        @IgnoredOnParcel
+        val itemCount
+            get() = shippingPackage.items.size
+
+        @IgnoredOnParcel
         val selectedRate: ShippingRate?
             get() {
                 return rateOptions.mapNotNull { rate ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
@@ -22,6 +22,7 @@ import com.woocommerce.android.model.ShippingRate.Option
 import com.woocommerce.android.model.ShippingRate.Option.ADULT_SIGNATURE
 import com.woocommerce.android.model.ShippingRate.Option.DEFAULT
 import com.woocommerce.android.model.ShippingRate.Option.SIGNATURE
+import com.woocommerce.android.model.getTitle
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrierRatesAdapter.RateItemDiffUtil.ChangePayload
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrierRatesAdapter.RateItemDiffUtil.ChangePayload.SELECTED_OPTION
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrierRatesAdapter.RateListAdapter.RateViewHolder
@@ -32,7 +33,6 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrier
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrierRatesAdapter.ShippingRateItem.ShippingCarrier.UPS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrierRatesAdapter.ShippingRateItem.ShippingCarrier.USPS
 import com.woocommerce.android.util.DateUtils
-import com.woocommerce.android.util.UiHelpers
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import java.util.Date
@@ -69,7 +69,7 @@ class ShippingCarrierRatesAdapter(
         }
         @SuppressLint("SetTextI18n")
         fun bind(rateList: PackageRateListItem) {
-            binding.packageName.text = UiHelpers.getTextOfUiString(binding.root.context, rateList.shippingPackage.title)
+            binding.packageName.text = rateList.shippingPackage.getTitle(binding.root.context)
 
             binding.packageItemsCount.text = "- ${binding.root.resources.getQuantityString(
                 R.plurals.shipping_label_package_details_items_count,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesViewModel.kt
@@ -206,7 +206,7 @@ class ShippingCarrierRatesViewModel @Inject constructor(
 
             PackageRateListItem(
                 pkg.boxId,
-                itemCount = arguments.packages[i].items.size,
+                shippingPackage = arguments.packages[i],
                 rateOptions = shippingRates
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
@@ -23,6 +23,7 @@ import com.woocommerce.android.extensions.setClickableText
 import com.woocommerce.android.model.ContentsType
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.model.RestrictionType
+import com.woocommerce.android.model.getTitle
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustomsAdapter.PackageCustomsViewHolder
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustomsLineAdapter.CustomsLineViewHolder
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustomsViewModel.CustomsPackageUiState
@@ -126,11 +127,8 @@ class ShippingCustomsAdapter(
         @SuppressLint("SetTextI18n")
         fun bind(uiState: CustomsPackageUiState) {
             val (customsPackage, validationState) = uiState
-            binding.packageId.text = context.getString(
-                R.string.orderdetail_shipping_label_item_header,
-                adapterPosition + 1
-            )
-            binding.packageName.text = "- ${customsPackage.box.title}"
+            binding.packageId.text = customsPackage.labelPackage.getTitle(context)
+            binding.packageName.text = "- ${customsPackage.labelPackage.selectedPackage!!.title}"
             binding.returnCheckbox.isChecked = customsPackage.returnToSender
 
             // Animate any potential change to visibility of the description fields

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
@@ -90,7 +90,7 @@ class ShippingCustomsViewModel @Inject constructor(
         return args.shippingPackages.map { labelPackage ->
             CustomsPackage(
                 id = labelPackage.packageId,
-                box = labelPackage.selectedPackage!!,
+                labelPackage = labelPackage,
                 contentsType = ContentsType.Merchandise,
                 restrictionType = RestrictionType.None,
                 returnToSender = true,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -67,7 +67,8 @@ class ShippingLabelPackagesAdapter(
     inner class ShippingLabelPackageViewHolder(
         val binding: ShippingLabelPackageDetailsListItemBinding
     ) : ViewHolder(binding.root) {
-        val isExpanded = binding.expandIcon.rotation == 180f
+        val isExpanded
+            get() = binding.expandIcon.rotation == 180f
 
         init {
             with(binding.itemsList) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -28,6 +28,10 @@ class ShippingLabelPackagesAdapter(
             diff.dispatchUpdatesTo(this)
         }
 
+    init {
+        setHasStableIds(true)
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ShippingLabelPackageViewHolder {
         val layoutInflater = LayoutInflater.from(parent.context)
         return ShippingLabelPackageViewHolder(
@@ -37,17 +41,10 @@ class ShippingLabelPackagesAdapter(
 
     override fun getItemCount() = shippingLabelPackages.count()
 
+    override fun getItemId(position: Int): Long = shippingLabelPackages[position].packageId.hashCode().toLong()
+
     override fun onBindViewHolder(holder: ShippingLabelPackageViewHolder, position: Int) {
         holder.bind(position)
-    }
-
-    override fun onBindViewHolder(holder: ShippingLabelPackageViewHolder, position: Int, payloads: MutableList<Any>) {
-        if (payloads.size == 1 && payloads[0] == ChangePayload.Weight) {
-            // If the only change is weight, avoid updating the view, as it already has the last changes
-            return
-        } else {
-            onBindViewHolder(holder, position)
-        }
     }
 
     inner class ShippingLabelPackageViewHolder(
@@ -100,7 +97,7 @@ class ShippingLabelPackagesAdapter(
             (binding.itemsList.adapter as PackageProductsAdapter).items = shippingLabelPackage.adaptItemsForUi()
             binding.selectedPackageSpinner.setText(shippingLabelPackage.selectedPackage?.title ?: "")
             if (!shippingLabelPackage.weight.isNaN()) {
-                binding.weightEditText.setText(shippingLabelPackage.weight.toString())
+                binding.weightEditText.setTextIfDifferent(shippingLabelPackage.weight.toString())
             }
         }
 
@@ -130,19 +127,6 @@ class ShippingLabelPackagesAdapter(
         override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
             return oldList[oldItemPosition] == newList[newItemPosition]
         }
-
-        override fun getChangePayload(oldItemPosition: Int, newItemPosition: Int): Any? {
-            return if (oldList[oldItemPosition].items == newList[newItemPosition].items &&
-                oldList[oldItemPosition].selectedPackage == newList[newItemPosition].selectedPackage
-            ) {
-                ChangePayload.Weight
-            } else null
-        }
-    }
-
-    // TODO We will the ExpansionState to animate collapsing expanding later
-    enum class ChangePayload {
-        Weight, ExpansionState
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -12,11 +12,11 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.ShippingLabelPackageDetailsListItemBinding
 import com.woocommerce.android.databinding.ShippingLabelPackageProductListItemBinding
 import com.woocommerce.android.model.ShippingLabelPackage
+import com.woocommerce.android.model.getTitle
 import com.woocommerce.android.ui.orders.shippinglabels.creation.PackageProductsAdapter.PackageProductViewHolder
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelPackagesAdapter.ShippingLabelPackageViewHolder
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.StringUtils
-import com.woocommerce.android.util.UiHelpers
 
 class ShippingLabelPackagesAdapter(
     val weightUnit: String,
@@ -91,7 +91,7 @@ class ShippingLabelPackagesAdapter(
         fun bind(position: Int) {
             val context = binding.root.context
             val shippingLabelPackage = shippingLabelPackages[position]
-            binding.packageName.text = UiHelpers.getTextOfUiString(context, shippingLabelPackage.title)
+            binding.packageName.text = shippingLabelPackage.getTitle(context)
             binding.packageItemsCount.text = "- ${context.resources.getQuantityString(
                 R.plurals.shipping_label_package_details_items_count,
                 shippingLabelPackage.items.size,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -63,6 +63,7 @@ class ShippingLabelPackagesAdapter(
         super.onBindViewHolder(holder, position, payloads)
     }
 
+    @Suppress("MagicNumber")
     inner class ShippingLabelPackageViewHolder(
         val binding: ShippingLabelPackageDetailsListItemBinding
     ) : ViewHolder(binding.root) {
@@ -102,7 +103,6 @@ class ShippingLabelPackagesAdapter(
                 binding.expandIcon.isVisible = false
             } else {
                 binding.titleLayout.setOnClickListener {
-                    @Suppress("MagicNumber")
                     if (isExpanded) {
                         binding.expandIcon.animate().rotation(0f).start()
                         binding.detailsLayout.collapse()
@@ -122,13 +122,11 @@ class ShippingLabelPackagesAdapter(
             val uiModel = uiModels[position]
             val shippingLabelPackage = uiModel.data
             binding.packageName.text = shippingLabelPackage.getTitle(context)
-            binding.packageItemsCount.text = "- ${
-                context.resources.getQuantityString(
-                    R.plurals.shipping_label_package_details_items_count,
-                    shippingLabelPackage.items.size,
-                    shippingLabelPackage.items.size
-                )
-            }"
+            binding.packageItemsCount.text = "- ${context.resources.getQuantityString(
+                R.plurals.shipping_label_package_details_items_count,
+                shippingLabelPackage.items.size,
+                shippingLabelPackage.items.size
+            )}"
             with(binding.itemsList.adapter as PackageProductsAdapter) {
                 items = shippingLabelPackage.adaptItemsForUi()
                 moveItemClickListener = { item -> onMoveItemClicked(item, shippingLabelPackage) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -21,7 +21,8 @@ import com.woocommerce.android.util.StringUtils
 class ShippingLabelPackagesAdapter(
     val weightUnit: String,
     val onWeightEdited: (Int, Float) -> Unit,
-    val onPackageSpinnerClicked: (Int) -> Unit
+    val onPackageSpinnerClicked: (Int) -> Unit,
+    val onMoveItemClicked: (ShippingLabelPackage.Item, ShippingLabelPackage) -> Unit
 ) : RecyclerView.Adapter<ShippingLabelPackageViewHolder>() {
     var shippingLabelPackages: List<ShippingLabelPackage> = emptyList()
         set(value) {
@@ -97,7 +98,10 @@ class ShippingLabelPackagesAdapter(
                 shippingLabelPackage.items.size,
                 shippingLabelPackage.items.size
             )}"
-            (binding.itemsList.adapter as PackageProductsAdapter).items = shippingLabelPackage.adaptItemsForUi()
+            with(binding.itemsList.adapter as PackageProductsAdapter) {
+                items = shippingLabelPackage.adaptItemsForUi()
+                moveItemClickListener = { item -> onMoveItemClicked(item, shippingLabelPackage) }
+            }
             binding.selectedPackageSpinner.setText(shippingLabelPackage.selectedPackage?.title ?: "")
             if (!shippingLabelPackage.weight.isNaN()) {
                 binding.weightEditText.setTextIfDifferent(shippingLabelPackage.weight.toString())
@@ -133,12 +137,16 @@ class ShippingLabelPackagesAdapter(
     }
 }
 
-class PackageProductsAdapter(private val weightUnit: String) : RecyclerView.Adapter<PackageProductViewHolder>() {
+class PackageProductsAdapter(
+    private val weightUnit: String
+) : RecyclerView.Adapter<PackageProductViewHolder>() {
     var items: List<ShippingLabelPackage.Item> = emptyList()
         set(value) {
             field = value
             notifyDataSetChanged()
         }
+
+    lateinit var moveItemClickListener: (ShippingLabelPackage.Item) -> Unit
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PackageProductViewHolder {
         val layoutInflater = LayoutInflater.from(parent.context)
@@ -169,6 +177,9 @@ class PackageProductsAdapter(private val weightUnit: String) : RecyclerView.Adap
             } else {
                 binding.productDetails.isVisible = true
                 binding.productDetails.text = details
+            }
+            binding.moveButton.setOnClickListener {
+                moveItemClickListener(item)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.databinding.ShippingLabelPackageProductListItemBi
 import com.woocommerce.android.model.ShippingLabelPackage
 import com.woocommerce.android.ui.orders.shippinglabels.creation.PackageProductsAdapter.PackageProductViewHolder
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelPackagesAdapter.ShippingLabelPackageViewHolder
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.StringUtils
 
 class ShippingLabelPackagesAdapter(
@@ -78,6 +79,10 @@ class ShippingLabelPackagesAdapter(
 
             binding.selectedPackageSpinner.setClickListener {
                 onPackageSpinnerClicked(adapterPosition)
+            }
+
+            if (!FeatureFlag.SHIPPING_LABELS_M4.isEnabled()) {
+                binding.expandIcon.isVisible = false
             }
         }
 
@@ -151,6 +156,12 @@ class PackageProductsAdapter(private val weightUnit: String) : RecyclerView.Adap
     inner class PackageProductViewHolder(
         val binding: ShippingLabelPackageProductListItemBinding
     ) : ViewHolder(binding.root) {
+        init {
+            if (!FeatureFlag.SHIPPING_LABELS_M4.isEnabled()) {
+                binding.moveButton.isVisible = false
+            }
+        }
+
         fun bind(item: ShippingLabelPackage.Item) {
             binding.productName.text = item.name
             val attributes = item.attributesList.takeIf { it.isNotEmpty() }?.let { "$it \u2981 " } ?: StringUtils.EMPTY

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.PackageProducts
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelPackagesAdapter.ShippingLabelPackageViewHolder
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.StringUtils
+import com.woocommerce.android.util.UiHelpers
 
 class ShippingLabelPackagesAdapter(
     val weightUnit: String,
@@ -90,10 +91,7 @@ class ShippingLabelPackagesAdapter(
         fun bind(position: Int) {
             val context = binding.root.context
             val shippingLabelPackage = shippingLabelPackages[position]
-            binding.packageName.text = context.getString(
-                R.string.shipping_label_package_details_title_template,
-                position + 1
-            )
+            binding.packageName.text = UiHelpers.getTextOfUiString(context, shippingLabelPackage.title)
             binding.packageItemsCount.text = "- ${context.resources.getQuantityString(
                 R.plurals.shipping_label_package_details_items_count,
                 shippingLabelPackage.items.size,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -116,13 +116,11 @@ class ShippingLabelPackagesAdapter(
             val uiModel = shippingLabelPackages[position]
             val shippingLabelPackage = uiModel.data
             binding.packageName.text = shippingLabelPackage.getTitle(context)
-            binding.packageItemsCount.text = "- ${
-                context.resources.getQuantityString(
-                    R.plurals.shipping_label_package_details_items_count,
-                    shippingLabelPackage.items.size,
-                    shippingLabelPackage.items.size
-                )
-            }"
+            binding.packageItemsCount.text = "- ${context.resources.getQuantityString(
+                R.plurals.shipping_label_package_details_items_count,
+                shippingLabelPackage.items.size,
+                shippingLabelPackage.items.size
+            )}"
             with(binding.itemsList.adapter as PackageProductsAdapter) {
                 items = shippingLabelPackage.adaptItemsForUi()
                 moveItemClickListener = { item -> onMoveItemClicked(item, shippingLabelPackage) }

--- a/WooCommerce/src/main/res/layout/dialog_move_shipping_item.xml
+++ b/WooCommerce/src/main/res/layout/dialog_move_shipping_item.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/dialog_move_shipping_item.xml
+++ b/WooCommerce/src/main/res/layout/dialog_move_shipping_item.xml
@@ -14,6 +14,7 @@
         android:textAppearance="?attr/textAppearanceSubtitle1" />
 
     <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/dialog_description"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="@dimen/minor_100"

--- a/WooCommerce/src/main/res/layout/dialog_move_shipping_item.xml
+++ b/WooCommerce/src/main/res/layout/dialog_move_shipping_item.xml
@@ -1,6 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="@dimen/major_100">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <com.google.android.material.textview.MaterialTextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/minor_100"
+        android:text="@string/shipping_label_move_item_dialog_title"
+        android:textAppearance="?attr/textAppearanceSubtitle1" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/minor_100"
+        android:layout_marginTop="@dimen/major_100"
+        android:textAppearance="?attr/textAppearanceBody2"
+        tools:text="This item is currently in Package 1: Small Package 1. Where would you like to move it?" />
+
+    <RadioGroup
+        android:id="@+id/options_group"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_100" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/move_button"
+        style="@style/Woo.Button.Colored"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_100"
+        android:text="@string/shipping_label_move_item_dialog_move" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/cancel_button"
+        style="@style/Woo.Button.Outlined"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/shipping_label_move_item_dialog_cancel" />
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
@@ -1,135 +1,127 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.woocommerce.android.widgets.WCElevatedConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<com.woocommerce.android.widgets.WCElevatedLinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/package_name"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/major_100"
-        android:layout_marginTop="@dimen/major_75"
-        android:textAppearance="?attr/textAppearanceSubtitle1"
-        android:textColor="@color/color_on_surface_high"
-        android:textStyle="bold"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="Package 1" />
+    <LinearLayout
+        android:id="@+id/title_layout"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/min_tap_target"
+        android:background="?attr/selectableItemBackground"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/package_items_count"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/minor_50"
-        android:textAppearance="@style/TextAppearance.Woo.Body1"
-        app:layout_constraintBaseline_toBaselineOf="@id/package_name"
-        app:layout_constraintStart_toEndOf="@id/package_name"
-        tools:text="- 10 items" />
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/package_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:textAppearance="?attr/textAppearanceSubtitle1"
+            android:textColor="@color/color_on_surface_high"
+            android:textStyle="bold"
+            tools:text="Package 1" />
 
-    <androidx.appcompat.widget.AppCompatImageView
-        android:id="@+id/expand_icon"
-        android:layout_width="@dimen/image_minor_50"
-        android:layout_height="@dimen/image_minor_50"
-        android:layout_marginEnd="@dimen/major_100"
-        android:src="@drawable/ic_arrow_down"
-        android:tint="@color/color_on_surface_high"
-        app:layout_constraintBottom_toBottomOf="@id/package_name"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@id/package_name" />
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/package_items_count"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/minor_50"
+            android:layout_weight="1"
+            android:textAppearance="@style/TextAppearance.Woo.Body1"
+            tools:text="- 10 items" />
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/expand_icon"
+            android:layout_width="@dimen/image_minor_50"
+            android:layout_height="@dimen/image_minor_50"
+            android:layout_gravity="end|center_vertical"
+            android:layout_marginEnd="@dimen/major_100"
+            android:src="@drawable/ic_arrow_down"
+            android:tint="@color/color_on_surface_high" />
+    </LinearLayout>
 
     <View
         android:id="@+id/divider_1"
-        style="@style/Woo.Divider"
-        android:layout_marginTop="@dimen/major_75"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/package_name" />
+        style="@style/Woo.Divider" />
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/items_section_title"
-        android:layout_width="0dp"
-        android:layout_height="@dimen/major_300"
-        android:background="?android:attr/colorBackground"
-        android:gravity="center_vertical"
-        android:paddingStart="@dimen/major_100"
-        android:paddingEnd="@dimen/major_100"
-        android:text="@string/shipping_label_package_details_items_section_title"
-        android:textAppearance="?attr/textAppearanceSubtitle2"
-        android:textColor="@color/color_on_surface_disabled"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/divider_1" />
-
-    <View
-        android:id="@+id/divider_2"
-        style="@style/Woo.Divider"
-        android:layout_marginStart="@dimen/major_100"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/items_section_title" />
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/items_list"
+    <LinearLayout
+        android:id="@+id/details_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/major_100"
-        app:layout_constraintTop_toBottomOf="@id/divider_2"
-        tools:itemCount="5"
-        tools:listitem="@layout/shipping_label_package_product_list_item" />
+        android:orientation="vertical">
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/details_section_title"
-        android:layout_width="0dp"
-        android:layout_height="@dimen/major_300"
-        android:background="@color/default_window_background"
-        android:gravity="center_vertical"
-        android:paddingStart="@dimen/major_100"
-        android:paddingEnd="@dimen/major_100"
-        android:text="@string/shipping_label_package_details_section_title"
-        android:textAppearance="?attr/textAppearanceSubtitle2"
-        android:textColor="@color/color_on_surface_disabled"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/items_list" />
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/items_section_title"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/major_300"
+            android:background="?android:attr/colorBackground"
+            android:gravity="center_vertical"
+            android:paddingStart="@dimen/major_100"
+            android:paddingEnd="@dimen/major_100"
+            android:text="@string/shipping_label_package_details_items_section_title"
+            android:textAppearance="?attr/textAppearanceSubtitle2"
+            android:textColor="@color/color_on_surface_disabled" />
 
-    <View
-        android:id="@+id/divider_3"
-        style="@style/Woo.Divider"
-        android:layout_marginStart="@dimen/major_100"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/details_section_title" />
+        <View
+            android:id="@+id/divider_2"
+            style="@style/Woo.Divider"
+            android:layout_marginStart="@dimen/major_100" />
 
-    <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-        android:id="@+id/selected_package_spinner"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/major_100"
-        android:layout_marginTop="@dimen/major_75"
-        android:layout_marginEnd="@dimen/major_100"
-        android:hint="@string/shipping_label_package_details_selected_package_hint"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/divider_3" />
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/items_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            tools:itemCount="5"
+            tools:listitem="@layout/shipping_label_package_product_list_item" />
 
-    <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-        android:id="@+id/weight_edit_text"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/major_100"
-        android:layout_marginTop="@dimen/major_175"
-        android:layout_marginEnd="@dimen/major_100"
-        android:layout_marginBottom="@dimen/major_200"
-        android:hint="@string/shipping_label_package_details_weight_hint"
-        android:inputType="numberDecimal"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/selected_package_spinner"
-        app:layout_constraintBottom_toTopOf="@+id/bottom_divider"
-        app:helperText="@string/shipping_label_package_details_weight_info"/>
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/details_section_title"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/major_300"
+            android:background="@color/default_window_background"
+            android:gravity="center_vertical"
+            android:paddingStart="@dimen/major_100"
+            android:paddingEnd="@dimen/major_100"
+            android:text="@string/shipping_label_package_details_section_title"
+            android:textAppearance="?attr/textAppearanceSubtitle2"
+            android:textColor="@color/color_on_surface_disabled" />
 
-    <View
-        android:id="@+id/bottom_divider"
-        style="@style/Woo.Divider"
-        app:layout_constraintBottom_toBottomOf="parent"/>
+        <View
+            android:id="@+id/divider_3"
+            style="@style/Woo.Divider"
+            android:layout_marginStart="@dimen/major_100"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/details_section_title" />
 
-</com.woocommerce.android.widgets.WCElevatedConstraintLayout>
+        <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+            android:id="@+id/selected_package_spinner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_75"
+            android:layout_marginEnd="@dimen/major_100"
+            android:hint="@string/shipping_label_package_details_selected_package_hint" />
+
+        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+            android:id="@+id/weight_edit_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_175"
+            android:layout_marginEnd="@dimen/major_100"
+            android:layout_marginBottom="@dimen/major_200"
+            android:hint="@string/shipping_label_package_details_weight_hint"
+            android:inputType="numberDecimal"
+            app:helperText="@string/shipping_label_package_details_weight_info" />
+
+        <View
+            android:id="@+id/bottom_divider"
+            style="@style/Woo.Divider"
+            app:layout_constraintBottom_toBottomOf="parent" />
+    </LinearLayout>
+
+</com.woocommerce.android.widgets.WCElevatedLinearLayout>

--- a/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
@@ -118,21 +118,18 @@
         android:layout_marginStart="@dimen/major_100"
         android:layout_marginTop="@dimen/major_175"
         android:layout_marginEnd="@dimen/major_100"
+        android:layout_marginBottom="@dimen/major_200"
         android:hint="@string/shipping_label_package_details_weight_hint"
         android:inputType="numberDecimal"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/selected_package_spinner" />
+        app:layout_constraintTop_toBottomOf="@id/selected_package_spinner"
+        app:layout_constraintBottom_toTopOf="@+id/bottom_divider"
+        app:helperText="@string/shipping_label_package_details_weight_info"/>
 
-    <com.google.android.material.textview.MaterialTextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/major_100"
-        android:layout_marginBottom="@dimen/minor_100"
-        android:text="@string/shipping_label_package_details_weight_info"
-        android:textAppearance="?attr/textAppearanceCaption"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="@id/weight_edit_text"
-        app:layout_constraintTop_toBottomOf="@id/weight_edit_text" />
+    <View
+        android:id="@+id/bottom_divider"
+        style="@style/Woo.Divider"
+        app:layout_constraintBottom_toBottomOf="parent"/>
 
 </com.woocommerce.android.widgets.WCElevatedConstraintLayout>

--- a/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
@@ -29,13 +29,13 @@
         tools:text="- 10 items" />
 
     <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/expand_icon"
         android:layout_width="@dimen/image_minor_50"
         android:layout_height="@dimen/image_minor_50"
         android:layout_marginEnd="@dimen/major_100"
         android:src="@drawable/ic_arrow_down"
         android:tint="@color/color_on_surface_high"
         app:layout_constraintBottom_toBottomOf="@id/package_name"
-        android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@id/package_name" />
 

--- a/WooCommerce/src/main/res/layout/shipping_label_package_product_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_label_package_product_list_item.xml
@@ -37,7 +37,6 @@
         android:layout_height="wrap_content"
         android:text="@string/shipping_label_package_details_move_item"
         android:textAllCaps="false"
-        android:visibility="gone"
         app:layout_constraintBottom_toTopOf="@id/divider"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -485,7 +485,14 @@
         android:id="@+id/moveShippingItemDialog"
         android:name="com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemDialog"
         android:label="MoveShippingItemDialog"
-        tools:layout="@layout/dialog_move_shipping_item"/>
+        tools:layout="@layout/dialog_move_shipping_item">
+        <argument
+            android:name="item"
+            app:argType="com.woocommerce.android.model.ShippingLabelPackage$Item" />
+        <argument
+            android:name="currentPackage"
+            app:argType="com.woocommerce.android.model.ShippingLabelPackage" />
+    </dialog>
     <action
         android:id="@+id/action_global_addOrderShipmentTrackingFragment"
         app:destination="@id/addOrderShipmentTrackingFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -401,6 +401,9 @@
             app:exitAnim="@anim/activity_slide_out_to_left"
             app:popEnterAnim="@anim/activity_slide_in_from_left"
             app:popExitAnim="@anim/activity_slide_out_to_right" />
+        <action
+            android:id="@+id/action_editShippingLabelPackagesFragment_to_moveShippingItemDialog"
+            app:destination="@id/moveShippingItemDialog" />
     </fragment>
     <fragment
         android:id="@+id/shippingPackageSelectorFragment"
@@ -478,6 +481,11 @@
             android:name="customsPackages"
             app:argType="com.woocommerce.android.model.CustomsPackage[]" />
     </fragment>
+    <dialog
+        android:id="@+id/moveShippingItemDialog"
+        android:name="com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemDialog"
+        android:label="MoveShippingItemDialog"
+        tools:layout="@layout/dialog_move_shipping_item"/>
     <action
         android:id="@+id/action_global_addOrderShipmentTrackingFragment"
         app:destination="@id/addOrderShipmentTrackingFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -492,6 +492,9 @@
         <argument
             android:name="currentPackage"
             app:argType="com.woocommerce.android.model.ShippingLabelPackage" />
+        <argument
+            android:name="packagesList"
+            app:argType="com.woocommerce.android.model.ShippingLabelPackage[]" />
     </dialog>
     <action
         android:id="@+id/action_global_addOrderShipmentTrackingFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -577,6 +577,9 @@
     <string name="shipping_label_move_item_dialog_title">Move item</string>
     <string name="shipping_label_move_item_dialog_move">Move</string>
     <string name="shipping_label_move_item_dialog_cancel">Cancel</string>
+    <string name="shipping_label_move_item_dialog_description">This item is currently in %s. Where would you like to move it?</string>
+    <string name="shipping_label_move_item_dialog_new_package_option">Add to new package</string>
+    <string name="shipping_label_move_item_dialog_original_packaging_option">Ship in original packaging</string>
     <!--
             Refunds
         -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -574,6 +574,9 @@
     <string name="shipping_label_print_customs_form">Print customs form</string>
     <string name="shipping_label_print_customs_form_screen_title">Print customs invoice</string>
     <string name="shipping_label_print_customs_form_download_failed">Error downloading the customs form</string>
+    <string name="shipping_label_move_item_dialog_title">Move item</string>
+    <string name="shipping_label_move_item_dialog_move">Move</string>
+    <string name="shipping_label_move_item_dialog_cancel">Cancel</string>
     <!--
             Refunds
         -->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelTestUtils.kt
@@ -75,7 +75,7 @@ object CreateShippingLabelTestUtils {
     fun generateCustomsPackage(packageId: String = "package1"): CustomsPackage {
         return CustomsPackage(
             id = packageId,
-            box = generatePackage(),
+            labelPackage = generateShippingLabelPackage(),
             returnToSender = true,
             contentsType = ContentsType.Merchandise,
             contentsDescription = null,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelTestUtils.kt
@@ -39,13 +39,13 @@ object CreateShippingLabelTestUtils {
     }
 
     fun generateShippingLabelPackage(
-        id: String = "package1",
+        position: Int = 1,
         weight: Float = 10f,
         selectedPackage: ShippingPackage? = null,
         items: List<Item>? = null
     ): ShippingLabelPackage {
         return ShippingLabelPackage(
-            id,
+            position,
             selectedPackage ?: generatePackage(),
             weight,
             listOf(Item(0L, "product", "", 2, 10f, BigDecimal.valueOf(10L)))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
@@ -89,8 +89,8 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
 
         verify(orderDetailRepository).getOrder(any())
         verify(shippingLabelRepository).getAccountSettings()
-        assertThat(viewState!!.shippingLabelPackages.size).isEqualTo(1)
-        assertThat(viewState!!.shippingLabelPackages.first().selectedPackage).isEqualTo(availablePackages.first())
+        assertThat(viewState!!.packagesUiModels.size).isEqualTo(1)
+        assertThat(viewState!!.packagesUiModels.first().selectedPackage).isEqualTo(availablePackages.first())
     }
 
     @Test
@@ -106,7 +106,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
 
         verify(orderDetailRepository, never()).getOrder(any())
         verify(shippingLabelRepository, never()).getAccountSettings()
-        assertThat(viewState!!.shippingLabelPackages).isEqualTo(currentShippingPackages.toList())
+        assertThat(viewState!!.packagesUiModels).isEqualTo(currentShippingPackages.toList())
     }
 
     @Test
@@ -118,7 +118,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
         var viewState: ViewState? = null
         viewModel.viewStateData.observeForever { _, new -> viewState = new }
 
-        assertThat(viewState!!.shippingLabelPackages.first().selectedPackage).isNull()
+        assertThat(viewState!!.packagesUiModels.first().selectedPackage).isNull()
     }
 
     @Test
@@ -130,7 +130,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
         var viewState: ViewState? = null
         viewModel.viewStateData.observeForever { _, new -> viewState = new }
 
-        assertThat(viewState!!.shippingLabelPackages.first().selectedPackage).isNull()
+        assertThat(viewState!!.packagesUiModels.first().selectedPackage).isNull()
     }
 
     @Test
@@ -142,7 +142,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
         viewModel.viewStateData.observeForever { _, new -> viewState = new }
 
         viewModel.onWeightEdited(0, 10.0f)
-        assertThat(viewState!!.shippingLabelPackages.first().weight).isEqualTo(10.0f)
+        assertThat(viewState!!.packagesUiModels.first().weight).isEqualTo(10.0f)
         assertThat(viewState!!.isDataValid).isTrue()
     }
 
@@ -156,7 +156,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
 
         viewModel.onPackageSpinnerClicked(0)
         viewModel.onPackageSelected(0, availablePackages[1])
-        assertThat(viewState!!.shippingLabelPackages.first().selectedPackage).isEqualTo(availablePackages[1])
+        assertThat(viewState!!.packagesUiModels.first().selectedPackage).isEqualTo(availablePackages[1])
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
@@ -90,7 +90,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
         verify(orderDetailRepository).getOrder(any())
         verify(shippingLabelRepository).getAccountSettings()
         assertThat(viewState!!.packagesUiModels.size).isEqualTo(1)
-        assertThat(viewState!!.packagesUiModels.first().selectedPackage).isEqualTo(availablePackages.first())
+        assertThat(viewState!!.packages.first().selectedPackage).isEqualTo(availablePackages.first())
     }
 
     @Test
@@ -106,7 +106,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
 
         verify(orderDetailRepository, never()).getOrder(any())
         verify(shippingLabelRepository, never()).getAccountSettings()
-        assertThat(viewState!!.packagesUiModels).isEqualTo(currentShippingPackages.toList())
+        assertThat(viewState!!.packages).isEqualTo(currentShippingPackages.toList())
     }
 
     @Test
@@ -118,7 +118,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
         var viewState: ViewState? = null
         viewModel.viewStateData.observeForever { _, new -> viewState = new }
 
-        assertThat(viewState!!.packagesUiModels.first().selectedPackage).isNull()
+        assertThat(viewState!!.packages.first().selectedPackage).isNull()
     }
 
     @Test
@@ -130,7 +130,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
         var viewState: ViewState? = null
         viewModel.viewStateData.observeForever { _, new -> viewState = new }
 
-        assertThat(viewState!!.packagesUiModels.first().selectedPackage).isNull()
+        assertThat(viewState!!.packages.first().selectedPackage).isNull()
     }
 
     @Test
@@ -142,7 +142,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
         viewModel.viewStateData.observeForever { _, new -> viewState = new }
 
         viewModel.onWeightEdited(0, 10.0f)
-        assertThat(viewState!!.packagesUiModels.first().weight).isEqualTo(10.0f)
+        assertThat(viewState!!.packagesUiModels.first().data.weight).isEqualTo(10.0f)
         assertThat(viewState!!.isDataValid).isTrue()
     }
 
@@ -156,7 +156,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
 
         viewModel.onPackageSpinnerClicked(0)
         viewModel.onPackageSelected(0, availablePackages[1])
-        assertThat(viewState!!.packagesUiModels.first().selectedPackage).isEqualTo(availablePackages[1])
+        assertThat(viewState!!.packages.first().selectedPackage).isEqualTo(availablePackages[1])
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModelTest.kt
@@ -101,7 +101,7 @@ class ShippingCustomsViewModelTest : BaseUnitTest() {
         assertThat(viewStatePackages[0].data.contentsType).isEqualTo(ContentsType.Merchandise)
         assertThat(viewStatePackages[0].data.restrictionType).isEqualTo(RestrictionType.None)
         assertThat(viewStatePackages[0].data.returnToSender).isEqualTo(true)
-        assertThat(viewStatePackages[0].data.box).isEqualTo(shippingPackage.selectedPackage)
+        assertThat(viewStatePackages[0].data.labelPackage).isEqualTo(shippingPackage)
         assertThat(viewStatePackages[0].data.lines).hasSize(shippingPackage.items.size)
         assertThat(viewStatePackages[0].data.lines[0].itemDescription).isEqualTo(shippingPackage.items[0].name)
         assertThat(viewStatePackages[0].data.lines[0].value).isEqualTo(shippingPackage.items[0].value)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
@@ -119,7 +119,7 @@ class ShippingLabelsStateMachineTest : BaseUnitTest() {
     fun `test show packages step`() = coroutinesTestRule.testDispatcher.runBlockingTest {
         val packagesList = listOf(
             ShippingLabelPackage(
-                packageId = "package1",
+                position = 1,
                 selectedPackage = ShippingPackage(
                     "id",
                     "title",


### PR DESCRIPTION
This handles the first task of #4002, by allowing moving items to new packages, the PR is bigger than I planned.

When reviewing, please note the following:
1. The commits 50be635, 868c6d8, 1f8286e, and 6ca704d were a preparation to allow having a consistent identification of packages (both their name and `packageId`) across different steps, and it will be used also when trying to move items to existing packages.
2. I didn't add any unit tests for the new functionality, it'll be done in a separate PR.

<img width=360 src="https://user-images.githubusercontent.com/1657201/124125324-64121b80-da71-11eb-92fc-6df24c8f3c78.gif" />


#### Testing
1. Create an order eligible for shipping label creation with multiple items.
2. Open the order in the app.
3. Click on Create shipping label button.
4. Pass the origin and destination steps.
5. Click on Continue in the packaging step.
6. Click on Move button in one of the items.
7. Notice that the Move Item dialog is displayed.
8. Select "Add to New Package" option.
9. Click on "Move"
10. Confirm that the item has been moved to a different package.
11. Confirm that the new package is expanded, and the other packages are collapsed.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
