### PR TITLE
Issue/4030 cancel payment intent

### DIFF
--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
@@ -27,6 +27,7 @@ interface CardReaderManager {
     ): Flow<CardPaymentStatus>
 
     suspend fun retryCollectPayment(orderId: Long, paymentData: PaymentData): Flow<CardPaymentStatus>
+    fun cancelPayment(paymentData: PaymentData)
 
     suspend fun softwareUpdateAvailability(): Flow<SoftwareUpdateAvailability>
     suspend fun updateSoftware(): Flow<SoftwareUpdateStatus>

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.cardreader.internal.firmware.actions.CheckSoftwar
 import com.woocommerce.android.cardreader.internal.firmware.actions.InstallSoftwareUpdateAction
 import com.woocommerce.android.cardreader.internal.payments.PaymentErrorMapper
 import com.woocommerce.android.cardreader.internal.payments.PaymentManager
+import com.woocommerce.android.cardreader.internal.payments.actions.CancelPaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.CreatePaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.ProcessPaymentAction
@@ -29,6 +30,7 @@ object CardReaderManagerFactory {
                 CreatePaymentAction(PaymentIntentParametersFactory(), terminal, logWrapper),
                 CollectPaymentAction(terminal, logWrapper),
                 ProcessPaymentAction(terminal, logWrapper),
+                CancelPaymentAction(terminal),
                 PaymentErrorMapper()
             ),
             ConnectionManager(terminal, logWrapper, DiscoverReadersAction(terminal)),

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.cardreader.internal.firmware.SoftwareUpdateManage
 import com.woocommerce.android.cardreader.internal.firmware.actions.CheckSoftwareUpdatesAction
 import com.woocommerce.android.cardreader.internal.firmware.actions.InstallSoftwareUpdateAction
 import com.woocommerce.android.cardreader.internal.payments.PaymentErrorMapper
+import com.woocommerce.android.cardreader.internal.payments.PaymentUtils
 import com.woocommerce.android.cardreader.internal.payments.PaymentManager
 import com.woocommerce.android.cardreader.internal.payments.actions.CancelPaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction
@@ -31,6 +32,7 @@ object CardReaderManagerFactory {
                 CollectPaymentAction(terminal, logWrapper),
                 ProcessPaymentAction(terminal, logWrapper),
                 CancelPaymentAction(terminal),
+                PaymentUtils(),
                 PaymentErrorMapper()
             ),
             ConnectionManager(terminal, logWrapper, DiscoverReadersAction(terminal)),

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -99,6 +99,8 @@ internal class CardReaderManagerImpl(
     override suspend fun retryCollectPayment(orderId: Long, paymentData: PaymentData): Flow<CardPaymentStatus> =
         paymentManager.retryPayment(orderId, paymentData)
 
+    override fun cancelPayment(paymentData: PaymentData) = paymentManager.cancelPayment(paymentData)
+
     private fun initStripeTerminal(logLevel: LogLevel) {
         terminal.initTerminal(application, logLevel, tokenProvider, connectionManager)
     }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -25,12 +25,8 @@ import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import java.math.BigDecimal
-import java.math.RoundingMode.HALF_UP
 
-internal const val USD_TO_CENTS_DECIMAL_PLACES = 2
-private const val USD_CURRENCY = "usd"
-
-@Suppress("TooManyFunctions", "LongParameterList")
+@Suppress("LongParameterList")
 internal class PaymentManager(
     private val terminalWrapper: TerminalWrapper,
     private val cardReaderStore: CardReaderStore,
@@ -38,6 +34,7 @@ internal class PaymentManager(
     private val collectPaymentAction: CollectPaymentAction,
     private val processPaymentAction: ProcessPaymentAction,
     private val cancelPaymentAction: CancelPaymentAction,
+    private val paymentUtils: PaymentUtils,
     private val errorMapper: PaymentErrorMapper
 ) {
     suspend fun acceptPayment(
@@ -47,12 +44,12 @@ internal class PaymentManager(
         currency: String,
         customerEmail: String?
     ): Flow<CardPaymentStatus> = flow {
-        if (!isSupportedCurrency(currency)) {
+        if (!paymentUtils.isSupportedCurrency(currency)) {
             emit(errorMapper.mapError(errorMessage = "Unsupported currency: $currency"))
             return@flow
         }
         val amountInSmallestCurrencyUnit = try {
-            convertBigDecimalInDollarsToIntegerInCents(amount)
+            paymentUtils.convertBigDecimalInDollarsToIntegerInCents(amount)
         } catch (e: ArithmeticException) {
             emit(errorMapper.mapError(errorMessage = "BigDecimal amount doesn't fit into an Integer: $amount"))
             return@flow
@@ -182,19 +179,6 @@ internal class PaymentManager(
             is CapturePaymentResponse.Error -> emit(errorMapper.mapCapturePaymentError(paymentIntent, captureResponse))
         }
     }
-
-    // TODO cardreader Add support for other currencies
-    private fun convertBigDecimalInDollarsToIntegerInCents(amount: BigDecimal): Int {
-        return amount
-            // round to USD_TO_CENTS_DECIMAL_PLACES decimal places
-            .setScale(USD_TO_CENTS_DECIMAL_PLACES, HALF_UP)
-            // convert dollars to cents
-            .movePointRight(USD_TO_CENTS_DECIMAL_PLACES)
-            .intValueExact()
-    }
-
-    // TODO Add Support for other currencies
-    private fun isSupportedCurrency(currency: String): Boolean = currency.equals(USD_CURRENCY, ignoreCase = true)
 }
 
 data class PaymentDataImpl(val paymentIntent: PaymentIntent) : PaymentData

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -30,6 +30,7 @@ import java.math.RoundingMode.HALF_UP
 internal const val USD_TO_CENTS_DECIMAL_PLACES = 2
 private const val USD_CURRENCY = "usd"
 
+@Suppress("TooManyFunctions", "LongParameterList")
 internal class PaymentManager(
     private val terminalWrapper: TerminalWrapper,
     private val cardReaderStore: CardReaderStore,

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentUtils.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentUtils.kt
@@ -1,0 +1,23 @@
+package com.woocommerce.android.cardreader.internal.payments
+
+import java.math.BigDecimal
+import java.math.RoundingMode
+import javax.inject.Inject
+
+private const val USD_CURRENCY = "usd"
+internal const val USD_TO_CENTS_DECIMAL_PLACES = 2
+
+class PaymentUtils @Inject constructor() {
+    // TODO cardreader Add support for other currencies
+    fun convertBigDecimalInDollarsToIntegerInCents(amount: BigDecimal): Int {
+        return amount
+            // round to USD_TO_CENTS_DECIMAL_PLACES decimal places
+            .setScale(USD_TO_CENTS_DECIMAL_PLACES, RoundingMode.HALF_UP)
+            // convert dollars to cents
+            .movePointRight(USD_TO_CENTS_DECIMAL_PLACES)
+            .intValueExact()
+    }
+
+    // TODO Add Support for other currencies
+    fun isSupportedCurrency(currency: String): Boolean = currency.equals(USD_CURRENCY, ignoreCase = true)
+}

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CancelPaymentAction.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CancelPaymentAction.kt
@@ -1,0 +1,27 @@
+package com.woocommerce.android.cardreader.internal.payments.actions
+
+import com.stripe.stripeterminal.callable.PaymentIntentCallback
+import com.stripe.stripeterminal.model.external.PaymentIntent
+import com.stripe.stripeterminal.model.external.TerminalException
+import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+
+internal class CancelPaymentAction(private val terminal: TerminalWrapper) {
+    fun cancelPayment(paymentIntent: PaymentIntent) {
+        // Usage of GlobalScope is intentional since the app should always try to cancel the payment intent
+        GlobalScope.launch {
+            terminal.cancelPayment(paymentIntent, noopCallback)
+        }
+    }
+}
+
+private val noopCallback = object : PaymentIntentCallback {
+    override fun onFailure(e: TerminalException) {
+        // noop
+    }
+
+    override fun onSuccess(paymentIntent: PaymentIntent) {
+        // noop
+    }
+}

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/wrappers/TerminalWrapper.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/wrappers/TerminalWrapper.kt
@@ -61,6 +61,9 @@ internal class TerminalWrapper {
     fun processPayment(paymentIntent: PaymentIntent, callback: PaymentIntentCallback) =
         Terminal.getInstance().processPayment(paymentIntent, callback)
 
+    fun cancelPayment(paymentIntent: PaymentIntent, callback: PaymentIntentCallback) =
+        Terminal.getInstance().cancelPaymentIntent(paymentIntent, callback)
+
     fun checkForUpdate(callback: ReaderSoftwareUpdateCallback) = Terminal.getInstance().checkForUpdate(callback)
     fun installSoftwareUpdate(
         updateData: ReaderSoftwareUpdate,


### PR DESCRIPTION
Parent issue #4030

This PR cancel payment intent when the user leaves "Payment failed" screen and the intent is in "requires_payment_method" or "requires_confirmation" state. When the intent is in "requires_capture" state, the app shouldn't cancel the intent as it doesn't know if the response from "capture_terminal_payment" endpoint got lost and the payment is already fully processed.

The current implementation won't cancel the payment intent if the user leaves the payment flow in the middle of processing, but it's a good first step. It's also worth noting that if the intent doesn't get canceled, the worst case scenario is that the money are put on hold on customer's account for up to 7 days.

The last commit extracts methods to a utility class to fix TooManyFunctions detekt issue.

To test:
- Make sure in-person payments are enabled on your store
1. Open a detail of an unpaid order
2. Tap on Collect payment button
3. Tap your card and quickly turn on airplane mode
4. Notice an error is shown -> disable the airplane mode
4. Dismiss the payment dialog
5. Notice the payment intent gets canceled - eg. using a breakpoint. (you can also check https://dashboard.stripe.com/[ACCOUNT_ID]/test/payments)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
