### PR TITLE
Issue/4421 Contacting support team regarding payments

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
+import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import com.woocommerce.android.AppPrefs
@@ -14,6 +15,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.databinding.ActivityHelpBinding
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.PackageUtils
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.fluxc.model.SiteModel
@@ -50,11 +52,16 @@ class HelpActivity : AppCompatActivity() {
         supportActionBar?.setHomeButtonEnabled(true)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-        binding.contactContainer.setOnClickListener { createNewZendeskTicket() }
-        binding.identityContainer.setOnClickListener { showIdentityDialog() }
+        binding.contactContainer.setOnClickListener { createNewZendeskTicket(TicketType.General) }
+        binding.identityContainer.setOnClickListener { showIdentityDialog(TicketType.General) }
         binding.myTicketsContainer.setOnClickListener { showZendeskTickets() }
         binding.faqContainer.setOnClickListener { showZendeskFaq() }
         binding.appLogContainer.setOnClickListener { showApplicationLog() }
+
+        with(binding.contactPaymentsContainer) {
+            visibility = if (FeatureFlag.CARD_READER.isEnabled()) View.VISIBLE else View.GONE
+            setOnClickListener { createNewZendeskTicket(TicketType.Payments) }
+        }
 
         binding.textVersion.text = getString(R.string.version_with_name_param, PackageUtils.getVersionName(this))
 
@@ -93,16 +100,22 @@ class HelpActivity : AppCompatActivity() {
         return super.onOptionsItemSelected(item)
     }
 
-    private fun createNewZendeskTicket() {
+    private fun createNewZendeskTicket(ticketType: TicketType) {
         if (!AppPrefs.hasSupportEmail()) {
-            showIdentityDialog()
+            showIdentityDialog(ticketType)
             return
         }
 
-        zendeskHelper.createNewTicket(this, originFromExtras, selectedSiteOrNull(), extraTagsFromExtras)
+        zendeskHelper.createNewTicket(
+            context = this,
+            origin = originFromExtras,
+            selectedSite = selectedSiteOrNull(),
+            extraTags = extraTagsFromExtras,
+            ticketType = ticketType,
+        )
     }
 
-    private fun showIdentityDialog() {
+    private fun showIdentityDialog(ticketType: TicketType) {
         val emailSuggestion = if (AppPrefs.hasSupportEmail()) {
             AppPrefs.getSupportEmail()
         } else {
@@ -113,7 +126,7 @@ class HelpActivity : AppCompatActivity() {
         supportHelper.showSupportIdentityInputDialog(this, emailSuggestion, isNameInputHidden = true) { email, _ ->
             zendeskHelper.setSupportEmail(email)
             AnalyticsTracker.track(Stat.SUPPORT_IDENTITY_SET)
-            createNewZendeskTicket()
+            createNewZendeskTicket(ticketType)
         }
         AnalyticsTracker.track(Stat.SUPPORT_IDENTITY_FORM_VIEWED)
     }
@@ -194,7 +207,7 @@ class HelpActivity : AppCompatActivity() {
         ): Intent {
             val intent = Intent(context, HelpActivity::class.java)
             intent.putExtra(ORIGIN_KEY, origin)
-            if (extraSupportTags != null && !extraSupportTags.isEmpty()) {
+            if (extraSupportTags != null && extraSupportTags.isNotEmpty()) {
                 intent.putStringArrayListExtra(EXTRA_TAGS_KEY, extraSupportTags as ArrayList<String>?)
             }
             return intent

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/ZendeskHelper.kt
@@ -2,9 +2,9 @@ package com.woocommerce.android.support
 
 import android.content.Context
 import android.net.ConnectivityManager
-import androidx.preference.PreferenceManager
 import android.telephony.TelephonyManager
 import android.text.TextUtils
+import androidx.preference.PreferenceManager
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -120,7 +120,8 @@ class ZendeskHelper(
         context: Context,
         origin: Origin?,
         selectedSite: SiteModel?,
-        extraTags: List<String>? = null
+        extraTags: List<String>? = null,
+        ticketType: TicketType = TicketType.General,
     ) {
         require(isZendeskEnabled) {
             zendeskNeedsToBeEnabledError
@@ -132,7 +133,17 @@ class ZendeskHelper(
             .withShowConversationsMenuButton(isIdentitySet)
         AnalyticsTracker.track(Stat.SUPPORT_HELP_CENTER_VIEWED)
         if (isIdentitySet) {
-            builder.show(context, buildZendeskConfig(context, siteStore.sites, origin, selectedSite, extraTags))
+            builder.show(
+                context,
+                buildZendeskConfig(
+                    context,
+                    ticketType,
+                    siteStore.sites,
+                    origin,
+                    selectedSite,
+                    extraTags
+                )
+            )
         } else {
             builder.show(context)
         }
@@ -148,13 +159,21 @@ class ZendeskHelper(
         context: Context,
         origin: Origin?,
         selectedSite: SiteModel?,
-        extraTags: List<String>? = null
+        extraTags: List<String>? = null,
+        ticketType: TicketType = TicketType.General,
     ) {
         require(isZendeskEnabled) {
             zendeskNeedsToBeEnabledError
         }
         requireIdentity(context, selectedSite) {
-            val config = buildZendeskConfig(context, siteStore.sites, origin, selectedSite, extraTags)
+            val config = buildZendeskConfig(
+                context,
+                ticketType,
+                siteStore.sites,
+                origin,
+                selectedSite,
+                extraTags
+            )
             RequestActivity.builder().show(context, config)
         }
     }
@@ -168,14 +187,18 @@ class ZendeskHelper(
         context: Context,
         origin: Origin?,
         selectedSite: SiteModel? = null,
-        extraTags: List<String>? = null
+        extraTags: List<String>? = null,
+        ticketType: TicketType = TicketType.General,
     ) {
         require(isZendeskEnabled) {
             zendeskNeedsToBeEnabledError
         }
         requireIdentity(context, selectedSite) {
             RequestListActivity.builder()
-                .show(context, buildZendeskConfig(context, siteStore.sites, origin, selectedSite, extraTags))
+                .show(
+                    context,
+                    buildZendeskConfig(context, ticketType, siteStore.sites, origin, selectedSite, extraTags)
+                )
         }
     }
 
@@ -353,16 +376,18 @@ class ZendeskHelper(
  */
 private fun buildZendeskConfig(
     context: Context,
+    ticketType: TicketType,
     allSites: List<SiteModel>?,
     origin: Origin?,
     selectedSite: SiteModel? = null,
     extraTags: List<String>? = null
 ): Configuration {
-    val customFields = buildZendeskCustomFields(context, allSites, selectedSite)
+    val customFields = buildZendeskCustomFields(context, ticketType, allSites, selectedSite)
+    val extraTagsWithTicketTypeTags = (extraTags ?: emptyList()) + ticketType.tags
     return RequestActivity.builder()
-        .withTicketForm(TicketFieldIds.form, customFields)
+        .withTicketForm(ticketType.form, customFields)
         .withRequestSubject(ZendeskConstants.ticketSubject)
-        .withTags(buildZendeskTags(allSites, origin ?: Origin.UNKNOWN, extraTags))
+        .withTags(buildZendeskTags(allSites, origin ?: Origin.UNKNOWN, extraTagsWithTicketTypeTags))
         .config()
 }
 
@@ -380,6 +405,7 @@ private fun getHomeURLOrHostName(site: SiteModel): String {
  */
 private fun buildZendeskCustomFields(
     context: Context,
+    ticketType: TicketType,
     allSites: List<SiteModel>?,
     selectedSite: SiteModel?
 ): List<CustomField> {
@@ -390,7 +416,7 @@ private fun buildZendeskCustomFields(
     }
     return listOf(
         CustomField(TicketFieldIds.categoryId, ZendeskConstants.categoryValue),
-        CustomField(TicketFieldIds.subcategoryId, ZendeskConstants.subcategoryValue),
+        CustomField(TicketFieldIds.subcategoryId, ticketType.subcategoryName),
         CustomField(TicketFieldIds.appVersion, PackageUtils.getVersionName(context)),
         CustomField(TicketFieldIds.blogList, getCombinedLogInformationOfSites(allSites)),
         CustomField(TicketFieldIds.currentSite, currentSiteInformation),
@@ -440,7 +466,7 @@ private fun getCombinedLogInformationOfSites(allSites: List<SiteModel>?): String
  * This is a helper function which returns a set of pre-defined tags depending on some conditions. It accepts a list of
  * custom tags to be added for special cases.
  */
-private fun buildZendeskTags(allSites: List<SiteModel>?, origin: Origin, extraTags: List<String>?): List<String> {
+private fun buildZendeskTags(allSites: List<SiteModel>?, origin: Origin, extraTags: List<String>): List<String> {
     val tags = ArrayList<String>()
     allSites?.let { it ->
         // Add wpcom tag if at least one site is WordPress.com site
@@ -461,9 +487,7 @@ private fun buildZendeskTags(allSites: List<SiteModel>?, origin: Origin, extraTa
     tags.add(origin.toString())
     // Add Android tag to make it easier to filter tickets by platform
     tags.add(ZendeskConstants.platformTag)
-    extraTags?.let {
-        tags.addAll(it)
-    }
+    tags.addAll(extraTags)
     return tags
 }
 
@@ -493,13 +517,15 @@ private object ZendeskConstants {
     const val jetpackTag = "jetpack"
     const val mobileHelpCategoryId = 360000041586
     const val categoryValue = "Support"
-    const val subcategoryValue = "WooCommerce Mobile Apps"
+    const val subcategoryGeneralValue = "WooCommerce Mobile Apps"
+    const val subcategoryPaymentsValue = "payment"
     const val networkWifi = "WiFi"
     const val networkWWAN = "Mobile"
     const val networkTypeLabel = "Network Type:"
     const val networkCarrierLabel = "Carrier:"
     const val networkCountryCodeLabel = "Country Code:"
     const val noneValue = "none"
+
     // We rely on this platform tag to filter tickets in Zendesk, so should be kept separate from the `articleLabel`
     const val platformTag = "Android"
     const val sourcePlatform = "Mobile_-_Woo_Android"
@@ -512,16 +538,44 @@ private object TicketFieldIds {
     const val appVersion = 360000086866L
     const val blogList = 360000087183L
     const val deviceFreeSpace = 360000089123L
-    const val form = 360000010286L
+    const val formGeneral = 360000010286L
+    const val formPayments = 189946L
+    const val categoryId = 25176003L
+    const val subcategoryId = 25176023L
     const val logs = 22871957L
     const val networkInformation = 360000086966L
     const val currentSite = 360000103103L
     const val appLanguage = 360008583691L
     const val sourcePlatform = 360009311651L
-    const val categoryId = 25176003L
-    const val subcategoryId = 25176023L
+}
+
+sealed class TicketType(
+    val form: Long,
+    val subcategoryName: String,
+    val tags: List<String> = emptyList(),
+) {
+    object General : TicketType(
+        form = TicketFieldIds.formGeneral,
+        subcategoryName = ZendeskConstants.subcategoryGeneralValue,
+    )
+
+    object Payments : TicketType(
+        form = TicketFieldIds.formPayments,
+        subcategoryName = ZendeskConstants.subcategoryPaymentsValue,
+        tags = arrayListOf(
+            ZendeskExtraTags.paymentsProduct,
+            ZendeskExtraTags.paymentsCategory,
+            ZendeskExtraTags.paymentsSubcategory,
+            ZendeskExtraTags.paymentsProductArea
+        )
+    )
 }
 
 object ZendeskExtraTags {
     const val connectingJetpack = "connecting_jetpack"
+
+    const val paymentsCategory = "support"
+    const val paymentsSubcategory = "payment"
+    const val paymentsProduct = "woocommerce_payments"
+    const val paymentsProductArea = "product_area_woo_payment_gateway"
 }

--- a/WooCommerce/src/main/res/layout/activity_help.xml
+++ b/WooCommerce/src/main/res/layout/activity_help.xml
@@ -50,6 +50,13 @@
                 app:optionValue="@string/support_contact_detail"/>
 
             <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+                android:id="@+id/contactPaymentsContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:optionTitle="@string/support_contact_payments"
+                app:optionValue="@string/support_contact_payments_detail"/>
+
+            <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
                 android:id="@+id/myTicketsContainer"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1279,6 +1279,8 @@
     <string name="support_contact_detail">Reach our happiness engineers who can help answer tough questions</string>
     <string name="support_my_tickets">My tickets</string>
     <string name="support_my_tickets_detail">View previously submitted support tickets</string>
+    <string name="support_contact_payments">Contact Payments Support</string>
+    <string name="support_contact_payments_detail">Reach our happiness engineers who can help answer tough questions</string>
     <string name="support_application_log">Application log</string>
     <string name="support_application_log_detail">Advanced tool to review the app status</string>
     <string name="help">Help</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1280,7 +1280,7 @@
     <string name="support_my_tickets">My tickets</string>
     <string name="support_my_tickets_detail">View previously submitted support tickets</string>
     <string name="support_contact_payments">Contact Payments Support</string>
-    <string name="support_contact_payments_detail">Reach our happiness engineers who can help answer tough questions</string>
+    <string name="support_contact_payments_detail">Reach our happiness engineers who can help answer payments related questions</string>
     <string name="support_application_log">Application log</string>
     <string name="support_application_log_detail">Advanced tool to review the app status</string>
     <string name="help">Help</string>


### PR DESCRIPTION
Resolves #4421 

The PR adds a contact payment support button on the help `Help & Support` screen. The button should be visible only for the websites which are rolled out for the Beta testing


<img width="407" alt="Screenshot 2021-07-28 at 09 52 13" src="https://user-images.githubusercontent.com/4923871/127270839-c72fbc99-e897-4dae-8359-4174a4d9ac17.png">
<img width="405" alt="Screenshot 2021-07-28 at 09 51 44" src="https://user-images.githubusercontent.com/4923871/127270846-443514d8-9f4c-4854-b0dc-88820da38d73.png">

---
### How to test
* First, check that the call for support only shows up in stores eligible for In-Person Payments. To do so, navigate to Settings > Help & Support and check the contents of the table. Switch stores and test that the call out shows up in eligible stores, and does not show up in stores that are not setup to take In-Person Payments
* Second, check that the requests are tagged properly. Requests sent through the regular queue should be tagged exactly how the production app does. Requests sent through the WCPay queue should be tagged like this one 4166955-zd-woothemes (see pbUcTB-kn-p2 for context)

Examples:

* "Payments" ticket: 4177407-zd-woothemes
* "General" ticket: 4177198-zd-woothemes


### Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to RELEASE-NOTES.txt if necessary.