### PR TITLE
Fluxc from s3

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -26,6 +26,8 @@ repositories {
         url 'https://a8c-libs.s3.amazonaws.com/android'
         content {
             includeGroup "org.wordpress"
+            includeGroup "org.wordpress.fluxc"
+            includeGroup "org.wordpress.fluxc.plugins"
         }
     }
     maven {
@@ -176,17 +178,20 @@ dependencies {
         }
     }
 
-    implementation("$gradle.ext.fluxCBinaryPath:fluxc:$fluxCVersion") {
+    implementation("${gradle.ext.fluxCBinaryPath}:$fluxCVersion") {
         exclude group: "com.android.support"
         exclude group: "org.wordpress", module: "utils"
     }
-    implementation("$gradle.ext.fluxCBinaryPath:woocommerce:$fluxCVersion") {
+    implementation("${gradle.ext.fluxCWooCommercePluginBinaryPath}:$fluxCVersion") {
         exclude group: "com.android.support"
         exclude group: "org.wordpress", module: "utils"
     }
 
     implementation ("$gradle.ext.loginFlowBinaryPath:$wordPressLoginVersion") {
         exclude group: "com.github.wordpress-mobile.WordPress-FluxC-Android", module: "fluxc"
+        exclude group: "org.wordpress", module: "fluxc"
+        exclude group: "org.wordpress.fluxc"
+        exclude group: "org.wordpress.fluxc.plugins"
         exclude group: "org.wordpress", module: "utils"
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2083-0712ed7d457e7a34c2d9d1951e95cf6ee3170c52'
+    fluxCVersion = 'develop-0193e64889a94b44c507c6aba5b83ce0fc96bc61'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '5a94ad8706556ea62988a0c5d4330e7cf512be7d'
+    fluxCVersion = '2083-327d81ba2b334df14e3ee0862956b7b77af16d11'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2083-327d81ba2b334df14e3ee0862956b7b77af16d11'
+    fluxCVersion = '2083-0712ed7d457e7a34c2d9d1951e95cf6ee3170c52'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,8 @@
 include ':libs:cardreader'
 include ':WooCommerce'
 
-gradle.ext.fluxCBinaryPath = "com.github.wordpress-mobile.WordPress-FluxC-Android"
+gradle.ext.fluxCBinaryPath = "org.wordpress:fluxc"
+gradle.ext.fluxCWooCommercePluginBinaryPath = "org.wordpress.fluxc.plugins:woocommerce"
 gradle.ext.loginFlowBinaryPath = "org.wordpress:login"
 
 def localBuilds = new File('local-builds.gradle')
@@ -22,9 +23,8 @@ if (localBuilds.exists()) {
         includeBuild(ext.localFluxCPath) {
             dependencySubstitution {
                 println "Substituting fluxc with the local build"
-                substitute module("$gradle.ext.fluxCBinaryPath:fluxc") with project(':fluxc')
-                substitute module("$gradle.ext.fluxCBinaryPath:woocommerce") with project(':plugins:woocommerce')
-
+                substitute module(gradle.ext.fluxCBinaryPath) with project(':fluxc')
+                substitute module(gradle.ext.fluxCWooCommercePluginBinaryPath) with project(':plugins:woocommerce')
             }
         }
     }


### PR DESCRIPTION
Updates FluxC dependency to be fetched from S3: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2083

Note that fluxc version needs to be updated before this can be merged.

**To test:**
* Smoke test the app
* Verify that composite build works for FluxC

**Update release notes:**

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
