### PR TITLE
issue/4478-payment-tutorial-tablets

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/tutorial/CardReaderTutorialViewPagerItemFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/tutorial/CardReaderTutorialViewPagerItemFragment.kt
@@ -25,22 +25,24 @@ class CardReaderTutorialViewPagerItemFragment : Fragment(R.layout.fragment_card_
             val isLandscape = DisplayUtils.isLandscape(context)
             val isTablet = DisplayUtils.isTablet(context) || DisplayUtils.isXLargeTablet(context)
 
-            // hide images in landscape unless this device is a tablet
-            if (isLandscape && !isTablet) {
+            // hide images in landscape
+            if (isLandscape) {
                 binding.imageView.hide()
             } else {
                 binding.imageView.setImageResource(args.getInt(ARG_DRAWABLE_ID))
             }
 
-            // adjust the view sizes based on orientation
-            val ratio = if (isLandscape) {
-                (DisplayUtils.getDisplayPixelWidth() * RATIO_LANDSCAPE).toInt()
-            } else {
-                (DisplayUtils.getDisplayPixelWidth() * RATIO_PORTRAIT).toInt()
+            // adjust the view sizes based on orientation (skipped for tablets)
+            if (!isTablet) {
+                val ratio = if (isLandscape) {
+                    (DisplayUtils.getDisplayPixelWidth() * RATIO_LANDSCAPE).toInt()
+                } else {
+                    (DisplayUtils.getDisplayPixelWidth() * RATIO_PORTRAIT).toInt()
+                }
+                binding.labelTextView.layoutParams.width = ratio
+                binding.detailTextView.layoutParams.width = ratio
+                binding.imageView.layoutParams.width = ratio
             }
-            binding.labelTextView.layoutParams.width = ratio
-            binding.detailTextView.layoutParams.width = ratio
-            binding.imageView.layoutParams.width = ratio
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/tutorial/CardReaderTutorialViewPagerItemFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/tutorial/CardReaderTutorialViewPagerItemFragment.kt
@@ -22,26 +22,11 @@ class CardReaderTutorialViewPagerItemFragment : Fragment(R.layout.fragment_card_
             binding.labelTextView.setText(args.getInt(ARG_LABEL_ID))
             binding.detailTextView.setText(args.getInt(ARG_DETAIL_ID))
 
-            val isLandscape = DisplayUtils.isLandscape(context)
-            val isTablet = DisplayUtils.isTablet(context) || DisplayUtils.isXLargeTablet(context)
-
             // hide images in landscape
-            if (isLandscape) {
+            if (DisplayUtils.isLandscape(context)) {
                 binding.imageView.hide()
             } else {
                 binding.imageView.setImageResource(args.getInt(ARG_DRAWABLE_ID))
-            }
-
-            // adjust the view sizes based on orientation (skipped for tablets)
-            if (!isTablet) {
-                val ratio = if (isLandscape) {
-                    (DisplayUtils.getDisplayPixelWidth() * RATIO_LANDSCAPE).toInt()
-                } else {
-                    (DisplayUtils.getDisplayPixelWidth() * RATIO_PORTRAIT).toInt()
-                }
-                binding.labelTextView.layoutParams.width = ratio
-                binding.detailTextView.layoutParams.width = ratio
-                binding.imageView.layoutParams.width = ratio
             }
         }
     }
@@ -50,9 +35,6 @@ class CardReaderTutorialViewPagerItemFragment : Fragment(R.layout.fragment_card_
         private const val ARG_DRAWABLE_ID = "drawable_id"
         private const val ARG_LABEL_ID = "label_id"
         private const val ARG_DETAIL_ID = "detail_id"
-
-        private const val RATIO_PORTRAIT = 0.6f
-        private const val RATIO_LANDSCAPE = 0.3f
 
         fun newInstance(
             @DrawableRes drawableId: Int,

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_tutorial_viewpager_item.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_tutorial_viewpager_item.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:gravity="center"
-    android:orientation="vertical">
+    android:paddingHorizontal="@dimen/major_200">
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/labelTextView"


### PR DESCRIPTION
Fixes #4478 - previously the payment tutorial was visually broken on tablets. This PR corrects this. Tablet portrait and landscape shots below. To test, I recommend changing the [onboarding click listener ](https://github.com/woocommerce/woocommerce-android/blob/3f310e4e6bb0d27c0c1d27f2bd5957c3d230bb98/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt#L124)to this, so you can easily view the tutorial:

```
childFragmentManager.beginTransaction()
                .add(CardReaderTutorialDialogFragment(), "TAG")
                .commitAllowingStateLoss()
```

![landscape](https://user-images.githubusercontent.com/3903757/126791085-77841b24-6f42-4a96-bde3-0a3684de82bf.png)
![portrait](https://user-images.githubusercontent.com/3903757/126791089-035d92b3-4087-4d95-b04f-b3a77fa5ca8a.png)





Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
