### PR TITLE
Issue/4413 unsupported country

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -27,27 +27,27 @@ class CardReaderOnboardingChecker @Inject constructor(
 ) {
     @Suppress("ReturnCount")
     suspend fun getOnboardingState(): CardReaderOnboardingState {
-        if (!isCountrySupported()) return COUNTRY_NOT_SUPPORTED
+        if (!isCountrySupported()) return CountryNotSupported
 
         val fetchSitePluginsResult = wooStore.fetchSitePlugins(selectedSite.get())
-        if (fetchSitePluginsResult.isError) return GENERIC_ERROR
+        if (fetchSitePluginsResult.isError) return GenericError
         val pluginInfo = wooStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_PAYMENTS)
 
-        if (!isWCPayInstalled(pluginInfo)) return WCPAY_NOT_INSTALLED
-        if (!isWCPayVersionSupported(requireNotNull(pluginInfo))) return WCPAY_UNSUPPORTED_VERSION
-        if (!isWCPayActivated(pluginInfo)) return WCPAY_NOT_ACTIVATED
+        if (!isWCPayInstalled(pluginInfo)) return WcpayNotInstalled
+        if (!isWCPayVersionSupported(requireNotNull(pluginInfo))) return WcpayUnsupportedVersion
+        if (!isWCPayActivated(pluginInfo)) return WcpayNotActivated
 
-        val paymentAccount = wcPayStore.loadAccount(selectedSite.get()).model ?: return GENERIC_ERROR
+        val paymentAccount = wcPayStore.loadAccount(selectedSite.get()).model ?: return GenericError
 
-        if (!isWCPaySetupCompleted(paymentAccount)) return WCPAY_SETUP_NOT_COMPLETED
-        if (isWCPayInTestModeWithLiveStripeAccount()) return WCPAY_IN_TEST_MODE_WITH_LIVE_STRIPE_ACCOUNT
-        if (isStripeAccountUnderReview(paymentAccount)) return STRIPE_ACCOUNT_UNDER_REVIEW
-        if (isStripeAccountPendingRequirements(paymentAccount)) return STRIPE_ACCOUNT_PENDING_REQUIREMENT
-        if (isStripeAccountOverdueRequirements(paymentAccount)) return STRIPE_ACCOUNT_OVERDUE_REQUIREMENT
-        if (isStripeAccountRejected(paymentAccount)) return STRIPE_ACCOUNT_REJECTED
-        if (isInUndefinedState(paymentAccount)) return GENERIC_ERROR
+        if (!isWCPaySetupCompleted(paymentAccount)) return WcpaySetupNotCompleted
+        if (isWCPayInTestModeWithLiveStripeAccount()) return WcpayInTestModeWithLiveStripeAccount
+        if (isStripeAccountUnderReview(paymentAccount)) return StripeAccountUnderReview
+        if (isStripeAccountPendingRequirements(paymentAccount)) return StripeAccountPendingRequirement
+        if (isStripeAccountOverdueRequirements(paymentAccount)) return StripeAccountOverdueRequirement
+        if (isStripeAccountRejected(paymentAccount)) return StripeAccountRejected
+        if (isInUndefinedState(paymentAccount)) return GenericError
 
-        return ONBOARDING_COMPLETED
+        return OnboardingCompleted
     }
 
     private suspend fun isCountrySupported(): Boolean {
@@ -95,72 +95,72 @@ class CardReaderOnboardingChecker @Inject constructor(
 private fun isInUndefinedState(paymentAccount: WCPaymentAccountResult): Boolean =
     paymentAccount.status != WCPaymentAccountResult.WCPayAccountStatusEnum.COMPLETE
 
-enum class CardReaderOnboardingState {
-    ONBOARDING_COMPLETED,
+sealed class CardReaderOnboardingState {
+    object OnboardingCompleted : CardReaderOnboardingState()
 
     /**
      * Store is not located in one of the supported countries.
      */
-    COUNTRY_NOT_SUPPORTED,
+    object CountryNotSupported : CardReaderOnboardingState()
 
     /**
      * WCPay plugin is not installed on the store.
      */
-    WCPAY_NOT_INSTALLED,
+    object WcpayNotInstalled : CardReaderOnboardingState()
 
     /**
      * WCPay plugin is installed on the store, but the version is out-dated and doesn't contain required APIs
      * for card present payments.
      */
-    WCPAY_UNSUPPORTED_VERSION,
+    object WcpayUnsupportedVersion : CardReaderOnboardingState()
 
     /**
      * WCPay is installed on the store but is not activated.
      */
-    WCPAY_NOT_ACTIVATED,
+    object WcpayNotActivated : CardReaderOnboardingState()
 
     /**
      * WCPay is installed and activated but requires to be setup first.
      */
-    WCPAY_SETUP_NOT_COMPLETED,
+    object WcpaySetupNotCompleted : CardReaderOnboardingState()
 
     /**
      * This is a bit special case: WCPay is set to "dev mode" but the connected Stripe account is in live mode.
      * Connecting to a reader or accepting payments is not supported in this state.
      */
-    WCPAY_IN_TEST_MODE_WITH_LIVE_STRIPE_ACCOUNT,
+    object WcpayInTestModeWithLiveStripeAccount : CardReaderOnboardingState()
 
     /**
      * The connected Stripe account has not been reviewed by Stripe yet. This is a temporary state and
      * the user needs to wait.
      */
-    STRIPE_ACCOUNT_UNDER_REVIEW,
+    object StripeAccountUnderReview : CardReaderOnboardingState()
 
     /**
      * There are some pending requirements on the connected Stripe account. The merchant still has some time before the
      * deadline to fix them expires. In-person payments should work without issues.
      */
-    STRIPE_ACCOUNT_PENDING_REQUIREMENT,
+    object StripeAccountPendingRequirement : CardReaderOnboardingState()
 
     /**
      * There are some overdue requirements on the connected Stripe account. Connecting to a reader or accepting
      * payments is not supported in this state.
      */
-    STRIPE_ACCOUNT_OVERDUE_REQUIREMENT,
+    object StripeAccountOverdueRequirement : CardReaderOnboardingState()
 
     /**
      * The Stripe account was rejected by Stripe. This can happen for example when the account is flagged as fraudulent
      * or the merchant violates the terms of service
      */
-    STRIPE_ACCOUNT_REJECTED,
+    object StripeAccountRejected : CardReaderOnboardingState()
 
     /**
      * Generic error - for example, one of the requests failed.
      */
-    GENERIC_ERROR,
+    object GenericError : CardReaderOnboardingState()
 
     /**
      * Internet connection is not available.
      */
-    NO_CONNECTION_ERROR
+    object NoConnectionError : CardReaderOnboardingState()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -4,12 +4,14 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import androidx.fragment.app.viewModels
+import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentCardReaderOnboardingBinding
 import com.woocommerce.android.databinding.FragmentCardReaderOnboardingLoadingBinding
 import com.woocommerce.android.databinding.FragmentCardReaderOnboardingUnsupportedCountryBinding
 import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.UiHelpers
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
@@ -29,6 +31,12 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
             viewLifecycleOwner,
             { event ->
                 when (event) {
+                    is CardReaderOnboardingViewModel.OnboardingEvent.NavigateToSupport -> {
+                        // todo cardreader start HelpActivity
+                    }
+                    is CardReaderOnboardingViewModel.OnboardingEvent.ViewLearnMore -> {
+                        ChromeCustomTabUtils.launchUrl(requireActivity(), AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS)
+                    }
                     is MultiLiveEvent.Event.Exit -> navigateBackWithNotice(KEY_READER_ONBOARDING_RESULT)
                     else -> event.isHandled = false
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
-import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
@@ -66,7 +65,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
                     viewState.value = OnboardingViewState.GenericErrorState
                 CardReaderOnboardingState.NoConnectionError ->
                     viewState.value = OnboardingViewState.NoConnectionErrorState
-            }.exhaustive
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -5,6 +5,7 @@ import androidx.annotation.LayoutRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.util.WooLog
@@ -75,11 +76,11 @@ class CardReaderOnboardingViewModel @Inject constructor(
     }
 
     private fun onContactSupportClicked() {
-        // TODO cardreader not implemented
+        triggerEvent(OnboardingEvent.NavigateToSupport)
     }
 
     private fun onLearnMoreClicked() {
-        // TODO cardreader not implemented
+        triggerEvent(OnboardingEvent.ViewLearnMore)
     }
 
     private fun exitFlow() {
@@ -89,13 +90,22 @@ class CardReaderOnboardingViewModel @Inject constructor(
     private fun convertCountryCodeToCountry(countryCode: String?) =
         Locale("", countryCode.orEmpty()).displayName
 
+    sealed class OnboardingEvent : Event() {
+        object ViewLearnMore : OnboardingEvent() {
+            const val url = AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS
+        }
+
+        object NavigateToSupport : Event()
+    }
+
     sealed class OnboardingViewState(@LayoutRes val layoutRes: Int) {
         object LoadingState : OnboardingViewState(R.layout.fragment_card_reader_onboarding_loading) {
             val headerLabel: UiString =
                 UiString.UiStringRes(R.string.card_reader_onboarding_loading)
             val hintLabel: UiString =
                 UiString.UiStringRes(R.string.please_wait)
-            @DrawableRes val illustration: Int = R.drawable.img_payment_onboarding_loading
+            @DrawableRes
+            val illustration: Int = R.drawable.img_payment_onboarding_loading
         }
 
         // TODO cardreader Update layout resource
@@ -111,8 +121,8 @@ class CardReaderOnboardingViewModel @Inject constructor(
         // TODO cardreader Update layout resource
         class UnsupportedCountryState(
             val countryDisplayName: String,
-            val onContactSupportActionClicked: (() -> Unit)? = null,
-            val onLearnMoreActionClicked: (() -> Unit)? = null
+            val onContactSupportActionClicked: (() -> Unit),
+            val onLearnMoreActionClicked: (() -> Unit)
         ) : OnboardingViewState(R.layout.fragment_card_reader_onboarding_unsupported_country) {
             val headerLabel = UiString.UiStringRes(
                 stringRes = R.string.card_reader_onboarding_country_not_supported_header,
@@ -141,7 +151,8 @@ class CardReaderOnboardingViewModel @Inject constructor(
                 UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_installed_hint)
             val learnMoreLabel =
                 UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true)
-            @DrawableRes val illustration: Int = R.drawable.img_woo_payments
+            @DrawableRes
+            val illustration: Int = R.drawable.img_woo_payments
             val refreshButtonLabel =
                 UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_installed_refresh_button)
         }
@@ -155,7 +166,8 @@ class CardReaderOnboardingViewModel @Inject constructor(
                 UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_activated_hint)
             val learnMoreLabel =
                 UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true)
-            @DrawableRes val illustration: Int = R.drawable.img_woo_payments
+            @DrawableRes
+            val illustration: Int = R.drawable.img_woo_payments
             val refreshButtonLabel =
                 UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_activated_refresh_button)
         }
@@ -169,7 +181,8 @@ class CardReaderOnboardingViewModel @Inject constructor(
                 UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_setup_hint)
             val learnMoreLabel =
                 UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true)
-            @DrawableRes val illustration: Int = R.drawable.img_woo_payments
+            @DrawableRes
+            val illustration: Int = R.drawable.img_woo_payments
             val refreshButtonLabel =
                 UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_setup_refresh_button)
         }
@@ -183,7 +196,8 @@ class CardReaderOnboardingViewModel @Inject constructor(
                 UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_unsupported_version_hint)
             val learnMoreLabel =
                 UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true)
-            @DrawableRes val illustration: Int = R.drawable.img_woo_payments
+            @DrawableRes
+            val illustration: Int = R.drawable.img_woo_payments
             val refreshButtonLabel =
                 UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_unsupported_version_refresh_button)
         }
