### PR TITLE
Prevent shipping carrier checkboxes cut-off on larger fonts.

### DIFF
--- a/WooCommerce/src/main/res/layout/shipping_rate_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_rate_list_item.xml
@@ -83,6 +83,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/major_75"
+        android:layout_marginEnd="@dimen/major_100"
         android:minHeight="@dimen/minor_00"
         android:textColor="@color/checkbox_shipping_rate_bg_selector"
         app:layout_constraintEnd_toEndOf="parent"
@@ -97,6 +98,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/minor_00"
+        android:layout_marginEnd="@dimen/major_100"
         android:minHeight="@dimen/minor_00"
         android:textColor="@color/checkbox_shipping_rate_bg_selector"
         app:layout_constraintEnd_toEndOf="parent"
@@ -118,7 +120,6 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:text="$22.00"
         tools:visibility="visible" />
-
 
     <View
         android:id="@+id/divider"

--- a/WooCommerce/src/main/res/layout/shipping_rate_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_rate_list_item.xml
@@ -80,11 +80,12 @@
     <com.google.android.material.checkbox.MaterialCheckBox
         android:id="@+id/signatureOption"
         style="@style/Woo.CheckBox"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/major_75"
         android:minHeight="@dimen/minor_00"
         android:textColor="@color/checkbox_shipping_rate_bg_selector"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@id/includedOptions"
         app:layout_constraintTop_toBottomOf="@+id/includedOptions"
         tools:text="Signature required (+2.60)"
@@ -93,14 +94,15 @@
     <com.google.android.material.checkbox.MaterialCheckBox
         android:id="@+id/adultSignatureOption"
         style="@style/Woo.CheckBox"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/minor_00"
         android:minHeight="@dimen/minor_00"
         android:textColor="@color/checkbox_shipping_rate_bg_selector"
-        app:layout_goneMarginTop="@dimen/major_75"
-        app:layout_constraintStart_toStartOf="@id/signatureOption"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@id/includedOptions"
         app:layout_constraintTop_toBottomOf="@+id/signatureOption"
+        app:layout_goneMarginTop="@dimen/major_75"
         tools:text="Adult signature required (+2.60)" />
 
     <com.google.android.material.textview.MaterialTextView


### PR DESCRIPTION
Fixes #4171 

This PR prevents the checkboxes in the screenshot below to be cut-off on larger font sizes:

<img src="https://user-images.githubusercontent.com/266376/127103399-0d23d5a9-8095-42a8-9eb2-53692f5d0d6c.png" width="42%" />

To test:

1. Set device system font size to be as large as possible,
2. Open app, pick an Order and create a Shipping Label for it,
3. Complete the "Ship from", "Ship to", and "Packaging details" steps,
4. Enter the "Shipping carriers and rates step,
5. Pick a carrier option, and ensure the signature required checkboxes that appear to still be completely readable and not cut-off to the side. The correct styling should be like on screenshot below:

<img src="https://user-images.githubusercontent.com/266376/127103682-b5769896-579a-4aed-a987-b58ae1f19cdd.png" width="42%" />

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
