### PR TITLE
Shipping Labels: multiple fixes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -338,7 +338,7 @@ class EditShippingLabelAddressViewModel @Inject constructor(
             phoneField = PhoneField(args.address.phone, args.requiresPhoneNumber, args.addressType),
             cityField = RequiredField(args.address.city),
             zipField = RequiredField(args.address.postcode),
-            stateField = LocationField(Location(code = args.address.state, name = "")),
+            stateField = LocationField(Location(code = args.address.state, name = args.address.state)),
             countryField = LocationField(Location(code = args.address.country, name = ""), isRequired = true)
         )
 

--- a/WooCommerce/src/main/res/layout/fragment_print_shipping_label.xml
+++ b/WooCommerce/src/main/res/layout/fragment_print_shipping_label.xml
@@ -1,192 +1,202 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/colorSurface">
-
-    <com.woocommerce.android.widgets.WCWarningBanner
-        android:id="@+id/expiration_warning_banner"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="parent"
-        app:message="@string/shipping_label_reprint_expired_message"
-        android:visibility="gone"/>
-
-    <androidx.constraintlayout.widget.Group
-        android:id="@+id/reprint_group"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:constraint_referenced_ids="shippingLabelPrint_errorMessage, shippingLabelPrint_disclaimerIcon, shippingLabelPrint_disclaimer" />
-
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/shippingLabelPrint_errorMessage"
-        style="@style/Woo.Card.Title"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:paddingBottom="@dimen/major_100"
-        android:text="@string/shipping_label_print_error_message"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/expiration_warning_banner" />
-
-    <ImageView
-        android:id="@+id/shippingLabelPrint_disclaimerIcon"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/major_100"
-        android:layout_marginTop="@dimen/minor_25"
-        android:layout_marginEnd="@dimen/major_100"
-        android:layout_marginBottom="@dimen/major_100"
-        android:contentDescription="@string/shipping_label_print_disclaimer"
-        android:src="@drawable/ic_info_outline_24dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/shippingLabelPrint_errorMessage" />
-
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/shippingLabelPrint_disclaimer"
-        style="@style/Woo.ListItem.Body"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:paddingBottom="@dimen/major_75"
-        android:text="@string/shipping_label_print_disclaimer"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/shippingLabelPrint_disclaimerIcon"
-        app:layout_constraintTop_toBottomOf="@+id/shippingLabelPrint_errorMessage" />
-
-    <androidx.constraintlayout.widget.Group
-        android:id="@+id/purchase_group"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:visibility="gone"
-        app:constraint_referenced_ids="label_purchased, label_purchased_img,save_for_later_button" />
-
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/label_purchased"
-        android:layout_width="wrap_content"
-        android:layout_height="0dp"
-        android:text="@string/shipping_label_print_purchase_success"
-        android:textAppearance="?attr/textAppearanceBody1"
-        android:textColor="@color/color_on_surface_high"
-        android:layout_marginTop="@dimen/major_100"
-        app:layout_constrainedWidth="true"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/expiration_warning_banner" />
-
-    <androidx.appcompat.widget.AppCompatImageView
-        android:id="@+id/label_purchased_img"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constrainedWidth="true"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/label_purchased"
-        app:srcCompat="@drawable/img_label_purchased" />
-
-    <androidx.constraintlayout.widget.Barrier
-        android:id="@+id/top_part_barrier"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:barrierDirection="bottom"
-        app:constraint_referenced_ids="label_purchased_img,shippingLabelPrint_disclaimer" />
-
-    <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-        android:id="@+id/shippingLabelPrint_paperSize"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/major_100"
-        android:hint="@string/shipping_label_paper_size"
-        android:text="@string/shipping_label_paper_size_legal"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/top_part_barrier" />
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/shippingLabelPrint_btn"
-        style="@style/Woo.Button.Colored"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/major_100"
-        android:text="@string/shipping_label_print_button"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/shippingLabelPrint_paperSize" />
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/save_for_later_button"
-        style="@style/Woo.Button.Outlined"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/major_100"
-        android:layout_marginEnd="@dimen/major_100"
-        android:text="@string/shipping_label_print_save_for_later"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/shippingLabelPrint_btn" />
+    android:fillViewport="true">
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/shippingLabelPrint_pageOptionsView"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/selectableItemBackground"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/save_for_later_button">
+        android:background="?attr/colorSurface">
 
