### PR TITLE
Show due date on pending requirements screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
@@ -70,6 +70,8 @@ fun Date.isToday() =
 
 fun Date.getTimeString(context: Context): String = DateFormat.getTimeFormat(context).format(this.time)
 
+fun Date.getShortDate(context: Context): String = DateFormat.getDateFormat(context).format(this)
+
 fun Date.getMediumDate(context: Context): String = DateFormat.getMediumDateFormat(context).format(this)
 
 fun Date?.offsetGmtDate(gmtOffset: Float) = this?.let { DateUtils.offsetGmtDate(it, gmtOffset) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -48,7 +48,9 @@ class CardReaderOnboardingChecker @Inject constructor(
         if (isWCPayInTestModeWithLiveStripeAccount()) return WcpayInTestModeWithLiveStripeAccount
         if (isStripeAccountUnderReview(paymentAccount)) return StripeAccountUnderReview
         if (isStripeAccountOverdueRequirements(paymentAccount)) return StripeAccountOverdueRequirement
-        if (isStripeAccountPendingRequirements(paymentAccount)) return StripeAccountPendingRequirement
+        if (isStripeAccountPendingRequirements(paymentAccount)) return StripeAccountPendingRequirement(
+            paymentAccount.currentDeadline
+        )
         if (isStripeAccountRejected(paymentAccount)) return StripeAccountRejected
         if (isInUndefinedState(paymentAccount)) return GenericError
 
@@ -151,7 +153,7 @@ sealed class CardReaderOnboardingState {
      * There are some pending requirements on the connected Stripe account. The merchant still has some time before the
      * deadline to fix them expires. In-person payments should work without issues.
      */
-    object StripeAccountPendingRequirement : CardReaderOnboardingState()
+    data class StripeAccountPendingRequirement(val dueDate: Long?) : CardReaderOnboardingState()
 
     /**
      * There are some overdue requirements on the connected Stripe account. Connecting to a reader or accepting

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.exhaustive
+import com.woocommerce.android.extensions.formatToMMMMdd
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
@@ -76,13 +77,13 @@ class CardReaderOnboardingViewModel @Inject constructor(
                         onContactSupportActionClicked = ::onContactSupportClicked,
                         onLearnMoreActionClicked = ::onLearnMoreClicked
                     )
-                CardReaderOnboardingState.StripeAccountPendingRequirement ->
+                is CardReaderOnboardingState.StripeAccountPendingRequirement ->
                     viewState.value = OnboardingViewState.WCStripeError
                         .WCPayAccountPendingRequirementsState(
                             onContactSupportActionClicked = ::onContactSupportClicked,
                             onLearnMoreActionClicked = ::onLearnMoreClicked,
                             onButtonActionClicked = ::onSkipPendingRequirementsClicked,
-                            dueDate = "" // TODO cardreader Pass due date to the state
+                            dueDate = formatDueDate(state)
                         )
                 CardReaderOnboardingState.StripeAccountOverdueRequirement ->
                     viewState.value = OnboardingViewState.WCStripeError.WCPayAccountOverdueRequirementsState(
@@ -118,7 +119,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
             CardReaderOnboardingState.OnboardingCompleted -> null
             is CardReaderOnboardingState.CountryNotSupported -> "country_not_supported"
             CardReaderOnboardingState.StripeAccountOverdueRequirement -> "account_overdue_requirements"
-            CardReaderOnboardingState.StripeAccountPendingRequirement -> "account_pending_requirements"
+            is CardReaderOnboardingState.StripeAccountPendingRequirement -> "account_pending_requirements"
             CardReaderOnboardingState.StripeAccountRejected -> "account_rejected"
             CardReaderOnboardingState.StripeAccountUnderReview -> "account_under_review"
             CardReaderOnboardingState.WcpayInTestModeWithLiveStripeAccount -> "wcpay_in_test_mode_with_live_account"
@@ -154,6 +155,9 @@ class CardReaderOnboardingViewModel @Inject constructor(
 
     private fun convertCountryCodeToCountry(countryCode: String?) =
         Locale("", countryCode.orEmpty()).displayName
+
+    private fun formatDueDate(state: CardReaderOnboardingState.StripeAccountPendingRequirement) =
+        state.dueDate?.let { Date(it).formatToMMMMdd() } ?: ""
 
     sealed class OnboardingEvent : Event() {
         object ViewLearnMore : OnboardingEvent() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -21,6 +21,8 @@ import kotlinx.coroutines.launch
 import java.util.*
 import javax.inject.Inject
 
+private const val UNIX_TO_JAVA_TIMESTAMP_OFFSET = 1000L
+
 @HiltViewModel
 class CardReaderOnboardingViewModel @Inject constructor(
     savedState: SavedStateHandle,
@@ -157,7 +159,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
         Locale("", countryCode.orEmpty()).displayName
 
     private fun formatDueDate(state: CardReaderOnboardingState.StripeAccountPendingRequirement) =
-        state.dueDate?.let { Date(it).formatToMMMMdd() } ?: ""
+        state.dueDate?.let { Date(it * UNIX_TO_JAVA_TIMESTAMP_OFFSET).formatToMMMMdd() } ?: ""
 
     sealed class OnboardingEvent : Event() {
         object ViewLearnMore : OnboardingEvent() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -188,7 +188,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.StripeAccountPendingRequirement)
+            assertThat(result).isInstanceOf(CardReaderOnboardingState.StripeAccountPendingRequirement::class.java)
         }
 
     @Test
@@ -204,7 +204,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
 
             val result = checker.getOnboardingState()
 
-            assertThat(result).isEqualTo(CardReaderOnboardingState.StripeAccountPendingRequirement)
+            assertThat(result).isInstanceOf(CardReaderOnboardingState.StripeAccountPendingRequirement::class.java)
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -159,13 +159,25 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when account pending requirements, then account pending requirements state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.StripeAccountPendingRequirement)
+                .thenReturn(CardReaderOnboardingState.StripeAccountPendingRequirement(0L))
 
             val viewModel = createVM()
 
             assertThat(viewModel.viewStateData.value).isInstanceOf(
                 WCStripeError.WCPayAccountPendingRequirementsState::class.java
             )
+        }
+
+    @Test
+    fun `when account pending requirements, then due date not empty`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(onboardingChecker.getOnboardingState())
+                .thenReturn(CardReaderOnboardingState.StripeAccountPendingRequirement(0L))
+
+            val viewModel = createVM()
+
+            assertThat((viewModel.viewStateData.value as WCStripeError.WCPayAccountPendingRequirementsState).dueDate)
+                .isNotEmpty()
         }
 
     @Test
@@ -313,7 +325,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
     fun `when account pending requirements, then event tracked`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(onboardingChecker.getOnboardingState())
-                .thenReturn(CardReaderOnboardingState.StripeAccountPendingRequirement)
+                .thenReturn(CardReaderOnboardingState.StripeAccountPendingRequirement(0L))
 
             createVM()
 


### PR DESCRIPTION
Parent issue #4413 

This PR adds "due date" to "account pending requirements" screen.

<img src="https://user-images.githubusercontent.com/2261188/128384145-5623dff7-9bc0-4ea0-b65f-f3c8b36bd030.jpg" width="250px" />

To test:
1. Use a site which is eligible for in-person payments and the stripe account is in "pending requirements" state
2. Tap on app settings
3. Tap on "in-person payments"
4. Notice pending requirements screen is shown and the text contains the due date (Note: I noticed one of my sites shows due date which is in the past - I'll report a bug in WCPay)



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
