### PR TITLE
Store payment receipts into persistent storage

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -5,9 +5,11 @@ package com.woocommerce.android
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
+import android.content.SharedPreferences.Editor
 import androidx.preference.PreferenceManager
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.DATABASE_DOWNGRADED
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.IMAGE_OPTIMIZE_ENABLED
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.RECEIPT_PREFIX
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.util.PreferenceUtils
@@ -377,9 +379,19 @@ object AppPrefs {
         val editor = getPreferences().edit()
         DeletablePrefKey.values().forEach { a -> editor.remove(a.name) }
         editor.remove(SelectedSite.SELECTED_SITE_LOCAL_ID)
+        removePreferencesWithDynamicKey(editor)
         editor.apply()
 
         resetSitePreferences()
+    }
+
+    private fun removePreferencesWithDynamicKey(editor: Editor) {
+        getPreferences()
+            .all
+            .filter { it.key.contains(RECEIPT_PREFIX.toString(), ignoreCase = true) }
+            .forEach {
+                editor.remove(it.key)
+            }
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -47,7 +47,8 @@ object AppPrefs {
         UNIFIED_LOGIN_LAST_ACTIVE_SOURCE,
         UNIFIED_LOGIN_LAST_ACTIVE_FLOW,
         IS_USER_ELIGIBLE,
-        USER_EMAIL
+        USER_EMAIL,
+        RECEIPT_PREFIX
     }
 
     /**
@@ -184,6 +185,18 @@ object AppPrefs {
     fun getUserEmail() = getString(DeletablePrefKey.USER_EMAIL)
 
     fun setUserEmail(email: String) = setString(DeletablePrefKey.USER_EMAIL, email)
+
+    fun getReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =
+        PreferenceUtils.getString(getPreferences(), getReceiptKey(localSiteId, remoteSiteId, selfHostedSiteId, orderId))
+
+    fun setReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long, url: String) =
+        PreferenceUtils.setString(
+            getPreferences(),
+            getReceiptKey(localSiteId, remoteSiteId, selfHostedSiteId, orderId),
+            url
+        )
+    private fun getReceiptKey(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =
+        "${DeletablePrefKey.RECEIPT_PREFIX}:$localSiteId:$remoteSiteId:$selfHostedSiteId:$orderId"
 
     /**
      * Flag to check products features are enabled

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -385,6 +385,12 @@ object AppPrefs {
         resetSitePreferences()
     }
 
+    /**
+     * This method removes entries in shared preferences which use dynamically created keys.
+     *
+     * For example order receipts are stored under "RECEIPT_PREFIX:siteId:...:orderId" - each entry has a different
+     * key based on the currently selected site and the order it's related to.
+     */
     private fun removePreferencesWithDynamicKey(editor: Editor) {
         getPreferences()
             .all

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -1,0 +1,16 @@
+package com.woocommerce.android
+
+import javax.inject.Inject
+
+class AppPrefsWrapper @Inject constructor() {
+    fun getReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =
+        AppPrefs.getReceiptUrl(localSiteId, remoteSiteId, selfHostedSiteId, orderId)
+
+    fun setReceiptUrl(
+        localSiteId: Int,
+        remoteSiteId: Long,
+        selfHostedSiteId: Long,
+        orderId: Long,
+        url: String
+    ) = AppPrefs.setReceiptUrl(localSiteId, remoteSiteId, selfHostedSiteId, orderId, url)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
@@ -19,8 +19,6 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.CardReaderPaymentEvent.PrintReceipt
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.CardReaderPaymentEvent.SendReceipt
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.PrintJobResult
-import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.PrintJobResult.CANCELLED
-import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.PrintJobResult.FAILED
 import com.woocommerce.android.util.PrintHtmlHelper
 import com.woocommerce.android.util.UiHelpers
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -113,17 +111,8 @@ class CardReaderPaymentDialog : DialogFragment(R.layout.fragment_card_reader_pay
     override fun onResume() {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
-        handlePrintResultIfAvailable()
-    }
-
-    private fun handlePrintResultIfAvailable() {
-        printHtmlHelper.getAndClearPrintJob()?.let {
-            val result = when {
-                it.isCancelled -> CANCELLED
-                it.isFailed -> FAILED
-                else -> PrintJobResult.STARTED
-            }
-            viewModel.onPrintResult(result)
+        printHtmlHelper.getAndClearPrintJobResult()?.let {
+            viewModel.onPrintResult(it)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
@@ -13,9 +13,9 @@ import com.woocommerce.android.databinding.FragmentCardReaderPaymentBinding
 import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.CardReaderPaymentEvent.PrintReceipt
-import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.CardReaderPaymentEvent.SendReceipt
-import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.PrintJobResult
+import com.woocommerce.android.ui.orders.cardreader.ReceiptEvent.PrintReceipt
+import com.woocommerce.android.ui.orders.cardreader.ReceiptEvent.SendReceipt
+import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.PrintHtmlHelper
 import com.woocommerce.android.util.UiHelpers
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
@@ -1,9 +1,6 @@
 package com.woocommerce.android.ui.orders.cardreader
 
 import android.app.Dialog
-import android.content.ActivityNotFoundException
-import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -108,6 +105,11 @@ class CardReaderPaymentDialog : DialogFragment(R.layout.fragment_card_reader_pay
         )
     }
 
+    private fun composeEmail(address: String, subject: UiString, content: UiString) {
+        val success = ActivityUtils.composeEmail(requireActivity(), address, subject, content)
+        if (!success) viewModel.onEmailActivityNotFound()
+    }
+
     override fun onResume() {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
@@ -118,19 +120,5 @@ class CardReaderPaymentDialog : DialogFragment(R.layout.fragment_card_reader_pay
 
     companion object {
         const val KEY_CARD_PAYMENT_RESULT = "key_card_payment_result"
-    }
-
-    private fun composeEmail(billingEmail: String, subject: UiString, content: UiString) {
-        val intent = Intent(Intent.ACTION_SENDTO).apply {
-            data = Uri.parse("mailto:") // only email apps should handle this
-            putExtra(Intent.EXTRA_EMAIL, arrayOf(billingEmail))
-            putExtra(Intent.EXTRA_SUBJECT, UiHelpers.getTextOfUiString(requireContext(), subject))
-            putExtra(Intent.EXTRA_TEXT, UiHelpers.getTextOfUiString(requireContext(), content))
-        }
-        try {
-            startActivity(intent)
-        } catch (e: ActivityNotFoundException) {
-            viewModel.onEmailActivityNotFound()
-        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -167,7 +167,6 @@ class CardReaderPaymentViewModel
             CollectingPayment -> viewState.postValue(CollectPaymentState(amountLabel))
             ProcessingPayment -> viewState.postValue(ProcessingPaymentState(amountLabel))
             CapturingPayment -> viewState.postValue(CapturingPaymentState(amountLabel))
-            // TODO cardreader store receipt data into a persistent storage
             is PaymentCompleted -> {
                 tracker.track(AnalyticsTracker.Stat.CARD_PRESENT_COLLECT_PAYMENT_SUCCESS)
                 onPaymentCompleted(paymentStatus, billingEmail, orderId, amountLabel)
@@ -283,12 +282,6 @@ class CardReaderPaymentViewModel
             this.number,
             selectedSite.get().name.orEmpty()
         )
-
-    sealed class CardReaderPaymentEvent : Event() {
-        data class PrintReceipt(val receiptUrl: String, val documentName: String) : CardReaderPaymentEvent()
-        data class SendReceipt(val content: UiString, val subject: UiString, val address: String) :
-            CardReaderPaymentEvent()
-    }
 
     fun onBackPressed() {
         if (refetchOrderJob?.isActive == true) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -7,6 +7,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.RECEIPT_EMAIL_FAILED
@@ -29,15 +30,9 @@ import com.woocommerce.android.cardreader.CardPaymentStatus.WaitingForInput
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.PaymentData
 import com.woocommerce.android.model.Order
-import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.CardReaderPaymentEvent.PrintReceipt
-import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.CardReaderPaymentEvent.SendReceipt
-import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.PrintJobResult.CANCELLED
-import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.PrintJobResult.FAILED
-import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.PrintJobResult.STARTED
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.CapturingPaymentState
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.CollectPaymentState
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.FailedPaymentState
@@ -45,9 +40,14 @@ import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.V
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.PaymentSuccessfulState
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.ProcessingPaymentState
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.ReFetchingOrderState
+import com.woocommerce.android.ui.orders.cardreader.ReceiptEvent.PrintReceipt
+import com.woocommerce.android.ui.orders.cardreader.ReceiptEvent.SendReceipt
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
+import com.woocommerce.android.util.PrintHtmlHelper.PrintJobResult
+import com.woocommerce.android.util.PrintHtmlHelper.PrintJobResult.CANCELLED
+import com.woocommerce.android.util.PrintHtmlHelper.PrintJobResult.FAILED
+import com.woocommerce.android.util.PrintHtmlHelper.PrintJobResult.STARTED
 import com.woocommerce.android.util.WooLog
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -71,6 +71,7 @@ class CardReaderPaymentViewModel
     private val orderRepository: OrderDetailRepository,
     private val resourceProvider: ResourceProvider,
     private val selectedSite: SelectedSite,
+    private val appPrefsWrapper: AppPrefsWrapper,
     private val paymentCollectibilityChecker: CardReaderPaymentCollectibilityChecker,
     private val tracker: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedState) {
@@ -203,7 +204,16 @@ class CardReaderPaymentViewModel
                 { onSendReceiptClicked(paymentStatus.receiptUrl, billingEmail) }
             )
         )
+        storeReceiptUrl(orderId, paymentStatus.receiptUrl)
         reFetchOrder()
+    }
+
+    private fun storeReceiptUrl(orderId: Long, receiptUrl: String) {
+        launch {
+            selectedSite.get().let {
+                appPrefsWrapper.setReceiptUrl(it.id, it.siteId, it.selfHostedSiteId, orderId, receiptUrl)
+            }
+        }
     }
 
     @VisibleForTesting
@@ -389,8 +399,4 @@ class CardReaderPaymentViewModel
             CardPaymentStatusErrorType.CARD_READ_TIMED_OUT,
             CardPaymentStatusErrorType.GENERIC_ERROR -> PaymentFlowError.GENERIC_ERROR
         }
-
-    enum class PrintJobResult {
-        CANCELLED, STARTED, FAILED
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/ReceiptEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/ReceiptEvent.kt
@@ -1,0 +1,9 @@
+package com.woocommerce.android.ui.orders.cardreader
+
+import com.woocommerce.android.model.UiString
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+
+sealed class ReceiptEvent : Event() {
+    data class PrintReceipt(val receiptUrl: String, val documentName: String) : ReceiptEvent()
+    data class SendReceipt(val content: UiString, val subject: UiString, val address: String) : ReceiptEvent()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ActivityUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ActivityUtils.kt
@@ -13,6 +13,7 @@ import androidx.annotation.ColorRes
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import com.woocommerce.android.R
+import com.woocommerce.android.model.UiString
 import com.woocommerce.android.util.WooLog.T
 import org.wordpress.android.util.ToastUtils
 import java.io.File
@@ -80,6 +81,21 @@ object ActivityUtils {
             activity.startActivity(sendIntent)
         } catch (exception: ActivityNotFoundException) {
             ToastUtils.showToast(activity, R.string.shipping_label_preview_pdf_app_missing)
+        }
+    }
+
+    fun composeEmail(activity: Activity, billingEmail: String, subject: UiString, content: UiString): Boolean {
+        val intent = Intent(Intent.ACTION_SENDTO).apply {
+            data = Uri.parse("mailto:") // only email apps should handle this
+            putExtra(Intent.EXTRA_EMAIL, arrayOf(billingEmail))
+            putExtra(Intent.EXTRA_SUBJECT, UiHelpers.getTextOfUiString(activity, subject))
+            putExtra(Intent.EXTRA_TEXT, UiHelpers.getTextOfUiString(activity, content))
+        }
+        return try {
+            activity.startActivity(intent)
+            true
+        } catch (e: ActivityNotFoundException) {
+            false
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/PrintHtmlHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/PrintHtmlHelper.kt
@@ -8,6 +8,8 @@ import android.print.PrintManager
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import com.woocommerce.android.util.PrintHtmlHelper.PrintJobResult.CANCELLED
+import com.woocommerce.android.util.PrintHtmlHelper.PrintJobResult.FAILED
 import com.woocommerce.android.util.WooLog.T
 import javax.inject.Inject
 
@@ -38,8 +40,14 @@ class PrintHtmlHelper @Inject constructor() {
         webViewInstance = webView
     }
 
-    fun getAndClearPrintJob(): PrintJob? {
-        return printJob?.also { printJob = null }
+    fun getAndClearPrintJobResult(): PrintJobResult? {
+        return printJob?.let {
+            when {
+                it.isCancelled -> CANCELLED
+                it.isFailed -> FAILED
+                else -> PrintJobResult.STARTED
+            }.also { printJob = null }
+        }
     }
 
     private fun enqueuePrintJob(activity: Activity, webView: WebView, documentName: String) {
@@ -48,5 +56,9 @@ class PrintHtmlHelper @Inject constructor() {
             webView.createPrintDocumentAdapter(documentName),
             PrintAttributes.Builder().build()
         ).also { printJob = it }
+    }
+
+    enum class PrintJobResult {
+        CANCELLED, STARTED, FAILED
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -10,6 +10,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.RECEIPT_EMAIL_FAILED
@@ -35,11 +36,6 @@ import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.CardReaderPaymentEvent.PrintReceipt
-import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.CardReaderPaymentEvent.SendReceipt
-import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.PrintJobResult.CANCELLED
-import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.PrintJobResult.FAILED
-import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.PrintJobResult.STARTED
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.CapturingPaymentState
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.CollectPaymentState
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.FailedPaymentState
@@ -47,7 +43,12 @@ import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.V
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.PaymentSuccessfulState
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.ProcessingPaymentState
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.ReFetchingOrderState
+import com.woocommerce.android.ui.orders.cardreader.ReceiptEvent.PrintReceipt
+import com.woocommerce.android.ui.orders.cardreader.ReceiptEvent.SendReceipt
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
+import com.woocommerce.android.util.PrintHtmlHelper.PrintJobResult.CANCELLED
+import com.woocommerce.android.util.PrintHtmlHelper.PrintJobResult.FAILED
+import com.woocommerce.android.util.PrintHtmlHelper.PrintJobResult.STARTED
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -84,6 +85,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     private val selectedSite: SelectedSite = mock()
     private val paymentCollectibilityChecker: CardReaderPaymentCollectibilityChecker = mock()
     private val tracker: AnalyticsTrackerWrapper = mock()
+    private val appPrefsWrapper: AppPrefsWrapper = mock()
 
     private val paymentFailedWithEmptyDataForRetry = PaymentFailed(GENERIC_ERROR, null, "dummy msg")
     private val paymentFailedWithValidDataForRetry = PaymentFailed(GENERIC_ERROR, mock(), "dummy msg")
@@ -99,7 +101,8 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             resourceProvider = resourceProvider,
             selectedSite = selectedSite,
             paymentCollectibilityChecker = paymentCollectibilityChecker,
-            tracker = tracker
+            tracker = tracker,
+            appPrefsWrapper = appPrefsWrapper
         )
 
         val mockedOrder = mock<Order>()
@@ -537,6 +540,19 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
             assertThat(viewState.paymentStateLabel).describedAs("paymentStateLabel")
                 .isEqualTo(R.string.card_reader_payment_failed_card_declined_state)
+        }
+
+    @Test
+    fun `when payment succeeds, then receiptUrl stored into a persistant storage`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            val receiptUrl = "testUrl"
+            whenever(cardReaderManager.collectPayment(any(), any(), any(), any(), any())).thenAnswer {
+                flow { emit(PaymentCompleted(receiptUrl)) }
+            }
+
+            viewModel.start()
+
+            verify(appPrefsWrapper).setReceiptUrl(any(), any(), any(), any(), eq(receiptUrl))
         }
 
     @Test


### PR DESCRIPTION
Parent issue #4039

This PR adds support for storing payment receipts into shared preferences. I considered storing them into a database, but decided against it. The main reason was that we plan to add receiptUrl to the OrderModel on the backend. When that's implemented the app won't need to manually store receipts.

To test:
Prerequisite - the store is included in the card reader beta
1. Open detail of an unpaid order in US
2. Tap on "Collect payment" button
3. Complete the payment
4. Verify that "RECEIPT_PREFIX:....." entry with receipt URL is in shared preferences
5. Log out of the app and verify the entry gets deleted


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
