### PR TITLE
Redirect to the previous screen when back button is clicked, even when images are uploading

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
@@ -57,7 +57,7 @@ interface UIMessageResolver {
         actionText: String,
         actionListener: View.OnClickListener
     ): Snackbar {
-        return getSnackbarWithAction(
+        return getIndefiniteSnackbarWithAction(
             snackbarRoot,
             String.format(message, *stringArgs),
             actionText,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
@@ -51,7 +51,7 @@ interface UIMessageResolver {
      * @param [stringArgs] Optional. One or more format argument stringArgs
      * @param [actionListener] Listener to handle the undo button click event
      */
-    fun getActionSnack(
+    fun getIndefiniteActionSnack(
         message: String,
         vararg stringArgs: String = arrayOf(),
         actionText: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -17,6 +17,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.LayoutManager
 import com.automattic.android.tracks.crashlogging.CrashLogging
+import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.R
 import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -46,6 +47,7 @@ import com.woocommerce.android.ui.products.variations.VariationListViewModel.Var
 import com.woocommerce.android.ui.wpmediapicker.WPMediaPickerFragment
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowActionSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.LaunchUrlInChromeTab
 import com.woocommerce.android.widgets.CustomProgressDialog
 import com.woocommerce.android.widgets.SkeletonView
@@ -79,6 +81,7 @@ class ProductDetailFragment :
     private var progressDialog: CustomProgressDialog? = null
     private var layoutManager: LayoutManager? = null
     private var updateMenuItem: MenuItem? = null
+    private var detailSnackbar: Snackbar? = null
 
     private val publishTitleId = R.string.product_add_tool_bar_menu_button_done
     private val updateTitleId = R.string.update
@@ -178,7 +181,7 @@ class ProductDetailFragment :
             )
             changesMade()
         }
-        handleResult<List<Product.Image>>(BaseProductEditorFragment.KEY_IMAGES_DIALOG_RESULT) {
+        handleResult<List<Image>>(BaseProductEditorFragment.KEY_IMAGES_DIALOG_RESULT) {
             viewModel.updateProductDraft(
                 images = it
             )
@@ -262,6 +265,7 @@ class ProductDetailFragment :
                             }
                         )
                     }
+                    is ShowActionSnackbar -> displayProductImageUploadErrorSnackBar(event.message, event.action)
                     else -> event.isHandled = false
                 }
             }
@@ -305,6 +309,22 @@ class ProductDetailFragment :
         return if (viewModel.isProductUnderCreation && product.name.isEmpty()) {
             getString(R.string.product_add_tool_bar_title)
         } else product.name.fastStripHtml()
+    }
+
+    private fun displayProductImageUploadErrorSnackBar(
+        message: String,
+        actionListener: View.OnClickListener
+    ) {
+        if (detailSnackbar == null) {
+            detailSnackbar = uiMessageResolver.getActionSnack(
+                message = message,
+                actionText = getString(R.string.details),
+                actionListener = actionListener
+            )
+        } else {
+            detailSnackbar?.setText(message)
+        }
+        detailSnackbar?.show()
     }
 
     private fun startAddImageContainer() {
@@ -462,7 +482,7 @@ class ProductDetailFragment :
         return viewModel.onBackButtonClickedProductDetail()
     }
 
