### PR TITLE
Added logic to create WCOrderModel from Order object

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -21,6 +21,7 @@ import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
+import org.wordpress.android.fluxc.model.order.toIdSet
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.util.DateTimeUtils
 import java.math.BigDecimal
@@ -189,6 +190,19 @@ data class Order(
 
         @Parcelize
         data class Custom(private val customValue: String) : Status(customValue)
+    }
+
+    /**
+     * This method converts the [Order] model to [WCOrderModel].
+     * Currently only includes the id, localSiteId and remoteOrderId
+     * since we only use these 3 fields when updating an order status
+     */
+    fun toDataModel(): WCOrderModel {
+        return WCOrderModel().also {
+            it.id = identifier.toIdSet().id
+            it.remoteOrderId = remoteId
+            it.localSiteId = localSiteId
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -34,6 +34,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCOrderAction
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
+import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
@@ -143,11 +144,13 @@ class OrderDetailRepository @Inject constructor(
         return result.model?.filter { it.status == LabelItem.STATUS_PURCHASED }?.map { it.toAppModel() } ?: emptyList()
     }
 
-    suspend fun updateOrderStatus(localOrderId: Int, newStatus: String): ContinuationResult<Boolean> {
-        val order = OrderSqlUtils.getOrderByLocalId(localOrderId)
+    suspend fun updateOrderStatus(
+        orderModel: WCOrderModel,
+        newStatus: String
+    ): ContinuationResult<Boolean> {
         return continuationUpdateOrderStatus.callAndWaitUntilTimeout(AppConstants.REQUEST_TIMEOUT) {
             val payload = UpdateOrderStatusPayload(
-                order, selectedSite.get(), newStatus
+                orderModel, selectedSite.get(), newStatus
             )
             dispatcher.dispatch(WCOrderActionBuilder.newUpdateOrderStatusAction(payload))
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -40,7 +40,6 @@ import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.model.order.toIdSet
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.LabelItem
-import org.wordpress.android.fluxc.persistence.OrderSqlUtils
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.AddOrderShipmentTrackingPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.DeleteOrderShipmentTrackingPayload

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -430,7 +430,7 @@ class OrderDetailViewModel @Inject constructor(
     private fun updateOrderStatus(newStatus: String) {
         if (networkStatus.isConnected()) {
             launch {
-                orderDetailRepository.updateOrderStatus(orderIdSet.id, newStatus)
+                orderDetailRepository.updateOrderStatus(order.toDataModel(), newStatus)
                     .let { it as? ContinuationWrapper.ContinuationResult.Success }
                     ?.takeIf { it.value.not() }
                     ?.let { triggerEvent(ShowSnackbar(string.order_error_update_general)) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -105,7 +105,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
-import org.wordpress.android.fluxc.model.order.toIdSet
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.AccountStore
@@ -499,9 +498,9 @@ class CreateShippingLabelViewModel @Inject constructor(
             PurchaseFailed
         } else {
             if (fulfillOrder) {
-                val orderIdSet = data.order.identifier.toIdSet()
+                val order = data.order.toDataModel()
                 val fulfillResult = orderDetailRepository.updateOrderStatus(
-                    localOrderId = orderIdSet.id,
+                    orderModel = order,
                     newStatus = CoreOrderStatus.COMPLETED.value
                 )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -54,7 +54,6 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.order.toIdSet
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.utils.DateUtils
 import java.math.BigDecimal
@@ -382,7 +381,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
             viewModel.start()
 
-            assertThat(areProductsVisible).isFalse()
+            assertThat(areProductsVisible).isFalse
             assertThat(refunds).isNotEmpty
         }
 
@@ -638,7 +637,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         snackbar?.undoAction?.onClick(mock())
         assertThat(snackbar?.message).isEqualTo(resources.getString(string.order_status_updated))
 
-        verify(repository, times(2)).updateOrderStatus(eq(order.identifier.toIdSet().id), statusChangeCaptor.capture())
+        verify(repository, times(2)).updateOrderStatus(eq(order.toDataModel()), statusChangeCaptor.capture())
 
         assertThat(listOf(initialStatus) + statusChangeCaptor.allValues).containsExactly(
             initialStatus, newStatus, initialStatus

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
@@ -56,7 +56,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.wordpress.android.fluxc.model.order.toIdSet
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.AccountStore
@@ -348,7 +347,7 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
         stateFlow.value = Transition(PurchaseLabels(doneData, fulfillOrder = true), null)
 
         verify(orderDetailRepository).updateOrderStatus(
-            doneData.order.identifier.toIdSet().id, CoreOrderStatus.COMPLETED.value
+            doneData.order.toDataModel(), CoreOrderStatus.COMPLETED.value
         )
     }
 


### PR DESCRIPTION
Fixes #4513. 

### Issue
The app is crashing when trying to fulfill an order after opening it from a notification. This is because [this PR](https://github.com/woocommerce/woocommerce-android/pull/4394) introduced a change where we fetch an order by it's id from the local db before updating the order status. But when opening a new order notification, the order is not found in the local db. 

### Changes
This PR fixes that by removing the logic to fetch the order from the local db, since the order is already available in local memory. Instead, we can convert the local `Order` to `WCOrderModel` and pass that object when updating the order status.

### Testing
##### Scenario 1: Fulfil order from notification
- Create a new order from your test site. Force close the app when a new order notification is received, otherwise the crash does not happen.
- Click on the new order notification from the order. 
- Click on the `Mark order complete` button in the Order detail screen.
- Click on the `Mark order complete` button in the Order Fulfill screen.
- Verify that the app does not crash and the order status is changed to completed.

##### Scenario 2: Change order status from the order list
- Click on an order from the Orders tab.
- Try changing the status of the order and verify that the correct status is reflected in both the order detail & order list.
- Try clicking on the undo button after changing the status and verify that the correct status is reflected in both the order detail & order list.

##### Scenario 3: Fulfil order from the order list
- Click on a processing order from the Orders tab.
- Click on the `Mark order complete` button in the Order detail screen.
- Click on the `Mark order complete` button in the Order Fulfill screen.
- Verify that the correct status is reflected in both the order detail & order list.
- Try clicking on the undo button after changing the status and verify that the correct status is reflected in both the order detail & order list.

cc @jkmassel, this would require a new beta release since this is a critical flow. Let me know if there is anything I can do to help 🙇‍♀️ Thank you! 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
