### PR TITLE
Fix charged amount for a partially refunded order

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -142,6 +142,8 @@ data class Order(
 
     fun getProductIds() = items.map { it.productId }
 
+    fun getNetTotal(): BigDecimal = total - refundTotal
+
     sealed class Status(val value: String) : Parcelable {
         companion object {
             fun fromValue(value: String): Status {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -71,6 +71,9 @@ data class Order(
     @IgnoredOnParcel
     val isRefundAvailable = refundTotal < total && availableRefundQuantity > 0
 
+    @IgnoredOnParcel
+    val netTotal: BigDecimal = total - refundTotal
+
     @Parcelize
     data class ShippingMethod(
         val id: String,
@@ -141,8 +144,6 @@ data class Order(
     }
 
     fun getProductIds() = items.map { it.productId }
-
-    fun getNetTotal(): BigDecimal = total - refundTotal
 
     sealed class Status(val value: String) : Parcelable {
         companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityChecker.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.cardreader
 import com.woocommerce.android.extensions.CASH_ON_DELIVERY_PAYMENT_TYPE
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
+import java.math.BigDecimal
 import javax.inject.Inject
 
 class CardReaderPaymentCollectibilityChecker @Inject constructor(
@@ -13,6 +14,9 @@ class CardReaderPaymentCollectibilityChecker @Inject constructor(
             currency.equals("USD", ignoreCase = true) &&
                 (listOf(Order.Status.Pending, Order.Status.Processing, Order.Status.OnHold)).any { it == status } &&
                 !isOrderPaid &&
+                // TODO cardreader remove the following check when the backend issue is fixed
+                // https://github.com/Automattic/woocommerce-payments/issues/2390
+                order.refundTotal == BigDecimal.ZERO &&
                 // Empty payment method explanation:
                 // https://github.com/woocommerce/woocommerce/issues/29471
                 (paymentMethod == CASH_ON_DELIVERY_PAYMENT_TYPE || paymentMethod.isEmpty()) &&

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityChecker.kt
@@ -16,7 +16,7 @@ class CardReaderPaymentCollectibilityChecker @Inject constructor(
                 !isOrderPaid &&
                 // TODO cardreader remove the following check when the backend issue is fixed
                 // https://github.com/Automattic/woocommerce-payments/issues/2390
-                order.refundTotal == BigDecimal.ZERO &&
+                BigDecimal.ZERO.compareTo(order.refundTotal) == 0 &&
                 // Empty payment method explanation:
                 // https://github.com/woocommerce/woocommerce/issues/29471
                 (paymentMethod == CASH_ON_DELIVERY_PAYMENT_TYPE || paymentMethod.isEmpty()) &&

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -322,7 +322,7 @@ class CardReaderPaymentViewModel
         )
 
     // TODO cardreader don't hardcode currency symbol ($)
-    private fun Order.getAmountLabel() = "$${netTotal}"
+    private fun Order.getAmountLabel() = "$$netTotal"
 
     private fun Order.getReceiptDocumentName() = "receipt-order-$remoteId"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -136,7 +136,7 @@ class CardReaderPaymentViewModel
         cardReaderManager.collectPayment(
             paymentDescription = order.getPaymentDescription(),
             orderId = order.remoteId,
-            amount = order.getNetTotal(),
+            amount = order.netTotal,
             currency = order.currency,
             customerEmail = customerEmail.ifEmpty { null }
         ).collect { paymentStatus ->
@@ -322,7 +322,7 @@ class CardReaderPaymentViewModel
         )
 
     // TODO cardreader don't hardcode currency symbol ($)
-    private fun Order.getAmountLabel() = "$${getNetTotal()}"
+    private fun Order.getAmountLabel() = "$${netTotal}"
 
     private fun Order.getReceiptDocumentName() = "receipt-order-$remoteId"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -108,10 +108,10 @@ class CardReaderPaymentViewModel
                     cardReaderManager,
                     order.getPaymentDescription(),
                     order.remoteId,
-                    order.total,
+                    order.getNetTotal(),
                     order.currency,
                     order.billingAddress.email,
-                    "$${order.total}"
+                    "$${order.getNetTotal()}"
                 )
             } ?: run {
                 tracker.track(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
@@ -99,7 +99,7 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
         // Populate or hide refund section
         if (order.refundTotal > BigDecimal.ZERO) {
             binding.paymentInfoRefundSection.show()
-            binding.paymentInfoNewTotal.text = formatCurrencyForDisplay(order.getNetTotal())
+            binding.paymentInfoNewTotal.text = formatCurrencyForDisplay(order.netTotal)
         } else {
             binding.paymentInfoRefundSection.hide()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
@@ -99,8 +99,7 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
         // Populate or hide refund section
         if (order.refundTotal > BigDecimal.ZERO) {
             binding.paymentInfoRefundSection.show()
-            val newTotal = order.total - order.refundTotal
-            binding.paymentInfoNewTotal.text = formatCurrencyForDisplay(newTotal)
+            binding.paymentInfoNewTotal.text = formatCurrencyForDisplay(order.getNetTotal())
         } else {
             binding.paymentInfoRefundSection.hide()
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import java.math.BigDecimal
 import java.util.Date
 
 class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
@@ -235,11 +236,27 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             assertThat(isCollectable).isFalse()
         }
 
+    @Test
+    // TODO cardreader remove the following test when the backend issue is fixed
+    // https://github.com/Automattic/woocommerce-payments/issues/2390
+    fun `when order has been refunded, then hide collect button `() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val order = getOrder(refundTotal = 99)
+
+            // WHEN
+            val isCollectable = checker.isCollectable(order)
+
+            // THEN
+            assertThat(isCollectable).isFalse()
+        }
+
     private fun getOrder(
         currency: String = "USD",
         paymentStatus: Order.Status = Order.Status.Processing,
         paymentMethod: String = "cod",
         paymentMethodTitle: String = "title",
+        refundTotal: Int = 0,
         datePaid: Date? = null
     ): Order {
         return generatedOrder.copy(
@@ -247,7 +264,8 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             paymentMethod = paymentMethod,
             paymentMethodTitle = paymentMethodTitle,
             datePaid = datePaid,
-            status = paymentStatus
+            status = paymentStatus,
+            refundTotal = BigDecimal(refundTotal)
         )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -853,7 +853,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given order partially refunded, when payment started, then net total is used`() =
+    fun `given order partially refunded, when payment started, then only the unpaid amount is charged`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             val expectedAmount = BigDecimal(123456789)
             whenever(mockedOrder.getNetTotal()).thenReturn(expectedAmount)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -69,7 +69,8 @@ import org.robolectric.RobolectricTestRunner
 import org.wordpress.android.fluxc.model.SiteModel
 import java.math.BigDecimal
 
-private val DUMMY_NET_TOTAL = BigDecimal(10.72)
+private val DUMMY_TOTAL = BigDecimal(10.72)
+private val DUMMY_NET_TOTAL = BigDecimal(7.01)
 private const val DUMMY_ORDER_NUMBER = "123"
 
 @Suppress("LargeClass")
@@ -89,7 +90,6 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     private val paymentCollectibilityChecker: CardReaderPaymentCollectibilityChecker = mock()
     private val tracker: AnalyticsTrackerWrapper = mock()
     private val appPrefsWrapper: AppPrefsWrapper = mock()
-    private val mockedOrder = mock<Order>()
 
     private val paymentFailedWithEmptyDataForRetry = PaymentFailed(GENERIC_ERROR, null, "dummy msg")
     private val paymentFailedWithValidDataForRetry = PaymentFailed(GENERIC_ERROR, mock(), "dummy msg")
@@ -111,7 +111,8 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
         val mockedOrder = mock<Order>()
         whenever(orderRepository.getOrder(any())).thenReturn(mockedOrder)
-        whenever(mockedOrder.getNetTotal()).thenReturn(DUMMY_NET_TOTAL)
+        whenever(mockedOrder.netTotal).thenReturn(DUMMY_NET_TOTAL)
+        whenever(mockedOrder.total).thenReturn(DUMMY_TOTAL)
         whenever(mockedOrder.currency).thenReturn("USD")
         val address = mock<Address>()
         whenever(mockedOrder.billingAddress).thenReturn(address)
@@ -855,15 +856,12 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given order partially refunded, when payment started, then only the unpaid amount is charged`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            val expectedAmount = BigDecimal(123456789)
-            whenever(mockedOrder.getNetTotal()).thenReturn(expectedAmount)
-
             val amountCaptor = argumentCaptor<BigDecimal>()
 
             viewModel.start()
 
             verify(cardReaderManager).collectPayment(any(), any(), amountCaptor.capture(), any(), any())
-            assertThat(amountCaptor.firstValue).isEqualTo(expectedAmount)
+            assertThat(amountCaptor.firstValue).isEqualTo(DUMMY_NET_TOTAL)
         }
 
     private fun simulateFetchOrderJobState(inProgress: Boolean) {


### PR DESCRIPTION
Fixes issue originally reported by @rachelmcr on iOS https://github.com/woocommerce/woocommerce-ios/issues/4583

Make sure https://github.com/woocommerce/woocommerce-android/pull/4388 is merged first. ☑️


To Test:

1. Make sure your store is set up to accept in-person payments.
2. Create a new order on your store with more than one product.
3. Partially refund the order, so there is still at least one product in the order.
4. In the app, open the order detail for that order.
5. Tap the "Collect payment" button.
6. Notice that the modal shows only the remaining amount the user needs to pay for the order
7. Finish the payment flow and verify the correct amount is shown on the receipt 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