@@ -199,7 +213,8 @@ class CardReaderOnboardingViewModel @Inject constructor(
                 UiString.UiStringRes(R.string.card_reader_onboarding_contact_support)
             val learnMoreLabel =
                 UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true)
-            @DrawableRes val illustration: Int = R.drawable.img_products_error
+            @DrawableRes
+            val illustration: Int = R.drawable.img_products_error
         }
 
         // TODO cardreader Update layout resource
@@ -213,7 +228,8 @@ class CardReaderOnboardingViewModel @Inject constructor(
                 UiString.UiStringRes(R.string.card_reader_onboarding_contact_support)
             val learnMoreLabel =
                 UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true)
-            @DrawableRes val illustration: Int = R.drawable.img_products_error
+            @DrawableRes
+            val illustration: Int = R.drawable.img_products_error
         }
 
         // TODO cardreader Update layout resource
@@ -227,7 +243,8 @@ class CardReaderOnboardingViewModel @Inject constructor(
                 UiString.UiStringRes(R.string.card_reader_onboarding_contact_support)
             val learnMoreLabel =
                 UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true)
-            @DrawableRes val illustration: Int = R.drawable.img_products_error
+            @DrawableRes
+            val illustration: Int = R.drawable.img_products_error
         }
 
         // TODO cardreader Update layout resource
