### PR TITLE
Issue/4309 Turning of bluetooth breaks the connection flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -244,7 +244,7 @@ class CardReaderConnectViewModel @Inject constructor(
             } else {
                 tracker.track(AnalyticsTracker.Stat.CARD_READER_CONNECTION_FAILED)
                 WooLog.e(WooLog.T.CARD_READER, "Connecting to reader failed.")
-                viewState.value = ConnectingFailedState({ onConnectToReaderClicked(cardReader) }, ::onCancelClicked)
+                viewState.value = ConnectingFailedState({ startFlow() }, ::onCancelClicked)
             }
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -454,7 +454,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given connecting failed screen shown, when user clicks on retry, then connecting restarted`() =
+    fun `given connecting failed screen shown, when user clicks on retry, then flow restarted`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             init(connectingSucceeds = false)
             (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
@@ -462,7 +462,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
             pauseDispatcher()
             (viewModel.viewStateData.value as ConnectingFailedState).onPrimaryActionClicked()
 
-            assertThat(viewModel.viewStateData.value).isInstanceOf(ConnectingState::class.java)
+            assertThat(viewModel.viewStateData.value).isInstanceOf(ScanningState::class.java)
             resumeDispatcher()
         }
 


### PR DESCRIPTION
Resolves #4309 

The PR restarts the flow from the beginning if an error happened during the connection phase.  In conjunction with the auto re-connection feature, I think it should be a quite reasonable approach (@malinajirka wdyt?)

### How to test
* Go to the settings
* Click connect to the reader
* During connection turn off Bluetooth
* Notice "We could not connect your reader"
* Turn on Bluetooth
* Click try again
* Notice the discovery has been restarted 

https://user-images.githubusercontent.com/4923871/124931835-4150ab80-e00b-11eb-963c-ca980685585b.mp4

