### PR TITLE
Make product title divider full width

### DIFF
--- a/WooCommerce/.idea/.gitignore
+++ b/WooCommerce/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/WooCommerce/.idea/gradle.xml
+++ b/WooCommerce/.idea/gradle.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="testRunner" value="PLATFORM" />
+        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="1.8" />
+        <option name="resolveModulePerSourceSet" value="false" />
+        <option name="useQualifiedModuleNames" value="true" />
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/WooCommerce/.idea/misc.xml
+++ b/WooCommerce/.idea/misc.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/build/classes" />
+  </component>
+  <component name="ProjectType">
+    <option name="id" value="Android" />
+  </component>
+</project>

--- a/WooCommerce/.idea/modules.xml
+++ b/WooCommerce/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/WooCommerce.iml" filepath="$PROJECT_DIR$/.idea/modules/WooCommerce.iml" />
+    </modules>
+  </component>
+</project>

--- a/WooCommerce/.idea/vcs.xml
+++ b/WooCommerce/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.products
 
+import android.content.Context
 import android.graphics.Color
 import android.os.Bundle
 import android.os.Parcelable
@@ -9,7 +10,9 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import android.widget.TextView
 import androidx.annotation.StringRes
+import androidx.core.content.ContextCompat
 import androidx.core.view.forEach
 import androidx.core.view.isVisible
 import androidx.lifecycle.Observer
@@ -51,6 +54,7 @@ import com.woocommerce.android.widgets.CustomProgressDialog
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageInteractionListener
 import dagger.hilt.android.AndroidEntryPoint
+import org.w3c.dom.Text
 import org.wordpress.android.util.ActivityUtils
 import javax.inject.Inject
 
@@ -96,6 +100,7 @@ class ProductDetailFragment :
 
         initializeViews(savedInstanceState)
         initializeViewModel()
+
     }
 
     override fun onDestroyView() {
@@ -320,6 +325,14 @@ class ProductDetailFragment :
         inflater.inflate(R.menu.menu_product_detail_fragment, menu)
         updateMenuItem = menu.findItem(R.id.menu_done)
 
+//        menu?.apply {
+//            for(index in 0 until this.size()){
+//                val item = this.getItem(index)
+//                val s = SpannableString(item.title)
+//                s.setSpan(ForegroundColorSpan(Color.MAGENTA),0,s.length,0)
+//                item.title = s
+//            }
+//        }
         super.onCreateOptionsMenu(menu, inflater)
     }
 

--- a/WooCommerce/src/main/res/layout/product_property_editable_view_layout.xml
+++ b/WooCommerce/src/main/res/layout/product_property_editable_view_layout.xml
@@ -31,7 +31,7 @@
     <View
         android:id="@+id/divider"
         style="@style/Woo.Divider"
-        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginStart="@dimen/minor_00"
         app:layout_constraintTop_toBottomOf="@id/editText"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/WooCommerce/src/main/res/layout/skeleton_product_detail.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_product_detail.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
@@ -41,19 +40,19 @@
                 android:id="@+id/divider"
                 style="@style/Woo.Divider"
                 android:layout_marginTop="@dimen/major_100"
-                app:layout_constraintTop_toBottomOf="@+id/view_image_1"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"/>
+                app:layout_constraintTop_toBottomOf="@+id/view_image_1" />
 
             <View
                 android:id="@+id/view_title"
                 android:layout_width="120dp"
                 android:layout_height="@dimen/skeleton_text_height_150"
-                android:layout_marginTop="@dimen/major_100"
                 android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_100"
                 android:background="@drawable/skeleton_background"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/divider"/>
+                app:layout_constraintTop_toBottomOf="@+id/divider" />
 
             <!-- divider -->
             <View
@@ -61,31 +60,31 @@
                 style="@style/Woo.Divider"
                 android:layout_marginStart="@dimen/major_100"
                 android:layout_marginTop="@dimen/major_100"
-                app:layout_constraintTop_toBottomOf="@+id/view_title"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"/>
+                app:layout_constraintTop_toBottomOf="@+id/view_title" />
 
             <View
                 android:id="@+id/view_description_label"
                 android:layout_width="150dp"
                 android:layout_height="@dimen/skeleton_text_height_100"
-                android:layout_marginTop="@dimen/major_100"
                 android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_100"
                 android:background="@drawable/skeleton_background"
-                app:layout_constraintTop_toBottomOf="@+id/divider1"
-                app:layout_constraintStart_toStartOf="parent"/>
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/divider1" />
 
             <View
                 android:id="@+id/view_description"
                 android:layout_width="0dp"
                 android:layout_height="@dimen/skeleton_text_height_75"
