### PR TITLE
Add unit tests for onAcceptCardPresentPaymentClicked function in OrderDetailViewModel

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -1029,7 +1029,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             viewModel.onAcceptCardPresentPaymentClicked(cardReaderManager)
 
             // Then
-            assertEquals(OrderNavigationTarget.StartCardReaderPaymentFlow(order.identifier), viewModel.event.value)
             assertThat(viewModel.event.value).isInstanceOf(OrderNavigationTarget.StartCardReaderPaymentFlow::class.java)
         }
 
@@ -1068,7 +1067,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given card reader connecting,when user clicks on accept card,then start card reader connect flow with data`() =
+    fun `given card reader connecting,when user clicks on accept card,then onboarding checks not skipped`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // Given
             doReturn(order).whenever(repository).getOrder(any())
@@ -1085,7 +1084,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given card reader NOT connected,when user clicks on accept card,then start reader connect flow with data`() =
+    fun `given card reader NOT connected,when user clicks on accept card,then onboarding checks not skipped`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // Given
             doReturn(order).whenever(repository).getOrder(any())


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parent issue: #4553 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds unit tests in OrderDetailViewModel for onAcceptCardPresentPaymentClicked function. 
In parent issue, it's this one 👉 OrderDetailViewModel::240 Add tests for this functionality
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
Running the unit tests and seeing those pass should be enough as changes are only in the test files 🙂 
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->


- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
