### PR TITLE
issue/4383-reader-detail-orange-divider

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailFragment.kt
@@ -85,6 +85,7 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
                     is ConnectedState -> {
                         with(binding.readerConnectedState) {
                             UiHelpers.setTextOrHide(enforcedUpdateTv, state.enforceReaderUpdate)
+                            enforcedUpdateDivider.visibility = enforcedUpdateTv.visibility
                             UiHelpers.setTextOrHide(readerNameTv, state.readerName)
                             UiHelpers.setTextOrHide(readerBatteryTv, state.readerBattery)
                             UiHelpers.setTextOrHide(primaryActionBtn, state.primaryButtonState?.text)

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_detail_connected_state.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_detail_connected_state.xml
@@ -19,20 +19,24 @@
         android:drawablePadding="@dimen/major_100"
         android:padding="@dimen/major_100"
         android:text="@string/card_reader_detail_connected_enforced_update_software"
-        android:textColor="@color/color_on_surface_high" />
+        android:textColor="@color/color_on_surface_high"
+        android:visibility="gone"
+        tools:visibility="visible" />
 
     <View
-        android:background="@color/warning_banner_foreground_color"
         android:id="@+id/enforced_update_divider"
-        style="@style/Woo.Divider" />
+        style="@style/Woo.Divider"
+        android:background="@color/warning_banner_foreground_color"
+        android:visibility="gone"
+        tools:visibility="visible" />
 
     <com.google.android.material.textview.MaterialTextView
         style="@style/Woo.TextView.Subtitle1"
         android:layout_width="wrap_content"
-        android:letterSpacing="0.15"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/major_100"
         android:layout_marginBottom="@dimen/minor_100"
+        android:letterSpacing="0.15"
         android:text="@string/card_reader_detail_connected_header"
         android:textColor="@color/color_on_surface_disabled"
         android:textSize="@dimen/text_minor_60" />


### PR DESCRIPTION
Fixes #4383 by setting the visibility of the "enforced update" divider to that of the "enforced update" TextView.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
