### PR TITLE
Remove android team from `CODEOWNER`s

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,3 @@
-# All files in repository
-* @woocommerce/android-developers
-
 # Build tools
 /.buildkite/        @woocommerce/owl-team
 /.bundle/           @woocommerce/owl-team


### PR DESCRIPTION
Discussed internally: p91TBi-5IV-p2

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.