@@ -244,7 +261,8 @@ class CardReaderOnboardingViewModel @Inject constructor(
                 UiString.UiStringRes(R.string.card_reader_onboarding_contact_support)
             val learnMoreLabel =
                 UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true)
-            @DrawableRes val illustration: Int = R.drawable.img_products_error
+            @DrawableRes
+            val illustration: Int = R.drawable.img_products_error
             val dismissButtonLabel =
                 UiString.UiStringRes(R.string.card_reader_onboarding_account_pending_requirements_dismiss_button)
         }
@@ -260,7 +278,8 @@ class CardReaderOnboardingViewModel @Inject constructor(
                 UiString.UiStringRes(R.string.card_reader_onboarding_contact_support)
             val learnMoreLabel =
                 UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true)
-            @DrawableRes val illustration: Int = R.drawable.img_products_error
+            @DrawableRes
+            val illustration: Int = R.drawable.img_products_error
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -34,36 +34,36 @@ class CardReaderOnboardingViewModel @Inject constructor(
         launch {
             viewState.value = OnboardingViewState.LoadingState
             when (cardReaderChecker.getOnboardingState()) {
-                CardReaderOnboardingState.ONBOARDING_COMPLETED -> exitFlow()
-                CardReaderOnboardingState.COUNTRY_NOT_SUPPORTED ->
+                CardReaderOnboardingState.OnboardingCompleted -> exitFlow()
+                CardReaderOnboardingState.CountryNotSupported ->
                     // todo cardreader add country display name
                     viewState.value = OnboardingViewState.UnsupportedCountryState(
                         "HC: United States",
                         ::onContactSupportClicked,
                         ::onLearnMoreClicked
                     )
-                CardReaderOnboardingState.WCPAY_NOT_INSTALLED ->
+                CardReaderOnboardingState.WcpayNotInstalled ->
                     viewState.value = OnboardingViewState.WCPayNotInstalledState(::refreshState)
-                CardReaderOnboardingState.WCPAY_UNSUPPORTED_VERSION ->
+                CardReaderOnboardingState.WcpayUnsupportedVersion ->
                     viewState.value = OnboardingViewState.WCPayUnsupportedVersionState(::refreshState)
-                CardReaderOnboardingState.WCPAY_NOT_ACTIVATED ->
+                CardReaderOnboardingState.WcpayNotActivated ->
                     viewState.value = OnboardingViewState.WCPayNotActivatedState(::refreshState)
-                CardReaderOnboardingState.WCPAY_SETUP_NOT_COMPLETED ->
+                CardReaderOnboardingState.WcpaySetupNotCompleted ->
                     viewState.value = OnboardingViewState.WCPayNotSetupState(::refreshState)
-                CardReaderOnboardingState.WCPAY_IN_TEST_MODE_WITH_LIVE_STRIPE_ACCOUNT ->
+                CardReaderOnboardingState.WcpayInTestModeWithLiveStripeAccount ->
                     viewState.value = OnboardingViewState.WCPayInTestModeWithLiveAccountState
-                CardReaderOnboardingState.STRIPE_ACCOUNT_UNDER_REVIEW ->
+                CardReaderOnboardingState.StripeAccountUnderReview ->
                     viewState.value = OnboardingViewState.WCPayAccountUnderReviewState
                 // TODO cardreader Pass due date to the state
-                CardReaderOnboardingState.STRIPE_ACCOUNT_PENDING_REQUIREMENT ->
+                CardReaderOnboardingState.StripeAccountPendingRequirement ->
                     viewState.value = OnboardingViewState.WCPayAccountPendingRequirementsState("", ::exitFlow)
-                CardReaderOnboardingState.STRIPE_ACCOUNT_OVERDUE_REQUIREMENT ->
+                CardReaderOnboardingState.StripeAccountOverdueRequirement ->
                     viewState.value = OnboardingViewState.WCPayAccountOverdueRequirementsState
-                CardReaderOnboardingState.STRIPE_ACCOUNT_REJECTED ->
+                CardReaderOnboardingState.StripeAccountRejected ->
                     viewState.value = OnboardingViewState.WCPayAccountRejectedState
-                CardReaderOnboardingState.GENERIC_ERROR ->
+                CardReaderOnboardingState.GenericError ->
                     viewState.value = OnboardingViewState.GenericErrorState
-                CardReaderOnboardingState.NO_CONNECTION_ERROR ->
+                CardReaderOnboardingState.NoConnectionError ->
                     viewState.value = OnboardingViewState.NoConnectionErrorState
             }
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -41,7 +41,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
         val result = checker.getOnboardingState()
 
-        assertThat(result).isEqualTo(CardReaderOnboardingState.CountryNotSupported)
+        assertThat(result).isInstanceOf(CardReaderOnboardingState.CountryNotSupported::class.java)
     }
 
     @Test
@@ -50,7 +50,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
         val result = checker.getOnboardingState()
 
-        assertThat(result).isNotEqualTo(CardReaderOnboardingState.CountryNotSupported)
+        assertThat(result).isNotInstanceOf(CardReaderOnboardingState.CountryNotSupported::class.java)
     }
 
     @Test
