### PR TITLE
Allow zero value for custom package creation's weight.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateCustomPackageViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateCustomPackageViewModel.kt
@@ -47,6 +47,7 @@ class ShippingLabelCreateCustomPackageViewModel @Inject constructor(
     fun onFieldTextChanged(value: String, field: InputName) {
         when (field) {
             InputName.NAME -> validateNameField(value)
+            InputName.EMPTY_WEIGHT -> validateFloatInput(value, field, isZeroAllowed = true)
             else -> validateFloatInput(value, field)
         }
         updateInputInViewState(value, field)
@@ -60,11 +61,17 @@ class ShippingLabelCreateCustomPackageViewModel @Inject constructor(
         }
     }
 
-    private fun validateFloatInput(input: String, name: InputName) {
+    private fun validateFloatInput(input: String, name: InputName, isZeroAllowed: Boolean = false) {
         val acc = inputToFloat(input)
         when {
             acc.isNaN() -> updateErrorInViewState(name, emptyInputError)
-            acc == 0f -> updateErrorInViewState(name, invalidInputError)
+            acc == 0f -> {
+                if (isZeroAllowed) {
+                    updateErrorInViewState(name, null)
+                } else {
+                    updateErrorInViewState(name, invalidInputError)
+                }
+            }
             else -> updateErrorInViewState(name, null)
         }
     }
@@ -95,7 +102,7 @@ class ShippingLabelCreateCustomPackageViewModel @Inject constructor(
         validateFloatInput(viewState.length, InputName.LENGTH)
         validateFloatInput(viewState.width, InputName.WIDTH)
         validateFloatInput(viewState.height, InputName.HEIGHT)
-        validateFloatInput(viewState.weight, InputName.EMPTY_WEIGHT)
+        validateFloatInput(viewState.weight, InputName.EMPTY_WEIGHT, isZeroAllowed = true)
 
         if (!viewState.areAllRequiredFieldsValid) return
 


### PR DESCRIPTION
Fixes #4416 

Previously, when creating custom package in the app, a zero empty package weight value wasn't allowed. However, this is allowed in core.

This PR makes the app accept such zero value as well.

## To test:
1. Open app, pick an order and create a Shipping Label for it,
2. Complete "Ship from" and "Ship to" steps,
3. Go into "Packaging details" step,
4. Tap "Package selected", then tap "Create New Package" button at the bottom,
5. In the "Custom Package" creation panel, enter "0" in the "Empty package weight" field. There should be no error message shown.
6. Fill in the remaining fields while keeping the weight value zero then tap Done. Make sure package is created properly.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
