### PR TITLE
Merge 7.2 release notes into develop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,17 +12,17 @@ GEM
     artifactory (3.0.15)
     atomos (0.1.3)
     aws-eventstream (1.1.1)
-    aws-partitions (1.479.0)
-    aws-sdk-core (3.117.0)
+    aws-partitions (1.481.0)
+    aws-sdk-core (3.118.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.44.0)
-      aws-sdk-core (~> 3, >= 3.112.0)
+    aws-sdk-kms (1.45.0)
+      aws-sdk-core (~> 3, >= 3.118.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.96.2)
-      aws-sdk-core (~> 3, >= 3.112.0)
+    aws-sdk-s3 (1.97.0)
+      aws-sdk-core (~> 3, >= 3.118.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.4)
@@ -68,7 +68,7 @@ GEM
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     fastimage (2.2.4)
-    fastlane (2.188.0)
+    fastlane (2.189.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
@@ -85,7 +85,7 @@ GEM
       faraday_middleware (~> 1.0)
       fastimage (>= 2.1.0, < 3.0.0)
       gh_inspector (>= 1.1.2, < 2.0.0)
-      google-apis-androidpublisher_v3 (~> 0.1)
+      google-apis-androidpublisher_v3 (~> 0.3)
       google-apis-playcustomapp_v1 (~> 0.1)
       google-cloud-storage (~> 1.31)
       highline (~> 2.0)
@@ -262,4 +262,4 @@ DEPENDENCIES
   nokogiri
 
 BUNDLED WITH
-   2.2.22
+   2.2.23

--- a/WooCommerce/metadata/PlayStoreStrings.pot
+++ b/WooCommerce/metadata/PlayStoreStrings.pot
@@ -11,18 +11,18 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_072"
+msgid ""
+"7.2:\n"
+"We focused on making the product more stable and reliable for you this time. Several bugs were addressed and fixed, including one where the list of products would be empty sometimes when a product contained a value in total sales that was unexpected. Thanks for keeping up to date, and always let us know if you have feedback!\n"
+msgstr ""
+
 msgctxt "release_note_071"
 msgid ""
 "7.1:\n"
 "Some merchants in the USA using the WooCommerce Shipping & Tax extension saw a bug when creating labels for orders with decimal product quantities. It’s fixed!\n"
 "\n"
 "Want to give label creation a try? Install and activate the WooCommerce Shipping & Tax extension in your store. Right now, we support merchants in the USA shipping worldwide. We welcome your feedback!\n"
-msgstr ""
-
-msgctxt "release_note_070"
-msgid ""
-"7.0:\n"
-"Creating international shipping labels is a breeze! Merchants in the USA using WooCommerce Shipping & Tax in their store can now generate shipping labels and customs forms for international destinations. We’re continuing to build this feature – give it a whirl and let us know how it goes!\n"
 msgstr ""
 
 #. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,2 +1,1 @@
-
-
+We focused on making the product more stable and reliable for you this time. Several bugs were addressed and fixed, including one where the list of products would be empty sometimes when a product contained a value in total sales that was unexpected. Thanks for keeping up to date, and always let us know if you have feedback!


### PR DESCRIPTION
Merges `7.2` release notes (and a `fastlane` update) into `develop`.