### PR TITLE
Implement no connection logic in onboarding checker

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.prefs.cardreader.onboarding
 
 import androidx.annotation.VisibleForTesting
 import com.woocommerce.android.extensions.semverCompareTo
+import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState.*
 import com.woocommerce.android.util.CoroutineDispatchers
@@ -24,10 +25,12 @@ class CardReaderOnboardingChecker @Inject constructor(
     private val selectedSite: SelectedSite,
     private val wooStore: WooCommerceStore,
     private val wcPayStore: WCPayStore,
-    private val dispatchers: CoroutineDispatchers
+    private val dispatchers: CoroutineDispatchers,
+    private val networkStatus: NetworkStatus,
 ) {
-    @Suppress("ReturnCount")
+    @Suppress("ReturnCount", "ComplexMethod")
     suspend fun getOnboardingState(): CardReaderOnboardingState {
+        if (!networkStatus.isConnected()) return NoConnectionError
         val countryCode = getCountryCode()
         if (!isCountrySupported(countryCode)) return CountryNotSupported(countryCode)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.prefs.cardreader.onboarding
 
 import com.nhaarman.mockitokotlin2.*
+import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -21,18 +22,44 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
     private val selectedSite: SelectedSite = mock()
     private val wooStore: WooCommerceStore = mock()
     private val wcPayStore: WCPayStore = mock()
+    private val networkStatus: NetworkStatus = mock()
 
     private val site = SiteModel()
 
     @Before
     fun setUp() = testBlocking {
-        checker = CardReaderOnboardingChecker(selectedSite, wooStore, wcPayStore, coroutinesTestRule.testDispatchers)
+        checker = CardReaderOnboardingChecker(
+            selectedSite,
+            wooStore,
+            wcPayStore,
+            coroutinesTestRule.testDispatchers,
+            networkStatus
+        )
+        whenever(networkStatus.isConnected()).thenReturn(true)
         whenever(selectedSite.get()).thenReturn(site)
         whenever(wooStore.getStoreCountryCode(site)).thenReturn("US")
         whenever(wcPayStore.loadAccount(site)).thenReturn(buildPaymentAccountResult())
         whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
         whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
             .thenReturn(buildWCPayPluginInfo())
+    }
+
+    @Test
+    fun `when not connected to network, then NO_CONNECTION returned`() = testBlocking {
+        whenever(networkStatus.isConnected()).thenReturn(false)
+
+        val result = checker.getOnboardingState()
+
+        assertThat(result).isInstanceOf(CardReaderOnboardingState.NoConnectionError::class.java)
+    }
+
+    @Test
+    fun `when connected to network, then NO_CONNECTION not returned`() = testBlocking {
+        whenever(networkStatus.isConnected()).thenReturn(true)
+
+        val result = checker.getOnboardingState()
+
+        assertThat(result).isNotInstanceOf(CardReaderOnboardingState.NoConnectionError::class.java)
     }
 
     @Test


### PR DESCRIPTION
Parent issue #4413

Needs to be merged when https://github.com/woocommerce/woocommerce-android/pull/4551 is merged (or we can merge this PR into its parent since they are very related).

I noticed the logic for network check is not implemented in the onboarding checker. This PR checks if the device is connected and returns NoConnectionError when it isn't.

To test
- Use a store eligible for in person payments
2. Tap on App settings
3. Enable airplane mode
4. Tap on in-person payments
5. Notice a connection error screen is shown 


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
