### PR TITLE
Fix dark mode background of card reader tutorial

### DIFF
--- a/WooCommerce/src/main/res/layout/dialog_card_reader_tutorial.xml
+++ b/WooCommerce/src/main/res/layout/dialog_card_reader_tutorial.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:background="?attr/colorSurface"
     tools:context=".ui.prefs.cardreader.tutorial.CardReaderTutorialDialogFragment">
 
     <androidx.constraintlayout.widget.ConstraintLayout


### PR DESCRIPTION
This PR updates dark mode color of the Card Reader tutorial so it's consistent with the connection and payment flows. 

@nbradbury Raised a concern [here](https://github.com/woocommerce/woocommerce-android/pull/4474#issuecomment-885134949) that showing a dialog with a dark background on top of a screen with a dark background doesn't look great - I agree and we plan to discuss this with the designers, however, I still believe that we should make all the three flows (connect/tutorial/payment) consistent and then discuss possible changes.

I noticed [this unrelated bug](https://github.com/woocommerce/woocommerce-android/issues/4478) when testing this PR. 

To test
- switch your device to dark mode
1. Clear app data or set the SHOW_CARD_READER_CONNECTED_TUTORIAL flag to true using Flipper
2. Click on App settings
3. Click on "Manage card reader"
4. Click on "Connect to card reader"
5. Finish the connection and notice the tutorial looks broken

| Before | After |
|----|-----|
| ![Screenshot_1627023557](https://user-images.githubusercontent.com/2261188/126747609-82b15ebe-1df6-4706-807c-f816075e3309.png) | ![Screenshot_1627025431](https://user-images.githubusercontent.com/2261188/126750462-02011177-4c87-46ae-958e-2bf9c36a235f.png) |


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
