### PR TITLE
Shipping Labels: multiple packages support part 2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabelPackage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabelPackage.kt
@@ -26,7 +26,12 @@ data class ShippingLabelPackage(
         val quantity: Int,
         val weight: Float,
         val value: BigDecimal
-    ) : Parcelable
+    ) : Parcelable {
+        fun isSameProduct(otherItem: Item): Boolean {
+            return productId == otherItem.productId &&
+                attributesList == otherItem.attributesList
+        }
+    }
 }
 
 fun ShippingLabelPackage.getTitle(context: Context) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabelPackage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabelPackage.kt
@@ -18,6 +18,10 @@ data class ShippingLabelPackage(
     val packageId: String
         get() = "package$position"
 
+    @IgnoredOnParcel
+    val itemsCount: Int
+        get() = items.sumBy { it.quantity }
+
     @Parcelize
     data class Item(
         val productId: Long,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabelPackage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabelPackage.kt
@@ -19,8 +19,7 @@ data class ShippingLabelPackage(
         get() = "package$position"
 
     @IgnoredOnParcel
-    val itemsCount: Int
-        get() = items.sumBy { it.quantity }
+    val itemsCount = items.sumBy { it.quantity }
 
     @Parcelize
     data class Item(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -240,7 +240,7 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
             )
 
             return packages.mapIndexed { index, shippingLabelPackageUiModel ->
-                // Collapse all items except the added one
+                // Collapse all items except the destination one
                 shippingLabelPackageUiModel.copy(isExpanded = index == indexOfDestinationPackage)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemDialog.kt
@@ -89,5 +89,6 @@ class MoveShippingItemDialog : DialogFragment(R.layout.dialog_move_shipping_item
     }
 
     private val ShippingLabelPackage.description
-        get() = getTitle(requireContext()) + (selectedPackage?.let { ": ${it.title}" } ?: "")
+        get() = if (selectedPackage == null) getTitle(requireContext())
+        else "${getTitle(requireContext())}: ${selectedPackage.title}"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemDialog.kt
@@ -8,10 +8,10 @@ import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
-import com.woocommerce.android.R.string
 import com.woocommerce.android.databinding.DialogMoveShippingItemBinding
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.takeIfNotEqualTo
+import com.woocommerce.android.model.ShippingLabelPackage
 import com.woocommerce.android.model.getTitle
 import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage
 import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage.ExistingPackage
@@ -37,10 +37,8 @@ class MoveShippingItemDialog : DialogFragment(R.layout.dialog_move_shipping_item
     }
 
     private fun initUi(binding: DialogMoveShippingItemBinding) {
-        val packageDescription = viewModel.currentPackage.getTitle(requireContext()) +
-            (viewModel.currentPackage.selectedPackage?.let { ": ${it.title}" } ?: "")
         binding.dialogDescription.text =
-            getString(string.shipping_label_move_item_dialog_description, packageDescription)
+            getString(R.string.shipping_label_move_item_dialog_description, viewModel.currentPackage.description)
 
         with(viewModel.availableDestinations) {
             forEach {
@@ -76,13 +74,11 @@ class MoveShippingItemDialog : DialogFragment(R.layout.dialog_move_shipping_item
 
     private fun DestinationPackage.generateRadioButton(): RadioButton {
         return RadioButton(requireContext()).apply {
-            setText(
-                when (this@generateRadioButton) {
-                    is ExistingPackage -> TODO()
-                    NewPackage -> R.string.shipping_label_move_item_dialog_new_package_option
-                    OriginalPackage -> R.string.shipping_label_move_item_dialog_original_packaging_option
-                }
-            )
+            text = when (this@generateRadioButton) {
+                is ExistingPackage -> destinationPackage.description
+                NewPackage -> getString(R.string.shipping_label_move_item_dialog_new_package_option)
+                OriginalPackage -> getString(R.string.shipping_label_move_item_dialog_original_packaging_option)
+            }
             setOnCheckedChangeListener { _, isChecked ->
                 if (isChecked) {
                     viewModel.onDestinationPackageSelected(this@generateRadioButton)
@@ -91,4 +87,7 @@ class MoveShippingItemDialog : DialogFragment(R.layout.dialog_move_shipping_item
             tag = this@generateRadioButton
         }
     }
+
+    private val ShippingLabelPackage.description
+        get() = getTitle(requireContext()) + (selectedPackage?.let { ": ${it.title}" } ?: "")
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
@@ -70,7 +70,7 @@ class MoveShippingItemViewModel @Inject constructor(
         object NewPackage : DestinationPackage()
 
         @Parcelize
-        class ExistingPackage(val destinationPackage: ShippingLabelPackage) : DestinationPackage()
+        data class ExistingPackage(val destinationPackage: ShippingLabelPackage) : DestinationPackage()
 
         @Parcelize
         object OriginalPackage : DestinationPackage()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
@@ -3,8 +3,7 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.model.ShippingLabelPackage
-import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage.NewPackage
-import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage.OriginalPackage
+import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage.*
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -28,8 +27,10 @@ class MoveShippingItemViewModel @Inject constructor(
     val currentPackage = navArgs.currentPackage
 
     init {
-        // TODO
-        availableDestinations = listOf(NewPackage, OriginalPackage)
+        val availableExistingPackages = navArgs.packagesList.filter { it != navArgs.currentPackage }
+            .map { ExistingPackage(it) }
+
+        availableDestinations = availableExistingPackages + listOf(NewPackage, OriginalPackage)
     }
 
     fun onDestinationPackageSelected(destinationPackage: DestinationPackage) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
@@ -27,10 +27,12 @@ class MoveShippingItemViewModel @Inject constructor(
     val currentPackage = navArgs.currentPackage
 
     init {
-        val availableExistingPackages = navArgs.packagesList.filter { it != navArgs.currentPackage }
+        val availableExistingPackages = navArgs.packagesList.filter { it != currentPackage }
             .map { ExistingPackage(it) }
 
-        availableDestinations = availableExistingPackages + listOf(NewPackage, OriginalPackage)
+        availableDestinations = availableExistingPackages +
+            if (currentPackage.items.size == 1 && navArgs.item.quantity == 1) listOf(OriginalPackage)
+            else listOf(NewPackage, OriginalPackage)
     }
 
     fun onDestinationPackageSelected(destinationPackage: DestinationPackage) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
@@ -73,8 +73,8 @@ class ShippingCarrierRatesAdapter(
 
             binding.packageItemsCount.text = "- ${binding.root.resources.getQuantityString(
                 R.plurals.shipping_label_package_details_items_count,
-                rateList.itemCount,
-                rateList.itemCount
+                rateList.shippingPackage.itemsCount,
+                rateList.shippingPackage.itemsCount
             )}"
 
             (binding.rateOptions.adapter as? RateListAdapter)?.updateRates(rateList)
@@ -300,10 +300,6 @@ class ShippingCarrierRatesAdapter(
         val shippingPackage: ShippingLabelPackage,
         val rateOptions: List<ShippingRateItem>
     ) : Parcelable {
-        @IgnoredOnParcel
-        val itemCount
-            get() = shippingPackage.items.size
-
         @IgnoredOnParcel
         val selectedRate: ShippingRate?
             get() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -123,11 +123,10 @@ class ShippingLabelPackagesAdapter(
             val uiModel = uiModels[position]
             val shippingLabelPackage = uiModel.data
             binding.packageName.text = shippingLabelPackage.getTitle(context)
-            val itemsCount = shippingLabelPackage.items.sumBy { it.quantity }
             binding.packageItemsCount.text = "- ${context.resources.getQuantityString(
                 R.plurals.shipping_label_package_details_items_count,
-                itemsCount,
-                itemsCount
+                shippingLabelPackage.itemsCount,
+                shippingLabelPackage.itemsCount
             )}"
             with(binding.itemsList.adapter as PackageProductsAdapter) {
                 items = shippingLabelPackage.adaptItemsForUi()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -123,10 +123,11 @@ class ShippingLabelPackagesAdapter(
             val uiModel = uiModels[position]
             val shippingLabelPackage = uiModel.data
             binding.packageName.text = shippingLabelPackage.getTitle(context)
+            val itemsCount = shippingLabelPackage.items.sumBy { it.quantity }
             binding.packageItemsCount.text = "- ${context.resources.getQuantityString(
                 R.plurals.shipping_label_package_details_items_count,
-                shippingLabelPackage.items.size,
-                shippingLabelPackage.items.size
+                itemsCount,
+                itemsCount
             )}"
             with(binding.itemsList.adapter as PackageProductsAdapter) {
                 items = shippingLabelPackage.adaptItemsForUi()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelTestUtils.kt
@@ -48,7 +48,7 @@ object CreateShippingLabelTestUtils {
             position,
             selectedPackage ?: generatePackage(),
             weight,
-            listOf(Item(0L, "product", "", 2, 10f, BigDecimal.valueOf(10L)))
+            items ?: listOf(Item(0L, "product", "", 2, 10f, BigDecimal.valueOf(10L)))
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
@@ -1,10 +1,6 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
+import com.nhaarman.mockitokotlin2.*
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.ShippingAccountSettings
 import com.woocommerce.android.model.ShippingLabelPackage
@@ -28,6 +24,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import java.math.BigDecimal
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
@@ -61,6 +58,14 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
     private val variationDetailRepository: VariationDetailRepository = mock()
     private val shippingLabelRepository: ShippingLabelRepository = mock()
     private val parameterRepository: ParameterRepository = mock()
+    private val defaultItem = ShippingLabelPackage.Item(
+        productId = 15,
+        name = "test",
+        quantity = 1,
+        attributesList = "",
+        weight = 1f,
+        value = BigDecimal.TEN
+    )
 
     private lateinit var viewModel: EditShippingLabelPackagesViewModel
 
@@ -187,5 +192,111 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
         val createdShippingPackages = (event as ExitWithResult<List<ShippingLabelPackage>>).data
         assertThat(createdShippingPackages.size).isEqualTo(1)
         assertThat(createdShippingPackages.first().weight).isEqualTo(10.0f)
+    }
+
+    @Test
+    fun `given item's quantity bigger than 1, when the item is moved, then decrease the quantity`() = testBlocking {
+        val item = defaultItem.copy(quantity = 2)
+        val currentShippingPackages = arrayOf(
+            CreateShippingLabelTestUtils.generateShippingLabelPackage(
+                items = listOf(item)
+            )
+        )
+        setup(currentShippingPackages)
+
+        viewModel.onMoveButtonClicked(item, currentShippingPackages.first())
+        viewModel.handleMoveItemResult(
+            MoveShippingItemViewModel.MoveItemResult(
+                item,
+                currentShippingPackages.first(),
+                MoveShippingItemViewModel.DestinationPackage.NewPackage
+            )
+        )
+
+        val newPackages = viewModel.viewStateData.liveData.value!!.packages
+        assertThat(newPackages.size).isEqualTo(2)
+        assertThat(newPackages[0].items.first().quantity).isEqualTo(1)
+        assertThat(newPackages[1].items).isEqualTo(listOf(item.copy(quantity = 1)))
+    }
+
+    @Test
+    fun `given item's quantity equals 1, when the item is moved, then remove it from the package`() = testBlocking {
+        val currentShippingPackages = arrayOf(
+            CreateShippingLabelTestUtils.generateShippingLabelPackage(
+                items = listOf(defaultItem, defaultItem.copy(productId = 16))
+            )
+        )
+        setup(currentShippingPackages)
+
+        viewModel.onMoveButtonClicked(defaultItem, currentShippingPackages.first())
+        viewModel.handleMoveItemResult(
+            MoveShippingItemViewModel.MoveItemResult(
+                defaultItem,
+                currentShippingPackages.first(),
+                MoveShippingItemViewModel.DestinationPackage.NewPackage
+            )
+        )
+
+        val newPackages = viewModel.viewStateData.liveData.value!!.packages
+        assertThat(newPackages.size).isEqualTo(2)
+        assertThat(newPackages[0].items).doesNotContain(defaultItem)
+        assertThat(newPackages[1].items).isEqualTo(listOf(defaultItem))
+    }
+
+    @Test
+    fun `given package has same product, when item is moved to this package, then increase quantity`() = testBlocking {
+        val currentShippingPackages = arrayOf(
+            CreateShippingLabelTestUtils.generateShippingLabelPackage(
+                position = 1,
+                items = listOf(defaultItem)
+            ),
+            CreateShippingLabelTestUtils.generateShippingLabelPackage(
+                position = 2,
+                items = listOf(defaultItem)
+            )
+        )
+        setup(currentShippingPackages)
+
+        viewModel.onMoveButtonClicked(defaultItem, currentShippingPackages[1])
+        viewModel.handleMoveItemResult(
+            MoveShippingItemViewModel.MoveItemResult(
+                defaultItem,
+                currentShippingPackages[1],
+                MoveShippingItemViewModel.DestinationPackage.ExistingPackage(currentShippingPackages[0])
+            )
+        )
+
+        val newPackages = viewModel.viewStateData.liveData.value!!.packages
+        assertThat(newPackages.size).isEqualTo(1)
+        assertThat(newPackages[0].items.first().quantity).isEqualTo(2)
+    }
+
+    @Test
+    fun `given package hasn't same product, when item is moved to this package, then add new item`() = testBlocking {
+        val currentShippingPackages = arrayOf(
+            CreateShippingLabelTestUtils.generateShippingLabelPackage(
+                position = 1,
+                items = listOf(defaultItem.copy(productId = 16))
+            ),
+            CreateShippingLabelTestUtils.generateShippingLabelPackage(
+                position = 2,
+                items = listOf(defaultItem)
+            )
+        )
+        setup(currentShippingPackages)
+
+        viewModel.onMoveButtonClicked(defaultItem, currentShippingPackages[1])
+        viewModel.handleMoveItemResult(
+            MoveShippingItemViewModel.MoveItemResult(
+                defaultItem,
+                currentShippingPackages[1],
+                MoveShippingItemViewModel.DestinationPackage.ExistingPackage(currentShippingPackages[0])
+            )
+        )
+
+        val newPackages = viewModel.viewStateData.liveData.value!!.packages
+        assertThat(newPackages.size).isEqualTo(1)
+        assertThat(newPackages[0].items.size).isEqualTo(2)
+        assertThat(newPackages[0].items).contains(defaultItem)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModelTest.kt
@@ -1,0 +1,117 @@
+package com.woocommerce.android.ui.orders.shippinglabels.creation
+
+import com.woocommerce.android.initSavedStateHandle
+import com.woocommerce.android.model.ShippingLabelPackage
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.math.BigDecimal
+
+@RunWith(RobolectricTestRunner::class)
+class MoveShippingItemViewModelTest : BaseUnitTest() {
+    lateinit var viewModel: MoveShippingItemViewModel
+
+    private val defaultItem = ShippingLabelPackage.Item(
+        productId = 0L,
+        name = "product",
+        attributesList = "",
+        quantity = 3,
+        weight = 10f,
+        value = BigDecimal.valueOf(10L)
+    )
+
+    private val defaultNavArgs by lazy {
+        val shippingLabelPackage = CreateShippingLabelTestUtils.generateShippingLabelPackage(items = listOf(defaultItem))
+        MoveShippingItemDialogArgs(
+            item = shippingLabelPackage.items.first(),
+            currentPackage = shippingLabelPackage,
+            packagesList = listOf(shippingLabelPackage).toTypedArray()
+        )
+    }
+
+    fun setup(args: MoveShippingItemDialogArgs = defaultNavArgs) {
+        viewModel = MoveShippingItemViewModel(
+            savedState = args.initSavedStateHandle()
+        )
+    }
+
+    @Test
+    fun `given the item's quantity is more than 1, when the UI loads, then display new package option`() {
+        setup()
+
+        assertThat(viewModel.availableDestinations).contains(MoveShippingItemViewModel.DestinationPackage.NewPackage)
+    }
+
+    @Test
+    fun `given the package has other items, when the UI loads, then display new package option`() {
+        val currentItem = defaultItem.copy(quantity = 1)
+        val otherItem = defaultItem.copy(productId = 1L)
+        val shippingLabelPackage = CreateShippingLabelTestUtils.generateShippingLabelPackage(items = listOf(currentItem, otherItem))
+        val args = MoveShippingItemDialogArgs(
+            item = currentItem,
+            currentPackage = shippingLabelPackage,
+            packagesList = listOf(shippingLabelPackage).toTypedArray()
+        )
+
+        setup(args)
+
+        assertThat(viewModel.availableDestinations).contains(MoveShippingItemViewModel.DestinationPackage.NewPackage)
+    }
+
+    @Test
+    fun `given the package has only a single item, when the UI loads, then display new package option`() {
+        val currentItem = defaultItem.copy(quantity = 1)
+        val shippingLabelPackage = CreateShippingLabelTestUtils.generateShippingLabelPackage(items = listOf(currentItem))
+        val args = MoveShippingItemDialogArgs(
+            item = currentItem,
+            currentPackage = shippingLabelPackage,
+            packagesList = listOf(shippingLabelPackage).toTypedArray()
+        )
+
+        setup(args)
+
+        assertThat(viewModel.availableDestinations).doesNotContain(MoveShippingItemViewModel.DestinationPackage.NewPackage)
+    }
+
+    @Test
+    fun `given there are other packages, when the UI loads, then display existing package`() {
+        val firstPackage = CreateShippingLabelTestUtils.generateShippingLabelPackage(position = 1)
+        val secondPackage = CreateShippingLabelTestUtils.generateShippingLabelPackage(position = 2)
+        val args = MoveShippingItemDialogArgs(
+            item = firstPackage.items.first(),
+            currentPackage = firstPackage,
+            packagesList = listOf(firstPackage, secondPackage).toTypedArray()
+        )
+
+        setup(args)
+
+        assertThat(viewModel.availableDestinations)
+            .contains(MoveShippingItemViewModel.DestinationPackage.ExistingPackage(secondPackage))
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    fun `when move button is clicked, then navigate back with the selected destination`() {
+        val destination = MoveShippingItemViewModel.DestinationPackage.NewPackage
+        setup()
+
+        viewModel.onDestinationPackageSelected(destination)
+        viewModel.onMoveButtonClicked()
+
+        assertThat(viewModel.event.value).isInstanceOf(MultiLiveEvent.Event.ExitWithResult::class.java)
+        val event = viewModel.event.value as MultiLiveEvent.Event.ExitWithResult<MoveShippingItemViewModel.MoveItemResult>
+        assertThat(event.data.destination).isEqualTo(destination)
+    }
+
+    @Test
+    fun `when cancel is clicked, then close the dialog`() {
+        setup()
+
+        viewModel.onCancelButtonClicked()
+
+        assertThat(viewModel.event.value).isEqualTo(MultiLiveEvent.Event.Exit)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModelTest.kt
@@ -24,7 +24,8 @@ class MoveShippingItemViewModelTest : BaseUnitTest() {
     )
 
     private val defaultNavArgs by lazy {
-        val shippingLabelPackage = CreateShippingLabelTestUtils.generateShippingLabelPackage(items = listOf(defaultItem))
+        val shippingLabelPackage =
+            CreateShippingLabelTestUtils.generateShippingLabelPackage(items = listOf(defaultItem))
         MoveShippingItemDialogArgs(
             item = shippingLabelPackage.items.first(),
             currentPackage = shippingLabelPackage,
@@ -49,7 +50,8 @@ class MoveShippingItemViewModelTest : BaseUnitTest() {
     fun `given the package has other items, when the UI loads, then display new package option`() {
         val currentItem = defaultItem.copy(quantity = 1)
         val otherItem = defaultItem.copy(productId = 1L)
-        val shippingLabelPackage = CreateShippingLabelTestUtils.generateShippingLabelPackage(items = listOf(currentItem, otherItem))
+        val shippingLabelPackage =
+            CreateShippingLabelTestUtils.generateShippingLabelPackage(items = listOf(currentItem, otherItem))
         val args = MoveShippingItemDialogArgs(
             item = currentItem,
             currentPackage = shippingLabelPackage,
@@ -64,7 +66,8 @@ class MoveShippingItemViewModelTest : BaseUnitTest() {
     @Test
     fun `given the package has only a single item, when the UI loads, then display new package option`() {
         val currentItem = defaultItem.copy(quantity = 1)
-        val shippingLabelPackage = CreateShippingLabelTestUtils.generateShippingLabelPackage(items = listOf(currentItem))
+        val shippingLabelPackage =
+            CreateShippingLabelTestUtils.generateShippingLabelPackage(items = listOf(currentItem))
         val args = MoveShippingItemDialogArgs(
             item = currentItem,
             currentPackage = shippingLabelPackage,
@@ -73,7 +76,8 @@ class MoveShippingItemViewModelTest : BaseUnitTest() {
 
         setup(args)
 
-        assertThat(viewModel.availableDestinations).doesNotContain(MoveShippingItemViewModel.DestinationPackage.NewPackage)
+        assertThat(viewModel.availableDestinations)
+            .doesNotContain(MoveShippingItemViewModel.DestinationPackage.NewPackage)
     }
 
     @Test
@@ -102,7 +106,8 @@ class MoveShippingItemViewModelTest : BaseUnitTest() {
         viewModel.onMoveButtonClicked()
 
         assertThat(viewModel.event.value).isInstanceOf(MultiLiveEvent.Event.ExitWithResult::class.java)
-        val event = viewModel.event.value as MultiLiveEvent.Event.ExitWithResult<MoveShippingItemViewModel.MoveItemResult>
+        val event =
+            viewModel.event.value as MultiLiveEvent.Event.ExitWithResult<MoveShippingItemViewModel.MoveItemResult>
         assertThat(event.data.destination).isEqualTo(destination)
     }
 


### PR DESCRIPTION
Closes #4002, this implements the 2nd part by adding support of moving items to existing packages, and it adds unit tests.

The PR fixes an additional issue that I noticed, it corrects how items are counted: 9bbca1924d379413734686d775562e1d22679d46

#### Screenshots
<img width="355" alt="Screen Shot 2021-07-06 at 14 25 42" src="https://user-images.githubusercontent.com/1657201/124607820-19741300-de66-11eb-8419-c687e85267a4.png"> <img width="355" alt="Screen Shot 2021-07-06 at 14 25 35" src="https://user-images.githubusercontent.com/1657201/124607830-1b3dd680-de66-11eb-8338-fa797f1ab54f.png">


#### Testing
##### Case 1: move item to existing package
1. Create a multi-item order eligible for shipping label creation.
2. Open the order details in the app.
3. Click on Create shipping label.
4. When getting to the packages step, click on move and move one item to a different package.
5. Click on move on another item.
6. Confirm that you see the existing package as a possible destination.
7. Select it, and click on Move.
8. Confirm that the item has been moved to the right package.

##### Case 1: don't display new package unless it's needed
1. Create a single item order eligible for shipping label creation.
2. Open the order details in the app.
3. Click on Create shipping label.
4. When getting to the packages step, click on move.
5. Confirm that the option "new package" is not displayed.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
