### PR TITLE
Update pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,18 @@
+<!-- Remember about a good descriptive title. -->
 
-Update release notes:
+Closes: #
+<!-- Id number of the GitHub issue this PR addresses. -->
+
+### Description
+<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
+
+### Testing instructions
+<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
+
+### Images/gif
+<!-- Include before and after images or gifs when appropriate. -->
+
 
 - [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
+
+<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->

--- a/README.md
+++ b/README.md
@@ -6,9 +6,13 @@
 
 <p align="center">
     <a href="https://circleci.com/gh/woocommerce/woocommerce-android">
-        <img src="https://circleci.com/gh/woocommerce/woocommerce-android.svg?style=svg" alt="CircleCI">
-    <img alt="Release" src="https://img.shields.io/github/v/tag/woocommerce/woocommerce-android?label=release&sort=semver">
-    <img alt="License" src="https://img.shields.io/github/license/woocommerce/woocommerce-android">
+        <img src="https://circleci.com/gh/woocommerce/woocommerce-android.svg?style=shield" alt="CircleCI">
+    </a>
+    <a href="https://github.com/woocommerce/woocommerce-android/releases">
+        <img alt="Release" src="https://img.shields.io/github/v/tag/woocommerce/woocommerce-android?label=release&sort=semver">
+    </a>
+    <a href="https://github.com/woocommerce/woocommerce-android/blob/develop/LICENSE.md">
+        <img alt="License" src="https://img.shields.io/github/license/woocommerce/woocommerce-android">
     </a>
 </p>
 


### PR DESCRIPTION
Closes: #4545

### Description

This PR updates a PR template to contain points that we'd like to see in every PR, based on [pull request guidelines](https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md).

It also fixes a minor issue with links on badges in our `README.md` - currently they all link to CircleCI.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