@@ -60,7 +60,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isNotEqualTo(CardReaderOnboardingState.CountryNotSupported)
+            assertThat(result).isNotInstanceOf(CardReaderOnboardingState.CountryNotSupported::class.java)
         }
 
     @Test
@@ -70,7 +70,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.CountryNotSupported)
+            assertThat(result).isInstanceOf(CardReaderOnboardingState.CountryNotSupported::class.java)
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -41,7 +41,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
         val result = checker.getOnboardingState()
 
-        assertThat(result).isEqualTo(CardReaderOnboardingState.COUNTRY_NOT_SUPPORTED)
+        assertThat(result).isEqualTo(CardReaderOnboardingState.CountryNotSupported)
     }
 
     @Test
@@ -50,7 +50,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
         val result = checker.getOnboardingState()
 
-        assertThat(result).isNotEqualTo(CardReaderOnboardingState.COUNTRY_NOT_SUPPORTED)
+        assertThat(result).isNotEqualTo(CardReaderOnboardingState.CountryNotSupported)
     }
 
     @Test
@@ -60,7 +60,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isNotEqualTo(CardReaderOnboardingState.COUNTRY_NOT_SUPPORTED)
+            assertThat(result).isNotEqualTo(CardReaderOnboardingState.CountryNotSupported)
         }
 
     @Test
