### PR TITLE
Show correct item's total price when using order addons

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
@@ -109,14 +109,14 @@ fun List<Refund>.getNonRefundedProducts(
             val newQuantity = leftoverProducts[it.itemId]
             if (newQuantity == it.quantity) return@map it
             val quantity = it.quantity.toBigDecimal()
-            val totalTax = if (quantity > BigDecimal.ZERO) {
+            val individualProductTax = if (quantity > BigDecimal.ZERO) {
                 it.totalTax.divide(quantity, 2, HALF_UP)
             } else BigDecimal.ZERO
 
             it.copy(
                 quantity = newQuantity ?: error("Missing product"),
                 total = it.price.times(newQuantity.toBigDecimal()),
-                totalTax = totalTax
+                totalTax = individualProductTax.times(newQuantity.toBigDecimal())
             )
         }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
@@ -107,6 +107,7 @@ fun List<Refund>.getNonRefundedProducts(
         .filter { leftoverProducts.contains(it.itemId) }
         .map {
             val newQuantity = leftoverProducts[it.itemId]
+            if (newQuantity == it.quantity) return@map it
             val quantity = it.quantity.toBigDecimal()
             val totalTax = if (quantity > BigDecimal.ZERO) {
                 it.totalTax.divide(quantity, 2, HALF_UP)


### PR DESCRIPTION
This partially fixes #4442, specifically the rounding issue that you can notice in the order 1465 in the screenshots of the issue.
The issue came from a price re-calculation that we do to exclude the refunded items from the total, but as the price is calculated by the backend by dividing the total by the quantity, the re-calculation can cause some precision loss which lead to our issue, so to solve it, unless the item has been refunded previously, we won't re-calculate the price now.

To make things clearer, for the example shown in the screenshot below, the API returns `3.714286` as the price, and with our logic for [rounding](https://github.com/woocommerce/woocommerce-android/blob/671a0f0519a53f3fbb741dc1f3975b5ef4b6c81d/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/BigDecimalExt.kt#L10), we'll use `3.71`, which will give the `3.71*3.5 = 12.985`

We should revisit the usage of the rounding above, to see if it's necessary or not, but as it's a bigger change, let's do it in a separate PR.

| Before | After |
|-----|------|
| <img width="354" alt="Screen Shot 2021-07-15 at 16 18 17" src="https://user-images.githubusercontent.com/1657201/125813168-6a9a6b25-ae87-4012-86f6-2ed38bdf6997.png"> | <img width="354" alt="Screen Shot 2021-07-15 at 16 17 55" src="https://user-images.githubusercontent.com/1657201/125813196-4246ee71-cc5d-48d6-b4bf-2c3d5d78992a.png"> |

The other issue mentioned in the ticket about the individual item price being wrong (2$ vs 3.710$) can't be fixed right now, the price shown is exactly the total price divided by the quantity, and that's how wp-admin calculates it too https://d.pr/i/6Jn4vP

I fixed a second issue about the `totalTax` calculation, for some reason we were dividing the `totalTax` by the `quantity`, which results in the wrong `totalTax` returned from this method, but as it wasn't used anywhere in the app, it hadn't any impact. (@anitaa1990 do you remember why this calculation was done like this?)
The new logic follows the same logic of the price, I calculate the individual item's tax, and multiply it by the remaining quantity.

#### Testing
1. Change a product's price to 2$.
2. Install Product Addons plugin.
3. Add an addon to the product that costs 6$.
4. Place an order in the store with the quantity 3.5 and including the addon.
5. Open the order in the app.
6. Confirm that you can see the correct total price.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
