### PR TITLE
Shipping Labels: add support for shipping items in original packaging

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ContextExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ContextExt.kt
@@ -1,0 +1,7 @@
+package com.woocommerce.android.extensions
+
+import android.content.Context
+import androidx.annotation.ColorRes
+import androidx.core.content.ContextCompat
+
+fun Context.getColorCompat(@ColorRes colorRes: Int) = ContextCompat.getColor(this, colorRes)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingPackage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingPackage.kt
@@ -43,6 +43,10 @@ data class PackageDimensions(
     val width: Float,
     val height: Float
 ) : Parcelable {
+    @IgnoredOnParcel
+    val isValid
+        get() = length > 0f && width > 0f && height > 0f
+
     override fun toString(): String {
         return "$length x $width x $height" // This formatting mirrors how it's done in core.
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingPackage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingPackage.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.annotation.StringRes
 import com.woocommerce.android.R
 import com.woocommerce.android.model.ShippingPackage.Companion.INDIVIDUAL_PACKAGE
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.shippinglabels.WCPackagesResult.CustomPackage
 import org.wordpress.android.fluxc.model.shippinglabels.WCPackagesResult.PredefinedOption
@@ -21,6 +22,10 @@ data class ShippingPackage(
         const val CUSTOM_PACKAGE_CATEGORY = "custom"
         const val INDIVIDUAL_PACKAGE = "individual"
     }
+
+    @IgnoredOnParcel
+    val isIndividual
+        get() = id == INDIVIDUAL_PACKAGE
 
     fun toCustomPackageDataModel(): CustomPackage {
         return CustomPackage(
@@ -82,7 +87,7 @@ enum class CustomPackageType(@StringRes val stringRes: Int) {
     ENVELOPE(R.string.shipping_label_create_custom_package_field_type_envelope)
 }
 
-fun Product?.createIndividualShippingPackage(): ShippingPackage {
+fun IProduct?.createIndividualShippingPackage(): ShippingPackage {
     return ShippingPackage(
         id = INDIVIDUAL_PACKAGE,
         title = INDIVIDUAL_PACKAGE,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingPackage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingPackage.kt
@@ -91,15 +91,15 @@ enum class CustomPackageType(@StringRes val stringRes: Int) {
     ENVELOPE(R.string.shipping_label_create_custom_package_field_type_envelope)
 }
 
-fun IProduct?.createIndividualShippingPackage(): ShippingPackage {
+fun ShippingLabelPackage.Item.createIndividualShippingPackage(product: IProduct?): ShippingPackage {
     return ShippingPackage(
         id = INDIVIDUAL_PACKAGE,
-        title = INDIVIDUAL_PACKAGE,
+        title = name,
         isLetter = false,
         dimensions = PackageDimensions(
-            length = this?.length ?: 0f,
-            width = this?.width ?: 0f,
-            height = this?.height ?: 0f
+            length = product?.length ?: 0f,
+            width = product?.width ?: 0f,
+            height = product?.height ?: 0f
         ),
         boxWeight = 0f,
         category = INDIVIDUAL_PACKAGE

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingPackage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingPackage.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.model
 import android.os.Parcelable
 import androidx.annotation.StringRes
 import com.woocommerce.android.R
+import com.woocommerce.android.model.ShippingPackage.Companion.INDIVIDUAL_PACKAGE
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.shippinglabels.WCPackagesResult.CustomPackage
 import org.wordpress.android.fluxc.model.shippinglabels.WCPackagesResult.PredefinedOption
@@ -18,6 +19,7 @@ data class ShippingPackage(
 ) : Parcelable {
     companion object {
         const val CUSTOM_PACKAGE_CATEGORY = "custom"
+        const val INDIVIDUAL_PACKAGE = "individual"
     }
 
     fun toCustomPackageDataModel(): CustomPackage {
@@ -78,4 +80,19 @@ fun PredefinedOption.toAppModel(): List<ShippingPackage> {
 enum class CustomPackageType(@StringRes val stringRes: Int) {
     BOX(R.string.shipping_label_create_custom_package_field_type_box),
     ENVELOPE(R.string.shipping_label_create_custom_package_field_type_envelope)
+}
+
+fun Product?.createIndividualShippingPackage(): ShippingPackage {
+    return ShippingPackage(
+        id = INDIVIDUAL_PACKAGE,
+        title = INDIVIDUAL_PACKAGE,
+        isLetter = false,
+        dimensions = PackageDimensions(
+            length = this?.length ?: 0f,
+            width = this?.width ?: 0f,
+            height = this?.height ?: 0f
+        ),
+        boxWeight = 0f,
+        category = INDIVIDUAL_PACKAGE
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
@@ -144,6 +144,16 @@ class ShippingLabelRepository @Inject constructor(
             }
     }
 
+    /**
+     * Returns the last used package.
+     * Please note that this will ignore all errors, and return null for those cases
+     */
+    suspend fun getLastUsedPackage(): ShippingPackage? {
+        return getAccountSettings().model?.lastUsedBoxId?.let { id ->
+            getShippingPackages().model?.firstOrNull { it.id == id }
+        }
+    }
+
     suspend fun updatePaymentSettings(selectedPaymentMethodId: Int, emailReceipts: Boolean): WooResult<Unit> {
         return shippingLabelStore.updateAccountSettings(
             site = selectedSite.get(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
@@ -29,6 +29,7 @@ import javax.inject.Singleton
 
 @OpenClassOnDebug
 @Singleton
+@Suppress("TooManyFunctions")
 class ShippingLabelRepository @Inject constructor(
     private val shippingLabelStore: WCShippingLabelStore,
     private val selectedSite: SelectedSite

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -45,7 +45,7 @@ class EditShippingLabelPackagesFragment :
 
     private val packagesAdapter: ShippingLabelPackagesAdapter by lazy {
         ShippingLabelPackagesAdapter(
-            viewModel.weightUnit,
+            viewModel.siteParameters,
             viewModel::onWeightEdited,
             viewModel::onExpandedChanged,
             viewModel::onPackageSpinnerClicked,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -251,7 +251,7 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
                     else productDetailRepository.getProduct(it.productId)
                 }
 
-            val individualPackage = product.createIndividualShippingPackage()
+            val individualPackage = item.createIndividualShippingPackage(product)
             updatedPackages.add(
                 ShippingLabelPackageUiModel(
                     data = ShippingLabelPackage(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingIte
 import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.MoveItemResult
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.ProductDetailRepository
+import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.ui.products.variations.VariationDetailRepository
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -47,10 +48,7 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 
-    val weightUnit: String by lazy {
-        val parameters = parameterRepository.getParameters(KEY_PARAMETERS, savedState)
-        parameters.weightUnit ?: ""
-    }
+    val siteParameters: SiteParameters by lazy { parameterRepository.getParameters(KEY_PARAMETERS, savedState) }
 
     init {
         initState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -333,16 +333,21 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
             get() = packagesUiModels.map { it.data }
         val isDataValid: Boolean
             get() = packagesUiModels.isNotEmpty() &&
-                packagesUiModels.all {
-                    !it.data.weight.isNaN() && it.data.weight > 0.0 && it.data.selectedPackage != null
-                }
+                packagesUiModels.all { it.isValid }
     }
 
     @Parcelize
     data class ShippingLabelPackageUiModel(
         val isExpanded: Boolean = false,
         val data: ShippingLabelPackage
-    ) : Parcelable
+    ) : Parcelable {
+        @IgnoredOnParcel
+        val isValid: Boolean
+            get() = !data.weight.isNaN() &&
+                data.weight > 0.0 &&
+                data.selectedPackage != null &&
+                data.selectedPackage.dimensions.isValid
+    }
 
     data class OpenPackageSelectorEvent(val position: Int) : MultiLiveEvent.Event()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -168,6 +168,8 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
         triggerEvent(ShowMoveItemDialog(item, shippingPackage, viewState.packages))
     }
 
+    // all the logic is inside local functions, so it should be OK, but detekt complains still
+    @Suppress("ComplexMethod")
     fun handleMoveItemResult(result: MoveItemResult) {
         val packages = viewState.packagesUiModels.toMutableList()
         val item = result.item
@@ -245,7 +247,7 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
                 ?.items
                 ?.find { it.uniqueId == item.productId }
                 ?.let {
-                    if(it.isVariation) variationDetailRepository.getVariation(it.productId, it.variationId)
+                    if (it.isVariation) variationDetailRepository.getVariation(it.productId, it.variationId)
                     else productDetailRepository.getProduct(it.productId)
                 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -230,7 +230,7 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
 
             val indexOfDestinationPackage = updatedPackages.indexOfFirst { it.data == destination }
             updatedPackages[indexOfDestinationPackage] = ShippingLabelPackageUiModel(
-                data = currentPackage.copy(items = updatedItemsOfDestination)
+                data = destination.copy(items = updatedItemsOfDestination)
             )
 
             return packages.mapIndexed { index, shippingLabelPackageUiModel ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
@@ -28,7 +28,8 @@ class MoveShippingItemViewModel @Inject constructor(
     val currentPackage = navArgs.currentPackage
 
     init {
-        val availableExistingPackages = navArgs.packagesList.filter { it != currentPackage }
+        val availableExistingPackages = navArgs.packagesList
+            .filter { it != currentPackage && it.selectedPackage?.isIndividual != true }
             .map { ExistingPackage(it) }
 
         availableDestinations = availableExistingPackages +

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.model.ShippingLabelPackage
+import com.woocommerce.android.model.ShippingPackage
 import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.DestinationPackage.*
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -31,8 +32,11 @@ class MoveShippingItemViewModel @Inject constructor(
             .map { ExistingPackage(it) }
 
         availableDestinations = availableExistingPackages +
-            if (currentPackage.items.size == 1 && navArgs.item.quantity == 1) listOf(OriginalPackage)
-            else listOf(NewPackage, OriginalPackage)
+            when {
+                currentPackage.selectedPackage?.id == ShippingPackage.INDIVIDUAL_PACKAGE -> listOf(NewPackage)
+                currentPackage.items.size == 1 && navArgs.item.quantity == 1 -> listOf(OriginalPackage)
+                else -> listOf(NewPackage, OriginalPackage)
+            }
     }
 
     fun onDestinationPackageSelected(destinationPackage: DestinationPackage) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.databinding.ShippingLabelPackageProductListItemBi
 import com.woocommerce.android.extensions.collapse
 import com.woocommerce.android.extensions.expand
 import com.woocommerce.android.extensions.formatToString
+import com.woocommerce.android.extensions.getColorCompat
 import com.woocommerce.android.model.ShippingLabelPackage
 import com.woocommerce.android.model.getTitle
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPackagesViewModel.ShippingLabelPackageUiModel
@@ -142,19 +143,24 @@ class ShippingLabelPackagesAdapter(
             }
             if (shippingLabelPackage.selectedPackage?.isIndividual == true) {
                 binding.selectedPackageSpinner.isVisible = false
-                binding.individualPackageLabel.isVisible = true
+                binding.individualPackageLayout.isVisible = true
                 binding.individualPackageDimensions.isVisible = true
-                binding.individualPackageDimensions.text = context.getString(
-                    R.string.shipping_label_package_details_individual_package_dimensions,
-                    dimensionUnit,
-                    shippingLabelPackage.selectedPackage.dimensions.length.formatToString(),
-                    shippingLabelPackage.selectedPackage.dimensions.width.formatToString(),
-                    shippingLabelPackage.selectedPackage.dimensions.height.formatToString()
-                )
+                binding.individualPackageDimensions.text = with(shippingLabelPackage.selectedPackage.dimensions) {
+                    "${length.formatToString()} $dimensionUnit x" +
+                        " ${width.formatToString()} $dimensionUnit x" +
+                        " ${height.formatToString()} $dimensionUnit"
+                }
+                if (!shippingLabelPackage.selectedPackage.dimensions.isValid) {
+                    binding.individualPackageDimensions.setTextColor(context.getColorCompat(R.color.color_error))
+                    binding.individualPackageError.isVisible = true
+                } else {
+                    binding.individualPackageDimensions
+                        .setTextColor(context.getColorCompat(R.color.color_on_surface_medium))
+                    binding.individualPackageError.isVisible = false
+                }
             } else {
                 binding.selectedPackageSpinner.isVisible = true
-                binding.individualPackageLabel.isVisible = false
-                binding.individualPackageDimensions.isVisible = false
+                binding.individualPackageLayout.isVisible = false
                 binding.selectedPackageSpinner.setText(shippingLabelPackage.selectedPackage?.title ?: "")
             }
             if (!shippingLabelPackage.weight.isNaN()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -13,16 +13,18 @@ import com.woocommerce.android.databinding.ShippingLabelPackageDetailsListItemBi
 import com.woocommerce.android.databinding.ShippingLabelPackageProductListItemBinding
 import com.woocommerce.android.extensions.collapse
 import com.woocommerce.android.extensions.expand
+import com.woocommerce.android.extensions.formatToString
 import com.woocommerce.android.model.ShippingLabelPackage
 import com.woocommerce.android.model.getTitle
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPackagesViewModel.ShippingLabelPackageUiModel
 import com.woocommerce.android.ui.orders.shippinglabels.creation.PackageProductsAdapter.PackageProductViewHolder
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelPackagesAdapter.ShippingLabelPackageViewHolder
+import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.StringUtils
 
 class ShippingLabelPackagesAdapter(
-    val weightUnit: String,
+    val siteParameters: SiteParameters,
     val onWeightEdited: (Int, Float) -> Unit,
     val onExpandedChanged: (Int, Boolean) -> Unit,
     val onPackageSpinnerClicked: (Int) -> Unit,
@@ -34,6 +36,12 @@ class ShippingLabelPackagesAdapter(
             field = value
             diff.dispatchUpdatesTo(this)
         }
+
+    private val weightUnit
+        get() = siteParameters.weightUnit.orEmpty()
+
+    private val dimensionUnit
+        get() = siteParameters.dimensionUnit.orEmpty()
 
     init {
         setHasStableIds(true)
@@ -132,7 +140,23 @@ class ShippingLabelPackagesAdapter(
                 items = shippingLabelPackage.adaptItemsForUi()
                 moveItemClickListener = { item -> onMoveItemClicked(item, shippingLabelPackage) }
             }
-            binding.selectedPackageSpinner.setText(shippingLabelPackage.selectedPackage?.title ?: "")
+            if (shippingLabelPackage.selectedPackage?.isIndividual == true) {
+                binding.selectedPackageSpinner.isVisible = false
+                binding.individualPackageLabel.isVisible = true
+                binding.individualPackageDimensions.isVisible = true
+                binding.individualPackageDimensions.text = context.getString(
+                    R.string.shipping_label_package_details_individual_package_dimensions,
+                    dimensionUnit,
+                    shippingLabelPackage.selectedPackage.dimensions.length.formatToString(),
+                    shippingLabelPackage.selectedPackage.dimensions.width.formatToString(),
+                    shippingLabelPackage.selectedPackage.dimensions.height.formatToString()
+                )
+            } else {
+                binding.selectedPackageSpinner.isVisible = true
+                binding.individualPackageLabel.isVisible = false
+                binding.individualPackageDimensions.isVisible = false
+                binding.selectedPackageSpinner.setText(shippingLabelPackage.selectedPackage?.title ?: "")
+            }
             if (!shippingLabelPackage.weight.isNaN()) {
                 binding.weightEditText.setTextIfDifferent(shippingLabelPackage.weight.toString())
             }

--- a/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
@@ -106,6 +106,27 @@
             android:layout_marginEnd="@dimen/major_100"
             android:hint="@string/shipping_label_package_details_selected_package_hint" />
 
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/individual_package_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_75"
+            android:layout_marginEnd="@dimen/major_100"
+            android:text="@string/shipping_label_package_details_individual_package"
+            android:textAppearance="?attr/textAppearanceSubtitle1"
+            android:visibility="gone" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/individual_package_dimensions"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginEnd="@dimen/major_100"
+            android:textAppearance="?attr/textAppearanceSubtitle2"
+            android:visibility="gone"
+            tools:text="Item dimensions - 10 cm x 10 cm x 10 cm" />
+
         <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
             android:id="@+id/weight_edit_text"
             android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
@@ -106,26 +106,66 @@
             android:layout_marginEnd="@dimen/major_100"
             android:hint="@string/shipping_label_package_details_selected_package_hint" />
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/individual_package_label"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:id="@+id/individual_package_layout"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_75"
-            android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/shipping_label_package_details_individual_package"
-            android:textAppearance="?attr/textAppearanceSubtitle1"
-            android:visibility="gone" />
+            android:orientation="vertical">
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/individual_package_dimensions"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginEnd="@dimen/major_100"
-            android:textAppearance="?attr/textAppearanceSubtitle2"
-            android:visibility="gone"
-            tools:text="Item dimensions - 10 cm x 10 cm x 10 cm" />
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/major_100"
+                android:layout_marginTop="@dimen/minor_100"
+                android:text="@string/shipping_label_package_details_individual_package_title"
+                android:textAppearance="?attr/textAppearanceSubtitle1" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/individual_package_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/major_100"
+                android:text="@string/shipping_label_package_details_individual_package_subtitle"
+                android:textAppearance="?attr/textAppearanceBody2" />
+
+            <View
+                style="@style/Woo.Divider"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/minor_100" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/major_100"
+                android:layout_marginTop="@dimen/minor_100"
+                android:text="@string/shipping_label_package_details_individual_package_dimensions"
+                android:textAppearance="?attr/textAppearanceSubtitle1" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/individual_package_dimensions"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/major_100"
+                android:textAppearance="?attr/textAppearanceBody2"
+                tools:text="10cm x 10cm x 10cm" />
+
+            <View
+                style="@style/Woo.Divider"
+                android:layout_marginTop="@dimen/minor_100" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/individual_package_error"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/major_100"
+                android:layout_marginTop="@dimen/minor_100"
+                android:drawablePadding="@dimen/minor_100"
+                android:text="@string/shipping_label_package_details_individual_package_dimensions_error"
+                android:textAppearance="?attr/textAppearanceCaption"
+                android:textColor="@color/color_error"
+                app:drawableStartCompat="@drawable/ic_info_outline_24dp"
+                app:drawableTint="@color/color_error" />
+        </LinearLayout>
 
         <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
             android:id="@+id/weight_edit_text"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -494,8 +494,10 @@
         <item quantity="one">%d item</item>
         <item quantity="other">%d items</item>
     </plurals>
-    <string name="shipping_label_package_details_individual_package">Individually Shipped Item</string>
-    <string name="shipping_label_package_details_individual_package_dimensions">Item Dimensions - %2$s %1$s x %3$s %1$s x %4$s %1$s</string>
+    <string name="shipping_label_package_details_individual_package_subtitle">Individually Shipped Item</string>
+    <string name="shipping_label_package_details_individual_package_dimensions">Item Dimensions</string>
+    <string name="shipping_label_package_details_individual_package_title">Original packaging</string>
+    <string name="shipping_label_package_details_individual_package_dimensions_error">Package dimensions must be greater than zero. Please update your item’s dimensions in the Shipping section of your product page to continue.</string>
     <string name="shipping_label_items_count_placeholder">Items count</string>
     <string name="shipping_label_package_details_title_template">Package %1$d</string>
     <string name="shipping_label_packages_loading_title">Loading Packages!</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -494,6 +494,8 @@
         <item quantity="one">%d item</item>
         <item quantity="other">%d items</item>
     </plurals>
+    <string name="shipping_label_package_details_individual_package">Individually Shipped Item</string>
+    <string name="shipping_label_package_details_individual_package_dimensions">Item Dimensions - %2$s %1$s x %3$s %1$s x %4$s %1$s</string>
     <string name="shipping_label_items_count_placeholder">Items count</string>
     <string name="shipping_label_package_details_title_template">Package %1$d</string>
     <string name="shipping_label_packages_loading_title">Loading Packages!</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelTestUtils.kt
@@ -38,6 +38,17 @@ object CreateShippingLabelTestUtils {
         )
     }
 
+    fun generateIndividualPackage(): ShippingPackage {
+        return ShippingPackage(
+            id = ShippingPackage.INDIVIDUAL_PACKAGE,
+            title = ShippingPackage.INDIVIDUAL_PACKAGE,
+            category = ShippingPackage.INDIVIDUAL_PACKAGE,
+            isLetter = false,
+            dimensions = PackageDimensions(1.0f, 1.0f, 1.0f),
+            boxWeight = 0f
+        )
+    }
+
     fun generateShippingLabelPackage(
         position: Int = 1,
         weight: Float = 10f,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
@@ -299,4 +299,33 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
         assertThat(newPackages[0].items.size).isEqualTo(2)
         assertThat(newPackages[0].items).contains(defaultItem)
     }
+
+    @Test
+    fun `when item is moved to original packaging, then add correct package to the list`() = testBlocking {
+        val currentShippingPackages = arrayOf(
+            CreateShippingLabelTestUtils.generateShippingLabelPackage(
+                position = 1,
+                items = listOf(defaultItem)
+            )
+        )
+        setup(currentShippingPackages)
+
+        viewModel.onMoveButtonClicked(defaultItem, currentShippingPackages[0])
+        viewModel.handleMoveItemResult(
+            MoveShippingItemViewModel.MoveItemResult(
+                defaultItem,
+                currentShippingPackages[0],
+                MoveShippingItemViewModel.DestinationPackage.OriginalPackage
+            )
+        )
+
+        val newPackages = viewModel.viewStateData.liveData.value!!.packages
+        assertThat(newPackages.size).isEqualTo(1)
+        assertThat(newPackages[0].selectedPackage!!.isIndividual).isTrue
+        with(newPackages[0].selectedPackage!!.dimensions) {
+            assertThat(width).isEqualTo(testProduct.width)
+            assertThat(length).isEqualTo(testProduct.length)
+            assertThat(height).isEqualTo(testProduct.height)
+        }
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
@@ -2,9 +2,7 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation
 
 import com.nhaarman.mockitokotlin2.*
 import com.woocommerce.android.initSavedStateHandle
-import com.woocommerce.android.model.ShippingAccountSettings
 import com.woocommerce.android.model.ShippingLabelPackage
-import com.woocommerce.android.model.StoreOwnerDetails
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRepository
@@ -36,18 +34,6 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
     private val availablePackages = listOf(
         CreateShippingLabelTestUtils.generatePackage("id1", "provider1"),
         CreateShippingLabelTestUtils.generatePackage("id2", "provider2")
-    )
-
-    private val shippingAccountSettings = ShippingAccountSettings(
-        canEditSettings = true,
-        canManagePayments = true,
-        paymentMethods = emptyList(),
-        selectedPaymentId = null,
-        lastUsedBoxId = "id1",
-        storeOwnerDetails = StoreOwnerDetails(
-            "email", "username", "username", "name"
-        ),
-        isEmailReceiptEnabled = true
     )
 
     private val testOrder = OrderTestUtils.generateTestOrder(ORDER_ID)
@@ -86,14 +72,14 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
 
     @Test
     fun `test first opening of the screen`() = coroutinesTestRule.testDispatcher.runBlockingTest {
-        whenever(shippingLabelRepository.getAccountSettings()).thenReturn(WooResult(shippingAccountSettings))
+        whenever(shippingLabelRepository.getLastUsedPackage()).thenReturn(availablePackages.first())
 
         setup(emptyArray())
         var viewState: ViewState? = null
         viewModel.viewStateData.observeForever { _, new -> viewState = new }
 
         verify(orderDetailRepository).getOrder(any())
-        verify(shippingLabelRepository).getAccountSettings()
+        verify(shippingLabelRepository).getLastUsedPackage()
         assertThat(viewState!!.packagesUiModels.size).isEqualTo(1)
         assertThat(viewState!!.packages.first().selectedPackage).isEqualTo(availablePackages.first())
     }
@@ -116,20 +102,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
 
     @Test
     fun `no last used package`() = coroutinesTestRule.testDispatcher.runBlockingTest {
-        val shippingAccountSettings = shippingAccountSettings.copy(lastUsedBoxId = null)
-        whenever(shippingLabelRepository.getAccountSettings()).thenReturn(WooResult(shippingAccountSettings))
-
-        setup(emptyArray())
-        var viewState: ViewState? = null
-        viewModel.viewStateData.observeForever { _, new -> viewState = new }
-
-        assertThat(viewState!!.packages.first().selectedPackage).isNull()
-    }
-
-    @Test
-    fun `last used package deleted`() = coroutinesTestRule.testDispatcher.runBlockingTest {
-        val shippingAccountSettings = shippingAccountSettings.copy(lastUsedBoxId = "missingId")
-        whenever(shippingLabelRepository.getAccountSettings()).thenReturn(WooResult(shippingAccountSettings))
+        whenever(shippingLabelRepository.getLastUsedPackage()).thenReturn(null)
 
         setup(emptyArray())
         var viewState: ViewState? = null
@@ -140,7 +113,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
 
     @Test
     fun `edit weight of package`() = coroutinesTestRule.testDispatcher.runBlockingTest {
-        whenever(shippingLabelRepository.getAccountSettings()).thenReturn(WooResult(shippingAccountSettings))
+        whenever(shippingLabelRepository.getLastUsedPackage()).thenReturn(availablePackages.first())
 
         setup(emptyArray())
         var viewState: ViewState? = null
@@ -153,7 +126,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
 
     @Test
     fun `select a package`() = coroutinesTestRule.testDispatcher.runBlockingTest {
-        whenever(shippingLabelRepository.getAccountSettings()).thenReturn(WooResult(shippingAccountSettings))
+        whenever(shippingLabelRepository.getLastUsedPackage()).thenReturn(availablePackages.first())
 
         setup(emptyArray())
         var viewState: ViewState? = null
@@ -166,7 +139,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
 
     @Test
     fun `exit without saving changes`() = coroutinesTestRule.testDispatcher.runBlockingTest {
-        whenever(shippingLabelRepository.getAccountSettings()).thenReturn(WooResult(shippingAccountSettings))
+        whenever(shippingLabelRepository.getLastUsedPackage()).thenReturn(availablePackages.first())
 
         setup(emptyArray())
         var event: MultiLiveEvent.Event? = null
@@ -179,7 +152,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
     @Suppress("UNCHECKED_CAST")
     @Test
     fun `save changes and exit`() = coroutinesTestRule.testDispatcher.runBlockingTest {
-        whenever(shippingLabelRepository.getAccountSettings()).thenReturn(WooResult(shippingAccountSettings))
+        whenever(shippingLabelRepository.getLastUsedPackage()).thenReturn(availablePackages.first())
 
         setup(emptyArray())
         var event: MultiLiveEvent.Event? = null

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModelTest.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation
 
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.ShippingLabelPackage
-import com.woocommerce.android.model.ShippingPackage
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import org.assertj.core.api.Assertions.assertThat
@@ -116,7 +115,6 @@ class MoveShippingItemViewModelTest : BaseUnitTest() {
 
         assertThat(viewModel.availableDestinations)
             .doesNotContain(MoveShippingItemViewModel.DestinationPackage.OriginalPackage)
-
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModelTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation
 
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.ShippingLabelPackage
+import com.woocommerce.android.model.ShippingPackage
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import org.assertj.core.api.Assertions.assertThat
@@ -64,7 +65,7 @@ class MoveShippingItemViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given the package has only a single item, when the UI loads, then display new package option`() {
+    fun `given the package has only a single item, when the UI loads, then hide new package option`() {
         val currentItem = defaultItem.copy(quantity = 1)
         val shippingLabelPackage =
             CreateShippingLabelTestUtils.generateShippingLabelPackage(items = listOf(currentItem))
@@ -94,6 +95,28 @@ class MoveShippingItemViewModelTest : BaseUnitTest() {
 
         assertThat(viewModel.availableDestinations)
             .contains(MoveShippingItemViewModel.DestinationPackage.ExistingPackage(secondPackage))
+    }
+
+    @Test
+    fun `given item is in individual package, when the UI loads, then hide the original package option`() {
+        val currentItem = defaultItem.copy(quantity = 1)
+        val shippingLabelPackage =
+            CreateShippingLabelTestUtils.generateShippingLabelPackage(
+                items = listOf(currentItem),
+                selectedPackage = CreateShippingLabelTestUtils.generateIndividualPackage()
+            )
+
+        val args = MoveShippingItemDialogArgs(
+            item = currentItem,
+            currentPackage = shippingLabelPackage,
+            packagesList = listOf(shippingLabelPackage).toTypedArray()
+        )
+
+        setup(args)
+
+        assertThat(viewModel.availableDestinations)
+            .doesNotContain(MoveShippingItemViewModel.DestinationPackage.OriginalPackage)
+
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModelTest.kt
@@ -97,6 +97,25 @@ class MoveShippingItemViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given there are individual packages, when the UI loads, then exclude them from existing packages list`() {
+        val firstPackage = CreateShippingLabelTestUtils.generateShippingLabelPackage(position = 1)
+        val secondPackage = CreateShippingLabelTestUtils.generateShippingLabelPackage(
+            position = 2,
+            selectedPackage = CreateShippingLabelTestUtils.generateIndividualPackage()
+        )
+        val args = MoveShippingItemDialogArgs(
+            item = firstPackage.items.first(),
+            currentPackage = firstPackage,
+            packagesList = listOf(firstPackage, secondPackage).toTypedArray()
+        )
+
+        setup(args)
+
+        assertThat(viewModel.availableDestinations)
+            .doesNotContain(MoveShippingItemViewModel.DestinationPackage.ExistingPackage(secondPackage))
+    }
+
+    @Test
     fun `given item is in individual package, when the UI loads, then hide the original package option`() {
         val currentItem = defaultItem.copy(quantity = 1)
         val shippingLabelPackage =


### PR DESCRIPTION
Closes #4003, this adds supporting for moving items to be shipped in their individual original packaging.

<img width="352" alt="Screen Shot 2021-07-08 at 11 25 29" src="https://user-images.githubusercontent.com/1657201/124907306-e3f33500-dfdf-11eb-9e57-d0d6ca693e94.png">   <img width="352" alt="Screen Shot 2021-07-08 at 11 25 13" src="https://user-images.githubusercontent.com/1657201/124907311-e5bcf880-dfdf-11eb-8247-fe289726bac2.png">

#### Testing
1. Make sure dimensions are cleared from [shipping settings](https://d.pr/i/gixQP4) of a  product in your store.
2. Create an order eligible for shipping label creation with this product.
3. Go to order details in the app.
4. Click on Create shipping labels.
5. When you reach the packaging step, click on "Move" button of the item.
6. Select the option "Ship in original packaging"
7. Confirm that there is an error displayed about missing dimensions.
8. Navigate back to the product details, and specify some dimensions in shipping settings.
9. Repeat steps 3 to 6
10. Confirm that the correct dimensions are displayed correctly.
11. Continue the label purchase process.
12. Go to the order details, and check the label details ([the button view details](https://d.pr/i/AmY0CH)), and confirm that it says "individual packaging" 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