-                android:layout_marginTop="@dimen/major_100"
                 android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_100"
                 android:layout_marginEnd="@dimen/major_100"
                 android:background="@drawable/skeleton_background"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/view_description_label"
-                app:layout_constraintEnd_toEndOf="parent"/>
+                app:layout_constraintTop_toBottomOf="@id/view_description_label" />
 
             <!-- divider -->
             <View
@@ -93,19 +92,19 @@
                 style="@style/Woo.Divider"
                 android:layout_marginStart="@dimen/major_100"
                 android:layout_marginTop="@dimen/major_100"
-                app:layout_constraintTop_toBottomOf="@+id/view_description"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"/>
+                app:layout_constraintTop_toBottomOf="@+id/view_description" />
 
             <View
                 android:id="@+id/view_orders_label"
                 android:layout_width="140dp"
                 android:layout_height="@dimen/skeleton_text_height_100"
-                android:layout_marginTop="@dimen/major_100"
                 android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_100"
                 android:background="@drawable/skeleton_background"
-                app:layout_constraintTop_toBottomOf="@+id/divider2"
-                app:layout_constraintStart_toStartOf="parent"/>
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/divider2" />
 
             <View
                 android:id="@+id/view_orders_total"
@@ -126,19 +125,19 @@
                 style="@style/Woo.Divider"
                 android:layout_marginStart="@dimen/major_100"
                 android:layout_marginTop="@dimen/major_100"
-                app:layout_constraintTop_toBottomOf="@+id/view_orders_label"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent" />
+                app:layout_constraintTop_toBottomOf="@+id/view_orders_label" />
 
             <View
                 android:id="@+id/view_reviews_label"
                 android:layout_width="120dp"
                 android:layout_height="@dimen/skeleton_text_height_100"
-                android:layout_marginTop="@dimen/major_100"
                 android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_100"
                 android:background="@drawable/skeleton_background"
-                app:layout_constraintTop_toBottomOf="@+id/divider3"
-                app:layout_constraintStart_toStartOf="parent"/>
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/divider3" />
 
             <View
                 android:id="@+id/view_reviews_count"
@@ -159,9 +158,9 @@
                 style="@style/Woo.Divider"
                 android:layout_marginStart="@dimen/major_100"
                 android:layout_marginTop="@dimen/major_100"
-                app:layout_constraintTop_toBottomOf="@+id/view_reviews_label"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent" />
+                app:layout_constraintTop_toBottomOf="@+id/view_reviews_label" />
 
             <View
                 android:id="@+id/view_product_external"
@@ -180,11 +179,11 @@
                 android:layout_height="@dimen/skeleton_text_button_height"
                 android:layout_margin="@dimen/major_100"
                 android:background="@drawable/skeleton_background"
+                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="1.0"
                 app:layout_constraintStart_toEndOf="@+id/view_reviews_label"
-                app:layout_constraintTop_toBottomOf="@+id/divider4"
-                app:layout_constraintBottom_toBottomOf="parent"/>
+                app:layout_constraintTop_toBottomOf="@+id/divider4" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </com.google.android.material.card.MaterialCardView>
@@ -199,7 +198,7 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <include layout="@layout/skeleton_product_secondary_card"/>
+            <include layout="@layout/skeleton_product_secondary_card" />
 
             <!-- divider -->
             <View
@@ -207,7 +206,7 @@
                 android:layout_marginStart="@dimen/margin_app_title_aligned"
                 android:layout_marginTop="@dimen/minor_00" />
 
-            <include layout="@layout/skeleton_product_secondary_card"/>
+            <include layout="@layout/skeleton_product_secondary_card" />
         </LinearLayout>
 
     </com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
Fixes #3633

## Changes

Set the start margin of the Product Title bottom divider to 0 (it was set to 16dp). 

##Screnshots

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/126575472-ccf441ee-b293-469e-abd4-b0820167e7d6.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/126575606-411b32e0-16e3-494b-bbd6-16b1c09a01c3.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/30724184/126575474-23c73470-ae7b-4935-af3f-6ffe85dad31e.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/126575476-ffa9dfd2-f71b-4db0-87d8-16f12aec534d.png" width="350"/> |

I realize it's really hard to see the difference with the light theme because of the screenshot border.

## Testing

- Navigate to the Products Screen
- tap on an existing product
- Note the Product name bottom divider is not set to full width. 

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