-        <ImageView
-            android:id="@+id/shippingLabelPrint_pagesIcon"
-            android:layout_width="wrap_content"
+        <com.woocommerce.android.widgets.WCWarningBanner
+            android:id="@+id/expiration_warning_banner"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_margin="@dimen/major_100"
-            android:contentDescription="@string/shipping_label_paper_size_options_info"
-            android:src="@drawable/ic_gridicons_pages"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            app:message="@string/shipping_label_reprint_expired_message"
+            android:visibility="gone"/>
+
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/reprint_group"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:visibility="gone"
+            app:constraint_referenced_ids="shippingLabelPrint_errorMessage, shippingLabelPrint_disclaimerIcon, shippingLabelPrint_disclaimer" />
 
         <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/shippingLabelPrint_pagesInfo"
-            style="@style/Woo.ListItem.Body"
+            android:id="@+id/shippingLabelPrint_errorMessage"
+            style="@style/Woo.Card.Title"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:text="@string/shipping_label_paper_size_options_info"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toEndOf="@id/shippingLabelPrint_pagesIcon"
+            android:paddingBottom="@dimen/major_100"
+            android:text="@string/shipping_label_print_error_message"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/shippingLabelPrint_infoView"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:background="?attr/selectableItemBackground"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/shippingLabelPrint_pageOptionsView">
+            app:layout_constraintTop_toBottomOf="@id/expiration_warning_banner" />
 
         <ImageView
-            android:id="@+id/shippingLabelPrint_infoIcon"
+            android:id="@+id/shippingLabelPrint_disclaimerIcon"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="@dimen/major_100"
-            android:contentDescription="@string/shipping_label_print_info"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/minor_25"
+            android:layout_marginEnd="@dimen/major_100"
+            android:layout_marginBottom="@dimen/major_100"
+            android:contentDescription="@string/shipping_label_print_disclaimer"
             android:src="@drawable/ic_info_outline_24dp"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toBottomOf="@+id/shippingLabelPrint_errorMessage" />
 
         <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/shippingLabelPrint_info"
+            android:id="@+id/shippingLabelPrint_disclaimer"
             style="@style/Woo.ListItem.Body"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:text="@string/shipping_label_print_info"
+            android:paddingBottom="@dimen/major_75"
+            android:text="@string/shipping_label_print_disclaimer"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/shippingLabelPrint_disclaimerIcon"
+            app:layout_constraintTop_toBottomOf="@+id/shippingLabelPrint_errorMessage" />
+
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/purchase_group"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:visibility="visible"
+            app:constraint_referenced_ids="label_purchased, label_purchased_img,save_for_later_button" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/label_purchased"
+            android:layout_width="wrap_content"
+            android:layout_height="0dp"
+            android:text="@string/shipping_label_print_purchase_success"
+            android:textAppearance="?attr/textAppearanceBody1"
+            android:textColor="@color/color_on_surface_high"
+            android:layout_marginTop="@dimen/major_100"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/expiration_warning_banner" />
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/label_purchased_img"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/label_purchased"
+            app:srcCompat="@drawable/img_label_purchased" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/top_part_barrier"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:barrierDirection="bottom"
+            app:constraint_referenced_ids="label_purchased_img,shippingLabelPrint_disclaimer" />
+
+        <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+            android:id="@+id/shippingLabelPrint_paperSize"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/major_100"
+            android:hint="@string/shipping_label_paper_size"
+            android:text="@string/shipping_label_paper_size_legal"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/top_part_barrier" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/shippingLabelPrint_btn"
+            style="@style/Woo.Button.Colored"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/major_100"
+            android:text="@string/shipping_label_print_button"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/shippingLabelPrint_paperSize" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/save_for_later_button"
+            style="@style/Woo.Button.Outlined"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginEnd="@dimen/major_100"
+            android:text="@string/shipping_label_print_save_for_later"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/shippingLabelPrint_btn" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/shippingLabelPrint_pageOptionsView"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/save_for_later_button">
+
+            <ImageView
+                android:id="@+id/shippingLabelPrint_pagesIcon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/major_100"
+                android:contentDescription="@string/shipping_label_paper_size_options_info"
+                android:src="@drawable/ic_gridicons_pages"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/shippingLabelPrint_pagesInfo"
+                style="@style/Woo.ListItem.Body"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="@string/shipping_label_paper_size_options_info"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toEndOf="@id/shippingLabelPrint_pagesIcon"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/shippingLabelPrint_infoView"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/shippingLabelPrint_infoIcon"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/shippingLabelPrint_pageOptionsView"
+            app:layout_constraintVertical_bias="0">
 
