### PR TITLE
issue/4347-update-reader-android5

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateDialogFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.Window
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.R
@@ -21,6 +22,7 @@ class CardReaderUpdateDialogFragment : DialogFragment(R.layout.dialog_card_reade
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         dialog!!.setCanceledOnTouchOutside(false)
+        dialog!!.requestWindowFeature(Window.FEATURE_NO_TITLE)
         return super.onCreateView(inflater, container, savedInstanceState)
     }
 

--- a/WooCommerce/src/main/res/layout/dialog_card_reader_update.xml
+++ b/WooCommerce/src/main/res/layout/dialog_card_reader_update.xml
@@ -14,7 +14,7 @@
         android:id="@+id/update_reader_title_tv"
         style="@style/Woo.TextView.Subtitle1"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_marginStart="0dp"
         android:textColor="@color/color_on_surface_high"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Fixes #4347 - the problem was due to setting the dialog heading's height to `match_parent`. Changing that to `wrap_content` fixes it. This PR also fixes the gray area above the heading on Android 5.

![update](https://user-images.githubusercontent.com/3903757/124294039-4605f300-db25-11eb-90df-23fb2812d84e.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
