### PR TITLE
Shipping Labels: hide delivery estimate when it's 0

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
@@ -128,16 +128,24 @@ class ShippingCarrierRatesAdapter(
             fun bind(rateItem: ShippingRateItem) {
                 binding.carrierServiceName.text = rateItem.title
 
-                if (rateItem.deliveryDate != null) {
-                    binding.deliveryTime.text = dateUtils.getShortMonthDayString(
-                        dateUtils.getYearMonthDayStringFromDate(rateItem.deliveryDate)
-                    )
-                } else {
-                    binding.deliveryTime.text = binding.root.resources.getQuantityString(
-                        R.plurals.shipping_label_shipping_carrier_rates_delivery_estimate,
-                        rateItem.deliveryEstimate,
-                        rateItem.deliveryEstimate
-                    )
+                when {
+                    rateItem.deliveryDate != null -> {
+                        binding.deliveryTime.isVisible = true
+                        binding.deliveryTime.text = dateUtils.getShortMonthDayString(
+                            dateUtils.getYearMonthDayStringFromDate(rateItem.deliveryDate)
+                        )
+                    }
+                    rateItem.deliveryEstimate != 0 -> {
+                        binding.deliveryTime.isVisible = true
+                        binding.deliveryTime.text = binding.root.resources.getQuantityString(
+                            R.plurals.shipping_label_shipping_carrier_rates_delivery_estimate,
+                            rateItem.deliveryEstimate,
+                            rateItem.deliveryEstimate
+                        )
+                    }
+                    else -> {
+                        binding.deliveryTime.isVisible = false
+                    }
                 }
 
                 binding.servicePrice.text = rateItem.options[rateItem.selectedOption ?: DEFAULT]?.formattedPrice


### PR DESCRIPTION
Fixes #4534, this just hides the delivery estimate text when the shipping method doesn't support it (when we get 0, from the API)

<img width=360 src="https://user-images.githubusercontent.com/1657201/127737476-f57f8e51-e091-4390-98bf-41db67ed1c52.png"/> <img width=360 src="https://user-images.githubusercontent.com/1657201/127737473-22a0043c-9eec-486a-a9b5-cdf805b10b67.png"/> 

#### Testing

1. Create a label with an international destination in Vietnam.
2. Select a custom package in the packaging step, with a low weight for your package (7 oz or less)
3. Complete all the details to get to the rates screen.
4. Confirm that the cheapest USPS option hides the delivery estimate.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
