### PR TITLE
Issue/4351 save for latter button

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
@@ -96,6 +96,9 @@ class CardReaderPaymentDialog : DialogFragment(R.layout.dialog_card_reader_payme
                 binding.secondaryActionBtn.setOnClickListener {
                     viewState.onSecondaryActionClicked?.invoke()
                 }
+                binding.tertiaryActionBtn.setOnClickListener {
+                    viewState.onTertiaryActionClicked?.invoke()
+                }
             }
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialog.kt
@@ -10,7 +10,7 @@ import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.databinding.FragmentCardReaderPaymentBinding
+import com.woocommerce.android.databinding.DialogCardReaderPaymentBinding
 import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -25,7 +25,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class CardReaderPaymentDialog : DialogFragment(R.layout.fragment_card_reader_payment) {
+class CardReaderPaymentDialog : DialogFragment(R.layout.dialog_card_reader_payment) {
     val viewModel: CardReaderPaymentViewModel by viewModels()
     @Inject lateinit var printHtmlHelper: PrintHtmlHelper
     @Inject lateinit var uiMessageResolver: UIMessageResolver
@@ -50,7 +50,7 @@ class CardReaderPaymentDialog : DialogFragment(R.layout.fragment_card_reader_pay
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val binding = FragmentCardReaderPaymentBinding.bind(view)
+        val binding = DialogCardReaderPaymentBinding.bind(view)
 
         initObservers(binding)
         initViewModel()
@@ -60,7 +60,7 @@ class CardReaderPaymentDialog : DialogFragment(R.layout.fragment_card_reader_pay
         viewModel.start()
     }
 
-    private fun initObservers(binding: FragmentCardReaderPaymentBinding) {
+    private fun initObservers(binding: DialogCardReaderPaymentBinding) {
         viewModel.event.observe(
             viewLifecycleOwner,
             { event ->
@@ -88,6 +88,7 @@ class CardReaderPaymentDialog : DialogFragment(R.layout.fragment_card_reader_pay
                 UiHelpers.setTextOrHide(binding.hintLabel, viewState.hintLabel)
                 UiHelpers.setTextOrHide(binding.primaryActionBtn, viewState.primaryActionLabel)
                 UiHelpers.setTextOrHide(binding.secondaryActionBtn, viewState.secondaryActionLabel)
+                UiHelpers.setTextOrHide(binding.tertiaryActionBtn, viewState.tertiaryActionLabel)
                 UiHelpers.updateVisibility(binding.progressBarWrapper, viewState.isProgressVisible)
                 binding.primaryActionBtn.setOnClickListener {
                     viewState.onPrimaryActionClicked?.invoke()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -231,7 +231,7 @@ class CardReaderPaymentViewModel
                     order.getAmountLabel(),
                     { onPrintReceiptClicked(amountLabel, receiptUrl, order.getReceiptDocumentName()) },
                     { onSendReceiptClicked(receiptUrl, order.billingAddress.email) },
-                    { triggerEvent(Exit) }
+                    { onBackPressed() }
                 )
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -230,7 +230,8 @@ class CardReaderPaymentViewModel
                 PaymentSuccessfulState(
                     order.getAmountLabel(),
                     { onPrintReceiptClicked(amountLabel, receiptUrl, order.getReceiptDocumentName()) },
-                    { onSendReceiptClicked(receiptUrl, order.billingAddress.email) }
+                    { onSendReceiptClicked(receiptUrl, order.billingAddress.email) },
+                    { triggerEvent(Exit) }
                 )
             )
         }
@@ -350,10 +351,12 @@ class CardReaderPaymentViewModel
         // TODO cardreader add tests
         open val isProgressVisible: Boolean = false,
         val primaryActionLabel: Int? = null,
-        val secondaryActionLabel: Int? = null
+        val secondaryActionLabel: Int? = null,
+        val tertiaryActionLabel: Int? = null,
     ) {
         open val onPrimaryActionClicked: (() -> Unit)? = null
         open val onSecondaryActionClicked: (() -> Unit)? = null
+        open val onTertiaryActionClicked: (() -> Unit)? = null
         open val amountWithCurrencyLabel: String? = null
 
         object LoadingDataState : ViewState(
@@ -403,12 +406,14 @@ class CardReaderPaymentViewModel
         data class PaymentSuccessfulState(
             override val amountWithCurrencyLabel: String,
             override val onPrimaryActionClicked: (() -> Unit),
-            override val onSecondaryActionClicked: (() -> Unit)
+            override val onSecondaryActionClicked: (() -> Unit),
+            override val onTertiaryActionClicked: (() -> Unit)
         ) : ViewState(
             headerLabel = R.string.card_reader_payment_completed_payment_header,
             illustration = R.drawable.img_celebration,
             primaryActionLabel = R.string.card_reader_payment_print_receipt,
-            secondaryActionLabel = R.string.card_reader_payment_send_receipt
+            secondaryActionLabel = R.string.card_reader_payment_send_receipt,
+            tertiaryActionLabel = R.string.card_reader_payment_save_for_later,
         )
 
         data class PrintingReceiptState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -231,10 +231,14 @@ class CardReaderPaymentViewModel
                     order.getAmountLabel(),
                     { onPrintReceiptClicked(amountLabel, receiptUrl, order.getReceiptDocumentName()) },
                     { onSendReceiptClicked(receiptUrl, order.billingAddress.email) },
-                    { onBackPressed() }
+                    { onSaveForLaterClicked() }
                 )
             )
         }
+    }
+
+    private fun onSaveForLaterClicked() {
+        onBackPressed()
     }
 
     private fun onPrintReceiptClicked(amountWithCurrencyLabel: String, receiptUrl: String, documentName: String) {

--- a/WooCommerce/src/main/res/layout/dialog_card_reader_payment.xml
+++ b/WooCommerce/src/main/res/layout/dialog_card_reader_payment.xml
@@ -120,8 +120,19 @@
             android:layout_marginHorizontal="@dimen/major_200"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/tertiary_action_btn"
             tools:text="Print receipt" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/tertiary_action_btn"
+            style="@style/Woo.Button.TextButton.Secondary"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/major_200"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            tools:text="Save for later" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </FrameLayout>

--- a/WooCommerce/src/main/res/layout/dialog_card_reader_payment.xml
+++ b/WooCommerce/src/main/res/layout/dialog_card_reader_payment.xml
@@ -32,7 +32,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_small_medium"
-            app:layout_constraintBottom_toTopOf="@id/illustration"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/header_label"
@@ -42,7 +41,7 @@
             android:id="@+id/illustration"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/major_175"
+            android:layout_marginTop="@dimen/major_125"
             android:contentDescription="@null"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -61,9 +60,9 @@
 
             <ProgressBar
                 android:id="@+id/progress_bar"
-                android:layout_marginTop="@dimen/minor_25"
                 android:layout_width="@dimen/progress_bar_large"
-                android:layout_height="@dimen/progress_bar_large" />
+                android:layout_height="@dimen/progress_bar_large"
+                android:layout_marginTop="@dimen/minor_25" />
         </FrameLayout>
 
         <androidx.constraintlayout.widget.Barrier
@@ -106,10 +105,9 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/major_200"
-            android:layout_marginBottom="@dimen/minor_100"
+            app:layout_constraintBottom_toTopOf="@id/secondary_action_btn"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintBottom_toTopOf="@id/secondary_action_btn"
             tools:text="Send receipt" />
 
         <com.google.android.material.button.MaterialButton
@@ -118,20 +116,21 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/major_200"
+            app:layout_constraintBottom_toTopOf="@id/tertiary_action_btn"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintBottom_toTopOf="@id/tertiary_action_btn"
             tools:text="Print receipt" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/tertiary_action_btn"
-            style="@style/Woo.Button.TextButton.Secondary"
+            style="@style/Woo.Button.TextButton"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/major_200"
+            android:textAllCaps="false"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
             tools:text="Save for later" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -758,6 +758,7 @@
 
     <string name="card_reader_payment_print_receipt">Print receipt</string>
     <string name="card_reader_payment_send_receipt">Send receipt</string>
+    <string name="card_reader_payment_save_for_later">Save for later</string>
 
     <string name="card_reader_payment_description">Online payment for order %s for %s</string>
     <string name="card_reader_payment_receipt_email_subject">Your receipt from %s</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -775,6 +775,20 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given re-fetching order, when user clicks on save for later button, then ReFetchingOrderState shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(PaymentCompleted("")) }
+            }
+            viewModel.start()
+            simulateFetchOrderJobState(inProgress = true)
+
+            (viewModel.viewStateData.value as PaymentSuccessfulState).onTertiaryActionClicked.invoke()
+
+            assertThat(viewModel.viewStateData.value).isInstanceOf(ReFetchingOrderState::class.java)
+        }
+
+    @Test
     fun `given user presses back, when already in ReFetchingOrderState, then snackbar shown and screen dismissed`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             simulateFetchOrderJobState(inProgress = true)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -593,6 +593,8 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
                 .isEqualTo(R.string.card_reader_payment_print_receipt)
             assertThat(viewState.secondaryActionLabel).describedAs("secondaryActionLabel")
                 .isEqualTo(R.string.card_reader_payment_send_receipt)
+            assertThat(viewState.tertiaryActionLabel).describedAs("tertiaryActionLabel")
+                .isEqualTo(R.string.card_reader_payment_save_for_later)
         }
 
     @Test
@@ -739,6 +741,19 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             (viewModel.viewStateData.value as PaymentSuccessfulState).onSecondaryActionClicked.invoke()
 
             verify(tracker).track(RECEIPT_EMAIL_TAPPED)
+        }
+
+    @Test
+    fun `when user clicks on save for later button, then Exit event emitted`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(PaymentCompleted("")) }
+            }
+            viewModel.start()
+
+            (viewModel.viewStateData.value as PaymentSuccessfulState).onTertiaryActionClicked.invoke()
+
+            assertThat(viewModel.event.value).isInstanceOf(Exit::class.java)
         }
 
     @Test


### PR DESCRIPTION
Resolves #4351 

Adds "Save for later" button to the Success state of the payment flow

---


https://user-images.githubusercontent.com/4923871/127313213-5e411c35-abf3-4486-8173-0fc8d717ff10.mp4

https://user-images.githubusercontent.com/4923871/127313240-88b86465-e33a-4572-a1ba-bb3ec3825f56.mp4

---
### How to test
1. Open eligible for CPP order
2. Click the collect button
3. On the final screen notice the "save for later" button

*The whole payment flow has to be tested from a visual point of view, due to potential side effects of the change*

---
Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
