### PR TITLE
Add Activate Service Package Empty View

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateServicePackageFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateServicePackageFragment.kt
@@ -6,12 +6,11 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.annotation.StringRes
+import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentShippingLabelCreateServicePackageBinding
-import com.woocommerce.android.extensions.hide
-import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -30,6 +29,7 @@ class ShippingLabelCreateServicePackageFragment :
     @Inject lateinit var uiMessageResolver: UIMessageResolver
     private val skeletonView: SkeletonView = SkeletonView()
     private var progressDialog: CustomProgressDialog? = null
+    private lateinit var doneMenuItem: MenuItem
 
     private val parentViewModel: ShippingLabelCreatePackageViewModel by viewModels({ requireParentFragment() })
     val viewModel: ShippingLabelCreateServicePackageViewModel by viewModels()
@@ -43,6 +43,10 @@ class ShippingLabelCreateServicePackageFragment :
         super.onCreateOptionsMenu(menu, inflater)
         menu.clear()
         inflater.inflate(R.menu.menu_done, menu)
+        doneMenuItem = menu.findItem(R.id.menu_done)
+        if (viewModel.viewStateData.liveData.value?.isEmpty == true) {
+            doneMenuItem.isVisible = false
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -71,10 +75,13 @@ class ShippingLabelCreateServicePackageFragment :
                     binding.errorView.show(
                         type = WCEmptyView.EmptyViewType.SHIPPING_LABEL_SERVICE_PACKAGE_LIST
                     )
-                    binding.servicePackagesListContainer.hide()
                 } else {
                     binding.errorView.hide()
-                    binding.servicePackagesListContainer.show()
+                }
+
+                binding.servicePackagesListContainer.isVisible = !isEmpty
+                if (::doneMenuItem.isInitialized) {
+                    doneMenuItem.isVisible = !isEmpty
                 }
             }
             new.uiModels.takeIfNotEqualTo(old?.uiModels) { uiModels ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateServicePackageFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateServicePackageFragment.kt
@@ -44,9 +44,7 @@ class ShippingLabelCreateServicePackageFragment :
         menu.clear()
         inflater.inflate(R.menu.menu_done, menu)
         doneMenuItem = menu.findItem(R.id.menu_done)
-        if (viewModel.viewStateData.liveData.value?.isEmpty == true) {
-            doneMenuItem.isVisible = false
-        }
+        doneMenuItem.isVisible = viewModel.viewStateData.liveData.value?.canSave ?: false
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -78,12 +76,15 @@ class ShippingLabelCreateServicePackageFragment :
                 } else {
                     binding.errorView.hide()
                 }
+            }
 
-                binding.servicePackagesListContainer.isVisible = !isEmpty
+            new.canSave.takeIfNotEqualTo(old?.canSave) {
+                binding.servicePackagesListContainer.isVisible = it
                 if (::doneMenuItem.isInitialized) {
-                    doneMenuItem.isVisible = !isEmpty
+                    doneMenuItem.isVisible = it
                 }
             }
+
             new.uiModels.takeIfNotEqualTo(old?.uiModels) { uiModels ->
                 adapter.updateData(uiModels)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateServicePackageFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateServicePackageFragment.kt
@@ -10,6 +10,8 @@ import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentShippingLabelCreateServicePackageBinding
+import com.woocommerce.android.extensions.hide
+import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -19,6 +21,7 @@ import org.wordpress.android.util.ActivityUtils
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreateServicePackageViewModel.PackageSuccessfullyMadeEvent
 import com.woocommerce.android.widgets.CustomProgressDialog
 import com.woocommerce.android.widgets.SkeletonView
+import com.woocommerce.android.widgets.WCEmptyView
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -63,6 +66,17 @@ class ShippingLabelCreateServicePackageFragment :
         adapter: ShippingLabelServicePackageAdapter
     ) {
         viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
+            new.isEmpty.takeIfNotEqualTo(old?.isEmpty) { isEmpty ->
+                if (isEmpty) {
+                    binding.errorView.show(
+                        type = WCEmptyView.EmptyViewType.SHIPPING_LABEL_SERVICE_PACKAGE_LIST
+                    )
+                    binding.servicePackagesListContainer.hide()
+                } else {
+                    binding.errorView.hide()
+                    binding.servicePackagesListContainer.show()
+                }
+            }
             new.uiModels.takeIfNotEqualTo(old?.uiModels) { uiModels ->
                 adapter.updateData(uiModels)
             }
@@ -125,6 +139,7 @@ class ShippingLabelCreateServicePackageFragment :
         ).also { it.show(parentFragmentManager, CustomProgressDialog.TAG) }
         progressDialog?.isCancelable = false
     }
