### PR TITLE
Issue/4356 printing on configuration change 2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
@@ -35,6 +35,7 @@ class CardReaderPaymentDialog : DialogFragment(R.layout.fragment_card_reader_pay
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        viewModel.onViewCreated()
         return object : Dialog(requireContext(), theme) {
             override fun onBackPressed() {
                 viewModel.onBackPressed()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -322,7 +322,7 @@ class CardReaderPaymentViewModel
         )
 
     // TODO cardreader don't hardcode currency symbol ($)
-    private fun Order.getAmountLabel() = "$${total}"
+    private fun Order.getAmountLabel() = "$$total"
 
     private fun Order.getReceiptDocumentName() = "receipt-order-$remoteId"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -140,7 +140,7 @@ class CardReaderPaymentViewModel
             currency = order.currency,
             customerEmail = customerEmail.ifEmpty { null }
         ).collect { paymentStatus ->
-            onPaymentStatusChanged(order.remoteId, customerEmail, paymentStatus, getAmountLabel(order))
+            onPaymentStatusChanged(order.remoteId, customerEmail, paymentStatus, order.getAmountLabel())
         }
     }
 
@@ -212,13 +212,13 @@ class CardReaderPaymentViewModel
         launch {
             val order = orderRepository.getOrder(arguments.orderIdentifier)
                 ?: throw IllegalStateException("Order URL not available.")
-            val amountLabel = getAmountLabel(order)
+            val amountLabel = order.getAmountLabel()
             val receiptUrl = getReceiptUrl(order.remoteId)
 
             viewState.postValue(
                 PaymentSuccessfulState(
-                    getAmountLabel(order),
-                    { onPrintReceiptClicked(amountLabel, receiptUrl, getReceiptDocumentName(order.remoteId)) },
+                    order.getAmountLabel(),
+                    { onPrintReceiptClicked(amountLabel, receiptUrl, order.getReceiptDocumentName()) },
                     { onSendReceiptClicked(receiptUrl, order.billingAddress.email) }
                 )
             )
@@ -242,7 +242,7 @@ class CardReaderPaymentViewModel
     private fun startPrintingFlow() {
         val order = orderRepository.getOrder(arguments.orderIdentifier)
             ?: throw IllegalStateException("Order URL not available.")
-        triggerEvent(PrintReceipt(getReceiptUrl(order.remoteId), getReceiptDocumentName(order.remoteId)))
+        triggerEvent(PrintReceipt(getReceiptUrl(order.remoteId), order.getReceiptDocumentName()))
     }
 
     private fun onSendReceiptClicked(receiptUrl: String, billingEmail: String) {
@@ -322,9 +322,9 @@ class CardReaderPaymentViewModel
         )
 
     // TODO cardreader don't hardcode currency symbol ($)
-    private fun getAmountLabel(order: Order) = "$${order.total}"
+    private fun Order.getAmountLabel() = "$${total}"
 
-    private fun getReceiptDocumentName(orderId: Long) = "receipt-order-$orderId"
+    private fun Order.getReceiptDocumentName() = "receipt-order-$remoteId"
 
     sealed class ViewState(
         @StringRes val hintLabel: Int? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -131,7 +131,6 @@ class CardReaderPaymentViewModel
         }
     }
 
-    @Suppress("LongParameterList")
     private suspend fun collectPaymentFlow(cardReaderManager: CardReaderManager, order: Order) {
         val customerEmail = order.billingAddress.email
         cardReaderManager.collectPayment(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -58,7 +58,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
-import java.math.BigDecimal
 import javax.inject.Inject
 
 private const val ARTIFICIAL_RETRY_DELAY = 500L
@@ -142,8 +141,8 @@ class CardReaderPaymentViewModel
             currency = order.currency,
             customerEmail = customerEmail.ifEmpty { null }
         ).collect { paymentStatus ->
-                onPaymentStatusChanged(order.remoteId, customerEmail, paymentStatus, getAmountLabel(order))
-            }
+            onPaymentStatusChanged(order.remoteId, customerEmail, paymentStatus, getAmountLabel(order))
+        }
     }
 
     private fun onPaymentStatusChanged(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -41,6 +41,7 @@ import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.V
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.FailedPaymentState
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.LoadingDataState
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.PaymentSuccessfulState
+import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.PrintingReceiptState
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.ProcessingPaymentState
 import com.woocommerce.android.ui.orders.cardreader.CardReaderPaymentViewModel.ViewState.ReFetchingOrderState
 import com.woocommerce.android.ui.orders.cardreader.ReceiptEvent.PrintReceipt
@@ -106,6 +107,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         )
 
         val mockedOrder = mock<Order>()
