### PR TITLE
Make the the “Update”/”Done”/Publish buttons Pink 50

### DIFF
--- a/WooCommerce/src/main/res/layout/view_toolbar.xml
+++ b/WooCommerce/src/main/res/layout/view_toolbar.xml
@@ -8,4 +8,5 @@
     app:layout_collapseMode="pin"
     tools:menu="@menu/menu_product_detail_fragment"
     tools:showIn="@layout/activity_app_settings"
+    style="@style/Widget.Woo.Toolbar"
     tools:title="@string/app_name" />

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -16,6 +16,11 @@ theme across the entire app. Overridden versions should be added to the styles.x
     <style name="Widget.Woo.Toolbar" parent="Widget.MaterialComponents.Toolbar.Surface">
         <item name="titleTextStyle">@style/TextAppearance.Woo.CollapsingToolbar.Collapsed</item>
         <item name="navigationIcon">@drawable/ic_back_24dp</item>
+        <item name="android:theme">@style/Widget.Woo.Toolbar.Surface</item>
+    </style>
+    <style name="Widget.Woo.Toolbar.Surface" parent="ThemeOverlay.MaterialComponents.Toolbar.Surface">
+        <item name="actionMenuTextColor">@color/woo_pink_50</item>
+        <item name="colorControlNormal">@color/woo_pink_50</item>
     </style>
     <style name="TextAppearance.Woo.CollapsingToolbar.Expanded" parent="TextAppearance.MaterialComponents.Headline4">
         <item name="android:textColor">@color/color_on_surface</item>


### PR DESCRIPTION
Fixes #3632

## Changes

Overrides Theme for Toolbar overlay in order to force the Publish/Update buttons to be Pink_50 instead of the default colour. 

## Screenshots

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/126225407-089cc7b9-9fa9-4c10-a7cc-58d4e2941241.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/126225483-3f94c0a4-7343-4192-a063-80617444867d.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/30724184/126225607-867f3b88-f0cb-4088-a097-9c16843db895.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/126225676-848a6c83-b6d2-4dce-8e47-549a0229a199.png" width="350"/> |

## Testing

- Navigate to the Products Screen
- tap on an existing product 
- Make a change (either change the name or description)
- tap the back button
- notice the Update button in the toolbar is set to the default colour
and
-tap the button to add a new product
- select product type
- notice Publish button in the toolbar is set to the default colour. 


Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
