### PR TITLE
Fix incorrect notice when saving product as draft

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -432,26 +432,6 @@ class ProductDetailFragment :
         progressDialog?.isCancelable = false
     }
 
-    private fun getSubmitDetailProgressDialog(): CustomProgressDialog {
-        val title: Int
-        val message: Int
-        when (viewModel.isProductUnderCreation) {
-            true -> {
-                title = if (viewModel.isDraftProduct()) {
-                    R.string.product_publish_draft_dialog_title
-                } else {
-                    R.string.product_publish_dialog_title
-                }
-                message = R.string.product_publish_dialog_message
-            }
-            else -> {
-                title = R.string.product_update_dialog_title
-                message = R.string.product_update_dialog_message
-            }
-        }
-        return CustomProgressDialog.show(getString(title), getString(message))
-    }
-
     private fun hideProgressDialog() {
         progressDialog?.dismiss()
         progressDialog = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1510,11 +1510,6 @@ class ProductDetailViewModel @Inject constructor(
     }
 
     /**
-     * Returns true if the product draft has a status of DRAFT
-     */
-    fun isDraftProduct() = viewState.productDraft?.status?.let { it == DRAFT } ?: false
-
-    /**
      * Add a new product to the backend only if network is connected.
      * Otherwise, an offline snackbar is displayed. Returns true only
      * if product successfully added

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -670,7 +670,8 @@ class ProductDetailViewModel @Inject constructor(
 
             launch {
                 val isSuccess = addProduct(it)
-                triggerEvent(ShowSnackbar(pickAddProductRequestSnackbarText(isSuccess)))
+                val snackbarMessage = pickAddProductRequestSnackbarText(isSuccess, productStatus)
+                triggerEvent(ShowSnackbar(snackbarMessage))
                 if (isSuccess) {
                     AnalyticsTracker.track(ADD_PRODUCT_SUCCESS)
                     if (exitWhenDone) {
@@ -697,15 +698,15 @@ class ProductDetailViewModel @Inject constructor(
         if (isAddFlowEntryPoint) string.product_detail_publish_product_success
         else string.product_detail_update_product_success
 
-    private fun pickAddProductRequestSnackbarText(productWasAdded: Boolean) =
+    private fun pickAddProductRequestSnackbarText(productWasAdded: Boolean, requestedProductStatus: ProductStatus) =
         if (productWasAdded) {
-            if (isDraftProduct()) {
+            if (requestedProductStatus == DRAFT) {
                 string.product_detail_publish_product_draft_success
             } else {
                 string.product_detail_publish_product_success
             }
         } else {
-            if (isDraftProduct()) {
+            if (requestedProductStatus == DRAFT) {
                 string.product_detail_publish_product_draft_error
             } else {
                 string.product_detail_publish_product_error

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -334,11 +334,9 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
 
         viewModel.start()
 
-        // change the status to draft so we can verify that isDraftProduct works - this will also
-        // force the viewModel to consider the product as changed, so when we click the back button
+        // this will force the viewModel to consider the product as changed, so when we click the back button
         // below it will show the discard dialog
         viewModel.updateProductDraft(productStatus = DRAFT)
-        assertThat(viewModel.isDraftProduct()).isTrue()
 
         var saveAsDraftShown = false
         viewModel.event.observeForever {


### PR DESCRIPTION
Summary
==========
Fixes issue #4371. This PR fixes the scenario where when creating a new product in the app and saving it as a draft for the first time, a notice appears and incorrectly states that the product was published when it was actually saved as a draft.

Screenshots
==========
| Expected  | Actual |
| ------------- | ------------- |
| <img width="280" height="585" alt="image" src="https://user-images.githubusercontent.com/1119271/124660333-4f63c800-de63-11eb-9069-61c5b01bf2b9.png"> | <img src="https://user-images.githubusercontent.com/5920403/124844931-faf83f80-df6b-11eb-8442-ac1b5896f1fe.png" width="280" height="585" /> |

Showcase
==========
<img src="https://user-images.githubusercontent.com/5920403/124844814-a654c480-df6b-11eb-8f79-38bf0e46fe95.gif" width="280" height="585" />

How to Test
==========
1. Go to Products > Add new product ("+" at bottom right).
1. Add a title, description, and price.
1. Tap the overflow menu and select "Save as draft".
1. Observe that a "Product published" notice is displayed briefly at the bottom of the screen.
1. Go to the product list and check to see if the product state is a draft or if it was published.

Update release notes:
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
