### PR TITLE
Added a learn more button to the product image uploads screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -21,6 +21,8 @@ object AppUrls {
         "https://docs.woocommerce.com/document/jetpack-setup-instructions-for-the-woocommerce-mobile-app/"
     const val JETPACK_TROUBLESHOOTING =
         "https://jetpack.com/support/getting-started-with-jetpack/troubleshooting-tips/"
+    const val PRODUCT_IMAGE_UPLOADS_TROUBLESHOOTING =
+        "https://docs.woocommerce.com/document/troubleshooting-image-upload-issues-in-the-woo-mobile-apps/"
 
     const val CROWDSIGNAL_MAIN_SURVEY = "https://automattic.survey.fm/woo-app-general-feedback-user-survey"
     const val CROWDSIGNAL_PRODUCT_SURVEY = "https://automattic.survey.fm/woo-app-feature-feedback-products"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -16,21 +16,20 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
+import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.databinding.FragmentProductImagesBinding
-import com.woocommerce.android.extensions.handleResult
-import com.woocommerce.android.extensions.navigateBackWithResult
-import com.woocommerce.android.extensions.navigateSafely
-import com.woocommerce.android.extensions.takeIfNotEqualTo
+import com.woocommerce.android.extensions.*
 import com.woocommerce.android.media.ProductImagesUtils
 import com.woocommerce.android.model.Product.Image
 import com.woocommerce.android.ui.products.ProductImagesViewModel.*
 import com.woocommerce.android.ui.products.ProductImagesViewModel.ProductImagesState.Browsing
 import com.woocommerce.android.ui.products.ProductImagesViewModel.ProductImagesState.Dragging
 import com.woocommerce.android.ui.wpmediapicker.WPMediaPickerFragment.Companion.KEY_WP_IMAGE_PICKER_RESULT
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.util.WooPermissionUtils
@@ -38,6 +37,7 @@ import com.woocommerce.android.util.setHomeIcon
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*
 import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageInteractionListener
+import com.woocommerce.android.widgets.WooClickableSpan
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -135,6 +135,14 @@ class ProductImagesFragment :
         binding.addImageButton.setOnClickListener {
             viewModel.onImageSourceButtonClicked()
         }
+        val learnMoreText = getString(R.string.product_images_learn_more)
+        binding.learnMoreButton.setClickableText(
+            content = getString(R.string.product_images_learn_more_button, learnMoreText),
+            clickableContent = learnMoreText,
+            clickAction = WooClickableSpan {
+                ChromeCustomTabUtils.launchUrl(it.context, AppUrls.PRODUCT_IMAGE_UPLOADS_TROUBLESHOOTING)
+            }
+        )
     }
 
     override fun onGalleryImageDeleteIconClicked(image: Image) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -5,11 +5,13 @@ import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.text.method.LinkMovementMethod
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.app.AlertDialog
+import androidx.core.text.HtmlCompat
 import androidx.core.view.isVisible
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
@@ -37,7 +39,6 @@ import com.woocommerce.android.util.setHomeIcon
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*
 import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageInteractionListener
-import com.woocommerce.android.widgets.WooClickableSpan
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -135,14 +136,16 @@ class ProductImagesFragment :
         binding.addImageButton.setOnClickListener {
             viewModel.onImageSourceButtonClicked()
         }
-        val learnMoreText = getString(R.string.product_images_learn_more)
-        binding.learnMoreButton.setClickableText(
-            content = getString(R.string.product_images_learn_more_button, learnMoreText),
-            clickableContent = learnMoreText,
-            clickAction = WooClickableSpan {
+        with(binding.learnMoreButton) {
+            text = HtmlCompat.fromHtml(
+                context.getString(R.string.product_images_learn_more_button),
+                HtmlCompat.FROM_HTML_MODE_LEGACY
+            )
+            movementMethod = LinkMovementMethod.getInstance()
+            setOnClickListener {
                 ChromeCustomTabUtils.launchUrl(it.context, AppUrls.PRODUCT_IMAGE_UPLOADS_TROUBLESHOOTING)
             }
-        )
+        }
     }
 
     override fun onGalleryImageDeleteIconClicked(image: Image) {

--- a/WooCommerce/src/main/res/layout/fragment_product_images.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_images.xml
@@ -17,6 +17,14 @@
         android:layout_marginEnd="@dimen/margin_extra_large"
         android:text="@string/product_add_photos" />
 
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/learnMoreButton"
+        style="@style/Woo.ListItem.Body"
+        android:layout_marginTop="@dimen/minor_75"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:text="@string/product_images_learn_more_button"/>
+
     <View
         android:id="@+id/divider"
         style="@style/Woo.Divider"

--- a/WooCommerce/src/main/res/layout/fragment_product_images.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_images.xml
@@ -20,6 +20,8 @@
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/learnMoreButton"
         style="@style/Woo.ListItem.Body"
+        android:gravity="center"
+        android:background="?android:attr/selectableItemBackground"
         android:layout_marginTop="@dimen/minor_75"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1053,8 +1053,7 @@
     <string name="product_trash_yes">Move to trash</string>
     <string name="product_trash_undo_snackbar_message">Product moved to trash</string>
     <string name="product_trash_error">Error trashing product</string>
-    <string name="product_images_learn_more">Learn more</string>
-    <string name="product_images_learn_more_button">%1$s about uploading images.</string>
+    <string name="product_images_learn_more_button">&lt;a href=\'\'&gt;Learn more&lt;/a&gt; about uploading images</string>
     <string name="product_status">Status</string>
     <string name="product_visibility">Visibility</string>
     <string name="product_visibility_public">Public</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1053,6 +1053,8 @@
     <string name="product_trash_yes">Move to trash</string>
     <string name="product_trash_undo_snackbar_message">Product moved to trash</string>
     <string name="product_trash_error">Error trashing product</string>
+    <string name="product_images_learn_more">Learn more</string>
+    <string name="product_images_learn_more_button">%1$s about uploading images.</string>
     <string name="product_status">Status</string>
     <string name="product_visibility">Visibility</string>
     <string name="product_visibility_public">Public</string>


### PR DESCRIPTION
Fixes #4330 by adding a Learn more button to the Product images screen. This redirects to the WooCommerce troubleshooting webpage.

### Screenshots
<img src="https://user-images.githubusercontent.com/22608780/127317090-a173bf79-e704-44f8-9798-412ed55fd092.gif" width="300"/>

### Testing
- Click on the Products TAB -> Product -> Images section.
- Notice the Learn more button.
- Click on it and verify that it redirects to the Troubleshooting page.

**This PR is in draft till #4505 can be reviewed & merged**

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
