### PR TITLE
Add view states to onboarding view model

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -13,7 +13,9 @@ import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_onboarding) {
     val viewModel: CardReaderOnboardingViewModel by viewModels()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -38,7 +38,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         viewModel.viewStateData.observe(
             viewLifecycleOwner,
             { state ->
-                showOnboardingLayout(binding, state.getLayoutRes())
+                showOnboardingLayout(binding, state.layoutRes)
             }
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -169,12 +169,12 @@ class CardReaderOnboardingViewModel @Inject constructor(
         }
 
         // TODO cardreader Update layout resource
-        object WCPayAccountRestrictedState :
+        object WCPayAccountRejectedState :
             OnboardingViewState(R.layout.fragment_card_reader_onboarding_loading) {
             val headerLabel: UiString =
-                UiString.UiStringRes(R.string.card_reader_onboarding_account_restricted_header)
+                UiString.UiStringRes(R.string.card_reader_onboarding_account_rejected_header)
             val hintLabel: UiString =
-                UiString.UiStringRes(R.string.card_reader_onboarding_account_restricted_hint)
+                UiString.UiStringRes(R.string.card_reader_onboarding_account_rejected_hint)
             val contactSupportLabel: UiString =
                 UiString.UiStringRes(R.string.card_reader_onboarding_contact_support)
             val learnMoreLabel =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -1,10 +1,12 @@
 package com.woocommerce.android.ui.prefs.cardreader.onboarding
 
+import androidx.annotation.DrawableRes
 import androidx.annotation.LayoutRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
+import com.woocommerce.android.model.UiString
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -21,8 +23,8 @@ class CardReaderOnboardingViewModel @Inject constructor(
 
     private lateinit var cardReaderChecker: CardReaderOnboardingChecker
 
-    private val viewState = MutableLiveData<ViewState>()
-    val viewStateData: LiveData<ViewState> = viewState
+    private val viewState = MutableLiveData<OnboardingViewState>()
+    val viewStateData: LiveData<OnboardingViewState> = viewState
 
     init {
         startFlow()
@@ -41,14 +43,159 @@ class CardReaderOnboardingViewModel @Inject constructor(
         triggerEvent(Event.Exit)
     }
 
-    sealed class ViewState(
-        val onboardingState: CardReaderOnboardingState
-    ) {
-        @LayoutRes
-        fun getLayoutRes(): Int {
-            return when (onboardingState) {
-                else -> R.layout.fragment_card_reader_onboarding_loading
-            }
+    sealed class OnboardingViewState(@LayoutRes layoutRes: Int) {
+        object LoadingState : OnboardingViewState(R.layout.fragment_card_reader_onboarding_loading) {
+            val headerLabel: UiString =
+                UiString.UiStringRes(R.string.payment_onboarding_loading)
+            val hintLabel: UiString =
+                UiString.UiStringRes(R.string.please_wait)
+            @DrawableRes val illustration: Int = R.drawable.img_payment_onboarding_loading
+        }
+
+        // TODO cardreader Update layout resource
+        object GenericErrorState : OnboardingViewState(R.layout.fragment_card_reader_onboarding_loading) {
+            // TODO cardreader implement generic error state
+        }
+
+        // TODO cardreader Update layout resource
+        object NoConnectionErrorState : OnboardingViewState(R.layout.fragment_card_reader_onboarding_loading) {
+            // TODO cardreader implement no connection error state
+        }
+
+        // TODO cardreader Update layout resource
+        object UnsupportedCountryState : OnboardingViewState(R.layout.fragment_card_reader_onboarding_loading) {
+            // TODO cardreader implement unsupported country state - !already in progress!
+        }
+
+        // TODO cardreader Update layout resource
+        data class WCPayNotInstalledState(val refreshButtonAction: () -> Unit) :
+            OnboardingViewState(R.layout.fragment_card_reader_onboarding_loading) {
+            val headerLabel: UiString =
+                UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_installed_header)
+            val hintLabel: UiString =
+                UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_installed_hint)
+            val learnMoreLabel =
+                UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true)
+            @DrawableRes val illustration: Int = R.drawable.img_woocommerce_payments
+            val refreshButtonLabel =
+                UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_installed_refresh_button)
+        }
+
+        // TODO cardreader Update layout resource
+        data class WCPayNotActivatedState(val refreshButtonAction: () -> Unit) :
+            OnboardingViewState(R.layout.fragment_card_reader_onboarding_loading) {
+            val headerLabel: UiString =
+                UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_activated_header)
+            val hintLabel: UiString =
+                UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_activated_hint)
+            val learnMoreLabel =
+                UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true)
+            @DrawableRes val illustration: Int = R.drawable.img_woocommerce_payments
+            val refreshButtonLabel =
+                UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_activated_refresh_button)
+        }
+
+        // TODO cardreader Update layout resource
+        data class WCPayNotSetupState(val refreshButtonAction: () -> Unit) :
+            OnboardingViewState(R.layout.fragment_card_reader_onboarding_loading) {
+            val headerLabel: UiString =
+                UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_setup_header)
+            val hintLabel: UiString =
+                UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_setup_hint)
+            val learnMoreLabel =
+                UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true)
+            @DrawableRes val illustration: Int = R.drawable.img_woocommerce_payments
+            val refreshButtonLabel =
+                UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_setup_refresh_button)
+        }
+
+        // TODO cardreader Update layout resource
+        data class WCPayUnsupportedVersionState(val refreshButtonAction: () -> Unit) :
+            OnboardingViewState(R.layout.fragment_card_reader_onboarding_loading) {
+            val headerLabel: UiString =
+                UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_unsupported_version_header)
+            val hintLabel: UiString =
+                UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_unsupported_version_hint)
+            val learnMoreLabel =
+                UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true)
+            @DrawableRes val illustration: Int = R.drawable.img_woocommerce_payments
+            val refreshButtonLabel =
+                UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_unsupported_version_refresh_button)
+        }
+
+        // TODO cardreader Update layout resource
+        object WCPayAccountUnderReviewState :
+            OnboardingViewState(R.layout.fragment_card_reader_onboarding_loading) {
+            val headerLabel: UiString =
+                UiString.UiStringRes(R.string.card_reader_onboarding_account_under_review_header)
+            val hintLabel: UiString =
+                UiString.UiStringRes(R.string.card_reader_onboarding_account_under_review_hint)
+            val contactSupportLabel: UiString =
+                UiString.UiStringRes(R.string.card_reader_onboarding_contact_support)
+            val learnMoreLabel =
+                UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true)
+            @DrawableRes val illustration: Int = R.drawable.img_products_error
+        }
+
+        // TODO cardreader Update layout resource
+        object WCPayAccountRestrictedState :
+            OnboardingViewState(R.layout.fragment_card_reader_onboarding_loading) {
+            val headerLabel: UiString =
+                UiString.UiStringRes(R.string.card_reader_onboarding_account_restricted_header)
+            val hintLabel: UiString =
+                UiString.UiStringRes(R.string.card_reader_onboarding_account_restricted_hint)
+            val contactSupportLabel: UiString =
+                UiString.UiStringRes(R.string.card_reader_onboarding_contact_support)
+            val learnMoreLabel =
+                UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true)
+            @DrawableRes val illustration: Int = R.drawable.img_products_error
+        }
+
+        // TODO cardreader Update layout resource
+        object WCPayAccountOverdueRequirementsState :
+            OnboardingViewState(R.layout.fragment_card_reader_onboarding_loading) {
+            val headerLabel: UiString =
+                UiString.UiStringRes(R.string.card_reader_onboarding_account_overdue_requirements_header)
+            val hintLabel: UiString =
+                UiString.UiStringRes(R.string.card_reader_onboarding_account_overdue_requirements_hint)
+            val contactSupportLabel: UiString =
+                UiString.UiStringRes(R.string.card_reader_onboarding_contact_support)
+            val learnMoreLabel =
+                UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true)
+            @DrawableRes val illustration: Int = R.drawable.img_products_error
+        }
+
+        // TODO cardreader Update layout resource
+        data class WCPayAccountPendingRequirementsState(val dueDate: String, val dismissButtonAction: () -> Unit) :
+            OnboardingViewState(R.layout.fragment_card_reader_onboarding_loading) {
+            val headerLabel: UiString =
+                UiString.UiStringRes(R.string.card_reader_onboarding_account_pending_requirements_header)
+            val hintLabel: UiString =
+                UiString.UiStringRes(
+                    R.string.card_reader_onboarding_account_pending_requirements_hint,
+                    listOf(UiString.UiStringText(dueDate))
+                )
+            val contactSupportLabel: UiString =
+                UiString.UiStringRes(R.string.card_reader_onboarding_contact_support)
+            val learnMoreLabel =
+                UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true)
+            @DrawableRes val illustration: Int = R.drawable.img_products_error
+            val dismissButtonLabel =
+                UiString.UiStringRes(R.string.card_reader_onboarding_account_pending_requirements_dismiss_button)
+        }
+
+        // TODO cardreader Update layout resource
+        object WCPayInTestModeWithLiveAccountState :
+            OnboardingViewState(R.layout.fragment_card_reader_onboarding_loading) {
+            val headerLabel: UiString =
+                UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_in_test_mode_with_live_account_header)
+            val hintLabel: UiString =
+                UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_in_test_mode_with_live_account_hint)
+            val contactSupportLabel: UiString =
+                UiString.UiStringRes(R.string.card_reader_onboarding_contact_support)
+            val learnMoreLabel =
+                UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true)
+            @DrawableRes val illustration: Int = R.drawable.img_products_error
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -23,7 +23,6 @@ class CardReaderOnboardingViewModel @Inject constructor(
     override val _event = SingleLiveEvent<Event>()
     override val event: LiveData<Event> = _event
 
-
     private val viewState = MutableLiveData<OnboardingViewState>()
     val viewStateData: LiveData<OnboardingViewState> = viewState
 
@@ -46,8 +45,8 @@ class CardReaderOnboardingViewModel @Inject constructor(
                     viewState.value = OnboardingViewState.WCPayNotActivatedState(::refreshState)
                 CardReaderOnboardingState.WCPAY_SETUP_NOT_COMPLETED ->
                     viewState.value = OnboardingViewState.WCPayNotSetupState(::refreshState)
-                CardReaderOnboardingState.WCPAY_IN_TEST_MODE_WITH_LIVE_STRIPE_ACCOUNT -> viewState.value =
-                    OnboardingViewState.WCPayInTestModeWithLiveAccountState
+                CardReaderOnboardingState.WCPAY_IN_TEST_MODE_WITH_LIVE_STRIPE_ACCOUNT ->
+                    viewState.value = OnboardingViewState.WCPayInTestModeWithLiveAccountState
                 CardReaderOnboardingState.STRIPE_ACCOUNT_UNDER_REVIEW ->
                     viewState.value = OnboardingViewState.WCPayAccountUnderReviewState
                 // TODO cardreader Pass due date to the state

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -822,6 +822,40 @@
     -->
     <string name="payment_onboarding_title">In-person payments</string>
     <string name="payment_onboarding_loading">Connecting to your account</string>
+    <string name="card_reader_onboarding_wcpay_not_installed_header">Install WooCommerce Payments</string>
+    <string name="card_reader_onboarding_wcpay_not_installed_hint">You\’ll need to install the free WooCommerce Payments extension on your store to accept In-Person Payments.</string>
+    <string name="card_reader_onboarding_wcpay_not_installed_refresh_button">Refresh after installing</string>
+
+    <string name="card_reader_onboarding_wcpay_not_activated_header">Activate WooCommerce Payments</string>
+    <string name="card_reader_onboarding_wcpay_not_activated_hint">The WooCommerce Payments extension is installed on your store but not activated. Please activate it to accept In-Person Payments.</string>
+    <string name="card_reader_onboarding_wcpay_not_activated_refresh_button">Refresh after activating</string>
+
+    <string name="card_reader_onboarding_wcpay_not_setup_header">Finish setup WooCommerce Payments in your store admin</string>
+    <string name="card_reader_onboarding_wcpay_not_setup_hint">You’re almost there! Please finish setting up WooCommerce Payments to start accepting Card-Present Payments.</string>
+    <string name="card_reader_onboarding_wcpay_not_setup_refresh_button">Refresh</string>
+
+    <string name="card_reader_onboarding_wcpay_unsupported_version_header">Update WooCommerce Payments</string>
+    <string name="card_reader_onboarding_wcpay_unsupported_version_hint">Outdated version of the WooCommerce Payments extension is installed on your store. Please update it to accept In-Person Payments.</string>
+    <string name="card_reader_onboarding_wcpay_unsupported_version_refresh_button">Refresh after updating</string>
+
+    <string name="card_reader_onboarding_account_restricted_header">In-Person Payments isn\’t available for this store</string>
+    <string name="card_reader_onboarding_account_restricted_hint">We are sorry but we can\’t support In-Person Payments for this store.</string>
+
+    <string name="card_reader_onboarding_account_under_review_header">In-Person Payments is currently unavailable</string>
+    <string name="card_reader_onboarding_account_under_review_hint">You\’ll be able to accept In-Person Payments as soon as we finish reviewing your account.</string>
+
+    <string name="card_reader_onboarding_account_overdue_requirements_header">In-Person Payments is currently unavailable</string>
+    <string name="card_reader_onboarding_account_overdue_requirements_hint">You have at least one overdue requirement on your account. Please take care of that to resume In-Person Payments</string>
+
+    <string name="card_reader_onboarding_account_pending_requirements_header">Your WooCommerce Payments account has pending requirements</string>
+    <string name="card_reader_onboarding_account_pending_requirements_hint">There are pending requirements in your account. Please complete those requirements by %1$s to keep accepting In-Person Payments.</string>
+    <string name="card_reader_onboarding_account_pending_requirements_dismiss_button" translatable="false">@string/dismiss</string>
+
+    <string name="card_reader_onboarding_wcpay_in_test_mode_with_live_account_header">In-Person Payments is currently unavailable</string>
+    <string name="card_reader_onboarding_wcpay_in_test_mode_with_live_account_hint">In-Person Payments isn\’t available in Test Mode. Please turn it off to continue.</string>
+
+    <string name="card_reader_onboarding_learn_more">&lt;a href=\'\'&gt;Learn more&lt;/a&gt; about accepting payments with your mobile device and ordering card readers</string>
+    <string name="card_reader_onboarding_contact_support">Need some help? &lt;a href=\'\'&gt;Contact support&lt;/a&gt;</string>
 
     <!--
         Card reader tutorial

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -838,8 +838,8 @@
     <string name="card_reader_onboarding_wcpay_unsupported_version_hint">Outdated version of the WooCommerce Payments extension is installed on your store. Please update it to accept In-Person Payments.</string>
     <string name="card_reader_onboarding_wcpay_unsupported_version_refresh_button">Refresh after updating</string>
 
-    <string name="card_reader_onboarding_account_restricted_header">In-Person Payments isn\’t available for this store</string>
-    <string name="card_reader_onboarding_account_restricted_hint">We are sorry but we can\’t support In-Person Payments for this store.</string>
+    <string name="card_reader_onboarding_account_rejected_header">In-Person Payments isn\’t available for this store</string>
+    <string name="card_reader_onboarding_account_rejected_hint">We are sorry but we can\’t support In-Person Payments for this store.</string>
 
     <string name="card_reader_onboarding_account_under_review_header">In-Person Payments is currently unavailable</string>
     <string name="card_reader_onboarding_account_under_review_hint">You\’ll be able to accept In-Person Payments as soon as we finish reviewing your account.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -106,7 +106,6 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             assertThat(viewModel.viewStateData.value).isInstanceOf(WCPayAccountRejectedState::class.java)
         }
 
-
     @Test
     fun `when account pending requirements, then account pending requirements state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -1,0 +1,166 @@
+package com.woocommerce.android.ui.prefs.cardreader.onboarding
+
+import androidx.lifecycle.SavedStateHandle
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.*
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class CardReaderOnboardingViewModelTest : BaseUnitTest() {
+    private val onboardingChecker: CardReaderOnboardingChecker = mock()
+
+    @Test
+    fun `when screen initialized, then loading state shown`() {
+        val viewModel = createVM()
+
+        assertThat(viewModel.viewStateData.value).isInstanceOf(LoadingState::class.java)
+    }
+
+    @Test
+    fun `when onboarding completed, then flow terminated`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState()).thenReturn(CardReaderOnboardingState.ONBOARDING_COMPLETED)
+
+            val viewModel = createVM()
+
+            assertThat(viewModel.event.value).isInstanceOf(MultiLiveEvent.Event.Exit::class.java)
+        }
+
+    @Test
+    fun `when country not supported, then country not supported state shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState()).thenReturn(CardReaderOnboardingState.COUNTRY_NOT_SUPPORTED)
+
+            val viewModel = createVM()
+
+            assertThat(viewModel.viewStateData.value).isInstanceOf(UnsupportedCountryState::class.java)
+        }
+
+    @Test
+    fun `when wcpay not installed, then wcpay not installed state shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState()).thenReturn(CardReaderOnboardingState.WCPAY_NOT_INSTALLED)
+
+            val viewModel = createVM()
+
+            assertThat(viewModel.viewStateData.value).isInstanceOf(WCPayNotInstalledState::class.java)
+        }
+
+    @Test
+    fun `when wcpay not activated, then wcpay not activated state shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState()).thenReturn(CardReaderOnboardingState.WCPAY_NOT_ACTIVATED)
+
+            val viewModel = createVM()
+
+            assertThat(viewModel.viewStateData.value).isInstanceOf(WCPayNotActivatedState::class.java)
+        }
+
+    @Test
+    fun `when wcpay not setup, then wcpay not setup state shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(CardReaderOnboardingState.WCPAY_SETUP_NOT_COMPLETED)
+
+            val viewModel = createVM()
+
+            assertThat(viewModel.viewStateData.value).isInstanceOf(WCPayNotSetupState::class.java)
+        }
+
+    @Test
+    fun `when unsupported wcpay version installed, then unsupported wcpay version state shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(CardReaderOnboardingState.WCPAY_UNSUPPORTED_VERSION)
+
+            val viewModel = createVM()
+
+            assertThat(viewModel.viewStateData.value).isInstanceOf(WCPayUnsupportedVersionState::class.java)
+        }
+
+    @Test
+    fun `when wcpay in test mode with live stripe account, then wcpay in test mode state shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(CardReaderOnboardingState.WCPAY_IN_TEST_MODE_WITH_LIVE_STRIPE_ACCOUNT)
+
+            val viewModel = createVM()
+
+            assertThat(viewModel.viewStateData.value).isInstanceOf(WCPayInTestModeWithLiveAccountState::class.java)
+        }
+
+    @Test
+    fun `when account rejected, then account rejected state shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(CardReaderOnboardingState.STRIPE_ACCOUNT_REJECTED)
+
+            val viewModel = createVM()
+
+            assertThat(viewModel.viewStateData.value).isInstanceOf(WCPayAccountRejectedState::class.java)
+        }
+
+
+    @Test
+    fun `when account pending requirements, then account pending requirements state shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(CardReaderOnboardingState.STRIPE_ACCOUNT_PENDING_REQUIREMENT)
+
+            val viewModel = createVM()
+
+            assertThat(viewModel.viewStateData.value).isInstanceOf(WCPayAccountPendingRequirementsState::class.java)
+        }
+
+    @Test
+    fun `when account overdue requirements, then account overdue requirements state shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(CardReaderOnboardingState.STRIPE_ACCOUNT_OVERDUE_REQUIREMENT)
+
+            val viewModel = createVM()
+
+            assertThat(viewModel.viewStateData.value).isInstanceOf(WCPayAccountOverdueRequirementsState::class.java)
+        }
+
+    @Test
+    fun `when account under review, then account under review state shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(CardReaderOnboardingState.STRIPE_ACCOUNT_UNDER_REVIEW)
+
+            val viewModel = createVM()
+
+            assertThat(viewModel.viewStateData.value).isInstanceOf(WCPayAccountUnderReviewState::class.java)
+        }
+
+    @Test
+    fun `when onboarding check fails, then generic state shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(CardReaderOnboardingState.GENERIC_ERROR)
+
+            val viewModel = createVM()
+
+            assertThat(viewModel.viewStateData.value).isInstanceOf(GenericErrorState::class.java)
+        }
+
+    @Test
+    fun `when network not available, then no connection error shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(CardReaderOnboardingState.NO_CONNECTION_ERROR)
+
+            val viewModel = createVM()
+
+            assertThat(viewModel.viewStateData.value).isInstanceOf(NoConnectionErrorState::class.java)
+        }
+
+    private fun createVM() = CardReaderOnboardingViewModel(SavedStateHandle(), onboardingChecker)
+}


### PR DESCRIPTION
Parent issue #4413 

Merge instructions:
1. ~~Make sure [the parent PR](https://github.com/woocommerce/woocommerce-android/pull/4434) is merged~~
2. ~~Remove "Do not merge" label~~
3. Merge this PR

This PR adds mapping from states provided by the CardReaderOnboardingChecker to view states. 

We re-used a single layout and viewState in CardReaderConnectViewModel and CardReaderPaymetnViewModel and it resulted in some troubles since each state had slighly different structure/margins/etc. The OnboardingViewModel follows a slightly different approach where each state is defined separately even though the states are very similar. 

To test:
The UI is TBD, so running the unit tests should be all we can test now.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
