### PR TITLE
Re-enable "Order card reader" flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -38,4 +38,5 @@ object AppUrls {
     const val WPCOM_ADD_PAYMENT_METHOD = "https://wordpress.com/me/purchases/add-payment-method"
     const val WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS =
         "https://docs.woocommerce.com/document/getting-started-with-in-person-payments-with-woocommerce-payments/"
+    const val WOOCOMMERCE_PURCHASE_CARD_READER = "https://woocommerce.com/products/bbpos-chipper2xbt-card-reader"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubFragment.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.prefs.cardreader.hub
 
-import android.content.Context
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubFragment.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.prefs.cardreader.hub
 
+import android.content.Context
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
@@ -10,6 +11,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentCardReaderHubBinding
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.util.ChromeCustomTabUtils
 
 class CardReaderHubFragment : BaseFragment(R.layout.fragment_card_reader_hub) {
     val viewModel: CardReaderHubViewModel by viewModels()
@@ -41,7 +43,7 @@ class CardReaderHubFragment : BaseFragment(R.layout.fragment_card_reader_hub) {
                     findNavController().navigate(R.id.action_cardReaderHubFragment_to_cardReaderDetailFragment)
                 }
                 is CardReaderHubViewModel.CardReaderHubEvents.NavigateToPurchaseCardReaderFlow -> {
-                    TODO()
+                    ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                 }
                 else -> event.isHandled = false
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/hub/CardReaderHubViewModel.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.prefs.cardreader.hub
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -41,7 +42,9 @@ class CardReaderHubViewModel @Inject constructor(
 
     sealed class CardReaderHubEvents : MultiLiveEvent.Event() {
         object NavigateToCardReaderDetail : CardReaderHubEvents()
-        object NavigateToPurchaseCardReaderFlow : CardReaderHubEvents()
+        object NavigateToPurchaseCardReaderFlow : CardReaderHubEvents() {
+            const val url = AppUrls.WOOCOMMERCE_PURCHASE_CARD_READER
+        }
     }
 
     sealed class CardReaderHubViewState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -49,7 +49,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
                         val inSettingsGraph = findNavController().graph.id == R.id.nav_graph_settings
                         if (inSettingsGraph) {
                             findNavController().navigate(
-                                R.id.action_cardReaderOnboardingFragment_to_cardReaderDetailFragment
+                                R.id.action_cardReaderOnboardingFragment_to_cardReaderHubFragment
                             )
                         } else {
                             navigateBackWithNotice(KEY_READER_ONBOARDING_SUCCESS)

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -107,15 +107,6 @@
             app:popExitAnim="@anim/activity_slide_out_to_right"
             app:popUpTo="@+id/mainSettingsFragment"
             app:popUpToInclusive="false" />
-        <action
-            android:id="@+id/action_cardReaderOnboardingFragment_to_cardReaderDetailFragment"
-            app:destination="@id/cardReaderDetailFragment"
-            app:enterAnim="@anim/activity_slide_in_from_right"
-            app:exitAnim="@anim/activity_slide_out_to_left"
-            app:popEnterAnim="@anim/activity_slide_in_from_left"
-            app:popExitAnim="@anim/activity_slide_out_to_right"
-            app:popUpTo="@+id/mainSettingsFragment"
-            app:popUpToInclusive="false" />
     </fragment>
     <fragment
         android:id="@+id/cardReaderHubFragment"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parent issue #4413

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR reverts changes done in https://github.com/woocommerce/woocommerce-android/pull/4572. We removed "Order card reader" flow from the app since the url was not created on the web.
However, since we have the url now, we decided to re-enable the flow even though the url currently returns 404. The product page will be implemented in the following 7 days (before the release). Even if it wasn't released, we are still in the beta, so it's not a big deal.

### Testing instructions
- Use a store which is eligible for card present payments and has onboarding completed (no pending requirements on stripe account etc)
1. Tap on App Settings
2. Tap on In-Person Payments
3. Notice a loading is shown and you get redirected after 0-2s
4. Tap on Order Card reader
5. Notice a webview (chrometab) is shown with "https://woocommerce.com/products/bbpos-chipper2xbt-card-reader " -> the url is empty as of now, so you'll see "Error 404"

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2261188/128670003-595b2eff-6242-4ef9-93bd-44d7509a90b4.mp4




- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
