### PR TITLE
Issue/4627 Replacing plurals with common strings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShippingLabelsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShippingLabelsAdapter.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.orders.OrderProductActionListener
 import com.woocommerce.android.ui.orders.OrderShipmentTrackingHelper
 import com.woocommerce.android.ui.orders.details.adapter.OrderDetailShippingLabelsAdapter.ShippingLabelsViewHolder
+import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.widgets.AlignedDividerDecoration
 import java.math.BigDecimal
 
@@ -119,10 +120,11 @@ class OrderDetailShippingLabelsAdapter(
             }
 
             // Set up the collapsible button to show/hide the products list.
-            viewBinding.shippingLabelListCountButtonTitle.text = viewBinding.root.resources.getQuantityString(
-                R.plurals.shipping_label_package_details_items_count,
-                shippingLabel.products.count(),
-                shippingLabel.products.count()
+            viewBinding.shippingLabelListCountButtonTitle.text = StringUtils.getQuantityString(
+                context = viewBinding.shippingLabelListCountButtonTitle.context,
+                quantity = shippingLabel.products.count(),
+                default = R.string.shipping_label_package_details_items_count_other,
+                one = R.string.shipping_label_package_details_items_count_one,
             )
             viewBinding.shippingLabelListViewItems.setOnClickListener {
                 val isChecked = viewBinding.shippingLabelListCountButtonImage.rotation == 0F

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShippingLabelsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShippingLabelsAdapter.kt
@@ -123,7 +123,7 @@ class OrderDetailShippingLabelsAdapter(
             viewBinding.shippingLabelListCountButtonTitle.text = StringUtils.getQuantityString(
                 context = viewBinding.shippingLabelListCountButtonTitle.context,
                 quantity = shippingLabel.products.count(),
-                default = R.string.shipping_label_package_details_items_count_other,
+                default = R.string.shipping_label_package_details_items_count_many,
                 one = R.string.shipping_label_package_details_items_count_one,
             )
             viewBinding.shippingLabelListViewItems.setOnClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailRefundsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailRefundsView.kt
@@ -24,7 +24,7 @@ class OrderDetailRefundsView @JvmOverloads constructor(
                 context = context,
                 quantity = refundsCount,
                 one = R.string.order_refunds_refund_info_description_one,
-                default = R.string.order_refunds_refund_info_description_other,
+                default = R.string.order_refunds_refund_info_description_many,
             )
             setOnClickListener { onTap() }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailRefundsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailRefundsView.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.OrderDetailRefundsInfoBinding
+import com.woocommerce.android.util.StringUtils
 
 class OrderDetailRefundsView @JvmOverloads constructor(
     ctx: Context,
@@ -19,10 +20,11 @@ class OrderDetailRefundsView @JvmOverloads constructor(
         onTap: () -> Unit
     ) {
         with(binding.refundsInfoCount) {
-            text = context.resources.getQuantityString(
-                R.plurals.order_refunds_refund_info_description,
-                refundsCount,
-                refundsCount
+            text = StringUtils.getQuantityString(
+                context = context,
+                quantity = refundsCount,
+                one = R.string.order_refunds_refund_info_description_one,
+                default = R.string.order_refunds_refund_info_description_other,
             )
             setOnClickListener { onTap() }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -594,7 +594,7 @@ class CreateShippingLabelViewModel @Inject constructor(
                     val deliveryDays = StringUtils.getQuantityString(
                         resourceProvider = resourceProvider,
                         quantity = rate.deliveryDays,
-                        default = string.shipping_label_shipping_carrier_rates_delivery_estimate_other,
+                        default = string.shipping_label_shipping_carrier_rates_delivery_estimate_many,
                         one = string.shipping_label_shipping_carrier_rates_delivery_estimate_one
                     )
                     secondLine = "$total - $deliveryDays"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -92,6 +92,7 @@ import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.PriceUtils
+import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.util.isSuccessful
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -590,9 +591,11 @@ class CreateShippingLabelViewModel @Inject constructor(
                     firstLine = rate.serviceName
 
                     val total = data.sumByBigDecimal { it.price }.format()
-                    val deliveryDays = resourceProvider.getPluralString(
-                        R.plurals.shipping_label_shipping_carrier_rates_delivery_estimate,
-                        rate.deliveryDays
+                    val deliveryDays = StringUtils.getQuantityString(
+                        resourceProvider = resourceProvider,
+                        quantity = rate.deliveryDays,
+                        default = string.shipping_label_shipping_carrier_rates_delivery_estimate_other,
+                        one = string.shipping_label_shipping_carrier_rates_delivery_estimate_one
                     )
                     secondLine = "$total - $deliveryDays"
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
@@ -26,6 +26,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrier
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrierRatesAdapter.RateListViewHolder
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrierRatesAdapter.ShippingRateItem.ShippingCarrier.*
 import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.util.StringUtils
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import java.util.*
@@ -81,14 +82,16 @@ class ShippingCarrierRatesAdapter(
                 }
             }
         }
+
         @SuppressLint("SetTextI18n")
         fun bind(rateList: PackageRateListItem) {
             binding.packageName.text = rateList.shippingPackage.getTitle(binding.root.context)
 
-            binding.packageItemsCount.text = "- ${binding.root.resources.getQuantityString(
-                R.plurals.shipping_label_package_details_items_count,
-                rateList.shippingPackage.itemsCount,
-                rateList.shippingPackage.itemsCount
+            binding.packageItemsCount.text = "- ${StringUtils.getQuantityString(
+                context = binding.packageItemsCount.context,
+                quantity = rateList.shippingPackage.itemsCount,
+                default = string.shipping_label_package_details_items_count_other,
+                one = string.shipping_label_package_details_items_count_one,
             )}"
 
             (binding.rateOptions.adapter as? RateListAdapter)?.updateRates(rateList)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
@@ -90,7 +90,7 @@ class ShippingCarrierRatesAdapter(
             binding.packageItemsCount.text = "- ${StringUtils.getQuantityString(
                 context = binding.packageItemsCount.context,
                 quantity = rateList.shippingPackage.itemsCount,
-                default = string.shipping_label_package_details_items_count_other,
+                default = string.shipping_label_package_details_items_count_many,
                 one = string.shipping_label_package_details_items_count_one,
             )}"
 
@@ -143,7 +143,7 @@ class ShippingCarrierRatesAdapter(
                         binding.deliveryTime.text = StringUtils.getQuantityString(
                             context = binding.deliveryTime.context,
                             quantity = rateItem.deliveryEstimate,
-                            default = string.shipping_label_shipping_carrier_rates_delivery_estimate_other,
+                            default = string.shipping_label_shipping_carrier_rates_delivery_estimate_many,
                             one = string.shipping_label_shipping_carrier_rates_delivery_estimate_one
                         )
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesAdapter.kt
@@ -140,10 +140,11 @@ class ShippingCarrierRatesAdapter(
                     }
                     rateItem.deliveryEstimate != 0 -> {
                         binding.deliveryTime.isVisible = true
-                        binding.deliveryTime.text = binding.root.resources.getQuantityString(
-                            R.plurals.shipping_label_shipping_carrier_rates_delivery_estimate,
-                            rateItem.deliveryEstimate,
-                            rateItem.deliveryEstimate
+                        binding.deliveryTime.text = StringUtils.getQuantityString(
+                            context = binding.deliveryTime.context,
+                            quantity = rateItem.deliveryEstimate,
+                            default = string.shipping_label_shipping_carrier_rates_delivery_estimate_other,
+                            one = string.shipping_label_shipping_carrier_rates_delivery_estimate_one
                         )
                     }
                     else -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -127,11 +127,14 @@ class ShippingLabelPackagesAdapter(
             val uiModel = uiModels[position]
             val shippingLabelPackage = uiModel.data
             binding.packageName.text = shippingLabelPackage.getTitle(context)
-            binding.packageItemsCount.text = "- ${context.resources.getQuantityString(
-                R.plurals.shipping_label_package_details_items_count,
-                shippingLabelPackage.itemsCount,
-                shippingLabelPackage.itemsCount
+
+            binding.packageItemsCount.text = "- ${StringUtils.getQuantityString(
+                context = binding.packageItemsCount.context,
+                quantity = shippingLabelPackage.itemsCount,
+                default = R.string.shipping_label_package_details_items_count_other,
+                one = R.string.shipping_label_package_details_items_count_one,
             )}"
+
             binding.errorView.isVisible = !uiModel.isValid
             with(binding.itemsList.adapter as PackageProductsAdapter) {
                 items = shippingLabelPackage.adaptItemsForUi()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -129,7 +129,7 @@ class ShippingLabelPackagesAdapter(
             binding.packageName.text = shippingLabelPackage.getTitle(context)
 
             binding.packageItemsCount.text = "- ${StringUtils.getQuantityString(
-                context = binding.packageItemsCount.context,
+                context = context,
                 quantity = shippingLabelPackage.itemsCount,
                 default = R.string.shipping_label_package_details_items_count_other,
                 one = R.string.shipping_label_package_details_items_count_one,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -131,7 +131,7 @@ class ShippingLabelPackagesAdapter(
             binding.packageItemsCount.text = "- ${StringUtils.getQuantityString(
                 context = context,
                 quantity = shippingLabelPackage.itemsCount,
-                default = R.string.shipping_label_package_details_items_count_other,
+                default = R.string.shipping_label_package_details_items_count_many,
                 one = R.string.shipping_label_package_details_items_count_one,
             )}"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/LinkedProductsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/LinkedProductsFragment.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.extensions.show
 import com.woocommerce.android.ui.products.GroupedProductListType.CROSS_SELLS
 import com.woocommerce.android.ui.products.GroupedProductListType.UPSELLS
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitLinkedProducts
+import com.woocommerce.android.util.StringUtils
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -76,7 +77,12 @@ class LinkedProductsFragment : BaseProductFragment(R.layout.fragment_linked_prod
 
         val numUpsells = viewModel.getProduct().productDraft?.upsellProductIds?.size ?: 0
         if (numUpsells > 0) {
-            binding.upsellsCount.text = resources.getQuantityString(R.plurals.product_count, numUpsells, numUpsells)
+            binding.upsellsCount.text = StringUtils.getQuantityString(
+                context = requireContext(),
+                quantity = numUpsells,
+                default = R.string.product_count_other,
+                one = R.string.product_count_one,
+            )
             binding.upsellsCount.show()
             binding.addUpsellProducts.text = getString(R.string.edit_products_button)
         } else {
@@ -86,10 +92,11 @@ class LinkedProductsFragment : BaseProductFragment(R.layout.fragment_linked_prod
 
         val numCrossSells = viewModel.getProduct().productDraft?.crossSellProductIds?.size ?: 0
         if (numCrossSells > 0) {
-            binding.crossSellsCount.text = resources.getQuantityString(
-                R.plurals.product_count,
-                numCrossSells,
-                numCrossSells
+            binding.crossSellsCount.text = StringUtils.getQuantityString(
+                context = requireContext(),
+                quantity = numCrossSells,
+                default = R.string.product_count_other,
+                one = R.string.product_count_one,
             )
             binding.crossSellsCount.show()
             binding.addCrossSellProducts.text = getString(R.string.edit_products_button)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/LinkedProductsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/LinkedProductsFragment.kt
@@ -80,7 +80,7 @@ class LinkedProductsFragment : BaseProductFragment(R.layout.fragment_linked_prod
             binding.upsellsCount.text = StringUtils.getQuantityString(
                 context = requireContext(),
                 quantity = numUpsells,
-                default = R.string.product_count_other,
+                default = R.string.product_count_many,
                 one = R.string.product_count_one,
             )
             binding.upsellsCount.show()
@@ -95,7 +95,7 @@ class LinkedProductsFragment : BaseProductFragment(R.layout.fragment_linked_prod
             binding.crossSellsCount.text = StringUtils.getQuantityString(
                 context = requireContext(),
                 quantity = numCrossSells,
-                default = R.string.product_count_other,
+                default = R.string.product_count_many,
                 one = R.string.product_count_one,
             )
             binding.crossSellsCount.show()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -458,10 +458,11 @@ class ProductDetailCardBuilder(
     private fun Product.linkedProducts(): ProductProperty? {
         if (!hasLinkedProducts()) return null
 
-        val upsellDesc = StringUtils.getPluralString(
-            resources,
-            this.upsellProductIds.size,
-            R.plurals.upsell_product_count
+        val upsellDesc = StringUtils.getQuantityString(
+            resourceProvider = resources,
+            quantity = this.upsellProductIds.size,
+            one = string.upsell_product_count_one,
+            default = string.upsell_product_count_other,
         )
         val crossSellDesc = StringUtils.getQuantityString(
             resourceProvider = resources,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -463,10 +463,11 @@ class ProductDetailCardBuilder(
             this.upsellProductIds.size,
             R.plurals.upsell_product_count
         )
-        val crossSellDesc = StringUtils.getPluralString(
-            resources,
-            this.crossSellProductIds.size,
-            R.plurals.cross_sell_product_count
+        val crossSellDesc = StringUtils.getQuantityString(
+            resourceProvider = resources,
+            quantity = this.crossSellProductIds.size,
+            one = string.cross_sell_product_count_one,
+            default = string.cross_sell_product_count_other,
         )
 
         return ComplexProperty(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -434,7 +434,7 @@ class ProductDetailCardBuilder(
             StringUtils.getQuantityString(
                 resourceProvider = resources,
                 quantity = groupedProductsSize,
-                default = string.product_count_other,
+                default = string.product_count_many,
                 one = string.product_count_one,
             )
         } else {
@@ -461,13 +461,13 @@ class ProductDetailCardBuilder(
             resourceProvider = resources,
             quantity = this.upsellProductIds.size,
             one = string.upsell_product_count_one,
-            default = string.upsell_product_count_other,
+            default = string.upsell_product_count_many,
         )
         val crossSellDesc = StringUtils.getQuantityString(
             resourceProvider = resources,
             quantity = this.crossSellProductIds.size,
             one = string.cross_sell_product_count_one,
-            default = string.cross_sell_product_count_other,
+            default = string.cross_sell_product_count_many,
         )
 
         return ComplexProperty(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.products
 
-import com.woocommerce.android.R
 import com.woocommerce.android.R.drawable
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsTracker

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -432,7 +432,12 @@ class ProductDetailCardBuilder(
         val showTitle = groupedProductsSize > 0
 
         val groupedProductsDesc = if (showTitle) {
-            StringUtils.getPluralString(resources, groupedProductsSize, R.plurals.product_count)
+            StringUtils.getQuantityString(
+                resourceProvider = resources,
+                quantity = groupedProductsSize,
+                default = string.product_count_other,
+                one = string.product_count_one,
+            )
         } else {
             resources.getString(string.grouped_product_empty)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
@@ -8,7 +8,6 @@ import android.os.Build
 import android.text.Html
 import android.text.Spanned
 import android.util.Patterns
-import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import com.woocommerce.android.extensions.isInteger
 import com.woocommerce.android.util.WooLog.T.UTILS
@@ -80,14 +79,6 @@ object StringUtils {
             1 -> resourceProvider.getString(one ?: default, quantity)
             else -> resourceProvider.getString(default, quantity)
         }
-    }
-
-    fun getPluralString(
-        resourceProvider: ResourceProvider,
-        quantity: Int,
-        @PluralsRes pluralId: Int
-    ): String {
-        return resourceProvider.getPluralString(pluralId, quantity)
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/ResourceProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/ResourceProvider.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.viewmodel
 import android.content.Context
 import androidx.annotation.ColorRes
 import androidx.annotation.DimenRes
-import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
 import javax.inject.Inject
@@ -15,10 +14,6 @@ class ResourceProvider @Inject constructor(private val context: Context) {
 
     fun getString(@StringRes resourceId: Int, vararg formatArgs: Any): String {
         return context.getString(resourceId, *formatArgs)
-    }
-
-    fun getPluralString(@PluralsRes pluralsId: Int, quantity: Int): String {
-        return context.resources.getQuantityString(pluralsId, quantity, quantity)
     }
 
     fun getColor(@ColorRes resourceId: Int): Int {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -498,7 +498,7 @@
     <string name="shipping_label_package_details_weight_info">Includes package weight</string>
     <string name="shipping_label_packages_loading_error">Unable to load package definitions</string>
     <string name="shipping_label_package_details_items_count_one">%d item</string>
-    <string name="shipping_label_package_details_items_count_other">%d items</string>
+    <string name="shipping_label_package_details_items_count_many">%d items</string>
     <string name="shipping_label_package_details_individual_package_subtitle">Individually Shipped Item</string>
     <string name="shipping_label_package_details_individual_package_dimensions">Item Dimensions</string>
     <string name="shipping_label_package_details_individual_package_title">Original packaging</string>
@@ -560,7 +560,7 @@
     <string name="shipping_label_shipping_carrier_rates_unavailable_title">No shipping rates available</string>
     <string name="shipping_label_shipping_carrier_rates_unavailable_message">Please double check your package dimensions and weight or try using a different package in Package Details</string>
     <string name="shipping_label_shipping_carrier_rates_delivery_estimate_one">%d business day</string>
-    <string name="shipping_label_shipping_carrier_rates_delivery_estimate_other">%d business days</string>
+    <string name="shipping_label_shipping_carrier_rates_delivery_estimate_many">%d business days</string>
     <string name="shipping_label_shipping_carrier_rates_generic_error">There was an error loading shipping options</string>
     <string name="shipping_label_woo_discount_bottomsheet_title">What is WooCommerce  Services discount?</string>
     <string name="shipping_label_woo_discount_bottomsheet_message" formatted="false">When purchasing shipping labels with WooCommerce, you get 5% to 40% off compared to post office rates.</string>
@@ -660,7 +660,7 @@
     <string name="order_refunds_refund_shipping">Refund shipping</string>
     <string name="order_refunds_refund_in_progress">Refund in progress, please wait…</string>
     <string name="order_refunds_refund_info_description_one">%d item</string>
-    <string name="order_refunds_refund_info_description_other">%d items</string>
+    <string name="order_refunds_refund_info_description_many">%d items</string>
     <string name="order_refunds_refund_info_title">Refunded products</string>
     <string name="order_refunds_shipping_refund_variable_notice">You can refund %1$s</string>
     <string name="order_refunds_store_admin_link_text">in your store admin</string>
@@ -1132,11 +1132,11 @@
     <string name="product_add_ons_card_button_title">Product Add-ons</string>
     <string name="product_add_ons_details_info_notice">You can edit product add-ons in the web dashboard.</string>
     <string name="product_count_one">%d product</string>
-    <string name="product_count_other">%d products</string>
+    <string name="product_count_many">%d products</string>
     <string name="cross_sell_product_count_one">%d cross-sell product</string>
-    <string name="cross_sell_product_count_other">%d cross-sell products</string>
+    <string name="cross_sell_product_count_many">%d cross-sell products</string>
     <string name="upsell_product_count_one">%d upsell product</string>
-    <string name="upsell_product_count_other">%d upsell products</string>
+    <string name="upsell_product_count_many">%d upsell products</string>
 
     <!--
         Product Add more details Bottom sheet

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -559,10 +559,8 @@
     <string name="shipping_label_shipping_carriers_title">Carriers and rates</string>
     <string name="shipping_label_shipping_carrier_rates_unavailable_title">No shipping rates available</string>
     <string name="shipping_label_shipping_carrier_rates_unavailable_message">Please double check your package dimensions and weight or try using a different package in Package Details</string>
-    <plurals name="shipping_label_shipping_carrier_rates_delivery_estimate">
-        <item quantity="one">%d business day</item>
-        <item quantity="other">%d business days</item>
-    </plurals>
+    <string name="shipping_label_shipping_carrier_rates_delivery_estimate_one">%d business day</string>
+    <string name="shipping_label_shipping_carrier_rates_delivery_estimate_other">%d business days</string>
     <string name="shipping_label_shipping_carrier_rates_generic_error">There was an error loading shipping options</string>
     <string name="shipping_label_woo_discount_bottomsheet_title">What is WooCommerce  Services discount?</string>
     <string name="shipping_label_woo_discount_bottomsheet_message" formatted="false">When purchasing shipping labels with WooCommerce, you get 5% to 40% off compared to post office rates.</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -497,10 +497,8 @@
     <string name="shipping_label_package_details_weight_hint">Total package weight (%1$s)</string>
     <string name="shipping_label_package_details_weight_info">Includes package weight</string>
     <string name="shipping_label_packages_loading_error">Unable to load package definitions</string>
-    <plurals name="shipping_label_package_details_items_count">
-        <item quantity="one">%d item</item>
-        <item quantity="other">%d items</item>
-    </plurals>
+    <string name="shipping_label_package_details_items_count_one">%d item</string>
+    <string name="shipping_label_package_details_items_count_other">%d items</string>
     <string name="shipping_label_package_details_individual_package_subtitle">Individually Shipped Item</string>
     <string name="shipping_label_package_details_individual_package_dimensions">Item Dimensions</string>
     <string name="shipping_label_package_details_individual_package_title">Original packaging</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -659,10 +659,8 @@
     <string name="order_refunds_select_quantity">Select quantity</string>
     <string name="order_refunds_refund_shipping">Refund shipping</string>
     <string name="order_refunds_refund_in_progress">Refund in progress, please wait…</string>
-    <plurals name="order_refunds_refund_info_description">
-        <item quantity="one">%d item</item>
-        <item quantity="other">%d items</item>
-    </plurals>
+    <string name="order_refunds_refund_info_description_one">%d item</string>
+    <string name="order_refunds_refund_info_description_other">%d items</string>
     <string name="order_refunds_refund_info_title">Refunded products</string>
     <string name="order_refunds_shipping_refund_variable_notice">You can refund %1$s</string>
     <string name="order_refunds_store_admin_link_text">in your store admin</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1133,10 +1133,8 @@
     <string name="product_add_ons_details_info_notice">You can edit product add-ons in the web dashboard.</string>
     <string name="product_count_one">%d product</string>
     <string name="product_count_other">%d products</string>
-    <plurals name="cross_sell_product_count">
-        <item quantity="one">%d cross-sell product</item>
-        <item quantity="other">%d cross-sell products</item>
-    </plurals>
+    <string name="cross_sell_product_count_one">%d cross-sell product</string>
+    <string name="cross_sell_product_count_other">%d cross-sell products</string>
     <plurals name="upsell_product_count">
         <item quantity="one">%d upsell product</item>
         <item quantity="other">%d upsell products</item>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1131,11 +1131,8 @@
     <string name="empty_product_message">Start selling today by adding your first product to the store.</string>
     <string name="product_add_ons_card_button_title">Product Add-ons</string>
     <string name="product_add_ons_details_info_notice">You can edit product add-ons in the web dashboard.</string>
-
-    <plurals name="product_count">
-        <item quantity="one">%d product</item>
-        <item quantity="other">%d products</item>
-    </plurals>
+    <string name="product_count_one">%d product</string>
+    <string name="product_count_other">%d products</string>
     <plurals name="cross_sell_product_count">
         <item quantity="one">%d cross-sell product</item>
         <item quantity="other">%d cross-sell products</item>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1135,10 +1135,8 @@
     <string name="product_count_other">%d products</string>
     <string name="cross_sell_product_count_one">%d cross-sell product</string>
     <string name="cross_sell_product_count_other">%d cross-sell products</string>
-    <plurals name="upsell_product_count">
-        <item quantity="one">%d upsell product</item>
-        <item quantity="other">%d upsell products</item>
-    </plurals>
+    <string name="upsell_product_count_one">%d upsell product</string>
+    <string name="upsell_product_count_other">%d upsell products</string>
 
     <!--
         Product Add more details Bottom sheet

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -2,6 +2,8 @@
 
 During development, adding a string in the [`values/strings.xml`](../WooCommerce/src/main/res/values/strings.xml) resource and using it in the code or layout file should be enough.
 
+**Important:** `plurals` are not supported at the moment. Use `StringUtils::getQuantityString` method.
+
 ```xml
 <!-- strings.xml -->
 <string name="orderdetail_shipping_details">Shipping details</string>


### PR DESCRIPTION
### Replacing plurals with common strings

Closes: #4627 

### Description
GlotPress does not support plurals at the moment, so we can not use them. I replaced them. Also, added this fact into the doc.

One commit contains replacing of one plural

### Testing instructions

Run:
* Shipping label creation
* Order refund
* Product creation

flows and check the work of that changed string as expected with different quantities


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
