### PR TITLE
Issue/4413 add tracking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -238,6 +238,10 @@ class AnalyticsTracker private constructor(private val context: Context) {
         SHIPPING_LABEL_ADD_PACKAGE_FAILED,
         SHIPPING_LABEL_ORDER_IS_ELIGIBLE,
 
+        // -- Card Present Payments - onboarding
+        CARD_PRESENT_ONBOARDING_LEARN_MORE_TAPPED,
+        CARD_PRESENT_ONBOARDING_NOT_COMPLETED,
+
         // -- Card Present Payments - collection
         CARD_PRESENT_COLLECT_PAYMENT_TAPPED,
         CARD_PRESENT_COLLECT_PAYMENT_FAILED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -121,7 +121,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
             CardReaderOnboardingState.StripeAccountPendingRequirement -> "account_pending_requirements"
             CardReaderOnboardingState.StripeAccountRejected -> "account_rejected"
             CardReaderOnboardingState.StripeAccountUnderReview -> "account_under_review"
-            CardReaderOnboardingState.WcpayInTestModeWithLiveStripeAccount -> ""
+            CardReaderOnboardingState.WcpayInTestModeWithLiveStripeAccount -> "wcpay_in_test_mode_with_live_account"
             CardReaderOnboardingState.WcpayNotActivated -> "wcpay_not_activated"
             CardReaderOnboardingState.WcpayNotInstalled -> "wcpay_not_installed"
             CardReaderOnboardingState.WcpaySetupNotCompleted -> "wcpay_not_setup"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -364,6 +364,20 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `when wcpay in test mode with live account, then event tracked`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(CardReaderOnboardingState.WcpayInTestModeWithLiveStripeAccount)
+
+            createVM()
+
+            verify(tracker).track(
+                AnalyticsTracker.Stat.CARD_PRESENT_ONBOARDING_NOT_COMPLETED,
+                mapOf("reason" to "wcpay_in_test_mode_with_live_account")
+            )
+        }
+
+    @Test
     fun `when onboarding completed, then event NOT tracked`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())


### PR DESCRIPTION
Parent issue #4413 

This PR adds tracking to the onboarding flow
- "card_present_onboarding_learn_more_tapped" - when user taps on "learn more" button
- "card_present_onboarding_not_completed" - when the onboarding checker finds that the onboarding was not completed yet -> it adds "reason" property with the following reasons
```
reason: country_not_supported

reason: wcpay_not_installed

reason: wcpay_not_activated

reason: wcpay_not_setup

reason: wcpay_unsupported_version

reason: account_rejected

reason: account_under_review

reason: account_pending_requirements

reason: account_overdue_requirements

reason: generic_error

reason: no_connection_error

reason: wcpay_in_test_mode_with_live_account
```

To test
1. Test the all the events are tracked (note: "wcpay_setup_not_completed" state is not reproducible due to a bug on the API)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

cc @koke 