### PR TITLE
Cancel collect payment action when user dismiss the payment dialog

### DIFF
--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersAction.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersAction.kt
@@ -1,16 +1,12 @@
 package com.woocommerce.android.cardreader.internal.connection.actions
 
 import com.stripe.stripeterminal.callable.Callback
-import com.stripe.stripeterminal.callable.Cancelable
 import com.stripe.stripeterminal.callable.DiscoveryListener
 import com.stripe.stripeterminal.model.external.DeviceType.CHIPPER_2X
 import com.stripe.stripeterminal.model.external.DiscoveryConfiguration
 import com.stripe.stripeterminal.model.external.Reader
 import com.stripe.stripeterminal.model.external.TerminalException
-import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Failure
-import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.FoundReaders
-import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Started
-import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Success
+import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.*
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CollectPaymentAction.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CollectPaymentAction.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.cardreader.internal.payments.actions
 
+import com.stripe.stripeterminal.callable.Callback
 import com.stripe.stripeterminal.callable.PaymentIntentCallback
 import com.stripe.stripeterminal.callable.ReaderDisplayListener
 import com.stripe.stripeterminal.model.external.PaymentIntent
@@ -28,7 +29,7 @@ internal class CollectPaymentAction(private val terminal: TerminalWrapper, priva
 
     fun collectPayment(paymentIntent: PaymentIntent): Flow<CollectPaymentStatus> {
         return callbackFlow {
-            terminal.collectPaymentMethod(
+            val cancelable = terminal.collectPaymentMethod(
                 paymentIntent,
                 object : ReaderDisplayListener {
                     override fun onRequestReaderDisplayMessage(message: ReaderDisplayMessage) {
@@ -48,19 +49,28 @@ internal class CollectPaymentAction(private val terminal: TerminalWrapper, priva
                         this@callbackFlow.close()
                     }
 
-                    override fun onFailure(exception: TerminalException) {
+                    override fun onFailure(e: TerminalException) {
                         logWrapper.d("CardReader", "Payment collection failed")
-                        this@callbackFlow.sendBlocking(Failure(exception))
+                        this@callbackFlow.sendBlocking(Failure(e))
                         this@callbackFlow.close()
                     }
                 }
             )
-            // TODO cardreader implement timeout
-            awaitClose()
+            awaitClose {
+                if (!cancelable.isCompleted) cancelable.cancel(noop)
+            }
         }
     }
 
     private fun <E> SendChannel<E>.sendBlockingIfOpen(element: E) {
         if (!isClosedForSend) sendBlocking(element)
+    }
+}
+
+private val noop = object : Callback {
+    override fun onFailure(e: TerminalException) {
+    }
+
+    override fun onSuccess() {
     }
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CollectPaymentAction.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CollectPaymentAction.kt
@@ -69,8 +69,10 @@ internal class CollectPaymentAction(private val terminal: TerminalWrapper, priva
 
 private val noop = object : Callback {
     override fun onFailure(e: TerminalException) {
+        // noop
     }
 
     override fun onSuccess() {
+        // noop
     }
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CollectPaymentActionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CollectPaymentActionTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.cardreader.internal.payments.actions
 
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import com.stripe.stripeterminal.callable.Cancelable
 import com.stripe.stripeterminal.callable.PaymentIntentCallback
@@ -13,8 +14,11 @@ import com.woocommerce.android.cardreader.internal.payments.actions.CollectPayme
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction.CollectPaymentStatus.Success
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -146,4 +150,19 @@ internal class CollectPaymentActionTest {
             val result = action.collectPayment(mock()).toList()
             assertThat(result.size).isEqualTo(1)
         }
+
+    @Test
+    fun `given flow not terminated, when job canceled, then collect payment gets canceled`() = runBlockingTest {
+        val cancelable = mock<Cancelable>()
+        whenever(cancelable.isCompleted).thenReturn(false)
+        whenever(terminal.collectPaymentMethod(any(), any(), any())).thenAnswer { cancelable }
+        val job = launch {
+            action.collectPayment(mock()).collect { }
+        }
+
+        job.cancel()
+        joinAll(job)
+
+        verify(cancelable).cancel(any())
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4570 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR cancels "collect payment" action as soon as the user dismisses the payment dialog. This allows the user to restart the payment flow right away - previously, the restarted flow would first wait up to 60 seconds before the previous "collect payment" action timed out.

This PR also refactors try/catch in the discover action to follow the same concise pattern - this pattern is recommended in comment of `awaitClose` method.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Use a site which is eligible for card present payments
1. Tap on App settings
2. Tap on In Person Payments
3. Tap on Manage Card Reader
4. Tap on Connect to Reader (leave your reader turned off)
5. Notice a connection dialog is shown
6. Tap on back (aka dismiss the dialog)
7. Tap on Connect to Reader
8. Turn on your reader and notice it's found by the discovery process
-------------
1. Open detail of an unpaid order in USD
2. Tap on Collect Payment
3. Connect to your reader if you are not already connected
4. When the flow reaches "collect payment" state, dismiss the dialog (press back)
5. Tap on Collect Payment button again
6. Notice the flow reaches "collect payment" dialog within 0-5 seconds (it doesn't wait for 60s before the previous action times out).


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