@@ -70,7 +70,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.COUNTRY_NOT_SUPPORTED)
+            assertThat(result).isEqualTo(CardReaderOnboardingState.CountryNotSupported)
         }
 
     @Test
@@ -91,7 +91,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.WCPAY_NOT_INSTALLED)
+            assertThat(result).isEqualTo(CardReaderOnboardingState.WcpayNotInstalled)
         }
 
     @Test
@@ -103,7 +103,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.WCPAY_UNSUPPORTED_VERSION)
+            assertThat(result).isEqualTo(CardReaderOnboardingState.WcpayUnsupportedVersion)
         }
 
     @Test
@@ -115,7 +115,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.WCPAY_NOT_ACTIVATED)
+            assertThat(result).isEqualTo(CardReaderOnboardingState.WcpayNotActivated)
         }
 
     @Test
@@ -129,7 +129,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.WCPAY_SETUP_NOT_COMPLETED)
+            assertThat(result).isEqualTo(CardReaderOnboardingState.WcpaySetupNotCompleted)
         }
 
     @Test
@@ -145,7 +145,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.STRIPE_ACCOUNT_UNDER_REVIEW)
+            assertThat(result).isEqualTo(CardReaderOnboardingState.StripeAccountUnderReview)
         }
 
     @Test
@@ -161,7 +161,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.STRIPE_ACCOUNT_PENDING_REQUIREMENT)
+            assertThat(result).isEqualTo(CardReaderOnboardingState.StripeAccountPendingRequirement)
         }
 
     @Test
