### PR TITLE
Add firmware version to card reader

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailFragment.kt
@@ -88,6 +88,7 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
                             enforcedUpdateDivider.visibility = enforcedUpdateTv.visibility
                             UiHelpers.setTextOrHide(readerNameTv, state.readerName)
                             UiHelpers.setTextOrHide(readerBatteryTv, state.readerBattery)
+                            UiHelpers.setTextOrHide(readerFirmwareVersionTv, state.readerFirmwareVersion)
                             UiHelpers.setTextOrHide(primaryActionBtn, state.primaryButtonState?.text)
                             primaryActionBtn.setOnClickListener { state.primaryButtonState?.onActionClicked?.invoke() }
                             UiHelpers.setTextOrHide(secondaryActionBtn, state.secondaryButtonState?.text)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
@@ -39,6 +39,8 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.math.roundToInt
 
+private const val PERCENT_100 = 100
+
 @HiltViewModel
 class CardReaderDetailViewModel @Inject constructor(
     val cardReaderManager: CardReaderManager,
@@ -148,32 +150,6 @@ class CardReaderDetailViewModel @Inject constructor(
         appPrefs.removeLastConnectedCardReaderId()
     }
 
-    private fun CardReader.getReadersName(): UiString {
-        return with(id) {
-            if (isNullOrEmpty()) {
-                UiStringRes(R.string.card_reader_detail_connected_reader_unknown)
-            } else {
-                UiStringText(this)
-            }
-        }
-    }
-
-    private fun CardReader.getReadersBatteryLevel(): UiString? {
-        return currentBatteryLevel?.let {
-            UiStringRes(
-                R.string.card_reader_detail_connected_battery_percentage,
-                listOf(UiStringText((it * 100).roundToInt().toString()))
-            )
-        }
-    }
-
-    private fun CardReader.getReaderFirmwareVersion(): UiString {
-        return UiStringRes(
-                R.string.card_reader_detail_connected_firmware_version,
-                listOf(UiStringText(this.firmwareVersion.substringBefore("-")))
-            )
-    }
-
     sealed class NavigationTarget : Event() {
         object CardReaderConnectScreen : NavigationTarget()
         data class CardReaderUpdateScreen(val startedByUser: Boolean) : NavigationTarget()
@@ -184,7 +160,9 @@ class CardReaderDetailViewModel @Inject constructor(
             val onPrimaryActionClicked: (() -> Unit)
         ) : ViewState() {
             val headerLabel = UiStringRes(R.string.card_reader_detail_not_connected_header)
-            @DrawableRes val illustration = R.drawable.img_card_reader_not_connected
+
+            @DrawableRes
+            val illustration = R.drawable.img_card_reader_not_connected
             val firstHintNumber = UiStringText("1")
             val secondHintNumber = UiStringText("2")
             val thirdHintNumber = UiStringText("3")
@@ -213,4 +191,30 @@ class CardReaderDetailViewModel @Inject constructor(
 
         object Loading : ViewState()
     }
+}
+
+private fun CardReader.getReadersName(): UiString {
+    return with(id) {
+        if (isNullOrEmpty()) {
+            UiStringRes(R.string.card_reader_detail_connected_reader_unknown)
+        } else {
+            UiStringText(this)
+        }
+    }
+}
+
+private fun CardReader.getReadersBatteryLevel(): UiString? {
+    return currentBatteryLevel?.let {
+        UiStringRes(
+            R.string.card_reader_detail_connected_battery_percentage,
+            listOf(UiStringText((it * PERCENT_100).roundToInt().toString()))
+        )
+    }
+}
+
+private fun CardReader.getReaderFirmwareVersion(): UiString {
+    return UiStringRes(
+        R.string.card_reader_detail_connected_firmware_version,
+        listOf(UiStringText(this.firmwareVersion.substringBefore("-")))
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
@@ -85,6 +85,7 @@ class CardReaderDetailViewModel @Inject constructor(
                 ),
                 readerName = readerStatus.cardReader.getReadersName(),
                 readerBattery = readerStatus.cardReader.getReadersBatteryLevel(),
+                readerFirmwareVersion = readerStatus.cardReader.getReaderFirmwareVersion(),
                 primaryButtonState = ButtonState(
                     onActionClicked = ::onUpdateReaderClicked,
                     text = UiStringRes(R.string.card_reader_detail_connected_update_software)
@@ -99,6 +100,7 @@ class CardReaderDetailViewModel @Inject constructor(
                 enforceReaderUpdate = null,
                 readerName = readerStatus.cardReader.getReadersName(),
                 readerBattery = readerStatus.cardReader.getReadersBatteryLevel(),
+                readerFirmwareVersion = readerStatus.cardReader.getReaderFirmwareVersion(),
                 primaryButtonState = ButtonState(
                     onActionClicked = ::onDisconnectClicked,
                     text = UiStringRes(R.string.card_reader_detail_connected_disconnect_reader)
@@ -165,6 +167,13 @@ class CardReaderDetailViewModel @Inject constructor(
         }
     }
 
+    private fun CardReader.getReaderFirmwareVersion(): UiString {
+        return UiStringRes(
+                R.string.card_reader_detail_connected_firmware_version,
+                listOf(UiStringText(this.firmwareVersion.substringBefore("-")))
+            )
+    }
+
     sealed class NavigationTarget : Event() {
         object CardReaderConnectScreen : NavigationTarget()
         data class CardReaderUpdateScreen(val startedByUser: Boolean) : NavigationTarget()
@@ -190,6 +199,7 @@ class CardReaderDetailViewModel @Inject constructor(
             val enforceReaderUpdate: UiString?,
             val readerName: UiString,
             val readerBattery: UiString?,
+            val readerFirmwareVersion: UiString,
             val primaryButtonState: ButtonState?,
             val secondaryButtonState: ButtonState?
         ) : ViewState() {

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_detail_connected_state.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_detail_connected_state.xml
@@ -56,6 +56,13 @@
         android:layout_height="wrap_content"
         tools:text="@string/card_reader_detail_connected_battery_percentage" />
 
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/reader_firmware_version_tv"
+        style="@style/Woo.TextView.Body2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:text="@string/card_reader_detail_connected_firmware_version" />
+
     <com.google.android.material.button.MaterialButton
         android:id="@+id/primary_action_btn"
         style="@style/Woo.Button.Colored"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -805,6 +805,7 @@
 
     <string name="card_reader_detail_connected_header">CONNECTED READER</string>
     <string name="card_reader_detail_connected_battery_percentage">%s%% battery</string>
+    <string name="card_reader_detail_connected_firmware_version">Firmware: %s</string>
     <string name="card_reader_detail_connected_update_software">Update reader\'s software</string>
     <string name="card_reader_detail_connected_enforced_update_software">Please update your reader software to keep accepting payments</string>
     <string name="card_reader_detail_connected_disconnect_reader">Disconnect reader</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
@@ -28,6 +28,9 @@ import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
+private const val DUMMY_FIRMWARE_VERSION = "1.0.0.123-abcd-test-3000"
+private const val DUMMY_FIRMWARE_VERSION_SIMPLIFIED = "1.0.0.123"
+
 @ExperimentalCoroutinesApi
 class CardReaderDetailViewModelTest : BaseUnitTest() {
     private val cardReaderManager: CardReaderManager = mock {
@@ -79,6 +82,10 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
                 viewModel,
                 UiStringText(READER_NAME),
                 UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("65"))),
+                UiStringRes(
+                    R.string.card_reader_detail_connected_firmware_version,
+                    listOf(UiStringText(DUMMY_FIRMWARE_VERSION_SIMPLIFIED))
+                ),
                 updateAvailable = false
             )
         }
@@ -97,6 +104,10 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
                 viewModel,
                 UiStringText(READER_NAME),
                 UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("33"))),
+                UiStringRes(
+                    R.string.card_reader_detail_connected_firmware_version,
+                    listOf(UiStringText(DUMMY_FIRMWARE_VERSION_SIMPLIFIED))
+                ),
                 updateAvailable = false
             )
         }
@@ -116,6 +127,10 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
                 viewModel,
                 UiStringRes(R.string.card_reader_detail_connected_reader_unknown),
                 null,
+                UiStringRes(
+                    R.string.card_reader_detail_connected_firmware_version,
+                    listOf(UiStringText(DUMMY_FIRMWARE_VERSION_SIMPLIFIED))
+                ),
                 updateAvailable = false
             )
         }