+
     private fun hideProgressDialog() {
         progressDialog?.dismiss()
         progressDialog = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateServicePackageViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateServicePackageViewModel.kt
@@ -110,7 +110,10 @@ class ShippingLabelCreateServicePackageViewModel @Inject constructor(
         val isLoading: Boolean = false,
         val isSavingProgressDialogVisible: Boolean? = null,
         val uiModels: List<ServicePackageUiModel> = emptyList()
-    ) : Parcelable
+    ) : Parcelable {
+        val canSave: Boolean
+            get() = !isEmpty
+    }
 
     @Parcelize
     data class ServicePackageUiModel(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateServicePackageViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateServicePackageViewModel.kt
@@ -50,7 +50,7 @@ class ShippingLabelCreateServicePackageViewModel @Inject constructor(
             }
 
             val uiModels = result.model!!.map { ServicePackageUiModel(it) }
-            viewState = viewState.copy(isLoading = false, uiModels = uiModels)
+            viewState = viewState.copy(isLoading = false, uiModels = uiModels, isEmpty = uiModels.isEmpty())
         }
     }
 
@@ -106,6 +106,7 @@ class ShippingLabelCreateServicePackageViewModel @Inject constructor(
 
     @Parcelize
     data class ViewState(
+        val isEmpty: Boolean = false,
         val isLoading: Boolean = false,
         val isSavingProgressDialogVisible: Boolean? = null,
         val uiModels: List<ServicePackageUiModel> = emptyList()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCEmptyView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCEmptyView.kt
@@ -14,20 +14,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.WcEmptyViewBinding
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
-import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.DASHBOARD
-import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.FILTER_RESULTS
-import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.NETWORK_ERROR
-import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.NETWORK_OFFLINE
-import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.ORDER_LIST
-import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.ORDER_LIST_ALL_PROCESSED
-import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.ORDER_LIST_FILTERED
-import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.ORDER_LIST_LOADING
-import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.PRODUCT_CATEGORY_LIST
-import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.PRODUCT_LIST
-import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.PRODUCT_TAG_LIST
-import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.REVIEW_LIST
-import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.SEARCH_RESULTS
-import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.SHIPPING_LABEL_CARRIER_RATES
+import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType.*
 import org.wordpress.android.util.DisplayUtils
 
 class WCEmptyView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? = null) : LinearLayout(ctx, attrs) {
@@ -47,7 +34,8 @@ class WCEmptyView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? =
         NETWORK_OFFLINE,
         PRODUCT_CATEGORY_LIST,
         PRODUCT_TAG_LIST,
-        SHIPPING_LABEL_CARRIER_RATES
+        SHIPPING_LABEL_CARRIER_RATES,
+        SHIPPING_LABEL_SERVICE_PACKAGE_LIST
     }
 
     init {
@@ -192,6 +180,13 @@ class WCEmptyView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? =
                 message = context.getString(R.string.shipping_label_shipping_carrier_rates_unavailable_message)
                 buttonText = null
                 drawableId = R.drawable.img_products_error
+            }
+            SHIPPING_LABEL_SERVICE_PACKAGE_LIST -> {
+                isTitleBold = true
+                title = context.getString(R.string.shipping_label_activate_service_package_empty_title)
+                message = null
+                buttonText = null
+                drawableId = R.drawable.img_empty_orders_all_fulfilled
             }
         }
 