@@ -177,7 +177,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.STRIPE_ACCOUNT_OVERDUE_REQUIREMENT)
+            assertThat(result).isEqualTo(CardReaderOnboardingState.StripeAccountOverdueRequirement)
         }
 
     @Test
@@ -191,7 +191,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.STRIPE_ACCOUNT_REJECTED)
+            assertThat(result).isEqualTo(CardReaderOnboardingState.StripeAccountRejected)
         }
 
     @Test
@@ -205,7 +205,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.STRIPE_ACCOUNT_REJECTED)
+            assertThat(result).isEqualTo(CardReaderOnboardingState.StripeAccountRejected)
         }
 
     @Test
@@ -219,7 +219,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.STRIPE_ACCOUNT_REJECTED)
+            assertThat(result).isEqualTo(CardReaderOnboardingState.StripeAccountRejected)
         }
 
     @Test
@@ -233,7 +233,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.STRIPE_ACCOUNT_REJECTED)
+            assertThat(result).isEqualTo(CardReaderOnboardingState.StripeAccountRejected)
         }
 
     private fun buildPaymentAccountResult(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -82,7 +82,6 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                 .isInstanceOf(CardReaderOnboardingViewModel.OnboardingEvent.NavigateToSupport::class.java)
         }
 
-
     @Test
     fun `when wcpay not installed, then wcpay not installed state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -25,7 +25,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     @Test
     fun `when onboarding completed, then flow terminated`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            whenever(onboardingChecker.getOnboardingState()).thenReturn(CardReaderOnboardingState.ONBOARDING_COMPLETED)
+            whenever(onboardingChecker.getOnboardingState()).thenReturn(CardReaderOnboardingState.OnboardingCompleted)
 
             val viewModel = createVM()
 
@@ -35,7 +35,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     @Test
     fun `when country not supported, then country not supported state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            whenever(onboardingChecker.getOnboardingState()).thenReturn(CardReaderOnboardingState.COUNTRY_NOT_SUPPORTED)
+            whenever(onboardingChecker.getOnboardingState()).thenReturn(CardReaderOnboardingState.CountryNotSupported)
 
             val viewModel = createVM()
 
@@ -45,7 +45,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     @Test
     fun `when wcpay not installed, then wcpay not installed state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            whenever(onboardingChecker.getOnboardingState()).thenReturn(CardReaderOnboardingState.WCPAY_NOT_INSTALLED)
+            whenever(onboardingChecker.getOnboardingState()).thenReturn(CardReaderOnboardingState.WcpayNotInstalled)
 
             val viewModel = createVM()
 
@@ -55,7 +55,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     @Test
     fun `when wcpay not activated, then wcpay not activated state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            whenever(onboardingChecker.getOnboardingState()).thenReturn(CardReaderOnboardingState.WCPAY_NOT_ACTIVATED)
+            whenever(onboardingChecker.getOnboardingState()).thenReturn(CardReaderOnboardingState.WcpayNotActivated)
 
             val viewModel = createVM()
 
@@ -66,7 +66,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when wcpay not setup, then wcpay not setup state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.WCPAY_SETUP_NOT_COMPLETED)
+                .thenReturn(CardReaderOnboardingState.WcpaySetupNotCompleted)
 
             val viewModel = createVM()
 
@@ -77,7 +77,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when unsupported wcpay version installed, then unsupported wcpay version state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.WCPAY_UNSUPPORTED_VERSION)
+                .thenReturn(CardReaderOnboardingState.WcpayUnsupportedVersion)
 
             val viewModel = createVM()
 
@@ -88,7 +88,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when wcpay in test mode with live stripe account, then wcpay in test mode state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.WCPAY_IN_TEST_MODE_WITH_LIVE_STRIPE_ACCOUNT)
+                .thenReturn(CardReaderOnboardingState.WcpayInTestModeWithLiveStripeAccount)
 
             val viewModel = createVM()
 
@@ -99,7 +99,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when account rejected, then account rejected state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.STRIPE_ACCOUNT_REJECTED)
+                .thenReturn(CardReaderOnboardingState.StripeAccountRejected)
 
             val viewModel = createVM()
 
