### PR TITLE
Never return cached data from fetchOrder method

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -208,7 +208,7 @@ class CardReaderPaymentViewModel
     }
 
     private suspend fun fetchOrder(): Order? {
-        return orderRepository.fetchOrder(arguments.orderIdentifier, useCachedOnFailure = false)
+        return orderRepository.fetchOrder(arguments.orderIdentifier)
     }
 
     private fun emitFailedPaymentState(orderId: Long, billingEmail: String, error: PaymentFailed, amountLabel: String) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -222,7 +222,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             // GIVEN
             doReturn(false).whenever(paymentCollectibilityChecker).isCollectable(any())
             doReturn(order).whenever(repository).getOrder(any())
-            doReturn(order).whenever(repository).fetchOrder(any(), any())
+            doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
 
             // WHEN
@@ -238,7 +238,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             // GIVEN
             doReturn(true).whenever(paymentCollectibilityChecker).isCollectable(any())
             doReturn(order).whenever(repository).getOrder(any())
-            doReturn(order).whenever(repository).fetchOrder(any(), any())
+            doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
 
             // WHEN
@@ -253,7 +253,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
             val order = order.copy(items = emptyList())
             doReturn(order).whenever(repository).getOrder(any())
-            doReturn(order).whenever(repository).fetchOrder(any(), any())
+            doReturn(order).whenever(repository).fetchOrder(any())
 
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
             doReturn(testOrderNotes).whenever(repository).getOrderNotes(any())
@@ -275,7 +275,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
             doReturn(true).whenever(repository).hasVirtualProductsOnly(listOf(3, 4))
             doReturn(virtualOrder).whenever(repository).getOrder(any())
-            doReturn(virtualOrder).whenever(repository).fetchOrder(any(), any())
+            doReturn(virtualOrder).whenever(repository).fetchOrder(any())
 
             doReturn(testOrderRefunds).whenever(repository).getOrderRefunds(any())
 
@@ -298,7 +298,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
             doReturn(false).whenever(repository).hasVirtualProductsOnly(listOf(1, 2))
             doReturn(mixedOrder).whenever(repository).getOrder(any())
-            doReturn(mixedOrder).whenever(repository).fetchOrder(any(), any())
+            doReturn(mixedOrder).whenever(repository).fetchOrder(any())
 
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
             doReturn(testOrderNotes).whenever(repository).getOrderNotes(any())
@@ -336,7 +336,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
             val order = order.copy(items = items)
             doReturn(order).whenever(repository).getOrder(any())
-            doReturn(order).whenever(repository).fetchOrder(any(), any())
+            doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(1).whenever(repository).getProductCountForOrder(ids)
 
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
@@ -355,7 +355,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     fun `Do not display product list when all products are refunded`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             doReturn(order).whenever(repository).getOrder(any())
-            doReturn(order).whenever(repository).fetchOrder(any(), any())
+            doReturn(order).whenever(repository).fetchOrder(any())
 
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
             doReturn(testOrderNotes).whenever(repository).getOrderNotes(any())
@@ -389,7 +389,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     fun `Display product list when shipping labels are available`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             doReturn(order).whenever(repository).getOrder(any())
-            doReturn(order).whenever(repository).fetchOrder(any(), any())
+            doReturn(order).whenever(repository).fetchOrder(any())
 
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
             doReturn(testOrderNotes).whenever(repository).getOrderNotes(any())
@@ -422,7 +422,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     fun `Hide Create shipping label button and show Products area menu when shipping labels are available`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             doReturn(order).whenever(repository).getOrder(any())
-            doReturn(order).whenever(repository).fetchOrder(any(), any())
+            doReturn(order).whenever(repository).fetchOrder(any())
 
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
             doReturn(testOrderNotes).whenever(repository).getOrderNotes(any())
@@ -468,7 +468,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     fun `Show Create shipping label button and hide Products area menu when no shipping labels are available`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             doReturn(order).whenever(repository).getOrder(any())
-            doReturn(order).whenever(repository).fetchOrder(any(), any())
+            doReturn(order).whenever(repository).fetchOrder(any())
 
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
             doReturn(testOrderNotes).whenever(repository).getOrderNotes(any())
