### PR TITLE
Hide collect button on orders with refund

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityChecker.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.cardreader
 import com.woocommerce.android.extensions.CASH_ON_DELIVERY_PAYMENT_TYPE
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
+import java.math.BigDecimal
 import javax.inject.Inject
 
 class CardReaderPaymentCollectibilityChecker @Inject constructor(
@@ -13,6 +14,9 @@ class CardReaderPaymentCollectibilityChecker @Inject constructor(
             currency.equals("USD", ignoreCase = true) &&
                 (listOf(Order.Status.Pending, Order.Status.Processing, Order.Status.OnHold)).any { it == status } &&
                 !isOrderPaid &&
+                // TODO cardreader remove the following check when the backend issue is fixed
+                // https://github.com/Automattic/woocommerce-payments/issues/2390
+                order.refundTotal == BigDecimal.ZERO &&
                 // Empty payment method explanation:
                 // https://github.com/woocommerce/woocommerce/issues/29471
                 (paymentMethod == CASH_ON_DELIVERY_PAYMENT_TYPE || paymentMethod.isEmpty()) &&

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityChecker.kt
@@ -16,7 +16,7 @@ class CardReaderPaymentCollectibilityChecker @Inject constructor(
                 !isOrderPaid &&
                 // TODO cardreader remove the following check when the backend issue is fixed
                 // https://github.com/Automattic/woocommerce-payments/issues/2390
-                order.refundTotal == BigDecimal.ZERO &&
+                BigDecimal.ZERO.compareTo(order.refundTotal) == 0 &&
                 // Empty payment method explanation:
                 // https://github.com/woocommerce/woocommerce/issues/29471
                 (paymentMethod == CASH_ON_DELIVERY_PAYMENT_TYPE || paymentMethod.isEmpty()) &&

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import java.math.BigDecimal
 import java.util.Date
 
 class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
@@ -235,11 +236,27 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             assertThat(isCollectable).isFalse()
         }
 
+    @Test
+    // TODO cardreader remove the following test when the backend issue is fixed
+    // https://github.com/Automattic/woocommerce-payments/issues/2390
+    fun `when order has been refunded, then hide collect button `() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val order = getOrder(refundTotal = 99)
+
+            // WHEN
+            val isCollectable = checker.isCollectable(order)
+
+            // THEN
+            assertThat(isCollectable).isFalse()
+        }
+
     private fun getOrder(
         currency: String = "USD",
         paymentStatus: Order.Status = Order.Status.Processing,
         paymentMethod: String = "cod",
         paymentMethodTitle: String = "title",
+        refundTotal: Int = 0,
         datePaid: Date? = null
     ): Order {
         return generatedOrder.copy(
@@ -247,7 +264,8 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
             paymentMethod = paymentMethod,
             paymentMethodTitle = paymentMethodTitle,
             datePaid = datePaid,
-            status = paymentStatus
+            status = paymentStatus,
+            refundTotal = BigDecimal(refundTotal)
         )
     }
 }


### PR DESCRIPTION
This PR hides the collect payment button on orders which were either fully or partially refunded. This is necessary since the "capture_terminal_payment" endpoint returns HTTP 500 when we try to charge just a part of `order.total`.

To test:
- open order with a partially refund and make sure collect payment button is hidden
- open order without any refunds and notice collect payment button is visible -> refund part of the order -> notice collect payment button disappears

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
