### PR TITLE
Shipping labels: fix "use address as entered" behavior 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -183,6 +183,9 @@ class EditShippingLabelAddressViewModel @Inject constructor(
 
     fun onUseAddressAsIsButtonClicked() {
         AnalyticsTracker.track(Stat.SHIPPING_LABEL_EDIT_ADDRESS_USE_ADDRESS_AS_IS_BUTTON_TAPPED)
+        // Clear remote validation error of `address1`
+        viewState = viewState.copy(address1Field = viewState.address1Field.copy(validationError = null))
+        // Validate fields locally
         viewState = viewState.validateAllFields()
         if (viewState.areAllRequiredFieldsValid) {
             triggerEvent(ExitWithResult(viewState.getAddress()))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
@@ -314,4 +314,16 @@ class EditShippingLabelAddressViewModelTest : BaseUnitTest() {
 
         assertThat(viewState?.phoneField?.error).isEqualTo(UiStringRes(string.shipping_label_address_phone_required))
     }
+
+    @Test
+    fun `given there is an address1 remote error, when use address as entered is clicked, then skip the error`() =
+        testBlocking {
+            validationResult = ValidationResult.Invalid("House number is missing")
+            createViewModel()
+
+            viewModel.onUseAddressAsIsButtonClicked()
+
+            val viewState = viewModel.viewStateData.liveData.value!!
+            assertThat(viewState.areAllRequiredFieldsValid).isTrue()
+        }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4631 

### Description
Currently when we receive an error from backend that touches the `address1` field, we show an error on this field, but if the user wants to ignore the error, they can use the button `Use address as entered`, where we should just check if the field is not empty.
This PR fixes this behavior.

### Testing instructions
1. Open an order eligible for shipping label creation.
1. Click on Create shipping label.
1. Tap continue to load the ship to screen.
1. Address validation fails in this case.
1. Tap Done.
1. Address validation runs again, then fails. Address line 1 is highlighted.
1. Scroll down and tap Use address as entered.
1. Confirm that the address is saved, and you can continue.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