+        whenever(orderRepository.getOrder(any())).thenReturn(mockedOrder)
         whenever(mockedOrder.total).thenReturn(DUMMY_TOTAL)
         whenever(mockedOrder.currency).thenReturn("USD")
         val address = mock<Address>()
@@ -122,6 +124,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         whenever(selectedSite.get()).thenReturn(SiteModel().apply { name = "testName" })
         whenever(resourceProvider.getString(anyOrNull(), anyOrNull())).thenReturn("")
         whenever(paymentCollectibilityChecker.isCollectable(any())).thenReturn(true)
+        whenever(appPrefsWrapper.getReceiptUrl(anyOrNull(),anyOrNull(),anyOrNull(),anyOrNull())).thenReturn("test url")
     }
 
     @Test
@@ -610,7 +613,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when user clicks on print receipt button, then progress shown`() =
+    fun `when user clicks on print receipt button, then printing receipt state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(cardReaderManager.collectPayment(any(), any(), any(), any(), any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
@@ -619,11 +622,12 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
             (viewModel.viewStateData.value as PaymentSuccessfulState).onPrimaryActionClicked.invoke()
 
-            assertThat((viewModel.viewStateData.value as PaymentSuccessfulState).isProgressVisible).isTrue()
+            assertThat(viewModel.viewStateData.value)
+                .isInstanceOf(PrintingReceiptState::class.java)
         }
 
     @Test
-    fun `when print result received, then progress hidden`() =
+    fun `when print result received, then payment successful state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(cardReaderManager.collectPayment(any(), any(), any(), any(), any())).thenAnswer {
                 flow { emit(PaymentCompleted("")) }
@@ -633,7 +637,36 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
             viewModel.onPrintResult(mock())
 
-            assertThat((viewModel.viewStateData.value as PaymentSuccessfulState).isProgressVisible).isFalse()
+            assertThat(viewModel.viewStateData.value).isInstanceOf(PaymentSuccessfulState::class.java)
+        }
+
+    @Test
+    fun `given in printing receipt state, when view recreated, then PrintReceipt event emitted`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(cardReaderManager.collectPayment(any(), any(), any(), any(), any())).thenAnswer {
+                flow { emit(PaymentCompleted("")) }
+            }
+            viewModel.start()
+            (viewModel.viewStateData.value as PaymentSuccessfulState).onPrimaryActionClicked.invoke()
+
+            viewModel.onViewCreated()
+
+            assertThat(viewModel.event.value).isInstanceOf(PrintReceipt::class.java)
+        }
+
+    @Test
+    fun `given not in printing receipt state, when view recreated, then state not changed`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(cardReaderManager.collectPayment(any(), any(), any(), any(), any())).thenAnswer {
+                flow<CardPaymentStatus> {}
+            }
+            viewModel.start()
+            val originalState = viewModel.viewStateData.value
+            assertThat(originalState).isNotInstanceOf(PrintingReceiptState::class.java)
+
+            viewModel.onViewCreated()
+
+            assertThat(viewModel.viewStateData.value).isEqualTo(originalState)
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -124,7 +124,8 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         whenever(selectedSite.get()).thenReturn(SiteModel().apply { name = "testName" })
         whenever(resourceProvider.getString(anyOrNull(), anyOrNull())).thenReturn("")
         whenever(paymentCollectibilityChecker.isCollectable(any())).thenReturn(true)
-        whenever(appPrefsWrapper.getReceiptUrl(anyOrNull(),anyOrNull(),anyOrNull(),anyOrNull())).thenReturn("test url")
+        whenever(appPrefsWrapper.getReceiptUrl(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()))
+            .thenReturn("test url")
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -71,6 +71,7 @@ import java.math.BigDecimal
 private val DUMMY_TOTAL = BigDecimal(10.72)
 private const val DUMMY_ORDER_NUMBER = "123"
 
+@Suppress("LargeClass")
 @InternalCoroutinesApi
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)


### PR DESCRIPTION
Resolves #4356

This PR is heavily based on [the solution implemented](https://github.com/woocommerce/woocommerce-android/pull/4359) by @kidinov with a few changes.

I recommend reviewing this PR by commits.

Summary of the changes - for details refer to [the original PR](https://github.com/woocommerce/woocommerce-android/pull/4359)
- Print/Send buttons are hidden when the OS printing UI is being loaded
- the OS printing UI is reshown after a configuration change = fixes an infinite loading state after a configuration change

To test:
Refer to [the original PR](https://github.com/woocommerce/woocommerce-android/pull/4359) for test instructions and video previews. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
