### PR TITLE
Issue/4357 Save web view state on configuration change

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/ReceiptPreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/ReceiptPreviewFragment.kt
@@ -30,11 +30,12 @@ class ReceiptPreviewFragment : BaseFragment(R.layout.fragment_receipt_preview) {
     @Inject lateinit var printHtmlHelper: PrintHtmlHelper
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
-    private lateinit var binding: FragmentReceiptPreviewBinding
+    private var _binding: FragmentReceiptPreviewBinding? = null
+    private val binding get() = _binding!!
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding = FragmentReceiptPreviewBinding.bind(view)
+        _binding = FragmentReceiptPreviewBinding.bind(view)
         initViews(binding, savedInstanceState)
         initObservers(binding)
     }
@@ -69,6 +70,11 @@ class ReceiptPreviewFragment : BaseFragment(R.layout.fragment_receipt_preview) {
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         binding.receiptPreviewPreviewWebview.saveState(outState)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     private fun initViews(binding: FragmentReceiptPreviewBinding, savedInstanceState: Bundle?) {


### PR DESCRIPTION
Resolves issue #4357 

The PR introduces webview state saving on configuration change

### How to test
1. Open paid order
2. Click "see receipt"
3. Notice a receipt
4. Rotate the device
5. Notice that receipt is still in place

https://user-images.githubusercontent.com/4923871/124578911-51c02500-de57-11eb-935e-9a90b1e39666.mp4

