### PR TITLE
change background colour on image selection screen

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_product_images.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_images.xml
@@ -5,6 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
+    android:background="@color/color_surface"
     tools:context="com.woocommerce.android.ui.products.ProductImagesFragment">
 
     <com.google.android.material.button.MaterialButton


### PR DESCRIPTION
Fixes #3818

## Changes

Set the background colour for the image selection fragment to "@color/color_surface" to make it white as opposed to the current grey. 

## Screenshots

Please note there is no change on the Dark Theme

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/127225226-55fa545f-4aea-4517-8f2f-f77ab9b33f3a.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/127225302-420c1f5e-e9f1-49c4-b0e5-0012d38e45d1.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/30724184/127225383-7b20037e-263f-43e8-b0a2-a1463185e0bc.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/127225415-9b8467ab-db55-4924-8a19-f732e8b44ad4.png" width="350"/> |

Also, this was affecting not only the Variation image selection screens but the simple products as well and this change applies to all of them:

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/127225816-dc8b6df7-8f2e-4bb4-94b9-41cbacde8544.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/127225857-89d17d81-67b0-49ff-81ec-80247c1b0868.png" width="350"/> |


## Steps to Reproduce it

- Navigate to the products screen 
- Click on a product (it can be a single, variable, virtual) and tap on the option to add a product image
- note the fragment background for the image gallery is grey

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
