### PR TITLE
Shipping Labels: update order summary to support multiple packages

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -390,7 +390,7 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
         // Discount
         if (state.discount.isNotEqualTo(BigDecimal.ZERO)) {
             discountGroup.isVisible = true
-            discountPrice.text = PriceUtils.formatCurrency(state.discount, state.currency, currencyFormatter)
+            discountPrice.text = PriceUtils.formatCurrency(-state.discount, state.currency, currencyFormatter)
         } else {
             discountGroup.isVisible = false
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -18,11 +18,7 @@ import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.isNotEqualTo
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
-import com.woocommerce.android.model.Address
-import com.woocommerce.android.model.CustomsPackage
-import com.woocommerce.android.model.PaymentMethod
-import com.woocommerce.android.model.ShippingLabelPackage
-import com.woocommerce.android.model.ShippingRate
+import com.woocommerce.android.model.*
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.dialog.WooDialog
@@ -371,13 +367,14 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
 
         // Individual packages prices
         individualPackagesPricesLayout.removeAllViews()
-        state.individualPackagesPrices.forEach { (title, price) ->
+        individualPackagesPricesLayout.isVisible = state.individualPackagesPrices.isNotEmpty()
+        state.individualPackagesPrices.forEach { (labelPackage, price) ->
             val binding = ViewShippingLabelOrderPackagePriceBinding.inflate(
-                LayoutInflater.from(context),
+                LayoutInflater.from(requireContext()),
                 individualPackagesPricesLayout,
                 true
             )
-            binding.packageTitle.text = title
+            binding.packageTitle.text = labelPackage.getTitle(requireContext())
             binding.packagePrice.text = PriceUtils.formatCurrency(price, state.currency, currencyFormatter)
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -71,11 +71,9 @@ import javax.inject.Inject
 class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shipping_label), BackPressListener {
     private var progressDialog: CustomProgressDialog? = null
 
-    @Inject
-    lateinit var uiMessageResolver: UIMessageResolver
+    @Inject lateinit var uiMessageResolver: UIMessageResolver
 
-    @Inject
-    lateinit var currencyFormatter: CurrencyFormatter
+    @Inject lateinit var currencyFormatter: CurrencyFormatter
 
     val viewModel: CreateShippingLabelViewModel by viewModels()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -30,13 +30,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_STARTE
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.extensions.sumByBigDecimal
 import com.woocommerce.android.extensions.sumByFloat
-import com.woocommerce.android.model.Address
-import com.woocommerce.android.model.CustomsPackage
-import com.woocommerce.android.model.Order
-import com.woocommerce.android.model.PaymentMethod
-import com.woocommerce.android.model.ShippingLabel
-import com.woocommerce.android.model.ShippingLabelPackage
-import com.woocommerce.android.model.ShippingRate
+import com.woocommerce.android.model.*
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRepository
@@ -392,9 +386,17 @@ class CreateShippingLabelViewModel @Inject constructor(
             with(stateMachineData.stepsState.carrierStep.data) {
                 val price = sumByBigDecimal { it.price }
                 val discount = sumByBigDecimal { it.discount }
+                val individualPackagesPrices = if (size > 1) {
+                    map { rate ->
+                        val labelPackage = stateMachineData.stepsState.packagingStep.data
+                            .first { it.packageId == rate.packageId }
+                        Pair(labelPackage, rate.price)
+                    }.toMap()
+                } else emptyMap()
 
                 return OrderSummaryState(
                     isVisible = true,
+                    individualPackagesPrices = individualPackagesPrices,
                     price = price,
                     discount = discount,
                     // TODO: Once we start supporting countries other than the US, we'll need to verify what currency the shipping labels purchases use
@@ -744,7 +746,7 @@ class CreateShippingLabelViewModel @Inject constructor(
     @Parcelize
     data class OrderSummaryState(
         val isVisible: Boolean = false,
-        val individualPackagesPrices: Map<String, BigDecimal> = emptyMap(),
+        val individualPackagesPrices: Map<ShippingLabelPackage, BigDecimal> = emptyMap(),
         val price: BigDecimal = BigDecimal.ZERO,
         val discount: BigDecimal = BigDecimal.ZERO,
         val currency: String? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -744,6 +744,7 @@ class CreateShippingLabelViewModel @Inject constructor(
     @Parcelize
     data class OrderSummaryState(
         val isVisible: Boolean = false,
+        val individualPackagesPrices: Map<String, BigDecimal> = emptyMap(),
         val price: BigDecimal = BigDecimal.ZERO,
         val discount: BigDecimal = BigDecimal.ZERO,
         val currency: String? = null

--- a/WooCommerce/src/main/res/layout/view_shipping_label_order_package_price.xml
+++ b/WooCommerce/src/main/res/layout/view_shipping_label_order_package_price.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:paddingVertical="@dimen/minor_50"
+    tools:showIn="@layout/view_shipping_label_order_summary">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/package_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:textAppearance="?attr/textAppearanceBody2"
+        android:textColor="@color/color_on_surface_high"
+        tools:text="Package 1" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/package_price"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceBody2"
+        android:textColor="@color/color_on_surface_high"
+        tools:text="10 $" />
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/view_shipping_label_order_package_price.xml
+++ b/WooCommerce/src/main/res/layout/view_shipping_label_order_package_price.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal"
-    android:paddingVertical="@dimen/minor_50"
+    android:paddingBottom="@dimen/minor_50"
     tools:showIn="@layout/view_shipping_label_order_summary">
 
     <com.google.android.material.textview.MaterialTextView

--- a/WooCommerce/src/main/res/layout/view_shipping_label_order_summary.xml
+++ b/WooCommerce/src/main/res/layout/view_shipping_label_order_summary.xml
@@ -38,16 +38,28 @@
         android:layout_marginTop="@dimen/major_75"
         app:layout_constraintTop_toBottomOf="@id/title" />
 
+    <LinearLayout
+        android:id="@+id/individual_packages_prices_layout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_100"
+        android:orientation="vertical"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="@id/end_guideline"
+        app:layout_constraintStart_toStartOf="@id/start_guideline"
+        app:layout_constraintTop_toBottomOf="@id/divider"
+        tools:visibility="visible" />
+
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/subtotal_label"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/major_100"
         android:text="@string/shipping_label_create_price_subtotal"
         android:textAppearance="?attr/textAppearanceBody2"
         android:textColor="@color/color_on_surface_high"
         app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintTop_toBottomOf="@id/divider" />
+        app:layout_constraintTop_toBottomOf="@id/individual_packages_prices_layout"
+        app:layout_goneMarginTop="@dimen/major_100" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/subtotal_price"
@@ -134,8 +146,8 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/minor_100"
         android:layout_marginTop="@dimen/major_100"
-        android:paddingStart="@dimen/major_75"
         android:gravity="top"
+        android:paddingStart="@dimen/major_75"
         android:text="@string/shipping_label_create_mark_order_complete"
         app:layout_constraintEnd_toEndOf="@id/end_guideline"
         app:layout_constraintStart_toStartOf="parent"
@@ -150,9 +162,9 @@
         android:layout_marginTop="@dimen/minor_100"
         android:layout_marginBottom="@dimen/major_100"
         android:text="@string/shipping_label_create_purchase"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="@id/end_guideline"
         app:layout_constraintStart_toStartOf="@id/start_guideline"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@id/mark_order_complete_checkbox" />
 
 </com.woocommerce.android.widgets.WCElevatedConstraintLayout>


### PR DESCRIPTION
Fixes #4443, this updates the order summary view to support showing packages individual prices when there are multiples packages in the order.

<img width="350" alt="Screen Shot 2021-07-15 at 15 45 33" src="https://user-images.githubusercontent.com/1657201/125816303-08fc7c32-ae6b-4256-8fa1-8828dcd9c794.png">

#### Testing
1. Create a multi product order in your store.
2. Open the order in the app.
3. Click on Create shipping label.
4. In the packaging step, move items to be in multiple packages.
5. Complete all the steps.
6. Confirm that you can see the individual packages prices in the order summary section.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
