### PR TITLE
Shipping Labels: handle trivial address suggestions

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -464,7 +464,13 @@ class CreateShippingLabelViewModel @Inject constructor(
     private suspend fun validateAddress(address: Address, type: AddressType, isCustomsFormRequired: Boolean): Event {
         return when (val result = addressValidator.validateAddress(address, type, isCustomsFormRequired)) {
             ValidationResult.Valid -> AddressValidated(address)
-            is ValidationResult.SuggestedChanges -> AddressChangeSuggested(result.suggested)
+            is ValidationResult.SuggestedChanges -> {
+                if (result.isTrivial) {
+                    AddressValidated(result.suggested)
+                } else {
+                    AddressChangeSuggested(result.suggested)
+                }
+            }
             is ValidationResult.NotFound,
             is ValidationResult.Invalid,
             is ValidationResult.NameMissing, ValidationResult.PhoneInvalid -> AddressInvalid(address, result)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -146,7 +146,7 @@ class EditShippingLabelAddressViewModel @Inject constructor(
                 )
             }
             is ValidationResult.SuggestedChanges -> {
-                if(result.isTrivial) {
+                if (result.isTrivial) {
                     triggerEvent(ExitWithResult(result.suggested))
                 } else {
                     triggerEvent(ShowSuggestedAddress(address, result.suggested, arguments.addressType))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -146,7 +146,11 @@ class EditShippingLabelAddressViewModel @Inject constructor(
                 )
             }
             is ValidationResult.SuggestedChanges -> {
-                triggerEvent(ShowSuggestedAddress(address, result.suggested, arguments.addressType))
+                if(result.isTrivial) {
+                    triggerEvent(ExitWithResult(result.suggested))
+                } else {
+                    triggerEvent(ShowSuggestedAddress(address, result.suggested, arguments.addressType))
+                }
             }
             is ValidationResult.NotFound -> {
                 viewState = viewState.copy(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
@@ -307,7 +307,6 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
             verify(stateMachine).handleEvent(Event.AddressChangeSuggested(suggestedAddress))
         }
 
-
     @Test
     fun `when the address validation has trivial suggestion, then use the suggested address`() = testBlocking {
         val suggestedAddress = originAddress.copy(address1 = "Suggested street")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
@@ -19,15 +19,15 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingL
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.StepUiState
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelViewModel.ViewState
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.ORIGIN
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.ValidationResult
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.*
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.AddressValidated
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.OriginAddressValidationStarted
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Event.PurchaseSuccess
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.SideEffect
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.SideEffect.NoOp
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.State
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.State.Idle
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.State.PurchaseLabels
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.State.WaitingForInput
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StateMachineData
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.CarrierStep
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.CustomsStep
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Step.OriginAddressStep
@@ -37,8 +37,6 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.DONE
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.NOT_READY
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.READY
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepsState
-import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.Transition
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.util.ContinuationWrapper
 import com.woocommerce.android.util.CurrencyFormatter
@@ -295,6 +293,30 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
         stateFlow.value = Transition(State.OriginAddressValidation(data), null)
 
         verify(addressValidator).validateAddress(originAddress, ORIGIN, requiresPhoneNumber = false)
+    }
+
+    @Test
+    fun `when the address validation has a non trivial suggestion, then show address suggestions screen`() =
+        testBlocking {
+            val suggestedAddress = originAddress.copy(address1 = "Suggested street")
+            whenever(addressValidator.validateAddress(any(), any(), any()))
+                .thenReturn(ValidationResult.SuggestedChanges(suggestedAddress, isTrivial = false))
+
+            stateFlow.value = Transition(State.OriginAddressValidation(data), null)
+
+            verify(stateMachine).handleEvent(Event.AddressChangeSuggested(suggestedAddress))
+        }
+
+
+    @Test
+    fun `when the address validation has trivial suggestion, then use the suggested address`() = testBlocking {
+        val suggestedAddress = originAddress.copy(address1 = "Suggested street")
+        whenever(addressValidator.validateAddress(any(), any(), any()))
+            .thenReturn(ValidationResult.SuggestedChanges(suggestedAddress, isTrivial = true))
+
+        stateFlow.value = Transition(State.OriginAddressValidation(data), null)
+
+        verify(stateMachine).handleEvent(AddressValidated(suggestedAddress))
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
@@ -225,20 +225,38 @@ class EditShippingLabelAddressViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given there are suggestions to improve address, when done is clicked, then display them`() = testBlocking {
-        val suggestedAddress = address.copy(address1 = "Suggested street")
-        whenever(addressValidator.validateAddress(any(), any(), any()))
-            .thenReturn(ValidationResult.SuggestedChanges(suggestedAddress))
+    fun `given there are non trivial suggestions to the address, when done is clicked, then display them`() =
+        testBlocking {
+            val suggestedAddress = address.copy(address1 = "Suggested street")
+            whenever(addressValidator.validateAddress(any(), any(), any()))
+                .thenReturn(ValidationResult.SuggestedChanges(suggestedAddress, isTrivial = false))
 
-        var event: Event? = null
-        viewModel.event.observeForever { event = it }
+            var event: Event? = null
+            viewModel.event.observeForever { event = it }
 
-        viewModel.onDoneButtonClicked()
+            viewModel.onDoneButtonClicked()
 
-        verify(addressValidator, atLeastOnce()).validateAddress(any(), any(), any())
+            verify(addressValidator, atLeastOnce()).validateAddress(any(), any(), any())
 
-        assertThat(event).isEqualTo(ShowSuggestedAddress(adjustedAddress, suggestedAddress, ORIGIN))
-    }
+            assertThat(event).isEqualTo(ShowSuggestedAddress(adjustedAddress, suggestedAddress, ORIGIN))
+        }
+
+    @Test
+    fun `given there are trivial suggestions to the address, when done is clicked, then use them directly`() =
+        testBlocking {
+            val suggestedAddress = address.copy(address1 = "Suggested street")
+            whenever(addressValidator.validateAddress(any(), any(), any()))
+                .thenReturn(ValidationResult.SuggestedChanges(suggestedAddress, isTrivial = true))
+
+            var event: Event? = null
+            viewModel.event.observeForever { event = it }
+
+            viewModel.onDoneButtonClicked()
+
+            verify(addressValidator, atLeastOnce()).validateAddress(any(), any(), any())
+
+            assertThat(event).isEqualTo(ExitWithResult(suggestedAddress))
+        }
 
     @Test
     fun `when country spinner is tapped, then display country selector`() = testBlocking {

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '1.23.0'
+    fluxCVersion = '2095-849f75cfea0f908f848ff74034bcf8c66a2ea8bb'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2095-849f75cfea0f908f848ff74034bcf8c66a2ea8bb'
+    fluxCVersion = 'develop-a9f0bda1e7eb1c89f462e818407a56e88c746824'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4466 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds handling of trivial address suggestions, when the backend suggests a trivial change, we should apply the suggested address automatically, without passing by the address suggestion screen.

This depends on the FluxC PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2095, please don't merge until the other one is merged.

### Testing instructions
1. Create an order eligible for shipping label creation, and use the following address for shipping (777 Brockton Avenue, Abington MA 02351)
2. Open the order in the app.
3. Click on "Create shipping label"
4. When validating the shipping address, confirm that it was validated and changed automatically (notice changing `Avenue` to `AVE`, and the zip code change)
5. Click on edit in the shipping address.
6. Change `AVE` to `Avenue`.
7. Click on Done.
8. Confirm that it was changed back to `AVE` automatically.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
