### PR TITLE
Issue/4310 CRD operations on shared preferences for the reader id

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -250,6 +250,7 @@ dependencies {
     // Dependencies for Espresso UI tests
     androidTestImplementation "androidx.test.ext:junit:$jUnitExtVersion"
     androidTestImplementation "androidx.test:rules:1.3.0"
+    androidTestImplementation "org.assertj:assertj-core:$assertjVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
     androidTestImplementation "androidx.test.espresso:espresso-contrib:$espressoVersion"
     androidTestImplementation "androidx.test.espresso:espresso-intents:$espressoVersion"

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
@@ -1,0 +1,32 @@
+package com.woocommerce.android
+
+import androidx.test.platform.app.InstrumentationRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+
+class AppPrefsTest {
+    @Before
+    fun setup() {
+        AppPrefs.init(InstrumentationRegistry.getInstrumentation().targetContext.applicationContext)
+    }
+
+    @Test
+    fun whenSetLastConnectedCardReaderIdThenIdStored() {
+        val readerId = "id"
+
+        AppPrefs.setLastConnectedCardReaderId(readerId)
+
+        assertThat(AppPrefs.getLastConnectedCardReaderId()).isEqualTo(readerId)
+    }
+
+    @Test
+    fun whenRemoveLastConnectedCardReaderIdThenIdIsNull() {
+        val readerId = "id"
+        AppPrefs.setLastConnectedCardReaderId(readerId)
+
+        AppPrefs.removeLastConnectedCardReaderId()
+
+        assertThat(AppPrefs.getLastConnectedCardReaderId()).isNull()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -88,8 +88,12 @@ object AppPrefs {
 
         // Application permissions
         ASKED_PERMISSION_CAMERA,
+
         // Date of the app installation
-        APP_INSTALATION_DATE
+        APP_INSTALATION_DATE,
+
+        // last connected card reader's id
+        LAST_CONNECTED_CARD_READER_ID
     }
 
     fun init(context: Context) {
@@ -125,7 +129,6 @@ object AppPrefs {
         get() = getString(UndeletablePrefKey.APP_INSTALATION_DATE)
             .toLongOrNull()
             ?.let { Date(it) }
-
         private set(value) = value
             ?.time.toString()
             .let { setString(UndeletablePrefKey.APP_INSTALATION_DATE, it) }
@@ -197,8 +200,17 @@ object AppPrefs {
             getReceiptKey(localSiteId, remoteSiteId, selfHostedSiteId, orderId),
             url
         )
+
     private fun getReceiptKey(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =
-        "${DeletablePrefKey.RECEIPT_PREFIX}:$localSiteId:$remoteSiteId:$selfHostedSiteId:$orderId"
+        "$RECEIPT_PREFIX:$localSiteId:$remoteSiteId:$selfHostedSiteId:$orderId"
+
+    fun setLastConnectedCardReaderId(readerId: String) =
+        setString(UndeletablePrefKey.LAST_CONNECTED_CARD_READER_ID, readerId)
+
+    fun getLastConnectedCardReaderId() =
+        PreferenceUtils.getString(getPreferences(), UndeletablePrefKey.LAST_CONNECTED_CARD_READER_ID.toString(), null)
+
+    fun removeLastConnectedCardReaderId() = remove(UndeletablePrefKey.LAST_CONNECTED_CARD_READER_ID)
 
     /**
      * Flag to check products features are enabled

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -13,4 +13,10 @@ class AppPrefsWrapper @Inject constructor() {
         orderId: Long,
         url: String
     ) = AppPrefs.setReceiptUrl(localSiteId, remoteSiteId, selfHostedSiteId, orderId, url)
+
+    fun setLastConnectedCardReaderId(readerId: String) = AppPrefs.setLastConnectedCardReaderId(readerId)
+
+    fun getLastConnectedCardReaderId() = AppPrefs.getLastConnectedCardReaderId()
+
+    fun removeLastConnectedCardReaderId() = AppPrefs.removeLastConnectedCardReaderId()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/PreferenceUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/PreferenceUtils.kt
@@ -19,7 +19,7 @@ object PreferenceUtils {
         setString(preferences, key, value.toString())
     }
 
-    fun getString(preferences: SharedPreferences, key: String, defaultValue: String = ""): String? {
+    fun getString(preferences: SharedPreferences, key: String, defaultValue: String? = ""): String? {
         return preferences.getString(key, defaultValue)
     }
 


### PR DESCRIPTION
Closes #4342 

The PR adds create, get, remove operations for the reader id in AppPreferences and the Wrapper.

Nothing can be tested manually at the moment