### PR TITLE
Fix Tracking Events documentation link in the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ $ ./gradlew :WooCommerce:connectedVanillaDebugAndroidTest # assemble, install an
     - [Themes & Styling Practices](docs/theming-styling-best-practices.md)
     - [Subtree'd Library Projects](docs/subtreed-library-projects.md)
 - Data
-    - [Tracking Events](docs/tracking-events)
+    - [Tracking Events](docs/tracking-events.md)
 - Accessibility
     - [Accessibility Guidelines](docs/accessibility-guidelines.md)
     - [Right to Left Layout Guidelines](docs/right-to-left-layout-guidelines.md)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4597 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR fixes the Tracking Events documentation link in the README file. File extension (.md) was missing from the existing Tracking Events documentation link.
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
Try to open Tracking Events under the Data section in the README. Github throws 404 error. Append .md to the URL and The link should work fine. Now, check if .md is appended to Tracking Events link in the README 😃 
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->


- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
