### PR TITLE
Add a mention the option "Simplify stroke" in Figma's export tool to the docs

### DIFF
--- a/docs/using-android-resources.md
+++ b/docs/using-android-resources.md
@@ -7,6 +7,7 @@ Adding a vector drawable (to `WooCommerce/src/main/res/drawable/`) should be the
 Some vector drawables may come from a SVG file and they are not the easiest file type to edit. If the SVG file is specific to the WooCommerce-Android project (like a banner image or unlike a gridicon), then add the SVG source in `WooCommerce/src/future/svg/`. This will make sure we can find and edit the SVG file and then export it in vector drawable format.
 
 *Tip:* If you’re given an SVG from a designer, try using [the SVGOMG tool](https://href.li/?https://jakearchibald.github.io/svgomg/) to optimize it before importing it as a vector. It usually significantly reduces the size of the SVG and cures the “path too large” warnings in Android Studio.
+*Tip 2:* If you're exporting the SVG from Figma, and you notice that the exported file has some issues or distortions, try to disable the option [Simplify stroke](https://help.figma.com/hc/en-us/articles/360040028114-Guide-to-exports-in-Figma#h_fee7100a-1540-4b62-bd45-e7ad6fa943b7) in the export tool.
 
 Please use the following naming convention for drawables:
 


### PR DESCRIPTION
### Description
This just adds a tip to our docs about disabling the option "Simplify storke" in Figma's export tool if the exported SVGs have some issues.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