-    override fun onGalleryImageClicked(image: Product.Image) {
+    override fun onGalleryImageClicked(image: Image) {
         viewModel.onImageClicked(image)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -316,7 +316,7 @@ class ProductDetailFragment :
         actionListener: View.OnClickListener
     ) {
         if (detailSnackbar == null) {
-            detailSnackbar = uiMessageResolver.getActionSnack(
+            detailSnackbar = uiMessageResolver.getIndefiniteActionSnack(
                 message = message,
                 actionText = getString(R.string.details),
                 actionListener = actionListener

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -12,7 +12,6 @@ import android.view.View
 import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
-import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -28,25 +27,16 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.media.ProductImagesUtils
 import com.woocommerce.android.model.Product.Image
+import com.woocommerce.android.ui.products.ProductImagesViewModel.*
 import com.woocommerce.android.ui.products.ProductImagesViewModel.ProductImagesState.Browsing
 import com.woocommerce.android.ui.products.ProductImagesViewModel.ProductImagesState.Dragging
-import com.woocommerce.android.ui.products.ProductImagesViewModel.ShowCamera
-import com.woocommerce.android.ui.products.ProductImagesViewModel.ShowDeleteImageConfirmation
-import com.woocommerce.android.ui.products.ProductImagesViewModel.ShowImageDetail
-import com.woocommerce.android.ui.products.ProductImagesViewModel.ShowImageSourceDialog
-import com.woocommerce.android.ui.products.ProductImagesViewModel.ShowStorageChooser
-import com.woocommerce.android.ui.products.ProductImagesViewModel.ShowWPMediaPicker
 import com.woocommerce.android.ui.wpmediapicker.WPMediaPickerFragment.Companion.KEY_WP_IMAGE_PICKER_RESULT
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.util.WooPermissionUtils
 import com.woocommerce.android.util.setHomeIcon
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowActionSnackbar
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*
 import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageInteractionListener
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -185,7 +175,7 @@ class ProductImagesFragment :
 
         viewModel.event.observe(
             viewLifecycleOwner,
-            Observer { event ->
+            { event ->
                 when (event) {
                     is Exit -> findNavController().navigateUp()
                     is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
@@ -218,7 +208,7 @@ class ProductImagesFragment :
         actionListener: View.OnClickListener
     ) {
         if (detailSnackbar == null) {
-            detailSnackbar = uiMessageResolver.getActionSnack(
+            detailSnackbar = uiMessageResolver.getIndefiniteActionSnack(
                 message = message,
                 actionText = getString(R.string.details),
                 actionListener = actionListener

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -46,6 +46,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowActionSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageInteractionListener
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -186,6 +187,7 @@ class ProductImagesFragment :
             viewLifecycleOwner,
             Observer { event ->
                 when (event) {
+                    is Exit -> findNavController().navigateUp()
                     is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                     is ShowActionSnackbar -> displayProductImageUploadErrorSnackBar(event.message, event.action)
                     is ProductNavigationTarget -> navigator.navigate(this, event)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
@@ -79,10 +79,8 @@ class ProductImagesViewModel @Inject constructor(
         if (navArgs.showChooser) {
             clearImageUploadErrors()
             triggerEvent(ShowImageSourceDialog)
-        } else {
-            navArgs.selectedImage.let {
-                triggerEvent(ShowImageDetail(it, true))
-            }
+        } else if (navArgs.selectedImage != null) {
+            triggerEvent(ShowImageDetail(navArgs.selectedImage!!, true))
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_DETAIL_IMAGE_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.PRODUCT_IMAGE_SETTINGS_ADD_IMAGES_BUTTON_TAPPED
+import com.woocommerce.android.extensions.areSameImagesAs
 import com.woocommerce.android.media.ProductImagesService
 import com.woocommerce.android.media.ProductImagesService.Companion.OnProductImageUploaded
 import com.woocommerce.android.media.ProductImagesService.Companion.OnProductImagesUpdateCompletedEvent
@@ -27,6 +28,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowActionSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -78,7 +80,7 @@ class ProductImagesViewModel @Inject constructor(
             clearImageUploadErrors()
             triggerEvent(ShowImageSourceDialog)
         } else {
-            navArgs.selectedImage?.let {
+            navArgs.selectedImage.let {
                 triggerEvent(ShowImageDetail(it, true))
             }
         }
@@ -156,7 +158,11 @@ class ProductImagesViewModel @Inject constructor(
                 )
             }
             Browsing -> {
-                triggerEvent(Exit)
+                if (images.areSameImagesAs(originalImages)) {
+                    triggerEvent(Exit)
+                } else {
+                    triggerEvent(ExitWithResult(images))
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.products
 
-import android.content.DialogInterface
 import android.net.Uri
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
@@ -21,14 +20,13 @@ import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.ui.products.ProductImagesViewModel.ProductImagesState.Browsing
 import com.woocommerce.android.ui.products.ProductImagesViewModel.ProductImagesState.Dragging
+import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewMediaUploadErrors
 import com.woocommerce.android.util.swap
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowActionSnackbar
-import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewMediaUploadErrors
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -158,27 +156,7 @@ class ProductImagesViewModel @Inject constructor(
                 )
             }
             Browsing -> {
-                onExit()
-            }
-        }
-    }
-
-    private fun onExit() {
-        when {
-            ProductImagesService.isUploadingForProduct(navArgs.remoteId) -> {
-                triggerEvent(
-                    ShowDialog(
-                        messageId = string.discard_images_message,
-                        positiveButtonId = string.discard,
-                        positiveBtnAction = DialogInterface.OnClickListener { _, _ ->
-                            ProductImagesService.cancel()
-                            triggerEvent(ExitWithResult(originalImages))
-                        }
-                    )
-                )
-            }
-            else -> {
-                triggerEvent(ExitWithResult(images))
+                triggerEvent(Exit)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
@@ -321,7 +321,7 @@ class VariationDetailFragment :
         actionListener: View.OnClickListener
     ) {
         if (detailSnackbar == null) {
-            detailSnackbar = uiMessageResolver.getActionSnack(
+            detailSnackbar = uiMessageResolver.getIndefiniteActionSnack(
                 message = message,
                 actionText = getString(R.string.details),
                 actionListener = actionListener

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -23,22 +23,19 @@ import com.woocommerce.android.model.ProductVariation.Option
 import com.woocommerce.android.model.VariantOption
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.NetworkStatus
-import com.woocommerce.android.ui.products.ParameterRepository
-import com.woocommerce.android.ui.products.ProductBackorderStatus
-import com.woocommerce.android.ui.products.ProductDetailRepository
-import com.woocommerce.android.ui.products.ProductStockStatus
+import com.woocommerce.android.ui.media.MediaFileUploadHandler
+import com.woocommerce.android.ui.products.*
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.ViewImageGallery
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.viewmodel.LiveDataDelegate
+import com.woocommerce.android.viewmodel.*
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
-import com.woocommerce.android.viewmodel.ResourceProvider
-import com.woocommerce.android.viewmodel.ScopedViewModel
-import com.woocommerce.android.viewmodel.navArgs
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowActionSnackbar
+import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewMediaUploadErrors
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
@@ -58,6 +55,7 @@ class VariationDetailViewModel @Inject constructor(
     private val networkStatus: NetworkStatus,
     private val currencyFormatter: CurrencyFormatter,
     private val parameterRepository: ParameterRepository,
+    private val mediaFileUploadHandler: MediaFileUploadHandler,
     private val resources: ResourceProvider
 ) : ScopedViewModel(savedState) {
     companion object {
@@ -427,7 +425,10 @@ class VariationDetailViewModel @Inject constructor(
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: OnProductImageUploaded) {
         if (event.isError) {
-            triggerEvent(ShowSnackbar(string.product_image_service_error_uploading))
+            val errorMsg = mediaFileUploadHandler.getMediaUploadErrorMessage(navArgs.remoteVariationId)
+            triggerEvent(
+                ShowActionSnackbar(errorMsg, { triggerEvent(ViewMediaUploadErrors(navArgs.remoteVariationId)) })
+            )
         } else {
             event.media?.let { media ->
                 viewState.variation?.let {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -28,6 +28,7 @@ import com.woocommerce.android.ui.products.*
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.ViewImageGallery
+import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.ViewMediaUploadErrors
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.*
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -35,7 +36,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowActionSnackbar
-import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewMediaUploadErrors
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationNavigationTarget.kt
@@ -17,8 +17,7 @@ sealed class VariationNavigationTarget : Event() {
     data class ViewPricing(val pricingData: PricingData) : VariationNavigationTarget()
     data class ViewShipping(val shippingData: ShippingData) : VariationNavigationTarget()
     data class ViewDescriptionEditor(val description: String, val title: String) : VariationNavigationTarget()
-    data class ViewMenuOrder(val menuOrder: Int) : VariationNavigationTarget()
-    data class ViewBottomSheet(val remoteId: Long) : VariationNavigationTarget()
+    data class ViewMediaUploadErrors(val remoteId: Long) : VariationNavigationTarget()
     data class ViewAttributes(
         val remoteProductId: Long,
         val remoteVariationId: Long

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationNavigator.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.products.variations
 
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.NavGraphProductsDirections
 import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.ViewAttributes
@@ -10,6 +11,7 @@ import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.
 import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.ViewInventory
 import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.ViewPricing
 import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.ViewShipping
+import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.ViewMediaUploadErrors
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -71,6 +73,10 @@ class VariationNavigator @Inject constructor() {
                         target.remoteProductId,
                         target.remoteVariationId
                     ).let { fragment.findNavController().navigateSafely(it) }
+            }
+            is ViewMediaUploadErrors -> {
+                val action = NavGraphProductsDirections.actionGlobalMediaUploadErrorsFragment(target.remoteId)
+                fragment.findNavController().navigateSafely(action)
             }
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.media.ProductImagesServiceWrapper
 import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductDetailViewState
 import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
 import com.woocommerce.android.ui.products.models.ProductProperty.ComplexProperty
@@ -78,6 +79,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     private val currencyFormatter: CurrencyFormatter = mock {
         on(it.formatCurrency(any<BigDecimal>(), any(), any())).thenAnswer { i -> "${i.arguments[1]}${i.arguments[0]}" }
     }
+    private val mediaFileUploadHandler: MediaFileUploadHandler = mock()
 
     private val savedState: SavedStateHandle =
         ProductDetailFragmentArgs(remoteProductId = PRODUCT_REMOTE_ID).initSavedStateHandle()
@@ -225,6 +227,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
                 productTagsRepository,
                 mediaFilesRepository,
                 variationRepository,
+                mediaFileUploadHandler,
                 prefs
             )
         )
@@ -623,7 +626,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
             clearInvocations(productRepository)
 
             // Precondition
-            assertThat(productData?.productDraft?.numVariations).isZero
+            assertThat(productData?.productDraft?.numVariations).isZero()
 
             doReturn(mock<ProductVariation>()).whenever(variationRepository).createEmptyVariation(any())
             doReturn(product.copy(numVariations = 1_914)).whenever(productRepository).fetchProduct(eq(product.remoteId))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.media.MediaFilesRepository
 import com.woocommerce.android.media.ProductImagesServiceWrapper
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductDetailViewState
 import com.woocommerce.android.ui.products.ProductStatus.DRAFT
 import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
@@ -70,6 +71,8 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
     private val currencyFormatter: CurrencyFormatter = mock {
         on(it.formatCurrency(any<BigDecimal>(), any(), any())).thenAnswer { i -> "${i.arguments[1]}${i.arguments[0]}" }
     }
+
+    private val mediaFileUploadHandler: MediaFileUploadHandler = mock()
 
     private val savedState: SavedStateHandle =
         ProductDetailFragmentArgs(remoteProductId = PRODUCT_REMOTE_ID, isAddProduct = true).initSavedStateHandle()
@@ -163,6 +166,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                 productTagsRepository,
                 mediaFilesRepository,
                 variationRepository,
+                mediaFileUploadHandler,
                 prefs
             )
         )
@@ -248,8 +252,8 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
         viewModel.onUpdateButtonClicked()
 
         // then
-        assertThat(successSnackbarShown).isTrue
-        assertThat(productData?.isProgressDialogShown).isFalse
+        assertThat(successSnackbarShown).isTrue()
+        assertThat(productData?.isProgressDialogShown).isFalse()
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModelTest.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.ui.products.ProductTestUtils.generateProductImage
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.data.Index
 import org.junit.Test
@@ -66,6 +67,19 @@ class ProductImagesViewModelTest : BaseUnitTest() {
 
         observeEvents { event ->
             assertThat(event).isEqualTo(Exit)
+        }
+    }
+
+    @Test
+    fun `Trigger exitWithResult event on back button clicked when in browsing state`() {
+        initialize()
+
+        val images = generateProductImagesList()
+        viewModel.onDeleteImageConfirmed(images[0])
+        viewModel.onNavigateBackButtonClicked()
+
+        observeEvents { event ->
+            assertThat(event).isEqualTo(ExitWithResult(images - images[0]))
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModelTest.kt
@@ -11,7 +11,7 @@ import com.woocommerce.android.ui.products.ProductImagesViewModel.ShowDeleteImag
 import com.woocommerce.android.ui.products.ProductTestUtils.generateProductImagesList
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.data.Index
 import org.junit.Test
@@ -65,7 +65,7 @@ class ProductImagesViewModelTest : BaseUnitTest() {
         viewModel.onNavigateBackButtonClicked()
 
         observeEvents { event ->
-            assertThat(event).isEqualTo(ExitWithResult(images))
+            assertThat(event).isEqualTo(Exit)
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModelTest.kt
@@ -7,6 +7,7 @@ import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.ProductVariation
+import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.generateVariation
 import com.woocommerce.android.ui.products.models.SiteParameters
@@ -58,6 +59,8 @@ class VariationDetailViewModelTest : BaseUnitTest() {
         on { getString(any()) } doAnswer { answer -> answer.arguments[0].toString() }
     }
 
+    private val mediaFileUploadHandler: MediaFileUploadHandler = mock()
+
     private val savedState = VariationDetailFragmentArgs(
         TEST_VARIATION.remoteProductId,
         TEST_VARIATION.remoteVariationId
@@ -72,7 +75,8 @@ class VariationDetailViewModelTest : BaseUnitTest() {
             networkStatus = mock(),
             currencyFormatter = mock(),
             parameterRepository = parameterRepository,
-            resources = resourceProvider
+            resources = resourceProvider,
+            mediaFileUploadHandler = mediaFileUploadHandler
         )
     }
 


### PR DESCRIPTION
Fixes #4333 .

**This PR is part of a work in progress feature so it is merged against a feature branch. It is in draft till #4432 can be reviewed and merged**

### Changes
- Allows the merchant to redirect to the Product detail screen when the back button is clicked, when images are being uploaded.
- If an image upload fails in the Product detail or Variation detail screen, a similar Snackbar would be displayed with a `Details` button. 
- Clicking on the `Details` would redirect to a new screen that displays the list of images that failed to upload.

### Screenshots
##### Product Detail redirection
<img src="https://user-images.githubusercontent.com/22608780/125621739-6626e6ce-49ad-4d4c-a0bc-7812facada02.gif" width="300"/>

##### Variation Detail redirection
<img src="https://user-images.githubusercontent.com/22608780/125621939-1f1f245c-8436-4671-87a5-05a9a8549528.gif" width="300"/>

### Testing
- Try to upload an image with an extension, other than `png, jpeg, jpg or gif`. There is local validation in FluxC so any images without these extensions will result in an error.
- While the image is being uploaded, click on the back button. You should be redirected to the Product Details screen.
- Verify that the error snackbar is displayed with a DETAILS button. Click on the `Details` button and note that you are redirected to a new screen that displays a list of errors.
- Follow the above steps for a variation of a product.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
