### PR TITLE
Fix hub fragment text color

### DIFF
--- a/WooCommerce/src/main/res/layout/card_reader_hub_list_item.xml
+++ b/WooCommerce/src/main/res/layout/card_reader_hub_list_item.xml
@@ -8,6 +8,7 @@
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/cardReaderHubListItemLabelTv"
         style="@style/Widget.Woo.Settings.OptionValue"
+        android:textColor="@color/color_on_surface"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:paddingStart="@dimen/major_100"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes text color on CardReaderHubFragment.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Make sure you are using store eligible for in person payments 
2. Tap on App settings
3. Tap on In Person Payments
4. Notice text color on list items on hub fragment look ok

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Light | Dark |
| --- | --- |
| ![Screenshot_20210819-121304_WooCommerce (Dev)](https://user-images.githubusercontent.com/2261188/130051875-8d2503e6-d2c9-4f72-88da-9b3561bdfd65.jpg) | ![Screenshot_20210819-121318_WooCommerce (Dev)](https://user-images.githubusercontent.com/2261188/130051884-27acce51-9f8b-4634-a37f-916eb1f54427.jpg) |


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
