### PR TITLE
Issue/4413 restricted soon status

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -86,7 +86,8 @@ class CardReaderOnboardingChecker @Inject constructor(
             !paymentAccount.hasOverdueRequirements
 
     private fun isStripeAccountPendingRequirements(paymentAccount: WCPaymentAccountResult): Boolean =
-        paymentAccount.status == RESTRICTED && paymentAccount.hasPendingRequirements
+        (paymentAccount.status == RESTRICTED && paymentAccount.hasPendingRequirements) ||
+            paymentAccount.status == RESTRICTED_SOON
 
     private fun isStripeAccountOverdueRequirements(paymentAccount: WCPaymentAccountResult): Boolean =
         paymentAccount.status == RESTRICTED &&

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -43,8 +43,8 @@ class CardReaderOnboardingChecker @Inject constructor(
         if (!isWCPaySetupCompleted(paymentAccount)) return WcpaySetupNotCompleted
         if (isWCPayInTestModeWithLiveStripeAccount()) return WcpayInTestModeWithLiveStripeAccount
         if (isStripeAccountUnderReview(paymentAccount)) return StripeAccountUnderReview
-        if (isStripeAccountPendingRequirements(paymentAccount)) return StripeAccountPendingRequirement
         if (isStripeAccountOverdueRequirements(paymentAccount)) return StripeAccountOverdueRequirement
+        if (isStripeAccountPendingRequirements(paymentAccount)) return StripeAccountPendingRequirement
         if (isStripeAccountRejected(paymentAccount)) return StripeAccountRejected
         if (isInUndefinedState(paymentAccount)) return GenericError
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.pay.WCPaymentAccountResult
+import org.wordpress.android.fluxc.model.pay.WCPaymentAccountResult.WCPayAccountStatusEnum.*
 import org.wordpress.android.fluxc.persistence.WCPluginSqlUtils
 import org.wordpress.android.fluxc.store.WCPayStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
@@ -73,34 +74,33 @@ class CardReaderOnboardingChecker @Inject constructor(
     private fun isWCPayActivated(pluginInfo: WCPluginSqlUtils.WCPluginModel): Boolean = pluginInfo.active
 
     private fun isWCPaySetupCompleted(paymentAccount: WCPaymentAccountResult): Boolean =
-        paymentAccount.status != WCPaymentAccountResult.WCPayAccountStatusEnum.NO_ACCOUNT
+        paymentAccount.status != NO_ACCOUNT
 
     // TODO cardreader Implement
     @Suppress("FunctionOnlyReturningConstant")
     private fun isWCPayInTestModeWithLiveStripeAccount(): Boolean = false
 
     private fun isStripeAccountUnderReview(paymentAccount: WCPaymentAccountResult): Boolean =
-        paymentAccount.status == WCPaymentAccountResult.WCPayAccountStatusEnum.RESTRICTED &&
+        paymentAccount.status == RESTRICTED &&
             !paymentAccount.hasPendingRequirements &&
             !paymentAccount.hasOverdueRequirements
 
     private fun isStripeAccountPendingRequirements(paymentAccount: WCPaymentAccountResult): Boolean =
-        paymentAccount.status == WCPaymentAccountResult.WCPayAccountStatusEnum.RESTRICTED &&
-            paymentAccount.hasPendingRequirements
+        paymentAccount.status == RESTRICTED && paymentAccount.hasPendingRequirements
 
     private fun isStripeAccountOverdueRequirements(paymentAccount: WCPaymentAccountResult): Boolean =
-        paymentAccount.status == WCPaymentAccountResult.WCPayAccountStatusEnum.RESTRICTED &&
+        paymentAccount.status == RESTRICTED &&
             paymentAccount.hasOverdueRequirements
 
     private fun isStripeAccountRejected(paymentAccount: WCPaymentAccountResult): Boolean =
-        paymentAccount.status == WCPaymentAccountResult.WCPayAccountStatusEnum.REJECTED_FRAUD ||
-            paymentAccount.status == WCPaymentAccountResult.WCPayAccountStatusEnum.REJECTED_LISTED ||
-            paymentAccount.status == WCPaymentAccountResult.WCPayAccountStatusEnum.REJECTED_TERMS_OF_SERVICE ||
-            paymentAccount.status == WCPaymentAccountResult.WCPayAccountStatusEnum.REJECTED_OTHER
+        paymentAccount.status == REJECTED_FRAUD ||
+            paymentAccount.status == REJECTED_LISTED ||
+            paymentAccount.status == REJECTED_TERMS_OF_SERVICE ||
+            paymentAccount.status == REJECTED_OTHER
 }
 
 private fun isInUndefinedState(paymentAccount: WCPaymentAccountResult): Boolean =
-    paymentAccount.status != WCPaymentAccountResult.WCPayAccountStatusEnum.COMPLETE
+    paymentAccount.status != COMPLETE
 
 sealed class CardReaderOnboardingState {
     object OnboardingCompleted : CardReaderOnboardingState()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -165,6 +165,22 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         }
 
     @Test
+    fun `when stripe account restricted soon, then STRIPE_ACCOUNT_PENDING_REQUIREMENT returned`() =
+        testBlocking {
+            whenever(wcPayStore.loadAccount(site)).thenReturn(
+                buildPaymentAccountResult(
+                    WCPaymentAccountResult.WCPayAccountStatusEnum.RESTRICTED_SOON,
+                    hasPendingRequirements = false,
+                    hadOverdueRequirements = false
+                )
+            )
+
+            val result = checker.getOnboardingState()
+
+            assertThat(result).isEqualTo(CardReaderOnboardingState.StripeAccountPendingRequirement)
+        }
+
+    @Test
     fun `when stripe account has overdue requirements, then STRIPE_ACCOUNT_OVERDUE_REQUIREMENT returned`() =
         testBlocking {
             whenever(wcPayStore.loadAccount(site)).thenReturn(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -181,6 +181,22 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         }
 
     @Test
+    fun `when stripe account has both pending and overdue requirements, then OVERDUE_REQUIREMENT returned`() =
+        testBlocking {
+            whenever(wcPayStore.loadAccount(site)).thenReturn(
+                buildPaymentAccountResult(
+                    WCPaymentAccountResult.WCPayAccountStatusEnum.RESTRICTED,
+                    hasPendingRequirements = true,
+                    hadOverdueRequirements = true
+                )
+            )
+
+            val result = checker.getOnboardingState()
+
+            assertThat(result).isEqualTo(CardReaderOnboardingState.StripeAccountOverdueRequirement)
+        }
+
+    @Test
     fun `when stripe account marked as fraud, then STRIPE_ACCOUNT_REJECTED returned`() =
         testBlocking {
             whenever(wcPayStore.loadAccount(site)).thenReturn(

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '30ddd953de81208daacd793c08ea9ff93de0448d'
+    fluxCVersion = 'ab7f12bd8b3a4837df068be116461a6d83babc84'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'ab7f12bd8b3a4837df068be116461a6d83babc84'
+    fluxCVersion = 'a9347903fb46c493eb91d069631ecfb42735769e'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'ab7f12bd8b3a4837df068be116461a6d83babc84'
+    fluxCVersion = '5a94ad8706556ea62988a0c5d4330e7cf512be7d'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'


### PR DESCRIPTION
Parent #4413 

Merge instructions:
1. Make sure https://github.com/woocommerce/woocommerce-android/pull/4532 is merged first
2. Make sure https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2082 is merged first
3. Update fluxC hash with merge commit hash
4. Merge this PR

This PR fixes parsing of "restricted_soon" status.

To test:
2. Select a store with both pending requirements which is eligible for card present payments (I'm using woowcpaystripeaccountpendingrequirementstestingsite.wpcomstaging.com, let me know if you want me to invite you)
3. Tap on app settings
4. Tap on "In-person payments"
5. Notice "Account pending requirements" screen is shown and the app doesn't crash

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
