### PR TITLE
issue/4465-crash-tutorial-payments-take2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -304,6 +304,7 @@ class CardReaderConnectViewModel @Inject constructor(
 
     private fun exitFlow(connected: Boolean) {
         triggerEvent(ExitWithResult(connected))
+        appPrefs.setShowCardReaderConnectedTutorial(true) // TODO remove
     }
 
     private fun storeConnectedReader(cardReader: CardReader) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -48,6 +48,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.SingleLiveEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
@@ -293,7 +294,12 @@ class CardReaderConnectViewModel @Inject constructor(
     }
 
     fun onTutorialClosed() {
-        exitFlow(connected = true)
+        launch {
+            // this workaround needs to be here since the navigation component hasn't finished the previous
+            // transaction when a result is received
+            delay(1)
+            exitFlow(connected = true)
+        }
     }
 
     private fun exitFlow(connected: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -304,7 +304,6 @@ class CardReaderConnectViewModel @Inject constructor(
 
     private fun exitFlow(connected: Boolean) {
         triggerEvent(ExitWithResult(connected))
-        appPrefs.setShowCardReaderConnectedTutorial(true) // TODO remove
     }
 
     private fun storeConnectedReader(cardReader: CardReader) {

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -482,7 +482,16 @@
         android:id="@+id/cardReaderConnectDialog"
         android:name="com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectFragment"
         android:label="CardReaderConnectDialog">
+        <action
+            android:id="@+id/action_cardReaderConnectFragment_to_cardReaderTutorialDialogFragment"
+            app:destination="@id/cardReaderTutorialDialogFragment"
+            app:enterAnim="@anim/activity_fade_in"
+            app:popExitAnim="@anim/activity_fade_out" />
     </dialog>
+    <dialog
+        android:id="@+id/cardReaderTutorialDialogFragment"
+        android:name="com.woocommerce.android.ui.prefs.cardreader.tutorial.CardReaderTutorialDialogFragment"
+        android:label="CardReaderTutorialDialogFragment" />
     <fragment
         android:id="@+id/receiptPreviewFragment"
         android:name="com.woocommerce.android.ui.orders.cardreader.ReceiptPreviewFragment"


### PR DESCRIPTION
Fixes #4465 - this PR is being submitted as a possible substitute for #4474, which made quite a few changes unrelated to the issue. To test:

1. Clear app's data to make sure the "tutorial seen" flag gets cleared
2. Start the app - make sure the store is eligible for in person payments
3. Open detail of an unpaid order in USD
4. Tap on "Collect payment" button
5. Notice the app starts connecting to the reader and shows the tutorial after

And:

1. Clear app's data to make sure the "tutorial seen" flag gets cleared
2. Start the app - make sure the store is eligible for in person payments
3. Open settings
4. Open "Manage reader"
5. Connect to a reader
6. Notice the app starts connecting to the reader and shows the tutorial after 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
