### PR TITLE
Add CardReaderEligibilityFragment and view model

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -119,6 +119,10 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
             findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_cardReaderDetailFragment)
         }
 
+        binding.optionCardReaderEligibility.setOnClickListener {
+            findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_cardReaderEligibilityFragment)
+        }
+
         binding.optionHelpAndSupport.setOnClickListener {
             AnalyticsTracker.track(Stat.MAIN_MENU_CONTACT_SUPPORT_TAPPED)
             startActivity(HelpActivity.createIntent(requireActivity(), Origin.SETTINGS, null))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/onboarding/CardReaderEligibilityFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/onboarding/CardReaderEligibilityFragment.kt
@@ -34,6 +34,12 @@ class CardReaderEligibilityFragment : BaseFragment(R.layout.fragment_card_reader
                         UiHelpers.setTextOrHide(binding.eligibilityHint, state.hintLabel)
                         UiHelpers.setTextOrHide(binding.eligibilityHelp, state.contactSupportLabel)
                         UiHelpers.setTextOrHide(binding.eligibilityLearnMore, state.learnMoreLabel)
+                        binding.eligibilityHelp.setOnClickListener {
+                            state.onContactSupportActionClicked?.invoke()
+                        }
+                        binding.eligibilityLearnMore.setOnClickListener {
+                            state.onLearnMoreActionClicked?.invoke()
+                        }
                     }
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/onboarding/CardReaderEligibilityFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/onboarding/CardReaderEligibilityFragment.kt
@@ -1,11 +1,42 @@
 package com.woocommerce.android.ui.prefs.cardreader.connect.onboarding
 
+import android.os.Bundle
+import android.view.View
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.R
+import com.woocommerce.android.databinding.FragmentCardReaderEligibilityBinding
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.prefs.cardreader.connect.onboarding.CardReaderEligibilityViewModel.ViewState.CountryNotSupportedState
+import com.woocommerce.android.util.UiHelpers
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class CardReaderEligibilityFragment : BaseFragment(R.layout.fragment_card_reader_eligibility) {
     val viewModel: CardReaderEligibilityViewModel by viewModels()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val binding = FragmentCardReaderEligibilityBinding.bind(view)
+
+        observeViewState(binding)
+    }
+
+    private fun observeViewState(binding: FragmentCardReaderEligibilityBinding) {
+        viewModel.viewStateData.observe(
+            viewLifecycleOwner,
+            { state ->
+                // We presume we are later going to have different states
+                when (state) {
+                    is CountryNotSupportedState -> {
+                        UiHelpers.setTextOrHide(binding.eligibilityHeader, state.headerLabel)
+                        UiHelpers.setImageOrHide(binding.eligibilityIllustration, state.illustration)
+                        UiHelpers.setTextOrHide(binding.eligibilityHint, state.hintLabel)
+                        UiHelpers.setTextOrHide(binding.eligibilityHelp, state.contactSupportLabel)
+                        UiHelpers.setTextOrHide(binding.eligibilityLearnMore, state.learnMoreLabel)
+                    }
+                }
+            }
+        )
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/onboarding/CardReaderEligibilityFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/onboarding/CardReaderEligibilityFragment.kt
@@ -1,0 +1,11 @@
+package com.woocommerce.android.ui.prefs.cardreader.connect.onboarding
+
+import androidx.fragment.app.viewModels
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.base.BaseFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class CardReaderEligibilityFragment : BaseFragment(R.layout.fragment_card_reader_eligibility) {
+    val viewModel: CardReaderEligibilityViewModel by viewModels()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/onboarding/CardReaderEligibilityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/onboarding/CardReaderEligibilityViewModel.kt
@@ -1,8 +1,12 @@
 package com.woocommerce.android.ui.prefs.cardreader.connect.onboarding
 
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
-import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.cardreader.CardReaderManager
+import com.woocommerce.android.R
+import com.woocommerce.android.model.UiString
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -11,5 +15,35 @@ import javax.inject.Inject
 class CardReaderEligibilityViewModel @Inject constructor(
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
+    private val viewState = MutableLiveData<ViewState>(ViewState.CountryNotSupportedState("US"))
+    val viewStateData: LiveData<ViewState> = viewState
 
+    sealed class ViewState(
+        val headerLabel: UiString? = null,
+        @DrawableRes val illustration: Int? = null,
+        val hintLabel: UiString? = null,
+        val contactSupportLabel: UiString? = null,
+        val learnMoreLabel: UiString? = null
+    ) {
+        data class CountryNotSupportedState(
+            val countryCode: String,
+        ) : ViewState(
+            headerLabel = UiString.UiStringRes(
+                stringRes = R.string.card_reader_eligibility_country_not_supported_header,
+                params = listOf(UiString.UiStringText(" HC: United States"))
+            ),
+            illustration = R.drawable.img_products_error,
+            hintLabel = UiString.UiStringRes(
+               stringRes = R.string.card_reader_eligibility_country_not_supported_hint
+            ),
+            contactSupportLabel = UiString.UiStringRes(
+                stringRes = R.string.card_reader_eligibility_country_not_supported_contact_support,
+                containsHtml = true
+            ),
+            learnMoreLabel = UiString.UiStringRes(
+                stringRes = R.string.card_reader_eligibility_country_not_supported_learn_more,
+                containsHtml = true
+            )
+        )
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/onboarding/CardReaderEligibilityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/onboarding/CardReaderEligibilityViewModel.kt
@@ -1,13 +1,11 @@
 package com.woocommerce.android.ui.prefs.cardreader.connect.onboarding
 
 import androidx.annotation.DrawableRes
-import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString
-import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -16,17 +14,22 @@ import javax.inject.Inject
 class CardReaderEligibilityViewModel @Inject constructor(
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
-    private val viewState = MutableLiveData<ViewState>(ViewState.CountryNotSupportedState("US",
-        ::onContactSupportClicked,
-        ::onLearnMoreClicked))
+    private val viewState = MutableLiveData<ViewState>(
+        ViewState.CountryNotSupportedState(
+            "US",
+            ::onContactSupportClicked,
+            ::onLearnMoreClicked
+        )
+    )
+
     val viewStateData: LiveData<ViewState> = viewState
 
     private fun onContactSupportClicked() {
-
+        // TODO()
     }
 
     private fun onLearnMoreClicked() {
-
+        // TODO()
     }
 
     sealed class ViewState(
@@ -50,7 +53,7 @@ class CardReaderEligibilityViewModel @Inject constructor(
             ),
             illustration = R.drawable.img_products_error,
             hintLabel = UiString.UiStringRes(
-               stringRes = R.string.card_reader_eligibility_country_not_supported_hint
+                stringRes = R.string.card_reader_eligibility_country_not_supported_hint
             ),
             contactSupportLabel = UiString.UiStringRes(
                 stringRes = R.string.card_reader_eligibility_country_not_supported_contact_support,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/onboarding/CardReaderEligibilityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/onboarding/CardReaderEligibilityViewModel.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.ui.prefs.cardreader.connect.onboarding
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.cardreader.CardReaderManager
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class CardReaderEligibilityViewModel @Inject constructor(
+    savedState: SavedStateHandle
+) : ScopedViewModel(savedState) {
+
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/onboarding/CardReaderEligibilityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/onboarding/CardReaderEligibilityViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -15,8 +16,18 @@ import javax.inject.Inject
 class CardReaderEligibilityViewModel @Inject constructor(
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
-    private val viewState = MutableLiveData<ViewState>(ViewState.CountryNotSupportedState("US"))
+    private val viewState = MutableLiveData<ViewState>(ViewState.CountryNotSupportedState("US",
+        ::onContactSupportClicked,
+        ::onLearnMoreClicked))
     val viewStateData: LiveData<ViewState> = viewState
+
+    private fun onContactSupportClicked() {
+
+    }
+
+    private fun onLearnMoreClicked() {
+
+    }
 
     sealed class ViewState(
         val headerLabel: UiString? = null,
@@ -25,8 +36,13 @@ class CardReaderEligibilityViewModel @Inject constructor(
         val contactSupportLabel: UiString? = null,
         val learnMoreLabel: UiString? = null
     ) {
+        open val onContactSupportActionClicked: (() -> Unit)? = null
+        open val onLearnMoreActionClicked: (() -> Unit)? = null
+
         data class CountryNotSupportedState(
             val countryCode: String,
+            override val onContactSupportActionClicked: (() -> Unit),
+            override val onLearnMoreActionClicked: (() -> Unit),
         ) : ViewState(
             headerLabel = UiString.UiStringRes(
                 stringRes = R.string.card_reader_eligibility_country_not_supported_header,

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_eligibility.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_eligibility.xml
@@ -49,7 +49,7 @@
     <com.google.android.material.textview.MaterialTextView
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@id/eligibility_help"
+        app:layout_constraintTop_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_eligibility.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_eligibility.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/eligibility_illustration"
+        app:layout_constraintVertical_chainStyle="packed"
+        android:layout_marginBottom="@dimen/margin_large"
+        android:id="@+id/eligibility_header"/>
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@+id/eligibility_header"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/eligibility_hint"
+        tools:src="@drawable/img_card_reader_connecting"
+        android:layout_marginBottom="@dimen/margin_large"
+        android:id="@+id/eligibility_illustration"/>
+
+    <com.google.android.material.textview.MaterialTextView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/eligibility_illustration"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/eligibility_help"
+        android:layout_marginBottom="@dimen/margin_extra_medium_large"
+        android:id="@+id/eligibility_hint"/>
+
+    <com.google.android.material.textview.MaterialTextView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/eligibility_hint"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/eligibility_learn_more"
+        android:id="@+id/eligibility_help"/>
+
+    <com.google.android.material.textview.MaterialTextView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/eligibility_help"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintVertical_bias="0.2"
+        android:id="@+id/eligibility_learn_more"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -60,6 +60,12 @@
             android:layout_height="wrap_content"
             app:optionTitle="@string/settings_card_reader" />
 
+        <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+            android:id="@+id/option_card_reader_eligibility"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:optionTitle="@string/settings_card_reader_eligibility" />
+
     </LinearLayout>
 
     <View style="@style/Woo.Divider" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -16,6 +16,13 @@
             app:popEnterAnim="@anim/activity_slide_in_from_left"
             app:popExitAnim="@anim/activity_slide_out_to_right" />
         <action
+            android:id="@+id/action_mainSettingsFragment_to_cardReaderEligibilityFragment"
+            app:destination="@id/cardReaderEligibilityFragment"
+            app:enterAnim="@anim/activity_slide_in_from_right"
+            app:exitAnim="@anim/activity_slide_out_to_left"
+            app:popEnterAnim="@anim/activity_slide_in_from_left"
+            app:popExitAnim="@anim/activity_slide_out_to_right" />
+        <action
             android:id="@+id/action_mainSettingsFragment_to_privacySettingsFragment"
             app:destination="@id/privacySettingsFragment"
             app:enterAnim="@anim/activity_slide_in_from_right"
@@ -79,6 +86,11 @@
             app:destination="@id/cardReaderUpdateDialogFragment"
             app:enterAnim="@anim/activity_fade_in"
             app:popExitAnim="@anim/activity_fade_out" />
+    </fragment>
+    <fragment
+        android:id="@+id/cardReaderEligibilityFragment"
+        android:name="com.woocommerce.android.ui.prefs.cardreader.connect.onboarding.CardReaderEligibilityFragment"
+        android:label="CardReaderEligibilityFragment" >
     </fragment>
     <fragment
         android:id="@+id/privacySettingsFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1161,6 +1161,7 @@
     <string name="settings_selected_store">Selected store</string>
     <string name="settings_store">Store settings</string>
     <string name="settings_card_reader">Manage card reader</string>
+    <string name="settings_card_reader_eligibility">Card reader eligibility</string>
     <string name="settings_card_reader_connect">Connect card reader</string>
     <string name="settings_notifs">Notifications</string>
     <string name="settings_notifs_device">Manage notifications</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -799,7 +799,7 @@
     <!--
      Card Reader eligibility
     -->
-    <string name="card_reader_eligibility_country_not_supported_header">We don\'t support In-Person Payments in %1$</string>
+    <string name="card_reader_eligibility_country_not_supported_header">We don\'t support In-Person Payments in %1$s</string>
     <string name="card_reader_eligibility_country_not_supported_hint">You can still accept In-Person Cash Payments by enabling the \"cash on delivery\" payment method on your store</string>
     <string name="card_reader_eligibility_country_not_supported_contact_support">Need some help? &lt;a href=\'\'&gt;Contact support&lt;/a&gt;</string>
     <string name="card_reader_eligibility_country_not_supported_learn_more">&lt;a href=\'\'&gt;Learn more&lt;/a&gt; about accepting payments with your mobile device and ordering card readers</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -797,6 +797,14 @@
     <string name="card_reader_detail_connected_update_failed">Reader\'s software update has failed</string>
 
     <!--
+     Card Reader eligibility
+    -->
+    <string name="card_reader_eligibility_country_not_supported_header">We don\'t support In-Person Payments in %1$</string>
+    <string name="card_reader_eligibility_country_not_supported_hint">You can still accept In-Person Cash Payments by enabling the \"cash on delivery\" payment method on your store</string>
+    <string name="card_reader_eligibility_country_not_supported_contact_support">Need some help? &lt;a href=\'\'&gt;Contact support&lt;/a&gt;</string>
+    <string name="card_reader_eligibility_country_not_supported_learn_more">&lt;a href=\'\'&gt;Learn more&lt;/a&gt; about accepting payments with your mobile device and ordering card readers</string>
+
+    <!--
         Card Reader Software update
     -->
     <string name="card_reader_software_update_update" translatable="false">@string/update</string>


### PR DESCRIPTION
⚠️ This is against a feature branch ⚠️ 

Partially implements #4029, adding a fragment and view model to render the UI for onboarding new merchants into In-Person Payments

<img width="350" alt="Screen Shot 2021-07-23 at 07 37 28" src="https://user-images.githubusercontent.com/2722505/126776514-4dc2ecc7-11aa-4cac-9008-bd22505c0273.png">


## Changes
* Add CardReaderEligibilityFragment, CardReaderEligibilityViewModel
* Add an entry to settings, and action to navigate to the new fragment (which I suppose will have to be reverted)

## Testing
* Build and run, navigate to settings, tap CardReaderEligibility. There should be a new screen with a very very temporary layout and content

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
