### PR TITLE
Shipping Labels: enable remaining M4 features

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 7.3
 -----
-
+- [***] Shipping Labels: merchants can add new payment methods and create packages directly from the app, the labels can also contain multiple packages [https://github.com/woocommerce/woocommerce-android/pull/4529]
 
 7.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -7,18 +7,9 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_API_FA
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_API_SUCCESS
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.annotations.OpenClassOnDebug
-import com.woocommerce.android.model.Order
+import com.woocommerce.android.model.*
 import com.woocommerce.android.model.Order.OrderStatus
-import com.woocommerce.android.model.OrderNote
-import com.woocommerce.android.model.OrderShipmentTracking
-import com.woocommerce.android.model.Refund
-import com.woocommerce.android.model.RequestResult
-import com.woocommerce.android.model.ShippingLabel
-import com.woocommerce.android.model.WooPlugin
-import com.woocommerce.android.model.toAppModel
-import com.woocommerce.android.model.toOrderStatus
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationFeatures
 import com.woocommerce.android.util.ContinuationWrapper
 import com.woocommerce.android.util.ContinuationWrapper.ContinuationResult
 import com.woocommerce.android.util.ContinuationWrapper.ContinuationResult.Cancellation
@@ -40,20 +31,9 @@ import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.model.order.toIdSet
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.LabelItem
-import org.wordpress.android.fluxc.store.WCOrderStore
-import org.wordpress.android.fluxc.store.WCOrderStore.AddOrderShipmentTrackingPayload
-import org.wordpress.android.fluxc.store.WCOrderStore.DeleteOrderShipmentTrackingPayload
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsPayload
-import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
-import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType
-import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload
-import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderStatusPayload
-import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.*
+import org.wordpress.android.fluxc.store.WCOrderStore.*
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
-import org.wordpress.android.fluxc.store.WCRefundStore
-import org.wordpress.android.fluxc.store.WCShippingLabelStore
-import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
 @OpenClassOnDebug
@@ -288,9 +268,9 @@ class OrderDetailRepository @Inject constructor(
         val result = shippingLabelStore.fetchShippingLabelCreationEligibility(
             site = selectedSite.get(),
             orderId = orderId,
-            canCreatePackage = ShippingLabelCreationFeatures.CAN_CREATE_PACKAGE,
-            canCreatePaymentMethod = ShippingLabelCreationFeatures.CAN_CREATE_PAYMENT_METHOD,
-            canCreateCustomsForm = ShippingLabelCreationFeatures.CAN_CREATE_CUSTOMS_FORM
+            canCreatePackage = true,
+            canCreatePaymentMethod = true,
+            canCreateCustomsForm = true
         )
         if (result.isError) {
             WooLog.e(
@@ -311,9 +291,9 @@ class OrderDetailRepository @Inject constructor(
         return shippingLabelStore.isOrderEligibleForShippingLabelCreation(
             site = selectedSite.get(),
             orderId = orderId,
-            canCreatePackage = ShippingLabelCreationFeatures.CAN_CREATE_PACKAGE,
-            canCreatePaymentMethod = ShippingLabelCreationFeatures.CAN_CREATE_PAYMENT_METHOD,
-            canCreateCustomsForm = ShippingLabelCreationFeatures.CAN_CREATE_CUSTOMS_FORM
+            canCreatePackage = true,
+            canCreatePaymentMethod = true,
+            canCreateCustomsForm = true
         )?.isEligible ?: false
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
@@ -26,7 +26,6 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrier
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrierRatesAdapter.RateListViewHolder
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrierRatesAdapter.ShippingRateItem.ShippingCarrier.*
 import com.woocommerce.android.util.DateUtils
-import com.woocommerce.android.util.FeatureFlag
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import java.util.*
@@ -69,20 +68,16 @@ class ShippingCarrierRatesAdapter(
                 }
             }
 
-            if (!FeatureFlag.SHIPPING_LABELS_M4.isEnabled()) {
-                binding.expandIcon.isVisible = false
-            } else {
-                // expand items by default
-                binding.expandIcon.rotation = 180f
-                binding.rateOptions.isVisible = true
-                binding.titleLayout.setOnClickListener {
-                    if (isExpanded) {
-                        binding.expandIcon.animate().rotation(0f).start()
-                        binding.rateOptions.collapse()
-                    } else {
-                        binding.expandIcon.animate().rotation(180f).start()
-                        binding.rateOptions.expand()
-                    }
+            // expand items by default
+            binding.expandIcon.rotation = 180f
+            binding.rateOptions.isVisible = true
+            binding.titleLayout.setOnClickListener {
+                if (isExpanded) {
+                    binding.expandIcon.animate().rotation(0f).start()
+                    binding.rateOptions.collapse()
+                } else {
+                    binding.expandIcon.animate().rotation(180f).start()
+                    binding.rateOptions.expand()
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsAdapter.kt
@@ -28,7 +28,6 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustoms
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustomsLineAdapter.CustomsLineViewHolder
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCustomsViewModel.CustomsPackageUiState
 import com.woocommerce.android.util.ChromeCustomTabUtils
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
 import com.woocommerce.android.widgets.WooClickableSpan
 
@@ -127,19 +126,15 @@ class ShippingCustomsAdapter(
             binding.itnEditText.setOnTextChangedListener {
                 it?.let { listener.onItnChanged(adapterPosition, it.toString()) }
             }
-            if (!FeatureFlag.SHIPPING_LABELS_M4.isEnabled()) {
-                binding.expandIcon.isVisible = false
-            } else {
-                binding.titleLayout.setOnClickListener {
-                    if (isExpanded) {
-                        binding.expandIcon.animate().rotation(0f).start()
-                        binding.detailsLayout.collapse()
-                        listener.onPackageExpandedChanged(adapterPosition, false)
-                    } else {
-                        binding.expandIcon.animate().rotation(180f).start()
-                        binding.detailsLayout.expand()
-                        listener.onPackageExpandedChanged(adapterPosition, true)
-                    }
+            binding.titleLayout.setOnClickListener {
+                if (isExpanded) {
+                    binding.expandIcon.animate().rotation(0f).start()
+                    binding.detailsLayout.collapse()
+                    listener.onPackageExpandedChanged(adapterPosition, false)
+                } else {
+                    binding.expandIcon.animate().rotation(180f).start()
+                    binding.detailsLayout.expand()
+                    listener.onPackageExpandedChanged(adapterPosition, true)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreationFeatures.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreationFeatures.kt
@@ -1,9 +1,7 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation
 
-import com.woocommerce.android.util.FeatureFlag
-
 object ShippingLabelCreationFeatures {
-    val CAN_CREATE_PAYMENT_METHOD = FeatureFlag.SHIPPING_LABELS_M4.isEnabled()
+    const val CAN_CREATE_PAYMENT_METHOD = true
     const val CAN_CREATE_PACKAGE = true
     const val CAN_CREATE_CUSTOMS_FORM = true
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreationFeatures.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreationFeatures.kt
@@ -4,6 +4,6 @@ import com.woocommerce.android.util.FeatureFlag
 
 object ShippingLabelCreationFeatures {
     val CAN_CREATE_PAYMENT_METHOD = FeatureFlag.SHIPPING_LABELS_M4.isEnabled()
-    val CAN_CREATE_PACKAGE = FeatureFlag.SHIPPING_LABELS_M4.isEnabled()
+    const val CAN_CREATE_PACKAGE = true
     const val CAN_CREATE_CUSTOMS_FORM = true
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreationFeatures.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreationFeatures.kt
@@ -1,7 +1,0 @@
-package com.woocommerce.android.ui.orders.shippinglabels.creation
-
-object ShippingLabelCreationFeatures {
-    const val CAN_CREATE_PAYMENT_METHOD = true
-    const val CAN_CREATE_PACKAGE = true
-    const val CAN_CREATE_CUSTOMS_FORM = true
-}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -21,7 +21,6 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLab
 import com.woocommerce.android.ui.orders.shippinglabels.creation.PackageProductsAdapter.PackageProductViewHolder
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelPackagesAdapter.ShippingLabelPackageViewHolder
 import com.woocommerce.android.ui.products.models.SiteParameters
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.StringUtils
 
 class ShippingLabelPackagesAdapter(
@@ -109,19 +108,15 @@ class ShippingLabelPackagesAdapter(
                 onPackageSpinnerClicked(adapterPosition)
             }
 
-            if (!FeatureFlag.SHIPPING_LABELS_M4.isEnabled()) {
-                binding.expandIcon.isVisible = false
-            } else {
-                binding.titleLayout.setOnClickListener {
-                    if (isExpanded) {
-                        binding.expandIcon.animate().rotation(0f).start()
-                        binding.detailsLayout.collapse()
-                        onExpandedChanged(adapterPosition, false)
-                    } else {
-                        binding.expandIcon.animate().rotation(180f).start()
-                        binding.detailsLayout.expand()
-                        onExpandedChanged(adapterPosition, true)
-                    }
+            binding.titleLayout.setOnClickListener {
+                if (isExpanded) {
+                    binding.expandIcon.animate().rotation(0f).start()
+                    binding.detailsLayout.collapse()
+                    onExpandedChanged(adapterPosition, false)
+                } else {
+                    binding.expandIcon.animate().rotation(180f).start()
+                    binding.detailsLayout.expand()
+                    onExpandedChanged(adapterPosition, true)
                 }
             }
         }
@@ -244,12 +239,6 @@ class PackageProductsAdapter(
     inner class PackageProductViewHolder(
         val binding: ShippingLabelPackageProductListItemBinding
     ) : ViewHolder(binding.root) {
-        init {
-            if (!FeatureFlag.SHIPPING_LABELS_M4.isEnabled()) {
-                binding.moveButton.isVisible = false
-            }
-        }
-
         fun bind(item: ShippingLabelPackage.Item) {
             binding.productName.text = item.name
             val attributes = item.attributesList.takeIf { it.isNotEmpty() }?.let { "$it \u2981 " } ?: StringUtils.EMPTY

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackageSelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackageSelectorFragment.kt
@@ -47,12 +47,8 @@ class ShippingPackageSelectorFragment : BaseFragment(R.layout.fragment_shipping_
             adapter = packagesAdapter
         }
 
-        if (!FeatureFlag.SHIPPING_LABELS_M4.isEnabled()) {
-            binding.packagesCreateNewContainer.isVisible = false
-        } else {
-            binding.packagesCreateNewButton.setOnClickListener {
-                viewModel.onCreateNewPackageButtonClicked()
-            }
+        binding.packagesCreateNewButton.setOnClickListener {
+            viewModel.onCreateNewPackageButtonClicked()
         }
         setupObservers(binding)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackageSelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackageSelectorFragment.kt
@@ -14,11 +14,10 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingPackageSelectorViewModel.ShowCreatePackageScreen
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingPackageSelectorViewModel.ShowCreatePackageScreen
-import com.woocommerce.android.util.FeatureFlag
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.util.payment.CardPresentEligibleFeatureChecker
  * "Feature flags" are used to hide in-progress features from release versions
  */
 enum class FeatureFlag {
-    SHIPPING_LABELS_M4,
     DB_DOWNGRADE,
     ORDER_CREATION,
     CARD_READER,
@@ -16,7 +15,6 @@ enum class FeatureFlag {
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
-            SHIPPING_LABELS_M4 -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
             DB_DOWNGRADE -> {
                 PackageUtils.isDebugBuild() || context != null && PackageUtils.isBetaBuild(context)
             }


### PR DESCRIPTION
This PR enables remaining shipping labels M4 features, and removes the feature flag:
- Enables package creation.
- Enables adding payment methods.
- Enable multiple packages.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
