### PR TITLE
issue/4518-stripe-onboarding-landscape

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.prefs.cardreader.onboarding
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
@@ -18,6 +19,7 @@ import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.UiHelpers
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.util.DisplayUtils
 
 @AndroidEntryPoint
 class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_onboarding) {
@@ -93,6 +95,20 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         UiHelpers.setImageOrHide(binding.illustration, state.illustration)
         binding.learnMoreContainer.learnMore.setOnClickListener {
             state.onLearnMoreActionClicked.invoke()
+        }
+
+        // decrease the margins for landscape unless this is a tablet
+        if (DisplayUtils.isLandscape(requireActivity()) &&
+            !DisplayUtils.isTablet(requireActivity()) &&
+            !DisplayUtils.isXLargeTablet(requireActivity())
+        ) {
+            fun setTopMargin(view: View) {
+                (view.layoutParams as ViewGroup.MarginLayoutParams).topMargin =
+                    resources.getDimensionPixelSize(R.dimen.major_200)
+            }
+            setTopMargin(binding.textHeader)
+            setTopMargin(binding.illustration)
+            setTopMargin(binding.textLabel)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.prefs.cardreader.onboarding
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
@@ -19,7 +18,6 @@ import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.UiHelpers
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.util.DisplayUtils
 
 @AndroidEntryPoint
 class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_onboarding) {
@@ -95,20 +93,6 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         UiHelpers.setImageOrHide(binding.illustration, state.illustration)
         binding.learnMoreContainer.learnMore.setOnClickListener {
             state.onLearnMoreActionClicked.invoke()
-        }
-
-        // decrease the margins for landscape unless this is a tablet
-        if (DisplayUtils.isLandscape(requireActivity()) &&
-            !DisplayUtils.isTablet(requireActivity()) &&
-            !DisplayUtils.isXLargeTablet(requireActivity())
-        ) {
-            fun setTopMargin(view: View) {
-                (view.layoutParams as ViewGroup.MarginLayoutParams).topMargin =
-                    resources.getDimensionPixelSize(R.dimen.major_200)
-            }
-            setTopMargin(binding.textHeader)
-            setTopMargin(binding.illustration)
-            setTopMargin(binding.textLabel)
         }
     }
 

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_onboarding_stripe.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_onboarding_stripe.xml
@@ -1,75 +1,81 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fillViewport="true">
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/textHeader"
-        style="@style/TextAppearance.Woo.Headline6"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/major_275"
-        android:gravity="center"
-        android:paddingHorizontal="@dimen/major_200"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_chainStyle="packed"
-        tools:text="@string/card_reader_onboarding_account_under_review_header" />
-
-    <androidx.appcompat.widget.AppCompatImageView
-        android:id="@+id/illustration"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/major_275"
-        app:layout_constraintBottom_toTopOf="@id/illustration"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textHeader"
-        tools:src="@drawable/img_products_error" />
-
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/textLabel"
-        style="@style/TextAppearance.Woo.Body1"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/major_275"
-        android:gravity="center"
-        android:paddingHorizontal="@dimen/major_200"
-        android:textColor="@color/color_on_surface_high"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/illustration"
-        tools:text="@string/card_reader_onboarding_country_not_supported_hint" />
-
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/textSupport"
-        style="@style/TextAppearance.Woo.Body1"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_medium"
-        android:background="?attr/selectableItemBackground"
-        android:gravity="center"
-        android:paddingHorizontal="@dimen/major_200"
-        android:paddingVertical="@dimen/major_100"
-        android:textColor="@color/color_on_surface_high"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/textLabel"
-        tools:text="@string/card_reader_onboarding_contact_support" />
-
-    <include
-        android:id="@+id/learn_more_container"
-        layout="@layout/card_reader_learn_more_section"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/major_350"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="1" />
+        android:layout_height="wrap_content">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/textHeader"
+            style="@style/TextAppearance.Woo.Headline6"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/major_275"
+            android:gravity="center"
+            android:paddingHorizontal="@dimen/major_200"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_chainStyle="packed"
+            tools:text="@string/card_reader_onboarding_account_under_review_header" />
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/illustration"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/major_275"
+            app:layout_constraintBottom_toTopOf="@id/illustration"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/textHeader"
+            tools:src="@drawable/img_products_error" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/textLabel"
+            style="@style/TextAppearance.Woo.Body1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/major_275"
+            android:gravity="center"
+            android:paddingHorizontal="@dimen/major_200"
+            android:textColor="@color/color_on_surface_high"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/illustration"
+            tools:text="@string/card_reader_onboarding_country_not_supported_hint" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/textSupport"
+            style="@style/TextAppearance.Woo.Body1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_medium"
+            android:background="?attr/selectableItemBackground"
+            android:gravity="center"
+            android:paddingHorizontal="@dimen/major_200"
+            android:paddingVertical="@dimen/major_100"
+            android:textColor="@color/color_on_surface_high"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/textLabel"
+            tools:text="@string/card_reader_onboarding_contact_support" />
+
+        <include
+            android:id="@+id/learn_more_container"
+            layout="@layout/card_reader_learn_more_section"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/major_350"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="1" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>


### PR DESCRIPTION
Fixes #4518 by reducing the top margin of three of the views. I'm not wild about this solution but wasn't sure how to best resolve it. At first I thought I could just wrap everything in a `ScrollView` but that breaks our desire to fix the "Learn more" at the bottom. I also thought of creating a separate layout for landscape, but I do that only as a last resort.

Open to ideas for other solutions!

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
