### PR TITLE
[Product Image Uploads] Step 3 - Display image upload details screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
@@ -20,6 +20,8 @@ class MediaFileUploadHandler @Inject constructor(
 
     fun getMediaUploadErrorCount(remoteProductId: Long) = currentUploadErrors.get(remoteProductId)?.size ?: 0
 
+    fun getMediaUploadErrors(remoteProductId: Long) = currentUploadErrors.get(remoteProductId)
+
     fun handleMediaUploadFailure(
         mediaModel: MediaModel,
         mediaUploadError: MediaStore.MediaError

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListAdapter.kt
@@ -13,13 +13,8 @@ import java.io.File
 class MediaUploadErrorListAdapter : RecyclerView.Adapter<MediaUploadErrorListItemViewHolder>() {
     var mediaErrorList: List<ProductImageUploadUiModel> = ArrayList()
         set(value) {
-            val diffResult = DiffUtil.calculateDiff(
-                MediaUploadErrorDiffUtil(
-                    field,
-                    value
-                ),
-                true
-            )
+            val diffUtil = MediaUploadErrorDiffUtil(field, value)
+            val diffResult = DiffUtil.calculateDiff(diffUtil, true)
             field = value
 
             diffResult.dispatchUpdatesTo(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListAdapter.kt
@@ -1,0 +1,69 @@
+package com.woocommerce.android.ui.media
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import com.woocommerce.android.databinding.MediaUploadErrorItemBinding
+import com.woocommerce.android.di.GlideApp
+import com.woocommerce.android.ui.media.MediaFileUploadHandler.ProductImageUploadUiModel
+import com.woocommerce.android.ui.media.MediaUploadErrorListAdapter.MediaUploadErrorListItemViewHolder
+import java.io.File
+
+class MediaUploadErrorListAdapter : RecyclerView.Adapter<MediaUploadErrorListItemViewHolder>() {
+    var mediaErrorList: List<ProductImageUploadUiModel> = ArrayList()
+        set(value) {
+            val diffResult = DiffUtil.calculateDiff(
+                MediaUploadErrorDiffUtil(
+                    field,
+                    value
+                ),
+                true
+            )
+            field = value
+
+            diffResult.dispatchUpdatesTo(this)
+        }
+
+    override fun getItemCount(): Int = mediaErrorList.size
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MediaUploadErrorListItemViewHolder {
+        return MediaUploadErrorListItemViewHolder(
+            MediaUploadErrorItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        )
+    }
+
+    override fun onBindViewHolder(holder: MediaUploadErrorListItemViewHolder, position: Int) {
+        holder.bind(mediaErrorList[position])
+    }
+
+    private class MediaUploadErrorDiffUtil(
+        private val oldList: List<ProductImageUploadUiModel>,
+        private val newList: List<ProductImageUploadUiModel>
+    ) : DiffUtil.Callback() {
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
+            oldList[oldItemPosition] == newList[newItemPosition]
+
+        override fun getOldListSize(): Int = oldList.size
+
+        override fun getNewListSize(): Int = newList.size
+
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
+            areItemsTheSame(oldItemPosition, newItemPosition)
+    }
+
+    class MediaUploadErrorListItemViewHolder(val viewBinding: MediaUploadErrorItemBinding) :
+        RecyclerView.ViewHolder(viewBinding.root) {
+        fun bind(productImageUploadUiModel: ProductImageUploadUiModel) {
+            with(productImageUploadUiModel) {
+                viewBinding.mediaFileName.text = media.fileName
+                viewBinding.mediaFileErrorText.text = mediaErrorMessage
+                if (media.filePath.isNotBlank()) {
+                    GlideApp.with(viewBinding.root.context)
+                        .load(File(media.filePath))
+                        .into(viewBinding.productImage)
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListFragment.kt
@@ -1,8 +1,53 @@
 package com.woocommerce.android.ui.media
 
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Observer
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.databinding.FragmentMediaUploadErrorListBinding
+import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class MediaUploadErrorListFragment : BaseFragment(R.layout.fragment_media_upload_error_list)
+class MediaUploadErrorListFragment : BaseFragment(R.layout.fragment_media_upload_error_list) {
+    private val mediaUploadErrorListAdapter: MediaUploadErrorListAdapter by lazy {
+        MediaUploadErrorListAdapter()
+    }
+
+    private val viewModel: MediaUploadErrorListViewModel by viewModels()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val binding = FragmentMediaUploadErrorListBinding.bind(view)
+
+        with(binding.mediaUploadErrorList) {
+            adapter = mediaUploadErrorListAdapter
+            layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
+        }
+
+        setupObservers(viewModel)
+    }
+
+    private fun setupObservers(viewModel: MediaUploadErrorListViewModel) {
+        viewModel.mediaUploadErrorList.observe(
+            viewLifecycleOwner,
+            Observer {
+                mediaUploadErrorListAdapter.mediaErrorList = it
+            }
+        )
+        viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
+            new.toolBarTitle.takeIfNotEqualTo(old?.toolBarTitle) {
+                activity?.title = it
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        AnalyticsTracker.trackViewShown(this)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListFragment.kt
@@ -1,0 +1,8 @@
+package com.woocommerce.android.ui.media
+
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.base.BaseFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class MediaUploadErrorListFragment : BaseFragment(R.layout.fragment_media_upload_error_list)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListViewModel.kt
@@ -1,0 +1,69 @@
+package com.woocommerce.android.ui.media
+
+import android.os.Parcelable
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.media.MediaFileUploadHandler.ProductImageUploadUiModel
+import com.woocommerce.android.media.ProductImagesService.Companion.OnProductImageUploaded
+import com.woocommerce.android.viewmodel.LiveDataDelegate
+import com.woocommerce.android.viewmodel.ResourceProvider
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.navArgs
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.parcelize.Parcelize
+import org.greenrobot.eventbus.EventBus
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import javax.inject.Inject
+
+@HiltViewModel
+class MediaUploadErrorListViewModel @Inject constructor(
+    private val resourceProvider: ResourceProvider,
+    private val mediaFileUploadHandler: MediaFileUploadHandler,
+    savedState: SavedStateHandle
+) : ScopedViewModel(savedState) {
+    private val navArgs: MediaUploadErrorListFragmentArgs by savedState.navArgs()
+
+    private val _mediaUploadErrorList = MutableLiveData<List<ProductImageUploadUiModel>>()
+    val mediaUploadErrorList: LiveData<List<ProductImageUploadUiModel>> = _mediaUploadErrorList
+
+    val viewStateData = LiveDataDelegate(
+        savedState, ViewState(toolBarTitle = getToolbarTitle())
+    )
+    private var viewState by viewStateData
+
+    init {
+        EventBus.getDefault().register(this)
+        start()
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        EventBus.getDefault().unregister(this)
+    }
+
+    private fun getToolbarTitle() = resourceProvider.getString(
+        R.string.product_images_error_detail_title,
+        mediaFileUploadHandler.getMediaUploadErrorCount(navArgs.remoteId)
+    )
+
+    private fun start() {
+        _mediaUploadErrorList.value = mediaFileUploadHandler.getMediaUploadErrors(navArgs.remoteId) ?: emptyList()
+        viewState = viewState.copy(toolBarTitle = getToolbarTitle())
+    }
+
+    @Parcelize
+    data class ViewState(
+        val toolBarTitle: String
+    ) : Parcelable
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onEventMainThread(event: OnProductImageUploaded) {
+        if (event.isError) {
+            start()
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -48,6 +48,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageInteractionListener
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class ProductImagesFragment :
@@ -59,6 +60,8 @@ class ProductImagesFragment :
 
     private val navArgs: ProductImagesFragmentArgs by navArgs()
     private val viewModel: ProductImagesViewModel by hiltNavGraphViewModels(R.id.nav_graph_image_gallery)
+
+    @Inject lateinit var navigator: ProductNavigator
 
     private var _binding: FragmentProductImagesBinding? = null
     private val binding get() = _binding!!
@@ -185,6 +188,7 @@ class ProductImagesFragment :
                 when (event) {
                     is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                     is ShowActionSnackbar -> displayProductImageUploadErrorSnackBar(event.message, event.action)
+                    is ProductNavigationTarget -> navigator.navigate(this, event)
                     is ExitWithResult<*> -> navigateBackWithResult(KEY_IMAGES_DIALOG_RESULT, event.data)
                     is ShowDialog -> event.showDialog()
                     ShowImageSourceDialog -> showImageSourceDialog()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
@@ -28,6 +28,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowActionSnackbar
+import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewMediaUploadErrors
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -246,7 +247,9 @@ class ProductImagesViewModel @Inject constructor(
     fun onEventMainThread(event: OnProductImageUploaded) {
         if (event.isError) {
             val errorMsg = mediaFileUploadHandler.getMediaUploadErrorMessage(navArgs.remoteId)
-            triggerEvent(ShowActionSnackbar(errorMsg, action = { }))
+            triggerEvent(ShowActionSnackbar(errorMsg, action = {
+                triggerEvent(ViewMediaUploadErrors(navArgs.remoteId))
+            }))
         } else {
             event.media?.let { media ->
                 viewState = if (isMultiSelectionAllowed) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
@@ -247,9 +247,7 @@ class ProductImagesViewModel @Inject constructor(
     fun onEventMainThread(event: OnProductImageUploaded) {
         if (event.isError) {
             val errorMsg = mediaFileUploadHandler.getMediaUploadErrorMessage(navArgs.remoteId)
-            triggerEvent(ShowActionSnackbar(errorMsg, action = {
-                triggerEvent(ViewMediaUploadErrors(navArgs.remoteId))
-            }))
+            triggerEvent(ShowActionSnackbar(errorMsg, { triggerEvent(ViewMediaUploadErrors(navArgs.remoteId)) }))
         } else {
             event.media?.let { media ->
                 viewState = if (isMultiSelectionAllowed) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
@@ -44,6 +44,7 @@ sealed class ProductNavigationTarget : Event() {
         val showChooser: Boolean = false,
         val selectedImage: Image? = null
     ) : ProductNavigationTarget()
+    data class ViewMediaUploadErrors(val remoteId: Long) : ProductNavigationTarget()
     data class ViewProductSettings(val remoteId: Long) : ProductNavigationTarget()
     data class ViewProductStatus(val status: ProductStatus?) : ProductNavigationTarget()
     data class ViewProductCatalogVisibility(val catalogVisibility: ProductCatalogVisibility?, val isFeatured: Boolean) :

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -45,6 +45,7 @@ import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductTa
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductTypes
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductVariations
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductVisibility
+import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewMediaUploadErrors
 import com.woocommerce.android.ui.products.categories.ProductCategoriesFragmentDirections
 import com.woocommerce.android.ui.products.downloads.ProductDownloadsFragmentDirections
 import com.woocommerce.android.ui.products.settings.ProductSettingsFragmentDirections
@@ -321,6 +322,11 @@ class ProductNavigator @Inject constructor() {
                     target.isVariationCreation
                 )
                 fragment.findNavController().navigate(action)
+            }
+
+            is ViewMediaUploadErrors -> {
+                val action = NavGraphProductsDirections.actionGlobalMediaUploadErrorsFragment(target.remoteId)
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ExitProduct -> fragment.findNavController().navigateUp()

--- a/WooCommerce/src/main/res/layout/fragment_media_upload_error_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_media_upload_error_list.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/fragment_media_upload_error_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_media_upload_error_list.xml
@@ -1,7 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/media_upload_error_list"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:itemCount="2"
+        tools:listitem="@layout/media_upload_error_item" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/media_upload_error_item.xml
+++ b/WooCommerce/src/main/res/layout/media_upload_error_item.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/linearLayout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <FrameLayout
+        android:id="@+id/mediaFrame"
+        android:layout_width="@dimen/image_minor_100"
+        android:layout_height="@dimen/image_minor_100"
+        android:layout_margin="@dimen/major_100"
+        android:background="@drawable/picture_frame"
+        android:padding="1dp"
+        app:layout_constraintBottom_toTopOf="@+id/divider"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.50">
+
+        <ImageView
+            android:id="@+id/productImage"
+            android:layout_width="@dimen/image_minor_100"
+            android:layout_height="@dimen/image_minor_100"
+            android:layout_gravity="center"
+            android:background="@drawable/picture_corners"
+            android:contentDescription="@string/product_image_content_description"
+            android:scaleType="centerCrop"
+            tools:src="@drawable/ic_product" />
+    </FrameLayout>
+
+    <!--
+        LinearLayout is necessary to ensure the contents will always center properly in the
+        view, even when the mediaFileErrorText is hidden, or if mediaFileName takes up
+        two lines.
+    -->
+    <LinearLayout
+        android:id="@+id/mediaInfoContainer"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/major_100"
+        android:orientation="vertical"
+        app:layout_constrainedWidth="true"
+        app:layout_constraintBottom_toTopOf="@+id/divider"
+        app:layout_constraintEnd_toStartOf="@+id/uploadError_btnRetry"
+        app:layout_constraintStart_toEndOf="@+id/mediaFrame"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.50">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/mediaFileName"
+            style="@style/Woo.ListItem.Title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/minor_00"
+            android:ellipsize="end"
+            android:includeFontPadding="false"
+            android:maxLines="2"
+            tools:text="Awesome Sauce and all that jazz is all I gotta tell you how do we go " />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/mediaFileErrorText"
+            style="@style/Woo.ListItem.Body"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/minor_00"
+            tools:text="Out of stock this is a really long version to see what happens when we move o"
+            tools:visibility="visible" />
+    </LinearLayout>
+
+    <ImageButton
+        android:id="@+id/uploadError_btnRetry"
+        style="@style/Woo.ImageButton.Close"
+        android:layout_margin="@dimen/minor_100"
+        android:contentDescription="@string/grouped_product_btn_delete"
+        android:scaleType="centerInside"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible" />
+
+    <View
+        android:id="@+id/divider"
+        style="@style/Woo.Divider"
+        android:layout_width="0dp"
+        android:layout_marginTop="@dimen/minor_100"
+        android:layout_marginBottom="@dimen/minor_00"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/mediaInfoContainer" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/navigation/nav_graph_products.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_products.xml
@@ -663,11 +663,27 @@
         android:id="@+id/productDownloadsSettingsFragment"
         android:name="com.woocommerce.android.ui.products.downloads.ProductDownloadsSettingsFragment"
         android:label="ProductDownloadsSettingsFragment" />
+    <fragment
+        android:id="@+id/mediaUploadErrorsFragment"
+        android:name="com.woocommerce.android.ui.media.MediaUploadErrorListFragment"
+        android:label="MediaUploadErrorsFragment">
+        <argument
+            android:name="remoteId"
+            android:defaultValue="0L"
+            app:argType="long" />
+    </fragment>
     <dialog
         android:id="@+id/addProductDownloadBottomSheetFragment"
         android:name="com.woocommerce.android.ui.products.downloads.AddProductDownloadBottomSheetFragment"
         android:label="AddProductDownloadBottomSheetFragment"
         tools:layout="@layout/dialog_product_add_downloadable_file" />
+    <action
+        android:id="@+id/action_global_mediaUploadErrorsFragment"
+        app:destination="@id/mediaUploadErrorsFragment"
+        app:enterAnim="@anim/activity_slide_in_from_right"
+        app:exitAnim="@anim/activity_slide_out_to_left"
+        app:popEnterAnim="@anim/activity_slide_in_from_left"
+        app:popExitAnim="@anim/activity_slide_out_to_right"/>
     <action
         android:id="@+id/action_global_productDownloadDetailsFragment"
         app:destination="@id/productDownloadDetailsFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1123,6 +1123,7 @@
     <string name="product_image_service_error_media_null">Media could not be found</string>
     <string name="product_image_service_error_uploading_single">%d file couldn\'t be uploaded</string>
     <string name="product_image_service_error_uploading_multiple">%d files couldn\'t be uploaded</string>
+    <string name="product_images_error_detail_title">Upload details (%d)</string>
 
     <!--
         Empty list messages


### PR DESCRIPTION
Fixes #4331 

**This PR is part of a work in progress feature so it is merged against a feature branch. It is in draft till #4411 can be reviewed and merged**

### Changes
- Clicking on the `Details` button on the error snackbar displayed when image upload fails, redirects to a new screen. 
- This screen displays the list of images that failed to upload, along with the error message. 

### Notes
- This change will need to be added to `ProductDetailFragment` and `VariationDetailFragment` as well. I plan to tackle those in a separate PR since this one already includes a lot of change.
- Unit tests for `ProductImagesViewModel` will be taken care of in another PR.

### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/125584213-b6814c0c-2769-4d52-8585-d37d8f38ffe7.gif" width="300"/>

### Testing
- Try to upload an image with an extension, other than `png, jpeg, jpg or gif`. There is local validation in FluxC so any images without these extensions will result in an error.
- Verify that the error snackbar is displayed with a DETAILS button. Click on the `Details` button and note that you are redirected to a new screen that displays a list of errors.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
