### PR TITLE
Bump min required version of WCPay

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -18,7 +18,7 @@ import javax.inject.Inject
 private val SUPPORTED_COUNTRIES = listOf("US")
 
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-const val SUPPORTED_WCPAY_VERSION = "2.5.0"
+const val SUPPORTED_WCPAY_VERSION = "2.8.2"
 
 @Suppress("TooManyFunctions")
 class CardReaderOnboardingChecker @Inject constructor(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -126,7 +126,7 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
         testBlocking {
             whenever(wooStore.fetchSitePlugins(site)).thenReturn(WooResult(listOf()))
             whenever(wooStore.getSitePlugin(site, WooCommerceStore.WooPlugin.WOO_PAYMENTS))
-                .thenReturn(buildWCPayPluginInfo(version = "2.4.0"))
+                .thenReturn(buildWCPayPluginInfo(version = "2.8.1"))
 
             val result = checker.getOnboardingState()
 


### PR DESCRIPTION
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR raises the minimal required version of WCPay plugin in flows related to in-person payments to v2.8.2. This is required in order to support "stripe customer creation". More info pdfdoF-2W-p2.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Install any version < 2.8.2 on your site ([you can download the old versions at the bottom](https://wordpress.org/plugins/woocommerce-payments/advanced/))
2. Tap on App settings 
3. Tap on In-person payments
4. Notice "Update WCPay" notice is shown
5. Install any version >=2.8.2
6. Tap on the refresh button on the "Update WCPay" screen
7. Notice the app reloads the state and doesn't show the "Update WCPay" screen again


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
