### PR TITLE
issue/4030-payment-cha-ching

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialogFragment.kt
@@ -1,6 +1,9 @@
 package com.woocommerce.android.ui.orders.cardreader
 
 import android.app.Dialog
+import android.content.ContentResolver
+import android.media.MediaPlayer
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -72,6 +75,7 @@ class CardReaderPaymentDialogFragment : DialogFragment(R.layout.card_reader_paym
                     )
                     is SendReceipt -> composeEmail(event.address, event.subject, event.content)
                     is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+                    is CardReaderPaymentViewModel.PlayChaChing -> playChaChing()
                     else -> event.isHandled = false
                 }
             }
@@ -112,6 +116,16 @@ class CardReaderPaymentDialogFragment : DialogFragment(R.layout.card_reader_paym
                 }
             }
         )
+    }
+
+    private fun playChaChing() {
+        val chaChingUri =
+            Uri.parse(
+                ContentResolver.SCHEME_ANDROID_RESOURCE +
+                    "://" + requireActivity().packageName + "/" + R.raw.cha_ching
+            )
+        val mp = MediaPlayer.create(requireActivity(), chaChingUri)
+        mp.start()
     }
 
     private fun composeEmail(address: String, subject: UiString, content: UiString) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -50,6 +50,7 @@ import com.woocommerce.android.util.PrintHtmlHelper.PrintJobResult.CANCELLED
 import com.woocommerce.android.util.PrintHtmlHelper.PrintJobResult.FAILED
 import com.woocommerce.android.util.PrintHtmlHelper.PrintJobResult.STARTED
 import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -196,6 +197,7 @@ class CardReaderPaymentViewModel
         orderId: Long,
     ) {
         storeReceiptUrl(orderId, paymentStatus.receiptUrl)
+        triggerEvent(PlayChaChing)
         showPaymentSuccessfulState()
         reFetchOrder()
     }
@@ -347,6 +349,8 @@ class CardReaderPaymentViewModel
         .formatAmountWithCurrency(this.currency, this.total.toDouble())
 
     private fun Order.getReceiptDocumentName() = "receipt-order-$remoteId"
+
+    object PlayChaChing : MultiLiveEvent.Event()
 
     sealed class ViewState(
         @StringRes val hintLabel: Int? = null,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -269,6 +269,22 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `when payment completed, then cha-ching sound is played`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(PaymentCompleted("")) }
+            }
+
+            viewModel.start()
+            val events = mutableListOf<Event>()
+            viewModel.event.observeForever {
+                events.add(it)
+            }
+
+            assertThat(events[0]).isInstanceOf(CardReaderPaymentViewModel.PlayChaChing::class.java)
+        }
+
+    @Test
     fun `when payment completed, then event tracked`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {


### PR DESCRIPTION
Parent issue #4030 

This PR adds a "cha-ching" sound upon successful in-person payment. To test, simply step through the payment flow and ensure the sound is played.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.