### PR TITLE
Change chevron color to "on surface/disabled".

### DIFF
--- a/WooCommerce/src/main/res/layout/order_detail_shipping_label_list_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_shipping_label_list_item.xml
@@ -78,7 +78,7 @@
                 android:importantForAccessibility="no"
                 android:padding="@dimen/minor_100"
                 android:src="@drawable/ic_arrow_down"
-                app:tint="@color/color_on_surface_medium"
+                app:tint="@color/color_on_surface_disabled"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
Fixes #4189 

This PR changes the chevron color for in this area of Order details:

<img src="https://user-images.githubusercontent.com/266376/127088130-692710e7-b1ac-49d6-b0b5-fc2d3434d661.png" width="42%" />

**With this PR:**

| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/266376/127087466-e9b73c40-e865-4880-8d54-f26c48db52f5.png) | ![image](https://user-images.githubusercontent.com/266376/127087607-32a5ea34-acbc-4b78-bfbb-b91be928d9a7.png) |
| ![image](https://user-images.githubusercontent.com/266376/127087499-1757a49f-d3c2-48de-9d89-254480d1fbb5.png) |  ![image](https://user-images.githubusercontent.com/266376/127087580-5e2e7e84-1fda-44e4-ba6e-bd3523cec7c5.png) |



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
