### PR TITLE
Issue/4356 Configuration change a user  stuck on payment-success state

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.databinding.FragmentCardReaderPaymentBinding
 import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.orders.cardreader.ReceiptEvent.PrintReceipt
 import com.woocommerce.android.ui.orders.cardreader.ReceiptEvent.SendReceipt
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.PrintHtmlHelper
@@ -60,11 +59,6 @@ class CardReaderPaymentDialog : DialogFragment(R.layout.fragment_card_reader_pay
             viewLifecycleOwner,
             { event ->
                 when (event) {
-                    is PrintReceipt -> printHtmlHelper.printReceipt(
-                        requireActivity(),
-                        event.receiptUrl,
-                        event.documentName
-                    )
                     is SendReceipt -> composeEmail(event.address, event.subject, event.content)
                     is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                     else -> event.isHandled = false
@@ -74,6 +68,13 @@ class CardReaderPaymentDialog : DialogFragment(R.layout.fragment_card_reader_pay
         viewModel.viewStateData.observe(
             viewLifecycleOwner,
             { viewState ->
+                if (viewState is CardReaderPaymentViewModel.ViewState.PrintingReceiptState) {
+                    printHtmlHelper.printReceipt(
+                        requireActivity(),
+                        viewState.receiptUrl,
+                        viewState.documentName
+                    )
+                }
                 UiHelpers.setTextOrHide(binding.headerLabel, viewState.headerLabel)
                 UiHelpers.setTextOrHide(binding.amountLabel, viewState.amountWithCurrencyLabel)
                 UiHelpers.setImageOrHide(binding.illustration, viewState.illustration)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -41,9 +41,9 @@ import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.V
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.FailedPaymentState
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.LoadingDataState
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.PaymentSuccessfulState
+import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.PrintingReceiptState
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.ProcessingPaymentState
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.ReFetchingOrderState
-import com.woocommerce.android.ui.orders.cardreader.ReceiptEvent.PrintReceipt
 import com.woocommerce.android.ui.orders.cardreader.ReceiptEvent.SendReceipt
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.util.PrintHtmlHelper.PrintJobResult.CANCELLED
@@ -597,7 +597,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when user clicks on print receipt button, then PrintReceipt event emitted`() =
+    fun `when user clicks on print receipt button, then PrintingReceiptState state emitted`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(cardReaderManager.collectPayment(any(), any(), any(), any(), any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
@@ -606,7 +606,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
             (viewModel.viewStateData.value as PaymentSuccessfulState).onPrimaryActionClicked.invoke()
 
-            assertThat(viewModel.event.value).isInstanceOf(PrintReceipt::class.java)
+            assertThat(viewModel.viewStateData.value).isInstanceOf(PrintingReceiptState::class.java)
         }
 
     @Test
@@ -619,7 +619,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
             (viewModel.viewStateData.value as PaymentSuccessfulState).onPrimaryActionClicked.invoke()
 
-            assertThat((viewModel.viewStateData.value as PaymentSuccessfulState).isProgressVisible).isTrue()
+            assertThat((viewModel.viewStateData.value as PrintingReceiptState).isProgressVisible).isTrue()
         }
 
     @Test
@@ -651,6 +651,8 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when OS accepts the print request, then print success event tracked`() {
+        viewModel.start()
+
         viewModel.onPrintResult(STARTED)
 
         verify(tracker).track(RECEIPT_PRINT_SUCCESS)
@@ -658,6 +660,8 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when OS refuses the print request, then print failed event tracked`() {
+        viewModel.start()
+
         viewModel.onPrintResult(FAILED)
 
         verify(tracker).track(RECEIPT_PRINT_FAILED)
@@ -665,6 +669,8 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when manually cancels the print request, then print cancelled event tracked`() {
+        viewModel.start()
+
         viewModel.onPrintResult(CANCELLED)
 
         verify(tracker).track(RECEIPT_PRINT_CANCELED)


### PR DESCRIPTION
Resolves #4356 

*Do not merge for 7.1 milestone, unless we decide that it's safe to include in the BETA 1*

The PR moves event of "print button clicked" to the "printing state", which makes the view model preserve it on configuration change. Also, I hide the "print button" in this state, because otherwise the user can end up in many printing windows at the same time

From the doc on PrintMangaer::print

> Note: Calling this method will bring the print dialog and the system will connect to the provided PrintDocumentAdapter.
> If a configuration change occurs that you application does not handle, for example a rotation change, the system will drop the connection to the adapter as the activity has to be recreated and the old adapter may be invalid in this context, hence a new adapter instance is required. As a consequence, if your activity does not handle configuration changes (default behavior), you have to save the state that you were printing and call this method again when your activity is recreated.
> 

This means we can not use an even to trigger the printing flow. 

### NOTE
@nbradbury @malinajirka I think the bug is not so crucial, and the fix is pretty complicated so I wouldn't merge it before the cut of. Wdyt?

Also, I don't like the way I fixed it, but I don't see a better way without changing the architecture a lot. Would like to hear your opinions on that as well

### Video

*Before*

https://user-images.githubusercontent.com/4923871/124560389-6bf10780-de45-11eb-8f76-cde44c4e5cd9.mp4

*After*

https://user-images.githubusercontent.com/4923871/124560429-757a6f80-de45-11eb-9d17-c0f98c4292b2.mp4


### How to test
1. Finish the payment flow with success
2. Click "print" button
3. Rotate the device
4. Notice that the printing window disappears and it will appear after some time. Also, notice that "print" button is not visible anymore.
