### PR TITLE
change product title bottom divider to full width

### DIFF
--- a/WooCommerce/src/main/res/layout/product_property_editable_view_layout.xml
+++ b/WooCommerce/src/main/res/layout/product_property_editable_view_layout.xml
@@ -31,7 +31,7 @@
     <View
         android:id="@+id/divider"
         style="@style/Woo.Divider"
-        android:layout_marginStart="@dimen/major_100"
+        android:layout_marginStart="@dimen/minor_00"
         app:layout_constraintTop_toBottomOf="@id/editText"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Fixes #3633

## Changes

Set the start margin of the Product Title bottom divider to 0 (it was set to 16dp). 

## Screnshots

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/126575472-ccf441ee-b293-469e-abd4-b0820167e7d6.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/126575606-411b32e0-16e3-494b-bbd6-16b1c09a01c3.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/30724184/126575474-23c73470-ae7b-4935-af3f-6ffe85dad31e.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/126575476-ffa9dfd2-f71b-4db0-87d8-16f12aec534d.png" width="350"/> |

I realize it's really hard to see the difference with the light theme because of the screenshot border.

## Testing

- Navigate to the Products Screen
- tap on an existing product
- Note the Product name bottom divider is not set to full width. 

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.



