### PR TITLE
Issue/4328 Always hide update available button if update was succesful

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.cardreader.CardReader
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.CardReaderStatus.Connected
+import com.woocommerce.android.cardreader.SoftwareUpdateAvailability
 import com.woocommerce.android.cardreader.SoftwareUpdateAvailability.CheckForUpdatesFailed
 import com.woocommerce.android.cardreader.SoftwareUpdateAvailability.Initializing
 import com.woocommerce.android.cardreader.SoftwareUpdateAvailability.UpToDate
@@ -50,30 +51,27 @@ class CardReaderDetailViewModel @Inject constructor(
         launch {
             cardReaderManager.readerStatus.collect { status ->
                 when (status) {
-                    is Connected -> checkForUpdates()
+                    is Connected -> cardReaderManager.softwareUpdateAvailability().collect(::handleSoftwareUpdateStatus)
                     else -> showNotConnectedState()
                 }
             }.exhaustive
         }
     }
 
-    private fun showNotConnectedState() {
-        viewState.value = NotConnectedState(onPrimaryActionClicked = ::onConnectBtnClicked)
+    fun onUpdateReaderResult(updateResult: UpdateResult) {
+        when (updateResult) {
+            SUCCESS -> {
+                handleSoftwareUpdateStatus(UpToDate)
+                triggerEvent(Event.ShowSnackbar(R.string.card_reader_detail_connected_update_success))
+            }
+            FAILED -> triggerEvent(Event.ShowSnackbar(R.string.card_reader_detail_connected_update_failed))
+            SKIPPED -> {
+            }
+        }.exhaustive
     }
 
-    private suspend fun checkForUpdates() {
-        cardReaderManager.softwareUpdateAvailability().collect { updateStatus ->
-            val readerStatus = cardReaderManager.readerStatus.value
-            if (readerStatus !is Connected) return@collect
-            when (updateStatus) {
-                Initializing -> viewState.value = Loading
-                UpToDate -> showConnectedState(readerStatus)
-                is UpdateAvailable -> showConnectedState(readerStatus, updateAvailable = true)
-                CheckForUpdatesFailed -> showConnectedState(readerStatus).also {
-                    triggerEvent(Event.ShowSnackbar(R.string.card_reader_detail_connected_update_check_failed))
-                }
-            }.exhaustive
-        }
+    private fun showNotConnectedState() {
+        viewState.value = NotConnectedState(onPrimaryActionClicked = ::onConnectBtnClicked)
     }
 
     private fun showConnectedState(readerStatus: Connected, updateAvailable: Boolean = false) {
@@ -128,14 +126,15 @@ class CardReaderDetailViewModel @Inject constructor(
         }
     }
 
-    fun onUpdateReaderResult(updateResult: UpdateResult) {
-        when (updateResult) {
-            SUCCESS -> {
-                launch { checkForUpdates() }
-                triggerEvent(Event.ShowSnackbar(R.string.card_reader_detail_connected_update_success))
-            }
-            FAILED -> triggerEvent(Event.ShowSnackbar(R.string.card_reader_detail_connected_update_failed))
-            SKIPPED -> {
+    private fun handleSoftwareUpdateStatus(updateStatus: SoftwareUpdateAvailability) {
+        val readerStatus = cardReaderManager.readerStatus.value
+        if (readerStatus !is Connected) return
+        when (updateStatus) {
+            Initializing -> viewState.value = Loading
+            UpToDate -> showConnectedState(readerStatus)
+            is UpdateAvailable -> showConnectedState(readerStatus, updateAvailable = true)
+            CheckForUpdatesFailed -> showConnectedState(readerStatus).also {
+                triggerEvent(Event.ShowSnackbar(R.string.card_reader_detail_connected_update_check_failed))
             }
         }.exhaustive
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
@@ -245,7 +245,6 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
             viewModel.onUpdateReaderResult(UpdateResult.SUCCESS)
 
             // THEN
-            verify(cardReaderManager).softwareUpdateAvailability()
             verifyConnectedState(
                 viewModel,
                 UiStringText(READER_NAME),
@@ -256,7 +255,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given software update available, when on update result successful, then connected with update emitted`() {
+    fun `given software update available, when on update result successful, then connected without update emitted`() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // GIVEN
             val viewModel = createViewModel()
@@ -266,12 +265,11 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
             viewModel.onUpdateReaderResult(UpdateResult.SUCCESS)
 
             // THEN
-            verify(cardReaderManager).softwareUpdateAvailability()
             verifyConnectedState(
                 viewModel,
                 UiStringText(READER_NAME),
                 UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("65"))),
-                updateAvailable = true
+                updateAvailable = false
             )
         }
     }
@@ -289,7 +287,6 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
             viewModel.onUpdateReaderResult(UpdateResult.SUCCESS)
 
             // THEN
-            verify(cardReaderManager).softwareUpdateAvailability()
             verifyConnectedState(
                 viewModel,
                 UiStringText(READER_NAME),
@@ -297,8 +294,6 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
                 updateAvailable = false
             )
             assertThat(events[0])
-                .isEqualTo(Event.ShowSnackbar(R.string.card_reader_detail_connected_update_check_failed))
-            assertThat(events[1])
                 .isEqualTo(Event.ShowSnackbar(R.string.card_reader_detail_connected_update_success))
         }
     }


### PR DESCRIPTION
Resolves #4328

Apparently, the SDK returns "update available" even if the update just has happened. I guess it refreshes the version of a reader when it connects to it. The current workaround is just to hide the update button when an update was successful.

### How to test
* Settings
* Manage readers
* Connect to the simulator
* Update
* Notice that the update button became invisible


https://user-images.githubusercontent.com/4923871/124753297-77b9f800-df31-11eb-9c66-776a1b0e7b40.mp4

