### PR TITLE
Add pending review status to unapproved  reviews

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListAdapter.kt
@@ -37,7 +37,7 @@ class ReviewListAdapter(
     private val removedRemoteIds = HashSet<Long>()
 
     interface OnReviewClickListener {
-        fun onReviewClick(review: ProductReview) { }
+        fun onReviewClick(review: ProductReview) {}
     }
 
     fun setReviews(reviews: List<ProductReview>) {
@@ -352,8 +352,12 @@ class ReviewListAdapter(
         override fun onBindItemViewHolder(holder: ViewHolder, position: Int) {
             val review = list[position]
             val itemHolder = holder as ItemViewHolder
-            itemHolder.bind(review, position, getContentItemsTotal(),
-                reviewStatus = ProductReviewStatus.fromString(review.status))
+            itemHolder.bind(
+                review,
+                position,
+                getContentItemsTotal(),
+                reviewStatus = ProductReviewStatus.fromString(review.status)
+            )
             itemHolder.itemView.setOnClickListener {
                 clickListener.onReviewClick(review)
             }
@@ -431,14 +435,15 @@ class ReviewListAdapter(
                 viewBinding.notifDivider.visibility = View.INVISIBLE
             }
         }
+
         private fun getPendingReviewLabel() =
             "<font color=$pendingLabelColor>${context.getString(R.string.pending_review_label)}</font>"
     }
-    }
+}
 
