### PR TITLE
Reorder onboarding checks and fix currentDeadline parsing error

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -43,8 +43,8 @@ class CardReaderOnboardingChecker @Inject constructor(
         if (!isWCPaySetupCompleted(paymentAccount)) return WcpaySetupNotCompleted
         if (isWCPayInTestModeWithLiveStripeAccount()) return WcpayInTestModeWithLiveStripeAccount
         if (isStripeAccountUnderReview(paymentAccount)) return StripeAccountUnderReview
-        if (isStripeAccountPendingRequirements(paymentAccount)) return StripeAccountPendingRequirement
         if (isStripeAccountOverdueRequirements(paymentAccount)) return StripeAccountOverdueRequirement
+        if (isStripeAccountPendingRequirements(paymentAccount)) return StripeAccountPendingRequirement
         if (isStripeAccountRejected(paymentAccount)) return StripeAccountRejected
         if (isInUndefinedState(paymentAccount)) return GenericError
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -181,6 +181,22 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         }
 
     @Test
+    fun `when stripe account has both pending and overdue requirements, then OVERDUE_REQUIREMENT returned`() =
+        testBlocking {
+            whenever(wcPayStore.loadAccount(site)).thenReturn(
+                buildPaymentAccountResult(
+                    WCPaymentAccountResult.WCPayAccountStatusEnum.RESTRICTED,
+                    hasPendingRequirements = true,
+                    hadOverdueRequirements = true
+                )
+            )
+
+            val result = checker.getOnboardingState()
+
+            assertThat(result).isEqualTo(CardReaderOnboardingState.StripeAccountOverdueRequirement)
+        }
+
+    @Test
     fun `when stripe account marked as fraud, then STRIPE_ACCOUNT_REJECTED returned`() =
         testBlocking {
             whenever(wcPayStore.loadAccount(site)).thenReturn(

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '30ddd953de81208daacd793c08ea9ff93de0448d'
+    fluxCVersion = 'ab7f12bd8b3a4837df068be116461a6d83babc84'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'ab7f12bd8b3a4837df068be116461a6d83babc84'
+    fluxCVersion = '5a94ad8706556ea62988a0c5d4330e7cf512be7d'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'


### PR DESCRIPTION
Parent issue #4413

`do not merge` - remove when [the PR in fluxC](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2077) is merged and the hash is updated with the merge commit.

This PR swaps checks for "account pending requirements" and "account overdue requirements". An account can have both requirements flags set to `true`. However, "account overdue requirements" is more strict since the app doesn't let the user collect payments -> if we didn't swap the lines, the app would let the user collect payment even when the account had some overdue requirements. cc @koke 

This PR fixes also updates fluxc to fix `currentDeadline` parsing issue (more info [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2077)).


To test:
1. Select a store with both pending and overdue requirements which is eligible for card present payments (I'm using woowcpaystripeaccountrejectedtestingaccount.wpcomstaging.com, let me know if you want me to invite you)
3. Tap on app settings
4. Tap on "In-person payments"
5. Notice "Account overdue requirements" screen is shown and the app doesn't crash

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
