### PR TITLE
Update login library to 0.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,7 @@
     $ cp ./gradle.properties-example ./gradle.properties
     ```
 
-1. Generate the `gradle.properties` file for the [Login Library](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android) dependency:
-
-    ```bash
-    $ cp ./libs/login/gradle.properties-example ./libs/login/gradle.properties
-    ```
-
-1. Open and modify the newly created `gradle.properties` files. See the [Configuration Files](docs/project_overview.md#configuration-files) section for a breakdown of the properties.
+1. Open and modify the newly created `gradle.properties` files. See the [Configuration Files](docs/project-overview.md#configuration-files) section for a breakdown of the properties.
 1. In Android Studio, open the project from the local repository. This will auto-generate `local.properties` with the SDK location.
 1. Go to Tools → AVD Manager and create an emulated device.
 1. Run.

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -188,10 +188,6 @@ dependencies {
     }
 
     implementation ("$gradle.ext.loginFlowBinaryPath:$wordPressLoginVersion") {
-        exclude group: "com.github.wordpress-mobile.WordPress-FluxC-Android", module: "fluxc"
-        exclude group: "org.wordpress", module: "fluxc"
-        exclude group: "org.wordpress.fluxc"
-        exclude group: "org.wordpress.fluxc.plugins"
         exclude group: "org.wordpress", module: "utils"
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlinVersion = '1.4.32'
     ext.navigationVersion = '2.3.5'
     ext.daggerVersion = '2.35.1'
-    ext.wordPressLoginVersion = '0.0.2'
+    ext.wordPressLoginVersion = '0.0.4'
     ext.detektVersion = '1.15.0'
 
     repositories {

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -44,15 +44,6 @@ Read more about [OAuth2][oauth] and the [WordPress.com REST endpoint][wp-api].
 | wc.reset_db_on_downgrade   | Debug/Beta builds: If `true` will drop all tables and recreate the db if a database downgrade is detected. |
 | wc.sentry.dsn              | Used for Sentry integration. Can be ignored.|
 
-#### Login library `gradle.properties`
-
-| Property                   | Description |
-|:---------------------------|:------------|
-| wp.debug.wpcom_login_email |Optional: used to autofill email during login on debug build only|
-| wp.debug.wpcom_login_username|Optional: used to autofill username during login on debug build only|
-|wp.debug.wpcom_login_password|Optional: used to autofill password during login on debug build only|
-|wp.debug.wpcom_website_url|Optional: used to autofill store url during login on debug build only|
-
 ### Setting up Checkstyle
 
 The woocommerce-android project uses [Checkstyle][checkstyle]. You can run checkstyle using `./gradlew checkstyle`.


### PR DESCRIPTION
This update brings in changes from https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/62 which should not have any impact on the app since the FluxC version is added as a dependency in the main module.

**To test:**
* Smoke test login(?)