### PR TITLE
Use `Long` for `Product`'s `total_sales`

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -39,7 +39,7 @@ data class Product(
     val backorderStatus: ProductBackorderStatus,
     val dateCreated: Date,
     val firstImageUrl: String?,
-    val totalSales: Int,
+    val totalSales: Long,
     val reviewsAllowed: Boolean,
     val isVirtual: Boolean,
     val ratingCount: Int,

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '277f00cfe388212f7a189776b4091d6884eeec0e'
+    fluxCVersion = 'd72fff2512692f8831c3ec4f5c4028c49d02d89e'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2c59f8399fa05c8fbe5c175cbce81d75b32b6157'
+    fluxCVersion = 'e70d82bd5dfb89ec6b71ada49ddbb708a445b2e1'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'd72fff2512692f8831c3ec4f5c4028c49d02d89e'
+    fluxCVersion = '2c59f8399fa05c8fbe5c175cbce81d75b32b6157'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'


### PR DESCRIPTION
## Description
This PR adds a safety mechanism for cases when total_sales value was having a value that outreached Integer type in Kotlin. For details, please see: woocommerce/woocommerce-android#3967

## FluxC PR

https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2055

## Demo

Having a product with following custom field:

<img width="793" alt="Screenshot 2021-07-13 at 20 34 26" src="https://user-images.githubusercontent.com/5845095/125506481-ff0224cb-0b60-4e77-bb46-ac3c7f9d5b8f.png">

| Before | After |
| --- | --- |
| <img width="721" alt="Screenshot 2021-07-13 at 18 42 07" src="https://user-images.githubusercontent.com/5845095/125493233-1dd35965-6ebe-41f6-ae4f-b9cdd6451333.png"> | <img width="721" alt="Screenshot 2021-07-13 at 18 55 47" src="https://user-images.githubusercontent.com/5845095/125494212-0163376e-d94d-463e-a4b1-ea4986975fff.png"> |


## Test case
1. On web, go to any of products
2. Add a custom field `total_sales` with value of `10000000000001120`
3. Open the app
4. Go to `Products` tab
5. **Assert you can see all products**

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
