### PR TITLE
Shipping labels: show a discard changes dialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -22,6 +22,7 @@ import com.woocommerce.android.model.ShippingLabelPackage
 import com.woocommerce.android.model.ShippingRate
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowAddressEditor
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowCustomsForm
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowPackageDetails
@@ -56,6 +57,8 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAd
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SUGGESTED_ADDRESS_DISCARDED
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.PriceUtils
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.widgets.CustomProgressDialog
 import com.woocommerce.android.widgets.SkeletonView
@@ -65,7 +68,7 @@ import java.math.BigDecimal
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shipping_label) {
+class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shipping_label), BackPressListener {
     private var progressDialog: CustomProgressDialog? = null
 
     @Inject lateinit var uiMessageResolver: UIMessageResolver
@@ -265,6 +268,8 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
                         )
                     findNavController().navigateSafely(action)
                 }
+                is ShowDialog -> event.showDialog()
+                is Exit -> findNavController().navigateUp()
                 else -> event.isHandled = false
             }
         }
@@ -333,6 +338,11 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
         binding.orderSummaryLayout.purchaseLabelButton.setOnClickListener {
             viewModel.onPurchaseButtonClicked(binding.orderSummaryLayout.markOrderCompleteCheckbox.isChecked)
         }
+    }
+
+    override fun onRequestAllowBackPress(): Boolean {
+        viewModel.onBackButtonClicked()
+        return false
     }
 
     private fun ShippingLabelCreationStepView.update(data: StepUiState) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -22,6 +22,7 @@ import com.woocommerce.android.model.ShippingLabelPackage
 import com.woocommerce.android.model.ShippingRate
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowAddressEditor
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowCustomsForm
@@ -89,9 +90,10 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
         initializeViews(binding)
     }
 
-    override fun onPause() {
-        super.onPause()
+    override fun onStop() {
+        super.onStop()
         progressDialog?.dismiss()
+        WooDialog.onCleared()
     }
 
     private fun initializeViewModel(binding: FragmentCreateShippingLabelBinding) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -694,6 +694,8 @@ class ShippingLabelsStateMachine @Inject constructor() {
     }
 
     sealed class State : Parcelable {
+        open val data: StateMachineData? = null
+
         @Parcelize
         object Idle : State()
 
@@ -704,40 +706,40 @@ class ShippingLabelsStateMachine @Inject constructor() {
         data class DataLoading(val orderId: String) : State()
 
         @Parcelize
-        data class WaitingForInput(val data: StateMachineData) : State()
+        data class WaitingForInput(override val data: StateMachineData) : State()
 
         @Parcelize
-        data class OriginAddressValidation(val data: StateMachineData) : State()
+        data class OriginAddressValidation(override val data: StateMachineData) : State()
 
         @Parcelize
-        data class OriginAddressSuggestion(val data: StateMachineData) : State()
+        data class OriginAddressSuggestion(override val data: StateMachineData) : State()
 
         @Parcelize
-        data class OriginAddressEditing(val data: StateMachineData) : State()
+        data class OriginAddressEditing(override val data: StateMachineData) : State()
 
         @Parcelize
-        data class ShippingAddressValidation(val data: StateMachineData) : State()
+        data class ShippingAddressValidation(override val data: StateMachineData) : State()
 
         @Parcelize
-        data class ShippingAddressSuggestion(val data: StateMachineData) : State()
+        data class ShippingAddressSuggestion(override val data: StateMachineData) : State()
 
         @Parcelize
-        data class ShippingAddressEditing(val data: StateMachineData) : State()
+        data class ShippingAddressEditing(override val data: StateMachineData) : State()
 
         @Parcelize
-        data class PackageSelection(val data: StateMachineData) : State()
+        data class PackageSelection(override val data: StateMachineData) : State()
 
         @Parcelize
-        data class CustomsDeclaration(val data: StateMachineData) : State()
+        data class CustomsDeclaration(override val data: StateMachineData) : State()
 
         @Parcelize
-        data class ShippingCarrierSelection(val data: StateMachineData) : State()
+        data class ShippingCarrierSelection(override val data: StateMachineData) : State()
 
         @Parcelize
-        data class PaymentSelection(val data: StateMachineData) : State()
+        data class PaymentSelection(override val data: StateMachineData) : State()
 
         @Parcelize
-        data class PurchaseLabels(val data: StateMachineData, val fulfillOrder: Boolean) : State()
+        data class PurchaseLabels(override val data: StateMachineData, val fulfillOrder: Boolean) : State()
     }
 
     sealed class Event {


### PR DESCRIPTION
Closes #4257, this adds a discard changes dialog if the shipping labels form has some changes.

<img width="352" alt="Screen Shot 2021-07-08 at 14 43 48" src="https://user-images.githubusercontent.com/1657201/124932510-0c3c5d00-dffb-11eb-8c73-25e1d0c5656b.png">

#### Testing
1. Create an order eligible for shipping label creation.
2. Open the order details in the app.
3. Click on "Create shipping label"
4. Click on back button.
5. Confirm that you can leave the form without any warning.
6. Click on "Create shipping label" a second time.
7. Finish some steps.
8. Click on back button on the main screen of the form.
9. Confirm that a discard changes dialog is shown.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
