### PR TITLE
Shipping Labels: update address validation error messages

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -142,7 +142,10 @@ class EditShippingLabelAddressViewModel @Inject constructor(
                 val validationErrorMessage = getAddressErrorStringRes(result.message)
                 viewState = viewState.copy(
                     address1Field = viewState.address1Field.copy(validationError = validationErrorMessage).validate(),
-                    bannerMessage = resourceProvider.getString(R.string.shipping_label_edit_address_error_warning)
+                    bannerMessage = resourceProvider.getString(
+                        if (arguments.addressType == ORIGIN) R.string.shipping_label_edit_origin_address_error_warning
+                        else R.string.shipping_label_edit_address_error_warning
+                    )
                 )
             }
             is ValidationResult.SuggestedChanges -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -319,6 +319,7 @@ class EditShippingLabelAddressViewModel @Inject constructor(
 
     @Parcelize
     data class ViewState(
+        private val addressType: AddressType,
         val bannerMessage: String? = null,
         val isValidationProgressDialogVisible: Boolean? = null,
         val isLoadingProgressDialogVisible: Boolean? = null,
@@ -335,6 +336,7 @@ class EditShippingLabelAddressViewModel @Inject constructor(
         @StringRes val title: Int? = null
     ) : Parcelable {
         constructor(args: EditShippingLabelAddressFragmentArgs) : this(
+            addressType = args.addressType,
             nameField = NameField(
                 content = "${args.address.firstName} ${args.address.lastName}".trim(),
                 companyContent = args.address.company
@@ -350,7 +352,8 @@ class EditShippingLabelAddressViewModel @Inject constructor(
         )
 
         @IgnoredOnParcel
-        val isContactCustomerButtonVisible = phoneField.content.isNotBlank()
+        val isContactCustomerButtonVisible
+            get() = addressType == DESTINATION && phoneField.content.isNotBlank()
 
         @IgnoredOnParcel
         val areAllRequiredFieldsValid

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -473,6 +473,7 @@
     <string name="shipping_label_edit_address_loading_progress_title">Loading address data</string>
     <string name="shipping_label_edit_address_progress_message">Please wait…</string>
     <string name="shipping_label_edit_address_validation_error">Address validation failed</string>
+    <string name="shipping_label_edit_origin_address_error_warning">We were unable to automatically verify the origin address. View it on Google Maps to make sure the address is correct.</string>
     <string name="shipping_label_edit_address_error_warning">We were unable to automatically verify the shipping address. View it on Google Maps or try contacting the customer to make sure the address is correct.</string>
     <string name="shipping_label_error_address_not_found">Address was not found</string>
     <string name="shipping_label_error_address_house_number_missing">House number missing</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -477,7 +477,7 @@
     <string name="shipping_label_error_address_not_found">Address was not found</string>
     <string name="shipping_label_error_address_house_number_missing">House number missing</string>
     <string name="shipping_label_error_address_invalid_street">Invalid street</string>
-    <string name="shipping_label_validation_error_template">Validation failed: %s</string>
+    <string name="shipping_label_validation_error_template">We were unable to automatically verify the shipping address: %s</string>
     <string name="shipping_label_validation_contact_customer">Contact Customer</string>
     <string name="shipping_label_validation_view_map">Open Map</string>
     <string name="shipping_label_address_suggestion_use_selected_address">Use selected address</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -479,7 +479,7 @@
     <string name="shipping_label_error_address_invalid_street">Invalid street</string>
     <string name="shipping_label_validation_error_template">We were unable to automatically verify the shipping address: %s</string>
     <string name="shipping_label_validation_contact_customer">Contact Customer</string>
-    <string name="shipping_label_validation_view_map">Open Map</string>
+    <string name="shipping_label_validation_view_map">Find on Map</string>
     <string name="shipping_label_address_suggestion_use_selected_address">Use selected address</string>
     <string name="shipping_label_address_suggestion_edit_selected_address">Edit selected address</string>
     <string name="shipping_label_address_suggestion_banner">We have slightly modified the address entered. If correct, please use the suggested address to ensure accurate delivery.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.*
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelAddressViewModel.Field
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelAddressViewModel.ViewState
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.DESTINATION
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.ORIGIN
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.ValidationResult
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -44,6 +45,7 @@ class EditShippingLabelAddressViewModelTest : BaseUnitTest() {
 
     private var validationResult: ValidationResult = ValidationResult.Valid
     private var isPhoneRequired = false
+    private var addressType = ORIGIN
 
     private val countries = listOf(
         WCLocationModel().also {
@@ -81,7 +83,7 @@ class EditShippingLabelAddressViewModelTest : BaseUnitTest() {
     private val savedState
         get() = EditShippingLabelAddressFragmentArgs(
             address = address,
-            addressType = ORIGIN,
+            addressType = addressType,
             validationResult = validationResult,
             requiresPhoneNumber = isPhoneRequired
         ).initSavedStateHandle()
@@ -126,7 +128,23 @@ class EditShippingLabelAddressViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given the address is invalid, when the screen loads, then display an error`() = testBlocking {
+    fun `given the origin address is invalid, when the screen loads, then display an error`() = testBlocking {
+        validationResult = ValidationResult.Invalid("House number is missing")
+
+        createViewModel()
+
+        var viewState: ViewState? = null
+        viewModel.viewStateData.observeForever { _, new -> viewState = new }
+
+        assertThat(viewState?.bannerMessage)
+            .isEqualTo(string.shipping_label_edit_origin_address_error_warning.toString())
+        assertThat(viewState?.address1Field?.error)
+            .isEqualTo(UiStringRes(string.shipping_label_error_address_house_number_missing))
+    }
+
+    @Test
+    fun `given the destination address is invalid, when the screen loads, then display an error`() = testBlocking {
+        addressType = DESTINATION
         validationResult = ValidationResult.Invalid("House number is missing")
 
         createViewModel()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4469, Closes: #4468
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR updates the error messages for address validation to make them more user-friendly and to match the design.

The changes done are:
1. Reword the error template when we have a specific address error to: "We were unable to automatically verify the shipping address: {error}"
2. Reword the origin address warning when we have an `address1` field error to: "We were unable to automatically verify the origin address. View it on Google Maps to make sure the address is correct"
3. Hide the contact customer button for the origin address form.

### Testing instructions
1. Create an order eligible for shipping label creation.
2. Open the order in the app.
3. Click on "Create shipping label"
4. Enter a valid address in the origin address form (for example: 777 Brockton Avenue, Abington MA 02351)
5. Remove the house number from the address1 field (777 from the example above)
6. Click on Done.
7. Confirm that you see a warning: "We were unable to automatically verify the origin address. View it on Google Maps to make sure the address is correct." with an error in the address1 field.
8. Enter "10 test" in the address1 field.
9. Confirm that you see a warning: "We were unable to automatically verify the shipping address: Address was not found".
10. Go to the destination address.
11. Repeat the steps 7 to 9, and confirm that you see matching errors for destination, and the correct action buttons (Contact customer should be displayed if there is a phone number)

### Images/gif
| Case | Screenshot|
| ---- | ----- |
| Origin address invalid | <img width=360 src="https://user-images.githubusercontent.com/1657201/129342155-e9c9c3fb-4c3c-4744-aa94-2a69d05462f2.png"> |
| Origin address1 field invalid | <img width=360 src="https://user-images.githubusercontent.com/1657201/129342195-a725c345-3de2-47b6-b1ee-88503c658f63.png"> |
| Destination address invalid | <img width=360 src="https://user-images.githubusercontent.com/1657201/129342254-844057fa-92bf-4df5-b01c-d6f41583f4b3.png"> |
| Destination address1 field invalid | <img width=360 src="https://user-images.githubusercontent.com/1657201/129342310-cef5787a-c501-4ad7-b35d-dd21d0a2b959.png"> |


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