--- a/WooCommerce/src/main/res/layout/fragment_shipping_label_create_service_package.xml
+++ b/WooCommerce/src/main/res/layout/fragment_shipping_label_create_service_package.xml
@@ -1,33 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <LinearLayout
-        android:id="@+id/service_packages_container"
+    <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:layout_height="match_parent">
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/custom_package_form_info"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_75"
-            android:layout_marginEnd="@dimen/major_100"
-            android:layout_marginBottom="@dimen/minor_50"
-            android:text="@string/shipping_label_create_package_field_info"
-            android:textAppearance="@style/TextAppearance.Woo.Body1" />
+            <LinearLayout
+                android:id="@+id/service_packages_list_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:paddingTop="@dimen/major_100"
-            android:id="@+id/service_packages_list"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:nestedScrollingEnabled="false"
-            tools:listitem="@layout/shipping_package_selectable_list_item"/>
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/custom_package_form_info"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_75"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:layout_marginBottom="@dimen/minor_50"
+                    android:text="@string/shipping_label_create_package_field_info"
+                    android:textAppearance="@style/TextAppearance.Woo.Body1" />
 
-    </LinearLayout>
-</androidx.core.widget.NestedScrollView>
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/service_packages_list"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:nestedScrollingEnabled="false"
+                    android:paddingTop="@dimen/major_100"
+                    tools:listitem="@layout/shipping_package_selectable_list_item" />
+            </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+
+    <com.woocommerce.android.widgets.WCEmptyView
+        android:visibility="gone"
+        android:id="@+id/error_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</FrameLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -541,6 +541,7 @@
     <string name="shipping_label_create_custom_package_success_message">\"%1$s\" saved</string>
     <string name="shipping_label_create_service_package_nothing_selected">Select a package to activate.</string>
     <string name="shipping_label_activate_service_package_saving_progress_title">Activating package</string>
+    <string name="shipping_label_activate_service_package_empty_title">All available packages have been activated</string>
     <string name="shipping_label_payments_selected_payment_method">Payment method selected</string>
     <string name="shipping_label_payments_add_credit_card">Add another credit card</string>
     <string name="shipping_label_payments_add_first_credit_card">Add a credit card</string>


### PR DESCRIPTION
Fixes #4458 

# What this PR does:

#4433 adds the feature to activate a service package (also known as predefined package), during shipping label creation process.

In the case where a user has activated all available service packages, then the activate service package screen should show an Empty View informing the user that there's nothing to activate anymore.

# Testing Instruction:

**Regular case test:**

0. Make sure the test site has Shipping Labels creation enabled, and have an Order where Shipping Labels can be created.
1. Activate all service packages in wp-admin: ` wp-admin/admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-setting`
2. In the app, find the Order from step 0 and create a Shipping Label, complete the "Ship from" and "Ship to" steps, then continue with the "Packaging details" step.
3. Tap the "Package selected" spinner, this will open the "Package selection" screen. Tap "Add New Package" at the bottom.
4. On "Package creation" screen, switch to the "Service Package" tab. This will show a loading screen, and then finally show the empty view. Make sure the "Done" menu item is not shown at the top.

**Cache test:**
0. Make sure the test site has Shipping Labels creation enabled, and have an Order where Shipping Labels can be created.
1. Activate all service packages in wp-admin: ` wp-admin/admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-setting`, but keep one service package inactivated
2. In the app, find the Order from step 0 and create a Shipping Label, complete the "Ship from" and "Ship to" steps, then continue with the "Packaging details" step.
3. Tap the "Package selected" spinner, this will open the "Add new package" screen.
4. Switch to the "Service Package" tab. Select the one remaining package, then tap Done to activate it.
5. You will be navigated back to the package editing screen.
6. Tap the "Package selected" spinner, this will open the "Package selection" screen. Tap "Add New Package" at the bottom.
7. On "Package creation" screen, switch to the "Service Package" tab. This will show the empty view. Make sure the "Done" menu item is not shown at the top.


| Light mode | Dark mode |
|-|-|
| ![image](https://user-images.githubusercontent.com/266376/126616135-042fe2fb-b7f9-403f-ac76-5bbf7b202c02.png) | ![image](https://user-images.githubusercontent.com/266376/126616052-ffab4d02-81f2-4391-9dff-68f6d3f7ce5a.png) |



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
