### PR TITLE
Clear last know reader on disconnect clicked

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
@@ -19,6 +20,7 @@ import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewMo
 import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewModel.ViewState.Loading
 import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewModel.ViewState.NotConnectedState
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.UpdateResult
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -36,6 +38,10 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
     }
 
     private val tracker: AnalyticsTrackerWrapper = mock()
+    private val appPrefs: AppPrefs = mock()
+    private val reconnectionFeatureFlag: FeatureFlag.CardReaderReconnectionWrapper = mock {
+        on { isEnabled() }.thenReturn(true)
+    }
 
     @Test
     fun `when view model init with connected state should emit loading view state`() {
@@ -446,7 +452,9 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
     private fun createViewModel() = CardReaderDetailViewModel(
         cardReaderManager,
         tracker,
-        SavedStateHandle()
+        appPrefs,
+        reconnectionFeatureFlag,
+        SavedStateHandle(),
     )
 
     private companion object {


### PR DESCRIPTION
Resolves #4343 

The PR adds clearning a stored reader's id from the app preferences when a user clicks on the "disconnect" button.

There is no UI facing changes.

**Merge after https://github.com/woocommerce/woocommerce-android/pull/4399**