### PR TITLE
Issue/4413 Check if card present payments supported in store's country

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -1,9 +1,19 @@
 package com.woocommerce.android.ui.prefs.cardreader.onboarding
 
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.CoroutineDispatchers
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
+private val SUPPORTED_COUNTRIES = listOf("US")
+
 @Suppress("TooManyFunctions")
-class CardReaderOnboardingChecker @Inject constructor() {
+class CardReaderOnboardingChecker @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val wooStore: WooCommerceStore,
+    private val dispatchers: CoroutineDispatchers
+) {
     suspend fun getOnboardingState(): CardReaderOnboardingState {
         return when {
             !isCountrySupported() -> CardReaderOnboardingState.COUNTRY_NOT_SUPPORTED
@@ -21,9 +31,12 @@ class CardReaderOnboardingChecker @Inject constructor() {
         }
     }
 
-    // TODO cardreader Implement
-    @Suppress("FunctionOnlyReturningConstant")
-    private fun isCountrySupported(): Boolean = true
+    private suspend fun isCountrySupported(): Boolean {
+        return withContext(dispatchers.io) {
+            val storeCountryCode = wooStore.getStoreCountryCode(selectedSite.get())
+            SUPPORTED_COUNTRIES.any { it.equals(storeCountryCode, ignoreCase = true) }
+        }
+    }
 
     // TODO cardreader Implement
     @Suppress("FunctionOnlyReturningConstant")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.prefs.cardreader.onboarding
 
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
@@ -33,8 +34,9 @@ class CardReaderOnboardingChecker @Inject constructor(
 
     private suspend fun isCountrySupported(): Boolean {
         return withContext(dispatchers.io) {
-            val storeCountryCode = wooStore.getStoreCountryCode(selectedSite.get())
-            SUPPORTED_COUNTRIES.any { it.equals(storeCountryCode, ignoreCase = true) }
+            wooStore.getStoreCountryCode(selectedSite.get())?.let { storeCountryCode ->
+                SUPPORTED_COUNTRIES.any { it.equals(storeCountryCode, ignoreCase = true) }
+            } ?: false.also { WooLog.e(WooLog.T.CARD_READER, "Store's country code not found.") }
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.ui.prefs.cardreader.onboarding
+
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import org.junit.Before
+
+class CardReaderOnboardingCheckerTest : BaseUnitTest() {
+    private lateinit var checker: CardReaderOnboardingChecker
+
+    @Before
+    fun setUp() {
+        checker = CardReaderOnboardingChecker()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -1,13 +1,58 @@
 package com.woocommerce.android.ui.prefs.cardreader.onboarding
 
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
+import org.junit.Test
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.WooCommerceStore
 
+@ExperimentalCoroutinesApi
 class CardReaderOnboardingCheckerTest : BaseUnitTest() {
     private lateinit var checker: CardReaderOnboardingChecker
 
+    private val selectedSite: SelectedSite = mock()
+    private val wooStore: WooCommerceStore = mock()
+
+    private val site = SiteModel()
+
+
     @Before
     fun setUp() {
-        checker = CardReaderOnboardingChecker()
+        checker = CardReaderOnboardingChecker(selectedSite, wooStore, coroutinesTestRule.testDispatchers)
+        whenever(selectedSite.get()).thenReturn(site)
+        whenever(wooStore.getStoreCountryCode(site)).thenReturn("US")
     }
+
+    @Test
+    fun `when store country not supported, then COUNTRY_NOT_SUPPORTED returned`() = testBlocking {
+        whenever(wooStore.getStoreCountryCode(site)).thenReturn("unsupported country abc")
+
+        val result = checker.getOnboardingState()
+
+        assertThat(result).isEqualTo(CardReaderOnboardingState.COUNTRY_NOT_SUPPORTED)
+    }
+
+    @Test
+    fun `when store country supported, then COUNTRY_NOT_SUPPORTED not returned`() = testBlocking {
+        whenever(wooStore.getStoreCountryCode(site)).thenReturn("US")
+
+        val result = checker.getOnboardingState()
+
+        assertThat(result).isNotEqualTo(CardReaderOnboardingState.COUNTRY_NOT_SUPPORTED)
+    }
+
+    @Test
+    fun `given country code in lower case, when store country supported, then COUNTRY_NOT_SUPPORTED not returned`() =
+        testBlocking {
+            whenever(wooStore.getStoreCountryCode(site)).thenReturn("us")
+
+            val result = checker.getOnboardingState()
+
+            assertThat(result).isNotEqualTo(CardReaderOnboardingState.COUNTRY_NOT_SUPPORTED)
+        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -20,7 +20,6 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
     private val site = SiteModel()
 
-
     @Before
     fun setUp() {
         checker = CardReaderOnboardingChecker(selectedSite, wooStore, coroutinesTestRule.testDispatchers)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -55,4 +55,14 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             assertThat(result).isNotEqualTo(CardReaderOnboardingState.COUNTRY_NOT_SUPPORTED)
         }
+
+    @Test
+    fun `when country code is not found, then COUNTRY_NOT_SUPPORTED returned`() =
+        testBlocking {
+            whenever(wooStore.getStoreCountryCode(site)).thenReturn(null)
+
+            val result = checker.getOnboardingState()
+
+            assertThat(result).isEqualTo(CardReaderOnboardingState.COUNTRY_NOT_SUPPORTED)
+        }
 }


### PR DESCRIPTION
Parent issue #4413 

This PR adds a check if card present payments are supported in store's country. We are hardcoding the list of supported countries for now. The main reason is that the connection and payment flows rely on the fact that the store is located in the US - eg. we are using dollars to cent conversion and we are also displaying "$" symbol at a couple different places. We'll update the logic when we add support for more countries in the future.

To test:
The class is not being used on the UI yet, so if CI checks pass I think it's safe to merge this PR.



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
