### PR TITLE
Some Detekt configuration changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Once installed, you can configure the plugin here:
 
 From there, add and enable the custom configuration file, located at [config/detekt/detekt.yml](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/config/detekt/detekt.yml).
 
+If you want to use the **AutoCorrect** feature of the plugin, make sure that the option `Enable formatting (ktlint) rules` is enabled in the above settings, then you will be able to reformat any file according to detekt's rules using the refactor menu `AutoCorrect by Detekt Rules`
+
 ### Google Configuration
 
 Google Sign-In is only available for WordPress.com accounts through the [official app][woo-app].

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -12,4 +12,9 @@ formatting:
   active: true
   Indentation:
     active: true
+  NoWildcardImports:
+    active: false
 
+style:
+  WildcardImport:
+    active: false

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -10,8 +10,10 @@ complexity:
 
 formatting:
   active: true
+  autoCorrect: true
   Indentation:
     active: true
+    autoCorrect: true
   NoWildcardImports:
     active: false
 


### PR DESCRIPTION
This PR contains two changes:
1. It disables the wildcard imports check from `detekt`, to align with the team's decision (internal discussion: p1624890279423800/1624890265.423700-slack-CGPNUU63E)
2. It updates the detekt configuration to allow using `AutoCorrect` option from the plugin, this will be useful when detekt's rule and AS rules don't align (see p1625141167154000-slack-C70PAM3RA for an example)


#### Testing
##### Change 1:
1. Checkout this branch.
2. Update a kotlin file to use some wildcard imports.
3. Run `gradlew detektAll`
4. Confirm that no issue is reported.

##### Change 2:
1. Checkout this branch.
2. Follow the guidelines for the README file to install and configure detekt plugin.
3. Make some changes that break the indentation of any kotlin file.
4. Make a Right-click on the mouse, and go to Refactor -> AutoCorrect by Detekt Rules.
5. Confirm that the file indentation has been corrected.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.