### PR TITLE
Issue/4030 init payment meta data

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -29,6 +29,7 @@ import com.woocommerce.android.cardreader.CardPaymentStatus.ShowAdditionalInfo
 import com.woocommerce.android.cardreader.CardPaymentStatus.WaitingForInput
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.PaymentData
+import com.woocommerce.android.cardreader.PaymentInfo
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
@@ -137,11 +138,16 @@ class CardReaderPaymentViewModel
     private suspend fun collectPaymentFlow(cardReaderManager: CardReaderManager, order: Order) {
         val customerEmail = order.billingAddress.email
         cardReaderManager.collectPayment(
-            paymentDescription = order.getPaymentDescription(),
-            orderId = order.remoteId,
-            amount = order.total,
-            currency = order.currency,
-            customerEmail = customerEmail.ifEmpty { null }
+            PaymentInfo(
+                paymentDescription = order.getPaymentDescription(),
+                orderId = order.remoteId,
+                amount = order.total,
+                currency = order.currency,
+                customerEmail = customerEmail.ifEmpty { null },
+                customerName = "${order.billingAddress.firstName} ${order.billingAddress.lastName}".ifBlank { null },
+                storeName = selectedSite.get().name.ifEmpty { null },
+                siteUrl = selectedSite.get().url.ifEmpty { null }
+            )
         ).collect { paymentStatus ->
             onPaymentStatusChanged(order.remoteId, customerEmail, paymentStatus, order.getAmountLabel())
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -117,10 +117,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         whenever(cardReaderManager.retryCollectPayment(any(), any())).thenAnswer {
             flow<CardPaymentStatus> { }
         }
-        whenever(selectedSite.get()).thenReturn(SiteModel().apply {
-            name = "testName"
-            url = "testUrl.com"
-        })
+        whenever(selectedSite.get()).thenReturn(SiteModel().apply { name = "testName" }.apply { url = "testUrl.com" })
         whenever(resourceProvider.getString(anyOrNull(), anyOrNull())).thenReturn("")
         whenever(paymentCollectibilityChecker.isCollectable(any())).thenReturn(true)
         whenever(appPrefsWrapper.getReceiptUrl(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()))

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.cardreader
 import android.app.Application
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
-import java.math.BigDecimal
 
 /**
  * Interface for consumers who want to start accepting POC card payments.

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
@@ -16,15 +16,8 @@ interface CardReaderManager {
     suspend fun connectToReader(cardReader: CardReader): Boolean
     suspend fun disconnectReader(): Boolean
 
-    // TODO cardreader Stripe accepts only Int, is that ok?
-    // TODO cardreader wrap payment params with a data class
-    suspend fun collectPayment(
-        paymentDescription: String,
-        orderId: Long,
-        amount: BigDecimal,
-        currency: String,
-        customerEmail: String?
-    ): Flow<CardPaymentStatus>
+    // TODO cardreader Stripe accepts only Int, is that ok? (v2.0 of the SDK uses Long)
+    suspend fun collectPayment(paymentInfo: PaymentInfo): Flow<CardPaymentStatus>
 
     suspend fun retryCollectPayment(orderId: Long, paymentData: PaymentData): Flow<CardPaymentStatus>
     fun cancelPayment(paymentData: PaymentData)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
@@ -28,7 +28,7 @@ object CardReaderManagerFactory {
             PaymentManager(
                 terminal,
                 cardReaderStore,
-                CreatePaymentAction(PaymentIntentParametersFactory(), terminal, logWrapper),
+                CreatePaymentAction(PaymentIntentParametersFactory(), terminal, PaymentUtils(), logWrapper),
                 CollectPaymentAction(terminal, logWrapper),
                 ProcessPaymentAction(terminal, logWrapper),
                 CancelPaymentAction(terminal),

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/PaymentInfo.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/PaymentInfo.kt
@@ -1,0 +1,14 @@
+package com.woocommerce.android.cardreader
+
+import java.math.BigDecimal
+
+data class PaymentInfo(
+    val paymentDescription: String,
+    val orderId: Long,
+    val amount: BigDecimal,
+    val currency: String,
+    val customerEmail: String?,
+    val customerName: String?,
+    val storeName: String?,
+    val siteUrl: String?
+)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -4,15 +4,7 @@ import android.app.Application
 import android.content.ComponentCallbacks2
 import android.content.res.Configuration
 import com.stripe.stripeterminal.log.LogLevel
-import com.woocommerce.android.cardreader.BuildConfig
-import com.woocommerce.android.cardreader.CardPaymentStatus
-import com.woocommerce.android.cardreader.CardReader
-import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents
-import com.woocommerce.android.cardreader.CardReaderManager
-import com.woocommerce.android.cardreader.CardReaderStatus
-import com.woocommerce.android.cardreader.PaymentData
-import com.woocommerce.android.cardreader.SoftwareUpdateAvailability
-import com.woocommerce.android.cardreader.SoftwareUpdateStatus
+import com.woocommerce.android.cardreader.*
 import com.woocommerce.android.cardreader.internal.connection.ConnectionManager
 import com.woocommerce.android.cardreader.internal.firmware.SoftwareUpdateManager
 import com.woocommerce.android.cardreader.internal.payments.PaymentManager
@@ -87,14 +79,8 @@ internal class CardReaderManagerImpl(
         return connectionManager.disconnectReader()
     }
 
-    override suspend fun collectPayment(
-        paymentDescription: String,
-        orderId: Long,
-        amount: BigDecimal,
-        currency: String,
-        customerEmail: String?
-    ): Flow<CardPaymentStatus> =
-        paymentManager.acceptPayment(paymentDescription, orderId, amount, currency, customerEmail)
+    override suspend fun collectPayment(paymentInfo: PaymentInfo): Flow<CardPaymentStatus> =
+        paymentManager.acceptPayment(paymentInfo)
 
     override suspend fun retryCollectPayment(orderId: Long, paymentData: PaymentData): Flow<CardPaymentStatus> =
         paymentManager.retryPayment(orderId, paymentData)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -12,7 +12,6 @@ import com.woocommerce.android.cardreader.internal.wrappers.LogWrapper
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import java.math.BigDecimal
 
 /**
  * Implementation of CardReaderManager using StripeTerminalSDK.

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/MetaDataKeys.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/MetaDataKeys.kt
@@ -1,0 +1,57 @@
+package com.woocommerce.android.cardreader.internal.payments
+
+internal enum class MetaDataKeys(val key: String) {
+    STORE("paymentintent.storename"),
+
+    /**
+     * The customer's name - first name then last name separated by a space, or
+     * empty if neither first name nor last name is given.
+     * This key is also used by the plugin when it creates payment intents.
+     */
+    CUSTOMER_NAME("customer_name"),
+
+    /**
+     *  The customer's email address, or empty if not given.
+     *  This key is also used by the plugin when it creates payment intents.
+     */
+    CUSTOMER_EMAIL("customer_email"),
+
+    /**
+     * The store URL, e.g. `https://mydomain.com`
+     * This key is also used by the plugin when it creates payment intents.
+     */
+    SITE_URL("site_url"),
+
+    /**
+     * The order ID, e.g. 6140
+     * This key is also used by the plugin when it creates payment intents.
+     */
+    ORDER_ID("order_id"),
+
+    /**
+     * The order key, e.g. `wc_order_0000000000000`
+     * This key is also used by the plugin when it creates payment intents.
+     */
+    ORDER_KEY("order_key"),
+
+    /**
+     * The payment type, i.e. `single` or `recurring`
+     * See also PaymentIntent.PaymentTypes
+     * This key is also used by the plugin when it creates payment intents.
+     */
+    PAYMENT_TYPE("payment_type");
+
+    enum class PaymentTypes(val key: String) {
+        /**
+         * A payment that IS NOT associated with an order containing a subscription
+         * This key is also used by the plugin when it creates payment intents.
+         */
+        SINGLE("single"),
+
+        /**
+         * A payment that IS associated with an order containing a subscription
+         * This key is also used by the plugin when it creates payment intents.
+         */
+        RECURRING("recurring")
+    }
+}

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentErrorMapper.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentErrorMapper.kt
@@ -13,7 +13,7 @@ import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse.Error.NetworkError
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse.Error.ServerError
 
-class PaymentErrorMapper {
+internal class PaymentErrorMapper {
     fun mapTerminalError(
         originalPaymentIntent: PaymentIntent?,
         exception: TerminalException

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErr
 import com.woocommerce.android.cardreader.CardReaderStore
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
 import com.woocommerce.android.cardreader.PaymentData
+import com.woocommerce.android.cardreader.PaymentInfo
 import com.woocommerce.android.cardreader.internal.payments.actions.CancelPaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction.CollectPaymentStatus
@@ -24,7 +25,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
-import java.math.BigDecimal
 
 @Suppress("LongParameterList")
 internal class PaymentManager(
@@ -37,37 +37,20 @@ internal class PaymentManager(
     private val paymentUtils: PaymentUtils,
     private val errorMapper: PaymentErrorMapper
 ) {
-    suspend fun acceptPayment(
-        paymentDescription: String,
-        orderId: Long,
-        amount: BigDecimal,
-        currency: String,
-        customerEmail: String?
-    ): Flow<CardPaymentStatus> = flow {
-        if (!paymentUtils.isSupportedCurrency(currency)) {
-            emit(errorMapper.mapError(errorMessage = "Unsupported currency: $currency"))
-            return@flow
-        }
-        val amountInSmallestCurrencyUnit = try {
-            paymentUtils.convertBigDecimalInDollarsToIntegerInCents(amount)
-        } catch (e: ArithmeticException) {
-            emit(errorMapper.mapError(errorMessage = "BigDecimal amount doesn't fit into an Integer: $amount"))
+    suspend fun acceptPayment(paymentInfo: PaymentInfo): Flow<CardPaymentStatus> = flow {
+        if (!paymentUtils.isSupportedCurrency(paymentInfo.currency)) {
+            emit(errorMapper.mapError(errorMessage = "Unsupported currency: $paymentInfo.currency"))
             return@flow
         }
         if (!terminalWrapper.isInitialized()) {
             emit(errorMapper.mapError(errorMessage = "Reader not connected"))
             return@flow
         }
-        val paymentIntent = createPaymentIntent(
-            paymentDescription,
-            amountInSmallestCurrencyUnit,
-            currency,
-            customerEmail
-        )
+        val paymentIntent = createPaymentIntent(paymentInfo)
         if (paymentIntent?.status != PaymentIntentStatus.REQUIRES_PAYMENT_METHOD) {
             return@flow
         }
-        processPaymentIntent(orderId, paymentIntent).collect { emit(it) }
+        processPaymentIntent(paymentInfo.orderId, paymentIntent).collect { emit(it) }
     }
 
     fun retryPayment(orderId: Long, paymentData: PaymentData) =
@@ -120,15 +103,10 @@ internal class PaymentManager(
         }
     }
 
-    private suspend fun FlowCollector<CardPaymentStatus>.createPaymentIntent(
-        paymentDescription: String,
-        amount: Int,
-        currency: String,
-        customerEmail: String?
-    ): PaymentIntent? {
+    private suspend fun FlowCollector<CardPaymentStatus>.createPaymentIntent(paymentInfo: PaymentInfo): PaymentIntent? {
         var paymentIntent: PaymentIntent? = null
         emit(InitializingPayment)
-        createPaymentAction.createPaymentIntent(paymentDescription, amount, currency, customerEmail).collect {
+        createPaymentAction.createPaymentIntent(paymentInfo).collect {
             when (it) {
                 is Failure -> emit(errorMapper.mapTerminalError(paymentIntent, it.exception))
                 is Success -> paymentIntent = it.paymentIntent

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentUtils.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentUtils.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 private const val USD_CURRENCY = "usd"
 internal const val USD_TO_CENTS_DECIMAL_PLACES = 2
 
-class PaymentUtils @Inject constructor() {
+internal class PaymentUtils @Inject constructor() {
     // TODO cardreader Add support for other currencies
     fun convertBigDecimalInDollarsToIntegerInCents(amount: BigDecimal): Int {
         return amount

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentAction.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentAction.kt
@@ -61,14 +61,23 @@ internal class CreatePaymentAction(
         return builder.build()
     }
 
-    private fun createMetaData(paymentInfo: PaymentInfo): Map<String, String> =
-        mapOf(
-            MetaDataKeys.STORE.key to paymentInfo.storeName.orEmpty(),
-            MetaDataKeys.CUSTOMER_NAME.key to paymentInfo.customerName.orEmpty(),
-            MetaDataKeys.CUSTOMER_EMAIL.key to paymentInfo.customerEmail.orEmpty(),
-            MetaDataKeys.SITE_URL.key to paymentInfo.siteUrl.orEmpty(),
-            MetaDataKeys.ORDER_ID.key to paymentInfo.orderId.toString(),
-            // TODO cardreader Needs to be fixed when we add support for recurring payments
-            MetaDataKeys.PAYMENT_TYPE.key to MetaDataKeys.PaymentTypes.SINGLE.key,
-        )
+    private fun createMetaData(paymentInfo: PaymentInfo): Map<String, String> {
+        val map = mutableMapOf<String, String>()
+        paymentInfo.storeName.takeUnless { it.isNullOrBlank() }
+            ?.let { map[MetaDataKeys.STORE.key] = it }
+
+        paymentInfo.customerName.takeUnless { it.isNullOrBlank() }
+            ?.let { map[MetaDataKeys.CUSTOMER_NAME.key] = it }
+
+        paymentInfo.customerEmail.takeUnless { it.isNullOrBlank() }
+            ?.let { map[MetaDataKeys.CUSTOMER_EMAIL.key] = it }
+
+        paymentInfo.siteUrl.takeUnless { it.isNullOrBlank() }
+            ?.let { map[MetaDataKeys.SITE_URL.key] = it }
+
+        map[MetaDataKeys.ORDER_ID.key] = paymentInfo.orderId.toString()
+        // TODO cardreader Needs to be fixed when we add support for recurring payments
+        map[MetaDataKeys.PAYMENT_TYPE.key] = MetaDataKeys.PaymentTypes.SINGLE.key
+        return map
+    }
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentAction.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentAction.kt
@@ -5,6 +5,7 @@ import com.stripe.stripeterminal.model.external.PaymentIntent
 import com.stripe.stripeterminal.model.external.PaymentIntentParameters
 import com.stripe.stripeterminal.model.external.TerminalException
 import com.woocommerce.android.cardreader.PaymentInfo
+import com.woocommerce.android.cardreader.internal.payments.MetaDataKeys
 import com.woocommerce.android.cardreader.internal.payments.PaymentUtils
 import com.woocommerce.android.cardreader.internal.payments.actions.CreatePaymentAction.CreatePaymentStatus.Failure
 import com.woocommerce.android.cardreader.internal.payments.actions.CreatePaymentAction.CreatePaymentStatus.Success
@@ -55,7 +56,19 @@ internal class CreatePaymentAction(
             .setDescription(paymentInfo.paymentDescription)
             .setAmount(amountInSmallestCurrencyUnit)
             .setCurrency(paymentInfo.currency)
+            .setMetadata(createMetaData(paymentInfo))
         paymentInfo.customerEmail?.takeIf { it.isNotEmpty() }?.let { builder.setReceiptEmail(it) }
         return builder.build()
     }
+
+    private fun createMetaData(paymentInfo: PaymentInfo): Map<String, String> =
+        mapOf(
+            MetaDataKeys.STORE.key to paymentInfo.storeName.orEmpty(),
+            MetaDataKeys.CUSTOMER_NAME.key to paymentInfo.customerName.orEmpty(),
+            MetaDataKeys.CUSTOMER_EMAIL.key to paymentInfo.customerEmail.orEmpty(),
+            MetaDataKeys.SITE_URL.key to paymentInfo.siteUrl.orEmpty(),
+            MetaDataKeys.ORDER_ID.key to paymentInfo.orderId.toString(),
+            // TODO cardreader Needs to be fixed when we add support for recurring payments
+            MetaDataKeys.PAYMENT_TYPE.key to MetaDataKeys.PaymentTypes.SINGLE.key,
+        )
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/wrappers/PaymentIntentParametersFactory.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/wrappers/PaymentIntentParametersFactory.kt
@@ -2,6 +2,6 @@ package com.woocommerce.android.cardreader.internal.wrappers
 
 import com.stripe.stripeterminal.model.external.PaymentIntentParameters
 
-class PaymentIntentParametersFactory {
+internal class PaymentIntentParametersFactory {
     fun createBuilder() = PaymentIntentParameters.Builder()
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
@@ -1,28 +1,12 @@
 package com.woocommerce.android.cardreader.internal.payments
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.anyOrNull
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
+import com.nhaarman.mockitokotlin2.*
 import com.stripe.stripeterminal.model.external.Charge
 import com.stripe.stripeterminal.model.external.PaymentIntent
 import com.stripe.stripeterminal.model.external.PaymentIntentStatus
-import com.stripe.stripeterminal.model.external.PaymentIntentStatus.CANCELED
-import com.stripe.stripeterminal.model.external.PaymentIntentStatus.REQUIRES_CAPTURE
-import com.stripe.stripeterminal.model.external.PaymentIntentStatus.REQUIRES_CONFIRMATION
-import com.stripe.stripeterminal.model.external.PaymentIntentStatus.REQUIRES_PAYMENT_METHOD
+import com.stripe.stripeterminal.model.external.PaymentIntentStatus.*
 import com.stripe.stripeterminal.model.external.TerminalException
-import com.woocommerce.android.cardreader.CardPaymentStatus.CapturingPayment
-import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErrorType
-import com.woocommerce.android.cardreader.CardPaymentStatus.CollectingPayment
-import com.woocommerce.android.cardreader.CardPaymentStatus.InitializingPayment
-import com.woocommerce.android.cardreader.CardPaymentStatus.PaymentCompleted
-import com.woocommerce.android.cardreader.CardPaymentStatus.PaymentFailed
-import com.woocommerce.android.cardreader.CardPaymentStatus.ProcessingPayment
-import com.woocommerce.android.cardreader.CardPaymentStatus.ShowAdditionalInfo
-import com.woocommerce.android.cardreader.CardPaymentStatus.WaitingForInput
+import com.woocommerce.android.cardreader.CardPaymentStatus.*
 import com.woocommerce.android.cardreader.CardReaderStore
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
 import com.woocommerce.android.cardreader.PaymentInfo
@@ -35,22 +19,13 @@ import com.woocommerce.android.cardreader.internal.payments.actions.ProcessPayme
 import com.woocommerce.android.cardreader.internal.payments.actions.ProcessPaymentAction.ProcessPaymentStatus
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.single
-import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.flow.withIndex
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.coroutines.withTimeoutOrNull
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.junit.MockitoJUnitRunner
 import java.math.BigDecimal
@@ -58,15 +33,14 @@ import kotlin.reflect.KClass
 
 private const val TIMEOUT = 1000L
 private val DUMMY_AMOUNT = BigDecimal(0)
-private val DUMMY_PAYMENT_DESCRIPTION = "test description"
-private val DUMMY_ORDER_ID = 5L
-private val USD_CURRENCY = "USD"
-private val NONE_USD_CURRENCY = "CZK"
-private val DUMMY_EMAIL = "test@test.test"
-private val DUMMY_CUSTOMER_NAME = "Tester"
-private val DUMMY_SITE_URL = "www.test.test/test"
-private val DUMMY_STORE_NAME = "Test store"
-
+private const val DUMMY_PAYMENT_DESCRIPTION = "test description"
+private const val DUMMY_ORDER_ID = 5L
+private const val USD_CURRENCY = "USD"
+private const val NONE_USD_CURRENCY = "CZK"
+private const val DUMMY_EMAIL = "test@test.test"
+private const val DUMMY_CUSTOMER_NAME = "Tester"
+private const val DUMMY_SITE_URL = "www.test.test/test"
+private const val DUMMY_STORE_NAME = "Test store"
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
@@ -97,7 +97,6 @@ class PaymentManagerTest {
             .thenReturn(PaymentFailed(CardPaymentStatusErrorType.GENERIC_ERROR, null, ""))
         whenever(paymentErrorMapper.mapError(anyOrNull(), anyOrNull<String>()))
             .thenReturn(PaymentFailed(CardPaymentStatusErrorType.GENERIC_ERROR, null, ""))
-        whenever(paymentUtils.convertBigDecimalInDollarsToIntegerInCents(any())).thenReturn(1)
         whenever(paymentUtils.isSupportedCurrency(any())).thenReturn(true)
     }
 

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentActionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentActionTest.kt
@@ -37,6 +37,7 @@ internal class CreatePaymentActionTest {
         whenever(intentParametersBuilder.setCurrency(any())).thenReturn(intentParametersBuilder)
         whenever(intentParametersBuilder.setReceiptEmail(any())).thenReturn(intentParametersBuilder)
         whenever(intentParametersBuilder.setDescription(any())).thenReturn(intentParametersBuilder)
+        whenever(intentParametersBuilder.setMetadata(any())).thenReturn(intentParametersBuilder)
         whenever(intentParametersBuilder.build()).thenReturn(mock())
 
         whenever(terminal.createPaymentIntent(any(), any())).thenAnswer {
@@ -124,12 +125,95 @@ internal class CreatePaymentActionTest {
     }
 
     @Test
-    fun `when creating payment intent, then sets payment description`() = runBlockingTest {
+    fun `when creating payment intent, then payment description set`() = runBlockingTest {
         val expectedDescription = "test description"
 
         action.createPaymentIntent(createPaymentInfo(paymentDescription = expectedDescription)).toList()
 
         verify(intentParametersBuilder).setDescription(expectedDescription)
+    }
+
+    @Test
+    fun `when creating payment intent, then store name set`() = runBlockingTest {
+        val expected = "dummy store name"
+        whenever(terminal.createPaymentIntent(any(), any())).thenAnswer {
+            (it.arguments[1] as PaymentIntentCallback).onSuccess(mock())
+        }
+        val captor = argumentCaptor<Map<String, String>>()
+
+        action.createPaymentIntent(createPaymentInfo(storeName = expected)).toList()
+        verify(intentParametersBuilder).setMetadata(captor.capture())
+
+        assertThat(captor.firstValue[MetaDataKeys.STORE.key]).isEqualTo(expected)
+    }
+
+    @Test
+    fun `when creating payment intent, then customer name set`() = runBlockingTest {
+        val expected = "dummy customer name"
+        whenever(terminal.createPaymentIntent(any(), any())).thenAnswer {
+            (it.arguments[1] as PaymentIntentCallback).onSuccess(mock())
+        }
+        val captor = argumentCaptor<Map<String, String>>()
+
+        action.createPaymentIntent(createPaymentInfo(customerName = expected)).toList()
+        verify(intentParametersBuilder).setMetadata(captor.capture())
+
+        assertThat(captor.firstValue[MetaDataKeys.CUSTOMER_NAME.key]).isEqualTo(expected)
+    }
+
+    @Test
+    fun `when creating payment intent, then customer email set`() = runBlockingTest {
+        val expected = "dummy customer email"
+        whenever(terminal.createPaymentIntent(any(), any())).thenAnswer {
+            (it.arguments[1] as PaymentIntentCallback).onSuccess(mock())
+        }
+        val captor = argumentCaptor<Map<String, String>>()
+
+        action.createPaymentIntent(createPaymentInfo(customerEmail = expected)).toList()
+        verify(intentParametersBuilder).setMetadata(captor.capture())
+
+        assertThat(captor.firstValue[MetaDataKeys.CUSTOMER_EMAIL.key]).isEqualTo(expected)
+    }
+
+    @Test
+    fun `when creating payment intent, then site url set`() = runBlockingTest {
+        val expected = "dummy site url"
+        whenever(terminal.createPaymentIntent(any(), any())).thenAnswer {
+            (it.arguments[1] as PaymentIntentCallback).onSuccess(mock())
+        }
+        val captor = argumentCaptor<Map<String, String>>()
+
+        action.createPaymentIntent(createPaymentInfo(siteUrl = expected)).toList()
+        verify(intentParametersBuilder).setMetadata(captor.capture())
+
+        assertThat(captor.firstValue[MetaDataKeys.SITE_URL.key]).isEqualTo(expected)
+    }
+
+    @Test
+    fun `when creating payment intent, then order id set`() = runBlockingTest {
+        val expected = 99L
+        whenever(terminal.createPaymentIntent(any(), any())).thenAnswer {
+            (it.arguments[1] as PaymentIntentCallback).onSuccess(mock())
+        }
+        val captor = argumentCaptor<Map<String, String>>()
+
+        action.createPaymentIntent(createPaymentInfo(orderId = expected)).toList()
+        verify(intentParametersBuilder).setMetadata(captor.capture())
+
+        assertThat(captor.firstValue[MetaDataKeys.ORDER_ID.key]).isEqualTo(expected.toString())
+    }
+
+    @Test
+    fun `when creating payment intent, then payment type set`() = runBlockingTest {
+        whenever(terminal.createPaymentIntent(any(), any())).thenAnswer {
+            (it.arguments[1] as PaymentIntentCallback).onSuccess(mock())
+        }
+        val captor = argumentCaptor<Map<String, String>>()
+
+        action.createPaymentIntent(createPaymentInfo()).toList()
+        verify(intentParametersBuilder).setMetadata(captor.capture())
+
+        assertThat(captor.firstValue[MetaDataKeys.PAYMENT_TYPE.key]).isEqualTo(MetaDataKeys.PaymentTypes.SINGLE.key)
     }
 
     @Test

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentActionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentActionTest.kt
@@ -38,6 +38,10 @@ internal class CreatePaymentActionTest {
         whenever(intentParametersBuilder.setReceiptEmail(any())).thenReturn(intentParametersBuilder)
         whenever(intentParametersBuilder.setDescription(any())).thenReturn(intentParametersBuilder)
         whenever(intentParametersBuilder.build()).thenReturn(mock())
+
+        whenever(terminal.createPaymentIntent(any(), any())).thenAnswer {
+            (it.arguments[1] as PaymentIntentCallback).onSuccess(mock())
+        }
     }
 
     @Test
@@ -99,9 +103,6 @@ internal class CreatePaymentActionTest {
     @Test
     fun `when customer email not empty, then PaymentIntent setReceiptEmail invoked`() = runBlockingTest {
         val expectedEmail = "test@test.cz"
-        whenever(terminal.createPaymentIntent(any(), any())).thenAnswer {
-            (it.arguments[1] as PaymentIntentCallback).onSuccess(mock())
-        }
 
         action.createPaymentIntent(createPaymentInfo(customerEmail = expectedEmail)).toList()
 
@@ -110,10 +111,6 @@ internal class CreatePaymentActionTest {
 
     @Test
     fun `when customer email is null, then PaymentIntent setReceiptEmail not invoked`() = runBlockingTest {
-        whenever(terminal.createPaymentIntent(any(), any())).thenAnswer {
-            (it.arguments[1] as PaymentIntentCallback).onSuccess(mock())
-        }
-
         action.createPaymentIntent(createPaymentInfo(customerEmail = null)).toList()
 
         verify(intentParametersBuilder, never()).setReceiptEmail(any())
@@ -121,21 +118,14 @@ internal class CreatePaymentActionTest {
 
     @Test
     fun `when customer email is empty, then PaymentIntent setReceiptEmail not invoked`() = runBlockingTest {
-        whenever(terminal.createPaymentIntent(any(), any())).thenAnswer {
-            (it.arguments[1] as PaymentIntentCallback).onSuccess(mock())
-        }
-
         action.createPaymentIntent(createPaymentInfo()).toList()
 
         verify(intentParametersBuilder, never()).setReceiptEmail(any())
     }
 
     @Test
-    fun `sets payment description on payment intent`() = runBlockingTest {
+    fun `when creating payment intent, then sets payment description`() = runBlockingTest {
         val expectedDescription = "test description"
-        whenever(terminal.createPaymentIntent(any(), any())).thenAnswer {
-            (it.arguments[1] as PaymentIntentCallback).onFailure(mock())
-        }
 
         action.createPaymentIntent(createPaymentInfo(paymentDescription = expectedDescription)).toList()
 


### PR DESCRIPTION
Parent issue #4030

This PR 
- adds basic metadata to payment intent
-  wraps all params related to payment with PaymentInfo object as the number of params was getting out of hand
- moves "convert to the smallest currency unit" from PaymentManager to CreatePaymentAction - the main reason for this change was that PaymentInfo object is immutable so updating/setting the amount was not feasible. In the end I think it kind of make sense to keep it in  CreatePaymentAction  anyway.

I recommend following the commits - the changes are quite straighforward and mostly done by the IDE

To test:
 - Make sure your store is eligible for in person payments
1. Connect to a reader (watch out for [this known issue](https://github.com/woocommerce/woocommerce-android/issues/4465)) 
2. Open detail of an unpaid order in USD
3. Tap on Collect Payment button
4. Finish the payment
5. Open Stripe's dashboard and search for the payment
6. Notice the payment contains "metadata" section, example:
<img width="500" alt="Screenshot 2021-07-21 at 12 28 44" src="https://user-images.githubusercontent.com/2261188/126476480-71234100-31e3-4826-b129-eb81f6aad439.png">

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
