### PR TITLE
Remove feature flag and Manage Card Reader row

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -39,7 +39,6 @@ import com.woocommerce.android.util.AnalyticsUtils
 import com.woocommerce.android.util.AppThemeUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.FeatureFlag.CARD_READER
-import com.woocommerce.android.util.FeatureFlag.CARD_READER_ONBOARDING
 import com.woocommerce.android.util.ThemeOption
 import com.woocommerce.android.widgets.WCPromoTooltip
 import com.woocommerce.android.widgets.WCPromoTooltip.Feature
@@ -116,10 +115,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         }
 
         updateStoreSettings()
-        binding.optionCardReader.setOnClickListener {
-            findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_cardReaderDetailFragment)
-        }
-
         binding.optionCardReaderPayments.setOnClickListener {
             findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_cardReaderOnboardingFragment)
         }
@@ -254,8 +249,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
     private fun updateStoreSettings() {
         binding.storeSettingsContainer.visibility =
             if (CARD_READER.isEnabled()) View.VISIBLE else View.GONE
-        binding.optionCardReaderPayments.visibility =
-            if (CARD_READER_ONBOARDING.isEnabled()) View.VISIBLE else View.GONE
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -10,7 +10,6 @@ enum class FeatureFlag {
     DB_DOWNGRADE,
     ORDER_CREATION,
     CARD_READER,
-    CARD_READER_ONBOARDING,
     PRODUCT_ADD_ONS;
 
     fun isEnabled(context: Context? = null): Boolean {
@@ -20,7 +19,6 @@ enum class FeatureFlag {
             }
             ORDER_CREATION, PRODUCT_ADD_ONS -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
             CARD_READER -> CardPresentEligibleFeatureChecker.isCardPresentEligible
-            CARD_READER_ONBOARDING -> CARD_READER.isEnabled() && PackageUtils.isDebugBuild()
         }
     }
 }

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -55,12 +55,6 @@
             Card Reader
         -->
         <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-            android:id="@+id/option_card_reader"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:optionTitle="@string/settings_card_reader" />
-
-        <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
             android:id="@+id/option_card_reader_payments"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -9,13 +9,6 @@
         android:name="com.woocommerce.android.ui.prefs.MainSettingsFragment"
         android:label="MainSettingsFragment">
         <action
-            android:id="@+id/action_mainSettingsFragment_to_cardReaderDetailFragment"
-            app:destination="@id/cardReaderDetailFragment"
-            app:enterAnim="@anim/activity_slide_in_from_right"
-            app:exitAnim="@anim/activity_slide_out_to_left"
-            app:popEnterAnim="@anim/activity_slide_in_from_left"
-            app:popExitAnim="@anim/activity_slide_out_to_right" />
-        <action
             android:id="@+id/action_mainSettingsFragment_to_cardReaderOnboardingFragment"
             app:destination="@id/cardReaderOnboardingFragment"
             app:enterAnim="@anim/activity_slide_in_from_right"


### PR DESCRIPTION
Parent issue #4413 

"do not merge" label -> we still haven't implemented "Purchase card reader" flow -> we are waiting for a final URL or a decision to hide this row in the app for this release.

This PR removes
- card reader onboarding feature flag
- "Manage Card Reader" row from app settings -> we will use the new "In-Person Payments" row instead


To Test
"In-Person Payments" row should be visible when
- Site is eligible for in person payments - aka it is onboarded into the beta (let me know if you need to onboard a site)
- Site has WCPay Installed, Active and Setup
What it comes down to is that you should be able to reach the following states in a release build:
- StripeAccountUnderReview
- StripeAccountPendingRequirement -> Tap on Dismiss -> Tap on Manage Card Reader and try to connect
- StripeAccountOverdueRequirement
- StripeAccountRejected
- NoConnectionError
- (GenericError)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
