### PR TITLE
Added an exception block to ensure app does not crash when Google Play services is not available

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/FCMRegistrationIntentService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/FCMRegistrationIntentService.kt
@@ -24,16 +24,22 @@ class FCMRegistrationIntentService : JobIntentService() {
     }
 
     override fun onHandleWork(intent: Intent) {
-        FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
-            val token = task.result
+        try {
+            FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
+                val token = task.result
 
-            token?.takeIf { it.isNotEmpty() }?.let {
-                WooLog.d(WooLog.T.NOTIFS, "Sending FCM token to our remote services: $it")
-                notificationRegistrationHandler.onNewFCMTokenReceived(it)
-            } ?: run {
-                WooLog.w(WooLog.T.NOTIFS, "Empty FCM token, can't register the id on remote services")
-                notificationRegistrationHandler.onEmptyFCMTokenReceived()
+                token?.takeIf { it.isNotEmpty() }?.let {
+                    WooLog.d(WooLog.T.NOTIFS, "Sending FCM token to our remote services: $it")
+                    notificationRegistrationHandler.onNewFCMTokenReceived(it)
+                } ?: run {
+                    WooLog.w(WooLog.T.NOTIFS, "Empty FCM token, can't register the id on remote services")
+                    notificationRegistrationHandler.onEmptyFCMTokenReceived()
+                }
             }
+        } catch (e: Exception) {
+            // SecurityException can happen on some devices without Google services (these devices probably strip
+            // the AndroidManifest.xml and remove unsupported permissions).
+            WooLog.e(WooLog.T.NOTIFS, "Google Play Services unavailable: ", e)
         }
     }
 


### PR DESCRIPTION
As part of [this PR](https://github.com/woocommerce/woocommerce-android/pull/4526), the `FCMRegistrationIntentService` was refactored to make it easier for testing. This PR just adds an exception block to the `onHandleWork()` method to ensure the app does not crash when Google Play Services is not available on the device.

#### Testing
There are no user facing changes. Testing the app to verify that you are able to receive new order, new review and Zendesk notifications when the app is in the foreground, background or closed completely, should be sufficient.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
