### PR TITLE
Shipping labels: add support of multiple packages in the customs step

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -526,10 +526,9 @@ class CreateShippingLabelViewModel @Inject constructor(
                 val firstLine = if (data.size == 1) {
                     data.first().selectedPackage!!.title
                 } else {
-                    // TODO properly test this during M3
                     resourceProvider.getString(
                         string.shipping_label_multi_packages_items_count,
-                        data.sumBy { it.items.size },
+                        data.sumBy { it.itemsCount },
                         data.size
                     )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
@@ -148,6 +148,7 @@ class ShippingCustomsAdapter(
             val (customsPackage, validationState) = uiState
             binding.packageId.text = customsPackage.labelPackage.getTitle(context)
             binding.packageName.text = "- ${customsPackage.labelPackage.selectedPackage!!.title}"
+            binding.errorView.isVisible = !validationState.isValid
             binding.returnCheckbox.isChecked = customsPackage.returnToSender
 
             // Animate any potential change to visibility of the description fields

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
@@ -66,6 +66,7 @@ class ShippingCustomsAdapter(
         return customsPackages[position].data.id.hashCode().toLong()
     }
 
+    @Suppress("MagicNumber")
     inner class PackageCustomsViewHolder(val binding: ShippingCustomsListItemBinding) : ViewHolder(binding.root) {
         private val linesAdapter: ShippingCustomsLineAdapter by lazy {
             ShippingCustomsLineAdapter(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
@@ -28,6 +28,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustoms
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustomsLineAdapter.CustomsLineViewHolder
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustomsViewModel.CustomsPackageUiState
 import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
 import com.woocommerce.android.widgets.WooClickableSpan
 
@@ -77,6 +78,9 @@ class ShippingCustomsAdapter(
         private val context
             get() = binding.root.context
 
+        private val isExpanded
+            get() = binding.expandIcon.rotation == 180f
+
         init {
             binding.itemsList.apply {
                 itemAnimator = null
@@ -122,6 +126,21 @@ class ShippingCustomsAdapter(
             binding.itnEditText.setOnTextChangedListener {
                 it?.let { listener.onItnChanged(adapterPosition, it.toString()) }
             }
+            if (!FeatureFlag.SHIPPING_LABELS_M4.isEnabled()) {
+                binding.expandIcon.isVisible = false
+            } else {
+                binding.titleLayout.setOnClickListener {
+                    if (isExpanded) {
+                        binding.expandIcon.animate().rotation(0f).start()
+                        binding.detailsLayout.collapse()
+                        listener.onPackageExpandedChanged(adapterPosition, false)
+                    } else {
+                        binding.expandIcon.animate().rotation(180f).start()
+                        binding.detailsLayout.expand()
+                        listener.onPackageExpandedChanged(adapterPosition, true)
+                    }
+                }
+            }
         }
 
         @SuppressLint("SetTextI18n")
@@ -152,6 +171,14 @@ class ShippingCustomsAdapter(
 
             linesAdapter.parentItemPosition = adapterPosition
             linesAdapter.customsLines = uiState.customsLinesUiState
+
+            if (uiState.isExpanded) {
+                binding.expandIcon.rotation = 180f
+                binding.detailsLayout.isVisible = true
+            } else {
+                binding.expandIcon.rotation = 0f
+                binding.detailsLayout.isVisible = false
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
@@ -308,6 +308,7 @@ class ShippingCustomsLineAdapter(
 }
 
 interface ShippingCustomsFormListener {
+    fun onPackageExpandedChanged(position: Int, isExpanded: Boolean)
     fun onReturnToSenderChanged(position: Int, returnToSender: Boolean)
     fun onContentsTypeChanged(position: Int, contentsType: ContentsType)
     fun onContentsDescriptionChanged(position: Int, contentsDescription: String)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -137,6 +137,7 @@ class ShippingLabelPackagesAdapter(
                 shippingLabelPackage.itemsCount,
                 shippingLabelPackage.itemsCount
             )}"
+            binding.errorView.isVisible = !uiModel.isValid
             with(binding.itemsList.adapter as PackageProductsAdapter) {
                 items = shippingLabelPackage.adaptItemsForUi()
                 moveItemClickListener = { item -> onMoveItemClicked(item, shippingLabelPackage) }

--- a/WooCommerce/src/main/res/layout/shipping_customs_line_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_customs_line_list_item.xml
@@ -110,7 +110,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/major_100"
             android:layout_marginEnd="@dimen/major_100"
-            android:layout_marginBottom="@dimen/major_100"
+            android:layout_marginBottom="@dimen/major_200"
             android:gravity="start"
             android:text="@string/shipping_label_customs_origin_country_explanation"
             android:textAppearance="?attr/textAppearanceCaption" />

--- a/WooCommerce/src/main/res/layout/shipping_customs_line_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_customs_line_list_item.xml
@@ -63,13 +63,13 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/major_100"
             android:hint="@string/shipping_label_customs_item_description_hint"
+            app:errorEnabled="true"
             android:inputType="text" />
 
         <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
             android:id="@+id/hs_tariff_number_edit_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/major_100"
             android:hint="@string/shipping_label_customs_hs_tariff_hint"
             android:inputType="number"
             android:maxLength="6" />
@@ -86,6 +86,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/major_100"
+            app:errorEnabled="true"
             android:inputType="numberDecimal"
             tools:hint="Weight (oz per unit)" />
 
@@ -93,7 +94,7 @@
             android:id="@+id/value_edit_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/major_100"
+            app:errorEnabled="true"
             android:inputType="numberDecimal"
             tools:hint="Value ($ per unit)" />
 
@@ -101,7 +102,6 @@
             android:id="@+id/country_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/major_100"
             android:hint="@string/shipping_label_customs_origin_country_hint" />
 
         <com.google.android.material.textview.MaterialTextView

--- a/WooCommerce/src/main/res/layout/shipping_customs_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_customs_list_item.xml
@@ -1,144 +1,117 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.woocommerce.android.widgets.WCElevatedConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<com.woocommerce.android.widgets.WCElevatedLinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
 
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/start_guideline"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:orientation="vertical"
-        app:layout_constraintGuide_begin="@dimen/major_100" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/end_guideline"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:orientation="vertical"
-        app:layout_constraintGuide_end="@dimen/major_100" />
-
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/package_id"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:id="@+id/title_layout"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/major_75"
-        android:textAppearance="?attr/textAppearanceSubtitle1"
-        android:textColor="@color/color_on_surface_high"
-        android:textStyle="bold"
-        app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="Package 1" />
+        android:background="?attr/selectableItemBackground"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/package_name"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/minor_50"
-        android:textAppearance="@style/TextAppearance.Woo.Body1"
-        app:layout_constraintBaseline_toBaselineOf="@id/package_id"
-        app:layout_constraintStart_toEndOf="@id/package_id"
-        tools:text="- Small Package" />
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/package_id"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceSubtitle1"
+            android:textColor="@color/color_on_surface_high"
+            android:textStyle="bold"
+            tools:text="Package 1" />
 
-    <androidx.appcompat.widget.AppCompatImageView
-        android:layout_width="@dimen/image_minor_50"
-        android:layout_height="@dimen/image_minor_50"
-        android:src="@drawable/ic_arrow_down"
-        android:tint="@color/color_on_surface_high"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="@id/package_id"
-        app:layout_constraintEnd_toEndOf="@id/end_guideline"
-        app:layout_constraintTop_toTopOf="@id/package_id"
-        tools:visibility="visible" />
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/package_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/minor_50"
+            android:layout_weight="1"
+            android:textAppearance="@style/TextAppearance.Woo.Body1"
+            tools:text="- Small Package" />
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/expand_icon"
+            android:layout_width="@dimen/image_major_50"
+            android:layout_height="@dimen/image_major_50"
+            android:padding="@dimen/major_75"
+            android:src="@drawable/ic_arrow_down"
+            android:tint="@color/color_on_surface_high" />
+    </LinearLayout>
 
     <View
         android:id="@+id/divider_1"
-        style="@style/Woo.Divider"
-        android:layout_marginTop="@dimen/major_75"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/package_name" />
+        style="@style/Woo.Divider" />
 
     <com.google.android.material.checkbox.MaterialCheckBox
         android:id="@+id/return_checkbox"
         style="@style/Woo.CheckBox"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/major_100"
         android:layout_marginTop="@dimen/minor_100"
-        android:text="@string/shipping_label_customs_return_to_sender"
-        app:layout_constraintEnd_toEndOf="@id/end_guideline"
-        app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/divider_1" />
+        android:text="@string/shipping_label_customs_return_to_sender" />
 
     <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
         android:id="@+id/contents_type_spinner"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/major_100"
         android:layout_marginTop="@dimen/major_100"
-        android:hint="@string/shipping_label_customs_contents_type_hint"
-        app:layout_constraintEnd_toEndOf="@id/end_guideline"
-        app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/return_checkbox" />
+        android:hint="@string/shipping_label_customs_contents_type_hint" />
 
     <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
         android:id="@+id/contents_type_description"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/major_100"
         android:layout_marginTop="@dimen/major_100"
         android:hint="@string/shipping_label_customs_contents_type_other_hint"
         android:inputType="text"
         android:visibility="gone"
-        app:layout_constraintEnd_toEndOf="@id/end_guideline"
-        app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/contents_type_spinner" />
+        tools:visibility="visible" />
 
     <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
         android:id="@+id/restriction_type_spinner"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/major_100"
         android:layout_marginTop="@dimen/major_100"
-        android:hint="@string/shipping_label_customs_restriction_type_hint"
-        app:layout_constraintEnd_toEndOf="@id/end_guideline"
-        app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/contents_type_description" />
+        android:hint="@string/shipping_label_customs_restriction_type_hint" />
 
     <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
         android:id="@+id/restriction_type_description"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/major_100"
         android:layout_marginTop="@dimen/major_100"
         android:hint="@string/shipping_label_customs_restriction_type_other_hint"
         android:inputType="text"
         android:visibility="gone"
-        app:layout_constraintEnd_toEndOf="@id/end_guideline"
-        app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/restriction_type_spinner" />
+        tools:visibility="visible" />
 
     <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
         android:id="@+id/itn_edit_text"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/major_100"
         android:layout_marginTop="@dimen/major_100"
         android:hint="@string/shipping_label_customs_itn_hint"
-        android:inputType="text"
-        app:layout_constraintEnd_toEndOf="@id/end_guideline"
-        app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/restriction_type_description" />
+        android:inputType="text" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/itn_description"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/major_100"
         android:layout_marginTop="@dimen/major_100"
         android:textAppearance="?attr/textAppearanceBody2"
-        app:layout_constraintEnd_toEndOf="@id/end_guideline"
-        app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/itn_edit_text"
         tools:text="Learn more about Internal Transaction Number" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/content_section_title"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="@dimen/major_300"
         android:layout_marginTop="@dimen/major_100"
         android:background="@color/default_window_background"
@@ -147,24 +120,18 @@
         android:paddingEnd="@dimen/major_100"
         android:text="@string/shipping_label_customs_package_content"
         android:textAppearance="?attr/textAppearanceSubtitle2"
-        android:textColor="@color/color_on_surface_disabled"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/itn_description" />
+        android:textColor="@color/color_on_surface_disabled" />
 
     <View
         android:id="@+id/divider_2"
         style="@style/Woo.Divider"
-        android:layout_marginStart="@dimen/major_100"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/content_section_title" />
+        android:layout_marginStart="@dimen/major_100" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/items_list"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@id/divider_2"
         tools:itemCount="1"
         tools:listitem="@layout/shipping_customs_line_list_item" />
 
-</com.woocommerce.android.widgets.WCElevatedConstraintLayout>
+</com.woocommerce.android.widgets.WCElevatedLinearLayout>

--- a/WooCommerce/src/main/res/layout/shipping_customs_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_customs_list_item.xml
@@ -8,8 +8,9 @@
     <LinearLayout
         android:id="@+id/title_layout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="@dimen/min_tap_target"
         android:background="?attr/selectableItemBackground"
+        android:paddingHorizontal="@dimen/major_100"
         android:gravity="center_vertical"
         android:orientation="horizontal">
 
@@ -33,105 +34,114 @@
 
         <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/expand_icon"
-            android:layout_width="@dimen/image_major_50"
-            android:layout_height="@dimen/image_major_50"
-            android:padding="@dimen/major_75"
+            android:layout_width="@dimen/image_minor_50"
+            android:layout_height="@dimen/image_minor_50"
+            android:layout_gravity="end|center_vertical"
             android:src="@drawable/ic_arrow_down"
             android:tint="@color/color_on_surface_high" />
     </LinearLayout>
 
-    <View
-        android:id="@+id/divider_1"
-        style="@style/Woo.Divider" />
-
-    <com.google.android.material.checkbox.MaterialCheckBox
-        android:id="@+id/return_checkbox"
-        style="@style/Woo.CheckBox"
+    <LinearLayout
+        android:id="@+id/details_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/major_100"
-        android:layout_marginTop="@dimen/minor_100"
-        android:text="@string/shipping_label_customs_return_to_sender" />
+        android:orientation="vertical">
+        <View
+            android:id="@+id/divider_1"
+            style="@style/Woo.Divider" />
 
-    <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-        android:id="@+id/contents_type_spinner"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/major_100"
-        android:layout_marginTop="@dimen/major_100"
-        android:hint="@string/shipping_label_customs_contents_type_hint" />
+        <com.google.android.material.checkbox.MaterialCheckBox
+            android:id="@+id/return_checkbox"
+            style="@style/Woo.CheckBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/major_100"
+            android:layout_marginTop="@dimen/minor_100"
+            android:text="@string/shipping_label_customs_return_to_sender" />
 
-    <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-        android:id="@+id/contents_type_description"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/major_100"
-        android:layout_marginTop="@dimen/major_100"
-        android:hint="@string/shipping_label_customs_contents_type_other_hint"
-        android:inputType="text"
-        android:visibility="gone"
-        tools:visibility="visible" />
+        <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+            android:id="@+id/contents_type_spinner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_100"
+            android:hint="@string/shipping_label_customs_contents_type_hint" />
 
-    <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-        android:id="@+id/restriction_type_spinner"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/major_100"
-        android:layout_marginTop="@dimen/major_100"
-        android:hint="@string/shipping_label_customs_restriction_type_hint" />
+        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+            android:id="@+id/contents_type_description"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_100"
+            android:hint="@string/shipping_label_customs_contents_type_other_hint"
+            android:inputType="text"
+            android:visibility="gone"
+            tools:visibility="visible" />
 
-    <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-        android:id="@+id/restriction_type_description"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/major_100"
-        android:layout_marginTop="@dimen/major_100"
-        android:hint="@string/shipping_label_customs_restriction_type_other_hint"
-        android:inputType="text"
-        android:visibility="gone"
-        tools:visibility="visible" />
+        <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+            android:id="@+id/restriction_type_spinner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_100"
+            android:hint="@string/shipping_label_customs_restriction_type_hint" />
 
-    <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-        android:id="@+id/itn_edit_text"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/major_100"
-        android:layout_marginTop="@dimen/major_100"
-        android:hint="@string/shipping_label_customs_itn_hint"
-        android:inputType="text" />
+        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+            android:id="@+id/restriction_type_description"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_100"
+            android:hint="@string/shipping_label_customs_restriction_type_other_hint"
+            android:inputType="text"
+            android:visibility="gone"
+            tools:visibility="visible" />
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/itn_description"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/major_100"
-        android:layout_marginTop="@dimen/major_100"
-        android:textAppearance="?attr/textAppearanceBody2"
-        tools:text="Learn more about Internal Transaction Number" />
+        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+            android:id="@+id/itn_edit_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_100"
+            android:hint="@string/shipping_label_customs_itn_hint"
+            android:inputType="text" />
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/content_section_title"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/major_300"
-        android:layout_marginTop="@dimen/major_100"
-        android:background="@color/default_window_background"
-        android:gravity="center_vertical"
-        android:paddingStart="@dimen/major_100"
-        android:paddingEnd="@dimen/major_100"
-        android:text="@string/shipping_label_customs_package_content"
-        android:textAppearance="?attr/textAppearanceSubtitle2"
-        android:textColor="@color/color_on_surface_disabled" />
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/itn_description"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_100"
+            android:textAppearance="?attr/textAppearanceBody2"
+            tools:text="Learn more about Internal Transaction Number" />
 
-    <View
-        android:id="@+id/divider_2"
-        style="@style/Woo.Divider"
-        android:layout_marginStart="@dimen/major_100" />
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/content_section_title"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/major_300"
+            android:layout_marginTop="@dimen/major_100"
+            android:background="@color/default_window_background"
+            android:gravity="center_vertical"
+            android:paddingStart="@dimen/major_100"
+            android:paddingEnd="@dimen/major_100"
+            android:text="@string/shipping_label_customs_package_content"
+            android:textAppearance="?attr/textAppearanceSubtitle2"
+            android:textColor="@color/color_on_surface_disabled" />
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/items_list"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        tools:itemCount="1"
-        tools:listitem="@layout/shipping_customs_line_list_item" />
+        <View
+            android:id="@+id/divider_2"
+            style="@style/Woo.Divider"
+            android:layout_marginStart="@dimen/major_100" />
 
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/items_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            tools:itemCount="1"
+            tools:listitem="@layout/shipping_customs_line_list_item" />
+
+        <View
+            android:id="@+id/bottom_divider"
+            style="@style/Woo.Divider" />
+    </LinearLayout>
 </com.woocommerce.android.widgets.WCElevatedLinearLayout>

--- a/WooCommerce/src/main/res/layout/shipping_customs_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_customs_list_item.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical">
 
     <LinearLayout
@@ -10,7 +11,6 @@
         android:layout_width="match_parent"
         android:layout_height="@dimen/min_tap_target"
         android:background="?attr/selectableItemBackground"
-        android:paddingHorizontal="@dimen/major_100"
         android:gravity="center_vertical"
         android:orientation="horizontal">
 
@@ -19,6 +19,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textAppearance="?attr/textAppearanceSubtitle1"
+            android:layout_marginStart="@dimen/major_100"
             android:textColor="@color/color_on_surface_high"
             android:textStyle="bold"
             tools:text="Package 1" />
@@ -33,10 +34,17 @@
             tools:text="- Small Package" />
 
         <androidx.appcompat.widget.AppCompatImageView
-            android:id="@+id/expand_icon"
+            android:id="@+id/error_view"
             android:layout_width="@dimen/image_minor_50"
             android:layout_height="@dimen/image_minor_50"
-            android:layout_gravity="end|center_vertical"
+            app:srcCompat="@drawable/mtrl_ic_error"
+            app:tint="@color/woo_red_50" />
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/expand_icon"
+            android:layout_width="@dimen/image_major_50"
+            android:layout_height="@dimen/image_major_50"
+            android:padding="@dimen/major_75"
             android:src="@drawable/ic_arrow_down"
             android:tint="@color/color_on_surface_high" />
     </LinearLayout>

--- a/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
@@ -9,7 +9,7 @@
     <LinearLayout
         android:id="@+id/title_layout"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/min_tap_target"
+        android:layout_height="wrap_content"
         android:background="?attr/selectableItemBackground"
         android:gravity="center_vertical"
         android:orientation="horizontal">
@@ -34,11 +34,17 @@
             tools:text="- 10 items" />
 
         <androidx.appcompat.widget.AppCompatImageView
-            android:id="@+id/expand_icon"
+            android:id="@+id/error_view"
             android:layout_width="@dimen/image_minor_50"
             android:layout_height="@dimen/image_minor_50"
-            android:layout_gravity="end|center_vertical"
-            android:layout_marginEnd="@dimen/major_100"
+            app:srcCompat="@drawable/mtrl_ic_error"
+            app:tint="@color/woo_red_50" />
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/expand_icon"
+            android:layout_width="@dimen/image_major_50"
+            android:layout_height="@dimen/image_major_50"
+            android:padding="@dimen/major_75"
             android:src="@drawable/ic_arrow_down"
             android:tint="@color/color_on_surface_high" />
     </LinearLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -509,7 +509,7 @@
     <string name="shipping_label_packages_custom_section_title">Custom packages</string>
     <string name="shipping_label_single_package_total_weight">Total package weight: %1$s %2$s</string>
     <string name="shipping_label_multi_packages_items_count">%1$d items in %2$d packages</string>
-    <string name="shipping_label_multi_packages_total_weight">Total package weight: %1$s %2$s</string>
+    <string name="shipping_label_multi_packages_total_weight">Total packages weight: %1$s %2$s</string>
     <string name="shipping_label_create_new_package_button">Create new package</string>
     <!--
     Shipping label package creation labels


### PR DESCRIPTION
Closes #4005, this PR updates the UI of customs step to allow collapsing and expanding packages.

<img width=360 src="https://user-images.githubusercontent.com/1657201/125477204-53be20e4-0fe2-4049-bde9-9dfa64733638.gif"/>

@woocommerce/mobile-designers I followed the same pattern that we did for customs lines, when the data is invalid, a red icon will be [displayed](https://d.pr/i/60l135) in the package title, to allow the users to know which item is invalid and preventing them from finishing the form, WDYT about that?

Additional changes in the PR:
1. Fixes the summary of the packaging step when there is multiple packages in the form 1451d06
2. Add an error view to the packaging step 2deca2c

#### Testing
1. Create an international multi-item order in your store.
2. Open the order details.
3. Click on Create shipping label.
4. Pass the origin and destination addresses steps.
5. Move items to have multiple packages in the shipping.
6. Open the customs step.
7. Confirm that you can expand and collapse items.
8. Confirm that if a package data is invalid, a red icon is displayed next to its title.
9. Make some change and click on "done"
10. Confirm that the customs form is saved.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.