### PR TITLE
issue/4525-notifications-cleanup-step4

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/FCMMessageService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/FCMMessageService.kt
@@ -1,23 +1,15 @@
 package com.woocommerce.android.push
 
-import android.os.Bundle
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
-import com.woocommerce.android.support.ZendeskHelper
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.fluxc.store.AccountStore
 import javax.inject.Inject
-
-private const val PUSH_TYPE_ZENDESK = "zendesk"
-private const val PUSH_ARG_ZENDESK_REQUEST_ID = "zendesk_sdk_request_id"
 
 @AndroidEntryPoint
 class FCMMessageService : FirebaseMessagingService() {
-    @Inject lateinit var accountStore: AccountStore
-    @Inject lateinit var zendeskHelper: ZendeskHelper
-    @Inject lateinit var notificationHandler: NotificationHandler
+    @Inject lateinit var notificationMessageHandler: NotificationMessageHandler
     @Inject lateinit var notificationRegistrationHandler: NotificationRegistrationHandler
 
     /**
@@ -32,29 +24,6 @@ class FCMMessageService : FirebaseMessagingService() {
 
     override fun onMessageReceived(message: RemoteMessage) {
         WooLog.v(T.NOTIFS, "Received message from Firebase")
-
-        if (!accountStore.hasAccessToken()) return
-
-        if (PUSH_TYPE_ZENDESK == message.data["type"]) {
-            val zendeskRequestId = message.data[PUSH_ARG_ZENDESK_REQUEST_ID]
-
-            // Try to refresh the Zendesk request page if it's currently being displayed;
-            // otherwise show a notification
-            if (!zendeskHelper.refreshRequest(this, zendeskRequestId)) {
-                notificationHandler.handleZendeskNotification(this.applicationContext)
-            }
-        } else {
-            notificationHandler.buildAndShowNotificationFromNoteData(
-                this.applicationContext,
-                convertMapToBundle(message.data),
-                accountStore.account
-            )
-        }
-    }
-
-    private fun convertMapToBundle(data: Map<String, String>): Bundle {
-        return Bundle().apply {
-            data.forEach { (key, value) -> putString(key, value) }
-        }
+        notificationMessageHandler.onNewMessageReceived(message.data)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationsProcessingService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationsProcessingService.kt
@@ -27,8 +27,7 @@ class NotificationsProcessingService : Service() {
     }
 
     private lateinit var actionProcessor: ActionProcessor
-    @Inject
-    lateinit var notificationMessageHandler: NotificationMessageHandler
+    @Inject lateinit var notificationMessageHandler: NotificationMessageHandler
 
     override fun onBind(intent: Intent): IBinder? {
         return null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -10,6 +10,7 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.view.WindowManager
+import androidx.activity.viewModels
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.Toolbar
@@ -22,27 +23,17 @@ import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.fragment.NavHostFragment
 import com.google.android.material.appbar.AppBarLayout
-import com.woocommerce.android.AppPrefs
-import com.woocommerce.android.BuildConfig
-import com.woocommerce.android.NavGraphMainDirections
-import com.woocommerce.android.R
+import com.woocommerce.android.*
 import com.woocommerce.android.R.dimen
-import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.databinding.ActivityMainBinding
+import com.woocommerce.android.extensions.*
+import com.woocommerce.android.model.Notification
+import com.woocommerce.android.navigation.KeepStateNavigator
 import com.woocommerce.android.push.WooNotificationType.NEW_ORDER
 import com.woocommerce.android.push.WooNotificationType.PRODUCT_REVIEW
-import com.woocommerce.android.extensions.active
-import com.woocommerce.android.extensions.getCommentId
-import com.woocommerce.android.extensions.getRemoteOrderId
 import com.woocommerce.android.push.getWooType
-import com.woocommerce.android.extensions.hide
-import com.woocommerce.android.extensions.navigateSafely
-import com.woocommerce.android.extensions.show
-import com.woocommerce.android.navigation.KeepStateNavigator
-import com.woocommerce.android.push.NotificationHandler
-import com.woocommerce.android.push.NotificationChannelType
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
 import com.woocommerce.android.tools.SelectedSite
@@ -50,10 +41,7 @@ import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.login.LoginActivity
-import com.woocommerce.android.ui.main.BottomNavigationPosition.MY_STORE
-import com.woocommerce.android.ui.main.BottomNavigationPosition.ORDERS
-import com.woocommerce.android.ui.main.BottomNavigationPosition.PRODUCTS
-import com.woocommerce.android.ui.main.BottomNavigationPosition.REVIEWS
+import com.woocommerce.android.ui.main.BottomNavigationPosition.*
 import com.woocommerce.android.ui.orders.list.OrderListFragmentDirections
 import com.woocommerce.android.ui.prefs.AppSettingsActivity
 import com.woocommerce.android.ui.products.ProductListFragmentDirections
@@ -72,7 +60,12 @@ import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.login.LoginAnalyticsListener
 import org.wordpress.android.login.LoginMode
 import org.wordpress.android.util.NetworkUtils
-import java.util.Locale
+import com.woocommerce.android.ui.main.MainActivityViewModel.ViewOrderDetail
+import com.woocommerce.android.ui.main.MainActivityViewModel.ViewOrderList
+import com.woocommerce.android.ui.main.MainActivityViewModel.ViewReviewDetail
+import com.woocommerce.android.ui.main.MainActivityViewModel.ViewZendeskTickets
+import com.woocommerce.android.ui.main.MainActivityViewModel.ViewMyStoreStats
+import com.woocommerce.android.ui.main.MainActivityViewModel.ViewReviewList
 import javax.inject.Inject
 import kotlin.math.abs
 
@@ -117,6 +110,8 @@ class MainActivity :
     @Inject lateinit var loginAnalyticsListener: LoginAnalyticsListener
     @Inject lateinit var selectedSite: SelectedSite
     @Inject lateinit var uiMessageResolver: UIMessageResolver
+
+    private val viewModel: MainActivityViewModel by viewModels()
 
     private var isBottomNavShowing = true
     private var previousDestinationId: Int? = null
@@ -644,7 +639,7 @@ class MainActivity :
 
     override fun hideReviewsBadge() {
         binding.bottomNav.showReviewsBadge(false)
-        NotificationHandler.removeAllReviewNotifsFromSystemBar(this)
+        viewModel.removeReviewNotifications()
     }
 
     override fun showReviewsBadge() {
@@ -678,9 +673,9 @@ class MainActivity :
         AnalyticsTracker.track(stat)
 
         if (navPos == REVIEWS) {
-            NotificationHandler.removeAllReviewNotifsFromSystemBar(this)
+            viewModel.removeReviewNotifications()
         } else if (navPos == ORDERS) {
-            NotificationHandler.removeAllOrderNotifsFromSystemBar(this)
+            viewModel.removeOrderNotifications()
         }
     }
 
@@ -708,6 +703,7 @@ class MainActivity :
 
     // region Fragment Processing
     private fun initFragment(savedInstanceState: Bundle?) {
+        setupObservers()
         val openedFromPush = intent.getBooleanExtra(FIELD_OPENED_FROM_PUSH, false)
 
         if (savedInstanceState != null) {
@@ -720,70 +716,42 @@ class MainActivity :
 
             menu?.close()
 
-            if (intent.getBooleanExtra(FIELD_OPENED_FROM_PUSH_GROUP, false)) {
-                // Reset this flag now that it's being processed
-                intent.removeExtra(FIELD_OPENED_FROM_PUSH_GROUP)
+            val localPushId = intent.getIntExtra(FIELD_PUSH_ID, 0)
+            val notification = intent.getParcelableExtra<Notification>(FIELD_REMOTE_NOTIFICATION)
+            // Reset this flag now that it's being processed
+            intent.removeExtra(FIELD_REMOTE_NOTIFICATION)
+            intent.removeExtra(FIELD_PUSH_ID)
 
-                // Send analytics for viewing all notifications
-                NotificationHandler.bumpPushNotificationsTappedAllAnalytics(this)
-
-                // Clear unread messages from the system bar
-                NotificationHandler.removeAllNotificationsFromSystemBar(this)
-
-                // User clicked on a group of notifications. Redirect to the order list screen if
-                // the last notification received is a new order. Otherwise, redirect to the reviews screen
-                val notificationChannelType = intent.getStringExtra(FIELD_NOTIFICATION_TYPE)?.let {
-                    NotificationChannelType.valueOf(it.toUpperCase(Locale.US))
-                } ?: NotificationChannelType.REVIEW
-
-                binding.bottomNav.currentPosition = when (notificationChannelType) {
-                    NotificationChannelType.NEW_ORDER -> ORDERS
-                    else -> REVIEWS
-                }
-            } else if (intent.getBooleanExtra(FIELD_OPENED_FROM_ZENDESK, false)) {
-                // Reset this flag now that it's being processed
-                intent.removeExtra(FIELD_OPENED_FROM_ZENDESK)
-
-                // Send track event for the zendesk notification id
-                val remoteNoteId = intent.getIntExtra(FIELD_REMOTE_NOTE_ID, 0)
-                NotificationHandler.bumpPushNotificationsTappedAnalytics(this, remoteNoteId.toString())
-
-                // Remove single notification from the system bar
-                NotificationHandler.removeNotificationWithNoteIdFromSystemBar(this, remoteNoteId.toString())
-
-                // leave the Main activity showing the Dashboard tab, so when the user comes back from Help & Support,
-                // the app is in the right section
-                binding.bottomNav.currentPosition = MY_STORE
-
-                // launch 'Tickets' page of Zendesk
-                startActivity(HelpActivity.createIntent(this, Origin.ZENDESK_NOTIFICATION, null))
-            } else {
-                // Check for a notification ID - if one is present, open notification
-                val remoteNoteId = intent.getLongExtra(FIELD_REMOTE_NOTE_ID, 0)
-                if (remoteNoteId > 0) {
-                    // Send track event
-                    NotificationHandler.bumpPushNotificationsTappedAnalytics(this, remoteNoteId.toString())
-
-                    // Remove single notification from the system bar
-                    NotificationHandler.removeNotificationWithNoteIdFromSystemBar(this, remoteNoteId.toString())
-
-                    showNotificationDetail(remoteNoteId)
-                } else {
-                    // Send analytics for viewing all notifications
-                    NotificationHandler.bumpPushNotificationsTappedAllAnalytics(this)
-
-                    // Clear unread messages from the system bar
-                    NotificationHandler.removeAllNotificationsFromSystemBar(this)
-
-                    // Just open the notifications tab
-                    binding.bottomNav.currentPosition = REVIEWS
-                }
-            }
-        } else {
-            binding.bottomNav.currentPosition = MY_STORE
+            viewModel.handleIncomingNotification(localPushId, notification)
         }
     }
     // endregion
+
+    private fun setupObservers() {
+        viewModel.event.observe(
+            this,
+            { event ->
+                when (event) {
+                    is ViewMyStoreStats -> binding.bottomNav.currentPosition = MY_STORE
+                    is ViewOrderList -> binding.bottomNav.currentPosition = ORDERS
+                    is ViewReviewList -> binding.bottomNav.currentPosition = REVIEWS
+                    is ViewZendeskTickets -> {
+                        startActivity(HelpActivity.createIntent(this, Origin.ZENDESK_NOTIFICATION, null))
+                    }
+                    is ViewOrderDetail -> {
+                        showOrderDetail(
+                            event.localSiteId,
+                            remoteOrderId = event.uniqueId,
+                            remoteNoteId = event.remoteNoteId
+                        )
+                    }
+                    is ViewReviewDetail -> {
+                        showReviewDetail(event.uniqueId, launchedFromNotification = true, enableModeration = true)
+                    }
+                }
+            }
+        )
+    }
 
     override fun showNotificationDetail(remoteNoteId: Long) {
         showBottomNav()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -1,0 +1,78 @@
+package com.woocommerce.android.ui.main
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.model.Notification
+import com.woocommerce.android.push.NotificationChannelType
+import com.woocommerce.android.push.NotificationMessageHandler
+import com.woocommerce.android.push.getGroupId
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import org.wordpress.android.fluxc.store.SiteStore
+import javax.inject.Inject
+
+@HiltViewModel
+class MainActivityViewModel @Inject constructor(
+    savedState: SavedStateHandle,
+    private val siteStore: SiteStore,
+    private val notificationHandler: NotificationMessageHandler
+) : ScopedViewModel(savedState) {
+    fun removeReviewNotifications() {
+        notificationHandler.removeNotificationsOfTypeFromSystemsBar(NotificationChannelType.REVIEW)
+    }
+
+    fun removeOrderNotifications() {
+        notificationHandler.removeNotificationsOfTypeFromSystemsBar(NotificationChannelType.NEW_ORDER)
+    }
+
+    fun handleIncomingNotification(localPushId: Int, notification: Notification?) {
+        notification?.let {
+            when (localPushId) {
+                it.channelType.getGroupId() -> onGroupMessageOpened(it.channelType)
+                it.noteId -> onZendeskNotificationOpened(localPushId, it.noteId.toLong())
+                else -> onSingleNotificationOpened(localPushId, it)
+            }
+        } ?: run {
+            triggerEvent(ViewMyStoreStats)
+        }
+    }
+
+    private fun onGroupMessageOpened(notificationChannelType: NotificationChannelType) {
+        notificationHandler.markNotificationsOfTypeTapped(notificationChannelType)
+        notificationHandler.removeNotificationsOfTypeFromSystemsBar(notificationChannelType)
+        when (notificationChannelType) {
+            NotificationChannelType.NEW_ORDER -> triggerEvent(ViewOrderList)
+            NotificationChannelType.REVIEW -> triggerEvent(ViewReviewList)
+            else -> triggerEvent(ViewMyStoreStats)
+        }
+    }
+
+    private fun onZendeskNotificationOpened(localPushId: Int, remoteNoteId: Long) {
+        notificationHandler.markNotificationTapped(remoteNoteId)
+        notificationHandler.removeNotificationByPushIdFromSystemsBar(localPushId)
+        triggerEvent(ViewMyStoreStats)
+        triggerEvent(ViewZendeskTickets)
+    }
+
+    private fun onSingleNotificationOpened(localPushId: Int, notification: Notification) {
+        notificationHandler.markNotificationTapped(notification.remoteNoteId)
+        notificationHandler.removeNotificationByPushIdFromSystemsBar(localPushId)
+        if (notification.channelType == NotificationChannelType.REVIEW) {
+            triggerEvent(ViewReviewDetail(notification.uniqueId))
+        } else if (notification.channelType == NotificationChannelType.NEW_ORDER) {
+            siteStore.getSiteBySiteId(notification.remoteSiteId)?.let { siteModel ->
+                triggerEvent(ViewOrderDetail(notification.uniqueId, siteModel.id, notification.remoteNoteId))
+            } ?: run {
+                // the site does not exist locally, open order list
+                triggerEvent(ViewOrderList)
+            }
+        }
+    }
+
+    object ViewOrderList : Event()
+    object ViewReviewList : Event()
+    object ViewMyStoreStats : Event()
+    object ViewZendeskTickets : Event()
+    data class ViewReviewDetail(val uniqueId: Long) : Event()
+    data class ViewOrderDetail(val uniqueId: Long, val localSiteId: Int, val remoteNoteId: Long) : Event()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
@@ -22,7 +22,7 @@ import com.woocommerce.android.di.GlideApp
 import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.ProductReview
-import com.woocommerce.android.push.NotificationHandler
+import com.woocommerce.android.push.NotificationMessageHandler
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -49,6 +49,7 @@ import javax.inject.Inject
 class ReviewDetailFragment : BaseFragment(R.layout.fragment_review_detail) {
     @Inject lateinit var uiMessageResolver: UIMessageResolver
     @Inject lateinit var productImageMap: ProductImageMap
+    @Inject lateinit var notificationMessageHandler: NotificationMessageHandler
 
     private val viewModel: ReviewDetailViewModel by viewModels()
 
@@ -126,9 +127,8 @@ class ReviewDetailFragment : BaseFragment(R.layout.fragment_review_detail) {
                 when (event) {
                     is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                     is MarkNotificationAsRead -> {
-                        NotificationHandler.removeNotificationWithNoteIdFromSystemBar(
-                            requireContext(),
-                            event.remoteNoteId.toString()
+                        notificationMessageHandler.removeNotificationByRemoteIdFromSystemsBar(
+                            event.remoteNoteId
                         )
                     }
                     is Exit -> exitDetailView()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListFragment.kt
@@ -20,7 +20,8 @@ import com.woocommerce.android.databinding.FragmentReviewsListBinding
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.ActionStatus
 import com.woocommerce.android.model.ProductReview
-import com.woocommerce.android.push.NotificationHandler
+import com.woocommerce.android.push.NotificationChannelType
+import com.woocommerce.android.push.NotificationMessageHandler
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -54,6 +55,7 @@ class ReviewListFragment :
 
     @Inject lateinit var uiMessageResolver: UIMessageResolver
     @Inject lateinit var selectedSite: SelectedSite
+    @Inject lateinit var notificationMessageHandler: NotificationMessageHandler
 
     private lateinit var reviewsAdapter: ReviewListAdapter
 
@@ -220,7 +222,7 @@ class ReviewListFragment :
                 showMarkAllReadMenuItem(show = false)
 
                 // Remove all active notifications from the system bar
-                context?.let { NotificationHandler.removeAllReviewNotifsFromSystemBar(it) }
+                notificationMessageHandler.removeNotificationsOfTypeFromSystemsBar(NotificationChannelType.REVIEW)
             }
             ActionStatus.ERROR -> menuMarkAllRead?.actionView = null
             else -> {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/push/NotificationTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/push/NotificationTestUtils.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.push
 
+import com.woocommerce.android.model.Notification
+
 object NotificationTestUtils {
     const val TEST_ORDER_NOTE_FULL_DATA_1 = "eNqlVFtr2zAU/iuaGGOjdiLbSZwYyqDdwyhbW2gZjKkUxVZibbYkdKkbSv77jpz" +
         "L3O5hlL3Yks79fN85T1gqxy0ufjxhUeFiOskzkiQzkkbYbTTHBbZOGX6vTMUNjrCXhjNQlL5pImyl0Jq7w3Wpqk3vyvFHeMSg3/JKsN3bzp" +
@@ -65,5 +67,24 @@ object NotificationTestUtils {
         "user" to userId.toString(),
         "note_id" to noteId,
         "note_full_data" to noteData
+    )
+
+    fun generateTestNotification(
+        noteId: Int = 0,
+        remoteNoteId: Long,
+        remoteSiteId: Long,
+        uniqueId: Long,
+        channelType: NotificationChannelType,
+        noteType: WooNotificationType
+    ) = Notification(
+        noteId = noteId,
+        uniqueId = uniqueId,
+        remoteNoteId = remoteNoteId,
+        remoteSiteId = remoteSiteId,
+        channelType = channelType,
+        noteType = noteType,
+        noteTitle = "",
+        noteMessage = "",
+        icon = ""
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -1,0 +1,232 @@
+package com.woocommerce.android.ui.main
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.push.NotificationChannelType
+import com.woocommerce.android.push.NotificationMessageHandler
+import com.woocommerce.android.push.NotificationTestUtils
+import com.woocommerce.android.push.WooNotificationType
+import com.woocommerce.android.ui.main.MainActivityViewModel.ViewOrderDetail
+import com.woocommerce.android.ui.main.MainActivityViewModel.ViewOrderList
+import com.woocommerce.android.ui.main.MainActivityViewModel.ViewReviewDetail
+import com.woocommerce.android.ui.main.MainActivityViewModel.ViewZendeskTickets
+import com.woocommerce.android.ui.main.MainActivityViewModel.ViewMyStoreStats
+import com.woocommerce.android.ui.main.MainActivityViewModel.ViewReviewList
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.*
+import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class MainActivityViewModelTest : BaseUnitTest() {
+    companion object {
+        private const val TEST_NEW_ORDER_REMOTE_NOTE_ID = 5473011602
+        private const val TEST_NEW_ORDER_ID_1 = 1915L
+
+        private const val TEST_NEW_REVIEW_REMOTE_NOTE_ID = 5604993863
+        private const val TEST_NEW_REVIEW_ID_1 = 4418L
+
+        private const val TEST_ZENDESK_PUSH_NOTIFICATION_ID = 1999999999
+    }
+
+    private lateinit var viewModel: MainActivityViewModel
+    private val savedStateHandle: SavedStateHandle = SavedStateHandle()
+
+    private val siteStore: SiteStore = mock()
+    private val siteModel: SiteModel = SiteModel().apply {
+        id = 1
+        siteId = 123456789
+    }
+
+    private val notificationMessageHandler: NotificationMessageHandler = mock()
+    private val testOrderNotification = NotificationTestUtils.generateTestNotification(
+        remoteNoteId = TEST_NEW_ORDER_REMOTE_NOTE_ID,
+        remoteSiteId = siteModel.siteId,
+        uniqueId = TEST_NEW_ORDER_ID_1,
+        channelType = NotificationChannelType.NEW_ORDER,
+        noteType = WooNotificationType.NEW_ORDER
+    )
+
+    private val testReviewNotification = NotificationTestUtils.generateTestNotification(
+        remoteNoteId = TEST_NEW_REVIEW_REMOTE_NOTE_ID,
+        remoteSiteId = siteModel.siteId,
+        uniqueId = TEST_NEW_REVIEW_ID_1,
+        channelType = NotificationChannelType.REVIEW,
+        noteType = WooNotificationType.PRODUCT_REVIEW
+    )
+
+    private val testZendeskNotification = NotificationTestUtils.generateTestNotification(
+        noteId = TEST_ZENDESK_PUSH_NOTIFICATION_ID,
+        remoteNoteId = TEST_ZENDESK_PUSH_NOTIFICATION_ID.toLong(),
+        remoteSiteId = siteModel.siteId,
+        uniqueId = 0,
+        channelType = NotificationChannelType.OTHER,
+        noteType = WooNotificationType.ZENDESK
+    )
+
+    @Before
+    fun setup() {
+        viewModel = spy(
+            MainActivityViewModel(
+                savedStateHandle,
+                siteStore,
+                notificationMessageHandler
+            )
+        )
+
+        clearInvocations(
+            viewModel,
+            siteStore,
+            notificationMessageHandler
+        )
+
+        doReturn(siteModel).whenever(siteStore).getSiteBySiteId(any())
+    }
+
+    @Test
+    fun `blank notification to open my store`() {
+        val localPushId = 1000
+        var event: ViewMyStoreStats? = null
+        viewModel.event.observeForever {
+            if (it is ViewMyStoreStats) event = it
+        }
+
+        viewModel.handleIncomingNotification(localPushId, null)
+        assertThat(event).isEqualTo(ViewMyStoreStats)
+    }
+
+    @Test
+    fun `incoming new order notification to open order detail`() {
+        val localPushId = 1000
+        var event: ViewOrderDetail? = null
+        viewModel.event.observeForever {
+            if (it is ViewOrderDetail) event = it
+        }
+
+        viewModel.handleIncomingNotification(localPushId, testOrderNotification)
+
+        verify(notificationMessageHandler, atLeastOnce()).markNotificationTapped(eq(testOrderNotification.remoteNoteId))
+        verify(notificationMessageHandler, atLeastOnce()).removeNotificationByPushIdFromSystemsBar(eq(localPushId))
+        assertThat(event).isEqualTo(
+            ViewOrderDetail(
+                testOrderNotification.uniqueId,
+                siteModel.id,
+                testOrderNotification.remoteNoteId
+            )
+        )
+    }
+
+    @Test
+    fun `incoming new order notification for non existent site to open my store`() {
+        doReturn(null).whenever(siteStore).getSiteBySiteId(any())
+
+        val localPushId = 1000
+        var event: ViewOrderList? = null
+        viewModel.event.observeForever {
+            if (it is ViewOrderList) event = it
+        }
+
+        viewModel.handleIncomingNotification(localPushId, testOrderNotification)
+
+        verify(notificationMessageHandler, atLeastOnce()).markNotificationTapped(eq(testOrderNotification.remoteNoteId))
+        verify(notificationMessageHandler, atLeastOnce()).removeNotificationByPushIdFromSystemsBar(eq(localPushId))
+        assertThat(event).isEqualTo(ViewOrderList)
+    }
+
+    @Test
+    fun `incoming new review notification to open review detail`() {
+        val localPushId = 1001
+        var event: ViewReviewDetail? = null
+        viewModel.event.observeForever {
+            if (it is ViewReviewDetail) event = it
+        }
+
+        viewModel.handleIncomingNotification(localPushId, testReviewNotification)
+
+        verify(notificationMessageHandler, atLeastOnce())
+            .markNotificationTapped(eq(testReviewNotification.remoteNoteId))
+        verify(notificationMessageHandler, atLeastOnce()).removeNotificationByPushIdFromSystemsBar(eq(localPushId))
+        assertThat(event).isEqualTo(ViewReviewDetail(testReviewNotification.uniqueId))
+    }
+
+    @Test
+    fun `incoming new zendesk notification to open zendesk tickets`() {
+        var event1: ViewMyStoreStats? = null
+        var event2: ViewZendeskTickets? = null
+        viewModel.event.observeForever {
+            if (it is ViewMyStoreStats) event1 = it
+            else if (it is ViewZendeskTickets) event2 = it
+        }
+
+        viewModel.handleIncomingNotification(TEST_ZENDESK_PUSH_NOTIFICATION_ID, testZendeskNotification)
+
+        verify(notificationMessageHandler, atLeastOnce()).markNotificationTapped(
+            eq(testZendeskNotification.remoteNoteId)
+        )
+        verify(notificationMessageHandler, atLeastOnce()).removeNotificationByPushIdFromSystemsBar(
+            eq(TEST_ZENDESK_PUSH_NOTIFICATION_ID)
+        )
+        assertThat(event1).isEqualTo(ViewMyStoreStats)
+        assertThat(event2).isEqualTo(ViewZendeskTickets)
+    }
+
+    @Test
+    fun `incoming multiple order notifications to open order list`() {
+        val orderPushId = 30001
+        var event: ViewOrderList? = null
+        viewModel.event.observeForever {
+            if (it is ViewOrderList) event = it
+        }
+
+        viewModel.handleIncomingNotification(orderPushId, testOrderNotification)
+        verify(notificationMessageHandler, atLeastOnce()).markNotificationsOfTypeTapped(
+            eq(testOrderNotification.channelType)
+        )
+        verify(notificationMessageHandler, atLeastOnce()).removeNotificationsOfTypeFromSystemsBar(
+            eq(testOrderNotification.channelType)
+        )
+        assertThat(event).isEqualTo(ViewOrderList)
+    }
+
+    @Test
+    fun `incoming multiple review notifications to open review list`() {
+        val reviewPushId = 30002
+        var event: ViewReviewList? = null
+        viewModel.event.observeForever {
+            if (it is ViewReviewList) event = it
+        }
+
+        viewModel.handleIncomingNotification(reviewPushId, testReviewNotification)
+        verify(notificationMessageHandler, atLeastOnce()).markNotificationsOfTypeTapped(
+            eq(testReviewNotification.channelType)
+        )
+        verify(notificationMessageHandler, atLeastOnce()).removeNotificationsOfTypeFromSystemsBar(
+            eq(testReviewNotification.channelType)
+        )
+        assertThat(event).isEqualTo(ViewReviewList)
+    }
+
+    @Test
+    fun `incoming multiple zendesk notifications to open my store`() {
+        val localPushId = 30003
+        var event: ViewMyStoreStats? = null
+        viewModel.event.observeForever {
+            if (it is ViewMyStoreStats) event = it
+        }
+
+        viewModel.handleIncomingNotification(localPushId, testZendeskNotification)
+        verify(notificationMessageHandler, atLeastOnce()).markNotificationsOfTypeTapped(
+            eq(testZendeskNotification.channelType)
+        )
+        verify(notificationMessageHandler, atLeastOnce()).removeNotificationsOfTypeFromSystemsBar(
+            eq(testZendeskNotification.channelType)
+        )
+        assertThat(event).isEqualTo(ViewMyStoreStats)
+    }
+}


### PR DESCRIPTION
Step 4 of #4525. Since the changes are substantial I decided to split it into smaller PRs. **This PR is part of a work on progress so it is merged into `feature/notifications-cleanup`**


### Description
This PR takes the fourth step in cleaning up NotificationHandler. This PR includes user facing changes:
- Updated `FCMMessageService` to use `NotificationMessageHandler`.
- Updated `NotificationsProcessingService` to use the injectable `NotificationMessageHandler`.
- Added a new `MainActivityViewModel` class along with unit tests - handles click logic of notifications.
- Updated `MainActivity` to use `MainActivityViewModel`.
- The main visual change in this PR is that each notification type is displayed is it's own group. For instance, all order notifications are displayed in a separate group and all review notifications are displayed in a separate group. Also the text of both orders and review notification have been updated according to the Push Notifications for all stores designs.


### Testing instructions
I apologise in advance for the list of testing scenarios in this PR 😬 

#### Reviews
- Create a review from your test store. 
	- Verify that the notification is displayed correctly in the notification tray. 
	- Clicking on a single review notification should open the review detail screen.
	- Verify that the correct analytics event is sent when a notification is received and clicked.
- Create 2 reviews from your test store (for the same product or multiple products). 
	- Verify that the notifications are displayed correctly in the notification tray. 
	- Click on one of  the review notifications and it should open the review detail screen for that specific review.
	- Click on the other review notifications when the app is open and it should open the review detail screen for that specific review.
	- Verify that the correct analytics event is sent when a notification is received and clicked.
- Create 2 or more reviews or more from your test store (for the same product or multiple products).
	- Don't expand the notification but click on them as a group. 
	- Clicking on 2 review notifications should open the review list screen.
	- Verify that the correct analytics event is sent for each of the notifications in the group.
- Create 2 or more reviews from your test store (for the same product or multiple products). 
	- Expand the notifications from the notification tray. 
	- Dismiss one of the notifications and verify that it is dismissed correctly.
- Create 2 or more reviews from your test store (for the same product or multiple products). 
	- Do not expand the notifications from the notification tray. 
	- Dismiss the group of notifications from the notifications tray. 
	- Verify that it is dismissed correctly. 

#### Orders
- Create an order from your test store. 
	- Verify that the notification is displayed correctly in the notification tray. 
	- Clicking on a single order notification should open the order detail screen.
	- Verify that the correct analytics event is sent when a notification is received and clicked.
- Create 2 orders from your test store. 
	- Verify that the notifications are displayed correctly in the notification tray. 
	- Click on one of the order notifications and it should open the order detail screen for that specific order.
	- Click on the other order notification when the app is open and it should open the order detail screen for that specific order.
	- Verify that the correct analytics event is sent when a notification is received and clicked.
- Create 2 or more orders or more from your test store.
	- Don't expand the notification but click on them as a group. 
	- Clicking on 2 order notifications should open the order list screen.
	- Verify that the correct analytics event is sent for each of the notifications in the group.
- Create 2 or more orders from your test store. 
	- Expand the notifications from the notification tray. 
	- Dismiss one of the notifications and verify that it is dismissed correctly.
- Create 2 or more orders from your test store. 
	- Do not expand the notifications from the notification tray. 
	- Dismiss the group of notifications from the notifications tray. 
	- Verify that it is dismissed correctly.

#### Orders + Reviews
- Create an order and a review from your test store. 
	- Verify that the notifications is displayed correctly in the notification tray. The order and review notification should be displayed in separately.
	- Clicking on a single order notification should open the order detail screen.
	- Clicking on a single review notification should open the review detail screen.
	- Verify that the correct analytics event is sent when a notification is received and clicked.
- Create 2 orders + 2 reviews from your test store. 
	- Verify that the notifications are displayed correctly in the notification tray. The order and review notification should be displayed in separately. 
	- Clicking on each of the order notifications separately should open the order detail screen.
	- Clicking on each of the review notifications separately should open the review detail screen.	
	- Verify that the correct analytics event is sent when a notification is received and clicked.
- Create 2 or more orders + 2 or more reviews from your test store.
	- Don't expand the notification but click on the order notifications as a group. 
	- Clicking on 2 order notifications should open the order list screen.
	- Click on the review notifications as aa group and it should open the review list screen.
	- Verify that the correct analytics event is sent for each of the notifications in the group.
- Create 2 or more orders + 2 or more reviews from your test store. 
	- Expand the notifications from the notification tray. 
	- Dismiss one of the order notifications and verify that it is dismissed correctly.
	- Dismiss one of the review notifications and verify that it is dismissed correctly.
- Create 2 or more orders + 2 or more reviews from your test store. 
	- Do not expand the notifications from the notification tray. 
	- Dismiss the group of order notifications from the notifications tray and verify that it is dismissed correctly.
	- Dismiss the group of review notifications from the notifications tray and verify that it is dismissed correctly.	

#### Zendesk notifications
- Open a ticket from the app to Zendesk.
- Open the ticket on Zendesk and reply to it.
- Verify that the notification is displayed in the app correctly.
- Clicking on the notification should open the tickets page correctly.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.