### PR TITLE
Handle site in test mode with live stripe account

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -45,7 +45,7 @@ class CardReaderOnboardingChecker @Inject constructor(
         val paymentAccount = wcPayStore.loadAccount(selectedSite.get()).model ?: return GenericError
 
         if (!isWCPaySetupCompleted(paymentAccount)) return WcpaySetupNotCompleted
-        if (isWCPayInTestModeWithLiveStripeAccount()) return WcpayInTestModeWithLiveStripeAccount
+        if (isWCPayInTestModeWithLiveStripeAccount(paymentAccount)) return WcpayInTestModeWithLiveStripeAccount
         if (isStripeAccountUnderReview(paymentAccount)) return StripeAccountUnderReview
         if (isStripeAccountOverdueRequirements(paymentAccount)) return StripeAccountOverdueRequirement
         if (isStripeAccountPendingRequirements(paymentAccount)) return StripeAccountPendingRequirement(
@@ -81,9 +81,8 @@ class CardReaderOnboardingChecker @Inject constructor(
     private fun isWCPaySetupCompleted(paymentAccount: WCPaymentAccountResult): Boolean =
         paymentAccount.status != NO_ACCOUNT
 
-    // TODO cardreader Implement
-    @Suppress("FunctionOnlyReturningConstant")
-    private fun isWCPayInTestModeWithLiveStripeAccount(): Boolean = false
+    private fun isWCPayInTestModeWithLiveStripeAccount(account: WCPaymentAccountResult): Boolean =
+        account.testMode == true && account.isLive
 
     private fun isStripeAccountUnderReview(paymentAccount: WCPaymentAccountResult): Boolean =
         paymentAccount.status == RESTRICTED &&

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -295,10 +295,72 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             assertThat(result).isEqualTo(CardReaderOnboardingState.StripeAccountRejected)
         }
 
+    @Test
+    fun `when test mode enabled on site with live account, then WcpayInTestModeWithLiveStripeAccount returned`() =
+        testBlocking {
+            whenever(wcPayStore.loadAccount(site)).thenReturn(
+                buildPaymentAccountResult(liveAccount = true, testModeEnabled = true)
+            )
+
+            val result = checker.getOnboardingState()
+
+            assertThat(result).isEqualTo(CardReaderOnboardingState.WcpayInTestModeWithLiveStripeAccount)
+        }
+
+    @Test
+    fun `when test mode disabled on site with live account, then WcpayInTestModeWithLiveStripeAccount NOT returned`() =
+        testBlocking {
+            whenever(wcPayStore.loadAccount(site)).thenReturn(
+                buildPaymentAccountResult(liveAccount = true, testModeEnabled = false)
+            )
+
+            val result = checker.getOnboardingState()
+
+            assertThat(result).isNotEqualTo(CardReaderOnboardingState.WcpayInTestModeWithLiveStripeAccount)
+        }
+
+    @Test
+    fun `when test mode disabled on site with test account, then WcpayInTestModeWithLiveStripeAccount NOT returned`() =
+        testBlocking {
+            whenever(wcPayStore.loadAccount(site)).thenReturn(
+                buildPaymentAccountResult(liveAccount = false, testModeEnabled = false)
+            )
+
+            val result = checker.getOnboardingState()
+
+            assertThat(result).isNotEqualTo(CardReaderOnboardingState.WcpayInTestModeWithLiveStripeAccount)
+        }
+
+    @Test
+    fun `when test mode enabled on site with test account, then WcpayInTestModeWithLiveStripeAccount NOT returned`() =
+        testBlocking {
+            whenever(wcPayStore.loadAccount(site)).thenReturn(
+                buildPaymentAccountResult(liveAccount = false, testModeEnabled = true)
+            )
+
+            val result = checker.getOnboardingState()
+
+            assertThat(result).isNotEqualTo(CardReaderOnboardingState.WcpayInTestModeWithLiveStripeAccount)
+        }
+
+    @Test
+    fun `when test mode flag not supported, then WcpayInTestModeWithLiveStripeAccount NOT returned`() =
+        testBlocking {
+            whenever(wcPayStore.loadAccount(site)).thenReturn(
+                buildPaymentAccountResult(testModeEnabled = null)
+            )
+
+            val result = checker.getOnboardingState()
+
+            assertThat(result).isNotEqualTo(CardReaderOnboardingState.WcpayInTestModeWithLiveStripeAccount)
+        }
+
     private fun buildPaymentAccountResult(
         status: WCPaymentAccountResult.WCPayAccountStatusEnum = WCPaymentAccountResult.WCPayAccountStatusEnum.COMPLETE,
         hasPendingRequirements: Boolean = false,
-        hadOverdueRequirements: Boolean = false
+        hadOverdueRequirements: Boolean = false,
+        liveAccount: Boolean = true,
+        testModeEnabled: Boolean? = false,
     ) = WooResult(
         WCPaymentAccountResult(
             status,
@@ -309,7 +371,8 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
             storeCurrencies = WCPaymentAccountResult.WCPayAccountStatusEnum.StoreCurrencies("", listOf()),
             country = "US",
             isCardPresentEligible = true,
-            isLive = true
+            isLive = liveAccount,
+            testMode = testModeEnabled
         )
     )
 

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '1.23.0'
+    fluxCVersion = '2096-7564900c55e441322454490773f6cef11587d52d'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2096-7564900c55e441322454490773f6cef11587d52d'
+    fluxCVersion = 'develop-d8ea001c73da43fb6abb80b6216f01d8b4cccdd9'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parent issue: #4579
<!-- Id number of the GitHub issue this PR addresses. -->

✅  ~FluxC PR - https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2096 needs to be merged first and the hash updated.~

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR handles "In person payments not supported on live stripe account when test mode is enabled on the site" scenario.

The "test_mode" flag is available only on wcpay v.2.9.0 which has not been released yet. However, these changes should be safe to merge - when the site is using an old version of wcpay plugin, the app won't show the warning - in other words only users with wcpay >= 2.9.0 of the plugin will be warned that in-person payments are not supported in test mode.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- I have NOT tested this with a live site as I don't have any (I tested it just by simulating a live site in the code)
- requires site which is eligible for in-person payments
1. Enable test mode on a site which is connected to a live stripe account
2. Tap on App Settings
3. Tap on In-Person Payments
4. Notice no warning is shown
5. Update wcpay to the current develop (build it locally or ping me and I'll send you a zip)
6. Tap on App Settings
7. Tap on In-Person Payments
8. Notice a warning informing you that you need to turn off the test mode is shown

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/2261188/129188470-b482319c-5436-4016-8b91-797f1f75d700.jpg" width="250px" />



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->

cc @ctarda @koke 