+            <ImageView
+                android:id="@+id/shippingLabelPrint_infoIcon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/major_100"
+                android:contentDescription="@string/shipping_label_print_info"
+                android:src="@drawable/ic_info_outline_24dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/shippingLabelPrint_info"
+                style="@style/Woo.ListItem.Body"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="@string/shipping_label_print_info"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/shippingLabelPrint_infoIcon"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
-</androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>

--- a/WooCommerce/src/main/res/layout/fragment_shipping_label_address_suggestion.xml
+++ b/WooCommerce/src/main/res/layout/fragment_shipping_label_address_suggestion.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
+<ScrollView
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:fillViewport="true">
 
     <com.woocommerce.android.widgets.WCElevatedConstraintLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:orientation="vertical"
         android:layout_marginBottom="@dimen/minor_100">
 
@@ -64,6 +68,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toBottomOf="@id/suggestionBanner"
+            app:layout_constraintBottom_toTopOf="@id/useSuggestedAddressButton"
+            app:layout_constraintVertical_bias="0"
             android:layout_marginStart="@dimen/major_75"
             android:layout_marginBottom="@dimen/major_100">
 
@@ -144,3 +150,4 @@
             android:text="@string/shipping_label_address_suggestion_edit_selected_address" />
 
     </com.woocommerce.android.widgets.WCElevatedConstraintLayout>
+</ScrollView>

--- a/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
@@ -1,194 +1,198 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.woocommerce.android.widgets.WCElevatedLinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    style="@style/Woo.Card.WithoutPadding">
 
-    <LinearLayout
-        android:id="@+id/title_layout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="?attr/selectableItemBackground"
-        android:gravity="center_vertical"
-        android:orientation="horizontal">
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/package_name"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:textAppearance="?attr/textAppearanceSubtitle1"
-            android:textColor="@color/color_on_surface_high"
-            android:textStyle="bold"
-            tools:text="Package 1" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/package_items_count"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/minor_50"
-            android:layout_weight="1"
-            android:textAppearance="@style/TextAppearance.Woo.Body1"
-            tools:text="- 10 items" />
-
-        <androidx.appcompat.widget.AppCompatImageView
-            android:id="@+id/error_view"
-            android:layout_width="@dimen/image_minor_50"
-            android:layout_height="@dimen/image_minor_50"
-            app:srcCompat="@drawable/mtrl_ic_error"
-            app:tint="@color/woo_red_50" />
-
-        <androidx.appcompat.widget.AppCompatImageView
-            android:id="@+id/expand_icon"
-            android:layout_width="@dimen/image_major_50"
-            android:layout_height="@dimen/image_major_50"
-            android:padding="@dimen/major_75"
-            android:src="@drawable/ic_arrow_down"
-            android:tint="@color/color_on_surface_high" />
-    </LinearLayout>
-
-    <View
-        android:id="@+id/divider_1"
-        style="@style/Woo.Divider" />
-
-    <LinearLayout
-        android:id="@+id/details_layout"
+    <LinearLayout xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/items_section_title"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/major_300"
-            android:background="?android:attr/colorBackground"
-            android:gravity="center_vertical"
-            android:paddingStart="@dimen/major_100"
-            android:paddingEnd="@dimen/major_100"
-            android:text="@string/shipping_label_package_details_items_section_title"
-            android:textAppearance="?attr/textAppearanceSubtitle2"
-            android:textColor="@color/color_on_surface_disabled" />
-
-        <View
-            android:id="@+id/divider_2"
-            style="@style/Woo.Divider"
-            android:layout_marginStart="@dimen/major_100" />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/items_list"
+        <LinearLayout
+            android:id="@+id/title_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            tools:itemCount="5"
-            tools:listitem="@layout/shipping_label_package_product_list_item" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/details_section_title"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/major_300"
-            android:background="@color/default_window_background"
+            android:background="?attr/selectableItemBackground"
             android:gravity="center_vertical"
