### PR TITLE
Redirect to onboarding from order detail on collect payment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
@@ -50,7 +50,7 @@ sealed class OrderNavigationTarget : Event() {
     object ViewShippingLabelFormatOptions : OrderNavigationTarget()
     data class ViewPrintCustomsForm(val invoices: List<String>, val isReprint: Boolean) : OrderNavigationTarget()
     data class StartShippingLabelCreationFlow(val orderIdentifier: String) : OrderNavigationTarget()
-    object StartCardReaderConnectFlow : OrderNavigationTarget()
+    data class StartCardReaderConnectFlow(val skipOnboarding: Boolean) : OrderNavigationTarget()
     data class StartCardReaderPaymentFlow(val orderIdentifier: String) : OrderNavigationTarget()
     object ViewPrintingInstructions : OrderNavigationTarget()
     data class PreviewReceipt(val billingEmail: String, val receiptUrl: String, val orderId: Long) :

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
@@ -141,7 +141,7 @@ class OrderNavigator @Inject constructor() {
             }
             is StartCardReaderConnectFlow -> {
                 val action = OrderDetailFragmentDirections
-                    .actionOrderDetailFragmentToCardReaderConnectDialog()
+                    .actionOrderDetailFragmentToCardReaderConnectDialog(target.skipOnboarding)
                 fragment.findNavController().navigateSafely(action)
             }
             is StartCardReaderPaymentFlow -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -53,6 +53,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.PrintShippingLabelFragme
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRefundFragment
 import com.woocommerce.android.ui.orders.tracking.AddOrderShipmentTrackingFragment
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectDialogFragment
+import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingFragment
 import com.woocommerce.android.ui.refunds.RefundSummaryFragment
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.DateUtils
@@ -261,6 +262,9 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
         }
         handleNotice(PrintShippingLabelFragment.KEY_LABEL_PURCHASED) {
             viewModel.onShippingLabelsPurchased()
+        }
+        handleNotice(CardReaderOnboardingFragment.KEY_READER_ONBOARDING_SUCCESS) {
+            viewModel.onOnboardingSuccess()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -241,8 +241,12 @@ class OrderDetailViewModel @Inject constructor(
         if (cardReaderManager.readerStatus.value is Connected) {
             triggerEvent(StartCardReaderPaymentFlow(order.identifier))
         } else {
-            triggerEvent(StartCardReaderConnectFlow)
+            triggerEvent(StartCardReaderConnectFlow(skipOnboarding = false))
         }
+    }
+
+    fun onOnboardingSuccess() {
+        triggerEvent(StartCardReaderConnectFlow(skipOnboarding = true))
     }
 
     fun onSeeReceiptClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectDialogFragment.kt
@@ -199,6 +199,10 @@ class CardReaderConnectDialogFragment : DialogFragment(R.layout.card_reader_conn
                     findNavController()
                         .navigateSafely(R.id.action_cardReaderConnectFragment_to_cardReaderTutorialDialogFragment)
                 }
+                is CardReaderConnectViewModel.CardReaderConnectEvent.NavigateToOnboardingFlow -> {
+                    findNavController()
+                        .navigateSafely(R.id.action_cardReaderConnectFragment_to_cardReaderOnboardingFragment)
+                }
                 is ExitWithResult<*> -> {
                     navigateBackWithResult(KEY_CONNECT_TO_READER_RESULT, event.data as Boolean)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectDialogFragment.kt
@@ -163,6 +163,7 @@ class CardReaderConnectDialogFragment : DialogFragment(R.layout.card_reader_conn
         (binding.illustration.drawable as? AnimatedVectorDrawable)?.start()
     }
 
+    @Suppress("ComplexMethod")
     private fun observeEvents() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -49,6 +49,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.SingleLiveEvent
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
@@ -64,6 +65,7 @@ class CardReaderConnectViewModel @Inject constructor(
     private val appPrefs: AppPrefs,
     private val onboardingChecker: CardReaderOnboardingChecker,
 ) : ScopedViewModel(savedState) {
+    private val arguments: CardReaderConnectDialogFragmentArgs by savedState.navArgs()
     /**
      * This is a workaround for a bug in MultiLiveEvent, which can't be fixed without vital changes.
      * When multiple events are send synchronously to MultiLiveEvent only the first one gets handled
@@ -90,7 +92,11 @@ class CardReaderConnectViewModel @Inject constructor(
 
     private fun startFlow() {
         viewState.value = ScanningState(::onCancelClicked)
-        checkOnboardingState()
+        if(arguments.skipOnboarding) {
+            triggerEvent(CheckLocationPermissions(::onCheckLocationPermissionsResult))
+        } else {
+            checkOnboardingState()
+        }
     }
 
     private fun checkOnboardingState() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -92,7 +92,7 @@ class CardReaderConnectViewModel @Inject constructor(
 
     private fun startFlow() {
         viewState.value = ScanningState(::onCancelClicked)
-        if(arguments.skipOnboarding) {
+        if (arguments.skipOnboarding) {
             triggerEvent(CheckLocationPermissions(::onCheckLocationPermissionsResult))
         } else {
             checkOnboardingState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -96,14 +96,14 @@ class CardReaderConnectViewModel @Inject constructor(
     private fun checkOnboardingState() {
         launch {
             when (onboardingChecker.getOnboardingState()) {
-                CardReaderOnboardingState.GenericError,
-                CardReaderOnboardingState.NoConnectionError -> {
+                is CardReaderOnboardingState.GenericError,
+                is CardReaderOnboardingState.NoConnectionError -> {
                     viewState.value = ScanningFailedState(::startFlow, ::onCancelClicked)
                 }
-                CardReaderOnboardingState.OnboardingCompleted -> {
+                is CardReaderOnboardingState.OnboardingCompleted -> {
                     triggerEvent(CheckLocationPermissions(::onCheckLocationPermissionsResult))
                 }
-                else -> triggerEvent(CardReaderConnectEvent.RedirectToOnboardingFlow)
+                else -> triggerEvent(CardReaderConnectEvent.NavigateToOnboardingFlow)
             }
         }
     }
@@ -360,7 +360,7 @@ class CardReaderConnectViewModel @Inject constructor(
 
         object ShowCardReaderTutorial : CardReaderConnectEvent()
 
-        object RedirectToOnboardingFlow : CardReaderConnectEvent()
+        object NavigateToOnboardingFlow : CardReaderConnectEvent()
     }
 
     @Suppress("LongParameterList")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailFragment.kt
@@ -57,7 +57,10 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
                 when (event) {
                     is CardReaderConnectScreen ->
                         findNavController()
-                            .navigateSafely(R.id.action_cardReaderDetailFragment_to_cardReaderConnectFragment)
+                            .navigateSafely(
+                                CardReaderDetailFragmentDirections
+                                    .actionCardReaderDetailFragmentToCardReaderConnectFragment(skipOnboarding = true)
+                            )
                     is CardReaderUpdateScreen ->
                         findNavController().navigateSafely(
                             CardReaderDetailFragmentDirections

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -45,12 +45,17 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
                     is CardReaderOnboardingViewModel.OnboardingEvent.ViewLearnMore -> {
                         ChromeCustomTabUtils.launchUrl(requireActivity(), AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS)
                     }
-                    is CardReaderOnboardingViewModel.OnboardingEvent.NavigateToCardReaderHubFragment -> {
-                        findNavController().navigate(
-                            R.id.action_cardReaderOnboardingFragment_to_cardReaderHubFragment
-                        )
+                    is CardReaderOnboardingViewModel.OnboardingEvent.Continue -> {
+                        val inSettingsGraph = findNavController().graph.id == R.id.nav_graph_settings
+                        if (inSettingsGraph) {
+                            findNavController().navigate(
+                                R.id.action_cardReaderOnboardingFragment_to_cardReaderHubFragment
+                            )
+                        } else {
+                            navigateBackWithNotice(KEY_READER_ONBOARDING_SUCCESS)
+                        }
                     }
-                    is MultiLiveEvent.Event.Exit -> navigateBackWithNotice(KEY_READER_ONBOARDING_RESULT)
+                    is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
                     else -> event.isHandled = false
                 }
             }
@@ -188,6 +193,6 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
     override fun getFragmentTitle() = resources.getString(R.string.card_reader_onboarding_title)
 
     companion object {
-        const val KEY_READER_ONBOARDING_RESULT = "key_reader_onboarding_result"
+        const val KEY_READER_ONBOARDING_SUCCESS = "key_reader_onboarding_result"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -193,6 +193,6 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
     override fun getFragmentTitle() = resources.getString(R.string.card_reader_onboarding_title)
 
     companion object {
-        const val KEY_READER_ONBOARDING_SUCCESS = "key_reader_onboarding_result"
+        const val KEY_READER_ONBOARDING_SUCCESS = "key_reader_onboarding_success"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -44,7 +44,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
             trackState(state)
             when (state) {
                 CardReaderOnboardingState.OnboardingCompleted ->
-                    triggerEvent(OnboardingEvent.NavigateToCardReaderHubFragment)
+                    triggerEvent(OnboardingEvent.Continue)
                 is CardReaderOnboardingState.CountryNotSupported ->
                     viewState.value = OnboardingViewState.UnsupportedCountryState(
                         convertCountryCodeToCountry(state.countryCode),
@@ -145,7 +145,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
     }
 
     private fun onSkipPendingRequirementsClicked() {
-        triggerEvent(OnboardingEvent.NavigateToCardReaderHubFragment)
+        triggerEvent(OnboardingEvent.Continue)
     }
 
     private fun exitFlow() {
@@ -162,7 +162,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
 
         object NavigateToSupport : Event()
 
-        object NavigateToCardReaderHubFragment : Event()
+        object Continue : Event()
     }
 
     sealed class OnboardingViewState(@LayoutRes val layoutRes: Int) {

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -268,7 +268,7 @@
             app:enterAnim="@anim/activity_slide_in_from_right"
             app:exitAnim="@anim/activity_slide_out_to_left"
             app:popEnterAnim="@anim/activity_slide_in_from_left"
-            app:popExitAnim="@anim/activity_slide_out_to_right"/>
+            app:popExitAnim="@anim/activity_slide_out_to_right" />
     </fragment>
     <dialog
         android:id="@+id/orderStatusSelectorDialog"
@@ -486,11 +486,22 @@
             app:destination="@id/cardReaderTutorialDialogFragment"
             app:enterAnim="@anim/activity_fade_in"
             app:popExitAnim="@anim/activity_fade_out" />
+        <action
+            android:id="@+id/action_cardReaderConnectFragment_to_cardReaderOnboardingFragment"
+            app:destination="@id/cardReaderOnboardingFragment"
+            app:enterAnim="@anim/activity_slide_in_from_right"
+            app:exitAnim="@anim/activity_slide_out_to_left"
+            app:popEnterAnim="@anim/activity_slide_in_from_left"
+            app:popExitAnim="@anim/activity_slide_out_to_right" />
     </dialog>
     <dialog
         android:id="@+id/cardReaderTutorialDialogFragment"
         android:name="com.woocommerce.android.ui.prefs.cardreader.tutorial.CardReaderTutorialDialogFragment"
         android:label="CardReaderTutorialDialogFragment" />
+    <fragment
+        android:id="@+id/cardReaderOnboardingFragment"
+        android:name="com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingFragment"
+        android:label="CardReaderOnboardingFragment" />
     <fragment
         android:id="@+id/receiptPreviewFragment"
         android:name="com.woocommerce.android.ui.orders.cardreader.ReceiptPreviewFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -481,6 +481,10 @@
         android:id="@+id/cardReaderConnectDialog"
         android:name="com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectDialogFragment"
         android:label="CardReaderConnectDialog">
+        <argument
+            android:name="skipOnboarding"
+            app:argType="boolean"
+            app:nullable="false" />
         <action
             android:id="@+id/action_cardReaderConnectFragment_to_cardReaderTutorialDialogFragment"
             app:destination="@id/cardReaderTutorialDialogFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -63,6 +63,10 @@
         android:id="@+id/cardReaderConnectFragment"
         android:name="com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectDialogFragment"
         android:label="CardReaderConnectFragment">
+        <argument
+            android:name="skipOnboarding"
+            app:argType="boolean"
+            app:nullable="false" />
         <action
             android:id="@+id/action_cardReaderConnectFragment_to_cardReaderTutorialDialogFragment"
             app:destination="@id/cardReaderTutorialDialogFragment"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -1,12 +1,6 @@
 package com.woocommerce.android.ui.prefs.cardreader.connect
 
-import androidx.lifecycle.SavedStateHandle
-import com.nhaarman.mockitokotlin2.anyOrNull
-import com.nhaarman.mockitokotlin2.argThat
-import com.nhaarman.mockitokotlin2.eq
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
+import com.nhaarman.mockitokotlin2.*
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -15,32 +9,14 @@ import com.woocommerce.android.cardreader.CardReader
 import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents.Failed
 import com.woocommerce.android.cardreader.CardReaderDiscoveryEvents.ReadersFound
 import com.woocommerce.android.cardreader.CardReaderManager
+import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.CheckBluetoothEnabled
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.CheckLocationEnabled
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.CheckLocationPermissions
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.InitializeCardReaderManager
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.OpenLocationSettings
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.OpenPermissionsSettings
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.RequestEnableBluetooth
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.RequestLocationPermissions
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.ShowCardReaderTutorial
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.CardReaderConnectEvent.*
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ListItemViewState.CardReaderListItem
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ListItemViewState.ScanningInProgressListItem
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.BluetoothDisabledError
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.ConnectingFailedState
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.ConnectingState
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.LocationDisabledError
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.MissingPermissionsError
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.MultipleReadersFoundState
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.ReaderFoundState
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.ScanningFailedState
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.ScanningState
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModelTest.ScanResult.FAILED
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModelTest.ScanResult.MULTIPLE_READERS_FOUND
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModelTest.ScanResult.READER_FOUND
-import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModelTest.ScanResult.SCANNING
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.*
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModelTest.ScanResult.*
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingChecker
 import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -54,11 +30,11 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyBoolean
-import org.mockito.junit.MockitoJUnitRunner
+import org.robolectric.RobolectricTestRunner
 
 @ExperimentalCoroutinesApi
 @InternalCoroutinesApi
-@RunWith(MockitoJUnitRunner::class)
+@RunWith(RobolectricTestRunner::class)
 class CardReaderConnectViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: CardReaderConnectViewModel
 
@@ -77,16 +53,24 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
     @Test
     fun `given onboarding not completed, when flow started, then app starts onboarding flow`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            val vm = initVM(CardReaderOnboardingState.WcpaySetupNotCompleted)
+            val vm = initVM(CardReaderOnboardingState.WcpaySetupNotCompleted, skipOnboarding = false)
 
             assertThat(vm.event.value)
                 .isInstanceOf(CardReaderConnectViewModel.CardReaderConnectEvent.NavigateToOnboardingFlow::class.java)
         }
 
     @Test
+    fun `when skip onboarding flag is true, then onboarding state ignored`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            val vm = initVM(CardReaderOnboardingState.WcpaySetupNotCompleted, skipOnboarding = true)
+
+            assertThat(vm.event.value).isNotInstanceOf(NavigateToOnboardingFlow::class.java)
+        }
+
+    @Test
     fun `given onboarding check fails, when flow started, then scanning failed state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            val vm = initVM(CardReaderOnboardingState.GenericError)
+            val vm = initVM(CardReaderOnboardingState.GenericError, skipOnboarding = false)
 
             assertThat(vm.viewStateData.value).isInstanceOf(ScanningFailedState::class.java)
         }
@@ -94,7 +78,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
     @Test
     fun `given connection not available, when flow started, then scanning failed state shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            val vm = initVM(CardReaderOnboardingState.GenericError)
+            val vm = initVM(CardReaderOnboardingState.GenericError, skipOnboarding = false)
 
             assertThat(vm.viewStateData.value).isInstanceOf(ScanningFailedState::class.java)
         }
@@ -830,10 +814,14 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
                 .isEqualTo(R.dimen.major_150)
         }
 
-    private suspend fun initVM(onboardingState: CardReaderOnboardingState): CardReaderConnectViewModel {
+    private suspend fun initVM(
+        onboardingState: CardReaderOnboardingState,
+        skipOnboarding: Boolean = false
+    ): CardReaderConnectViewModel {
+        val savedState = CardReaderConnectDialogFragmentArgs(skipOnboarding = skipOnboarding).initSavedStateHandle()
         whenever(onboardingChecker.getOnboardingState()).thenReturn(onboardingState)
         return CardReaderConnectViewModel(
-            SavedStateHandle(),
+            savedState,
             coroutinesTestRule.testDispatchers,
             tracker,
             appPrefs,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -41,6 +41,8 @@ import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectView
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModelTest.ScanResult.MULTIPLE_READERS_FOUND
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModelTest.ScanResult.READER_FOUND
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModelTest.ScanResult.SCANNING
+import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingChecker
+import com.woocommerce.android.ui.prefs.cardreader.onboarding.CardReaderOnboardingState
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -63,6 +65,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
     private val tracker: AnalyticsTrackerWrapper = mock()
     private val cardReaderManager: CardReaderManager = mock()
     private val appPrefs: AppPrefs = mock()
+    private val onboardingChecker: CardReaderOnboardingChecker = mock()
     private val reader = mock<CardReader>().also { whenever(it.id).thenReturn("Dummy1") }
     private val reader2 = mock<CardReader>().also { whenever(it.id).thenReturn("Dummy2") }
 
@@ -73,7 +76,9 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
             coroutinesTestRule.testDispatchers,
             tracker,
             appPrefs,
+            onboardingChecker,
         )
+        whenever(onboardingChecker.getOnboardingState()).thenReturn(CardReaderOnboardingState.OnboardingCompleted)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -37,7 +37,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             val viewModel = createVM()
 
             assertThat(viewModel.event.value)
-                .isInstanceOf(CardReaderOnboardingViewModel.OnboardingEvent.NavigateToCardReaderHubFragment::class.java)
+                .isInstanceOf(CardReaderOnboardingViewModel.OnboardingEvent.Continue::class.java)
         }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parent isuee: #4413 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds support for redirecting to Onboarding flow when the onboarding is not completed and the user taps on "Collect payment" button on Order Detail screen. The Connect flow re-uses CardReaderOnboardingChecker to get the current state of the onboarding - if it's completed, it continues with the connection, but when it's not completed it redirects the user to the onboarding flow.
If the onboarding issue is non-blocking (aka it is AccountPendingRequirements) the user can press "SKIP" button and the app redirects back to the order detail screen with connection dialog -> collects the payment.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Make sure your site is eligible for payments and the onboarding is completed
2. Tap on App settings
3. Tap on In-Person payments
4. Tap on Manage Card Reader
5. Tap on Connect to reader (unless you have been connected before in which case the app connects automatically)
6. Notice you get redirected to the Reader Detail screen
7. Tap on Disconnect
8. Go back to dashboard
9. Open detail of an unpaid order in USD
10. Tap on Collect Payment
11. Notice the connection flow starts, the app connects to your reader and prompts you to tap/insert/swipe your card
-----------------------
1. Go to Wp-admin of your site
2. Tap on Payments
3. Under the "Account details" section, tap on "Edit details" 
4. Edit details of the person and change social security number to "111-11-1111" (this will move your account into "Pending requirements" state)
5. Open the App
6. Tap on app settings
7. Tap on in-person payments
8. Notice pending requirements warning is shown
9. Tap on skip
10. Tap on Manage card reader
11. Notice you get connected to the reader (aka onboarding flow is not shown again)
12. Tap on disconnect
13. Go back to dashboard
14. Open detail of an unpaid order in USD
15. Tap on collect payment
16. Notice after a bit you get redirected to the pending requiorements screen
17. Tap on skip
18. Notice you get redirected back to the order detail and get connected to the reader
19. Notice tap/insert/swipe your card prompt is shown
20. HOOORAY

<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