@@ -515,7 +515,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     fun `Do not display shipment tracking when shipping labels are available`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             doReturn(order).whenever(repository).getOrder(any())
-            doReturn(order).whenever(repository).fetchOrder(any(), any())
+            doReturn(order).whenever(repository).fetchOrder(any())
 
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
             doReturn(testOrderNotes).whenever(repository).getOrderNotes(any())
@@ -588,7 +588,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         viewModel.start()
 
         verify(repository, times(1)).getOrder(ORDER_IDENTIFIER)
-        verify(repository, times(0)).fetchOrder(any(), any())
+        verify(repository, times(0)).fetchOrder(any())
 
         assertThat(snackbar).isEqualTo(ShowSnackbar(string.offline_error))
     }
@@ -598,7 +598,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         val newOrderStatus = OrderStatus(CoreOrderStatus.PROCESSING.value, CoreOrderStatus.PROCESSING.value)
 
         doReturn(order).whenever(repository).getOrder(any())
-        doReturn(order).whenever(repository).fetchOrder(any(), any())
+        doReturn(order).whenever(repository).fetchOrder(any())
         doReturn(orderStatus).doReturn(newOrderStatus).doReturn(orderStatus).whenever(repository).getOrderStatus(any())
 
         doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
@@ -649,7 +649,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         val newOrderStatus = OrderStatus(CoreOrderStatus.PROCESSING.value, CoreOrderStatus.PROCESSING.value)
 
         doReturn(order).whenever(repository).getOrder(any())
-        doReturn(order).whenever(repository).fetchOrder(any(), any())
+        doReturn(order).whenever(repository).fetchOrder(any())
         doReturn(orderStatus).doReturn(newOrderStatus).whenever(repository).getOrderStatus(any())
 
         doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
@@ -713,7 +713,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         )
 
         doReturn(order).whenever(repository).getOrder(any())
-        doReturn(order).whenever(repository).fetchOrder(any(), any())
+        doReturn(order).whenever(repository).fetchOrder(any())
 
         doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
 
