### PR TITLE
Register fcm token for a site only if it exists

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationRegistrationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationRegistrationHandler.kt
@@ -17,8 +17,8 @@ class NotificationRegistrationHandler @Inject constructor(
     private val selectedSite: SelectedSite
 ) {
     fun onNewFCMTokenReceived(token: String) {
-        // Register for WordPress.com notifications only if user is logged in
-        if (accountStore.hasAccessToken()) {
+        // Register for WordPress.com notifications only if user is logged in & if site exists
+        if (accountStore.hasAccessToken() && selectedSite.exists()) {
             preferencesWrapper.setFCMToken(token)
 
             val payload = RegisterDevicePayload(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/push/NotificationRegistrationHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/push/NotificationRegistrationHandlerTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.push
 
 import com.nhaarman.mockitokotlin2.*
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.PreferencesWrapper
 import org.junit.Before
 import org.junit.Test
@@ -15,6 +16,7 @@ class NotificationRegistrationHandlerTest {
 
     private val dispatcher: Dispatcher = mock()
     private val accountStore: AccountStore = mock()
+    private val selectedSite: SelectedSite = mock()
     private val preferencesWrapper: PreferencesWrapper = mock()
 
     @Before
@@ -24,7 +26,7 @@ class NotificationRegistrationHandlerTest {
             accountStore = accountStore,
             notificationStore = mock(),
             preferencesWrapper = preferencesWrapper,
-            selectedSite = mock()
+            selectedSite = selectedSite
         )
     }
 
@@ -41,8 +43,23 @@ class NotificationRegistrationHandlerTest {
     }
 
     @Test
+    fun `do not register new fcm token if site does not exist`() {
+        doReturn(true).whenever(accountStore).hasAccessToken()
+        doReturn(false).whenever(selectedSite).exists()
+
+        val fcmToken = "123456"
+        notificationRegistrationHandler.onNewFCMTokenReceived(token = fcmToken)
+
+        verify(accountStore, atLeastOnce()).hasAccessToken()
+        verify(selectedSite, atLeastOnce()).exists()
+        verify(preferencesWrapper, never()).setFCMToken(any())
+        verify(dispatcher, never()).dispatch(any())
+    }
+
+    @Test
     fun `new fcm token is registered successfully only if user is logged in`() {
         doReturn(true).whenever(accountStore).hasAccessToken()
+        doReturn(true).whenever(selectedSite).exists()
 
         val fcmToken = "123456"
         notificationRegistrationHandler.onNewFCMTokenReceived(token = fcmToken)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -308,7 +308,8 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             statementDescriptor = "",
             storeCurrencies = WCPaymentAccountResult.WCPayAccountStatusEnum.StoreCurrencies("", listOf()),
             country = "US",
-            isCardPresentEligible = true
+            isCardPresentEligible = true,
+            isLive = false
         )
     )
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes #4584 

### Description
This PR checks if a site exists before trying to register a FCM token for that site. This was caused by the changes in [this PR](https://github.com/woocommerce/woocommerce-android/pull/4526). I failed to add the `selectedSite.exists()` check to the code when cleaning up the notification service 🤦‍♀️ . 

**Since this is an important fix it should be merged to the release branch.**

cc @jkmassel this would require a new beta to be released, since this affects users during startup. Thank you do much 🙇‍♀️ 

### Testing instructions
- Try to login to a site using the magic link flow and you will notice the app crashing consistently.
- Pull the changes from this PR and ensure that the app no longer crashes.
- Run `NotificationRegistrationHandlerTest`.
- It would be good to check that FCM registration is successful after login and after selecting site.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.