-            android:paddingStart="@dimen/major_100"
-            android:paddingEnd="@dimen/major_100"
-            android:text="@string/shipping_label_package_details_section_title"
-            android:textAppearance="?attr/textAppearanceSubtitle2"
-            android:textColor="@color/color_on_surface_disabled" />
+            android:orientation="horizontal">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/package_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:textAppearance="?attr/textAppearanceSubtitle1"
+                android:textColor="@color/color_on_surface_high"
+                android:textStyle="bold"
+                tools:text="Package 1" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/package_items_count"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/minor_50"
+                android:layout_weight="1"
+                android:textAppearance="@style/TextAppearance.Woo.Body1"
+                tools:text="- 10 items" />
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/error_view"
+                android:layout_width="@dimen/image_minor_50"
+                android:layout_height="@dimen/image_minor_50"
+                app:srcCompat="@drawable/mtrl_ic_error"
+                app:tint="@color/woo_red_50" />
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/expand_icon"
+                android:layout_width="@dimen/image_major_50"
+                android:layout_height="@dimen/image_major_50"
+                android:padding="@dimen/major_75"
+                android:src="@drawable/ic_arrow_down"
+                android:tint="@color/color_on_surface_high" />
+        </LinearLayout>
 
         <View
-            android:id="@+id/divider_3"
-            style="@style/Woo.Divider"
-            android:layout_marginStart="@dimen/major_100"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/details_section_title" />
-
-        <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-            android:id="@+id/selected_package_spinner"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_75"
-            android:layout_marginEnd="@dimen/major_100"
-            android:hint="@string/shipping_label_package_details_selected_package_hint" />
+            android:id="@+id/divider_1"
+            style="@style/Woo.Divider" />
 
         <LinearLayout
-            android:id="@+id/individual_package_layout"
+            android:id="@+id/details_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
             <com.google.android.material.textview.MaterialTextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/major_100"
-                android:layout_marginTop="@dimen/minor_100"
-                android:text="@string/shipping_label_package_details_individual_package_title"
-                android:textAppearance="?attr/textAppearanceSubtitle1" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/individual_package_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/major_100"
-                android:text="@string/shipping_label_package_details_individual_package_subtitle"
-                android:textAppearance="?attr/textAppearanceBody2" />
+                android:id="@+id/items_section_title"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/major_300"
+                android:background="?android:attr/colorBackground"
+                android:gravity="center_vertical"
+                android:paddingStart="@dimen/major_100"
+                android:paddingEnd="@dimen/major_100"
+                android:text="@string/shipping_label_package_details_items_section_title"
+                android:textAppearance="?attr/textAppearanceSubtitle2"
+                android:textColor="@color/color_on_surface_disabled" />
 
             <View
+                android:id="@+id/divider_2"
+                style="@style/Woo.Divider"
+                android:layout_marginStart="@dimen/major_100" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/items_list"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                tools:itemCount="5"
+                tools:listitem="@layout/shipping_label_package_product_list_item" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/details_section_title"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/major_300"
+                android:background="@color/default_window_background"
+                android:gravity="center_vertical"
+                android:paddingStart="@dimen/major_100"
+                android:paddingEnd="@dimen/major_100"
+                android:text="@string/shipping_label_package_details_section_title"
+                android:textAppearance="?attr/textAppearanceSubtitle2"
+                android:textColor="@color/color_on_surface_disabled" />
+
+            <View
+                android:id="@+id/divider_3"
                 style="@style/Woo.Divider"
                 android:layout_marginStart="@dimen/major_100"
-                android:layout_marginTop="@dimen/minor_100" />
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/details_section_title" />
 
