### PR TITLE
issue/4375 Error texts for the payment flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -395,6 +395,7 @@ class CardReaderPaymentViewModel
     enum class PaymentFlowError(val message: Int) {
         FETCHING_ORDER_FAILED(R.string.order_error_fetch_generic),
         NO_NETWORK(R.string.card_reader_payment_failed_no_network_state),
+        SERVER_ERROR(R.string.card_reader_payment_failed_server_error_state),
         PAYMENT_DECLINED(R.string.card_reader_payment_failed_card_declined_state),
         GENERIC_ERROR(R.string.card_reader_payment_failed_unexpected_error_state)
     }
@@ -405,5 +406,6 @@ class CardReaderPaymentViewModel
             CardPaymentStatusErrorType.PAYMENT_DECLINED -> PaymentFlowError.PAYMENT_DECLINED
             CardPaymentStatusErrorType.CARD_READ_TIMED_OUT,
             CardPaymentStatusErrorType.GENERIC_ERROR -> PaymentFlowError.GENERIC_ERROR
+            CardPaymentStatusErrorType.SERVER_ERROR -> PaymentFlowError.SERVER_ERROR
         }
 }

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_payment.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_payment.xml
@@ -106,11 +106,10 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/major_200"
-            android:layout_marginTop="@dimen/major_175"
-            android:layout_marginBottom="@dimen/major_100"
+            android:layout_marginBottom="@dimen/minor_100"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/payment_state_label"
+            app:layout_constraintBottom_toTopOf="@id/secondary_action_btn"
             tools:text="Send receipt" />
 
         <com.google.android.material.button.MaterialButton
@@ -121,7 +120,7 @@
             android:layout_marginHorizontal="@dimen/major_200"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/primary_action_btn"
+            app:layout_constraintBottom_toBottomOf="parent"
             tools:text="Print receipt" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -740,10 +740,11 @@
     <string name="card_reader_payment_collect_payment_state">Reader is ready</string>
     <string name="card_reader_payment_processing_payment_state">Processing payment</string>
     <string name="card_reader_payment_capturing_payment_state">Capturing payment</string>
-    <string name="card_reader_payment_failed_no_network_state" translatable="false">@string/error_generic_network</string>
+    <string name="card_reader_payment_failed_no_network_state">No internet connection</string>
+    <string name="card_reader_payment_failed_server_error_state">No connection to server</string>
     <string name="card_reader_payment_failed_card_declined_state">Card declined</string>
     <string name="card_reader_payment_failed_collecting_payment_timed_out_state">Card declined</string>
-    <string name="card_reader_payment_failed_unexpected_error_state">The payment did not succeed</string>
+    <string name="card_reader_payment_failed_unexpected_error_state">Sorry, this payment couldn\’t be processed</string>
 
     <string name="card_reader_payment_print_receipt">Print receipt</string>
     <string name="card_reader_payment_send_receipt">Send receipt</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.cardreader.CardPaymentStatus.CapturingPayment
 import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErrorType.GENERIC_ERROR
 import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErrorType.NO_NETWORK
 import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErrorType.PAYMENT_DECLINED
+import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErrorType.SERVER_ERROR
 import com.woocommerce.android.cardreader.CardPaymentStatus.CollectingPayment
 import com.woocommerce.android.cardreader.CardPaymentStatus.InitializingPayment
 import com.woocommerce.android.cardreader.CardPaymentStatus.PaymentCompleted
@@ -540,6 +541,20 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
             assertThat(viewState.paymentStateLabel).describedAs("paymentStateLabel")
                 .isEqualTo(R.string.card_reader_payment_failed_card_declined_state)
+        }
+
+    @Test
+    fun `when payment fails with server error, then correct paymentStateLabel is shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(cardReaderManager.collectPayment(any(), any(), any(), any(), any())).thenAnswer {
+                flow { emit(PaymentFailed(SERVER_ERROR, null, "")) }
+            }
+
+            viewModel.start()
+            val viewState = viewModel.viewStateData.value!!
+
+            assertThat(viewState.paymentStateLabel).describedAs("paymentStateLabel")
+                .isEqualTo(R.string.card_reader_payment_failed_server_error_state)
         }
 
     @Test

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardPaymentStatus.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardPaymentStatus.kt
@@ -18,6 +18,7 @@ sealed class CardPaymentStatus {
     enum class CardPaymentStatusErrorType {
         CARD_READ_TIMED_OUT,
         NO_NETWORK,
+        SERVER_ERROR,
         PAYMENT_DECLINED,
         GENERIC_ERROR
     }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentErrorMapper.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentErrorMapper.kt
@@ -6,12 +6,10 @@ import com.stripe.stripeterminal.model.external.TerminalException.TerminalErrorC
 import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErrorType.CARD_READ_TIMED_OUT
 import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErrorType.GENERIC_ERROR
 import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErrorType.NO_NETWORK
+import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErrorType.SERVER_ERROR
 import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErrorType.PAYMENT_DECLINED
 import com.woocommerce.android.cardreader.CardPaymentStatus.PaymentFailed
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
-import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse.Error.CaptureError
-import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse.Error.GenericError
-import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse.Error.MissingOrder
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse.Error.NetworkError
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse.Error.ServerError
 
@@ -41,10 +39,8 @@ class PaymentErrorMapper {
         val message = "Capturing payment failed: $capturePaymentResponse"
         val type = when (capturePaymentResponse) {
             NetworkError -> NO_NETWORK
-            GenericError,
-            MissingOrder,
-            CaptureError,
-            ServerError -> GENERIC_ERROR
+            ServerError -> SERVER_ERROR
+            else -> GENERIC_ERROR
         }
         return PaymentFailed(type, paymentData, message)
     }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentErrorMapperTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentErrorMapperTest.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErr
 import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErrorType.GENERIC_ERROR
 import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErrorType.NO_NETWORK
 import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErrorType.PAYMENT_DECLINED
+import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErrorType.SERVER_ERROR
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -118,9 +119,9 @@ class PaymentErrorMapperTest {
     }
 
     @Test
-    fun `when SERVER_ERROR capture payment exception thrown, then NO_NETWORK type returned`() {
+    fun `when SERVER_ERROR capture payment exception thrown, then SERVER_ERROR type returned`() {
         val result = mapper.mapCapturePaymentError(mock(), CapturePaymentResponse.Error.ServerError)
 
-        assertThat(result.type).isEqualTo(GENERIC_ERROR)
+        assertThat(result.type).isEqualTo(SERVER_ERROR)
     }
 }


### PR DESCRIPTION
Closes #4375 

The PR contains:
* SERVER_ERROR error to show specific text for this case
* Fixed layout to fit 2 lines error
* Text adjusted as per design

# How to test
* Open card-present payment eligible order (cash on delivery + USD)
* Click connect button
* Try to disable Bluetooth or the internet during different phases of the payment collection flow
* Notice the error cases and it's texts

![screen](https://user-images.githubusercontent.com/4923871/124770467-05eaaa00-df43-11eb-97a4-f07e3814b453.png)
![screen1](https://user-images.githubusercontent.com/4923871/124770473-07b46d80-df43-11eb-939d-3e15084f0f89.png)
![screen2](https://user-images.githubusercontent.com/4923871/124770477-084d0400-df43-11eb-8c75-60a6f1a1308b.png)
