### PR TITLE
[Mobile Payments] Do not display Create Shipping Label for cash-on-delivery orders

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -593,7 +593,9 @@ class OrderDetailViewModel @Inject constructor(
         }
 
         viewState = viewState.copy(
-            isCreateShippingLabelButtonVisible = isOrderEligibleForSLCreation && !shippingLabels.isVisible && viewState.orderInfo?.isPaymentCollectableWithCardReader == false,
+            isCreateShippingLabelButtonVisible = isOrderEligibleForSLCreation &&
+                !shippingLabels.isVisible &&
+                viewState.orderInfo?.isPaymentCollectableWithCardReader == false,
             isProductListMenuVisible = isOrderEligibleForSLCreation && shippingLabels.isVisible,
             isShipmentTrackingAvailable = shipmentTracking.isVisible,
             isProductListVisible = orderProducts.isVisible,
@@ -647,7 +649,8 @@ class OrderDetailViewModel @Inject constructor(
 
         val isCreateShippingLabelBannerVisible: Boolean
             get() = isCreateShippingLabelButtonVisible == true &&
-                    isProductListVisible == true && orderInfo?.isPaymentCollectableWithCardReader == false
+                isProductListVisible == true &&
+                orderInfo?.isPaymentCollectableWithCardReader == false
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -576,7 +576,8 @@ class OrderDetailViewModel @Inject constructor(
         }
 
         val isOrderEligibleForSLCreation = isShippingPluginReady &&
-            orderDetailRepository.isOrderEligibleForSLCreation(order.remoteId)
+            orderDetailRepository.isOrderEligibleForSLCreation(order.remoteId) &&
+            viewState.orderInfo?.isPaymentCollectableWithCardReader != true
 
         if (isOrderEligibleForSLCreation &&
             viewState.isCreateShippingLabelButtonVisible != true &&
@@ -596,7 +597,8 @@ class OrderDetailViewModel @Inject constructor(
             isCreateShippingLabelButtonVisible = isOrderEligibleForSLCreation &&
                 !shippingLabels.isVisible &&
                 viewState.orderInfo?.isPaymentCollectableWithCardReader != true,
-            isProductListMenuVisible = isOrderEligibleForSLCreation && shippingLabels.isVisible,
+            isProductListMenuVisible = isOrderEligibleForSLCreation && shippingLabels.isVisible &&
+                viewState.orderInfo?.isPaymentCollectableWithCardReader != true,
             isShipmentTrackingAvailable = shipmentTracking.isVisible,
             isProductListVisible = orderProducts.isVisible,
             areShippingLabelsVisible = shippingLabels.isVisible

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -595,7 +595,7 @@ class OrderDetailViewModel @Inject constructor(
         viewState = viewState.copy(
             isCreateShippingLabelButtonVisible = isOrderEligibleForSLCreation &&
                 !shippingLabels.isVisible &&
-                viewState.orderInfo?.isPaymentCollectableWithCardReader == false,
+                viewState.orderInfo?.isPaymentCollectableWithCardReader != true,
             isProductListMenuVisible = isOrderEligibleForSLCreation && shippingLabels.isVisible,
             isShipmentTrackingAvailable = shipmentTracking.isVisible,
             isProductListVisible = orderProducts.isVisible,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -593,7 +593,7 @@ class OrderDetailViewModel @Inject constructor(
         }
 
         viewState = viewState.copy(
-            isCreateShippingLabelButtonVisible = isOrderEligibleForSLCreation && !shippingLabels.isVisible,
+            isCreateShippingLabelButtonVisible = isOrderEligibleForSLCreation && !shippingLabels.isVisible && viewState.orderInfo?.isPaymentCollectableWithCardReader == false,
             isProductListMenuVisible = isOrderEligibleForSLCreation && shippingLabels.isVisible,
             isShipmentTrackingAvailable = shipmentTracking.isVisible,
             isProductListVisible = orderProducts.isVisible,
@@ -646,7 +646,8 @@ class OrderDetailViewModel @Inject constructor(
             get() = if (orderStatus != null) orderStatus.statusKey == CoreOrderStatus.PROCESSING.value else null
 
         val isCreateShippingLabelBannerVisible: Boolean
-            get() = isCreateShippingLabelButtonVisible == true && isProductListVisible == true
+            get() = isCreateShippingLabelButtonVisible == true &&
+                    isProductListVisible == true && orderInfo?.isPaymentCollectableWithCardReader == false
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -648,9 +648,7 @@ class OrderDetailViewModel @Inject constructor(
             get() = if (orderStatus != null) orderStatus.statusKey == CoreOrderStatus.PROCESSING.value else null
 
         val isCreateShippingLabelBannerVisible: Boolean
-            get() = isCreateShippingLabelButtonVisible == true &&
-                isProductListVisible == true &&
-                orderInfo?.isPaymentCollectableWithCardReader == false
+            get() = isCreateShippingLabelButtonVisible == true && isProductListVisible == true
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -595,10 +595,8 @@ class OrderDetailViewModel @Inject constructor(
 
         viewState = viewState.copy(
             isCreateShippingLabelButtonVisible = isOrderEligibleForSLCreation &&
-                !shippingLabels.isVisible &&
-                viewState.orderInfo?.isPaymentCollectableWithCardReader != true,
-            isProductListMenuVisible = isOrderEligibleForSLCreation && shippingLabels.isVisible &&
-                viewState.orderInfo?.isPaymentCollectableWithCardReader != true,
+                !shippingLabels.isVisible,
+            isProductListMenuVisible = isOrderEligibleForSLCreation && shippingLabels.isVisible,
             isShipmentTrackingAvailable = shipmentTracking.isVisible,
             isProductListVisible = orderProducts.isVisible,
             areShippingLabelsVisible = shippingLabels.isVisible

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -594,8 +594,7 @@ class OrderDetailViewModel @Inject constructor(
         }
 
         viewState = viewState.copy(
-            isCreateShippingLabelButtonVisible = isOrderEligibleForSLCreation &&
-                !shippingLabels.isVisible,
+            isCreateShippingLabelButtonVisible = isOrderEligibleForSLCreation && !shippingLabels.isVisible,
             isProductListMenuVisible = isOrderEligibleForSLCreation && shippingLabels.isVisible,
             isShipmentTrackingAvailable = shipmentTracking.isVisible,
             isProductListVisible = orderProducts.isVisible,


### PR DESCRIPTION
Closes: #4588 

### Description
This PR hides the shipping labels banner and the "create shipping labels" button for orders that are eligible for In-Person Payments regardless of their eligibility for creating shipping labels.

| Before | After |
| <img src="https://user-images.githubusercontent.com/2722505/129345507-b0cbe8ba-d7fd-46be-8f05-9bcd66e10a34.png" width="350"/> | <img src="https://user-images.githubusercontent.com/2722505/129345509-33e42cfd-a381-4422-add6-03091f7cfea4.png" width="350"/> |

### Changes
* Added a check to the visibility flags in OrderDetailViewModel to take the eligibility for In-Person Payments into account

### Testing instructions
1. Navigate to an order that is both eligible for In-Person Payments and for Shipping Label creation (for example, an order purchased on Cash On Delivery and that contains physical products only)
2. The "Create shipping labels" button and banner should not be visible.
3. Capture payment for this order
4. The "Create Shipping labels" button and banner should be visible now

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
