### PR TITLE
issue/4324-payments-misleading-no-reader-found 

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -730,7 +730,7 @@
     <string name="card_reader_connect_connecting_header">Connecting to reader</string>
     <string name="card_reader_connect_connecting_hint" translatable="false">@string/please_wait</string>
     <string name="card_reader_connect_failed_header">We couldn\’t connect your reader</string>
-    <string name="card_reader_connect_scanning_failed_header">No reader found</string>
+    <string name="card_reader_connect_scanning_failed_header">No reader connected</string>
     <string name="card_reader_connect_connecting_failed_hint">We couldn\'t connect to the reader.</string>
     <string name="card_reader_connect_missing_permissions_header">Missing required location permission</string>
     <string name="card_reader_connect_location_provider_disabled_header">Location is disabled</string>


### PR DESCRIPTION
Fixes #4324 - this simple PR changes the "No reader found" message to "No reader connected". The reason for this change is that we can't detect whether the failure happened due to no reader being found, or no reader being connected. So now we show a message that handles both situation.

To test:

- Settings > Manage card reader
- Tap "Connect card reader"
- Wait for the reader to be found
- Leave the dialog open for a minute so it times out
- Notice the message reads "No reader connected"

![dialog](https://user-images.githubusercontent.com/3903757/124007451-61e48a00-d9a9-11eb-8481-dcbf411f467b.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
