### PR TITLE
Hide purchase card reader flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -49,7 +49,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
                         val inSettingsGraph = findNavController().graph.id == R.id.nav_graph_settings
                         if (inSettingsGraph) {
                             findNavController().navigate(
-                                R.id.action_cardReaderOnboardingFragment_to_cardReaderHubFragment
+                                R.id.action_cardReaderOnboardingFragment_to_cardReaderDetailFragment
                             )
                         } else {
                             navigateBackWithNotice(KEY_READER_ONBOARDING_SUCCESS)

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -107,6 +107,15 @@
             app:popExitAnim="@anim/activity_slide_out_to_right"
             app:popUpTo="@+id/mainSettingsFragment"
             app:popUpToInclusive="false" />
+        <action
+            android:id="@+id/action_cardReaderOnboardingFragment_to_cardReaderDetailFragment"
+            app:destination="@id/cardReaderDetailFragment"
+            app:enterAnim="@anim/activity_slide_in_from_right"
+            app:exitAnim="@anim/activity_slide_out_to_left"
+            app:popEnterAnim="@anim/activity_slide_in_from_left"
+            app:popExitAnim="@anim/activity_slide_out_to_right"
+            app:popUpTo="@+id/mainSettingsFragment"
+            app:popUpToInclusive="false" />
     </fragment>
     <fragment
         android:id="@+id/cardReaderHubFragment"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parent issue: #4413
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR skips the "Hub" fragment and navigates directly to CardReaderDetail. The purchase reader flow is not implemented yet and the only other button on the Hub is navigating the user to CardReaderDetail screen.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Use a site which is eligible for in person payments and has completed onboarding
1. Tap on app settings
2. Tap on In Person Payments
3. Notice you get redirected to CardReaderDetail screen and not the Hub fragment

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
