### PR TITLE
Shipping Labels: update feedback card

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -728,8 +728,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_FEEDBACK_DISMISSED = "dismissed"
         const val VALUE_FEEDBACK_GIVEN = "gave_feedback"
         const val VALUE_PRODUCTS_VARIATIONS_FEEDBACK = "products_variations"
-        const val VALUE_SHIPPING_LABELS_M1_FEEDBACK = "shipping_labels_m1"
-        const val VALUE_SHIPPING_LABELS_M2_FEEDBACK = "shipping_labels_m2"
+        const val VALUE_SHIPPING_LABELS_M4_FEEDBACK = "shipping_labels_m4"
 
         // -- Downloadable Files
         const val KEY_DOWNLOADABLE_FILE_ACTION = "action"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
@@ -16,7 +16,7 @@ data class FeatureFeedbackSettings(
     }
 
     enum class Feature(val description: String) {
-        SHIPPING_LABELS_M1("shipping_labels_m1"),
+        SHIPPING_LABELS_M4("shipping_labels_m4"),
         PRODUCTS_VARIATIONS("products_variations")
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.feedback
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.BuildConfig
 
+@Suppress("MagicNumber")
 enum class SurveyType(private val untaggedUrl: String, private val milestone: Int? = null) {
     PRODUCT(AppUrls.CROWDSIGNAL_PRODUCT_SURVEY, 4),
     SHIPPING_LABELS(AppUrls.CROWDSIGNAL_SHIPPING_LABELS_SURVEY, 4),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
@@ -5,7 +5,7 @@ import com.woocommerce.android.BuildConfig
 
 enum class SurveyType(private val untaggedUrl: String, private val milestone: Int? = null) {
     PRODUCT(AppUrls.CROWDSIGNAL_PRODUCT_SURVEY, 4),
-    SHIPPING_LABELS(AppUrls.CROWDSIGNAL_SHIPPING_LABELS_SURVEY, 1),
+    SHIPPING_LABELS(AppUrls.CROWDSIGNAL_SHIPPING_LABELS_SURVEY, 4),
     MAIN(AppUrls.CROWDSIGNAL_MAIN_SURVEY);
 
     val url

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -150,10 +150,7 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
                 showProductListMenuButton(it)
             }
             new.isCreateShippingLabelBannerVisible.takeIfNotEqualTo(old?.isCreateShippingLabelBannerVisible) {
-                displayShippingLabelsWIPCard(it, false)
-            }
-            new.isReprintShippingLabelBannerVisible.takeIfNotEqualTo(old?.isReprintShippingLabelBannerVisible) {
-                displayShippingLabelsWIPCard(it, true)
+                displayShippingLabelsWIPCard(it)
             }
             new.isProductListVisible?.takeIfNotEqualTo(old?.isProductListVisible) {
                 binding.orderDetailProductList.isVisible = it
@@ -431,30 +428,21 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
         }
     }
 
-    private fun displayShippingLabelsWIPCard(show: Boolean, isReprintBanner: Boolean) {
+    private fun displayShippingLabelsWIPCard(show: Boolean) {
         if (show && feedbackState != DISMISSED) {
             binding.orderDetailShippingLabelsWipCard.isVisible = true
-            val (wipCardTitleId, wipCardMessageId) = if (isReprintBanner) {
-                R.string.orderdetail_shipping_label_wip_title to R.string.orderdetail_shipping_label_wip_message
-            } else {
-                R.string.orderdetail_shipping_label_m2_wip_title to R.string.orderdetail_shipping_label_m3_wip_message
-            }
 
             binding.orderDetailShippingLabelsWipCard.initView(
-                getString(wipCardTitleId),
-                getString(wipCardMessageId),
-                onGiveFeedbackClick = { onGiveFeedbackClicked(isReprintBanner) },
-                onDismissClick = { onDismissProductWIPNoticeCardClicked(isReprintBanner) }
+                getString(R.string.orderdetail_shipping_label_m2_wip_title),
+                getString(R.string.orderdetail_shipping_label_m3_wip_message),
+                onGiveFeedbackClick = { onGiveFeedbackClicked() },
+                onDismissClick = { onDismissProductWIPNoticeCardClicked() }
             )
         } else binding.orderDetailShippingLabelsWipCard.isVisible = false
     }
 
-    private fun onGiveFeedbackClicked(isM1: Boolean) {
-        val context = if (isM1) {
-            AnalyticsTracker.VALUE_SHIPPING_LABELS_M1_FEEDBACK
-        } else {
-            AnalyticsTracker.VALUE_SHIPPING_LABELS_M2_FEEDBACK
-        }
+    private fun onGiveFeedbackClicked() {
+        val context = AnalyticsTracker.VALUE_SHIPPING_LABELS_M4_FEEDBACK
 
         AnalyticsTracker.track(
             FEATURE_FEEDBACK_BANNER,
@@ -469,12 +457,8 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
             .apply { findNavController().navigateSafely(this) }
     }
 
-    private fun onDismissProductWIPNoticeCardClicked(isM1: Boolean) {
-        val context = if (isM1) {
-            AnalyticsTracker.VALUE_SHIPPING_LABELS_M1_FEEDBACK
-        } else {
-            AnalyticsTracker.VALUE_SHIPPING_LABELS_M2_FEEDBACK
-        }
+    private fun onDismissProductWIPNoticeCardClicked() {
+        val context = AnalyticsTracker.VALUE_SHIPPING_LABELS_M4_FEEDBACK
 
         AnalyticsTracker.track(
             FEATURE_FEEDBACK_BANNER,
@@ -484,7 +468,7 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
             )
         )
         registerFeedbackSetting(DISMISSED)
-        displayShippingLabelsWIPCard(false, isM1)
+        displayShippingLabelsWIPCard(false)
     }
 
     private fun registerFeedbackSetting(state: FeedbackState) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -25,7 +25,7 @@ import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.extensions.whenNotNullNorEmpty
 import com.woocommerce.android.model.FeatureFeedbackSettings
-import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.SHIPPING_LABELS_M1
+import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.SHIPPING_LABELS_M4
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.DISMISSED
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.GIVEN
@@ -488,7 +488,7 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
     }
 
     private fun registerFeedbackSetting(state: FeedbackState) {
-        FeatureFeedbackSettings(SHIPPING_LABELS_M1.name, state)
+        FeatureFeedbackSettings(SHIPPING_LABELS_M4.name, state)
             .run { FeedbackPrefs.setFeatureFeedbackSettings(TAG, this) }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -645,9 +645,6 @@ class OrderDetailViewModel @Inject constructor(
 
         val isCreateShippingLabelBannerVisible: Boolean
             get() = isCreateShippingLabelButtonVisible == true && isProductListVisible == true
-
-        val isReprintShippingLabelBannerVisible: Boolean
-            get() = !isCreateShippingLabelBannerVisible && areShippingLabelsVisible == true
     }
 
     @Parcelize


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
As @anitaa1990 pointed in Slack p1628512168005500-slack-C026HH75ECA, we are still sending M1 in the crowdsignal survey link, this PR fixes this by updating it to M4.
The PR also removes the outdated shipping label reprinting feedback card, and shows only the feedback card for creating labels.

### Testing instructions
1. Create an order that's eligible for shipping label creation.
2. Open the order in the app.
3. Confirm that the feedback card is displayed.
4. Submit some feedback.
5. Go to crowdsignal and confirm that the `shipping_label_milestone` contains `4` now.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->