### PR TITLE
Shipping Labels: update Rates UI to support multiple packages

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingRate.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingRate.kt
@@ -14,6 +14,7 @@ data class ShippingRate(
     val serviceName: String,
     val deliveryDays: Int,
     val price: BigDecimal,
+    val formattedPrice: String,
     val discount: BigDecimal,
     val formattedFee: String,
     val option: Option

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
@@ -121,7 +121,7 @@ class ShippingLabelRepository @Inject constructor(
             carrierRates.model == null || carrierRates.model!!.packageRates.isEmpty() -> {
                 WooResult(WooError(INVALID_RESPONSE, GenericErrorType.PARSE_ERROR, "Empty response"))
             }
-            carrierRates.model!!.packageRates.all { pack ->
+            carrierRates.model!!.packageRates.any { pack ->
                 pack.shippingOptions.isEmpty() || pack.shippingOptions.all { option ->
                     option.rates.isEmpty()
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRepository.kt
@@ -126,6 +126,7 @@ class ShippingLabelRepository @Inject constructor(
                     option.rates.isEmpty()
                 }
             } -> {
+                // if any of the packages doesn't have any rates, show the empty state screen
                 WooResult(WooError(GENERIC_ERROR, NOT_FOUND, "Empty result"))
             }
             else -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
@@ -13,9 +13,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.R.string
 import com.woocommerce.android.databinding.ShippingRateListBinding
 import com.woocommerce.android.databinding.ShippingRateListItemBinding
-import com.woocommerce.android.extensions.hide
-import com.woocommerce.android.extensions.isEqualTo
-import com.woocommerce.android.extensions.show
+import com.woocommerce.android.extensions.*
 import com.woocommerce.android.model.ShippingLabelPackage
 import com.woocommerce.android.model.ShippingRate
 import com.woocommerce.android.model.ShippingRate.Option
@@ -33,6 +31,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrier
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrierRatesAdapter.ShippingRateItem.ShippingCarrier.UPS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrierRatesAdapter.ShippingRateItem.ShippingCarrier.USPS
 import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.util.FeatureFlag
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import java.util.Date
@@ -61,10 +60,30 @@ class ShippingCarrierRatesAdapter(
     }
 
     inner class RateListViewHolder(private val binding: ShippingRateListBinding) : ViewHolder(binding.root) {
+        private val isExpanded
+            get() = binding.expandIcon.rotation == 180f
+
         init {
             binding.rateOptions.apply {
                 adapter = RateListAdapter()
                 layoutManager = LinearLayoutManager(context)
+            }
+
+            if (!FeatureFlag.SHIPPING_LABELS_M4.isEnabled()) {
+                binding.expandIcon.isVisible = false
+            } else {
+                // expand items by default
+                binding.expandIcon.rotation = 180f
+                binding.rateOptions.isVisible = true
+                binding.titleLayout.setOnClickListener {
+                    if (isExpanded) {
+                        binding.expandIcon.animate().rotation(0f).start()
+                        binding.rateOptions.collapse()
+                    } else {
+                        binding.expandIcon.animate().rotation(180f).start()
+                        binding.rateOptions.expand()
+                    }
+                }
             }
         }
         @SuppressLint("SetTextI18n")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
@@ -59,6 +59,7 @@ class ShippingCarrierRatesAdapter(
         holder.bind(items[position])
     }
 
+    @Suppress("MagicNumber")
     inner class RateListViewHolder(private val binding: ShippingRateListBinding) : ViewHolder(binding.root) {
         private val isExpanded
             get() = binding.expandIcon.rotation == 180f

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
@@ -63,6 +63,10 @@ class ShippingCarrierRatesAdapter(
             binding.rateOptions.apply {
                 adapter = RateListAdapter()
                 layoutManager = LinearLayoutManager(context)
+                itemAnimator = DefaultItemAnimator().apply {
+                    // Disable change animations to avoid flashing items when data changes
+                    supportsChangeAnimations = false
+                }
             }
 
             if (!FeatureFlag.SHIPPING_LABELS_M4.isEnabled()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesFragment.kt
@@ -9,7 +9,6 @@ import android.view.View
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.observe
 import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesViewModel.kt
@@ -145,8 +145,9 @@ class ShippingCarrierRatesViewModel @Inject constructor(
                         default.title,
                         default.deliveryDays,
                         default.rate,
-                        defaultDiscount,
                         default.rate.format(),
+                        defaultDiscount,
+                        "",
                         DEFAULT
                     ),
                     SIGNATURE to signature?.let { option ->
@@ -159,6 +160,7 @@ class ShippingCarrierRatesViewModel @Inject constructor(
                             option.title,
                             default.deliveryDays,
                             option.rate,
+                            option.rate.format(),
                             signatureDiscount,
                             signatureFee.format(),
                             SIGNATURE
@@ -174,6 +176,7 @@ class ShippingCarrierRatesViewModel @Inject constructor(
                             option.title,
                             default.deliveryDays,
                             option.rate,
+                            option.rate.format(),
                             adultSignatureDiscount,
                             adultSignatureFee.format(),
                             ADULT_SIGNATURE

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCEmptyView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCEmptyView.kt
@@ -188,10 +188,10 @@ class WCEmptyView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? =
             }
             SHIPPING_LABEL_CARRIER_RATES -> {
                 isTitleBold = false
-                title = context.getString(R.string.shipping_label_shipping_carrier_rates_unavailable)
-                message = null
+                title = context.getString(R.string.shipping_label_shipping_carrier_rates_unavailable_title)
+                message = context.getString(R.string.shipping_label_shipping_carrier_rates_unavailable_message)
                 buttonText = null
-                drawableId = R.drawable.img_empty_orders_all_fulfilled
+                drawableId = R.drawable.img_products_error
             }
         }
 

--- a/WooCommerce/src/main/res/layout/shipping_rate_list.xml
+++ b/WooCommerce/src/main/res/layout/shipping_rate_list.xml
@@ -1,43 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/package_name"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/major_100"
-        android:layout_marginTop="@dimen/major_75"
-        android:textAppearance="?attr/textAppearanceSubtitle1"
-        android:textColor="@color/color_on_surface_high"
-        android:textStyle="bold"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="Package 1" />
+    <LinearLayout
+        android:id="@+id/title_layout"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/min_tap_target"
+        android:background="?attr/selectableItemBackground"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/package_items_count"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/minor_50"
-        android:textAppearance="@style/TextAppearance.Woo.Body1"
-        app:layout_constraintBaseline_toBaselineOf="@id/package_name"
-        app:layout_constraintStart_toEndOf="@id/package_name"
-        tools:text="- 10 items" />
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/package_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:textAppearance="?attr/textAppearanceSubtitle1"
+            android:textColor="@color/color_on_surface_high"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Package 1" />
 
-    <androidx.appcompat.widget.AppCompatImageView
-        android:layout_width="@dimen/image_minor_50"
-        android:layout_height="@dimen/image_minor_50"
-        android:layout_marginEnd="@dimen/major_100"
-        android:src="@drawable/ic_arrow_down"
-        android:tint="@color/color_on_surface_high"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="@id/package_name"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@id/package_name" />
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/package_items_count"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/minor_50"
+            android:layout_weight="1"
+            android:textAppearance="@style/TextAppearance.Woo.Body1"
+            app:layout_constraintBaseline_toBaselineOf="@id/package_name"
+            app:layout_constraintStart_toEndOf="@id/package_name"
+            tools:text="- 10 items" />
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/expand_icon"
+            android:layout_width="@dimen/image_major_50"
+            android:layout_height="@dimen/image_major_50"
+            android:padding="@dimen/major_75"
+            android:src="@drawable/ic_arrow_down"
+            android:tint="@color/color_on_surface_high"
+            app:layout_constraintBottom_toBottomOf="@id/package_name"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/package_name" />
+    </LinearLayout>
 
     <View
         android:id="@+id/divider_1"
@@ -54,4 +64,4 @@
         tools:itemCount="5"
         tools:listitem="@layout/shipping_rate_list_item" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/shipping_rate_list.xml
+++ b/WooCommerce/src/main/res/layout/shipping_rate_list.xml
@@ -22,8 +22,6 @@
             android:textAppearance="?attr/textAppearanceSubtitle1"
             android:textColor="@color/color_on_surface_high"
             android:textStyle="bold"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
             tools:text="Package 1" />
 
         <com.google.android.material.textview.MaterialTextView
@@ -33,8 +31,6 @@
             android:layout_marginStart="@dimen/minor_50"
             android:layout_weight="1"
             android:textAppearance="@style/TextAppearance.Woo.Body1"
-            app:layout_constraintBaseline_toBaselineOf="@id/package_name"
-            app:layout_constraintStart_toEndOf="@id/package_name"
             tools:text="- 10 items" />
 
         <androidx.appcompat.widget.AppCompatImageView
@@ -43,25 +39,17 @@
             android:layout_height="@dimen/image_major_50"
             android:padding="@dimen/major_75"
             android:src="@drawable/ic_arrow_down"
-            android:tint="@color/color_on_surface_high"
-            app:layout_constraintBottom_toBottomOf="@id/package_name"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@id/package_name" />
+            android:tint="@color/color_on_surface_high" />
     </LinearLayout>
 
     <View
         android:id="@+id/divider_1"
-        style="@style/Woo.Divider"
-        android:layout_marginTop="@dimen/major_75"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/package_name" />
+        style="@style/Woo.Divider" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rate_options"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@id/divider_1"
         tools:itemCount="5"
         tools:listitem="@layout/shipping_rate_list_item" />
-
 </LinearLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -550,7 +550,8 @@
     <string name="shipping_label_payments_saving_error">Error while saving your settings</string>
     <string name="shipping_label_payment_method_added">Payment method added</string>
     <string name="shipping_label_shipping_carriers_title">Carriers and rates</string>
-    <string name="shipping_label_shipping_carrier_rates_unavailable">There are no shipping options for the selected address and packages</string>
+    <string name="shipping_label_shipping_carrier_rates_unavailable_title">No shipping rates available</string>
+    <string name="shipping_label_shipping_carrier_rates_unavailable_message">Please double check your package dimensions and weight or try using a different package in Package Details</string>
     <plurals name="shipping_label_shipping_carrier_rates_delivery_estimate">
         <item quantity="one">%d business day</item>
         <item quantity="other">%d business days</item>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelTestUtils.kt
@@ -77,6 +77,7 @@ object CreateShippingLabelTestUtils {
             serviceName = "service",
             deliveryDays = 10,
             price = BigDecimal.TEN,
+            formattedPrice = "10 $",
             discount = BigDecimal.ZERO,
             formattedFee = "10 $",
             option = ShippingRate.Option.DEFAULT


### PR DESCRIPTION
This PR contains the following changes:
- Fixes #4004 by adding support for collapsing/expanding views in the rates step (f386322, 199b73c, bb661da, c3b1bd4 and 27f2feb)
<img width=320 src="https://user-images.githubusercontent.com/1657201/125766851-7aeec24a-a0ef-4b0e-92ee-a8210bbd5242.gif"/>

- fixes #4188 (c3b1bd4)
- fixes #4101 (ff6db92)
<img width="320" alt="Screen Shot 2021-07-15 at 10 40 32" src="https://user-images.githubusercontent.com/1657201/125767517-9e8af39a-a25f-4e91-b201-4e0aecb82385.png">

#### Testing
##### Test 1
1. Create a US national order with multiple items in your store.
2. Open the order in the app.
3. Click on Create shipping label.
4. In the packaging step, move items to multiple packages.
5. In the rates screen, **confirm** that you can collapse/expand packages.
6. Select some rates, and confirm that selecting **non-free** options updates the rate price (#4188's fix)

##### Test 2
1. Create an order eligible for shipping label creation.
2. Open the order in the app
3. Click on Create shipping label.
4. In the packaging step, enter a very big weight that you are sure it won't be supported by the package (for example 9999)
5. Go to the rates screen and confirm that you can see the updated empty state.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
