### PR TITLE
Removed `CARD_READER_RECONNECTION` feature flag

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -42,7 +42,6 @@ import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectView
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.ScanningFailedState
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.ScanningState
 import com.woocommerce.android.util.CoroutineDispatchers
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -60,7 +59,6 @@ class CardReaderConnectViewModel @Inject constructor(
     private val dispatchers: CoroutineDispatchers,
     private val tracker: AnalyticsTrackerWrapper,
     private val appPrefs: AppPrefs,
-    private val reconnectionFeatureFlag: FeatureFlag.CardReaderReconnectionWrapper
 ) : ScopedViewModel(savedState) {
     /**
      * This is a workaround for a bug in MultiLiveEvent, which can't be fixed without vital changes.
@@ -303,15 +301,11 @@ class CardReaderConnectViewModel @Inject constructor(
     }
 
     private fun storeConnectedReader(cardReader: CardReader) {
-        if (reconnectionFeatureFlag.isEnabled()) {
-            cardReader.id?.let { id -> appPrefs.setLastConnectedCardReaderId(id) }
-        }
+        cardReader.id?.let { id -> appPrefs.setLastConnectedCardReaderId(id) }
     }
 
     private fun findLastKnowReader(readers: List<CardReader>): CardReader? {
-        return if (reconnectionFeatureFlag.isEnabled()) readers.find {
-            it.id == appPrefs.getLastConnectedCardReaderId()
-        } else null
+        return readers.find { it.id == appPrefs.getLastConnectedCardReaderId() }
     }
 
     fun onScreenResumed() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
@@ -30,7 +30,6 @@ import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewMo
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.UpdateResult.FAILED
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.UpdateResult.SKIPPED
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.UpdateResult.SUCCESS
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -45,7 +44,6 @@ class CardReaderDetailViewModel @Inject constructor(
     val cardReaderManager: CardReaderManager,
     private val tracker: AnalyticsTrackerWrapper,
     private val appPrefs: AppPrefs,
-    private val reconnectionFeatureFlag: FeatureFlag.CardReaderReconnectionWrapper,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
     private val viewState = MutableLiveData<ViewState>(Loading)
@@ -145,9 +143,7 @@ class CardReaderDetailViewModel @Inject constructor(
     }
 
     private fun clearLastKnowReader() {
-        if (reconnectionFeatureFlag.isEnabled()) {
-            appPrefs.removeLastConnectedCardReaderId()
-        }
+        appPrefs.removeLastConnectedCardReaderId()
     }
 
     private fun CardReader.getReadersName(): UiString {
@@ -198,6 +194,7 @@ class CardReaderDetailViewModel @Inject constructor(
             val secondaryButtonState: ButtonState?
         ) : ViewState() {
             val learnMoreLabel = UiStringRes(R.string.card_reader_detail_learn_more, containsHtml = true)
+
             data class ButtonState(
                 val onActionClicked: (() -> Unit),
                 val text: UiString

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.util
 
 import android.content.Context
 import com.woocommerce.android.util.payment.CardPresentEligibleFeatureChecker
-import javax.inject.Inject
 
 /**
  * "Feature flags" are used to hide in-progress features from release versions
@@ -12,8 +11,8 @@ enum class FeatureFlag {
     DB_DOWNGRADE,
     ORDER_CREATION,
     CARD_READER,
-    CARD_READER_RECONNECTION,
     CARD_READER_ONBOARDING;
+
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
             SHIPPING_LABELS_M4 -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
@@ -22,12 +21,7 @@ enum class FeatureFlag {
             }
             ORDER_CREATION -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
             CARD_READER -> CardPresentEligibleFeatureChecker.isCardPresentEligible.get()
-            CARD_READER_RECONNECTION -> CARD_READER.isEnabled() && PackageUtils.isDebugBuild()
             CARD_READER_ONBOARDING -> CARD_READER.isEnabled() && PackageUtils.isDebugBuild()
         }
-    }
-
-    class CardReaderReconnectionWrapper @Inject constructor() {
-        fun isEnabled() = CARD_READER_RECONNECTION.isEnabled()
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -1,12 +1,12 @@
 package com.woocommerce.android.ui.prefs.cardreader.connect
 
 import androidx.lifecycle.SavedStateHandle
+import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.argThat
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import com.nhaarman.mockitokotlin2.anyOrNull
-import com.nhaarman.mockitokotlin2.eq
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -41,7 +41,6 @@ import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectView
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModelTest.ScanResult.MULTIPLE_READERS_FOUND
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModelTest.ScanResult.READER_FOUND
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModelTest.ScanResult.SCANNING
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -64,9 +63,6 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
     private val tracker: AnalyticsTrackerWrapper = mock()
     private val cardReaderManager: CardReaderManager = mock()
     private val appPrefs: AppPrefs = mock()
-    private val reconnectionFeatureFlag: FeatureFlag.CardReaderReconnectionWrapper = mock {
-        on { isEnabled() }.thenReturn(true)
-    }
     private val reader = mock<CardReader>().also { whenever(it.id).thenReturn("Dummy1") }
     private val reader2 = mock<CardReader>().also { whenever(it.id).thenReturn("Dummy2") }
 
@@ -77,7 +73,6 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
             coroutinesTestRule.testDispatchers,
             tracker,
             appPrefs,
-            reconnectionFeatureFlag
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
@@ -20,7 +20,6 @@ import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewMo
 import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewModel.ViewState.Loading
 import com.woocommerce.android.ui.prefs.cardreader.detail.CardReaderDetailViewModel.ViewState.NotConnectedState
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.UpdateResult
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -39,9 +38,6 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
     private val tracker: AnalyticsTrackerWrapper = mock()
     private val appPrefs: AppPrefs = mock()
-    private val reconnectionFeatureFlag: FeatureFlag.CardReaderReconnectionWrapper = mock {
-        on { isEnabled() }.thenReturn(true)
-    }
 
     @Test
     fun `when view model init with connected state should emit loading view state`() {
@@ -453,7 +449,6 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
         cardReaderManager,
         tracker,
         appPrefs,
-        reconnectionFeatureFlag,
         SavedStateHandle(),
     )
 


### PR DESCRIPTION
Resolves #4317 

The PR removes the feature flag for the card reader auto reconnection feature, which makes it available for every user with CPP enabled.

### How to test
#### Payment flow
1. Open eligible order
2. Collection money
3. Notice that you were asked to connect to a specific reader
4. Kill the app
5. Collect money again
6. Notice that in case if the reader used it before still available the app will automatically connect to it

#### Manage reader flow
1. Settings
2. Manage reader
3. Connect to a reader
4. Kill the app
5. Go back to the Manager reader section
6. Connect to a reader
7. Notice it's automatically connected to the reader used in step 3

Disconnect button in manage reader flow forgets the last know reader
