### PR TITLE
Shipping Labels: print multiple commercial invoices

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.orders
 
 import com.woocommerce.android.model.Order
-import com.woocommerce.android.model.ShippingLabel
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelPaperSizeSelectorDialog.ShippingLabelPaperSize
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders
 
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.model.ShippingLabel
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelPaperSizeSelectorDialog.ShippingLabelPaperSize
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 
@@ -48,7 +49,7 @@ sealed class OrderNavigationTarget : Event() {
     object ViewCreateShippingLabelInfo : OrderNavigationTarget()
     object ViewPrintShippingLabelInfo : OrderNavigationTarget()
     object ViewShippingLabelFormatOptions : OrderNavigationTarget()
-    data class ViewPrintCustomsForm(val invoiceUrl: String, val isReprint: Boolean) : OrderNavigationTarget()
+    data class ViewPrintCustomsForm(val invoices: List<String>, val isReprint: Boolean) : OrderNavigationTarget()
     data class StartShippingLabelCreationFlow(val orderIdentifier: String) : OrderNavigationTarget()
     object StartCardReaderConnectFlow : OrderNavigationTarget()
     data class StartCardReaderPaymentFlow(val orderIdentifier: String) : OrderNavigationTarget()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
@@ -122,13 +122,13 @@ class OrderNavigator @Inject constructor() {
                 val action = if (target.isReprint) {
                     OrderDetailFragmentDirections
                         .actionOrderDetailFragmentToPrintShippingLabelCustomsFormFragment(
-                            url = target.invoiceUrl,
+                            invoices = target.invoices.toTypedArray(),
                             isReprint = target.isReprint
                         )
                 } else {
                     PrintShippingLabelFragmentDirections
                         .actionPrintShippingLabelFragmentToPrintShippingLabelCustomsFormFragment(
-                            url = target.invoiceUrl,
+                            invoices = target.invoices.toTypedArray(),
                             isReprint = target.isReprint
                         )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -291,7 +291,7 @@ class OrderDetailViewModel @Inject constructor(
 
     fun onPrintCustomsFormClicked(shippingLabel: ShippingLabel) {
         shippingLabel.commercialInvoiceUrl?.let {
-            triggerEvent(ViewPrintCustomsForm(it, isReprint = true))
+            triggerEvent(ViewPrintCustomsForm(listOf(it), isReprint = true))
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelCustomsFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelCustomsFormFragment.kt
@@ -64,7 +64,7 @@ class PrintShippingLabelCustomsFormFragment :
             new.isProgressDialogShown.takeIfNotEqualTo(old?.isProgressDialogShown) {
                 showProgressDialog(it)
             }
-            new.hasMultipleInvoices.takeIfNotEqualTo(old?.hasMultipleInvoices) {
+            new.showInvoicesAsAList.takeIfNotEqualTo(old?.showInvoicesAsAList) {
                 binding.invoicesList.isVisible = it
                 binding.printButton.isVisible = !it
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelCustomsFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelCustomsFormFragment.kt
@@ -36,8 +36,7 @@ class PrintShippingLabelCustomsFormFragment :
     BaseFragment(R.layout.fragment_print_label_customs_form), BackPressListener {
     private val viewModel: PrintShippingLabelCustomsFormViewModel by viewModels()
 
-    @Inject
-    lateinit var uiMessageResolver: UIMessageResolver
+    @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     private var progressDialog: CustomProgressDialog? = null
     private val navArgs: PrintShippingLabelCustomsFormFragmentArgs by navArgs()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelCustomsFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelCustomsFormFragment.kt
@@ -2,18 +2,25 @@ package com.woocommerce.android.ui.orders.shippinglabels
 
 import android.os.Bundle
 import android.os.Environment
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentPrintLabelCustomsFormBinding
+import com.woocommerce.android.databinding.PrintCustomsFormListItemBinding
 import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
+import com.woocommerce.android.ui.orders.shippinglabels.PrintCustomsFormAdapter.PrintCustomsFormViewHolder
 import com.woocommerce.android.ui.orders.shippinglabels.PrintShippingLabelCustomsFormViewModel.PrintCustomsForm
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -28,10 +35,14 @@ import javax.inject.Inject
 class PrintShippingLabelCustomsFormFragment :
     BaseFragment(R.layout.fragment_print_label_customs_form), BackPressListener {
     private val viewModel: PrintShippingLabelCustomsFormViewModel by viewModels()
-    @Inject lateinit var uiMessageResolver: UIMessageResolver
+
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
 
     private var progressDialog: CustomProgressDialog? = null
     private val navArgs: PrintShippingLabelCustomsFormFragmentArgs by navArgs()
+
+    private val invoicesAdapter by lazy { PrintCustomsFormAdapter(viewModel::onInvoicePrintButtonClicked) }
 
     override fun getFragmentTitle(): String = getString(R.string.shipping_label_print_customs_form_screen_title)
 
@@ -44,14 +55,21 @@ class PrintShippingLabelCustomsFormFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val binding = FragmentPrintLabelCustomsFormBinding.bind(view)
-        setupObservers()
+        setupObservers(binding)
         setupView(binding)
     }
 
-    private fun setupObservers() {
+    private fun setupObservers(binding: FragmentPrintLabelCustomsFormBinding) {
         viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
             new.isProgressDialogShown.takeIfNotEqualTo(old?.isProgressDialogShown) {
                 showProgressDialog(it)
+            }
+            new.hasMultipleInvoices.takeIfNotEqualTo(old?.hasMultipleInvoices) {
+                binding.invoicesList.isVisible = it
+                binding.printButton.isVisible = !it
+            }
+            new.commercialInvoices.takeIfNotEqualTo(old?.commercialInvoices) {
+                invoicesAdapter.invoices = it
             }
         }
 
@@ -76,6 +94,10 @@ class PrintShippingLabelCustomsFormFragment :
 
     private fun setupView(binding: FragmentPrintLabelCustomsFormBinding) {
         binding.saveForLaterButton.isVisible = !navArgs.isReprint
+        binding.invoicesList.apply {
+            layoutManager = LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false)
+            adapter = invoicesAdapter
+        }
         binding.printButton.setOnClickListener {
             viewModel.onPrintButtonClicked()
         }
@@ -102,5 +124,40 @@ class PrintShippingLabelCustomsFormFragment :
     override fun onRequestAllowBackPress(): Boolean {
         viewModel.onBackButtonClicked()
         return false
+    }
+}
+
+class PrintCustomsFormAdapter(
+    private val onPrintClicked: (String) -> Unit
+) : RecyclerView.Adapter<PrintCustomsFormViewHolder>() {
+    var invoices: List<String> = emptyList()
+        set(value) {
+            field = value
+            notifyDataSetChanged()
+        }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PrintCustomsFormViewHolder {
+        return PrintCustomsFormViewHolder(
+            PrintCustomsFormListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        )
+    }
+
+    override fun onBindViewHolder(holder: PrintCustomsFormViewHolder, position: Int) {
+        holder.bind(position)
+    }
+
+    override fun getItemCount(): Int = invoices.size
+
+    inner class PrintCustomsFormViewHolder(val binding: PrintCustomsFormListItemBinding) : ViewHolder(binding.root) {
+        fun bind(position: Int) {
+            val context = binding.root.context
+            binding.packageTitle.text = context.getString(
+                R.string.shipping_label_package_details_title_template,
+                position + 1
+            )
+            binding.printButton.setOnClickListener {
+                onPrintClicked(invoices[position])
+            }
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelCustomsFormViewModel.kt
@@ -71,7 +71,7 @@ class PrintShippingLabelCustomsFormViewModel @Inject constructor(
             prefix = "PDF",
             fileExtension = "pdf"
         ) ?: return null
-        return if (fileDownloader.downloadFile(navArgs.url, file)) {
+        return if (fileDownloader.downloadFile(navArgs.invoices.first(), file)) {
             file
         } else {
             null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelCustomsFormViewModel.kt
@@ -93,7 +93,7 @@ class PrintShippingLabelCustomsFormViewModel @Inject constructor(
         val isProgressDialogShown: Boolean = false
     ) : Parcelable {
         @IgnoredOnParcel
-        val hasMultipleInvoices
+        val showInvoicesAsAList
             get() = commercialInvoices.size > 1
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelViewModel.kt
@@ -127,11 +127,10 @@ class PrintShippingLabelViewModel @Inject constructor(
 
     fun onPreviewLabelCompleted() {
         viewState = viewState.copy(tempFile = null, previewShippingLabel = null)
-        labels.first()?.let {
-            if (it.hasCommercialInvoice) {
-                triggerEvent(ViewPrintCustomsForm(it.commercialInvoiceUrl!!, arguments.isReprint))
-            }
-        }
+        labels.filter { it?.hasCommercialInvoice == true }
+            .map { it!!.commercialInvoiceUrl!! }
+            .takeIf { it.isNotEmpty() }
+            ?.let { triggerEvent(ViewPrintCustomsForm(it, arguments.isReprint)) }
     }
 
     private suspend fun handlePreviewError() {

--- a/WooCommerce/src/main/res/layout/fragment_print_label_customs_form.xml
+++ b/WooCommerce/src/main/res/layout/fragment_print_label_customs_form.xml
@@ -63,6 +63,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/major_100"
+            android:layout_marginBottom="@dimen/major_100"
             android:text="@string/shipping_label_print_save_for_later"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/WooCommerce/src/main/res/layout/fragment_print_label_customs_form.xml
+++ b/WooCommerce/src/main/res/layout/fragment_print_label_customs_form.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fillViewport="true">
@@ -9,8 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center_horizontal"
-        android:orientation="vertical"
-        android:paddingHorizontal="@dimen/major_100">
+        android:orientation="vertical">
 
         <com.google.android.material.textview.MaterialTextView
             android:layout_width="wrap_content"
@@ -36,11 +36,21 @@
             android:textAppearance="?attr/textAppearanceBody2"
             android:textColor="@color/color_on_surface_high" />
 
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/invoices_list"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="@dimen/major_200"
+            android:layout_weight="1"
+            tools:itemCount="2"
+            tools:listitem="@layout/print_customs_form_list_item" />
+
         <com.google.android.material.button.MaterialButton
             android:id="@+id/print_button"
             style="@style/Woo.Button.Colored"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/major_100"
             android:layout_marginTop="@dimen/major_200"
             android:text="@string/shipping_label_print_customs_form"
             app:layout_constraintEnd_toEndOf="parent"
@@ -52,6 +62,7 @@
             style="@style/Woo.Button.Outlined"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/major_100"
             android:text="@string/shipping_label_print_save_for_later"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/WooCommerce/src/main/res/layout/print_customs_form_list_item.xml
+++ b/WooCommerce/src/main/res/layout/print_customs_form_list_item.xml
@@ -15,6 +15,8 @@
         app:layout_constraintEnd_toStartOf="@id/print_button"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        android:textAppearance="?attr/textAppearanceSubtitle1"
+        android:textStyle="bold"
         tools:text="Package 1" />
 
     <com.google.android.material.button.MaterialButton

--- a/WooCommerce/src/main/res/layout/print_customs_form_list_item.xml
+++ b/WooCommerce/src/main/res/layout/print_customs_form_list_item.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/package_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/major_100"
+        app:layout_constraintBottom_toTopOf="@id/divider"
+        app:layout_constraintEnd_toStartOf="@id/print_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Package 1" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/print_button"
+        style="@style/Woo.Button.TextButton.Secondary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@id/divider"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Print" />
+
+    <View
+        android:id="@+id/divider"
+        style="@style/Woo.Divider"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/print_customs_form_list_item.xml
+++ b/WooCommerce/src/main/res/layout/print_customs_form_list_item.xml
@@ -22,10 +22,10 @@
         style="@style/Woo.Button.TextButton.Secondary"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:text="@string/shipping_label_multiple_customs_form_print_button"
         app:layout_constraintBottom_toTopOf="@id/divider"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="Print" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <View
         android:id="@+id/divider"

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -77,8 +77,8 @@
         android:label="PrintShippingLabelCustomsFormFragment"
         tools:layout="@layout/fragment_print_label_customs_form">
         <argument
-            android:name="url"
-            app:argType="string" />
+            android:name="invoices"
+            app:argType="string[]" />
         <argument
             android:name="isReprint"
             app:argType="boolean" />

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -616,6 +616,7 @@
     <string name="shipping_label_customs_form">Customs form</string>
     <string name="shipping_label_print_customs_explanation">A customs form must be printed and included on this international shipment</string>
     <string name="shipping_label_print_customs_form">Print customs form</string>
+    <string name="shipping_label_multiple_customs_form_print_button">Print</string>
     <string name="shipping_label_print_customs_form_screen_title">Print customs invoice</string>
     <string name="shipping_label_print_customs_form_download_failed">Error downloading the customs form</string>
     <string name="shipping_label_move_item_dialog_title">Move item</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelCustomsFormViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelCustomsFormViewModelTest.kt
@@ -26,13 +26,17 @@ class PrintShippingLabelCustomsFormViewModelTest : BaseUnitTest() {
     private val fileDownloader: FileDownloader = mock()
     private val fileUtils: FileUtils = mock()
     private val storageDirectory: File = File(".")
-    private val url = "test_url"
+    private var urls = mutableListOf("test_url")
 
     @Before
     fun setup() {
         whenever(fileUtils.createTempTimeStampedFile(any(), any(), any())).thenReturn(File("./test"))
+        initViewModel()
+    }
+
+    fun initViewModel() {
         viewModel = PrintShippingLabelCustomsFormViewModel(
-            savedStateHandle = PrintShippingLabelCustomsFormFragmentArgs(url, true).initSavedStateHandle(),
+            savedStateHandle = PrintShippingLabelCustomsFormFragmentArgs(urls.toTypedArray(), true).initSavedStateHandle(),
             fileDownloader = fileDownloader,
             fileUtils = fileUtils
         )
@@ -40,14 +44,14 @@ class PrintShippingLabelCustomsFormViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `start download when print button is clicked`() = testBlocking {
+    fun `when print button is clicked, then start download`() = testBlocking {
         viewModel.onPrintButtonClicked()
 
         verify(fileDownloader).downloadFile(any(), any())
     }
 
     @Test
-    fun `open pdf reader when download is complete`() = testBlocking {
+    fun `when download is complete, then print file`() = testBlocking {
         whenever(fileDownloader.downloadFile(any(), any())).thenReturn(true)
 
         viewModel.onPrintButtonClicked()
@@ -56,7 +60,7 @@ class PrintShippingLabelCustomsFormViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `show error when the file creation fails`() = testBlocking {
+    fun `when file creation fails, then show an error`() = testBlocking {
         whenever(fileUtils.createTempTimeStampedFile(any(), any(), any())).thenReturn(null)
 
         viewModel.onPrintButtonClicked()
@@ -66,7 +70,7 @@ class PrintShippingLabelCustomsFormViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `show error when the file download fails`() = testBlocking {
+    fun `when the file download fails, then show an error`() = testBlocking {
         whenever(fileDownloader.downloadFile(any(), any())).thenReturn(false)
 
         viewModel.onPrintButtonClicked()
@@ -76,7 +80,7 @@ class PrintShippingLabelCustomsFormViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `navigates back when save for later is clicked`() = testBlocking {
+    fun `when save for later is clicked, then navigate back`() = testBlocking {
         viewModel.onSaveForLaterClicked()
 
         assertThat(viewModel.event.value)
@@ -84,10 +88,33 @@ class PrintShippingLabelCustomsFormViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `navigates back when back button is clicked`() = testBlocking {
+    fun `when back button is clicked, then navigate back`() = testBlocking {
         viewModel.onBackButtonClicked()
 
         assertThat(viewModel.event.value)
             .isEqualTo(Exit)
+    }
+
+    @Test
+    fun `when there are multiple invoices, then show a list`() = testBlocking {
+        urls.add("second_url")
+
+        initViewModel()
+
+        assertThat(viewModel.viewStateData.liveData.value?.showInvoicesAsAList).isTrue
+        assertThat(viewModel.viewStateData.liveData.value?.commercialInvoices?.size).isEqualTo(2)
+    }
+
+    @Test
+    fun `given there are multiple invoices, when print is clicked, then start download`() = testBlocking {
+        val url = "second_url"
+        urls.add(url)
+        whenever(fileDownloader.downloadFile(any(), any())).thenReturn(true)
+
+        initViewModel()
+        viewModel.onInvoicePrintButtonClicked(url)
+
+        verify(fileDownloader).downloadFile(any(), any())
+        assertThat(viewModel.event.value).isInstanceOf(PrintCustomsForm::class.java)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelCustomsFormViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelCustomsFormViewModelTest.kt
@@ -36,7 +36,8 @@ class PrintShippingLabelCustomsFormViewModelTest : BaseUnitTest() {
 
     fun initViewModel() {
         viewModel = PrintShippingLabelCustomsFormViewModel(
-            savedStateHandle = PrintShippingLabelCustomsFormFragmentArgs(urls.toTypedArray(), true).initSavedStateHandle(),
+            savedStateHandle = PrintShippingLabelCustomsFormFragmentArgs(urls.toTypedArray(), true)
+                .initSavedStateHandle(),
             fileDownloader = fileDownloader,
             fileUtils = fileUtils
         )


### PR DESCRIPTION
Finishes #4444, this adds support for printing multiple commercial invoices after a shipping label purchase.

<img width=360 src="https://user-images.githubusercontent.com/1657201/127187318-46156577-f925-41b7-b03c-b699052b05b5.png"/>

please don't merge before #4487 is merged.

#### Testing
1. Create a multi-item order that's eligible for shipping label creation.
2. Open the order details in the app.
3. Click on Create shipping label.
4. Make sure that the shipping address is international if it wasn't done in step one.
5. In the packaging step, move items to different packages.
6. Select dhl express in the rates step.
7. Complete the purchase process.
8. Print the label.
9. Confirm that the customs form screen is displayed with multiple invoices.
10. Test printing each invoice, and confirm that it works.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