@@ -187,6 +202,10 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
                 viewModel,
                 UiStringText(READER_NAME),
                 UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("65"))),
+                UiStringRes(
+                    R.string.card_reader_detail_connected_firmware_version,
+                    listOf(UiStringText(DUMMY_FIRMWARE_VERSION_SIMPLIFIED))
+                ),
                 updateAvailable = true
             )
         }
@@ -205,6 +224,10 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
                 viewModel,
                 UiStringText(READER_NAME),
                 UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("65"))),
+                UiStringRes(
+                    R.string.card_reader_detail_connected_firmware_version,
+                    listOf(UiStringText(DUMMY_FIRMWARE_VERSION_SIMPLIFIED))
+                ),
                 updateAvailable = false
             )
             assertThat(viewModel.event.value)
@@ -251,6 +274,10 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
                 viewModel,
                 UiStringText(READER_NAME),
                 UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("65"))),
+                UiStringRes(
+                    R.string.card_reader_detail_connected_firmware_version,
+                    listOf(UiStringText(DUMMY_FIRMWARE_VERSION_SIMPLIFIED))
+                ),
                 updateAvailable = false
             )
         }
@@ -271,6 +298,10 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
                 viewModel,
                 UiStringText(READER_NAME),
                 UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("65"))),
+                UiStringRes(
+                    R.string.card_reader_detail_connected_firmware_version,
+                    listOf(UiStringText(DUMMY_FIRMWARE_VERSION_SIMPLIFIED))
+                ),
                 updateAvailable = false
             )
         }
