### PR TITLE
Shipping Labels: fix tracking option text

### DIFF
--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -51,7 +51,6 @@ Language: ar
     <string name="product_create_attribute_helper">لإنشاء مجموعة، ستحتاج إلى تعيين سماتها (أي \"اللون\"، \"والحجم\") أولاً</string>
     <string name="product_variation_single_count">مجموعة واحدة</string>
     <string name="product_variation_multiple_count">⁦%1$s⁩ من المجموعات</string>
-    <string name="shipping_label_rate_included_options_usps_tracking">تعقُّب %s</string>
     <string name="card_reader_software_update_in_progress_title">تحديث برنامج قارئك</string>
     <string name="card_reader_software_update_title">تحديث برنامج</string>
     <string name="card_reader_software_update_description">يتعين تحديث برنامج قارئ بطاقتك لكي يعمل بسلاسة. هل ترغب في تحديثه الآن؟</string>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -98,7 +98,6 @@ Language: de
     <string name="product_create_attribute_helper">Um eine Variation zu erstellen, musst du zuerst deren Attribute festlegen (d. h. Farbe, Größe).</string>
     <string name="product_variation_single_count">1 Variante</string>
     <string name="product_variation_multiple_count">%1$s Varianten</string>
-    <string name="shipping_label_rate_included_options_usps_tracking">Sendungsverfolgung für %s</string>
     <string name="card_reader_software_update_in_progress_title">Die Software deines Kartenlesegeräts wird aktualisiert</string>
     <string name="card_reader_software_update_title">Software-Update</string>
     <string name="card_reader_software_update_description">Damit die Software deines Kartenlesegeräts weiter problemlos funktioniert, ist eine Aktualisierung erforderlich. Möchtest du sie jetzt aktualisieren?</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -98,7 +98,6 @@ Language: es
     <string name="product_create_attribute_helper">Para crear una variación, antes debes especificar los atributos (p. ej., \"Color\" y \"Talla\")</string>
     <string name="product_variation_single_count">1 variación</string>
     <string name="product_variation_multiple_count">%1$s variaciones</string>
-    <string name="shipping_label_rate_included_options_usps_tracking">%s seguimiento</string>
     <string name="card_reader_software_update_in_progress_title">Actualizar el software del lector</string>
     <string name="card_reader_software_update_title">Actualización del software</string>
     <string name="card_reader_software_update_description">El software de tu lector de tarjetas tiene que estar actualizado para que funcione correctamente. ¿Quieres actualizarlo ahora?</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -98,7 +98,6 @@ Language: fr
     <string name="product_create_attribute_helper">Pour créer une variante, vous devez d’abord définir ses attributs (« Couleur », « Taille »)</string>
     <string name="product_variation_single_count">1 variante</string>
     <string name="product_variation_multiple_count">%1$s variantes</string>
-    <string name="shipping_label_rate_included_options_usps_tracking">Suivi de %s</string>
     <string name="card_reader_software_update_in_progress_title">Mise à jour du logiciel de votre lecteur</string>
     <string name="card_reader_software_update_title">Mise à jour du logiciel</string>
     <string name="card_reader_software_update_description">Le logiciel de votre lecteur de carte doit être mis à jour pour continuer à fonctionner parfaitement. Voulez-vous le mettre à jour maintenant ?</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -98,7 +98,6 @@ Language: he_IL
     <string name="product_create_attribute_helper">כדי ליצור סוג, עליך קודם כל להגדיר את המאפיינים שלו (למשל, \'צבע\', \'מידה\')</string>
     <string name="product_variation_single_count">סוג אחד</string>
     <string name="product_variation_multiple_count">⁦%1$s⁩ סוגים</string>
-    <string name="shipping_label_rate_included_options_usps_tracking">מבצע מעקב של %s</string>
     <string name="card_reader_software_update_in_progress_title">מעדכן את התוכנה של הקורא שלך</string>
     <string name="card_reader_software_update_title">עדכון תוכנה</string>
     <string name="card_reader_software_update_description">עליך לעדכן את התוכנה של קורא הכרטיסים שלך כדי להבטיח את הפעילות התקינה שלה. האם ברצונך לעדכן כעת?</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -98,7 +98,6 @@ Language: id
     <string name="product_create_attribute_helper">Untuk membuat variasi, Anda perlu mengatur atributnya (yaitu \"Warna\", \"Ukuran\") terlebih dahulu</string>
     <string name="product_variation_single_count">1 variasi</string>
     <string name="product_variation_multiple_count">%1$s variasi</string>
-    <string name="shipping_label_rate_included_options_usps_tracking">%s pelacakan</string>
     <string name="card_reader_software_update_in_progress_title">Memperbarui perangkat lunak pembaca Anda</string>
     <string name="card_reader_software_update_title">Pembaruan perangkat lunak</string>
     <string name="card_reader_software_update_description">Perangkat lunak pembaca kartu Anda perlu diperbarui agar dapat berfungsi normal. Apakah Anda ingin memperbaruinya sekarang?</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -98,7 +98,6 @@ Language: it
     <string name="product_create_attribute_helper">Per creare una variante, dovrai prima impostare i suoi attributi (ad esempio \"Colore\", \"Dimensione\")</string>
     <string name="product_variation_single_count">1 variante</string>
     <string name="product_variation_multiple_count">%1$s varianti</string>
-    <string name="shipping_label_rate_included_options_usps_tracking">Tracciabilità %s</string>
     <string name="card_reader_software_update_in_progress_title">Aggiornamento del software del lettore</string>
     <string name="card_reader_software_update_title">Aggiornamento del software</string>
     <string name="card_reader_software_update_description">Il software del lettore di carte deve essere aggiornato per funzionare perfettamente. Desideri aggiornarlo ora?</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -98,7 +98,6 @@ Language: ja_JP
     <string name="product_create_attribute_helper">バリエーションを作るには、最初にその属性 (「色」、「サイズ」など) を設定する必要があります</string>
     <string name="product_variation_single_count">1個のバリエーション</string>
     <string name="product_variation_multiple_count">%1$s個のバリエーション</string>
-    <string name="shipping_label_rate_included_options_usps_tracking">%s追跡</string>
     <string name="card_reader_software_update_in_progress_title">Reader のソフトウェアを更新しています</string>
     <string name="card_reader_software_update_title">ソフトウェア更新</string>
     <string name="card_reader_software_update_description">カードリーダーのソフトウェアを更新して順調な稼働が続くようにする必要があります。 今すぐ更新しますか ? </string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -98,7 +98,6 @@ Language: ko_KR
     <string name="product_create_attribute_helper">변형을 만들려면 속성(즉, \"색상\", \"사이즈\")을 먼저 설정해야 합니다.</string>
     <string name="product_variation_single_count">변형 1개</string>
     <string name="product_variation_multiple_count">변형 %1$s개</string>
-    <string name="shipping_label_rate_included_options_usps_tracking">%s 추적</string>
     <string name="card_reader_software_update_in_progress_title">리더의 소프트웨어 업데이트하기</string>
     <string name="card_reader_software_update_title">소프트웨어 업데이트</string>
     <string name="card_reader_software_update_description">카드 리더가 계속 원활하게 작동하려면 소프트웨어를 업데이트해야 합니다.  지금 업데이트하시겠어요?</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -98,7 +98,6 @@ Language: nl
     <string name="product_create_attribute_helper">Om een variatie aan te maken moet je de eigenschappen (bv. \'kleur\', \'maat\') eerst instellen</string>
     <string name="product_variation_single_count">1 variatie</string>
     <string name="product_variation_multiple_count">%1$s Variaties</string>
-    <string name="shipping_label_rate_included_options_usps_tracking">%s volgen</string>
     <string name="card_reader_software_update_in_progress_title">De software van je lezer wordt bijgewerkt</string>
     <string name="card_reader_software_update_title">Software-update</string>
     <string name="card_reader_software_update_description">De software van je kaartlezer moet bijgewerkt worden om alles soepel te laten verlopen. Wil je nu bijwerken?</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -98,7 +98,6 @@ Language: pt_BR
     <string name="product_create_attribute_helper">Para criar uma variação, primeiro você precisará definir os atributos, como \"cor\" e \"tamanho\"</string>
     <string name="product_variation_single_count">1 variação</string>
     <string name="product_variation_multiple_count">%1$s variações</string>
-    <string name="shipping_label_rate_included_options_usps_tracking">Rastreamento de %s</string>
     <string name="card_reader_software_update_in_progress_title">Atualizando seu software do leitor</string>
     <string name="card_reader_software_update_title">Atualização de software</string>
     <string name="card_reader_software_update_description">Seu software do leitor de cartão precisa ser atualizado para continuar funcionando sem problemas. Deseja atualizá-lo agora?</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -98,7 +98,6 @@ Language: ru
     <string name="product_create_attribute_helper">Чтобы создать вариант, необходимо сначала задать атрибуты (например, «Цвет» или «Размер»).</string>
     <string name="product_variation_single_count">1 вариант</string>
     <string name="product_variation_multiple_count">Вариантов: %1$s</string>
-    <string name="shipping_label_rate_included_options_usps_tracking">Отслеживание %s</string>
     <string name="card_reader_software_update_in_progress_title">Обновление ПО устройства чтения</string>
     <string name="card_reader_software_update_title">Обновление ПО</string>
     <string name="card_reader_software_update_description">Для корректной работы устройства чтения необходимо обновить его ПО. Обновить сейчас?</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -99,7 +99,6 @@ Language: sv_SE
     <string name="product_create_attribute_helper">För att skapa en variation måste du först ställa in dess attribut (dvs. \"Färg\", \"Storlek\")</string>
     <string name="product_variation_single_count">1 variation</string>
     <string name="product_variation_multiple_count">%1$s variationer</string>
-    <string name="shipping_label_rate_included_options_usps_tracking">%s-spårning</string>
     <string name="card_reader_software_update_in_progress_title">Uppdaterar din läsares programvara</string>
     <string name="card_reader_software_update_title">Programvaruuppdatering</string>
     <string name="card_reader_software_update_description">Din kortläsares programvara behöver uppdateras för att fungera korrekt. Vill du uppdatera den nu?</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -98,7 +98,6 @@ Language: tr
     <string name="product_create_attribute_helper">Bir varyasyon oluşturmak için önce niteliklerini (yani \"Renk\", \"Boyut\") ayarlamanız gerekir.</string>
     <string name="product_variation_single_count">1 varyasyon</string>
     <string name="product_variation_multiple_count">%1$s varyasyon</string>
-    <string name="shipping_label_rate_included_options_usps_tracking">%s izleniyor</string>
     <string name="card_reader_software_update_in_progress_title">Okuyucunuzun yazılımını güncelleme</string>
     <string name="card_reader_software_update_title">Yazılım güncellemesi</string>
     <string name="card_reader_software_update_description">Sorunsuz çalışmaya devam etmesi için kart okuyucunuzun yazılımının güncellenmesi gerekir. Şimdi güncellemek istiyor musunuz?</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -98,7 +98,6 @@ Language: zh_CN
     <string name="product_create_attribute_helper">要创建变体，您需要先设置它的属性（即“颜色”、“大小”）</string>
     <string name="product_variation_single_count">1 个变体</string>
     <string name="product_variation_multiple_count">%1$s 个变体</string>
-    <string name="shipping_label_rate_included_options_usps_tracking">%s 追踪</string>
     <string name="card_reader_software_update_in_progress_title">更新读卡器软件</string>
     <string name="card_reader_software_update_title">软件更新</string>
     <string name="card_reader_software_update_description">您的读卡器软件需要更新，然后才能顺畅运行。 是否要立即更新？</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -98,7 +98,6 @@ Language: zh_TW
     <string name="product_create_attribute_helper">若要建立款式，需要先設定其屬性 (即「顏色」、「尺寸」)</string>
     <string name="product_variation_single_count">1 種款式</string>
     <string name="product_variation_multiple_count">%1$s 種款式</string>
-    <string name="shipping_label_rate_included_options_usps_tracking">%s 追蹤中</string>
     <string name="card_reader_software_update_in_progress_title">正在更新讀卡機軟體</string>
     <string name="card_reader_software_update_title">軟體更新</string>
     <string name="card_reader_software_update_description">你的讀卡機軟體需要更新才能正常執行功能。 是否要立即更新？</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -571,7 +571,7 @@
     <string name="shipping_label_rate_option_signature_required">Signature required (%s)</string>
     <string name="shipping_label_rate_option_adult_signature_required">Adult signature required (%s)</string>
     <string name="shipping_label_rate_included_options">Includes %s</string>
-    <string name="shipping_label_rate_included_options_usps_tracking">%s tracking</string>
+    <string name="shipping_label_rate_included_options_usps_tracking">USPS tracking</string>
     <string name="shipping_label_rate_included_options_tracking">tracking</string>
     <string name="shipping_label_rate_insurance_up_to">up to %s</string>
     <string name="shipping_label_rate_included_options_insurance">Insurance (%s)</string>


### PR DESCRIPTION
Closes #4519, I introduced this bug when I worked on #4060, I missed updating the wording of the USPS tracking.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
