### PR TITLE
Shipping Labels: Add create custom package form when there are no existing active packages

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPackagesViewModel.OpenPackageSelectorEvent
+import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPackagesViewModel.OpenPackageCreatorEvent
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPackagesViewModel.ShowMoveItemDialog
 import com.woocommerce.android.ui.orders.shippinglabels.creation.MoveShippingItemViewModel.MoveItemResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -133,6 +134,15 @@ class EditShippingLabelPackagesFragment :
 
                     findNavController().navigateSafely(action)
                 }
+                is OpenPackageCreatorEvent -> {
+                    val action = EditShippingLabelPackagesFragmentDirections
+                        .actionEditShippingLabelPackagesFragmentToShippingLabelCreatePackageFragment(
+                            position = event.position
+                        )
+
+                    findNavController().navigateSafely(action)
+                }
+
                 is ShowMoveItemDialog -> {
                     val action = EditShippingLabelPackagesFragmentDirections
                         .actionEditShippingLabelPackagesFragmentToMoveShippingItemDialog(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.ProductDetailRepository
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.ui.products.variations.VariationDetailRepository
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -68,11 +67,6 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
                 triggerEvent(Exit)
             } else {
                 availablePackages = shippingPackagesResult.model
-
-                if (availablePackages.isNullOrEmpty() && !FeatureFlag.SHIPPING_LABELS_M4.isEnabled()) {
-                    triggerEvent(ShowSnackbar(string.shipping_label_packages_loading_error))
-                    triggerEvent(Exit)
-                }
             }
 
             val packagesList = if (arguments.shippingLabelPackages.isEmpty()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -50,7 +50,7 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
 
     val siteParameters: SiteParameters by lazy { parameterRepository.getParameters(KEY_PARAMETERS, savedState) }
 
-    private var createdPackages: List<ShippingPackage>? = null
+    private var availablePackages: List<ShippingPackage>? = null
 
     init {
         initState()
@@ -66,7 +66,7 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
                 triggerEvent(ShowSnackbar(string.shipping_label_packages_loading_error))
                 triggerEvent(Exit)
             } else {
-                createdPackages = shippingPackagesResult.model
+                availablePackages = shippingPackagesResult.model
             }
 
             val packagesList = if (arguments.shippingLabelPackages.isEmpty()) {
@@ -149,7 +149,7 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
     }
 
     fun onPackageSpinnerClicked(position: Int) {
-        createdPackages?.let {
+        availablePackages?.let {
             if (it.isNotEmpty()) {
                 triggerEvent(OpenPackageSelectorEvent(position))
             } else {
@@ -159,8 +159,8 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
     }
 
     fun onPackageSelected(position: Int, selectedPackage: ShippingPackage) {
-        if (createdPackages.isNullOrEmpty()) {
-            createdPackages = listOf(selectedPackage)
+        launch {
+            availablePackages = shippingLabelRepository.getShippingPackages().model ?: listOf(selectedPackage)
         }
 
         val packages = viewState.packagesUiModels.toMutableList()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.ProductDetailRepository
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.ui.products.variations.VariationDetailRepository
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -67,6 +68,11 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
                 triggerEvent(Exit)
             } else {
                 availablePackages = shippingPackagesResult.model
+
+                if (availablePackages.isNullOrEmpty() && !FeatureFlag.SHIPPING_LABELS_M4.isEnabled()) {
+                    triggerEvent(ShowSnackbar(string.shipping_label_packages_loading_error))
+                    triggerEvent(Exit)
+                }
             }
 
             val packagesList = if (arguments.shippingLabelPackages.isEmpty()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreationFeatures.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreationFeatures.kt
@@ -4,6 +4,6 @@ import com.woocommerce.android.util.FeatureFlag
 
 object ShippingLabelCreationFeatures {
     val CAN_CREATE_PAYMENT_METHOD = FeatureFlag.SHIPPING_LABELS_M4.isEnabled()
-    const val CAN_CREATE_PACKAGE = false
+    val CAN_CREATE_PACKAGE = FeatureFlag.SHIPPING_LABELS_M4.isEnabled()
     const val CAN_CREATE_CUSTOMS_FORM = true
 }

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -411,6 +411,13 @@
         <action
             android:id="@+id/action_editShippingLabelPackagesFragment_to_moveShippingItemDialog"
             app:destination="@id/moveShippingItemDialog" />
+        <action
+            android:id="@+id/action_editShippingLabelPackagesFragment_to_shippingLabelCreatePackageFragment"
+            app:destination="@id/shippingLabelCreatePackageFragment"
+            app:enterAnim="@anim/activity_slide_in_from_right"
+            app:exitAnim="@anim/activity_slide_out_to_left"
+            app:popEnterAnim="@anim/activity_slide_in_from_left"
+            app:popExitAnim="@anim/activity_slide_out_to_right" />
     </fragment>
     <fragment
         android:id="@+id/shippingPackageSelectorFragment"


### PR DESCRIPTION
# What this PR is for:

This PR adds a functionality to allow users to add a custom package, during shipping label creation process, it closes #4000.

There are several cases where the "add custom package" form can be shown. This PR specifically handles the case where the "add custom package" functionality is added where the user's site **has no activated packages yet**.

# Testing instructions:
0. Make sure the site has Shipping Labels creation enabled, and have an Order where Shipping Labels can be created.
1. Delete all activated packages in wp-admin: `wp-admin/admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings`.
2. In the app, find the Order from step 0 and create a Shipping Label, complete the "Ship from" and "Ship to" steps, then continue with the "Packaging details" step.
3. Tap the "Package selected" spinner, this will open the "Add new package" screen.
4. Create a Custom Package. Once done correctly, the screen will be navigated back to the "Package Details" screen.Make sure the name of the recently created package is shown in the "Package selected" spinner.
5. Tap the "Package selected" spinner. Make sure this opens the "Selected Package" screen, and the recently added package is listed there.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
