### PR TITLE
Shipping Labels: Only show Add Payment Button if current user is store owner

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
@@ -139,10 +139,12 @@ class EditShippingLabelPaymentFragment :
                 it.isEmpty().let { isListEmpty ->
                     binding.paymentMethodsSectionTitle.isVisible = !isListEmpty
                     binding.paymentMethodsList.isVisible = !isListEmpty
-                    binding.addFirstPaymentMethodButton.isVisible = isListEmpty
                 }
             }
-            new.canShowAddPaymentButton.takeIfNotEqualTo(old?.canShowAddPaymentButton) {
+            new.showAddFirstPaymentButton.takeIfNotEqualTo(old?.showAddFirstPaymentButton) {
+                binding.addFirstPaymentMethodButton.isVisible = it
+            }
+            new.showAddPaymentButton.takeIfNotEqualTo(old?.showAddPaymentButton) {
                 binding.addPaymentMethodButton.isVisible = it
             }
             new.canEditSettings.takeIfNotEqualTo(old?.canEditSettings) { canEditSettings ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
@@ -139,9 +139,11 @@ class EditShippingLabelPaymentFragment :
                 it.isEmpty().let { isListEmpty ->
                     binding.paymentMethodsSectionTitle.isVisible = !isListEmpty
                     binding.paymentMethodsList.isVisible = !isListEmpty
-                    binding.addPaymentMethodButton.isVisible = !isListEmpty
                     binding.addFirstPaymentMethodButton.isVisible = isListEmpty
                 }
+            }
+            new.canShowAddPaymentButton.takeIfNotEqualTo(old?.canShowAddPaymentButton) {
+                binding.addPaymentMethodButton.isVisible = it
             }
             new.canEditSettings.takeIfNotEqualTo(old?.canEditSettings) { canEditSettings ->
                 binding.emailReceiptsCheckbox.isEnabled = canEditSettings

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentViewModel.kt
@@ -138,6 +138,8 @@ class EditShippingLabelPaymentViewModel @Inject constructor(
     ) : Parcelable {
         val canSave: Boolean
             get() = canEditSettings && paymentMethods.any { it.isSelected }
+        val canShowAddPaymentButton: Boolean
+            get() = canManagePayments && paymentMethods.isNotEmpty()
     }
 
     enum class DataLoadState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentViewModel.kt
@@ -138,8 +138,10 @@ class EditShippingLabelPaymentViewModel @Inject constructor(
     ) : Parcelable {
         val canSave: Boolean
             get() = canEditSettings && paymentMethods.any { it.isSelected }
-        val canShowAddPaymentButton: Boolean
+        val showAddPaymentButton: Boolean
             get() = canManagePayments && paymentMethods.isNotEmpty()
+        val showAddFirstPaymentButton: Boolean
+            get() = canManagePayments && paymentMethods.isEmpty()
     }
 
     enum class DataLoadState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentViewModel.kt
@@ -34,7 +34,10 @@ class EditShippingLabelPaymentViewModel @Inject constructor(
     private fun loadInitialData() {
         launch {
             loadPaymentMethods(forceRefresh = false)
-            if (viewState.dataLoadState == DataLoadState.Success && viewState.paymentMethods.isEmpty()) {
+            if (viewState.dataLoadState == DataLoadState.Success &&
+                viewState.paymentMethods.isEmpty() &&
+                viewState.canManagePayments
+            ) {
                 triggerEvent(AddPaymentMethod)
             }
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentViewModelTest.kt
@@ -196,4 +196,40 @@ class EditShippingLabelPaymentViewModelTest : BaseUnitTest() {
         assertThat(viewModel.event.value)
             .isEqualTo(ShowSnackbar(R.string.shipping_label_payment_method_added))
     }
+
+    @Test
+    fun `given no existing payment methods, when user is store owner, then show Add First Payment button`() {
+        val accountSettings = shippingAccountSettings.copy(paymentMethods = emptyList())
+        setup(WooResult(accountSettings))
+
+        val viewState = viewModel.viewStateData.liveData.value
+        assertThat(viewState!!.showAddFirstPaymentButton).isEqualTo(true)
+    }
+
+    @Test
+    fun `given existing payment methods, when user is store owner, then show Add Payment button`() {
+        setup(WooResult(shippingAccountSettings))
+
+        val viewState = viewModel.viewStateData.liveData.value
+        assertThat(viewState!!.showAddPaymentButton).isEqualTo(true)
+    }
+
+    @Test
+    fun `when user is not store owner, then hide both Add First Payment button and Add Payment Button`() {
+        val accountSettings = shippingAccountSettings.copy(canManagePayments = false)
+        setup(WooResult(accountSettings))
+
+        var viewState: ViewState? = null
+        viewModel.viewStateData.observeForever { _, new -> viewState = new }
+
+        assertThat(viewState!!.showAddFirstPaymentButton).isEqualTo(false)
+        assertThat(viewState!!.showAddPaymentButton).isEqualTo(false)
+    }
+
+    @Test
+    fun `given no existing payments, when user is store owner, redirect to add payment method screen`() {
+        val accountSettings = shippingAccountSettings.copy(paymentMethods = emptyList())
+        setup(WooResult(accountSettings))
+        assertThat(viewModel.event.value).isEqualTo(AddPaymentMethod)
+    }
 }


### PR DESCRIPTION
Fixes #4321

This PR hides the add payment button if the current user is not store owner, and the payment methods list is not empty.

To test:

1. Have a test site with Shipping labels feature enabled, payment method already added, and the site already having an account in it that is not the store owner,
2. Log in to app as a non-store owner account,
3. Find an Order and create a shipping label,
4. Go through all steps until the "Payment method" step is active.
5. Tap "Edit" on the "Payment method" step.
6. Make sure "Add another credit card" button is not shown.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
