### PR TITLE
Shipping labels: address form fixes

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_address.xml
+++ b/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_address.xml
@@ -119,7 +119,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/major_100"
-            android:hint="@string/shipping_label_edit_address_address"
+            android:hint="@string/shipping_label_edit_address_line1"
             android:inputType="text"
             android:nextFocusForward="@+id/address2"
             app:errorEnabled="true" />
@@ -129,7 +129,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/major_100"
-            android:hint="@string/shipping_label_edit_address_address"
+            android:hint="@string/shipping_label_edit_address_line2"
             android:inputType="text"
             android:nextFocusForward="@+id/city"
             app:errorEnabled="true" />

--- a/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_address.xml
+++ b/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_address.xml
@@ -144,6 +144,19 @@
             android:nextFocusForward="@+id/state"
             app:errorEnabled="true"/>
 
+        <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+            android:id="@+id/countrySpinner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/minor_00"
+            android:layout_marginEnd="@dimen/major_100"
+            android:layout_marginBottom="@dimen/major_100"
+            android:hint="@string/shipping_label_edit_address_country"
+            android:inputType="text"
+            android:nextFocusForward="@+id/useAddressAsIsButton"
+            android:textAppearance="@style/TextAppearance.Woo.Caption" />
+
         <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
             android:id="@+id/state"
             android:layout_width="match_parent"
@@ -176,19 +189,6 @@
             android:hint="@string/shipping_label_edit_address_zip"
             android:nextFocusForward="@+id/countrySpinner"
             app:errorEnabled="true"/>
-
-        <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-            android:id="@+id/countrySpinner"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/minor_00"
-            android:layout_marginEnd="@dimen/major_100"
-            android:layout_marginBottom="@dimen/major_100"
-            android:hint="@string/shipping_label_edit_address_country"
-            android:inputType="text"
-            android:nextFocusForward="@+id/useAddressAsIsButton"
-            android:textAppearance="@style/TextAppearance.Woo.Caption" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/useAddressAsIsButton"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -461,7 +461,8 @@
     <string name="shipping_label_edit_address_name">Name</string>
     <string name="shipping_label_edit_address_company">Company</string>
     <string name="shipping_label_edit_address_phone">Phone</string>
-    <string name="shipping_label_edit_address_address">Address</string>
+    <string name="shipping_label_edit_address_line1">Address line 1</string>
+    <string name="shipping_label_edit_address_line2">Address line 2</string>
     <string name="shipping_label_edit_address_city">City</string>
     <string name="shipping_label_edit_address_state">State</string>
     <string name="shipping_label_edit_address_zip">Zip / Postal Code</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -464,7 +464,7 @@
     <string name="shipping_label_edit_address_line1">Address line 1</string>
     <string name="shipping_label_edit_address_line2">Address line 2</string>
     <string name="shipping_label_edit_address_city">City</string>
-    <string name="shipping_label_edit_address_state">State</string>
+    <string name="shipping_label_edit_address_state">State / County</string>
     <string name="shipping_label_edit_address_zip">Zip / Postal Code</string>
     <string name="shipping_label_edit_address_country">Country</string>
     <string name="shipping_label_edit_address_use_address_as_is">Use address as entered</string>


### PR DESCRIPTION
Closes #4387, this PR addresses the following points:
1. Fixes the wording of the address lines, by changing it to `Address line 1` and `Address line 2`.
2. Moves the country field above the state.
3. Change the state hint to `State / County` to make it clearer for countries that don't have states.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