@@ -110,7 +110,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when account pending requirements, then account pending requirements state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.STRIPE_ACCOUNT_PENDING_REQUIREMENT)
+                .thenReturn(CardReaderOnboardingState.StripeAccountPendingRequirement)
 
             val viewModel = createVM()
 
@@ -121,7 +121,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when account overdue requirements, then account overdue requirements state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.STRIPE_ACCOUNT_OVERDUE_REQUIREMENT)
+                .thenReturn(CardReaderOnboardingState.StripeAccountOverdueRequirement)
 
             val viewModel = createVM()
 
@@ -132,7 +132,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when account under review, then account under review state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.STRIPE_ACCOUNT_UNDER_REVIEW)
+                .thenReturn(CardReaderOnboardingState.StripeAccountUnderReview)
 
             val viewModel = createVM()
 
@@ -143,7 +143,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when onboarding check fails, then generic state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.GENERIC_ERROR)
+                .thenReturn(CardReaderOnboardingState.GenericError)
 
             val viewModel = createVM()
 
@@ -154,7 +154,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when network not available, then no connection error shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.NO_CONNECTION_ERROR)
+                .thenReturn(CardReaderOnboardingState.NoConnectionError)
 
             val viewModel = createVM()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.prefs.cardreader.onboarding
 import androidx.lifecycle.SavedStateHandle
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
+import com.woocommerce.android.model.UiString
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingViewModel.OnboardingViewState.*
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -35,12 +36,52 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     @Test
     fun `when country not supported, then country not supported state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            whenever(onboardingChecker.getOnboardingState()).thenReturn(CardReaderOnboardingState.CountryNotSupported)
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(CardReaderOnboardingState.CountryNotSupported(""))
 
             val viewModel = createVM()
 
             assertThat(viewModel.viewStateData.value).isInstanceOf(UnsupportedCountryState::class.java)
         }
+
+    @Test
+    fun `when country not supported, then current store country name shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(CardReaderOnboardingState.CountryNotSupported("US"))
+            val viewModel = createVM()
+
+            val countryName = (viewModel.viewStateData.value as UnsupportedCountryState).headerLabel.params[0]
+
+            assertThat(countryName).isEqualTo(UiString.UiStringText("United States"))
+        }
+
+    @Test
+    fun `given country not supported, when learn more clicked, then app shows learn more section`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(CardReaderOnboardingState.CountryNotSupported(""))
+            val viewModel = createVM()
+
+            (viewModel.viewStateData.value as UnsupportedCountryState).onLearnMoreActionClicked.invoke()
+
+            assertThat(viewModel.event.value)
+                .isInstanceOf(CardReaderOnboardingViewModel.OnboardingEvent.ViewLearnMore::class.java)
+        }
+
+    @Test
+    fun `given country not supported, when contact support clicked, then app navigates to support screen`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(CardReaderOnboardingState.CountryNotSupported(""))
+            val viewModel = createVM()
+
+            (viewModel.viewStateData.value as UnsupportedCountryState).onContactSupportActionClicked.invoke()
+
+            assertThat(viewModel.event.value)
+                .isInstanceOf(CardReaderOnboardingViewModel.OnboardingEvent.NavigateToSupport::class.java)
+        }
+
 
     @Test
     fun `when wcpay not installed, then wcpay not installed state shown`() =


### PR DESCRIPTION
Parent issue #4413 

This PR
- Refactors OnboardingState enum to a sealed class 
- Adds support for showing display name of Store's country on the Ui when Unsupported country state shown
- Implements "learn more" and "contact support" on click listeners - the contact support listener is still not implemented in the fragment since I didn't want to introduce a new origin before https://github.com/woocommerce/woocommerce-android/issues/4421 is implemented

To test:
- This flow is not reproducible yet, since the In Person Payments UI is disabled on stores without WCPay and in non-us countries. You can return COUNTRY_NOT_SUPPORTED from[ this method](https://github.com/woocommerce/woocommerce-android/blob/18c64f1610e9a24ecf4a0b409beaadbcae5ca4e3/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt#L29) to test this flow.
1. Open App settings
2. Tap on "InPerson Payments"
2. Notice the header contains name of store's country

<img width="250px" alt="Screenshot 2021-07-27 at 7 16 36" src="https://user-images.githubusercontent.com/2261188/127099640-c54e434e-88f1-48a3-91f6-1bf188e016aa.png">



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