@@ -741,7 +741,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `show shipping label creation if the order is eligible`() = coroutinesTestRule.testDispatcher.runBlockingTest {
         doReturn(order).whenever(repository).getOrder(any())
-        doReturn(order).whenever(repository).fetchOrder(any(), any())
+        doReturn(order).whenever(repository).fetchOrder(any())
 
         doReturn(WooPlugin(isInstalled = true, isActive = true, version = OrderDetailViewModel.SUPPORTED_WCS_VERSION))
             .whenever(repository).getWooServicesPluginInfo()
@@ -768,7 +768,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     fun `hide shipping label creation if wcs is older than supported version`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             doReturn(order).whenever(repository).getOrder(any())
-            doReturn(order).whenever(repository).fetchOrder(any(), any())
+            doReturn(order).whenever(repository).fetchOrder(any())
 
             doReturn(WooPlugin(isInstalled = true, isActive = true, version = "1.25.10")).whenever(repository)
                 .getWooServicesPluginInfo()
@@ -795,7 +795,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     fun `hide shipping label creation if the order is not eligible`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             doReturn(order).whenever(repository).getOrder(any())
-            doReturn(order).whenever(repository).fetchOrder(any(), any())
+            doReturn(order).whenever(repository).fetchOrder(any())
 
             doReturn(
                 WooPlugin(
@@ -828,7 +828,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     fun `hide shipping label creation if wcs plugin is not installed`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             doReturn(order).whenever(repository).getOrder(any())
-            doReturn(order).whenever(repository).fetchOrder(any(), any())
+            doReturn(order).whenever(repository).fetchOrder(any())
 
             doReturn(
                 WooPlugin(
@@ -868,7 +868,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `show order status updated snackbar on updating status from dialog`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            doReturn(order).whenever(repository).fetchOrder(any(), any())
+            doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
             var snackbar: ShowUndoSnackbar? = null
             viewModel.event.observeForever {
@@ -889,7 +889,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `show order status updated snackbar on updating status to completed from dialog`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            doReturn(order).whenever(repository).fetchOrder(any(), any())
+            doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
             var snackbar: ShowUndoSnackbar? = null
             viewModel.event.observeForever {
@@ -910,7 +910,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `show order completed snackbar on updating status to completed from fulfill screen`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            doReturn(order).whenever(repository).fetchOrder(any(), any())
+            doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
             var snackbar: ShowUndoSnackbar? = null
             viewModel.event.observeForever {
@@ -926,7 +926,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `show error changing order snackbar if updating status failed`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            doReturn(order).whenever(repository).fetchOrder(any(), any())
+            doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
             doReturn(ContinuationWrapper.ContinuationResult.Success(false)).whenever(repository)
                 .updateOrderStatus(any(), any())
@@ -944,7 +944,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `do not show error changing order snackbar if updating status failed because of cancellation`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            doReturn(order).whenever(repository).fetchOrder(any(), any())
+            doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
             doReturn(ContinuationWrapper.ContinuationResult.Cancellation<Boolean>(CancellationException())).whenever(
                 repository
@@ -963,7 +963,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `do not show error changing order snackbar if updating status did not fail`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            doReturn(order).whenever(repository).fetchOrder(any(), any())
+            doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
             doReturn(ContinuationWrapper.ContinuationResult.Success<Boolean>(true)).whenever(repository)
                 .updateOrderStatus(any(), any())
@@ -982,7 +982,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     fun `given receipt url available, when user taps on see receipt, then preview receipt screen shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             doReturn(order).whenever(repository).getOrder(any())
-            doReturn(order).whenever(repository).fetchOrder(any(), any())
+            doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(false).whenever(repository).fetchOrderNotes(any(), any())
             doReturn("testing url")
                 .whenever(appPrefsWrapper).getReceiptUrl(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -112,7 +112,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         whenever(address.firstName).thenReturn("Tester")
         whenever(address.lastName).thenReturn("Test")
         whenever(mockedOrder.number).thenReturn(DUMMY_ORDER_NUMBER)
-        whenever(orderRepository.fetchOrder(ORDER_IDENTIFIER, false)).thenReturn(mockedOrder)
+        whenever(orderRepository.fetchOrder(ORDER_IDENTIFIER)).thenReturn(mockedOrder)
         whenever(cardReaderManager.collectPayment(any())).thenAnswer {
             flow<CardPaymentStatus> { }
         }
@@ -129,7 +129,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given fetching order fails, when payment screen shown, then FailedPayment state is shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            whenever(orderRepository.fetchOrder(ORDER_IDENTIFIER, false)).thenReturn(null)
+            whenever(orderRepository.fetchOrder(ORDER_IDENTIFIER)).thenReturn(null)
 
             viewModel.start()
 
@@ -139,7 +139,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `when fetching order fails, then event tracked`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            whenever(orderRepository.fetchOrder(ORDER_IDENTIFIER, false)).thenReturn(null)
+            whenever(orderRepository.fetchOrder(ORDER_IDENTIFIER)).thenReturn(null)
 
             viewModel.start()
 
@@ -151,7 +151,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given fetching order fails, when payment screen shown, then correct error message shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            whenever(orderRepository.fetchOrder(ORDER_IDENTIFIER, false)).thenReturn(null)
+            whenever(orderRepository.fetchOrder(ORDER_IDENTIFIER)).thenReturn(null)
 
             viewModel.start()
 
@@ -866,7 +866,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `when re-fetching order fails, then SnackBar shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            whenever(orderRepository.fetchOrder(any(), any())).thenReturn(null)
+            whenever(orderRepository.fetchOrder(any())).thenReturn(null)
             val events = mutableListOf<Event>()
             viewModel.event.observeForever {
                 events.add(it)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4222 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

I noticed, about a two months ago, that `OrderDetailRepository.fetchOrder(..)` was returning a cached value when the request to fetch the order failed. Back then I didn't want to touch the existing logic so I introduced `useCachedOnFailure` flag with the default value set to `true`.
This works as expected, but feels a bit weird. I planned to deprecate the current method and rename it to something like `fetchOrderOrReturnCached`. However, as it turned out the only usage of `fetchOrder(useCachedOnFailure = true)` is OrderDetail screen - AFAICT that screen expects an up-to-date value as well and doesn't expect a cached value to be returned on failure.
Therefore, I changed my original plan and simply updated `fetchOrder` method to return the Order only when it was just fetched from the server (aka it doesn't return a cached value on failure).


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Smoke test order detail screen


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
