### PR TITLE
Add product filtering by category

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -850,9 +850,14 @@ class MainActivity :
         navController.navigateSafely(action)
     }
 
-    override fun showProductFilters(stockStatus: String?, productType: String?, productStatus: String?) {
+    override fun showProductFilters(
+        stockStatus: String?,
+        productType: String?,
+        productStatus: String?,
+        productCategory: String?
+    ) {
         val action = ProductListFragmentDirections.actionProductListFragmentToProductFilterListFragment(
-            stockStatus, productStatus, productType
+            stockStatus, productStatus, productType, productCategory
         )
         navController.navigateSafely(action)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
@@ -20,7 +20,7 @@ interface MainNavigationRouter {
         enableModeration: Boolean,
         tempStatus: String? = null
     )
-    fun showProductFilters(stockStatus: String?, productType: String?, productStatus: String?)
+    fun showProductFilters(stockStatus: String?, productType: String?, productStatus: String?, productCategory: String?)
     fun showFeedbackSurvey()
     fun showProductAddBottomSheet()
     fun showSettingsScreen()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -175,7 +175,7 @@ class ProductFilterListViewModel @Inject constructor(
     }
 
     private fun buildFilterListItemUiModel(): List<FilterListItemUiModel> {
-        return listOf(
+        val filterListItems = mutableListOf(
             FilterListItemUiModel(
                 STOCK_STATUS,
                 resourceProvider.getString(string.product_stock_status),
@@ -217,6 +217,31 @@ class ProductFilterListViewModel @Inject constructor(
                     }.toMutableList(),
                     productFilterOptions[TYPE].isNullOrEmpty()
                 )
+            )
+        )
+
+        _productCategories.value?.let { categoryList ->
+            filterListItems.add(
+                buildCategoryFilterListItemUiModel(categoryList)
+            )
+        }
+
+        return filterListItems
+    }
+
+    private fun buildCategoryFilterListItemUiModel(categoryList: List<ProductCategory>): FilterListItemUiModel {
+        return FilterListItemUiModel(
+            CATEGORY,
+            resourceProvider.getString(string.product_category),
+            addDefaultFilterOption(
+                categoryList.map { category ->
+                    FilterListOptionItemUiModel(
+                        category.name,
+                        category.remoteCategoryId.toString(),
+                        isSelected = productFilterOptions[CATEGORY] == category.remoteCategoryId.toString()
+                    )
+                }.toMutableList(),
+                productFilterOptions[CATEGORY].isNullOrEmpty()
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -77,11 +77,13 @@ class ProductFilterListViewModel @Inject constructor(
 
     fun getFilterString() = productFilterOptions.values.joinToString(", ")
 
-    fun getFilterByStockStatus() = productFilterOptions[STOCK_STATUS]
+    private fun getFilterByStockStatus() = productFilterOptions[STOCK_STATUS]
 
-    fun getFilterByProductStatus() = productFilterOptions[STATUS]
+    private fun getFilterByProductStatus() = productFilterOptions[STATUS]
 
-    fun getFilterByProductType() = productFilterOptions[TYPE]
+    private fun getFilterByProductType() = productFilterOptions[TYPE]
+
+    private fun getFilterByProductCategory() = productFilterOptions[CATEGORY]
 
     private suspend fun loadCategories() {
         if (networkStatus.isConnected()) {
@@ -169,7 +171,8 @@ class ProductFilterListViewModel @Inject constructor(
         val result = ProductFilterResult(
             productStatus = getFilterByProductStatus(),
             stockStatus = getFilterByStockStatus(),
-            productType = getFilterByProductType()
+            productType = getFilterByProductType(),
+            productCategory = getFilterByProductCategory()
         )
         triggerEvent(ExitWithResult(result))
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -56,8 +56,7 @@ class ProductFilterListViewModel @Inject constructor(
         LiveDataDelegate(savedState, ProductFilterOptionListViewState())
     private var productFilterOptionListViewState by productFilterOptionListViewStateData
 
-    private val _productCategories = MutableLiveData<List<ProductCategory>>()
-    val productCategories: LiveData<List<ProductCategory>> = _productCategories
+    private lateinit var productCategories: List<ProductCategory>
 
     /**
      * Holds the filter properties (stock_status, status, type) already selected by the user in a [Map]
@@ -87,10 +86,10 @@ class ProductFilterListViewModel @Inject constructor(
     private fun getFilterByProductCategory() = productFilterOptions[CATEGORY]
 
     private suspend fun loadCategories() {
-        if (networkStatus.isConnected()) {
-            _productCategories.value = productCategoriesRepository.fetchProductCategories()
+        productCategories = if (networkStatus.isConnected()) {
+            productCategoriesRepository.fetchProductCategories()
         } else {
-            _productCategories.value = productCategoriesRepository.getProductCategoriesList()
+            productCategoriesRepository.getProductCategoriesList()
         }
     }
 
@@ -223,26 +222,21 @@ class ProductFilterListViewModel @Inject constructor(
                 )
             )
         )
-
-        _productCategories.value?.let { categoryList ->
-            filterListItems.add(
-                buildCategoryFilterListItemUiModel(categoryList)
-            )
-        }
+        filterListItems.add(buildCategoryFilterListItemUiModel())
 
         return filterListItems
     }
 
-    private fun buildCategoryFilterListItemUiModel(categoryList: List<ProductCategory>): FilterListItemUiModel {
+    private fun buildCategoryFilterListItemUiModel(): FilterListItemUiModel {
         return FilterListItemUiModel(
             CATEGORY,
             resourceProvider.getString(string.product_category),
             addDefaultFilterOption(
-                categoryList.map { category ->
+                productCategories.map {
                     FilterListOptionItemUiModel(
-                        category.name,
-                        category.remoteCategoryId.toString(),
-                        isSelected = productFilterOptions[CATEGORY] == category.remoteCategoryId.toString()
+                        it.name,
+                        it.remoteCategoryId.toString(),
+                        isSelected = productFilterOptions[CATEGORY] == it.remoteCategoryId.toString()
                     )
                 }.toMutableList(),
                 productFilterOptions[CATEGORY].isNullOrEmpty()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -71,6 +71,7 @@ class ProductFilterListViewModel @Inject constructor(
         arguments.selectedStockStatus?.let { params.put(STOCK_STATUS, it) }
         arguments.selectedProductType?.let { params.put(TYPE, it) }
         arguments.selectedProductStatus?.let { params.put(STATUS, it) }
+        arguments.selectedProductCategory?.let { params.put(CATEGORY, it) }
         savedState[KEY_PRODUCT_FILTER_OPTIONS] = params
         params
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterResult.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterResult.kt
@@ -7,5 +7,6 @@ import kotlinx.parcelize.Parcelize
 data class ProductFilterResult(
     val stockStatus: String?,
     val productType: String?,
-    val productStatus: String?
+    val productStatus: String?,
+    val productCategory: String?
 ) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -292,7 +292,7 @@ class ProductListFragment :
                         event.stockStatusFilter,
                         event.productTypeFilter,
                         event.productStatusFilter,
-                        event.productCategory
+                        event.productCategoryFilter
                     )
                     is ShowProductSortingBottomSheet -> showProductSortingBottomSheet()
                     else -> event.isHandled = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -291,7 +291,8 @@ class ProductListFragment :
                     is ShowProductFilterScreen -> showProductFilterScreen(
                         event.stockStatusFilter,
                         event.productTypeFilter,
-                        event.productStatusFilter
+                        event.productStatusFilter,
+                        event.productCategory
                     )
                     is ShowProductSortingBottomSheet -> showProductSortingBottomSheet()
                     else -> event.isHandled = false
@@ -449,8 +450,18 @@ class ProductListFragment :
         viewModel.onLoadMoreRequested()
     }
 
-    private fun showProductFilterScreen(stockStatus: String?, productType: String?, productStatus: String?) {
-        (activity as? MainNavigationRouter)?.showProductFilters(stockStatus, productType, productStatus)
+    private fun showProductFilterScreen(
+        stockStatus: String?,
+        productType: String?,
+        productStatus: String?,
+        productCategory: String?
+    ) {
+        (activity as? MainNavigationRouter)?.showProductFilters(
+            stockStatus,
+            productType,
+            productStatus,
+            productCategory
+        )
     }
 
     override fun onFilterOptionSelected() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -313,7 +313,8 @@ class ProductListFragment :
             viewModel.onFiltersChanged(
                 stockStatus = result.stockStatus,
                 productStatus = result.productStatus,
-                productType = result.productType
+                productType = result.productType,
+                productCategory = result.productCategory
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -134,7 +134,8 @@ class ProductListViewModel @Inject constructor(
             ShowProductFilterScreen(
                 productFilterOptions[ProductFilterOption.STOCK_STATUS],
                 productFilterOptions[ProductFilterOption.TYPE],
-                productFilterOptions[ProductFilterOption.STATUS]
+                productFilterOptions[ProductFilterOption.STATUS],
+                productFilterOptions[ProductFilterOption.CATEGORY]
             )
         )
     }
@@ -428,7 +429,8 @@ class ProductListViewModel @Inject constructor(
         data class ShowProductFilterScreen(
             val stockStatusFilter: String?,
             val productTypeFilter: String?,
-            val productStatusFilter: String?
+            val productStatusFilter: String?,
+            val productCategory: String?
         ) : ProductListEvent()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -430,7 +430,7 @@ class ProductListViewModel @Inject constructor(
             val stockStatusFilter: String?,
             val productTypeFilter: String?,
             val productStatusFilter: String?,
-            val productCategory: String?
+            val productCategoryFilter: String?
         ) : ProductListEvent()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -101,20 +101,31 @@ class ProductListViewModel @Inject constructor(
     fun onFiltersChanged(
         stockStatus: String?,
         productStatus: String?,
-        productType: String?
+        productType: String?,
+        productCategory: String?
     ) {
-        if (stockStatus != productFilterOptions[ProductFilterOption.STOCK_STATUS] ||
-            productStatus != productFilterOptions[ProductFilterOption.STATUS] ||
-            productType != productFilterOptions[ProductFilterOption.TYPE]
-        ) {
+        if (areFiltersChanged(stockStatus, productStatus, productType, productCategory)) {
             productFilterOptions.clear()
             stockStatus?.let { productFilterOptions[ProductFilterOption.STOCK_STATUS] = it }
             productStatus?.let { productFilterOptions[ProductFilterOption.STATUS] = it }
             productType?.let { productFilterOptions[ProductFilterOption.TYPE] = it }
+            productCategory?.let { productFilterOptions[ProductFilterOption.CATEGORY] = it }
 
             viewState = viewState.copy(filterCount = productFilterOptions.size)
             refreshProducts()
         }
+    }
+
+    private fun areFiltersChanged(
+        stockStatus: String?,
+        productStatus: String?,
+        productType: String?,
+        productCategory: String?
+    ): Boolean {
+        return stockStatus != productFilterOptions[ProductFilterOption.STOCK_STATUS] ||
+            productStatus != productFilterOptions[ProductFilterOption.STATUS] ||
+            productType != productFilterOptions[ProductFilterOption.TYPE] ||
+            productCategory != productFilterOptions[ProductFilterOption.CATEGORY]
     }
 
     fun onFiltersButtonTapped() {

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -51,6 +51,10 @@
                 android:name="selectedProductType"
                 app:argType="string"
                 app:nullable="true" />
+            <argument
+                android:name="selectedProductCategory"
+                app:argType="string"
+                app:nullable="true" />
         </action>
         <action
             android:id="@+id/action_productListFragment_to_productTypesBottomSheet"

--- a/WooCommerce/src/main/res/navigation/nav_graph_product_filters.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_product_filters.xml
@@ -20,6 +20,10 @@
             android:name="selectedProductType"
             app:nullable="true"
             app:argType="string" />
+        <argument
+            android:name="selectedProductCategory"
+            app:nullable="true"
+            app:argType="string" />
         <action
             android:id="@+id/action_productFilterListFragment_to_productFilterOptionListFragment"
             app:destination="@id/productFilterOptionListFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -968,6 +968,8 @@
     <string name="product_sku_summary">Helps to easily identify this product</string>
     <string name="product_stock_status">Stock status</string>
     <string name="product_type">Product type</string>
+    <string name="product_category">Category</string>
+    <string name="product_category_fetch_error">Your network is unavailable. Categories list might not be accurate.</string>
     <string name="product_type_description">%s product</string>
     <string name="product_filter_default">Any</string>
     <string name="product_manage_stock">Manage stock</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -969,7 +969,6 @@
     <string name="product_stock_status">Stock status</string>
     <string name="product_type">Product type</string>
     <string name="product_category">Category</string>
-    <string name="product_category_fetch_error">Your network is unavailable. Categories list might not be accurate.</string>
     <string name="product_type_description">%s product</string>
     <string name="product_filter_default">Any</string>
     <string name="product_manage_stock">Manage stock</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
@@ -214,7 +214,8 @@ class ProductListViewModelTest : BaseUnitTest() {
         val stockStatus = "instock"
         val status = "simple"
         val type = "draft"
-        viewModel.onFiltersChanged(stockStatus, status, type)
+        val category = "hoodie"
+        viewModel.onFiltersChanged(stockStatus, status, type, category)
 
         val events = mutableListOf<Event>()
         viewModel.event.observeForever {
@@ -227,6 +228,7 @@ class ProductListViewModelTest : BaseUnitTest() {
         assertThat(event.productStatusFilter).isEqualTo(status)
         assertThat(event.productTypeFilter).isEqualTo(type)
         assertThat(event.stockStatusFilter).isEqualTo(stockStatus)
+        assertThat(event.productCategoryFilter).isEqualTo(category)
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '1.23.0'
+    fluxCVersion = 'develop-860a15cf52056406003f35818ce29d603068672e'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'


### PR DESCRIPTION
This is part of #4578

### Description
This PR adds the capability to filter products by category. In general what it does is:
1. When the product filter screen is opened, fetch list of categories (if there's internet) or get from db, and add them to the list of filters,
2. When a category filter is selected and the "Show products" button is tapped, include the category as criteria for filtering and show the result,
3. On products list screen, if a category filter is already selected and user taps the "Filters" button again, make sure the selected category is persisted and already selected in the "Category" filter.

---

### Testing instructions
1. In wp-admin, open **Products > Categories**. It should show the category list and the count of products under each. We will return to this screen later.
2. Open app, go to **Products**, and tap **Filters**.
3. Make sure the **"Category"** filter is shown, with "Any" listed on it. Tap the **"Category"** filter.
4. The screen will show a list of categories. Compare this to the wp-admin category list and make sure the list is the same.
5. Select a category. Try then tapping "Back" or the "Show products" button. Both action will open the main filter screen. Make sure it says **"Filters (1)"** at the top, and that the selected category is now listed to the right of the "Category" filter.
6. Tap "Show products". This will open the products list screen, showing the filtering result. Make sure it says **"Filters • 1"** on the filters button at the top.
7. Count the product result, and compare it to the count in wp-admin category list screen. Make sure they are the same. Also do a spot check and make sure the returned products indeed have the selected category.
8. Tap the "Filters • 1" button. When the filters list is loaded, make sure the selected category is still shown to the right of the "Category" filter.

Finally, also try combining filters between a category and the other filters. Make sure the filters count on filters and product lists category stay correct, and that the filter result stay correct as well.

---

### Known issues

**UI:**
- The app now has to load a list of categories to add in the filters area, and this introduces some pause before the full list of filters is shown. I plan to add a loading screen to make the pause less jarring in a separate PR.
- At the moment there is no indicator in the product list which category is selected as filter. I will figure out some way to expose that, if possible, in a separate PR.
- The list of categories to select is sorted alphabetically, instead of sorted by parent-child relationship like in wp-admin. This can probably be filed as future enhancement.

**Functionality:**
The REST API's behavior when doing the filtering is to return only products that **directly has the category set to them**. However, in Core when filtering for Products in `All Products > Categories`,  the search result includes products that are set with **children categories of the selected category**. This is even true when the products do not have the selected category set to them. 

Matching that core behavior will require more work and exploration, and I plan to handle that later in a separate PR.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
