### PR TITLE
Add unit tests in OrderDetailViewModel.kt for onConnectToReaderResultReceived function

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -237,7 +237,6 @@ class OrderDetailViewModel @Inject constructor(
 
     fun onAcceptCardPresentPaymentClicked(cardReaderManager: CardReaderManager) {
         AnalyticsTracker.track(CARD_PRESENT_COLLECT_PAYMENT_TAPPED)
-        // TODO cardreader add tests for this functionality
         if (cardReaderManager.readerStatus.value is Connected) {
             triggerEvent(StartCardReaderPaymentFlow(order.identifier))
         } else {
@@ -266,7 +265,6 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     fun onConnectToReaderResultReceived(connected: Boolean) {
-        // TODO cardreader add tests for this functionality
         launch {
             // this dummy delay needs to be here since the navigation component hasn't finished the previous
             // transaction when a result is received

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -1099,4 +1099,56 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             // Then
             assertEquals(OrderNavigationTarget.StartCardReaderConnectFlow(false), viewModel.event.value)
         }
+
+    @Test
+    fun `given card reader result is received, when it is connected, then trigger start card reader payment flow`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // Given
+            doReturn(order).whenever(repository).getOrder(any())
+            doReturn(order).whenever(repository).fetchOrder(any())
+            doReturn(false).whenever(repository).fetchOrderNotes(any(), any())
+            viewModel.start()
+
+            // When
+            viewModel.onConnectToReaderResultReceived(connected = true)
+            advanceUntilIdle()
+
+            // Then
+            assertThat(viewModel.event.value).isInstanceOf(OrderNavigationTarget.StartCardReaderPaymentFlow::class.java)
+        }
+
+    @Test
+    fun `given card reader result is received,when it is connected,then trigger card reader payment flow with data`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // Given
+            doReturn(order).whenever(repository).getOrder(any())
+            doReturn(order).whenever(repository).fetchOrder(any())
+            doReturn(false).whenever(repository).fetchOrderNotes(any(), any())
+            viewModel.start()
+
+            // When
+            viewModel.onConnectToReaderResultReceived(connected = true)
+            advanceUntilIdle()
+
+            // Then
+            assertEquals(OrderNavigationTarget.StartCardReaderPaymentFlow(order.identifier), viewModel.event.value)
+        }
+
+    @Test
+    fun `given card reader result is received,when it is NOT connected,then do not trigger card reader payment flow`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // Given
+            doReturn(order).whenever(repository).getOrder(any())
+            doReturn(order).whenever(repository).fetchOrder(any())
+            doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
+            viewModel.start()
+
+            // When
+            viewModel.onConnectToReaderResultReceived(connected = false)
+            advanceUntilIdle()
+
+            // Then
+            assertThat(viewModel.event.value)
+                .isNotInstanceOf(OrderNavigationTarget.StartCardReaderPaymentFlow::class.java)
+        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -1140,7 +1140,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             // Given
             doReturn(order).whenever(repository).getOrder(any())
             doReturn(order).whenever(repository).fetchOrder(any())
-            doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
+            doReturn(false).whenever(repository).fetchOrderNotes(any(), any())
             viewModel.start()
 
             // When


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parent issue: #4553 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds unit tests in OrderDetailViewModel.kt for onConnectToReaderResultReceived function.
In parent issue, it's this one 👉 OrderDetailViewModel::265 Add tests for this functionality 
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
Running the unit tests and seeing those pass should be enough as changes are only in the test files 🙂
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->


- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
