### PR TITLE
Shipping Labels: require customs form for US military states

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -181,7 +181,7 @@ class CreateShippingLabelViewModel @Inject constructor(
                             validateAddress(
                                 address = transition.state.data.stepsState.originAddressStep.data,
                                 type = ORIGIN,
-                                isInternationalShipment = transition.state.data.isInternationalShipment
+                                isCustomsFormRequired = transition.state.data.isCustomsFormRequired
                             )
                         }
                     }
@@ -193,7 +193,7 @@ class CreateShippingLabelViewModel @Inject constructor(
                             validateAddress(
                                 address = transition.state.data.stepsState.shippingAddressStep.data,
                                 type = DESTINATION,
-                                isInternationalShipment = transition.state.data.isInternationalShipment
+                                isCustomsFormRequired = transition.state.data.isCustomsFormRequired
                             )
                         }
                     }
@@ -461,8 +461,8 @@ class CreateShippingLabelViewModel @Inject constructor(
         return order.shippingAddress.copy(phone = phoneNumber)
     }
 
-    private suspend fun validateAddress(address: Address, type: AddressType, isInternationalShipment: Boolean): Event {
-        return when (val result = addressValidator.validateAddress(address, type, isInternationalShipment)) {
+    private suspend fun validateAddress(address: Address, type: AddressType, isCustomsFormRequired: Boolean): Event {
+        return when (val result = addressValidator.validateAddress(address, type, isCustomsFormRequired)) {
             ValidationResult.Valid -> AddressValidated(address)
             is ValidationResult.SuggestedChanges -> AddressChangeSuggested(result.suggested)
             is ValidationResult.NotFound,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -194,7 +194,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
                     SideEffect.OpenAddressEditor(
                         address = data.stepsState.originAddressStep.data,
                         type = ORIGIN,
-                        requiresPhoneNumber = data.isInternationalShipment
+                        requiresPhoneNumber = data.isCustomsFormRequired
                     )
                 )
             }
@@ -204,7 +204,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
                     SideEffect.OpenAddressEditor(
                         address = data.stepsState.shippingAddressStep.data,
                         type = DESTINATION,
-                        requiresPhoneNumber = data.isInternationalShipment &&
+                        requiresPhoneNumber = data.isCustomsFormRequired &&
                             data.stepsState.carrierStep.requiresDestinationPhoneNumber
                     )
                 )
@@ -261,7 +261,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
                         address = data.stepsState.originAddressStep.data,
                         type = ORIGIN,
                         validationResult = event.validationResult,
-                        requiresPhoneNumber = data.isInternationalShipment
+                        requiresPhoneNumber = data.isCustomsFormRequired
                     )
                 )
             }
@@ -283,7 +283,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
                     SideEffect.OpenAddressEditor(
                         address = event.address,
                         type = ORIGIN,
-                        requiresPhoneNumber = data.isInternationalShipment
+                        requiresPhoneNumber = data.isCustomsFormRequired
                     )
                 )
             }
@@ -328,7 +328,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
                         address = data.stepsState.shippingAddressStep.data,
                         type = DESTINATION,
                         validationResult = event.validationResult,
-                        requiresPhoneNumber = data.isInternationalShipment &&
+                        requiresPhoneNumber = data.isCustomsFormRequired &&
                             data.stepsState.carrierStep.requiresDestinationPhoneNumber
                     )
                 )
@@ -351,7 +351,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
                     SideEffect.OpenAddressEditor(
                         address = event.address,
                         type = DESTINATION,
-                        requiresPhoneNumber = data.isInternationalShipment &&
+                        requiresPhoneNumber = data.isCustomsFormRequired &&
                             data.stepsState.carrierStep.requiresDestinationPhoneNumber
                     )
                 )
@@ -488,7 +488,7 @@ class ShippingLabelsStateMachine @Inject constructor() {
         val stepsState: StepsState
     ) : Parcelable {
         @IgnoredOnParcel
-        val isInternationalShipment
+        val isCustomsFormRequired
             get() = stepsState.isCustomsFormRequired
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachine.kt
@@ -631,7 +631,9 @@ class ShippingLabelsStateMachine @Inject constructor() {
             .fixStates()
 
         private fun updateForInternationalRequirements(): StepsState {
-            val originAddressStep = if (isCustomsFormRequired && !originAddressStep.data.phone.isValidPhoneNumber(ORIGIN)) {
+            val originAddressStep = if (isCustomsFormRequired &&
+                !originAddressStep.data.phone.isValidPhoneNumber(ORIGIN)
+            ) {
                 originAddressStep.copy(status = READY)
             } else originAddressStep
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
@@ -11,7 +11,6 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.DataLoaded
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.SideEffect
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.State
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.State.DataLoading
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StateMachineData
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.CarrierStep
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.CustomsStep
@@ -25,7 +24,6 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepsState
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Transition
 import com.woocommerce.android.viewmodel.BaseUnitTest
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.take


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4555 

### Description
This PR changes the logic to always require a customs form if the shipping or destination addresses are within US military states, this is needed for [legal requirements](https://www.stamps.com/whitepapers/usps-military-mail-guide.pdf) and to align with the plugin's implementation.

### Testing instructions
1. Create an order that's eligible for shipping label creation.
2. Open the order in the app.
3. Click on Create shipping label.
4. Edit the origin address to one of the US military states.
5. Confirm that the customs form step is displayed.
6. Re-edit the origin address to another state.
7. Edit the shipping address to one of the US military states.
8. Confirm that the customs form step is displayed.
9. Change the origin and shipping addresses in order to have different countries.
10. Confirm that the customs step is displayed.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
