### PR TITLE
Make order addon metadata available

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -98,12 +98,19 @@ data class Order(
         val totalTax: BigDecimal,
         val total: BigDecimal,
         val variationId: Long,
-        val attributesDescription: String
+        val attributesDescription: String,
+        val attributesList: List<Attribute>
     ) : Parcelable {
         @IgnoredOnParcel
         val uniqueId: Long = ProductHelper.productOrVariationId(productId, variationId)
         @IgnoredOnParcel
         val isVariation: Boolean = variationId != 0L
+
+        @Parcelize
+        data class Attribute(
+            val key: String,
+            val value: String
+        ) : Parcelable
     }
 
     @Parcelize
@@ -284,7 +291,10 @@ fun WCOrderModel.toAppModel(): Order {
                     it.totalTax?.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
                     it.total?.toBigDecimalOrNull()?.roundError() ?: BigDecimal.ZERO,
                     it.variationId ?: 0,
-                    it.getAttributesAsString()
+                    it.getAttributesAsString(),
+                    it.getAttributeList().map { attribute ->
+                        Item.Attribute(attribute.key.orEmpty(), attribute.value.orEmpty())
+                    }
                 )
             },
         shippingLines = getShippingLineList().map {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -98,7 +98,7 @@ data class Order(
         val totalTax: BigDecimal,
         val total: BigDecimal,
         val variationId: Long,
-        val attributesList: String
+        val attributesDescription: String
     ) : Parcelable {
         @IgnoredOnParcel
         val uniqueId: Long = ProductHelper.productOrVariationId(productId, variationId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabelPackage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingLabelPackage.kt
@@ -25,14 +25,14 @@ data class ShippingLabelPackage(
     data class Item(
         val productId: Long,
         val name: String,
-        val attributesList: String,
+        val attributesDescription: String,
         val quantity: Int,
         val weight: Float,
         val value: BigDecimal
     ) : Parcelable {
         fun isSameProduct(otherItem: Item): Boolean {
             return productId == otherItem.productId &&
-                attributesList == otherItem.attributesList
+                attributesDescription == otherItem.attributesDescription
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
@@ -32,7 +32,10 @@ class OrderDetailProductItemView @JvmOverloads constructor(
         binding.productInfoTotal.text = orderTotal
 
         val productPrice = formatCurrencyForDisplay(item.price)
-        val attributes = item.attributesDescription.takeIf { it.isNotEmpty() }?.let { "$it \u2981 " } ?: StringUtils.EMPTY
+        val attributes = item.attributesDescription
+            .takeIf { it.isNotEmpty() }
+            ?.let { "$it \u2981 " }
+            ?: StringUtils.EMPTY
         binding.productInfoAttributes.text = context.getString(
             R.string.orderdetail_product_lineitem_attributes,
             attributes, item.quantity.formatToString(), productPrice

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
@@ -32,7 +32,7 @@ class OrderDetailProductItemView @JvmOverloads constructor(
         binding.productInfoTotal.text = orderTotal
 
         val productPrice = formatCurrencyForDisplay(item.price)
-        val attributes = item.attributesList.takeIf { it.isNotEmpty() }?.let { "$it \u2981 " } ?: StringUtils.EMPTY
+        val attributes = item.attributesDescription.takeIf { it.isNotEmpty() }?.let { "$it \u2981 " } ?: StringUtils.EMPTY
         binding.productInfoAttributes.text = context.getString(
             R.string.orderdetail_product_lineitem_attributes,
             attributes, item.quantity.formatToString(), productPrice

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -328,7 +328,7 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
         return ShippingLabelPackage.Item(
             productId = uniqueId,
             name = name,
-            attributesList = attributesList,
+            attributesDescription = attributesDescription,
             // for shipping purposes, consider portion quantities as complete values
             quantity = ceil(quantity).toInt(),
             value = price,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
@@ -98,7 +98,7 @@ class ShippingCustomsViewModel @Inject constructor(
                 returnToSender = true,
                 itn = "",
                 lines = labelPackage.items.map { item ->
-                    val attributes = item.attributesList.ifEmpty { null }?.let { " $it" } ?: ""
+                    val attributes = item.attributesDescription.ifEmpty { null }?.let { " $it" } ?: ""
                     val defaultDescription = item.name.substringBefore("-").trim() + attributes
                     CustomsLine(
                         productId = item.productId,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -241,7 +241,10 @@ class PackageProductsAdapter(
     ) : ViewHolder(binding.root) {
         fun bind(item: ShippingLabelPackage.Item) {
             binding.productName.text = item.name
-            val attributes = item.attributesDescription.takeIf { it.isNotEmpty() }?.let { "$it \u2981 " } ?: StringUtils.EMPTY
+            val attributes = item.attributesDescription
+                .takeIf { it.isNotEmpty() }
+                ?.let { "$it \u2981 " }
+                ?: StringUtils.EMPTY
             val details = "$attributes${item.weight} $weightUnit"
             if (details.isEmpty()) {
                 binding.productDetails.isVisible = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -241,7 +241,7 @@ class PackageProductsAdapter(
     ) : ViewHolder(binding.root) {
         fun bind(item: ShippingLabelPackage.Item) {
             binding.productName.text = item.name
-            val attributes = item.attributesList.takeIf { it.isNotEmpty() }?.let { "$it \u2981 " } ?: StringUtils.EMPTY
+            val attributes = item.attributesDescription.takeIf { it.isNotEmpty() }?.let { "$it \u2981 " } ?: StringUtils.EMPTY
             val details = "$attributes${item.weight} $weightUnit"
             if (details.isEmpty()) {
                 binding.productDetails.isVisible = false

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/OrderItemTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/OrderItemTest.kt
@@ -1,0 +1,55 @@
+package com.woocommerce.android.model
+
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class OrderItemTest {
+    private lateinit var orderItemUnderTest: Order.Item
+
+    @Before
+    fun setUp() {
+        orderItemUnderTest = Order.Item(
+            itemId = 123,
+            productId = 123,
+            name = "test-name",
+            price = (123).toBigDecimal(),
+            sku = "test-sku",
+            quantity = 123f,
+            subtotal = (123).toBigDecimal(),
+            totalTax = (123).toBigDecimal(),
+            total = (123).toBigDecimal(),
+            variationId = 123,
+            attributesList = listOf()
+        )
+    }
+
+    @Test
+    fun `should parse attributeList to String description correctly`() {
+        orderItemUnderTest = orderItemUnderTest.copy(attributesList = listOf(
+            Order.Item.Attribute("First Key", "First Value"),
+            Order.Item.Attribute("Second Key", "Second Value")
+        ))
+        assertEquals("First Value, Second Value", orderItemUnderTest.attributesDescription)
+    }
+
+    @Test
+    fun `should ignore empty values from the String description`() {
+        orderItemUnderTest = orderItemUnderTest.copy(attributesList = listOf(
+            Order.Item.Attribute("First Key", "First Value"),
+            Order.Item.Attribute("Empty Key", ""),
+            Order.Item.Attribute("Second Key", "Second Value")
+        ))
+        assertEquals("First Value, Second Value", orderItemUnderTest.attributesDescription)
+    }
+
+    @Test
+    fun `should ignore values starting with _ character`() {
+        orderItemUnderTest = orderItemUnderTest.copy(attributesList = listOf(
+            Order.Item.Attribute("First Key", "First Value"),
+            Order.Item.Attribute("_Invalid Key", "Ignored Value"),
+            Order.Item.Attribute("Second Key", "Second Value")
+        ))
+        assertEquals("First Value, Second Value", orderItemUnderTest.attributesDescription)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/OrderItemTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/OrderItemTest.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android.model
 
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
@@ -26,30 +26,36 @@ class OrderItemTest {
 
     @Test
     fun `should parse attributeList to String description correctly`() {
-        orderItemUnderTest = orderItemUnderTest.copy(attributesList = listOf(
-            Order.Item.Attribute("First Key", "First Value"),
-            Order.Item.Attribute("Second Key", "Second Value")
-        ))
+        orderItemUnderTest = orderItemUnderTest.copy(
+            attributesList = listOf(
+                Order.Item.Attribute("First Key", "First Value"),
+                Order.Item.Attribute("Second Key", "Second Value")
+            )
+        )
         assertEquals("First Value, Second Value", orderItemUnderTest.attributesDescription)
     }
 
     @Test
     fun `should ignore empty values from the String description`() {
-        orderItemUnderTest = orderItemUnderTest.copy(attributesList = listOf(
-            Order.Item.Attribute("First Key", "First Value"),
-            Order.Item.Attribute("Empty Key", ""),
-            Order.Item.Attribute("Second Key", "Second Value")
-        ))
+        orderItemUnderTest = orderItemUnderTest.copy(
+            attributesList = listOf(
+                Order.Item.Attribute("First Key", "First Value"),
+                Order.Item.Attribute("Empty Key", ""),
+                Order.Item.Attribute("Second Key", "Second Value")
+            )
+        )
         assertEquals("First Value, Second Value", orderItemUnderTest.attributesDescription)
     }
 
     @Test
     fun `should ignore values starting with _ character`() {
-        orderItemUnderTest = orderItemUnderTest.copy(attributesList = listOf(
-            Order.Item.Attribute("First Key", "First Value"),
-            Order.Item.Attribute("_Invalid Key", "Ignored Value"),
-            Order.Item.Attribute("Second Key", "Second Value")
-        ))
+        orderItemUnderTest = orderItemUnderTest.copy(
+            attributesList = listOf(
+                Order.Item.Attribute("First Key", "First Value"),
+                Order.Item.Attribute("_Invalid Key", "Ignored Value"),
+                Order.Item.Attribute("Second Key", "Second Value")
+            )
+        )
         assertEquals("First Value, Second Value", orderItemUnderTest.attributesDescription)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
@@ -48,7 +48,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
         productId = 15,
         name = "test",
         quantity = 1,
-        attributesList = "",
+        attributesDescription = "",
         weight = 1f,
         value = BigDecimal.TEN
     )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModelTest.kt
@@ -17,7 +17,7 @@ class MoveShippingItemViewModelTest : BaseUnitTest() {
     private val defaultItem = ShippingLabelPackage.Item(
         productId = 0L,
         name = "product",
-        attributesList = "",
+        attributesDescription = "",
         quantity = 3,
         weight = 10f,
         value = BigDecimal.valueOf(10L)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModelTest.kt
@@ -79,7 +79,7 @@ class ShippingCustomsViewModelTest : BaseUnitTest() {
                 Item(
                     productId = it.uniqueId,
                     name = it.name,
-                    attributesList = it.attributesList,
+                    attributesDescription = it.attributesDescription,
                     weight = 0f,
                     value = it.price,
                     quantity = ceil(it.quantity).toInt()


### PR DESCRIPTION
Summary
==========
Fixes issue #4406 by splitting the `Order.Item.attributeList` string into two properties, now the string itself is called `attributesDescription`, meanwhile, we use FluxC `WCOrderModel.getAttributeList()` method to define an actual list of Attributes containing `key` and `value` data, so now `attributeList` is of `List<Order.Item.Attribute>` type. 

This becomes necessary for tackling #4407 since we need Products metadata and Order attributes as a workaround to obtain a way to present the selected Product Add-ons for a given order. (p91TBi-4MK-p2 for reference)

How to Test
==========
Since this PR only redistributes data already available, there's not much to test but making sure the Attributes info for a given Product remains unchanged before and after this Pr changes.

<img src="https://user-images.githubusercontent.com/5920403/128288669-b724ed20-4e7f-4797-b7d6-c5b9025f680e.png" width="280" height="585" />

Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
