### PR TITLE
Remove empty customer info card

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -127,6 +127,9 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
             binding.customerInfoMorePanel.hide()
             binding.customerInfoViewMore.setOnClickListener(null)
         }
+        if (shippingAddress.isEmpty() && billingInfo.isEmpty()) {
+            hide()
+        }
     }
 
     private fun showCallOrMessagePopup(order: Order) {


### PR DESCRIPTION
Fixes #3468

## Changes

Hides the orderDetailCustomerInfoView card when a manual order is created without billing and shipping addresses.

## Screenshots

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/127383675-ae7950e3-7234-43d2-9eda-d644d077c053.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/127383686-53357c1a-0923-416e-a343-c3c24d589ad1.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/30724184/127383693-3e4373d3-dbfd-4f04-920d-5cc05ba865a2.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/127383696-afa809e4-a126-42d0-8b7e-5e5b98d66780.png" width="350"/> |

## Steps to reproduce

- Go to your site's dashboard on a browser
- Click on WooCommerce - Orders - Add Order
- Create a new order manually without adding the shipping and billing address
- Note the empty Customer info card in the App

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
