### PR TITLE
Create ordered addons view

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
@@ -56,7 +56,7 @@ class OrderDetailProductItemView @JvmOverloads constructor(
                 if (item.containsAddons && PRODUCT_ADD_ONS.isEnabled()) VISIBLE
                 else GONE
             binding.productInfoAddons.setOnClickListener { it(item) }
-        } ?: binding.productInfoAddons.let { visibility = GONE }
+        } ?: binding.productInfoAddons.let { it.visibility = GONE }
 
         productImage?.let {
             val imageSize = context.resources.getDimensionPixelSize(R.dimen.image_minor_100)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
@@ -55,9 +55,6 @@ sealed class OrderNavigationTarget : Event() {
     object ViewPrintingInstructions : OrderNavigationTarget()
     data class PreviewReceipt(val billingEmail: String, val receiptUrl: String, val orderId: Long) :
         OrderNavigationTarget()
-    data class ViewOrderedAddons(
-        val remoteOrderID: Long,
-        val orderItemID: Long,
-        val addonsProductID: Long
-        ) : OrderNavigationTarget()
+    data class ViewOrderedAddons(val remoteOrderID: Long, val orderItemID: Long, val addonsProductID: Long) :
+        OrderNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
@@ -55,6 +55,9 @@ sealed class OrderNavigationTarget : Event() {
     object ViewPrintingInstructions : OrderNavigationTarget()
     data class PreviewReceipt(val billingEmail: String, val receiptUrl: String, val orderId: Long) :
         OrderNavigationTarget()
-    data class ViewOrderedAddons(val remoteOrderID: Long, val orderItemID: Long) :
-        OrderNavigationTarget()
+    data class ViewOrderedAddons(
+        val remoteOrderID: Long,
+        val orderItemID: Long,
+        val addonsProductID: Long
+        ) : OrderNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
@@ -55,4 +55,6 @@ sealed class OrderNavigationTarget : Event() {
     object ViewPrintingInstructions : OrderNavigationTarget()
     data class PreviewReceipt(val billingEmail: String, val receiptUrl: String, val orderId: Long) :
         OrderNavigationTarget()
+    data class ViewOrderedAddons(val remoteOrderID: Long, val orderItemID: Long) :
+        OrderNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
@@ -168,7 +168,8 @@ class OrderNavigator @Inject constructor() {
                 OrderDetailFragmentDirections
                     .actionOrderDetailFragmentToOrderedAddonFragment(
                         orderId = target.remoteOrderID,
-                        orderItemId = target.orderItemID
+                        orderItemId = target.orderItemID,
+                        addonsProductId = target.addonsProductID
                     ).let { fragment.findNavController().navigateSafely(it) }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.orders.OrderNavigationTarget.StartShippingLabe
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewCreateShippingLabelInfo
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderFulfillInfo
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderedAddons
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewPrintCustomsForm
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewPrintShippingLabelInfo
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewPrintingInstructions
@@ -162,6 +163,13 @@ class OrderNavigator @Inject constructor() {
                         orderId = target.orderId
                     )
                 fragment.findNavController().navigateSafely(action)
+            }
+            is ViewOrderedAddons -> {
+                OrderDetailFragmentDirections
+                    .actionOrderDetailFragmentToOrderedAddonFragment(
+                        orderId = target.remoteOrderID,
+                        orderItemId = target.orderItemID
+                    ).let { fragment.findNavController().navigateSafely(it) }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -41,6 +41,7 @@ import com.woocommerce.android.ui.orders.OrderNavigationTarget.StartShippingLabe
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewCreateShippingLabelInfo
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderFulfillInfo
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
+import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderedAddons
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewPrintCustomsForm
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewPrintingInstructions
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewRefundedProducts
@@ -460,8 +461,9 @@ class OrderDetailViewModel @Inject constructor(
         triggerEvent(ViewOrderFulfillInfo(order.identifier))
     }
 
-    fun onViewOrderedAddonButtonTapped(product: Order.Item) {
-        // trigger OrderedAddonsFragment
+    fun onViewOrderedAddonButtonTapped(orderItem: Order.Item) {
+        // track add-ons event
+        triggerEvent(ViewOrderedAddons(orderIdSet.remoteOrderId, orderItem.itemId))
     }
 
     private fun updateOrderState() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -463,7 +463,13 @@ class OrderDetailViewModel @Inject constructor(
 
     fun onViewOrderedAddonButtonTapped(orderItem: Order.Item) {
         // track add-ons event
-        triggerEvent(ViewOrderedAddons(orderIdSet.remoteOrderId, orderItem.itemId))
+        triggerEvent(
+            ViewOrderedAddons(
+                orderIdSet.remoteOrderId,
+                orderItem.itemId,
+                orderItem.productId
+            )
+        )
     }
 
     private fun updateOrderState() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -618,7 +618,7 @@ class ProductDetailCardBuilder(
     private fun Product.addons(): ProductProperty? =
         takeIf { addons.isNotEmpty() && FeatureFlag.PRODUCT_ADD_ONS.isEnabled() }?.let {
             ComplexProperty(
-                value = resources.getString(string.product_add_ons_card_button_title),
+                value = resources.getString(string.product_add_ons_title),
                 icon = drawable.ic_gridicon_circle_plus,
                 showTitle = false,
                 onClick = { viewModel.onEditProductCardClicked(ViewProductAddonsDetails) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/AddonListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/AddonListAdapter.kt
@@ -8,13 +8,14 @@ import java.math.BigDecimal
 
 class AddonListAdapter(
     private val addons: List<ProductAddon>,
-    private val formatCurrencyForDisplay: (BigDecimal) -> String
+    private val formatCurrencyForDisplay: (BigDecimal) -> String,
+    private val orderMode: Boolean = false
 ) : RecyclerView.Adapter<AddonsViewHolder>() {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
         AddonsViewHolder(ProductAddonCard(parent.context))
 
     override fun onBindViewHolder(holder: AddonsViewHolder, position: Int) {
-        holder.addonCard.bind(addons[position], formatCurrencyForDisplay)
+        holder.addonCard.bind(addons[position], formatCurrencyForDisplay, orderMode)
     }
 
     override fun getItemCount() = addons.size

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/ProductAddonCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/ProductAddonCard.kt
@@ -48,11 +48,12 @@ class ProductAddonCard @JvmOverloads constructor(
 
     fun bind(
         addon: ProductAddon,
-        formatCurrencyForDisplay: (BigDecimal) -> String
+        formatCurrencyForDisplay: (BigDecimal) -> String,
+        orderMode: Boolean
     ) = with(binding) {
         addonName.text = addon.name
-        bindDescription(addon)
         bindOptionList(addon, formatCurrencyForDisplay)
+        if(orderMode.not()) bindDescription(addon)
     }
 
     private fun ProductAddonCardBinding.bindDescription(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/ProductAddonCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/ProductAddonCard.kt
@@ -53,7 +53,7 @@ class ProductAddonCard @JvmOverloads constructor(
     ) = with(binding) {
         addonName.text = addon.name
         bindOptionList(addon, formatCurrencyForDisplay)
-        if(orderMode.not()) bindDescription(addon)
+        if (orderMode.not()) bindDescription(addon)
     }
 
     private fun ProductAddonCardBinding.bindDescription(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
@@ -1,10 +1,26 @@
 package com.woocommerce.android.ui.products.addons.order
 
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.viewModels
 import com.woocommerce.android.R
+import com.woocommerce.android.databinding.FragmentOrderedAddonBinding
 import com.woocommerce.android.ui.base.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
+    companion object {
+        val TAG: String = OrderedAddonFragment::class.java.simpleName
+    }
 
+    private val viewModel: OrderedAddonViewModel by viewModels()
+
+    private var _binding: FragmentOrderedAddonBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        _binding = FragmentOrderedAddonBinding.bind(view)
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
@@ -1,0 +1,10 @@
+package com.woocommerce.android.ui.products.addons.order
+
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.base.BaseFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
+
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.products.addons.order
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentOrderedAddonBinding
 import com.woocommerce.android.ui.base.BaseFragment
@@ -16,11 +17,18 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
 
     private val viewModel: OrderedAddonViewModel by viewModels()
 
+    private val navArgs: OrderedAddonFragmentArgs by navArgs()
+
     private var _binding: FragmentOrderedAddonBinding? = null
     private val binding get() = _binding!!
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentOrderedAddonBinding.bind(view)
+        viewModel.start(
+            navArgs.orderId,
+            navArgs.orderItemId,
+            navArgs.addonsProductId
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
@@ -3,11 +3,19 @@ package com.woocommerce.android.ui.products.addons.order
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Observer
 import androidx.navigation.fragment.navArgs
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.LayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentOrderedAddonBinding
+import com.woocommerce.android.model.ProductAddon
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.products.addons.AddonListAdapter
+import com.woocommerce.android.util.CurrencyFormatter
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
@@ -15,20 +23,46 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
         val TAG: String = OrderedAddonFragment::class.java.simpleName
     }
 
+    @Inject lateinit var currencyFormatter: CurrencyFormatter
+
     private val viewModel: OrderedAddonViewModel by viewModels()
 
     private val navArgs: OrderedAddonFragmentArgs by navArgs()
 
     private var _binding: FragmentOrderedAddonBinding? = null
     private val binding get() = _binding!!
+    private var layoutManager: LayoutManager? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentOrderedAddonBinding.bind(view)
+        setupObservers()
         viewModel.start(
             navArgs.orderId,
             navArgs.orderItemId,
             navArgs.addonsProductId
+        )
+    }
+
+    private fun setupObservers() {
+        viewModel.orderedAddonsData
+            .observe(viewLifecycleOwner, Observer(::onOrderedAddonsReceived))
+    }
+
+    private fun onOrderedAddonsReceived(orderedAddons: List<ProductAddon>) {
+        setupRecyclerViewWith(orderedAddons, "")
+    }
+
+    private fun setupRecyclerViewWith(addonList: List<ProductAddon>, currencyCode: String) {
+        layoutManager = LinearLayoutManager(
+            activity,
+            RecyclerView.VERTICAL,
+            false
+        )
+        binding.addonsList.layoutManager = layoutManager
+        binding.addonsList.adapter = AddonListAdapter(
+            addonList,
+            currencyFormatter.buildBigDecimalFormatter(currencyCode)
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
@@ -62,7 +62,8 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
         binding.addonsList.layoutManager = layoutManager
         binding.addonsList.adapter = AddonListAdapter(
             addonList,
-            currencyFormatter.buildBigDecimalFormatter(viewModel.currencyCode)
+            currencyFormatter.buildBigDecimalFormatter(viewModel.currencyCode),
+            orderMode = true
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
@@ -50,10 +50,10 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
     }
 
     private fun onOrderedAddonsReceived(orderedAddons: List<ProductAddon>) {
-        setupRecyclerViewWith(orderedAddons, "")
+        setupRecyclerViewWith(orderedAddons)
     }
 
-    private fun setupRecyclerViewWith(addonList: List<ProductAddon>, currencyCode: String) {
+    private fun setupRecyclerViewWith(addonList: List<ProductAddon>) {
         layoutManager = LinearLayoutManager(
             activity,
             RecyclerView.VERTICAL,
@@ -62,7 +62,7 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
         binding.addonsList.layoutManager = layoutManager
         binding.addonsList.adapter = AddonListAdapter(
             addonList,
-            currencyFormatter.buildBigDecimalFormatter(currencyCode)
+            currencyFormatter.buildBigDecimalFormatter(viewModel.currencyCode)
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.products.addons.order
 
 import android.os.Bundle
 import android.view.View
+import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.navArgs
@@ -32,10 +33,16 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
     private var _binding: FragmentOrderedAddonBinding? = null
     private val binding get() = _binding!!
     private var layoutManager: LayoutManager? = null
+    private val supportActionBar
+        get() = activity
+            ?.let { it as? AppCompatActivity }
+            ?.supportActionBar
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentOrderedAddonBinding.bind(view)
+        supportActionBar?.setHomeAsUpIndicator(R.drawable.ic_gridicons_cross_24dp)
+
         setupObservers()
         viewModel.start(
             navArgs.orderId,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
@@ -44,6 +44,8 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
         )
     }
 
+    override fun getFragmentTitle() = getString(R.string.product_add_ons_title)
+
     private fun setupObservers() {
         viewModel.orderedAddonsData
             .observe(viewLifecycleOwner, Observer(::onOrderedAddonsReceived))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.ProductAddon
 import com.woocommerce.android.model.ProductAddonOption
+import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.addons.AddonRepository
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -18,10 +19,24 @@ import javax.inject.Inject
 class OrderedAddonViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val dispatchers: CoroutineDispatchers,
-    private val addonsRepository: AddonRepository
+    private val addonsRepository: AddonRepository,
+    parameterRepository: ParameterRepository
 ) : ScopedViewModel(savedState) {
+    companion object {
+        private const val KEY_PRODUCT_PARAMETERS = "key_product_parameters"
+    }
+
     private val _orderedAddons = MutableLiveData<List<ProductAddon>>()
     val orderedAddonsData: LiveData<List<ProductAddon>> = _orderedAddons
+
+    /**
+     * Provides the currencyCode for views who requires display prices
+     */
+    val currencyCode =
+        parameterRepository
+            .getParameters(KEY_PRODUCT_PARAMETERS, savedState)
+            .currencyCode
+            .orEmpty()
 
     fun start(
         orderID: Long,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/product/ProductAddonsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/product/ProductAddonsFragment.kt
@@ -48,7 +48,7 @@ class ProductAddonsFragment : BaseProductFragment(R.layout.fragment_product_addo
         }
     }
 
-    override fun getFragmentTitle() = getString(R.string.product_add_ons_card_button_title)
+    override fun getFragmentTitle() = getString(R.string.product_add_ons_title)
 
     private fun setupRecyclerViewWith(addonList: List<ProductAddon>, currencyCode: String) {
         layoutManager = LinearLayoutManager(

--- a/WooCommerce/src/main/res/layout/fragment_ordered_addon.xml
+++ b/WooCommerce/src/main/res/layout/fragment_ordered_addon.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/fragment_ordered_addon.xml
+++ b/WooCommerce/src/main/res/layout/fragment_ordered_addon.xml
@@ -1,6 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/addons_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            tools:itemCount="3"
+            tools:listitem="@layout/product_addon_card" />
+
+        <com.google.android.material.textview.MaterialTextView
+            style="@style/Woo.TextView.Caption"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/minor_10"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginEnd="@dimen/major_100"
+            android:text="@string/product_add_ons_details_info_notice"
+            android:drawableStart="@drawable/ic_info_outline_24dp"
+            android:drawablePadding="@dimen/minor_100"
+            android:gravity="center_vertical"
+            android:visibility="visible"
+            tools:text="You can edit product add-ons in the web dashboard." />
+    </LinearLayout>
+
+</androidx.core.widget.NestedScrollView>

--- a/WooCommerce/src/main/res/layout/fragment_ordered_addon.xml
+++ b/WooCommerce/src/main/res/layout/fragment_ordered_addon.xml
@@ -22,12 +22,12 @@
             android:layout_marginTop="@dimen/minor_10"
             android:layout_marginStart="@dimen/major_100"
             android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/product_add_ons_details_info_notice"
+            android:text="@string/ordered_add_ons_details_info_notice"
             android:drawableStart="@drawable/ic_info_outline_24dp"
             android:drawablePadding="@dimen/minor_100"
             android:gravity="center_vertical"
             android:visibility="visible"
-            tools:text="You can edit product add-ons in the web dashboard." />
+            tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit." />
     </LinearLayout>
 
 </androidx.core.widget.NestedScrollView>

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -592,5 +592,9 @@
             android:name="orderItemId"
             app:argType="long"
             app:nullable="false" />
+        <argument
+            android:name="addonsProductId"
+            app:argType="long"
+            app:nullable="false" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -269,6 +269,13 @@
             app:exitAnim="@anim/activity_slide_out_to_left"
             app:popEnterAnim="@anim/activity_slide_in_from_left"
             app:popExitAnim="@anim/activity_slide_out_to_right" />
+        <action
+            android:id="@+id/action_orderDetailFragment_to_orderedAddonFragment"
+            app:destination="@id/orderedAddonFragment"
+            app:enterAnim="@anim/activity_slide_in_from_right"
+            app:exitAnim="@anim/activity_slide_out_to_left"
+            app:popEnterAnim="@anim/activity_slide_in_from_left"
+            app:popExitAnim="@anim/activity_slide_out_to_right" />
     </fragment>
     <dialog
         android:id="@+id/orderStatusSelectorDialog"
@@ -572,4 +579,18 @@
         app:exitAnim="@anim/activity_slide_out_to_left"
         app:popEnterAnim="@anim/activity_slide_in_from_left"
         app:popExitAnim="@anim/activity_slide_out_to_right" />
+    <fragment
+        android:id="@+id/orderedAddonFragment"
+        android:name="com.woocommerce.android.ui.products.addons.order.OrderedAddonFragment"
+        android:label="OrderedAddonFragment"
+        tools:layout="@layout/fragment_ordered_addon">
+        <argument
+            android:name="orderId"
+            app:argType="long"
+            app:nullable="false" />
+        <argument
+            android:name="orderItemId"
+            app:argType="long"
+            app:nullable="false" />
+    </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1131,7 +1131,7 @@
     <string name="edit_products_button">Edit products</string>
     <string name="empty_product_add_product_button">Add product</string>
     <string name="empty_product_message">Start selling today by adding your first product to the store.</string>
-    <string name="product_add_ons_card_button_title">Product Add-ons</string>
+    <string name="product_add_ons_title">Product Add-ons</string>
     <string name="product_add_ons_details_info_notice">You can edit product add-ons in the web dashboard.</string>
     <string name="product_count_one">%d product</string>
     <string name="product_count_many">%d products</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -366,6 +366,7 @@
     <string name="order_shipment_tracking_delete_snackbar_msg">Deleted shipment tracking</string>
     <string name="order_shipment_tracking_delete_error">Error deleting tracking</string>
     <string name="order_shipment_tracking_delete_success">Tracking deleted</string>
+    <string name="ordered_add_ons_details_info_notice">If renaming an add-on in your web dashboard, please note that previous orders will no longer show that add-on within the app.</string>
     <!--
         Shipping label Refunds
     -->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModelTest.kt
@@ -1,14 +1,17 @@
 package com.woocommerce.android.ui.products.addons.order
 
+import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.ProductAddon
 import com.woocommerce.android.model.ProductAddonOption
+import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.addons.AddonRepository
 import com.woocommerce.android.ui.products.addons.AddonTestFixtures.defaultOrderAttributes
 import com.woocommerce.android.ui.products.addons.AddonTestFixtures.defaultOrderedAddonList
 import com.woocommerce.android.ui.products.addons.AddonTestFixtures.defaultProductAddonList
 import com.woocommerce.android.ui.products.addons.AddonTestFixtures.emptyProductAddon
 import com.woocommerce.android.ui.products.addons.AddonTestFixtures.listWithSingleAddonAndTwoValidOptions
+import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
@@ -31,10 +34,20 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
+        val savedStateMock = mock<SavedStateHandle>()
+        val storeParametersMock = mock<SiteParameters>().apply {
+            whenever(currencyCode).doReturn("currency-code")
+        }
+        val parameterRepositoryMock = mock<ParameterRepository>().apply {
+            whenever(getParameters("key_product_parameters", savedStateMock))
+                .doReturn(storeParametersMock)
+        }
+
         viewModelUnderTest = OrderedAddonViewModel(
-            mock(),
+            savedStateMock,
             coroutinesTestRule.testDispatchers,
-            addonRepositoryMock
+            addonRepositoryMock,
+            parameterRepositoryMock
         )
     }
 


### PR DESCRIPTION
Summary
==========
Fixes issue #4408 by introducing the `OrderedAddonFragment`. This fragment takes the output of the already implemented `OrderedAddonViewModel` and presents the data in a very similar aspect of the `ProductAddonFragment`.

### ⚠️ Be aware the Global add-ons feature is still under development, so this view is only capable of displaying the Ordered Add-ons attached directly to the Ordered Product.

Screenshots
==========
| Expected  | Actual |
| ------------- | ------------- |
| <img width="1000" alt="image" src="https://user-images.githubusercontent.com/5920403/130002860-148fff58-d0a9-4503-af51-bc2e1937ab9f.png"> | <img width="1000" alt="image" src="https://user-images.githubusercontent.com/5920403/130002824-758c2d20-ba16-49e2-9d7a-156729653cf5.png"> |

How to Test
==========
Prerequisites: Have your site with the add ons plugin installed, configured, and with at least one product with add-ons and at least one order of the configured product. ⚠️ Note that you should configure the Product directly from the Edit Product page of wp-admin, if you create Global add-ons only, they will not show up here yet.

1 - Launch the Woo app.
2 - Navigate to an order with a Product configured with Add-ons, verify if the `View Add-ons` Button is showing up for products that contain Add-ons inside the current Order, but doesn't show up for Products without Add-ons for that order or Products that don't have Add-ons configured at all.
3 - Click on `View Add-ons` and verify if the Ordered Addons view is displayed with all the expected data.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
