### PR TITLE
Store readers id when a reader connected

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -67,7 +67,7 @@ class CardReaderConnectViewModel @Inject constructor(
      * as MultiLiveEvent.pending field gets set to false when the first events is handled and all the other events
      * are ignored.
      * Example: Imagine VM sends CheckPermissions event -> the view layer synchronously checks the permissions and
-     * invokes vm.permissionChecked(true), the vm sendsF CheckBluetoothEvent, but this event is never observed by the
+     * invokes vm.permissionChecked(true), the vm sends CheckBluetoothEvent, but this event is never observed by the
      * view layer, since `MultiLiveEvent.pending` was set to false by the previous event.
      * Since this VM doesn't need to have support for MultiLiveEvent, it overrides _event from the parent
      * with SingleLiveEvent.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.util
 
 import android.content.Context
 import com.woocommerce.android.util.payment.CardPresentEligibleFeatureChecker
+import javax.inject.Inject
 
 /**
  * "Feature flags" are used to hide in-progress features from release versions
@@ -22,5 +23,9 @@ enum class FeatureFlag {
             CARD_READER -> CardPresentEligibleFeatureChecker.isCardPresentEligible.get()
             CARD_READER_RECONNECTION -> CARD_READER.isEnabled() && PackageUtils.isDebugBuild()
         }
+    }
+
+    class CardReaderReconnectionWrapper @Inject constructor() {
+        fun isEnabled() = CARD_READER_RECONNECTION.isEnabled()
     }
 }


### PR DESCRIPTION
Resolves #4310 

The PR implements saving in the App Prefs reader id when it's connected

There is no visual changes so testing manually not really possible