### PR TITLE
Check for FCM token presence

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/FCMRegistrationIntentService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/FCMRegistrationIntentService.kt
@@ -8,6 +8,7 @@ import com.google.firebase.messaging.FirebaseMessaging
 import com.woocommerce.android.JobServiceIds.JOB_FCM_REGISTRATION_SERVICE_ID
 import com.woocommerce.android.util.WooLog
 import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.util.NetworkUtils
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -30,8 +31,13 @@ class FCMRegistrationIntentService : JobIntentService() {
         FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
             if (!task.isSuccessful) {
                 val message = "Fetching FCM registration token failed"
-                WooLog.e(WooLog.T.NOTIFS, message, task.exception)
-                crashLogging.sendReport(task.exception, message = message)
+                val exception = task.exception
+                WooLog.e(WooLog.T.NOTIFS, message, exception)
+
+                if (NetworkUtils.isNetworkAvailable(this)) {
+                    crashLogging.sendReport(exception = exception, message = message)
+                }
+
                 return@addOnCompleteListener
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/FCMRegistrationIntentService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/FCMRegistrationIntentService.kt
@@ -12,11 +12,9 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class FCMRegistrationIntentService : JobIntentService() {
-    @Inject
-    lateinit var notificationRegistrationHandler: NotificationRegistrationHandler
+    @Inject lateinit var notificationRegistrationHandler: NotificationRegistrationHandler
 
-    @Inject
-    lateinit var crashLogging: CrashLogging
+    @Inject lateinit var crashLogging: CrashLogging
 
     companion object {
         fun enqueueWork(context: Context) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/FCMRegistrationIntentService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/FCMRegistrationIntentService.kt
@@ -8,7 +8,7 @@ import com.google.firebase.messaging.FirebaseMessaging
 import com.woocommerce.android.JobServiceIds.JOB_FCM_REGISTRATION_SERVICE_ID
 import com.woocommerce.android.util.WooLog
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.util.NetworkUtils
+import java.io.IOException
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -34,7 +34,7 @@ class FCMRegistrationIntentService : JobIntentService() {
                 val exception = task.exception
                 WooLog.e(WooLog.T.NOTIFS, message, exception)
 
-                if (NetworkUtils.isNetworkAvailable(this)) {
+                if (exception?.isServiceUnavailable() == false) {
                     crashLogging.sendReport(exception = exception, message = message)
                 }
 
@@ -56,5 +56,9 @@ class FCMRegistrationIntentService : JobIntentService() {
     override fun onStopCurrentWork(): Boolean {
         // Ensure that the job is rescheduled if stopped
         return true
+    }
+
+    private fun Exception.isServiceUnavailable(): Boolean {
+        return this is IOException && this.message == "SERVICE_NOT_AVAILABLE"
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4600

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a check for success of reciving FCM token. If token has not been received, don't crash the app and send report to Sentry.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Make sure you can reproduce the original issue
1. Check-out `release/7.3` branch
1. Go to `build.gradle` 
1. Comment lines `393-404` (those responsible for using shared debug key). This will make Google Cloud Messaging to return error `403`
1. Install `vanillaDebug` variant on the device (just to force error from Google Cloud Messaging, not to test `vanillaDebug` itself)
1. Run the app
1. Assert the app crashed

#### Check fix
1. Check-out `fix/crashing_on_reciving_firebase_notif_error` branch
1. Repeat steps 2-5 from above
1. Assert the app did not crash

#### Test devices without Google Play Services:

App won't crash on devices without Google Play Services, Firebase checks automatically for that earlier in the lifecycle and logs `Google Play services missing or without correct permission.`.

You can check that by installing this PR on emulator (without Google Play Services).


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
