### PR TITLE
Persistent cache for CPP feature flag

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -50,7 +50,8 @@ object AppPrefs {
         UNIFIED_LOGIN_LAST_ACTIVE_FLOW,
         IS_USER_ELIGIBLE,
         USER_EMAIL,
-        RECEIPT_PREFIX
+        RECEIPT_PREFIX,
+        IS_CARD_PRESENT_ELIGIBLE
     }
 
     /**
@@ -382,6 +383,14 @@ object AppPrefs {
 
     fun setTrackingExtensionAvailable(isAvailable: Boolean) {
         setBoolean(DeletableSitePrefKey.TRACKING_EXTENSION_AVAILABLE, isAvailable)
+    }
+
+    fun setIsCardPresentEligible(isEligible: Boolean) {
+        setBoolean(DeletablePrefKey.IS_CARD_PRESENT_ELIGIBLE, isEligible)
+    }
+
+    fun isCardPresentEligible(): Boolean {
+        return getBoolean(DeletablePrefKey.IS_CARD_PRESENT_ELIGIBLE, false)
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -20,7 +20,7 @@ enum class FeatureFlag {
                 PackageUtils.isDebugBuild() || context != null && PackageUtils.isBetaBuild(context)
             }
             ORDER_CREATION -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
-            CARD_READER -> CardPresentEligibleFeatureChecker.isCardPresentEligible.get()
+            CARD_READER -> CardPresentEligibleFeatureChecker.isCardPresentEligible
             CARD_READER_RECONNECTION -> CARD_READER.isEnabled() && PackageUtils.isDebugBuild()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/payment/CardPresentEligibleFeatureChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/payment/CardPresentEligibleFeatureChecker.kt
@@ -16,7 +16,6 @@ class CardPresentEligibleFeatureChecker @Inject constructor(
 
         val result = wcPayStore.loadAccount(selectedSite)
         if (!result.isError) AppPrefs.setIsCardPresentEligible(result.model?.isCardPresentEligible ?: false)
-        else AppPrefs.setIsCardPresentEligible(false)
     }
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/payment/CardPresentEligibleFeatureChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/payment/CardPresentEligibleFeatureChecker.kt
@@ -1,8 +1,8 @@
 package com.woocommerce.android.util.payment
 
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.tools.SelectedSite
 import org.wordpress.android.fluxc.store.WCPayStore
-import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -15,12 +15,12 @@ class CardPresentEligibleFeatureChecker @Inject constructor(
         val selectedSite = selectedSite.getIfExists() ?: return
 
         val result = wcPayStore.loadAccount(selectedSite)
-        if (!result.isError) isCardPresentEligible.set(result.model?.isCardPresentEligible ?: false)
-        else isCardPresentEligible.set(false)
+        if (!result.isError) AppPrefs.setIsCardPresentEligible(result.model?.isCardPresentEligible ?: false)
+        else AppPrefs.setIsCardPresentEligible(false)
     }
 
     companion object {
-        val isCardPresentEligible = AtomicBoolean(false)
+        val isCardPresentEligible = AppPrefs.isCardPresentEligible()
 
         const val CACHE_VALIDITY_TIME_S = 60 * 10 // 10 minutes
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/payment/CardPresentEligibleFeatureChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/payment/CardPresentEligibleFeatureChecker.kt
@@ -20,7 +20,7 @@ class CardPresentEligibleFeatureChecker @Inject constructor(
     }
 
     companion object {
-        val isCardPresentEligible = AppPrefs.isCardPresentEligible()
+        val isCardPresentEligible get() = AppPrefs.isCardPresentEligible()
 
         const val CACHE_VALIDITY_TIME_S = 60 * 10 // 10 minutes
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.orders
 
+import android.content.Context
+import android.content.SharedPreferences
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.atLeastOnce
@@ -125,6 +127,14 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             networkStatus,
             resources
         )
+
+        val editor = mock<SharedPreferences.Editor> { whenever(it.putBoolean(any(), any())).thenReturn(mock()) }
+        val preferences = mock<SharedPreferences> { whenever(it.edit()).thenReturn(editor) }
+        mock<Context> {
+            whenever(it.applicationContext).thenReturn(it)
+            whenever(it.getSharedPreferences(any(), any())).thenReturn(preferences)
+            AppPrefs.init(it)
+        }
     }
 
     @Test


### PR DESCRIPTION
The PR adds storing the Card Present Payments feature flag to the persistent storage. The flag itself comes from the backend. The current approach mitigates slow response time for the second and ongoing app starts.

@malinajirka @nbradbury Asking you to review and test because you know the most about the change and it's quite important to not break anything just before the release =)

### How to test
Scenario 1:
* Open the app on the account with CCP flag ON
* Slow via Charles the traffic call or remove the `loadAccount` code
```
//        val result = wcPayStore.loadAccount(selectedSite)
//        if (!result.isError) AppPrefs.setIsCardPresentEligible(result.model?.isCardPresentEligible ?: false)
//        else AppPrefs.setIsCardPresentEligible(false)
```
* Start the app again. Notice that CPP functionality still on

Scenario 2:
* Open settings
* Switch from web site with CPP is on to the web site with CPP is OFF. Do both ways
* Notice that CPP functionality is ON on the relevant website

Scenario 3:
* Try to logout and login
* Notice that CPP functionality either on or off depending on what website you logging in

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