-    private class HeaderViewHolder(val viewBinding: OrderListHeaderBinding) :
-        RecyclerView.ViewHolder(viewBinding.root) {
-        fun bind(@StringRes headerId: Int) {
-            viewBinding.orderListHeader.text = viewBinding.root.context.getString(headerId)
-        }
+private class HeaderViewHolder(val viewBinding: OrderListHeaderBinding) :
+    RecyclerView.ViewHolder(viewBinding.root) {
+    fun bind(@StringRes headerId: Int) {
+        viewBinding.orderListHeader.text = viewBinding.root.context.getString(headerId)
     }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListAdapter.kt
@@ -417,25 +417,20 @@ class ReviewListAdapter(
             val reviewText: String = StringUtils.getRawTextFromHtml(review.review)
 
             if (reviewStatus == ProductReviewStatus.HOLD) {
-
                 val pendingReviewText = getPendingReviewLabel()
                 viewBinding.notifDesc.text = HtmlCompat.fromHtml(
                     "$pendingReviewText $bullet $reviewText",
                     HtmlCompat.FROM_HTML_MODE_LEGACY
                 )
                 viewBinding.notifIcon.setColorFilter(notifsIconPendingColor)
-
             } else {
-
                 viewBinding.notifIcon.colorFilter = null
                 viewBinding.notifDesc.text = reviewText
             }
-
             if (position == totalItems - 1) {
                 viewBinding.notifDivider.visibility = View.INVISIBLE
             }
         }
-
         private fun getPendingReviewLabel() =
             "<font color=$pendingLabelColor>${context.getString(R.string.pending_review_label)}</font>"
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListAdapter.kt
@@ -1,10 +1,14 @@
 package com.woocommerce.android.ui.reviews
 
 import android.content.Context
+import android.text.Spannable
+import android.text.SpannableStringBuilder
+import android.text.style.ForegroundColorSpan
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.StringRes
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.woocommerce.android.R
@@ -350,7 +354,8 @@ class ReviewListAdapter(
         override fun onBindItemViewHolder(holder: ViewHolder, position: Int) {
             val review = list[position]
             val itemHolder = holder as ItemViewHolder
-            itemHolder.bind(review, position, getContentItemsTotal())
+            itemHolder.bind(review, position, getContentItemsTotal(),
+                reviewStatus = ProductReviewStatus.fromString(review.status))
             itemHolder.itemView.setOnClickListener {
                 clickListener.onReviewClick(review)
             }
@@ -383,7 +388,7 @@ class ReviewListAdapter(
 
     private class ItemViewHolder(val viewBinding: NotifsListItemBinding) :
         RecyclerView.ViewHolder(viewBinding.root) {
-        fun bind(review: ProductReview, position: Int, totalItems: Int) {
+        fun bind(review: ProductReview, position: Int, totalItems: Int, reviewStatus: ProductReviewStatus) {
             viewBinding.notifRating.visibility = View.GONE
             viewBinding.notifIcon.setImageResource(R.drawable.ic_comment)
             viewBinding.notifDesc.maxLines = 2
@@ -406,7 +411,31 @@ class ReviewListAdapter(
                 )
             }
 
-            viewBinding.notifDesc.text = StringUtils.getRawTextFromHtml(review.review)
+            val pendingReviewLabel: String = viewBinding.root.context.getString(
+                R.string.pending_review_label
+            )
+            val reviewText: String = StringUtils.getRawTextFromHtml(review.review)
+            val spannableReviewText = SpannableStringBuilder(pendingReviewLabel)
+            val pendingLabelColor: Int = ContextCompat.getColor(viewBinding.root.context, R.color.woo_orange_50)
+            val notifsIconPendingColor: Int = ContextCompat.getColor(viewBinding.root.context, R.color.woo_purple_60)
+
+            spannableReviewText.setSpan(
+                ForegroundColorSpan(pendingLabelColor),
+                0, // start
+                14, // end
+                Spannable.SPAN_INCLUSIVE_INCLUSIVE
+            )
+            spannableReviewText.insert(17, reviewText)
+
+            if (reviewStatus == ProductReviewStatus.HOLD ) {
+
+                viewBinding.notifDesc.text = spannableReviewText
+                viewBinding.notifIcon.setColorFilter(notifsIconPendingColor)
+
+            } else {
+
+                viewBinding.notifDesc.text = reviewText
+            }
 
             if (position == totalItems - 1) {
                 viewBinding.notifDivider.visibility = View.INVISIBLE

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModel.kt
@@ -232,6 +232,7 @@ class ReviewListViewModel @Inject constructor(
     fun onEventMainThread(event: OnRequestModerateReviewEvent) {
         if (networkStatus.isConnected()) {
             // Send the request to the UI to show the UNDO snackbar
+            viewState = viewState.copy(isRefreshing = true)
             _moderateProductReview.value = event.request
         } else {
             // Network not connected
@@ -260,6 +261,7 @@ class ReviewListViewModel @Inject constructor(
                 sendReviewModerationUpdate(ActionStatus.ERROR)
             } else {
                 sendReviewModerationUpdate(ActionStatus.SUCCESS)
+                reloadReviewsFromCache()
             }
         }
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1916,4 +1916,5 @@
     <string name="product_downloadable_files_download_settings">Download Settings</string>
     <string name="shipping_label_payments_cant_edit_warning">Only the site owner can manage the shipping label payment methods. Please contact Store Owner %1$s (%2$s) to manage payment methods.</string>
     <string name="magic_link_not_meaning_to_create_account">Didn\'t mean to create a new account? Go back to re-enter your email address.</string>
+    <string name="pending_review_label">Pending Review • \</string>
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -922,6 +922,7 @@
     <string name="wc_mark_all_read">Mark all as read</string>
     <string name="wc_mark_all_read_success">All reviews marked as read</string>
     <string name="wc_mark_all_read_error">Error marking all reviews as read</string>
+    <string name="pending_review_label">Pending Review</string>
     <!--
         Products
     -->
@@ -1916,5 +1917,4 @@
     <string name="product_downloadable_files_download_settings">Download Settings</string>
     <string name="shipping_label_payments_cant_edit_warning">Only the site owner can manage the shipping label payment methods. Please contact Store Owner %1$s (%2$s) to manage payment methods.</string>
     <string name="magic_link_not_meaning_to_create_account">Didn\'t mean to create a new account? Go back to re-enter your email address.</string>
-    <string name="pending_review_label">Pending Review • \</string>
 </resources>


### PR DESCRIPTION
Fixes #1763

## Changes

- Adds a Pending review label and change the notif Icon colour on unapproved reviews
- Forces a reloadReviewsFromCache() after the status of a review is changed to display the new status on the review list screen. 

## Screenshots

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/129804077-bfcc631a-25af-434b-af88-f4f1affd6950.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/129804074-2725def1-8521-4d94-b858-957157bc32da.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/30724184/129804363-5a515c73-8214-4769-8f21-b2bbc81124df.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/129804361-91086d7c-9788-47b6-ad41-eed6c02db181.png" width="350"/> |

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1 - Go to WooCommerce - Settings - Products on a browser
2 - Enable Reviews
3 - Leave a new review on a product (while logged out)
4 - Open the app and navigate to the Reviews tab
5 - Note the Pending Review Label and the icon on a different colour
6 - click on the review and change the status
7 - Note the status updated on the review list screen (although it takes a few seconds)

### Video

https://d.pr/v/GJygiQ


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
