### PR TITLE
Shipping Labels: nullify name field if it's empty

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Address.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Address.kt
@@ -84,7 +84,7 @@ data class Address(
     fun toShippingLabelModel(): ShippingLabelAddress {
         return ShippingLabelAddress(
             company = company,
-            name = "$firstName $lastName",
+            name = "$firstName $lastName".trim().takeIf { it.isNotBlank() },
             phone = phone,
             address = address1,
             address2 = address2,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/AddressTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/AddressTest.kt
@@ -1,0 +1,48 @@
+package com.woocommerce.android.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class AddressTest {
+    @Test
+    fun `when name is blank, then nullify the name of data model`() {
+        val address = Address(
+            firstName = "",
+            lastName = " ",
+            company = "Company",
+            phone = "",
+            address1 = "Address 1",
+            address2 = "",
+            city = "City",
+            postcode = "",
+            email = "email",
+            country = "country",
+            state = "state"
+        )
+
+        val dataModel = address.toShippingLabelModel()
+
+        assertThat(dataModel.name).isNull()
+    }
+
+    @Test
+    fun `when first and last name are not blank, then concatenate them for the data model`() {
+        val address = Address(
+            firstName = "first name",
+            lastName = "last name",
+            company = "Company",
+            phone = "",
+            address1 = "Address 1",
+            address2 = "",
+            city = "City",
+            postcode = "",
+            email = "email",
+            country = "country",
+            state = "state"
+        )
+
+        val dataModel = address.toShippingLabelModel()
+
+        assertThat(dataModel.name).isEqualTo("${address.firstName} ${address.lastName}")
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4502 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR makes sure that the name field is set to `null` if it's empty, this is needed for now because the API will throw an error if we send an empty string, while the logic in the client is that when a company name is present, the name should be optional.

Check the parent ticket for more details.

### Testing instructions
1. Create an order eligible for shipping label creation.
2. Open the order in the app.
3. Click on "Create shipping label"
4. Make sure that you enter a company name, and that the name field is empty in one of the addresses.
5. Confirm that you can purchase a shipping label.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
