### PR TITLE
[Product Image Uploads] Step 2 - display the count of upload errors in the SnackBar 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -161,11 +161,13 @@ class ProductImagesService : JobIntentService() {
 
             if (currentMediaUpload == null) {
                 WooLog.w(T.MEDIA, "productImagesService > null media")
-                handleFailure(MediaModel(),
-                    MediaError(
+                handleFailure(
+                    mediaModel = MediaModel(),
+                    mediaUploadError = MediaError(
                         MediaErrorType.NULL_MEDIA_ARG,
                         resources.getString(R.string.product_image_service_error_media_null)
-                    ))
+                    )
+                )
             } else {
                 currentMediaUpload!!.postId = id
                 currentMediaUpload!!.setUploadState(MediaModel.MediaUploadState.UPLOADING)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt
@@ -4,11 +4,13 @@ import android.content.Intent
 import android.net.Uri
 import androidx.collection.LongSparseArray
 import androidx.core.app.JobIntentService
+import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_IMAGE_UPLOAD_FAILED
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import dagger.hilt.android.AndroidEntryPoint
@@ -19,6 +21,8 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.MediaActionBuilder
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.store.MediaStore
+import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType
+import org.wordpress.android.fluxc.store.MediaStore.MediaError
 import org.wordpress.android.fluxc.store.MediaStore.CancelMediaPayload
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded
 import org.wordpress.android.fluxc.store.MediaStore.UploadMediaPayload
@@ -97,6 +101,7 @@ class ProductImagesService : JobIntentService() {
     @Inject lateinit var selectedSite: SelectedSite
     @Inject lateinit var productImageMap: ProductImageMap
     @Inject lateinit var networkStatus: NetworkStatus
+    @Inject lateinit var mediaFileUploadHandler: MediaFileUploadHandler
 
     private var doneSignal: CountDownLatch? = null
     private var currentMediaUpload: MediaModel? = null
@@ -156,7 +161,11 @@ class ProductImagesService : JobIntentService() {
 
             if (currentMediaUpload == null) {
                 WooLog.w(T.MEDIA, "productImagesService > null media")
-                handleFailure()
+                handleFailure(MediaModel(),
+                    MediaError(
+                        MediaErrorType.NULL_MEDIA_ARG,
+                        resources.getString(R.string.product_image_service_error_media_null)
+                    ))
             } else {
                 currentMediaUpload!!.postId = id
                 currentMediaUpload!!.setUploadState(MediaModel.MediaUploadState.UPLOADING)
@@ -224,7 +233,7 @@ class ProductImagesService : JobIntentService() {
                         AnalyticsTracker.KEY_ERROR_DESC to event.error?.message
                     )
                 )
-                handleFailure()
+                handleFailure(event.media, event.error)
             }
             event.canceled -> {
                 WooLog.d(T.MEDIA, "productImagesService > upload media cancelled")
@@ -247,8 +256,12 @@ class ProductImagesService : JobIntentService() {
         EventBus.getDefault().post(OnProductImageUploaded(uploadedMedia))
     }
 
-    private fun handleFailure() {
+    private fun handleFailure(
+        mediaModel: MediaModel,
+        mediaUploadError: MediaError
+    ) {
         countDown()
+        mediaFileUploadHandler.handleMediaUploadFailure(mediaModel, mediaUploadError)
         EventBus.getDefault().post(OnProductImageUploaded(isError = true))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
@@ -44,6 +44,28 @@ interface UIMessageResolver {
     }
 
     /**
+     * Create and return a snackbar displaying the provided message and a generic action button.
+     *
+     * @param [message] The message string
+     * @param [message] The action string
+     * @param [stringArgs] Optional. One or more format argument stringArgs
+     * @param [actionListener] Listener to handle the undo button click event
+     */
+    fun getActionSnack(
+        message: String,
+        vararg stringArgs: String = arrayOf(),
+        actionText: String,
+        actionListener: View.OnClickListener
+    ): Snackbar {
+        return getSnackbarWithAction(
+            snackbarRoot,
+            String.format(message, *stringArgs),
+            actionText,
+            actionListener
+        )
+    }
+
+    /**
      * Create and return a snackbar displaying the provided message and a RETRY button.
      *
      * @param [stringResId] The string resource id of the base message

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
@@ -149,15 +149,6 @@ interface UIMessageResolver {
      */
     fun showSnack(@StringRes msgId: Int) = Snackbar.make(snackbarRoot, msgId, BaseTransientBottomBar.LENGTH_LONG).show()
 
-    /**
-     * Display a generic offline message.
-     */
-    fun showOfflineSnack() = Snackbar.make(
-        snackbarRoot,
-        snackbarRoot.context.getString(R.string.offline_error),
-        BaseTransientBottomBar.LENGTH_LONG
-    ).show()
-
     private fun getIndefiniteSnackbarWithAction(
         view: View,
         msg: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
@@ -1,0 +1,48 @@
+package com.woocommerce.android.ui.media
+
+import android.os.Parcelable
+import androidx.collection.LongSparseArray
+import com.woocommerce.android.R
+import com.woocommerce.android.util.StringUtils
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.parcelize.Parcelize
+import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.store.MediaStore
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class MediaFileUploadHandler @Inject constructor(
+    private val resourceProvider: ResourceProvider
+) {
+    // array of ID / images that have failed to upload for that product
+    private val currentUploadErrors = LongSparseArray<List<ProductImageUploadUiModel>>()
+
+    fun getMediaUploadErrorCount(remoteProductId: Long) = currentUploadErrors.get(remoteProductId)?.size ?: 0
+
+    fun handleMediaUploadFailure(
+        mediaModel: MediaModel,
+        mediaUploadError: MediaStore.MediaError
+    ) {
+        val newErrors = currentUploadErrors.get(mediaModel.postId, mutableListOf()) +
+            ProductImageUploadUiModel(mediaModel, mediaUploadError.type, mediaUploadError.message)
+        currentUploadErrors.put(mediaModel.postId, newErrors)
+    }
+
+    fun getMediaUploadErrorMessage(remoteProductId: Long): String {
+        return StringUtils.getQuantityString(
+            resourceProvider = resourceProvider,
+            quantity = getMediaUploadErrorCount(remoteProductId),
+            default = R.string.product_image_service_error_uploading_multiple,
+            one = R.string.product_image_service_error_uploading_single,
+            zero = R.string.product_image_service_error_uploading
+        )
+    }
+
+    @Parcelize
+    data class ProductImageUploadUiModel(
+        val media: MediaModel,
+        val mediaErrorType: MediaStore.MediaErrorType,
+        val mediaErrorMessage: String
+    ) : Parcelable
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
@@ -20,13 +20,18 @@ class MediaFileUploadHandler @Inject constructor(
 
     fun getMediaUploadErrorCount(remoteProductId: Long) = currentUploadErrors.get(remoteProductId)?.size ?: 0
 
+    fun onCleanup() {
+        currentUploadErrors.clear()
+    }
+
     fun handleMediaUploadFailure(
         mediaModel: MediaModel,
         mediaUploadError: MediaStore.MediaError
     ) {
-        val newErrors = currentUploadErrors.get(mediaModel.postId, mutableListOf()) +
+        val remoteProductId = mediaModel.postId
+        val newErrors = currentUploadErrors.get(remoteProductId, mutableListOf()) +
             ProductImageUploadUiModel(mediaModel, mediaUploadError.type, mediaUploadError.message)
-        currentUploadErrors.put(mediaModel.postId, newErrors)
+        currentUploadErrors.put(remoteProductId, newErrors)
     }
 
     fun getMediaUploadErrorMessage(remoteProductId: Long): String {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -16,6 +16,7 @@ import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.R
 import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -42,6 +43,7 @@ import com.woocommerce.android.util.WooPermissionUtils
 import com.woocommerce.android.util.setHomeIcon
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowActionSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageInteractionListener
@@ -66,6 +68,7 @@ class ProductImagesFragment :
 
     private var imageSourceDialog: AlertDialog? = null
     private var capturedPhotoUri: Uri? = null
+    private var detailSnackbar: Snackbar? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -181,6 +184,7 @@ class ProductImagesFragment :
             Observer { event ->
                 when (event) {
                     is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+                    is ShowActionSnackbar -> displayProductImageUploadErrorSnackBar(event.message, event.action)
                     is ExitWithResult<*> -> navigateBackWithResult(KEY_IMAGES_DIALOG_RESULT, event.data)
                     is ShowDialog -> event.showDialog()
                     ShowImageSourceDialog -> showImageSourceDialog()
@@ -201,6 +205,22 @@ class ProductImagesFragment :
             onPositiveButton = { viewModel.onDeleteImageConfirmed(image) },
             onNegativeButton = { /* no-op */ }
         ).show()
+    }
+
+    private fun displayProductImageUploadErrorSnackBar(
+        message: String,
+        actionListener: View.OnClickListener
+    ) {
+        if (detailSnackbar == null) {
+            detailSnackbar = uiMessageResolver.getActionSnack(
+                message = message,
+                actionText = getString(R.string.details),
+                actionListener = actionListener
+            )
+        } else {
+            detailSnackbar?.setText(message)
+        }
+        detailSnackbar?.show()
     }
 
     private fun updateImages(images: List<Image>, uris: List<Uri>?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.media.ProductImagesServiceWrapper
 import com.woocommerce.android.model.Product.Image
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.ui.products.ProductImagesViewModel.ProductImagesState.Browsing
 import com.woocommerce.android.ui.products.ProductImagesViewModel.ProductImagesState.Dragging
 import com.woocommerce.android.util.swap
@@ -26,6 +27,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowActionSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -39,6 +41,7 @@ import javax.inject.Inject
 class ProductImagesViewModel @Inject constructor(
     private val networkStatus: NetworkStatus,
     private val productImagesServiceWrapper: ProductImagesServiceWrapper,
+    private val mediaFileUploadHandler: MediaFileUploadHandler,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
     private val navArgs: ProductImagesFragmentArgs by savedState.navArgs()
@@ -242,7 +245,10 @@ class ProductImagesViewModel @Inject constructor(
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: OnProductImageUploaded) {
         if (event.isError) {
-            triggerEvent(ShowSnackbar(string.product_image_service_error_uploading))
+            val errorMsg = mediaFileUploadHandler.getMediaUploadErrorMessage(navArgs.remoteId)
+            triggerEvent(ShowActionSnackbar(errorMsg, action = {
+                // TODO: will be taken care of in another commit
+            }))
         } else {
             event.media?.let { media ->
                 viewState = if (isMultiSelectionAllowed) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
@@ -246,9 +246,7 @@ class ProductImagesViewModel @Inject constructor(
     fun onEventMainThread(event: OnProductImageUploaded) {
         if (event.isError) {
             val errorMsg = mediaFileUploadHandler.getMediaUploadErrorMessage(navArgs.remoteId)
-            triggerEvent(ShowActionSnackbar(errorMsg, action = {
-                // TODO: will be taken care of in another commit
-            }))
+            triggerEvent(ShowActionSnackbar(errorMsg, action = { }))
         } else {
             event.media?.let { media ->
                 viewState = if (isMultiSelectionAllowed) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
@@ -135,6 +135,9 @@ class ProductImagesViewModel @Inject constructor(
     fun onImageSourceButtonClicked() {
         AnalyticsTracker.track(PRODUCT_IMAGE_SETTINGS_ADD_IMAGES_BUTTON_TAPPED)
         triggerEvent(ShowImageSourceDialog)
+
+        // clear existing image upload errors from the backlog
+        mediaFileUploadHandler.onCleanup()
     }
 
     fun onGalleryImageClicked(image: Image) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
@@ -76,6 +76,7 @@ class ProductImagesViewModel @Inject constructor(
         EventBus.getDefault().register(this)
 
         if (navArgs.showChooser) {
+            clearImageUploadErrors()
             triggerEvent(ShowImageSourceDialog)
         } else {
             navArgs.selectedImage?.let {
@@ -133,11 +134,9 @@ class ProductImagesViewModel @Inject constructor(
     }
 
     fun onImageSourceButtonClicked() {
+        clearImageUploadErrors()
         AnalyticsTracker.track(PRODUCT_IMAGE_SETTINGS_ADD_IMAGES_BUTTON_TAPPED)
         triggerEvent(ShowImageSourceDialog)
-
-        // clear existing image upload errors from the backlog
-        mediaFileUploadHandler.onCleanup()
     }
 
     fun onGalleryImageClicked(image: Image) {
@@ -198,6 +197,11 @@ class ProductImagesViewModel @Inject constructor(
         viewState = viewState.copy(
             isDragDropDescriptionVisible = viewState.productImagesState is Dragging || images.size > 1
         )
+    }
+
+    private fun clearImageUploadErrors() {
+        // clear existing image upload errors from the backlog
+        mediaFileUploadHandler.onCleanup()
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
@@ -113,8 +113,7 @@ open class MultiLiveEvent<T : Event> : MutableLiveData<T>() {
         data class ShowActionSnackbar(
             val message: String,
             val action: View.OnClickListener
-        ) : Event() {
-        }
+        ) : Event()
 
         object Logout : Event()
         object Exit : Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
@@ -114,21 +114,6 @@ open class MultiLiveEvent<T : Event> : MutableLiveData<T>() {
             val message: String,
             val action: View.OnClickListener
         ) : Event() {
-            override fun equals(other: Any?): Boolean {
-                if (this === other) return true
-                if (other !is ShowActionSnackbar) return false
-
-                if (message != other.message) return false
-                if (action != other.action) return false
-
-                return true
-            }
-
-            override fun hashCode(): Int {
-                var result = message.hashCode()
-                result = 31 * result + action.hashCode()
-                return result
-            }
         }
 
         object Logout : Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
@@ -110,6 +110,27 @@ open class MultiLiveEvent<T : Event> : MutableLiveData<T>() {
             }
         }
 
+        data class ShowActionSnackbar(
+            val message: String,
+            val action: View.OnClickListener
+        ) : Event() {
+            override fun equals(other: Any?): Boolean {
+                if (this === other) return true
+                if (other !is ShowActionSnackbar) return false
+
+                if (message != other.message) return false
+                if (action != other.action) return false
+
+                return true
+            }
+
+            override fun hashCode(): Int {
+                var result = message.hashCode()
+                result = 31 * result + action.hashCode()
+                return result
+            }
+        }
+
         object Logout : Event()
         object Exit : Event()
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1120,6 +1120,7 @@
     <string name="product_images_image_limit_warning">Only one photo can be displayed per product variation</string>
     <string name="product_images_drag_and_drop_description">Drag and drop to re-order photos</string>
     <string name="product_images_validate_drag_and_drop">Validate</string>
+    <string name="product_image_service_error_media_null">Media could not be found</string>
     <string name="product_image_service_error_uploading_single">%d file couldn\'t be uploaded</string>
     <string name="product_image_service_error_uploading_multiple">%d files couldn\'t be uploaded</string>
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1120,7 +1120,8 @@
     <string name="product_images_image_limit_warning">Only one photo can be displayed per product variation</string>
     <string name="product_images_drag_and_drop_description">Drag and drop to re-order photos</string>
     <string name="product_images_validate_drag_and_drop">Validate</string>
-
+    <string name="product_image_service_error_uploading_single">%d file couldn\'t be uploaded</string>
+    <string name="product_image_service_error_uploading_multiple">%d files couldn\'t be uploaded</string>
 
     <!--
         Empty list messages

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandlerTest.kt
@@ -1,0 +1,40 @@
+package com.woocommerce.android.ui.media
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.spy
+import com.woocommerce.android.ui.products.ProductTestUtils
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class MediaFileUploadHandlerTest : BaseUnitTest() {
+    companion object {
+        private const val REMOTE_PRODUCT_ID = 1L
+        private const val REMOTE_SITE_ID = 1L
+    }
+
+    private val resources: ResourceProvider = mock()
+    private val testMediaModel = ProductTestUtils.generateProductMedia(REMOTE_PRODUCT_ID, REMOTE_SITE_ID)
+    private val testMediaModelError = ProductTestUtils.generateMediaUploadErrorModel()
+    private lateinit var mediaFileUploadHandler: MediaFileUploadHandler
+
+    @Before
+    fun setup() {
+        mediaFileUploadHandler = spy(MediaFileUploadHandler(resources))
+    }
+
+    @Test
+    fun `Handles product image upload error correctly`() {
+        assertThat(mediaFileUploadHandler.getMediaUploadErrorCount(testMediaModel.postId)).isEqualTo(0)
+
+        mediaFileUploadHandler.handleMediaUploadFailure(testMediaModel, testMediaModelError)
+        assertThat(mediaFileUploadHandler.getMediaUploadErrorCount(testMediaModel.postId)).isEqualTo(1)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandlerTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.media
 
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.spy
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -36,5 +37,8 @@ class MediaFileUploadHandlerTest : BaseUnitTest() {
 
         mediaFileUploadHandler.handleMediaUploadFailure(testMediaModel, testMediaModelError)
         assertThat(mediaFileUploadHandler.getMediaUploadErrorCount(testMediaModel.postId)).isEqualTo(1)
+        assertThat(mediaFileUploadHandler.getMediaUploadErrorMessage(testMediaModel.postId)).isEqualTo(
+            resources.getString(R.string.product_image_service_error_uploading_single)
+        )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModelTest.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.media.ProductImagesServiceWrapper
 import com.woocommerce.android.model.Product.Image
 import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.ui.products.ProductImagesViewModel.ProductImagesState.Dragging
 import com.woocommerce.android.ui.products.ProductImagesViewModel.ShowDeleteImageConfirmation
 import com.woocommerce.android.ui.products.ProductTestUtils.generateProductImagesList
@@ -22,6 +23,7 @@ class ProductImagesViewModelTest : BaseUnitTest() {
     lateinit var viewModel: ProductImagesViewModel
 
     private val networkStatus: NetworkStatus = mock()
+    private val mediaFileUploadHandler: MediaFileUploadHandler = mock()
 
     private val productImagesServiceWrapper: ProductImagesServiceWrapper = mock()
 
@@ -37,6 +39,7 @@ class ProductImagesViewModelTest : BaseUnitTest() {
         viewModel = ProductImagesViewModel(
             networkStatus,
             productImagesServiceWrapper,
+            mediaFileUploadHandler,
             savedState(productImages)
         ).apply {
             viewStateData.observeForever { _, _ -> }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -6,8 +6,10 @@ import com.woocommerce.android.model.ProductCategory
 import com.woocommerce.android.model.ProductTag
 import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.model.toAppModel
+import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
+import org.wordpress.android.fluxc.store.MediaStore
 import java.sql.Date
 import java.time.Instant
 
@@ -119,6 +121,21 @@ object ProductTestUtils {
             source = "Image $imageId source",
             dateCreated = Date.from(Instant.EPOCH)
         )
+
+    fun generateProductMedia(remoteProductId: Long = 1, siteId: Long = 1) =
+        MediaModel().apply {
+            id = 1
+            localPostId = remoteProductId.toInt()
+            localSiteId = siteId.toInt()
+            mediaId = 1L
+            fileName = "Image filename $remoteProductId"
+            url = "google.com"
+        }
+
+    fun generateMediaUploadErrorModel() = MediaStore.MediaError(
+        MediaStore.MediaErrorType.GENERIC_ERROR,
+        "Error uploading media"
+    )
 
     fun generateProductImagesList() =
         (1L..10L).map { id -> generateProductImage(imageId = id) }


### PR DESCRIPTION
Fixes #4331. 

**This PR is part of a work in progress feature so it is merged against a feature branch.** 

### Changes
- This PR modifies the text on the SnackBar that is displayed when an image upload process fails. 
- I introduced a new class called `MediaFileUploadHandler` that keeps track of the number of images that failed to upload and the reason for that error. This makes it easier to unit test this functionality. I do think we should refactor `ProductImagesService` and move all the logic in that service class to this class at some point so that it is easier to test but that is out of scope for this project atleast. I'll open a separate issue for that.

### Notes
- This PR only displays the snackbar with a `Details` button. The actual click action will be taken care of in a different PR. 
- This change will need to be added to `ProductDetailFragment` and `VariationDetailFragment` as well. I plan to tackle those in a separate PR since this one already includes a lot of change.

### Screenshots
LEFT: Before.  RIGHT: After
<img src="https://user-images.githubusercontent.com/22608780/125402362-f4395480-e3d1-11eb-8a80-56585084481c.gif" width="300"/>. <img src="https://user-images.githubusercontent.com/22608780/125402262-d23fd200-e3d1-11eb-906a-992a8be585f6.gif" width="300"/>

### Testing
- Try to upload an image with an extension, other than `png`, `jpeg`, `jpg` or `gif`. There is local validation in FluxC so any images without these extensions will result in an error.
- Verify that the text displayed in the SnackBar for a single file is: `1 file couldn't be uploaded` and for multiple errors: `2 files couldn't be uploaded`.
- Run `MediaFileUploadHandlerTest`.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
