### PR TITLE
Issue/4413 onboarding stripe live account

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -47,8 +47,9 @@ class CardReaderOnboardingChecker @Inject constructor(
         val tokenResponse = wcPayStore.fetchConnectionToken(selectedSite.get()).model ?: return GenericError
 
         if (!isWCPaySetupCompleted(paymentAccount)) return WcpaySetupNotCompleted
-        if (isWCPayInTestModeWithLiveStripeAccount(paymentAccount.isLive, tokenResponse.isTestMode))
+        if (isWCPayInTestModeWithLiveStripeAccount(paymentAccount.isLive, tokenResponse.isTestMode)) {
             return WcpayInTestModeWithLiveStripeAccount
+        }
         if (isStripeAccountUnderReview(paymentAccount)) return StripeAccountUnderReview
         if (isStripeAccountOverdueRequirements(paymentAccount)) return StripeAccountOverdueRequirement
         if (isStripeAccountPendingRequirements(paymentAccount)) return StripeAccountPendingRequirement

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'develop-0193e64889a94b44c507c6aba5b83ce0fc96bc61'
+    fluxCVersion = '2087-66c17c1c3fea77b423e73f7a444875650f94fc5f'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'


### PR DESCRIPTION
Parent issue #4413 

This PR adds support for detecting live account in test mode and shows an error that card present payments are not supported in this setup.

"do not merge" label - we need to merge fluxc and update the has before the merge.


To test:
I've tested this just manually not against a real site with live account since I don't have any.
1. Use a site with live Stripe account and test mode enabled in WCPay dev plugin
2. Tap on App settings
3. Tap on In-Person payments
4. Notice an error saying that you need to turn off the test mode is shown

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
