### PR TITLE
Update fluxc

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -279,7 +279,7 @@ class OrderDetailRepository @Inject constructor(
         .map { it.toAppModel() }
 
     fun getWooServicesPluginInfo(): WooPlugin {
-        val info = wooCommerceStore.getWooCommerceServicesPluginInfo(selectedSite.get())
+        val info = wooCommerceStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_SERVICES)
         return WooPlugin(info != null, info?.active ?: false, info?.version)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -131,7 +131,7 @@ class OrderListViewModel @Inject constructor(
             _orderStatusOptions.value = repository.getCachedOrderStatusOptions()
 
             // refresh plugin information
-            wooCommerceStore.fetchWooCommerceServicesPluginInfo(selectedSite.get())
+            wooCommerceStore.fetchSitePlugins(selectedSite.get())
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'c64ce519824722e8658ecd5c95612d3263531d53'
+    fluxCVersion = '64becff7e10681286b8c68330f0b8c0be02b5c9b'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'e70d82bd5dfb89ec6b71ada49ddbb708a445b2e1'
+    fluxCVersion = 'c64ce519824722e8658ecd5c95612d3263531d53'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'


### PR DESCRIPTION
This PR updates fluxc - more info on [the PR in fluxC](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2064).

Merge instructions: 
1. Make sure https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2064 is merged
2. Update fluxc hash with the merge commit
3. Merge this PR

To test:
- Prerequisites: Use a store with shipping labels support
1. Open detail of an order
2. Notice "Create Shipping labels" button is visible

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
