### PR TITLE
issue/4496-missing-settings-on-tablet 

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -39,7 +39,7 @@
     <LinearLayout
         android:id="@+id/store_settings_container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:visibility="gone"
         android:orientation="vertical">
 


### PR DESCRIPTION
Fixes #4496 - this small PR uses `wrap_content` rather than `match_parent` for the store settings container. Using `matcb_parent` was causing the remaining settings to be off screen.

BEFORE:

![tablet](https://user-images.githubusercontent.com/3903757/127147466-9ef1a88f-af3c-470b-8d22-11a2a991e549.png)

AFTER:

![after](https://user-images.githubusercontent.com/3903757/127147491-1c1c55fb-ca15-46e7-86f6-84ae9dbba78f.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
