### PR TITLE
Clear card present payments eligibility on site switch

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
@@ -89,6 +89,7 @@ class SitePickerPresenter
     override fun fetchUserRoleFromAPI(site: SiteModel) {
         coroutineScope.launch {
             val fetchUserJob = async { userEligibilityFetcher.fetchUserInfo() }
+            AppPrefs.setIsCardPresentEligible(false)
             async { cardPresentEligibleFeatureChecker.doCheck() }.await()
             val userModel = fetchUserJob.await()
             view?.hideProgressDialog()


### PR DESCRIPTION
This PR fixes an issue with the card present payments feature flag.

1. Select a site which is eligible for card present paymetns
2. Open App settings and notice "Manage card reader" is visible
3. Select a site which doesn't have WCPay installed
4. Notice "Manage card reader" is not visible in the settings 

Before this PR the "Manage card reader" was visible in step 4 -> the flag was getting updated [only when the request succeeded](https://github.com/woocommerce/woocommerce-android/blob/4716d17c43697a56b3d5fb52b035479d6c599e97/WooCommerce/src/main/kotlin/com/woocommerce/android/util/payment/CardPresentEligibleFeatureChecker.kt#L18).


cc @jkmassel This PR is targeting a frozen branch - it fixes an edge case scenario but I still think it's worth including it in 7.2 if possible. Thanks




Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