@@ -293,6 +324,10 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
                 viewModel,
                 UiStringText(READER_NAME),
                 UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("65"))),
+                UiStringRes(
+                    R.string.card_reader_detail_connected_firmware_version,
+                    listOf(UiStringText(DUMMY_FIRMWARE_VERSION_SIMPLIFIED))
+                ),
                 updateAvailable = false
             )
             assertThat(events[0])
@@ -411,11 +446,13 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
         viewModel: CardReaderDetailViewModel,
         readerName: UiString,
         batteryLevel: UiString?,
+        firmwareVersion: UiString,
         updateAvailable: Boolean
     ) {
         val state = viewModel.viewStateData.value as ConnectedState
         assertThat(state.readerName).isEqualTo(readerName)
         assertThat(state.readerBattery).isEqualTo(batteryLevel)
+        assertThat(state.readerFirmwareVersion).isEqualTo(firmwareVersion)
         if (updateAvailable) {
             assertThat(state.enforceReaderUpdate)
                 .isEqualTo(UiStringRes(R.string.card_reader_detail_connected_enforced_update_software))
@@ -434,11 +471,13 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
     private fun initConnectedState(
         readersName: String? = READER_NAME,
         batteryLevel: Float? = 0.65F,
+        firmwareVersion: String = DUMMY_FIRMWARE_VERSION,
         updateAvailable: SoftwareUpdateAvailability = SoftwareUpdateAvailability.UpToDate
     ) = coroutinesTestRule.testDispatcher.runBlockingTest {
         val reader: CardReader = mock {
-            on { id }.thenReturn(readersName)
-            on { currentBatteryLevel }.thenReturn(batteryLevel)
+            on { this.id }.thenReturn(readersName)
+            on { this.currentBatteryLevel }.thenReturn(batteryLevel)
+            on { this.firmwareVersion }.thenReturn(firmwareVersion)
         }
         val status = MutableStateFlow(CardReaderStatus.Connected(reader))
         whenever(cardReaderManager.readerStatus).thenReturn(status)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReader.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReader.kt
@@ -4,4 +4,5 @@ interface CardReader {
     val id: String?
     val type: String?
     val currentBatteryLevel: Float?
+    val firmwareVersion: String
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderImpl.kt
@@ -9,4 +9,6 @@ class CardReaderImpl(val cardReader: Reader) : CardReader {
         get() = cardReader.deviceType.name
     override val currentBatteryLevel: Float?
         get() = cardReader.batteryLevel
+    override val firmwareVersion: String
+        get() = cardReader.softwareVersion
 }


### PR DESCRIPTION
This PR implements https://github.com/woocommerce/woocommerce-ios/issues/4661#issuecomment-891166865 on Android

Adds firmware version to card reader detail screen -> only the part in front of "-" delimiter is displayed.

To test:
- Make sure you store is eligible for in-person payments
1. Tap on App settings
2. Tap on Manage Card Reader
3. Tap on Connect
4. Connect to a reader and notice software version is displayed on the UI

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
