### PR TITLE
Issue/4413 onboarding click listeners

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -34,5 +34,6 @@ object AppUrls {
         "https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#section-29"
 
     const val WPCOM_ADD_PAYMENT_METHOD = "https://wordpress.com/me/purchases/add-payment-method"
-    const val WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS = "https://woocommerce.com/payments/"
+    const val WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS =
+        "https://docs.woocommerce.com/document/getting-started-with-in-person-payments-with-woocommerce-payments/"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -174,6 +174,7 @@ class HelpActivity : AppCompatActivity() {
     enum class Origin(private val stringValue: String) {
         UNKNOWN("origin:unknown"),
         SETTINGS("origin:settings"),
+        CARD_READER_ONBOARDING("origin:card_reader_onboarding"),
         FEEDBACK_SURVEY("origin:feedback_survey"),
         USER_ELIGIBILITY_ERROR("origin:user_eligibility_error"),
         MY_STORE("origin:my_store"),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -13,6 +13,8 @@ import com.woocommerce.android.databinding.FragmentCardReaderOnboardingUnsupport
 import com.woocommerce.android.databinding.FragmentCardReaderOnboardingWcpayBinding
 import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.extensions.navigateBackWithNotice
+import com.woocommerce.android.extensions.startHelpActivity
+import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.UiHelpers
@@ -35,7 +37,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
             { event ->
                 when (event) {
                     is CardReaderOnboardingViewModel.OnboardingEvent.NavigateToSupport -> {
-                        // todo cardreader start HelpActivity
+                        requireActivity().startHelpActivity(HelpActivity.Origin.CARD_READER_ONBOARDING)
                     }
                     is CardReaderOnboardingViewModel.OnboardingEvent.ViewLearnMore -> {
                         ChromeCustomTabUtils.launchUrl(requireActivity(), AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS)


### PR DESCRIPTION
Parent issue #4413 

- Replaces woocommerce.com/payments url with an url for in-person payments documentation
- Redirects the user to HelpActivity when they tap on "Contact support" button


To test:
The easiest way how to test this is to modify CardReaderOnboardingChecker and always return for example CountryNotSupported("US").
1. Tap on App settings
2. Tap on in-person payments
3. Tap on Learn more and notice you are navigated to the docs for in-person payments
4. Go back and tap on Contact Support and notice you are navigated to the help activty

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
