### PR TITLE
Remove cancel button on loading screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -71,7 +71,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         binding.container.addView(layout)
         when (state) {
             is CardReaderOnboardingViewModel.OnboardingViewState.GenericErrorState -> TODO()
-            is CardReaderOnboardingViewModel.OnboardingViewState.LoadingState -> showLoadingState(layout)
+            is CardReaderOnboardingViewModel.OnboardingViewState.LoadingState -> showLoadingState(layout, state)
             is CardReaderOnboardingViewModel.OnboardingViewState.NoConnectionErrorState -> TODO()
             is CardReaderOnboardingViewModel.OnboardingViewState.UnsupportedCountryState ->
                 showCountryNotSupportedState(layout, state)
@@ -82,11 +82,14 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         }.exhaustive
     }
 
-    private fun showLoadingState(view: View) {
+    private fun showLoadingState(
+        view: View,
+        state: CardReaderOnboardingViewModel.OnboardingViewState.LoadingState
+    ) {
         val binding = FragmentCardReaderOnboardingLoadingBinding.bind(view)
-        binding.cancelButton.setOnClickListener {
-            viewModel.onCancelClicked()
-        }
+        UiHelpers.setTextOrHide(binding.textHeaderTv, state.headerLabel)
+        UiHelpers.setTextOrHide(binding.hintTv, state.hintLabel)
+        UiHelpers.setImageOrHide(binding.illustrationIv, state.illustration)
     }
 
     private fun showWCStripeError(

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_onboarding_loading.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_onboarding_loading.xml
@@ -7,44 +7,43 @@
     android:paddingHorizontal="@dimen/major_200">
 
     <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/textHeader"
+        android:id="@+id/textHeaderTv"
         style="@style/Woo.TextView.Headline6"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:gravity="center_horizontal"
-        android:text="@string/card_reader_onboarding_loading"
+        app:layout_constraintBottom_toTopOf="@+id/illustrationIv"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed"
+        tools:text="@string/card_reader_onboarding_loading" />
 
     <ImageView
-        android:id="@+id/illustration"
+        android:id="@+id/illustrationIv"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_325"
         android:contentDescription="@null"
-        app:layout_constraintBottom_toTopOf="@+id/cancelButton"
+        app:layout_constraintBottom_toTopOf="@+id/hintTv"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textHeader"
+        app:layout_constraintTop_toBottomOf="@+id/textHeaderTv"
         app:srcCompat="@drawable/img_payment_onboarding_loading" />
 
-    <ProgressBar
-        android:id="@+id/progress"
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/hintTv"
+        style="@style/TextAppearance.Woo.Body1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/major_325"
         android:layout_marginBottom="@dimen/major_200"
-        android:visibility="gone"
-        app:layout_constraintBottom_toTopOf="@+id/cancelButton"
+        android:textColor="@color/color_on_surface"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/illustrationIv"
+        tools:text="@string/please_wait"
         tools:visibility="visible" />
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/cancelButton"
-        style="@style/Woo.Button.Outlined"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/cancel"
-        app:layout_constraintBottom_toBottomOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Parent issue #4413 

This PR updates the loading screen as per the updated designs - removes "Cancel" button since Android users can use "back and up" buttons and it's consistent with the rest of the app.


| Light | Dark | 
| --- | ---- | 
| ![Screenshot_20210804-124646_WooCommerce (Dev)](https://user-images.githubusercontent.com/2261188/128168888-167bd479-adcb-4ad5-ad3c-8db43dc8e080.jpg) | ![Screenshot_20210804-124633_WooCommerce (Dev)](https://user-images.githubusercontent.com/2261188/128168903-d941db58-7869-44cd-88e0-6925af207a50.jpg) |

To test:
1. Use a store eligible for card present payments or manually enable CARD_READER feature flag
2. Tap on App settings
3. Tap on In Person Payments
4. Notice the loading screen


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
