### PR TITLE
Suppress `LargeClass` Detekt rule for tests

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -52,7 +52,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.utils.DateUtils
 import java.math.BigDecimal
 
-@Suppress("LargeClass")
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 class OrderDetailViewModelTest : BaseUnitTest() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -72,7 +72,6 @@ import java.math.BigDecimal
 private val DUMMY_TOTAL = BigDecimal(10.72)
 private const val DUMMY_ORDER_NUMBER = "123"
 
-@Suppress("LargeClass")
 @InternalCoroutinesApi
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -2,6 +2,8 @@ build:
   maxIssues: 0
 
 complexity:
+  LargeClass:
+    excludes: ['**/test/**', '**/androidTest/**']
   LongParameterList:
     ignoreDefaultParameters: true
     ignoreAnnotated: ['Inject']

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -3,7 +3,7 @@ build:
 
 complexity:
   LargeClass:
-    excludes: ['**/test/**', '**/androidTest/**']
+    excludes: ['**/test/**']
   LongParameterList:
     ignoreDefaultParameters: true
     ignoreAnnotated: ['Inject']


### PR DESCRIPTION
## Description

As discussed internally (p91TBi-5lF-p2#comment-5301) this PR suppresses `LargeClass` rule for test classes.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.