### PR TITLE
Issue/4413 Stripe Account verifications

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -80,9 +80,9 @@ class CardReaderOnboardingChecker @Inject constructor(
             paymentAccount.hasOverdueRequirements
 
     private fun isStripeAccountRejected(paymentAccount: WCPaymentAccountResult): Boolean =
-        paymentAccount.status == WCPaymentAccountResult.WCPayAccountStatusEnum.REJECTED_FRAUD &&
-            paymentAccount.status == WCPaymentAccountResult.WCPayAccountStatusEnum.REJECTED_LISTED &&
-            paymentAccount.status == WCPaymentAccountResult.WCPayAccountStatusEnum.REJECTED_TERMS_OF_SERVICE &&
+        paymentAccount.status == WCPaymentAccountResult.WCPayAccountStatusEnum.REJECTED_FRAUD ||
+            paymentAccount.status == WCPaymentAccountResult.WCPayAccountStatusEnum.REJECTED_LISTED ||
+            paymentAccount.status == WCPaymentAccountResult.WCPayAccountStatusEnum.REJECTED_TERMS_OF_SERVICE ||
             paymentAccount.status == WCPaymentAccountResult.WCPayAccountStatusEnum.REJECTED_OTHER
 
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.model.pay.WCPaymentAccountResult
 import org.wordpress.android.fluxc.store.WCPayStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
+import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState.*
 
 private val SUPPORTED_COUNTRIES = listOf("US")
 
@@ -18,35 +19,24 @@ class CardReaderOnboardingChecker @Inject constructor(
     private val wcPayStore: WCPayStore,
     private val dispatchers: CoroutineDispatchers
 ) {
+    @Suppress("ReturnCount")
     suspend fun getOnboardingState(): CardReaderOnboardingState {
-        if (!isCountrySupported())
-            return CardReaderOnboardingState.COUNTRY_NOT_SUPPORTED
-        if (!isWCPayInstalled())
-            return CardReaderOnboardingState.WCPAY_NOT_INSTALLED
-        if (!isWCPayVersionSupported())
-            return CardReaderOnboardingState.WCPAY_UNSUPPORTED_VERSION
-        if (!isWCPayActivated())
-            return CardReaderOnboardingState.WCPAY_NOT_ACTIVATED
+        if (!isCountrySupported()) return COUNTRY_NOT_SUPPORTED
+        if (!isWCPayInstalled()) return WCPAY_NOT_INSTALLED
+        if (!isWCPayVersionSupported()) return WCPAY_UNSUPPORTED_VERSION
+        if (!isWCPayActivated()) return WCPAY_NOT_ACTIVATED
 
-        val paymentAccount = wcPayStore.loadAccount(selectedSite.get()).model
-            ?: return CardReaderOnboardingState.GENERIC_ERROR
+        val paymentAccount = wcPayStore.loadAccount(selectedSite.get()).model ?: return GENERIC_ERROR
 
-        if (!isWCPaySetupCompleted(paymentAccount))
-            return CardReaderOnboardingState.WCPAY_SETUP_NOT_COMPLETED
-        if (isWCPayInTestModeWithLiveStripeAccount())
-            return CardReaderOnboardingState.WCPAY_IN_TEST_MODE_WITH_LIVE_STRIPE_ACCOUNT
-        if (isStripeAccountUnderReview(paymentAccount))
-            return CardReaderOnboardingState.STRIPE_ACCOUNT_UNDER_REVIEW
-        if (isStripeAccountPendingRequirements(paymentAccount))
-            return CardReaderOnboardingState.STRIPE_ACCOUNT_PENDING_REQUIREMENT
-        if (isStripeAccountOverdueRequirements(paymentAccount))
-            return CardReaderOnboardingState.STRIPE_ACCOUNT_OVERDUE_REQUIREMENT
-        if (isStripeAccountRejected(paymentAccount))
-            return CardReaderOnboardingState.STRIPE_ACCOUNT_REJECTED
-        if (isInUndefinedState(paymentAccount))
-            return CardReaderOnboardingState.GENERIC_ERROR
+        if (!isWCPaySetupCompleted(paymentAccount)) return WCPAY_SETUP_NOT_COMPLETED
+        if (isWCPayInTestModeWithLiveStripeAccount()) return WCPAY_IN_TEST_MODE_WITH_LIVE_STRIPE_ACCOUNT
+        if (isStripeAccountUnderReview(paymentAccount)) return STRIPE_ACCOUNT_UNDER_REVIEW
+        if (isStripeAccountPendingRequirements(paymentAccount)) return STRIPE_ACCOUNT_PENDING_REQUIREMENT
+        if (isStripeAccountOverdueRequirements(paymentAccount)) return STRIPE_ACCOUNT_OVERDUE_REQUIREMENT
+        if (isStripeAccountRejected(paymentAccount)) return STRIPE_ACCOUNT_REJECTED
+        if (isInUndefinedState(paymentAccount)) return GENERIC_ERROR
 
-        return CardReaderOnboardingState.ONBOARDING_COMPLETED
+        return ONBOARDING_COMPLETED
     }
 
     private suspend fun isCountrySupported(): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -94,7 +94,6 @@ class CardReaderOnboardingChecker @Inject constructor(
             paymentAccount.status == WCPaymentAccountResult.WCPayAccountStatusEnum.REJECTED_LISTED ||
             paymentAccount.status == WCPaymentAccountResult.WCPayAccountStatusEnum.REJECTED_TERMS_OF_SERVICE ||
             paymentAccount.status == WCPaymentAccountResult.WCPayAccountStatusEnum.REJECTED_OTHER
-
 }
 
 private fun isInUndefinedState(paymentAccount: WCPaymentAccountResult): Boolean =

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.prefs.cardreader.onboarding
 
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
+import com.nhaarman.mockitokotlin2.*
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -71,11 +70,23 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given country not supported, then stripe account loading does not even start`() =
+        testBlocking {
+            whenever(wooStore.getStoreCountryCode(site)).thenReturn("unsupported country abc")
+
+            checker.getOnboardingState()
+
+            verify(wcPayStore, never()).loadAccount(anyOrNull())
+        }
+
+    @Test
     fun `when stripe account not connected, then WCPAY_SETUP_NOT_COMPLETED returned`() =
         testBlocking {
-            whenever(wcPayStore.loadAccount(site)).thenReturn(buildPaymentAccountResult(
-                WCPaymentAccountResult.WCPayAccountStatusEnum.NO_ACCOUNT
-            ))
+            whenever(wcPayStore.loadAccount(site)).thenReturn(
+                buildPaymentAccountResult(
+                    WCPaymentAccountResult.WCPayAccountStatusEnum.NO_ACCOUNT
+                )
+            )
 
             val result = checker.getOnboardingState()
 
@@ -85,11 +96,13 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
     @Test
     fun `when stripe account under review, then WCPAY_SETUP_NOT_COMPLETED returned`() =
         testBlocking {
-            whenever(wcPayStore.loadAccount(site)).thenReturn(buildPaymentAccountResult(
-                WCPaymentAccountResult.WCPayAccountStatusEnum.RESTRICTED,
-                hasPendingRequirements = false,
-                hadOverdueRequirements = false
-            ))
+            whenever(wcPayStore.loadAccount(site)).thenReturn(
+                buildPaymentAccountResult(
+                    WCPaymentAccountResult.WCPayAccountStatusEnum.RESTRICTED,
+                    hasPendingRequirements = false,
+                    hadOverdueRequirements = false
+                )
+            )
 
             val result = checker.getOnboardingState()
 
@@ -99,11 +112,13 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
     @Test
     fun `when stripe account pending requirements, then STRIPE_ACCOUNT_PENDING_REQUIREMENT returned`() =
         testBlocking {
-            whenever(wcPayStore.loadAccount(site)).thenReturn(buildPaymentAccountResult(
-                WCPaymentAccountResult.WCPayAccountStatusEnum.RESTRICTED,
-                hasPendingRequirements = true,
-                hadOverdueRequirements = false
-            ))
+            whenever(wcPayStore.loadAccount(site)).thenReturn(
+                buildPaymentAccountResult(
+                    WCPaymentAccountResult.WCPayAccountStatusEnum.RESTRICTED,
+                    hasPendingRequirements = true,
+                    hadOverdueRequirements = false
+                )
+            )
 
             val result = checker.getOnboardingState()
 
@@ -113,11 +128,13 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
     @Test
     fun `when stripe account has overdue requirements, then STRIPE_ACCOUNT_OVERDUE_REQUIREMENT returned`() =
         testBlocking {
-            whenever(wcPayStore.loadAccount(site)).thenReturn(buildPaymentAccountResult(
-                WCPaymentAccountResult.WCPayAccountStatusEnum.RESTRICTED,
-                hasPendingRequirements = false,
-                hadOverdueRequirements = true
-            ))
+            whenever(wcPayStore.loadAccount(site)).thenReturn(
+                buildPaymentAccountResult(
+                    WCPaymentAccountResult.WCPayAccountStatusEnum.RESTRICTED,
+                    hasPendingRequirements = false,
+                    hadOverdueRequirements = true
+                )
+            )
 
             val result = checker.getOnboardingState()
 
@@ -127,9 +144,11 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
     @Test
     fun `when stripe account marked as fraud, then STRIPE_ACCOUNT_REJECTED returned`() =
         testBlocking {
-            whenever(wcPayStore.loadAccount(site)).thenReturn(buildPaymentAccountResult(
-                WCPaymentAccountResult.WCPayAccountStatusEnum.REJECTED_FRAUD,
-            ))
+            whenever(wcPayStore.loadAccount(site)).thenReturn(
+                buildPaymentAccountResult(
+                    WCPaymentAccountResult.WCPayAccountStatusEnum.REJECTED_FRAUD,
+                )
+            )
 
             val result = checker.getOnboardingState()
 
@@ -139,9 +158,11 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
     @Test
     fun `when stripe account listed, then STRIPE_ACCOUNT_REJECTED returned`() =
         testBlocking {
-            whenever(wcPayStore.loadAccount(site)).thenReturn(buildPaymentAccountResult(
-                WCPaymentAccountResult.WCPayAccountStatusEnum.REJECTED_LISTED,
-            ))
+            whenever(wcPayStore.loadAccount(site)).thenReturn(
+                buildPaymentAccountResult(
+                    WCPaymentAccountResult.WCPayAccountStatusEnum.REJECTED_LISTED,
+                )
+            )
 
             val result = checker.getOnboardingState()
 
@@ -151,9 +172,11 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
     @Test
     fun `when stripe account violates terms of service, then STRIPE_ACCOUNT_REJECTED returned`() =
         testBlocking {
-            whenever(wcPayStore.loadAccount(site)).thenReturn(buildPaymentAccountResult(
-                WCPaymentAccountResult.WCPayAccountStatusEnum.REJECTED_TERMS_OF_SERVICE,
-            ))
+            whenever(wcPayStore.loadAccount(site)).thenReturn(
+                buildPaymentAccountResult(
+                    WCPaymentAccountResult.WCPayAccountStatusEnum.REJECTED_TERMS_OF_SERVICE,
+                )
+            )
 
             val result = checker.getOnboardingState()
 
@@ -163,9 +186,11 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
     @Test
     fun `when stripe account rejected for other reasons, then STRIPE_ACCOUNT_REJECTED returned`() =
         testBlocking {
-            whenever(wcPayStore.loadAccount(site)).thenReturn(buildPaymentAccountResult(
-                WCPaymentAccountResult.WCPayAccountStatusEnum.REJECTED_OTHER,
-            ))
+            whenever(wcPayStore.loadAccount(site)).thenReturn(
+                buildPaymentAccountResult(
+                    WCPaymentAccountResult.WCPayAccountStatusEnum.REJECTED_OTHER,
+                )
+            )
 
             val result = checker.getOnboardingState()
 


### PR DESCRIPTION
Parent issue #4413 

This PR introduces checks if Stripe account is valid and ready to be used with in person payments.

The different states are defined in the comments [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/841c191b8fde6218db2aa71fddfe57ca8c8cd961/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCPaymentAccountResult.kt#L46).

To test:
The code is not used on the UI yet. I'd consider testing the different states when the UI is implemented and rely on tests until then. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
