### PR TITLE
Commit for changing text from "Update" to "Save" in Product Details screen.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -84,7 +84,7 @@ class ProductDetailFragment :
     private var detailSnackbar: Snackbar? = null
 
     private val publishTitleId = R.string.product_add_tool_bar_menu_button_done
-    private val updateTitleId = R.string.save
+    private val saveTitleId = R.string.save
 
     private var _binding: FragmentProductDetailBinding? = null
     private val binding get() = _binding!!
@@ -385,7 +385,7 @@ class ProductDetailFragment :
         menu.findItem(R.id.menu_save_as_draft)?.isVisible = viewModel.canBeStoredAsDraft && viewModel.hasChanges()
 
         updateMenuItem?.let {
-            it.title = if (viewModel.isAddFlowEntryPoint) getString(publishTitleId) else getString(updateTitleId)
+            it.title = if (viewModel.isAddFlowEntryPoint) getString(publishTitleId) else getString(saveTitleId)
             it.isVisible = viewModel.hasChanges() or viewModel.isProductUnderCreation
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -84,7 +84,7 @@ class ProductDetailFragment :
     private var detailSnackbar: Snackbar? = null
 
     private val publishTitleId = R.string.product_add_tool_bar_menu_button_done
-    private val updateTitleId = R.string.update
+    private val updateTitleId = R.string.save
 
     private var _binding: FragmentProductDetailBinding? = null
     private val binding get() = _binding!!
@@ -218,7 +218,7 @@ class ProductDetailFragment :
             new.isSkeletonShown?.takeIfNotEqualTo(old?.isSkeletonShown) { showSkeleton(it) }
             new.isProgressDialogShown?.takeIfNotEqualTo(old?.isProgressDialogShown) {
                 if (it) {
-                    showProgressDialog(R.string.product_update_dialog_title, R.string.product_update_dialog_message)
+                    showProgressDialog(R.string.product_save_dialog_title, R.string.product_update_dialog_message)
                 } else {
                     hideProgressDialog()
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -715,7 +715,7 @@ class ProductDetailViewModel @Inject constructor(
      */
     private fun pickProductUpdateSuccessText() =
         if (isAddFlowEntryPoint) string.product_detail_publish_product_success
-        else string.product_detail_update_product_success
+        else string.product_detail_save_product_success
 
     private fun pickAddProductRequestSnackbarText(productWasAdded: Boolean, requestedProductStatus: ProductStatus) =
         if (productWasAdded) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
@@ -217,7 +217,7 @@ class VariationDetailFragment :
             }
             new.isSkeletonShown?.takeIfNotEqualTo(old?.isSkeletonShown) { showSkeleton(it) }
             new.isProgressDialogShown?.takeIfNotEqualTo(old?.isProgressDialogShown) {
-                showProgressDialog(it, R.string.product_update_dialog_title)
+                showProgressDialog(it, R.string.product_save_dialog_title)
             }
             new.isDoneButtonVisible?.takeIfNotEqualTo(old?.isDoneButtonVisible) {
                 doneOrUpdateMenuItem?.isVisible = it

--- a/WooCommerce/src/main/res/layout/view_progress_dialog.xml
+++ b/WooCommerce/src/main/res/layout/view_progress_dialog.xml
@@ -19,7 +19,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="@string/product_update_dialog_title"/>
+        tools:text="@string/product_save_dialog_title"/>
 
     <ProgressBar
         android:id="@+id/progress_bar"

--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -749,10 +749,10 @@ Language: ar
     <string name="orderlist_loading">جارٍ البحث عن طلباتك…</string>
     <string name="product_detail_editable_text_hint">إدخال نص</string>
     <string name="product_detail_title_hint">إدخال عنوان الموقع</string>
-    <string name="product_detail_update_product_success">تم تحديث المنتج</string>
+    <string name="product_detail_save_product_success">تم تحديث المنتج</string>
     <string name="product_detail_update_product_error">خطأ في أثناء تحرير المنتج</string>
     <string name="product_update_dialog_message">يُرجى الانتظار…</string>
-    <string name="product_update_dialog_title">تحديث المنتج</string>
+    <string name="product_save_dialog_title">تحديث المنتج</string>
     <string name="product_description_empty">وصف منتجك</string>
     <string name="product_description">الوصف</string>
     <string name="product_edit_description">تحرير الوصف</string>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -749,10 +749,10 @@ Language: de
     <string name="orderlist_loading">Deine Bestellungen werden abgerufen …</string>
     <string name="product_detail_editable_text_hint">Text eingeben</string>
     <string name="product_detail_title_hint">Produkttitel eingeben</string>
-    <string name="product_detail_update_product_success">Produkt aktualisiert</string>
+    <string name="product_detail_save_product_success">Produkt aktualisiert</string>
     <string name="product_detail_update_product_error">Fehler beim Aktualisieren des Produkts</string>
     <string name="product_update_dialog_message">Bitte warten …</string>
-    <string name="product_update_dialog_title">Produkt aktualisieren</string>
+    <string name="product_save_dialog_title">Produkt aktualisieren</string>
     <string name="product_description_empty">Produkt beschreiben</string>
     <string name="product_description">Beschreibung</string>
     <string name="product_edit_description">Beschreibung bearbeiten</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -749,10 +749,10 @@ Language: es
     <string name="orderlist_loading">Buscando tus pedidos…</string>
     <string name="product_detail_editable_text_hint">Introduce texto</string>
     <string name="product_detail_title_hint">Introduce el título del producto</string>
-    <string name="product_detail_update_product_success">Se ha actualizado el producto</string>
+    <string name="product_detail_save_product_success">Se ha actualizado el producto</string>
     <string name="product_detail_update_product_error">Se ha producido un error al actualizar el producto</string>
     <string name="product_update_dialog_message">Por favor, espera…</string>
-    <string name="product_update_dialog_title">Actualizando el producto</string>
+    <string name="product_save_dialog_title">Actualizando el producto</string>
     <string name="product_description_empty">Describe tu producto</string>
     <string name="product_description">Descripción</string>
     <string name="product_edit_description">Editar descripción</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -749,10 +749,10 @@ Language: fr
     <string name="orderlist_loading">Recherche dans vos commandes…</string>
     <string name="product_detail_editable_text_hint">Saisissez du texte</string>
     <string name="product_detail_title_hint">Entrer le nom du produit</string>
-    <string name="product_detail_update_product_success">Produit mis à jour</string>
+    <string name="product_detail_save_product_success">Produit mis à jour</string>
     <string name="product_detail_update_product_error">Erreur lors de la mise à jour du produit</string>
     <string name="product_update_dialog_message">Veuillez patienter…</string>
-    <string name="product_update_dialog_title">Mise à jour du produit</string>
+    <string name="product_save_dialog_title">Mise à jour du produit</string>
     <string name="product_description_empty">Décrivez votre produit</string>
     <string name="product_description">Description</string>
     <string name="product_edit_description">Modifier la description</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -749,10 +749,10 @@ Language: he_IL
     <string name="orderlist_loading">מחפש את ההזמנות שלך…</string>
     <string name="product_detail_editable_text_hint">להזין טקסט</string>
     <string name="product_detail_title_hint">להזין את שם המוצר</string>
-    <string name="product_detail_update_product_success">המוצר עודכן</string>
+    <string name="product_detail_save_product_success">המוצר עודכן</string>
     <string name="product_detail_update_product_error">שגיאה בעדכון המוצר</string>
     <string name="product_update_dialog_message">נא להמתין…</string>
-    <string name="product_update_dialog_title">מעדכן את המוצר</string>
+    <string name="product_save_dialog_title">מעדכן את המוצר</string>
     <string name="product_description_empty">יש לתאר את המוצר שלך</string>
     <string name="product_description">תיאור</string>
     <string name="product_edit_description">לערוך את התיאור</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -749,10 +749,10 @@ Language: id
     <string name="orderlist_loading">Mencari pesanan Anda…</string>
     <string name="product_detail_editable_text_hint">Masukkan teks</string>
     <string name="product_detail_title_hint">Masukkan Nama Produk</string>
-    <string name="product_detail_update_product_success">Produk diperbarui</string>
+    <string name="product_detail_save_product_success">Produk diperbarui</string>
     <string name="product_detail_update_product_error">Error saat memperbarui produk</string>
     <string name="product_update_dialog_message">Harap tunggu…</string>
-    <string name="product_update_dialog_title">Memperbarui produk</string>
+    <string name="product_save_dialog_title">Memperbarui produk</string>
     <string name="product_description_empty">Deskripsikan produk Anda</string>
     <string name="product_description">Deskripsi</string>
     <string name="product_edit_description">Sunting deskripsi</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -700,10 +700,10 @@ Language: it
     <string name="orderlist_loading">Ricerca dei tuoi ordini in corso…</string>
     <string name="product_detail_editable_text_hint">Inserisci testo</string>
     <string name="product_detail_title_hint">Inserisci il titolo del prodotto</string>
-    <string name="product_detail_update_product_success">Prodotto aggiornato</string>
+    <string name="product_detail_save_product_success">Prodotto aggiornato</string>
     <string name="product_detail_update_product_error">Errore durante l\'aggiornamento del prodotto</string>
     <string name="product_update_dialog_message">Attendi…</string>
-    <string name="product_update_dialog_title">Aggiornamento prodotto</string>
+    <string name="product_save_dialog_title">Aggiornamento prodotto</string>
     <string name="product_description_empty">Descrivi il tuo prodotto</string>
     <string name="product_description">Descrizione</string>
     <string name="product_edit_description">Modifica descrizione</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -749,10 +749,10 @@ Language: ja_JP
     <string name="orderlist_loading">注文を検索しています…</string>
     <string name="product_detail_editable_text_hint">テキストを入力</string>
     <string name="product_detail_title_hint">商品名を入力</string>
-    <string name="product_detail_update_product_success">商品更新</string>
+    <string name="product_detail_save_product_success">商品更新</string>
     <string name="product_detail_update_product_error">商品の更新中にエラーが発生しました。</string>
     <string name="product_update_dialog_message">しばらくお待ちください…</string>
-    <string name="product_update_dialog_title">商品を更新しています</string>
+    <string name="product_save_dialog_title">商品を更新しています</string>
     <string name="product_description_empty">商品を説明</string>
     <string name="product_description">説明</string>
     <string name="product_edit_description">説明を編集</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -749,10 +749,10 @@ Language: ko_KR
     <string name="orderlist_loading">주문 검색 중…</string>
     <string name="product_detail_editable_text_hint">텍스트 입력</string>
     <string name="product_detail_title_hint">제품 제목 입력</string>
-    <string name="product_detail_update_product_success">제품 업데이트됨</string>
+    <string name="product_detail_save_product_success">제품 업데이트됨</string>
     <string name="product_detail_update_product_error">제품을 업데이트하는 중 오류 발생</string>
     <string name="product_update_dialog_message">기다려주세요…</string>
-    <string name="product_update_dialog_title">제품을 업데이트하는 중</string>
+    <string name="product_save_dialog_title">제품을 업데이트하는 중</string>
     <string name="product_description_empty">제품 설명</string>
     <string name="product_description">설명</string>
     <string name="product_edit_description">설명 수정</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -749,10 +749,10 @@ Language: nl
     <string name="orderlist_loading">Je bestellingen worden opgezocht …</string>
     <string name="product_detail_editable_text_hint">Voer tekst in</string>
     <string name="product_detail_title_hint">Voer producttitel</string>
-    <string name="product_detail_update_product_success">Product bijgewerkt</string>
+    <string name="product_detail_save_product_success">Product bijgewerkt</string>
     <string name="product_detail_update_product_error">Bijwerken product mislukt</string>
     <string name="product_update_dialog_message">Een moment geduld…</string>
-    <string name="product_update_dialog_title">Product wordt bijgewerkt</string>
+    <string name="product_save_dialog_title">Product wordt bijgewerkt</string>
     <string name="product_description_empty">Beschrijf je product</string>
     <string name="product_description">Beschrijving</string>
     <string name="product_edit_description">Beschrijving bewerken</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -748,10 +748,10 @@ Language: pt_BR
     <string name="orderlist_loading">Procurando por pedidos…</string>
     <string name="product_detail_editable_text_hint">Inserir texto</string>
     <string name="product_detail_title_hint">Insira o título do produto</string>
-    <string name="product_detail_update_product_success">Produto atualizado</string>
+    <string name="product_detail_save_product_success">Produto atualizado</string>
     <string name="product_detail_update_product_error">Erro ao atualizar produto</string>
     <string name="product_update_dialog_message">Aguarde…</string>
-    <string name="product_update_dialog_title">Atualizando produto</string>
+    <string name="product_save_dialog_title">Atualizando produto</string>
     <string name="product_description_empty">Descreva o produto</string>
     <string name="product_description">Descrição</string>
     <string name="product_edit_description">Editar descrição</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -749,10 +749,10 @@ Language: ru
     <string name="orderlist_loading">Просмотр информации о ваших заказах…</string>
     <string name="product_detail_editable_text_hint">Введите текст</string>
     <string name="product_detail_title_hint">Введите название товара</string>
-    <string name="product_detail_update_product_success">Продукт обновлен</string>
+    <string name="product_detail_save_product_success">Продукт обновлен</string>
     <string name="product_detail_update_product_error">Ошибка обновления продукта</string>
     <string name="product_update_dialog_message">Пожалуйста, подождите…</string>
-    <string name="product_update_dialog_title">Обновление продукта</string>
+    <string name="product_save_dialog_title">Обновление продукта</string>
     <string name="product_description_empty">Опишите продукт</string>
     <string name="product_description">Описание</string>
     <string name="product_edit_description">Редактировать описание</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -750,10 +750,10 @@ Language: sv_SE
     <string name="orderlist_loading">Kollar upp din beställning…</string>
     <string name="product_detail_editable_text_hint">Ange text</string>
     <string name="product_detail_title_hint">Ange produktrubrik</string>
-    <string name="product_detail_update_product_success">Produkt uppdaterad</string>
+    <string name="product_detail_save_product_success">Produkt uppdaterad</string>
     <string name="product_detail_update_product_error">Det gick inte att uppdatera produkten</string>
     <string name="product_update_dialog_message">Vänta …</string>
-    <string name="product_update_dialog_title">Uppdaterar produkt</string>
+    <string name="product_save_dialog_title">Uppdaterar produkt</string>
     <string name="product_description_empty">Beskriv din produkt</string>
     <string name="product_description">Beskrivning</string>
     <string name="product_edit_description">Redigera beskrivning</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -749,10 +749,10 @@ Language: tr
     <string name="orderlist_loading">Siparişleriniz aranıyor…</string>
     <string name="product_detail_editable_text_hint">Metin girin</string>
     <string name="product_detail_title_hint">Ürün Başlığını Gir</string>
-    <string name="product_detail_update_product_success">Ürün güncellendi</string>
+    <string name="product_detail_save_product_success">Ürün güncellendi</string>
     <string name="product_detail_update_product_error">Ürün güncellenirken hata oluştu</string>
     <string name="product_update_dialog_message">Lütfen bekleyin…</string>
-    <string name="product_update_dialog_title">Ürün güncelleniyor</string>
+    <string name="product_save_dialog_title">Ürün güncelleniyor</string>
     <string name="product_description_empty">Ürününüzü tanımlayın</string>
     <string name="product_description">Tanım</string>
     <string name="product_edit_description">Tanımı düzenle</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -749,10 +749,10 @@ Language: zh_CN
     <string name="orderlist_loading">正在查找您的订单…</string>
     <string name="product_detail_editable_text_hint">输入文本</string>
     <string name="product_detail_title_hint">输入产品标题</string>
-    <string name="product_detail_update_product_success">产品已更新</string>
+    <string name="product_detail_save_product_success">产品已更新</string>
     <string name="product_detail_update_product_error">更新产品时出错</string>
     <string name="product_update_dialog_message">请稍候…</string>
-    <string name="product_update_dialog_title">正在更新产品</string>
+    <string name="product_save_dialog_title">正在更新产品</string>
     <string name="product_description_empty">描述您的产品</string>
     <string name="product_description">描述</string>
     <string name="product_edit_description">编辑描述</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -749,10 +749,10 @@ Language: zh_TW
     <string name="orderlist_loading">查詢你的訂單…</string>
     <string name="product_detail_editable_text_hint">輸入文字</string>
     <string name="product_detail_title_hint">請輸入商品標題</string>
-    <string name="product_detail_update_product_success">商品已更新</string>
+    <string name="product_detail_save_product_success">商品已更新</string>
     <string name="product_detail_update_product_error">更新商品時發生錯誤</string>
     <string name="product_update_dialog_message">請稍候…</string>
-    <string name="product_update_dialog_title">更新商品</string>
+    <string name="product_save_dialog_title">更新商品</string>
     <string name="product_description_empty">請描述你的產品</string>
     <string name="product_description">說明</string>
     <string name="product_edit_description">編輯說明</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -107,6 +107,7 @@
     <string name="type">Type</string>
     <string name="try_again">Try again</string>
     <string name="update">Update</string>
+    <string name="save">Save</string>
     <string name="skip">Skip</string>
     <string name="discard_message">Do you want to discard your changes?</string>
     <string name="discard_images_message">Product images are still uploading. Do you want to discard your changes?</string>
@@ -1045,11 +1046,11 @@
     <string name="product_description_empty">Describe your product</string>
     <string name="product_short_description">Short description</string>
     <string name="product_short_description_empty">Brief summary about the product</string>
-    <string name="product_update_dialog_title">Updating product</string>
+    <string name="product_save_dialog_title">Saving your product</string>
     <string name="product_delete_dialog_title">Deleting product</string>
     <string name="product_update_dialog_message">Please wait…</string>
     <string name="product_detail_update_product_error">Error updating product</string>
-    <string name="product_detail_update_product_success">Product updated</string>
+    <string name="product_detail_save_product_success">Product saved</string>
     <string name="product_detail_update_product_password_error">Error updating password</string>
     <string name="product_detail_title_hint">Enter Product Title</string>
     <string name="product_detail_editable_text_hint">Enter text</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -428,7 +428,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
         var successSnackbarShown = false
         viewModel.event.observeForever {
-            if (it is ShowSnackbar && it.message == R.string.product_detail_update_product_success) {
+            if (it is ShowSnackbar && it.message == R.string.product_detail_save_product_success) {
                 successSnackbarShown = true
             }
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -320,7 +320,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
             verify(productRepository, times(1)).updateProduct(any())
 
             viewModel.event.observeForever {
-                if (it is ShowSnackbar && it.message == R.string.product_detail_update_product_success) {
+                if (it is ShowSnackbar && it.message == R.string.product_detail_save_product_success) {
                     successSnackbarShown = true
                 }
             }


### PR DESCRIPTION


<!-- Remember about a good descriptive title. -->

Closes: #4362 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR changes the text from **Update** to **Save** in the `Product Detail` screen to match iOS. Basically, there are three text changes which are as follows
1. **Update** to **Save**
2. **Updating product** to **Saving your product**
3. **Product updated** to **Product saved**
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
1. Go to the `Products` tab
2. Select any Product by clicking on it which takes you to the `Product Detail` screen.
3. In the `Product Detail` screen, change any of the attributes (Price, Inventory, Categories..etc). Basically, update your product.
4. Once updated, come back to the `Product Listing` screen by clicking the back button
5. Here, you should see **Save** text in the toolbar instead of **Update**
6. Click on **Save** text, you will see progress dialog which should contain the title as **Saving your product** instead of **Updating product**
7. Once the dialog dismisses, you should see Snackbar with the message **Product saved** instead of **Product updated**
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Gif
<img src="https://user-images.githubusercontent.com/1331230/129713433-90d6578e-c964-405a-828f-2e26a73deff8.gif" width="300" height="600">
<br>

### Screenshots
<img src="https://user-images.githubusercontent.com/1331230/129713967-91357cf7-09a8-4730-98fc-6d89900d13d5.png" width="300" height="600"> 
<img src="https://user-images.githubusercontent.com/1331230/129714299-fca4ea18-5585-497a-ac13-99d965429a38.png" width="300" height="600">
<img src="https://user-images.githubusercontent.com/1331230/129714575-67a97da4-00b8-4177-8d90-ca8041fc51d2.png" width="300" height="600">


<!-- Include before and after images or gifs when appropriate. -->


- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
