### PR TITLE
Add crash logging http interceptor

### DIFF
--- a/WooCommerce/src/debug/kotlin/com.woocommerce.android/di/InterceptorModule.kt
+++ b/WooCommerce/src/debug/kotlin/com.woocommerce.android/di/InterceptorModule.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.di
 
+import com.automattic.android.tracks.crashlogging.CrashLoggingOkHttpInterceptorProvider
 import com.facebook.flipper.android.AndroidFlipperClient
 import com.facebook.flipper.plugins.network.FlipperOkhttpInterceptor
 import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
@@ -18,4 +19,7 @@ class InterceptorModule {
     fun provideNetworkInterceptor(): Interceptor = FlipperOkhttpInterceptor(
         AndroidFlipperClient.getInstanceIfInitialized()?.getPlugin(NetworkFlipperPlugin.ID)
     )
+
+    @Provides @IntoSet @Named("network-interceptors")
+    fun provideCrashLoggingInterceptor(): Interceptor = CrashLoggingOkHttpInterceptorProvider.createInstance()
 }


### PR DESCRIPTION
Closes #4420 

## Description

This PR introduces `CrashLoggingOkHttpInterceptor` which will log to Sentry's `breadcrumbs` information about recent http requests.

## Demo 

![image](https://user-images.githubusercontent.com/5845095/125575402-58605169-82c0-479d-9abf-955e15b8b492.png)

As we use Jetpack proxy, calls are not so-easy to read - but I think those breadcrumbs will still be helpful, especially for #4206.

I plan to work on better Jetpack proxied requests on next possibly occasion (hack week): https://github.com/Automattic/Automattic-Tracks-Android/issues/101

## To test

1. Make sure there's a valid Sentry DSN defined in `gradle.properties`.
2. Apply patch available at the bottom.
3. Open the app.
4. Go to Sentry console.
5. Find `This is just a test` event.
6. Assert there are some http requests logged in breadcrumbs.

```
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProvider.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
--- WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProvider.kt	(revision 03f52240d2fa10b7df6a57835721eb60b1654dd0)
+++ WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProvider.kt	(date 1626247564213)
@@ -47,7 +47,7 @@
     }
 
     override fun crashLoggingEnabled(): Boolean {
-        return appPrefs.isCrashReportingEnabled()
+        return true
     }
 
     override fun extraKnownKeys(): List<ExtraKnownKey> {
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
--- WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt	(revision 03f52240d2fa10b7df6a57835721eb60b1654dd0)
+++ WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt	(date 1626247564208)
@@ -21,6 +21,7 @@
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.fragment.NavHostFragment
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.google.android.material.appbar.AppBarLayout
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig
@@ -115,6 +116,7 @@
     @Inject lateinit var loginAnalyticsListener: LoginAnalyticsListener
     @Inject lateinit var selectedSite: SelectedSite
     @Inject lateinit var uiMessageResolver: UIMessageResolver
+    @Inject lateinit var crashLogging: CrashLogging
 
     private var isBottomNavShowing = true
     private var previousDestinationId: Int? = null
@@ -246,6 +248,8 @@
         if (!BuildConfig.DEBUG) {
             checkForAppUpdates()
         }
+
+        crashLogging.sendReport(message = "This is just a test")
     }
 
     override fun hideProgressDialog() {

```


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
