### PR TITLE
Improve input validation for shipping labels address form

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Address.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Address.kt
@@ -5,14 +5,11 @@ import com.google.i18n.addressinput.common.AddressData
 import com.google.i18n.addressinput.common.FormOptions
 import com.google.i18n.addressinput.common.FormatInterpreter
 import com.woocommerce.android.extensions.appendWithIfNotEmpty
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.DESTINATION
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.ORIGIN
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress
-import java.util.Locale
+import java.util.*
 
 @Parcelize
 data class Address(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Address.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Address.kt
@@ -84,23 +84,6 @@ data class Address(
             state.isNotEmpty() || city.isNotEmpty()
     }
 
-    /**
-     * Checks whether the phone number is valid or not, depending on the [addressType], the check is:
-     * - [ORIGIN]: Checks whether the phone number contains 10 digits exactly after deleting an optional 1 as
-     *             the area code.
-     * - [DESTINATION]: Checks whether the phone has any digits.
-     *
-     * As EasyPost is permissive for the presence of other characters, we delete all other characters before checking,
-     * and that's similar to what the web client does.
-     * Source: https://github.com/Automattic/woocommerce-services/issues/1351
-     */
-    fun hasValidPhoneNumber(addressType: AddressType): Boolean {
-        return when (addressType) {
-            ORIGIN -> phone.replace(Regex("^1|[^\\d]"), "").length == 10
-            DESTINATION -> phone.contains(Regex("\\d"))
-        }
-    }
-
     fun toShippingLabelModel(): ShippingLabelAddress {
         return ShippingLabelAddress(
             company = company,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/InputField.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/InputField.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.ui.common
 
 import android.os.Parcelable
-import com.woocommerce.android.R.string
+import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import kotlinx.parcelize.Parcelize
@@ -55,7 +55,7 @@ data class RequiredField(
     override val content: String
 ) : InputField<RequiredField>(content) {
     override fun validateInternal(): UiString? {
-        return if (content.isBlank()) UiStringRes(string.shipping_label_error_required_field)
+        return if (content.isBlank()) UiStringRes(R.string.error_required_field)
         else null
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/InputField.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/InputField.kt
@@ -1,0 +1,59 @@
+package com.woocommerce.android.ui.common
+
+import android.os.Parcelable
+import com.woocommerce.android.R.string
+import com.woocommerce.android.model.UiString
+import com.woocommerce.android.model.UiString.UiStringRes
+import kotlinx.parcelize.Parcelize
+
+abstract class InputField<T : InputField<T>>(open val content: String) : Parcelable, Cloneable {
+    var error: UiString? = null
+        private set
+    private var hasBeenValidated: Boolean = false
+    val isValid: Boolean
+        get() {
+            return if (!hasBeenValidated) validateInternal() == null
+            else error == null
+        }
+
+    fun validate(): T {
+        val clone = this.clone() as T
+        clone.error = validateInternal()
+        clone.hasBeenValidated = true
+        return clone
+    }
+
+    final override fun hashCode(): Int {
+        return content.hashCode() + error.hashCode() + hasBeenValidated.hashCode()
+    }
+
+    final override fun equals(other: Any?): Boolean {
+        if (other !is InputField<*>) return false
+        return content == other.content &&
+            error == other.error &&
+            hasBeenValidated == other.hasBeenValidated
+    }
+
+    /**
+     * Perform specific field's validation
+     * @return [UiString] holding the error to be displayed or null if it's valid
+     */
+    protected abstract fun validateInternal(): UiString?
+}
+
+@Parcelize
+data class RequiredField(
+    override val content: String
+) : InputField<RequiredField>(content) {
+    override fun validateInternal(): UiString? {
+        return if (content.isBlank()) UiStringRes(string.shipping_label_error_required_field)
+        else null
+    }
+}
+
+@Parcelize
+data class OptionalField(
+    override val content: String
+) : InputField<OptionalField>(content) {
+    override fun validateInternal(): UiString? = null
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/InputField.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/InputField.kt
@@ -6,6 +6,15 @@ import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import kotlinx.parcelize.Parcelize
 
+/**
+ * Base class for representing an input field, it allows holding the current content, to allow prefilling
+ * and restoring it.
+ * And allows representing [error] message that can be displayed if the input is not valid, the [error] is not
+ * calculated until [validate] is called.
+ * [isValid] will return the current validation status independently of whether an error is displayed or not.
+ *
+ * Child classes will have to implement the validation logic.
+ */
 abstract class InputField<T : InputField<T>>(open val content: String) : Parcelable, Cloneable {
     var error: UiString? = null
         private set

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/InputField.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/InputField.kt
@@ -33,7 +33,10 @@ abstract class InputField<T : InputField<T>>(open val content: String) : Parcela
     }
 
     final override fun hashCode(): Int {
-        return content.hashCode() + error.hashCode() + hasBeenValidated.hashCode()
+        var result = content.hashCode()
+        result = 31 * result + (error?.hashCode() ?: 0)
+        result = 31 * result + hasBeenValidated.hashCode()
+        return result
     }
 
     final override fun equals(other: Any?): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/InputField.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/InputField.kt
@@ -14,6 +14,8 @@ import kotlinx.parcelize.Parcelize
  * [isValid] will return the current validation status independently of whether an error is displayed or not.
  *
  * Child classes will have to implement the validation logic.
+ *
+ * This class is using a reverse generic type to allow returning the exact type of the class in [validate] function.
  */
 abstract class InputField<T : InputField<T>>(open val content: String) : Parcelable, Cloneable {
     var error: UiString? = null
@@ -32,6 +34,10 @@ abstract class InputField<T : InputField<T>>(open val content: String) : Parcela
         return clone
     }
 
+    /**
+     * Marking the implementation as final to avoid overriding it by Kotlin's data classes, as the generated one
+     * doesn't check the parent class's fields, and would skip important details.
+     */
     final override fun hashCode(): Int {
         var result = content.hashCode()
         result = 31 * result + (error?.hashCode() ?: 0)
@@ -39,6 +45,10 @@ abstract class InputField<T : InputField<T>>(open val content: String) : Parcela
         return result
     }
 
+    /**
+     * Marking the implementation as final to avoid overriding it by Kotlin's data classes, as the generated one
+     * doesn't check the parent class's fields, and would skip important details.
+     */
     final override fun equals(other: Any?): Boolean {
         if (other !is InputField<*>) return false
         return content == other.content &&

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
@@ -1,11 +1,6 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation
 
-import com.woocommerce.android.model.Address
-import com.woocommerce.android.model.CustomsPackage
-import com.woocommerce.android.model.Order
-import com.woocommerce.android.model.ShippingLabel
-import com.woocommerce.android.model.ShippingLabelPackage
-import com.woocommerce.android.model.ShippingRate
+import com.woocommerce.android.model.*
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.ValidationResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -31,13 +26,13 @@ sealed class CreateShippingLabelEvent : MultiLiveEvent.Event() {
     data class EditSelectedAddress(val address: Address) : CreateShippingLabelEvent()
 
     data class ShowCountrySelector(
-        val locations: List<WCLocationModel>,
-        val currentCountry: String?
+        val locations: List<Location>,
+        val currentCountryCode: String?
     ) : CreateShippingLabelEvent()
 
     data class ShowStateSelector(
-        val locations: List<WCLocationModel>,
-        val currentState: String?
+        val locations: List<Location>,
+        val currentStateCode: String?
     ) : CreateShippingLabelEvent()
 
     data class OpenMapWithAddress(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
@@ -4,7 +4,6 @@ import com.woocommerce.android.model.*
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.ValidationResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent
-import org.wordpress.android.fluxc.model.data.WCLocationModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 
 sealed class CreateShippingLabelEvent : MultiLiveEvent.Event() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -162,16 +162,16 @@ class EditShippingLabelAddressFragment :
                 binding.company.updateFromField(field)
             }
             new.address1Field.takeIfNotEqualTo(old?.address1Field) { field ->
-                binding.address1
+                binding.address1.updateFromField(field)
             }
             new.address2Field.takeIfNotEqualTo(old?.address1Field) { field ->
-                binding.address2
+                binding.address2.updateFromField(field)
+            }
+            new.phoneField.takeIfNotEqualTo(old?.phoneField) {field ->
+                binding.phone.updateFromField(field)
             }
             new.title?.takeIfNotEqualTo(old?.title) {
                 screenTitle = getString(it)
-            }
-            new.phoneError.takeIfNotEqualTo(old?.phoneError) {
-                showErrorOrClear(binding.phoneLayout, it)
             }
             new.cityError.takeIfNotEqualTo(old?.cityError) {
                 showErrorOrClear(binding.cityLayout, it)
@@ -326,18 +326,11 @@ class EditShippingLabelAddressFragment :
     }
 
     private fun initializeViews() {
-        binding.name.setOnTextChangedListener {
-            viewModel.onFieldEdited(Field.Name, it?.toString().orEmpty())
-        }
-        binding.company.setOnTextChangedListener {
-            viewModel.onFieldEdited(Field.Company, it?.toString().orEmpty())
-        }
-        binding.address1.setOnTextChangedListener {
-            viewModel.onFieldEdited(Field.Address1, it?.toString().orEmpty())
-        }
-        binding.address2.setOnTextChangedListener {
-            viewModel.onFieldEdited(Field.Address2, it?.toString().orEmpty())
-        }
+        binding.name.bindToField(Field.Name)
+        binding.company.bindToField(Field.Company)
+        binding.address1.bindToField(Field.Address1)
+        binding.address2.bindToField(Field.Address2)
+        binding.phone.bindToField(Field.Phone)
         binding.useAddressAsIsButton.onClick {
             viewModel.onUseAddressAsIsButtonClicked()
         }
@@ -352,6 +345,12 @@ class EditShippingLabelAddressFragment :
         }
         binding.contactCustomerButton.onClick {
             viewModel.onContactCustomerTapped()
+        }
+    }
+
+    private fun WCMaterialOutlinedEditTextView.bindToField(field: Field) {
+        setOnTextChangedListener {
+            viewModel.onFieldEdited(field, it?.toString().orEmpty())
         }
     }
 
@@ -374,9 +373,9 @@ class EditShippingLabelAddressFragment :
             company = binding.company.getText(),
             firstName = binding.name.getText(),
             lastName = "",
-            phone = binding.phone.text.toString(),
-            address1 = binding.address1.toString(),
-            address2 = binding.address2.toString(),
+            phone = binding.phone.getText(),
+            address1 = binding.address1.getText(),
+            address2 = binding.address2.getText(),
             postcode = binding.zip.text.toString(),
             state = binding.stateSpinner.tag as String,
             city = binding.city.text.toString(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -170,14 +170,14 @@ class EditShippingLabelAddressFragment :
             new.phoneField.takeIfNotEqualTo(old?.phoneField) {field ->
                 binding.phone.updateFromField(field)
             }
+            new.cityField.takeIfNotEqualTo(old?.cityField) { field ->
+                binding.city.updateFromField(field)
+            }
+            new.zipField.takeIfNotEqualTo(old?.zipField) {field ->
+                binding.zip.updateFromField(field)
+            }
             new.title?.takeIfNotEqualTo(old?.title) {
                 screenTitle = getString(it)
-            }
-            new.cityError.takeIfNotEqualTo(old?.cityError) {
-                showErrorOrClear(binding.cityLayout, it)
-            }
-            new.zipError.takeIfNotEqualTo(old?.zipError) {
-                showErrorOrClear(binding.zipLayout, it)
             }
             new.bannerMessage?.takeIfNotEqualTo(old?.bannerMessage) {
                 if (it.isBlank()) {
@@ -331,6 +331,8 @@ class EditShippingLabelAddressFragment :
         binding.address1.bindToField(Field.Address1)
         binding.address2.bindToField(Field.Address2)
         binding.phone.bindToField(Field.Phone)
+        binding.city.bindToField(Field.City)
+        binding.zip.bindToField(Field.Zip)
         binding.useAddressAsIsButton.onClick {
             viewModel.onUseAddressAsIsButtonClicked()
         }
@@ -376,9 +378,9 @@ class EditShippingLabelAddressFragment :
             phone = binding.phone.getText(),
             address1 = binding.address1.getText(),
             address2 = binding.address2.getText(),
-            postcode = binding.zip.text.toString(),
+            postcode = binding.zip.getText(),
             state = binding.stateSpinner.tag as String,
-            city = binding.city.text.toString(),
+            city = binding.city.getText(),
             country = binding.countrySpinner.tag as String,
             email = ""
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -145,7 +145,7 @@ class EditShippingLabelAddressFragment :
         return when (item.itemId) {
             R.id.menu_done -> {
                 ActivityUtils.hideKeyboard(activity)
-                viewModel.onDoneButtonClicked(gatherData())
+                viewModel.onDoneButtonClicked()
                 true
             }
             else -> super.onOptionsItemSelected(item)
@@ -335,6 +335,7 @@ class EditShippingLabelAddressFragment :
         binding.phone.bindToField(Field.Phone)
         binding.city.bindToField(Field.City)
         binding.zip.bindToField(Field.Zip)
+        binding.state.bindToField(Field.State)
         binding.useAddressAsIsButton.onClick {
             viewModel.onUseAddressAsIsButtonClicked()
         }
@@ -360,32 +361,14 @@ class EditShippingLabelAddressFragment :
 
     private fun WCMaterialOutlinedSpinnerView.onClick(onClick: () -> Unit) {
         this.setClickListener {
-            viewModel.updateAddress(gatherData())
             onClick()
         }
     }
 
     private fun Button.onClick(onButtonClick: () -> Unit) {
         setOnClickListener {
-            viewModel.updateAddress(gatherData())
             onButtonClick()
         }
-    }
-
-    private fun gatherData(): Address {
-        return Address(
-            company = binding.company.getText(),
-            firstName = binding.name.getText(),
-            lastName = "",
-            phone = binding.phone.getText(),
-            address1 = binding.address1.getText(),
-            address2 = binding.address2.getText(),
-            postcode = binding.zip.getText(),
-            state = binding.stateSpinner.getText(),
-            city = binding.city.getText(),
-            country = binding.countrySpinner.getText(),
-            email = ""
-        )
     }
 
     // Let the ViewModel know the user is attempting to close the screen

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -164,9 +164,12 @@ class EditShippingLabelAddressFragment :
                 binding.zip.updateFromField(field)
             }
             new.stateField.takeIfNotEqualTo(old?.stateField) { field ->
-                binding.state.updateFromField(field)
-                binding.stateSpinner.setText(field.content)
-                binding.stateSpinner.error = field.error?.let { UiHelpers.getTextOfUiString(requireContext(), it) }
+                if (new.isStateFieldSpinner == true) {
+                    binding.stateSpinner.setText(field.content)
+                    binding.stateSpinner.error = field.error?.let { UiHelpers.getTextOfUiString(requireContext(), it) }
+                } else {
+                    binding.state.updateFromField(field)
+                }
             }
             new.countryField.takeIfNotEqualTo(old?.countryField) { field ->
                 binding.countrySpinner.setText(field.content)
@@ -331,7 +334,9 @@ class EditShippingLabelAddressFragment :
 
     private fun WCMaterialOutlinedEditTextView.bindToField(field: Field) {
         setOnTextChangedListener {
-            viewModel.onFieldEdited(field, it?.toString().orEmpty())
+            // trigger event only if this view is visible, avoids issues when the field can have different field types
+            // like the state
+            if (this.isVisible) viewModel.onFieldEdited(field, it?.toString().orEmpty())
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -101,7 +101,8 @@ class EditShippingLabelAddressFragment :
     }
 
     private fun initializeViewModel() {
-        subscribeObservers()
+        observeEvents()
+        observeViewState()
         setupResultHandlers()
     }
 
@@ -139,8 +140,8 @@ class EditShippingLabelAddressFragment :
         }
     }
 
-    @SuppressLint("SetTextI18n")
-    private fun subscribeObservers() {
+    @Suppress("LongMethod")
+    private fun observeViewState() {
         viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
             new.nameField.takeIfNotEqualTo(old?.nameField) { field ->
                 binding.name.updateFromField(field)
@@ -154,13 +155,13 @@ class EditShippingLabelAddressFragment :
             new.address2Field.takeIfNotEqualTo(old?.address1Field) { field ->
                 binding.address2.updateFromField(field)
             }
-            new.phoneField.takeIfNotEqualTo(old?.phoneField) {field ->
+            new.phoneField.takeIfNotEqualTo(old?.phoneField) { field ->
                 binding.phone.updateFromField(field)
             }
             new.cityField.takeIfNotEqualTo(old?.cityField) { field ->
                 binding.city.updateFromField(field)
             }
-            new.zipField.takeIfNotEqualTo(old?.zipField) {field ->
+            new.zipField.takeIfNotEqualTo(old?.zipField) { field ->
                 binding.zip.updateFromField(field)
             }
             new.stateField.takeIfNotEqualTo(old?.stateField) { field ->
@@ -215,7 +216,10 @@ class EditShippingLabelAddressFragment :
                 binding.contactCustomerButton.isVisible = isVisible
             }
         }
+    }
 
+    @SuppressLint("SetTextI18n")
+    private fun observeEvents() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -29,6 +29,7 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.common.InputField
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.DialPhoneNumber
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.OpenMapWithAddress
@@ -36,7 +37,6 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingL
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowStateSelector
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowSuggestedAddress
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelAddressViewModel.Field
-import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelAddressViewModel.InputField
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SELECTED_ADDRESS_ACCEPTED
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SELECTED_ADDRESS_TO_BE_EDITED
 import com.woocommerce.android.util.UiHelpers

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -52,8 +52,6 @@ class EditShippingLabelAddressFragment :
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     private var progressDialog: CustomProgressDialog? = null
-    private var _binding: FragmentEditShippingLabelAddressBinding? = null
-    private val binding get() = _binding!!
 
     val viewModel: EditShippingLabelAddressViewModel by viewModels()
 
@@ -86,23 +84,18 @@ class EditShippingLabelAddressFragment :
         }
     }
 
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        _binding = FragmentEditShippingLabelAddressBinding.bind(view)
+        val binding = FragmentEditShippingLabelAddressBinding.bind(view)
 
-        initializeViewModel()
-        initializeViews()
+        initializeViewModel(binding)
+        initializeViews(binding)
     }
 
-    private fun initializeViewModel() {
+    private fun initializeViewModel(binding: FragmentEditShippingLabelAddressBinding) {
+        observeViewState(binding)
         observeEvents()
-        observeViewState()
         setupResultHandlers()
     }
 
@@ -141,7 +134,7 @@ class EditShippingLabelAddressFragment :
     }
 
     @Suppress("LongMethod")
-    private fun observeViewState() {
+    private fun observeViewState(binding: FragmentEditShippingLabelAddressBinding) {
         viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
             new.nameField.takeIfNotEqualTo(old?.nameField) { field ->
                 binding.name.updateFromField(field)
@@ -310,7 +303,7 @@ class EditShippingLabelAddressFragment :
         }
     }
 
-    private fun initializeViews() {
+    private fun initializeViews(binding: FragmentEditShippingLabelAddressBinding) {
         binding.name.bindToField(Field.Name)
         binding.company.bindToField(Field.Company)
         binding.address1.bindToField(Field.Address1)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -123,7 +123,7 @@ class EditShippingLabelAddressFragment :
             viewModel.onCountrySelected(it)
         }
         handleResult<String>(SELECT_STATE_REQUEST) {
-            viewModel.onStateSelected(it)
+            viewModel.onFieldEdited(Field.State, it)
         }
         handleResult<Address>(SELECTED_ADDRESS_ACCEPTED) {
             viewModel.onAddressSelected(it)
@@ -176,6 +176,15 @@ class EditShippingLabelAddressFragment :
             new.zipField.takeIfNotEqualTo(old?.zipField) {field ->
                 binding.zip.updateFromField(field)
             }
+            new.stateField.takeIfNotEqualTo(old?.stateField) { field ->
+                binding.state.updateFromField(field)
+                binding.stateSpinner.setText(field.content)
+                binding.stateSpinner.error = field.error?.let { UiHelpers.getTextOfUiString(requireContext(), it) }
+            }
+            new.countryField.takeIfNotEqualTo(old?.countryField) { field ->
+                binding.countrySpinner.setText(field.content)
+                binding.countrySpinner.error = field.error?.let { UiHelpers.getTextOfUiString(requireContext(), it) }
+            }
             new.title?.takeIfNotEqualTo(old?.title) {
                 screenTitle = getString(it)
             }
@@ -208,16 +217,9 @@ class EditShippingLabelAddressFragment :
                     hideProgressDialog()
                 }
             }
-            new.selectedCountryName?.takeIfNotEqualTo(old?.selectedCountryName) {
-                binding.countrySpinner.setText(it)
-            }
-            new.selectedStateName?.takeIfNotEqualTo(old?.selectedStateName) {
-                binding.stateSpinner.setText(it)
-                binding.state.setText(it)
-            }
             new.isStateFieldSpinner?.takeIfNotEqualTo(old?.isStateFieldSpinner) { isSpinner ->
                 binding.stateSpinner.isVisible = isSpinner
-                binding.stateLayout.isVisible = !isSpinner
+                binding.state.isVisible = !isSpinner
             }
             new.isContactCustomerButtonVisible.takeIfNotEqualTo(old?.isContactCustomerButtonVisible) { isVisible ->
                 binding.contactCustomerButton.isVisible = isVisible
@@ -243,7 +245,7 @@ class EditShippingLabelAddressFragment :
                     is ShowCountrySelector -> {
                         val action = EditShippingLabelAddressFragmentDirections
                             .actionEditShippingLabelAddressFragmentToItemSelectorDialog(
-                                event.currentCountry,
+                                event.currentCountryCode,
                                 event.locations.map { it.name }.toTypedArray(),
                                 event.locations.map { it.code }.toTypedArray(),
                                 SELECT_COUNTRY_REQUEST,
@@ -254,7 +256,7 @@ class EditShippingLabelAddressFragment :
                     is ShowStateSelector -> {
                         val action = EditShippingLabelAddressFragmentDirections
                             .actionEditShippingLabelAddressFragmentToItemSelectorDialog(
-                                event.currentState,
+                                event.currentStateCode,
                                 event.locations.map { it.name }.toTypedArray(),
                                 event.locations.map { it.code }.toTypedArray(),
                                 SELECT_STATE_REQUEST,
@@ -379,9 +381,9 @@ class EditShippingLabelAddressFragment :
             address1 = binding.address1.getText(),
             address2 = binding.address2.getText(),
             postcode = binding.zip.getText(),
-            state = binding.stateSpinner.tag as String,
+            state = binding.stateSpinner.getText(),
             city = binding.city.getText(),
-            country = binding.countrySpinner.tag as String,
+            country = binding.countrySpinner.getText(),
             email = ""
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -145,7 +145,7 @@ class EditShippingLabelAddressFragment :
             new.address1Field.takeIfNotEqualTo(old?.address1Field) { field ->
                 binding.address1.updateFromField(field)
             }
-            new.address2Field.takeIfNotEqualTo(old?.address1Field) { field ->
+            new.address2Field.takeIfNotEqualTo(old?.address2Field) { field ->
                 binding.address2.updateFromField(field)
             }
             new.phoneField.takeIfNotEqualTo(old?.phoneField) { field ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -118,16 +118,17 @@ class EditShippingLabelAddressViewModel @Inject constructor(
                 dataStore.fetchCountriesAndStates(site.get())
                 viewState = viewState.copy(isLoadingProgressDialogVisible = false)
             }
+            val isStateFieldSpinner = states.isNotEmpty()
             val countryField = countries.firstOrNull { it.code == viewState.countryField.location.code }?.let {
                 viewState.countryField.copy(location = it)
             } ?: viewState.countryField
             val stateField = states.firstOrNull { it.code == viewState.stateField.location.code }?.let {
-                viewState.stateField.copy(location = it)
-            } ?: viewState.stateField
+                viewState.stateField.copy(location = it, isRequired = isStateFieldSpinner)
+            } ?: viewState.stateField.copy(isRequired = isStateFieldSpinner)
 
             viewState = viewState.copy(
                 isValidationProgressDialogVisible = false,
-                isStateFieldSpinner = states.isNotEmpty(),
+                isStateFieldSpinner = isStateFieldSpinner,
                 countryField = countryField,
                 stateField = stateField
             )
@@ -141,6 +142,7 @@ class EditShippingLabelAddressViewModel @Inject constructor(
                 val validationErrorMessage = getAddressErrorStringRes(result.message)
                 viewState = viewState.copy(
                     address1Field = viewState.address1Field.copy(validationError = validationErrorMessage).validate(),
+                    bannerMessage = resourceProvider.getString(R.string.shipping_label_edit_address_error_warning)
                 )
             }
             is ValidationResult.SuggestedChanges -> {
@@ -221,7 +223,7 @@ class EditShippingLabelAddressViewModel @Inject constructor(
         }
         viewState = viewState.copy(
             stateField = stateField,
-            isStateFieldSpinner = states.isNotEmpty()
+            isStateFieldSpinner = isStateFieldSpinner
         )
     }
 
@@ -272,7 +274,7 @@ class EditShippingLabelAddressViewModel @Inject constructor(
                 Field.State -> {
                     val state = states.firstOrNull { it.code == content } ?: Location(code = content, name = content)
                     copy(
-                        stateField = stateField.copy(location = state)
+                        stateField = stateField.copy(location = state).validate()
                     )
                 }
                 Field.Zip -> copy(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -397,7 +397,7 @@ class EditShippingLabelAddressViewModel @Inject constructor(
     ) : InputField<NameField>(content) {
         override fun validateInternal(): UiString? {
             return if (content.isNotBlank() || companyContent.isNotBlank()) null
-            else UiStringRes(R.string.shipping_label_error_required_field)
+            else UiStringRes(R.string.error_required_field)
         }
     }
 
@@ -409,7 +409,7 @@ class EditShippingLabelAddressViewModel @Inject constructor(
         override fun validateInternal(): UiString? {
             return when {
                 validationError != null -> UiStringRes(validationError)
-                content.isBlank() -> UiStringRes(R.string.shipping_label_error_required_field)
+                content.isBlank() -> UiStringRes(R.string.error_required_field)
                 else -> null
             }
         }
@@ -440,7 +440,7 @@ class EditShippingLabelAddressViewModel @Inject constructor(
         val isRequired: Boolean = false
     ) : InputField<LocationField>(location.name) {
         override fun validateInternal(): UiString? {
-            return if (isRequired && content.isBlank()) UiStringRes(R.string.shipping_label_error_required_field)
+            return if (isRequired && content.isBlank()) UiStringRes(R.string.error_required_field)
             else null
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -179,10 +179,6 @@ class EditShippingLabelAddressViewModel @Inject constructor(
         }
     }
 
-    fun updateAddress(address: Address) {
-        // TODO viewState = viewState.copy(address = address)
-    }
-
     fun onUseAddressAsIsButtonClicked() {
         AnalyticsTracker.track(Stat.SHIPPING_LABEL_EDIT_ADDRESS_USE_ADDRESS_AS_IS_BUTTON_TAPPED)
         viewState = viewState.validateAllFields()
@@ -234,7 +230,21 @@ class EditShippingLabelAddressViewModel @Inject constructor(
     }
 
     fun onEditRequested(address: Address) {
-        updateAddress(address)
+        val country = countries.first { it.code == address.country }
+        val state = dataStore.getStates(address.country).firstOrNull { it.code == address.state }?.toAppModel()
+            ?: Location(code = address.state, name = address.state)
+        viewState = with(viewState) {
+            copy(
+                nameField = nameField.copy(content = "${address.firstName} ${address.lastName}"),
+                companyField = companyField.copy(content = address.company),
+                phoneField = phoneField.copy(content = address.phone),
+                address1Field = address1Field.copy(content = address.address1),
+                address2Field = address2Field.copy(content = address.address2),
+                cityField = cityField.copy(content = address.city),
+                stateField = stateField.copy(location = state),
+                countryField = countryField.copy(location = country)
+            )
+        }
     }
 
     fun onFieldEdited(field: Field, content: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -442,8 +442,9 @@ class EditShippingLabelAddressViewModel @Inject constructor(
         Name, Company, Phone, Address1, Address2, City, State, Zip, Country
     }
 
-    abstract class InputField<T: InputField<T>>(open val content: String): Parcelable {
+    abstract class InputField<T: InputField<T>>(open val content: String): Parcelable, Cloneable {
         var error: UiString? = null
+            private set
         private var hasBeenValidated: Boolean = false
         val isValid: Boolean
             get() {
@@ -452,9 +453,10 @@ class EditShippingLabelAddressViewModel @Inject constructor(
             }
 
         fun validate(): T {
-            error = validateInternal()
-            hasBeenValidated = true
-            return this as T
+            val clone = this.clone() as T
+            clone.error = validateInternal()
+            clone.hasBeenValidated = true
+            return clone
         }
 
         final override fun hashCode(): Int {
@@ -489,7 +491,7 @@ class EditShippingLabelAddressViewModel @Inject constructor(
     data class CustomField(
         override val content: String,
         val validateInput: (String) -> Boolean
-    ): InputField<CustomField>(content) {
+    ) : InputField<CustomField>(content) {
         override fun validateInternal(): UiString? {
             return if (validateInput(content)) null
             else UiStringRes(R.string.shipping_label_error_required_field)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -12,9 +12,10 @@ import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowCountrySelector
-import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowStateSelector
-import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowSuggestedAddress
+import com.woocommerce.android.ui.common.InputField
+import com.woocommerce.android.ui.common.OptionalField
+import com.woocommerce.android.ui.common.RequiredField
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.*
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.DESTINATION
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.ORIGIN
@@ -203,17 +204,13 @@ class EditShippingLabelAddressViewModel @Inject constructor(
     fun onOpenMapTapped() {
         AnalyticsTracker.track(Stat.SHIPPING_LABEL_EDIT_ADDRESS_OPEN_MAP_BUTTON_TAPPED)
 
-//        viewState.address?.let { address ->
-//            triggerEvent(OpenMapWithAddress(address))
-//        }
+        triggerEvent(OpenMapWithAddress(viewState.getAddress()))
     }
 
     fun onContactCustomerTapped() {
         AnalyticsTracker.track(Stat.SHIPPING_LABEL_EDIT_ADDRESS_CONTACT_CUSTOMER_BUTTON_TAPPED)
 
-//        viewState.address?.phone?.let {
-//            triggerEvent(DialPhoneNumber(it))
-//        }
+        triggerEvent(DialPhoneNumber(viewState.phoneField.content))
     }
 
     fun onCountrySelected(countryCode: String) {
@@ -440,68 +437,5 @@ class EditShippingLabelAddressViewModel @Inject constructor(
 
     enum class Field {
         Name, Company, Phone, Address1, Address2, City, State, Zip, Country
-    }
-
-    abstract class InputField<T: InputField<T>>(open val content: String): Parcelable, Cloneable {
-        var error: UiString? = null
-            private set
-        private var hasBeenValidated: Boolean = false
-        val isValid: Boolean
-            get() {
-                return if(!hasBeenValidated) validateInternal() == null
-                else error == null
-            }
-
-        fun validate(): T {
-            val clone = this.clone() as T
-            clone.error = validateInternal()
-            clone.hasBeenValidated = true
-            return clone
-        }
-
-        final override fun hashCode(): Int {
-            return content.hashCode() + error.hashCode() + hasBeenValidated.hashCode()
-        }
-
-        final override fun equals(other: Any?): Boolean {
-            if (other !is InputField<*>) return false
-            return content == other.content &&
-                error == other.error &&
-                hasBeenValidated == other.hasBeenValidated
-        }
-
-        /**
-         * Perform specific field's validation
-         * @return [UiString] holding the error to be displayed or null if it's valid
-         */
-        protected abstract fun validateInternal(): UiString?
-    }
-
-    @Parcelize
-    data class RequiredField(
-        override val content: String
-    ) : InputField<RequiredField>(content) {
-        override fun validateInternal(): UiString? {
-            return if (content.isBlank()) UiStringRes(R.string.shipping_label_error_required_field)
-            else null
-        }
-    }
-
-    @Parcelize
-    data class CustomField(
-        override val content: String,
-        val validateInput: (String) -> Boolean
-    ) : InputField<CustomField>(content) {
-        override fun validateInternal(): UiString? {
-            return if (validateInput(content)) null
-            else UiStringRes(R.string.shipping_label_error_required_field)
-        }
-    }
-
-    @Parcelize
-    data class OptionalField(
-        override val content: String
-    ) : InputField<OptionalField>(content) {
-        override fun validateInternal(): UiString? = null
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -187,8 +187,6 @@ class EditShippingLabelAddressViewModel @Inject constructor(
     private fun clearErrors() {
         viewState = viewState.copy(
             bannerMessage = "",
-            cityError = 0,
-            zipError = 0
         )
     }
 
@@ -200,11 +198,6 @@ class EditShippingLabelAddressViewModel @Inject constructor(
                 null
             }
         }
-
-        viewState = viewState.copy(
-            cityError = getErrorOrClear(address.city),
-            zipError = getErrorOrClear(address.postcode)
-        )
     }
 
     fun updateAddress(address: Address) {
@@ -300,8 +293,8 @@ class EditShippingLabelAddressViewModel @Inject constructor(
         val phoneField: PhoneField,
         val address1Field: Address1Field,
         val address2Field: OptionalField,
-        @StringRes val cityError: Int? = null,
-        @StringRes val zipError: Int? = null,
+        val cityField: RequiredField,
+        val zipField: RequiredField,
         @StringRes val title: Int? = null
     ) : Parcelable {
         constructor(args: EditShippingLabelAddressFragmentArgs): this(
@@ -312,7 +305,9 @@ class EditShippingLabelAddressViewModel @Inject constructor(
             companyField = OptionalField(content = args.address.company),
             address1Field = Address1Field(args.address.address1),
             address2Field = OptionalField(args.address.address2),
-            phoneField = PhoneField(args.address.phone, args.requiresPhoneNumber, args.addressType)
+            phoneField = PhoneField(args.address.phone, args.requiresPhoneNumber, args.addressType),
+            cityField = RequiredField(args.address.city),
+            zipField = RequiredField(args.address.postcode)
         )
 
         @IgnoredOnParcel
@@ -344,16 +339,22 @@ class EditShippingLabelAddressViewModel @Inject constructor(
                     companyField = companyField.copy(content = content).validate(),
                     nameField = nameField.copy(companyContent = content).validate()
                 )
-                Field.Phone -> TODO()
+                Field.Phone -> copy(
+                    phoneField = phoneField.copy(content = content).validate()
+                )
                 Field.Address1 -> copy(
                     address1Field = address1Field.copy(content = content, validationError = null).validate()
                 )
                 Field.Address2 -> copy(
                     address2Field = address2Field.copy(content = content).validate()
                 )
-                Field.City -> TODO()
+                Field.City -> copy(
+                    cityField = cityField.copy(content = content).validate()
+                )
                 Field.State -> TODO()
-                Field.Zip -> TODO()
+                Field.Zip -> copy(
+                    zipField = zipField.copy(content = content).validate()
+                )
                 Field.Country -> TODO()
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressValidator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressValidator.kt
@@ -6,6 +6,9 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.DESTINATION
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.ORIGIN
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
@@ -29,7 +32,7 @@ class ShippingLabelAddressValidator @Inject constructor(
     ): ValidationResult {
         return when {
             isNameMissing(address) -> ValidationResult.NameMissing
-            requiresPhoneNumber && !address.hasValidPhoneNumber(type) -> ValidationResult.PhoneInvalid
+            requiresPhoneNumber && !address.phone.isValidPhoneNumber(type) -> ValidationResult.PhoneInvalid
             else -> verifyAddress(address, type)
         }
     }
@@ -126,5 +129,22 @@ class ShippingLabelAddressValidator @Inject constructor(
                 DESTINATION -> Type.DESTINATION
             }
         }
+    }
+}
+
+/**
+ * Checks whether the phone number is valid or not, depending on the [addressType], the check is:
+ * - [ORIGIN]: Checks whether the phone number contains 10 digits exactly after deleting an optional 1 as
+ *             the area code.
+ * - [DESTINATION]: Checks whether the phone has any digits.
+ *
+ * As EasyPost is permissive for the presence of other characters, we delete all other characters before checking,
+ * and that's similar to what the web client does.
+ * Source: https://github.com/Automattic/woocommerce-services/issues/1351
+ */
+fun String.isValidPhoneNumber(addressType: AddressType): Boolean {
+    return when (addressType) {
+        ORIGIN -> replace(Regex("^1|[^\\d]"), "").length == 10
+        DESTINATION -> contains(Regex("\\d"))
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressValidator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressValidator.kt
@@ -142,6 +142,7 @@ class ShippingLabelAddressValidator @Inject constructor(
  * and that's similar to what the web client does.
  * Source: https://github.com/Automattic/woocommerce-services/issues/1351
  */
+@Suppress("MagicNumber")
 fun String.isValidPhoneNumber(addressType: AddressType): Boolean {
     return when (addressType) {
         ORIGIN -> replace(Regex("^1|[^\\d]"), "").length == 10

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -612,13 +612,13 @@ class ShippingLabelsStateMachine @Inject constructor() {
         }
 
         private fun updateForInternationalRequirements(): StepsState {
-            val originAddressStep = if (isInternational && !originAddressStep.data.hasValidPhoneNumber(ORIGIN)) {
+            val originAddressStep = if (isInternational && !originAddressStep.data.phone.isValidPhoneNumber(ORIGIN)) {
                 originAddressStep.copy(status = READY)
             } else originAddressStep
 
             val shippingAddressStep = if (isInternational &&
                 carrierStep.requiresDestinationPhoneNumber &&
-                !shippingAddressStep.data.hasValidPhoneNumber(DESTINATION)
+                !shippingAddressStep.data.phone.isValidPhoneNumber(DESTINATION)
             ) {
                 shippingAddressStep.copy(status = READY)
             } else shippingAddressStep

--- a/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_address.xml
+++ b/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_address.xml
@@ -104,24 +104,15 @@
             android:nextFocusForward="@+id/phone"
             app:errorEnabled="true" />
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/phoneLayout"
-            style="@style/Woo.TextInputLayout"
+        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+            android:id="@+id/phone"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/major_100"
             android:hint="@string/shipping_label_edit_address_phone"
-            app:errorEnabled="true"
-            tools:visibility="visible">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/phone"
-                style="@style/Woo.TextInputEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:inputType="text"
-                android:nextFocusForward="@+id/address1" />
-
-        </com.google.android.material.textfield.TextInputLayout>
+            android:inputType="text"
+            android:nextFocusForward="@+id/address1"
+            app:errorEnabled="true" />
 
         <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
             android:id="@+id/address1"

--- a/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_address.xml
+++ b/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_address.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:tools="http://schemas.android.com/tools">
+    android:layout_height="match_parent">
 
     <com.woocommerce.android.widgets.WCElevatedLinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:layout_marginBottom="@dimen/minor_100">
+        android:layout_marginBottom="@dimen/minor_100"
+        android:orientation="vertical">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/errorBanner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:visibility="gone"
-            android:background="@color/warning_banner_background_color"
             android:animateLayoutChanges="true"
+            android:background="@color/warning_banner_background_color"
             android:clickable="true"
             android:focusable="true"
+            android:visibility="gone"
             tools:visibility="visible">
 
             <ImageView
@@ -43,10 +43,10 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/shipping_label_validation_contact_customer"
-                app:layout_constraintEnd_toEndOf="parent"
                 android:textColor="@color/color_on_surface_high"
-                app:layout_constraintTop_toBottomOf="@id/errorBannerMessage"
-                app:layout_constraintBottom_toTopOf="@id/errorBannerDivider" />
+                app:layout_constraintBottom_toTopOf="@id/errorBannerDivider"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/errorBannerMessage" />
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/errorBannerMessage"
@@ -69,9 +69,9 @@
                 android:layout_height="wrap_content"
                 android:text="@string/shipping_label_validation_view_map"
                 android:textColor="@color/color_on_surface_high"
+                app:layout_constraintBottom_toTopOf="@id/errorBannerDivider"
                 app:layout_constraintEnd_toStartOf="@id/contactCustomerButton"
-                app:layout_constraintTop_toBottomOf="@id/errorBannerMessage"
-                app:layout_constraintBottom_toTopOf="@id/errorBannerDivider" />
+                app:layout_constraintTop_toBottomOf="@id/errorBannerMessage" />
 
             <View
                 android:id="@+id/errorBannerDivider"
@@ -83,43 +83,26 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/nameLayout"
-            style="@style/Woo.TextInputLayout"
+        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+            android:id="@+id/name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/major_100"
             android:layout_marginTop="@dimen/major_100"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
             android:hint="@string/shipping_label_edit_address_name"
-            tools:visibility="visible">
+            android:inputType="text"
+            android:nextFocusForward="@id/company"
+            app:errorEnabled="true" />
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/name"
-                style="@style/Woo.TextInputEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:inputType="text"
-                android:nextFocusForward="@+id/company" />
-
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/companyLayout"
-            style="@style/Woo.TextInputLayout"
+        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+            android:id="@+id/company"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/major_100"
             android:hint="@string/shipping_label_edit_address_company"
-            tools:visibility="visible"
-            app:errorEnabled="true">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/company"
-                style="@style/Woo.TextInputEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:inputType="text"
-                android:nextFocusForward="@+id/phone" />
-
-        </com.google.android.material.textfield.TextInputLayout>
+            android:inputType="text"
+            android:nextFocusForward="@+id/phone"
+            app:errorEnabled="true" />
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/phoneLayout"
@@ -127,8 +110,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/shipping_label_edit_address_phone"
-            tools:visibility="visible"
-            app:errorEnabled="true">
+            app:errorEnabled="true"
+            tools:visibility="visible">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/phone"
@@ -140,44 +123,25 @@
 
         </com.google.android.material.textfield.TextInputLayout>
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/address1Layout"
-            style="@style/Woo.TextInputLayout"
+        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+            android:id="@+id/address1"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/minor_00"
+            android:layout_marginHorizontal="@dimen/major_100"
             android:hint="@string/shipping_label_edit_address_address"
-            tools:visibility="visible"
-            app:errorEnabled="true">
+            android:inputType="text"
+            android:nextFocusForward="@+id/address2"
+            app:errorEnabled="true" />
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/address1"
-                style="@style/Woo.TextInputEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:inputType="text"
-                android:nextFocusForward="@+id/address2" />
-
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/address2Layout"
-            style="@style/Woo.TextInputLayout"
-            android:layout_marginTop="@dimen/minor_00"
+        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+            android:id="@+id/address2"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            tools:visibility="visible"
-            app:errorEnabled="true">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/address2"
-                style="@style/Woo.TextInputEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:inputType="text"
-                android:nextFocusForward="@+id/city" />
-
-        </com.google.android.material.textfield.TextInputLayout>
+            android:layout_marginHorizontal="@dimen/major_100"
+            android:hint="@string/shipping_label_edit_address_address"
+            android:inputType="text"
+            android:nextFocusForward="@+id/city"
+            app:errorEnabled="true" />
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/cityLayout"
@@ -185,8 +149,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/shipping_label_edit_address_city"
-            tools:visibility="visible"
-            app:errorEnabled="true">
+            app:errorEnabled="true"
+            tools:visibility="visible">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/city"
@@ -204,8 +168,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/shipping_label_edit_address_state"
-            tools:visibility="visible"
-            app:errorEnabled="true">
+            app:errorEnabled="true"
+            tools:visibility="visible">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/state"
@@ -221,14 +185,14 @@
             android:id="@+id/stateSpinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:inputType="text"
             android:layout_marginStart="@dimen/major_100"
-            android:layout_marginEnd="@dimen/major_100"
             android:layout_marginTop="@dimen/minor_00"
+            android:layout_marginEnd="@dimen/major_100"
             android:layout_marginBottom="@dimen/major_100"
-            android:textAppearance="@style/TextAppearance.Woo.Caption"
             android:hint="@string/shipping_label_edit_address_state"
-            android:nextFocusForward="@+id/zip" />
+            android:inputType="text"
+            android:nextFocusForward="@+id/zip"
+            android:textAppearance="@style/TextAppearance.Woo.Caption" />
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/zipLayout"
@@ -236,8 +200,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/shipping_label_edit_address_zip"
-            tools:visibility="visible"
-            app:errorEnabled="true">
+            app:errorEnabled="true"
+            tools:visibility="visible">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/zip"
@@ -253,14 +217,14 @@
             android:id="@+id/countrySpinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:inputType="text"
             android:layout_marginStart="@dimen/major_100"
-            android:layout_marginEnd="@dimen/major_100"
             android:layout_marginTop="@dimen/minor_00"
+            android:layout_marginEnd="@dimen/major_100"
             android:layout_marginBottom="@dimen/major_100"
-            android:textAppearance="@style/TextAppearance.Woo.Caption"
             android:hint="@string/shipping_label_edit_address_country"
-            android:nextFocusForward="@+id/useAddressAsIsButton" />
+            android:inputType="text"
+            android:nextFocusForward="@+id/useAddressAsIsButton"
+            android:textAppearance="@style/TextAppearance.Woo.Caption" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/useAddressAsIsButton"
@@ -270,8 +234,8 @@
             android:layout_marginStart="@dimen/major_100"
             android:layout_marginEnd="@dimen/major_100"
             android:layout_marginBottom="@dimen/major_100"
-            app:layout_goneMarginBottom="@dimen/major_100"
-            android:text="@string/shipping_label_edit_address_use_address_as_is" />
+            android:text="@string/shipping_label_edit_address_use_address_as_is"
+            app:layout_goneMarginBottom="@dimen/major_100" />
 
     </com.woocommerce.android.widgets.WCElevatedLinearLayout>
 

--- a/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_address.xml
+++ b/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_address.xml
@@ -134,24 +134,15 @@
             android:nextFocusForward="@+id/city"
             app:errorEnabled="true" />
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/cityLayout"
-            style="@style/Woo.TextInputLayout"
+        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+            android:id="@+id/city"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/shipping_label_edit_address_city"
-            app:errorEnabled="true"
-            tools:visibility="visible">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/city"
-                style="@style/Woo.TextInputEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:inputType="text"
-                android:nextFocusForward="@+id/state" />
-
-        </com.google.android.material.textfield.TextInputLayout>
+            android:layout_marginHorizontal="@dimen/major_100"
+            android:inputType="text"
+            android:nextFocusForward="@+id/state"
+            app:errorEnabled="true"/>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/stateLayout"
@@ -185,24 +176,15 @@
             android:nextFocusForward="@+id/zip"
             android:textAppearance="@style/TextAppearance.Woo.Caption" />
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/zipLayout"
-            style="@style/Woo.TextInputLayout"
+        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+            android:id="@+id/zip"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/major_100"
+            android:inputType="text"
             android:hint="@string/shipping_label_edit_address_zip"
-            app:errorEnabled="true"
-            tools:visibility="visible">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/zip"
-                style="@style/Woo.TextInputEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:inputType="text"
-                android:nextFocusForward="@+id/countrySpinner" />
-
-        </com.google.android.material.textfield.TextInputLayout>
+            android:nextFocusForward="@+id/countrySpinner"
+            app:errorEnabled="true"/>
 
         <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
             android:id="@+id/countrySpinner"

--- a/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_address.xml
+++ b/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_address.xml
@@ -144,24 +144,15 @@
             android:nextFocusForward="@+id/state"
             app:errorEnabled="true"/>
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/stateLayout"
-            style="@style/Woo.TextInputLayout"
+        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+            android:id="@+id/state"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/shipping_label_edit_address_state"
-            app:errorEnabled="true"
-            tools:visibility="visible">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/state"
-                style="@style/Woo.TextInputEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:inputType="text"
-                android:nextFocusForward="@+id/zip" />
-
-        </com.google.android.material.textfield.TextInputLayout>
+            android:layout_marginHorizontal="@dimen/major_100"
+            android:inputType="text"
+            android:nextFocusForward="@+id/zip"
+            app:errorEnabled="true"/>
 
         <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
             android:id="@+id/stateSpinner"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -116,6 +116,7 @@
     <string name="free">free</string>
     <string name="and">and</string>
     <string name="generic_string" translatable="false">%s</string>
+    <string name="error_required_field">Required field</string>
     <!--
         Date/Time Labels
     -->
@@ -470,7 +471,6 @@
     <string name="shipping_label_error_address_not_found">Address was not found</string>
     <string name="shipping_label_error_address_house_number_missing">House number missing</string>
     <string name="shipping_label_error_address_invalid_street">Invalid street</string>
-    <string name="shipping_label_error_required_field">Required field</string>
     <string name="shipping_label_validation_error_template">Validation failed: %s</string>
     <string name="shipping_label_validation_contact_customer">Contact Customer</string>
     <string name="shipping_label_validation_view_map">Open Map</string>


### PR DESCRIPTION
Closes #4177, if you feel that the PR has to be split, please tell me and I'll see how to do it.

I took this PR as a chance to rewrite the whole validation logic, to ensure that the ViewModel's ViewState is the source of truth for data input (a way of two way databinding), so that prefilling data, and restoration upon a configuration change will follow the same path, and would avoid us depending on the view's internal state, and also allows a validation while typing.
Another advantage, is that events callback won't have to read data from the views, but will be a better representation of the actual event (done button would trigger a dummy method callback `onDoneButtonClicked` without any data, the data is already present in the ViewState)

To achieve the above points, I created a [class](https://github.com/woocommerce/woocommerce-android/blob/84eeb38a402eed4b178ecfa182a54f78f78b717b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/InputField.kt#L18) that can represent an Input field, and which can be reused for other screens, the class is flexible in the way that it doesn't associate the error displayed to the validation of the field necessarily, to allow cases where we want to delay displaying the error until the user takes an action.

The change handles also some edge cases that we were missing, for example when the country has a list of defined states, we should enforce selecting a state, which wasn't done before.

#### Scenarios
##### Phone validation
<img width=360 src="https://user-images.githubusercontent.com/1657201/125321923-15983300-e335-11eb-8358-68b2ba639449.gif"/>
##### State validation
<img width=360 src="https://user-images.githubusercontent.com/1657201/125321946-1cbf4100-e335-11eb-9e06-74d6a11b6f26.gif"/>
##### Address 1 validation
<img width=360 src="https://user-images.githubusercontent.com/1657201/125322330-8f302100-e335-11eb-8951-e21973a31c2a.gif"/>

#### Testing
The form has many validation cases, but tries to follow these two points:
1. Don't display an error until the user starts typing, unless there is an earlier validation error that needs the user's attention right away (for example the phone in the above gif).
2. Hide the error when the entered data is valid, without waiting for clicking on done button.

So testing this feature should just validate these two points, with the following requirements:
- Either name or company is required.
-  Phone is required for origin addresses for all international shipments, and for destination addresses for DHL international shipments.
- Address1 is required.
- State is required only if the spinner is displayed.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
