### PR TITLE
Issue/4398 Fixed configuration change cause not receiving an event from the payments dialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.FEATURE_FEEDBACK_
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.ORDER_DETAIL_PRODUCT_TAPPED
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.databinding.FragmentOrderDetailBinding
+import com.woocommerce.android.extensions.handleDialogNotice
 import com.woocommerce.android.extensions.handleDialogResult
 import com.woocommerce.android.extensions.handleNotice
 import com.woocommerce.android.extensions.handleResult
@@ -247,7 +248,10 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
                 viewModel.onConnectToReaderResultReceived(connected)
             }
         }
-        handleNotice(CardReaderPaymentDialog.KEY_CARD_PAYMENT_RESULT) {
+        handleDialogNotice<String>(
+            key = CardReaderPaymentDialog.KEY_CARD_PAYMENT_RESULT,
+            entryId = R.id.orderDetailFragment
+        ) {
             if (FeatureFlag.CARD_READER.isEnabled()) {
                 viewModel.onCardReaderPaymentCompleted()
             }


### PR DESCRIPTION
Resolves #4398

https://user-images.githubusercontent.com/4923871/127628630-10beda5a-639c-4b79-8b2d-da0bdd637b53.mp4

### How to test

1. Go to a detail of an unpaid order
2. Click on Collect Payment button
3. Finish the payment flow - rotate your device at any point
4. Dismiss the payment successful dialog
5. Notice the order detail screen is refreshed


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