-            <com.google.android.material.textview.MaterialTextView
-                android:layout_width="wrap_content"
+            <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+                android:id="@+id/selected_package_spinner"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/major_100"
-                android:layout_marginTop="@dimen/minor_100"
-                android:text="@string/shipping_label_package_details_individual_package_dimensions"
-                android:textAppearance="?attr/textAppearanceSubtitle1" />
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_75"
+                android:layout_marginEnd="@dimen/major_100"
+                android:hint="@string/shipping_label_package_details_selected_package_hint" />
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/individual_package_dimensions"
-                android:layout_width="wrap_content"
+            <LinearLayout
+                android:id="@+id/individual_package_layout"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/major_100"
-                android:textAppearance="?attr/textAppearanceBody2"
-                tools:text="10cm x 10cm x 10cm" />
+                android:orientation="vertical">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/major_100"
+                    android:layout_marginTop="@dimen/minor_100"
+                    android:text="@string/shipping_label_package_details_individual_package_title"
+                    android:textAppearance="?attr/textAppearanceSubtitle1" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/individual_package_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/major_100"
+                    android:text="@string/shipping_label_package_details_individual_package_subtitle"
+                    android:textAppearance="?attr/textAppearanceBody2" />
+
+                <View
+                    style="@style/Woo.Divider"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/minor_100" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/major_100"
+                    android:layout_marginTop="@dimen/minor_100"
+                    android:text="@string/shipping_label_package_details_individual_package_dimensions"
+                    android:textAppearance="?attr/textAppearanceSubtitle1" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/individual_package_dimensions"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/major_100"
+                    android:textAppearance="?attr/textAppearanceBody2"
+                    tools:text="10cm x 10cm x 10cm" />
+
+                <View
+                    style="@style/Woo.Divider"
+                    android:layout_marginTop="@dimen/minor_100" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/individual_package_error"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/major_100"
+                    android:layout_marginTop="@dimen/minor_100"
+                    android:drawablePadding="@dimen/minor_100"
+                    android:text="@string/shipping_label_package_details_individual_package_dimensions_error"
+                    android:textAppearance="?attr/textAppearanceCaption"
+                    android:textColor="@color/color_error"
+                    app:drawableStartCompat="@drawable/ic_info_outline_24dp"
+                    app:drawableTint="@color/color_error" />
+            </LinearLayout>
+
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                android:id="@+id/weight_edit_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_175"
+                android:layout_marginEnd="@dimen/major_100"
+                android:layout_marginBottom="@dimen/major_200"
+                android:hint="@string/shipping_label_package_details_weight_hint"
+                android:inputType="numberDecimal"
+                app:helperText="@string/shipping_label_package_details_weight_info" />
 
             <View
+                android:id="@+id/bottom_divider"
                 style="@style/Woo.Divider"
-                android:layout_marginTop="@dimen/minor_100" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/individual_package_error"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/major_100"
-                android:layout_marginTop="@dimen/minor_100"
-                android:drawablePadding="@dimen/minor_100"
-                android:text="@string/shipping_label_package_details_individual_package_dimensions_error"
-                android:textAppearance="?attr/textAppearanceCaption"
-                android:textColor="@color/color_error"
-                app:drawableStartCompat="@drawable/ic_info_outline_24dp"
-                app:drawableTint="@color/color_error" />
+                app:layout_constraintBottom_toBottomOf="parent" />
         </LinearLayout>
-
-        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-            android:id="@+id/weight_edit_text"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_175"
-            android:layout_marginEnd="@dimen/major_100"
-            android:layout_marginBottom="@dimen/major_200"
-            android:hint="@string/shipping_label_package_details_weight_hint"
-            android:inputType="numberDecimal"
-            app:helperText="@string/shipping_label_package_details_weight_info" />
-
-        <View
-            android:id="@+id/bottom_divider"
-            style="@style/Woo.Divider"
-            app:layout_constraintBottom_toBottomOf="parent" />
     </LinearLayout>
-
-</com.woocommerce.android.widgets.WCElevatedLinearLayout>
+</androidx.cardview.widget.CardView>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4595 #4594 #4592 #4593 

### Description
This PR attempts to fix multiple issues that @koke raised after testing the app (p5T066-2yT-p2#comment-9497):
1. 919c85c fixes a crash that occurs when moving items between packages, I don't really understand why the `MaterialShapeDrawable` used in `WCElevatedLinearLayout` caused the crash, but it seems that against our initial thought, using a `CardView` is lighter.
2. a18a3c8 updates constraints of the address suggestion screen, and makes it scrollable for smaller devices.
3. cfe8959 updates constraints of the print screen, and makes it scrollable in smaller devices.
4. 849570b pre-fill the state's name using the passed address to the ViewModel, to avoid emptying the field when not using the spinner.

If you need any info on testing the scenarios, please DM directly 🙏

Please also note that the changes are small, it's just that Github counted also the indentation changes in the XML layouts as additions/deletions, Android Studio's diff tool seems to do a better job if you want to use it.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->