### PR TITLE
Product addon beta banner

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/FeedbackPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/FeedbackPrefs.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android
 
+import android.annotation.SuppressLint
 import android.content.Context
 import androidx.preference.PreferenceManager
 import com.google.gson.Gson
@@ -12,6 +13,8 @@ import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.util.PreferenceUtils
 import java.util.Date
 
+// Guaranteed to hold a reference to the application context, which is safe
+@SuppressLint("StaticFieldLeak")
 object FeedbackPrefs {
     private lateinit var context: Context
     private val gson by lazy { Gson() }
@@ -61,9 +64,8 @@ object FeedbackPrefs {
     }
 
     private fun getString(key: FeedbackPrefKey, defaultValue: String = ""): String {
-        return PreferenceUtils.getString(sharedPreferences, key.toString(), defaultValue)?.let {
-            it
-        } ?: defaultValue
+        return PreferenceUtils.getString(sharedPreferences, key.toString(), defaultValue)
+            ?: defaultValue
     }
 
     private fun setString(key: FeedbackPrefKey, value: String) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.model
 
+import com.woocommerce.android.FeedbackPrefs
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.UNANSWERED
 
 data class FeatureFeedbackSettings(
@@ -19,5 +20,9 @@ data class FeatureFeedbackSettings(
         SHIPPING_LABELS_M4("shipping_labels_m4"),
         PRODUCTS_VARIATIONS("products_variations"),
         PRODUCT_ADDONS("product_addons")
+    }
+
+    fun registerItselfWith(featureKey: String) {
+        FeedbackPrefs.setFeatureFeedbackSettings(featureKey, this)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
@@ -17,6 +17,7 @@ data class FeatureFeedbackSettings(
 
     enum class Feature(val description: String) {
         SHIPPING_LABELS_M4("shipping_labels_m4"),
-        PRODUCTS_VARIATIONS("products_variations")
+        PRODUCTS_VARIATIONS("products_variations"),
+        PRODUCT_ADDONS("product_addons")
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/FeatureWIPNoticeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/FeatureWIPNoticeCard.kt
@@ -14,7 +14,7 @@ class FeatureWIPNoticeCard @JvmOverloads constructor(
 ) : MaterialCardView(ctx, attrs, defStyleAttr) {
     private val binding = FeatureWipNoticeBinding.inflate(LayoutInflater.from(ctx), this)
 
-    private var isExpanded: Boolean
+    var isExpanded: Boolean
         set(value) {
             binding.featureWipViewMore.isChecked = value
             if (value) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
@@ -105,8 +105,8 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
     private fun showWIPNoticeCard(shouldBeVisible: Boolean) =
         with(binding.addonsWipCard) {
             initView(
-                title = "View add-ons from your device!",
-                message = "We are working on making it easier for you to see product add-ons from your device! For now, you’ll be able to see the add-ons for your orders. You can create and edit these add-ons in your web dashbaord.",
+                title = getString(R.string.ordered_add_ons_wip_title),
+                message = getString(R.string.ordered_add_ons_wip_message),
                 onGiveFeedbackClick = ::onGiveFeedbackClicked,
                 onDismissClick = ::onDismissWIPCardClicked
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
@@ -11,7 +11,6 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import androidx.recyclerview.widget.RecyclerView.LayoutManager
 import com.woocommerce.android.FeedbackPrefs
 import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
@@ -74,6 +74,11 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
         )
     }
 
+    override fun onResume() {
+        super.onResume()
+        binding.addonsWipCard.isExpanded = false
+    }
+
     override fun getFragmentTitle() = getString(R.string.product_add_ons_title)
 
     private fun setupObservers() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
@@ -19,7 +19,6 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.DISMISSED
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.GIVEN
-import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.UNANSWERED
 import com.woocommerce.android.model.ProductAddon
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.feedback.SurveyType
@@ -55,10 +54,7 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
                 .apply { registerItselfWith(TAG) }
 
     private val shouldRequestFeedback
-        get() = currentFeedbackSettings
-            .takeIf { it.name == CURRENT_WIP_NOTICE_FEATURE.name }
-            ?.let { it.state != DISMISSED }
-            ?: false
+        get() = currentFeedbackSettings.state != DISMISSED
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -139,7 +135,7 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
 
         FeatureFeedbackSettings(
             CURRENT_WIP_NOTICE_FEATURE.name,
-            UNANSWERED
+            DISMISSED
         ).registerItselfWith(TAG)
 
         showWIPNoticeCard(false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
@@ -36,8 +36,7 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
         val CURRENT_WIP_NOTICE_FEATURE = FeatureFeedbackSettings.Feature.PRODUCT_ADDONS
     }
 
-    @Inject
-    lateinit var currencyFormatter: CurrencyFormatter
+    @Inject lateinit var currencyFormatter: CurrencyFormatter
 
     private val viewModel: OrderedAddonViewModel by viewModels()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
@@ -44,7 +44,6 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
 
     private var _binding: FragmentOrderedAddonBinding? = null
     private val binding get() = _binding!!
-    private var layoutManager: LayoutManager? = null
 
     private val supportActionBar
         get() = activity
@@ -68,6 +67,8 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
         supportActionBar?.setHomeAsUpIndicator(R.drawable.ic_gridicons_cross_24dp)
 
         setupObservers()
+        setupViews()
+
         viewModel.start(
             navArgs.orderId,
             navArgs.orderItemId,
@@ -82,18 +83,27 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
             .observe(viewLifecycleOwner, Observer(::onOrderedAddonsReceived))
     }
 
+    private fun setupViews() {
+        binding.addonsWipCard.initView(
+            title = getString(R.string.ordered_add_ons_wip_title),
+            message = getString(R.string.ordered_add_ons_wip_message),
+            onGiveFeedbackClick = ::onGiveFeedbackClicked,
+            onDismissClick = ::onDismissWIPCardClicked
+        )
+
+        binding.addonsList.layoutManager = LinearLayoutManager(
+            activity,
+            RecyclerView.VERTICAL,
+            false
+        )
+    }
+
     private fun onOrderedAddonsReceived(orderedAddons: List<ProductAddon>) {
         showWIPNoticeCard(true)
         setupRecyclerViewWith(orderedAddons)
     }
 
     private fun setupRecyclerViewWith(addonList: List<ProductAddon>) {
-        layoutManager = LinearLayoutManager(
-            activity,
-            RecyclerView.VERTICAL,
-            false
-        )
-        binding.addonsList.layoutManager = layoutManager
         binding.addonsList.adapter = AddonListAdapter(
             addonList,
             currencyFormatter.buildBigDecimalFormatter(viewModel.currencyCode),
@@ -101,19 +111,11 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
         )
     }
 
-    private fun showWIPNoticeCard(shouldBeVisible: Boolean) =
-        with(binding.addonsWipCard) {
-            initView(
-                title = getString(R.string.ordered_add_ons_wip_title),
-                message = getString(R.string.ordered_add_ons_wip_message),
-                onGiveFeedbackClick = ::onGiveFeedbackClicked,
-                onDismissClick = ::onDismissWIPCardClicked
-            )
-
-            visibility =
-                if (shouldBeVisible && shouldRequestFeedback) VISIBLE
-                else GONE
-        }
+    private fun showWIPNoticeCard(shouldBeVisible: Boolean) {
+        binding.addonsWipCard.visibility =
+            if (shouldBeVisible && shouldRequestFeedback) VISIBLE
+            else GONE
+    }
 
     private fun onGiveFeedbackClicked() {
         // should send track event

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
@@ -2,19 +2,27 @@ package com.woocommerce.android.ui.products.addons.order
 
 import android.os.Bundle
 import android.view.View
+import android.view.View.GONE
+import android.view.View.VISIBLE
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.LayoutManager
 import com.woocommerce.android.FeedbackPrefs
+import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentOrderedAddonBinding
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.FeatureFeedbackSettings
+import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.GIVEN
+import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.UNANSWERED
 import com.woocommerce.android.model.ProductAddon
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.products.addons.AddonListAdapter
 import com.woocommerce.android.util.CurrencyFormatter
 import dagger.hilt.android.AndroidEntryPoint
@@ -27,7 +35,8 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
         val CURRENT_WIP_NOTICE_FEATURE = FeatureFeedbackSettings.Feature.PRODUCT_ADDONS
     }
 
-    @Inject lateinit var currencyFormatter: CurrencyFormatter
+    @Inject
+    lateinit var currencyFormatter: CurrencyFormatter
 
     private val viewModel: OrderedAddonViewModel by viewModels()
 
@@ -44,9 +53,9 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
 
     private val shouldRequestFeedback
         get() = FeedbackPrefs.getFeatureFeedbackSettings(TAG)
-                ?.takeIf { it.name == CURRENT_WIP_NOTICE_FEATURE.name }
-                ?.shouldRequestFeedback
-                ?: false
+            ?.takeIf { it.name == CURRENT_WIP_NOTICE_FEATURE.name }
+            ?.shouldRequestFeedback
+            ?: false
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -69,6 +78,7 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
     }
 
     private fun onOrderedAddonsReceived(orderedAddons: List<ProductAddon>) {
+        showWIPNoticeCard(true)
         setupRecyclerViewWith(orderedAddons)
     }
 
@@ -84,5 +94,41 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
             currencyFormatter.buildBigDecimalFormatter(viewModel.currencyCode),
             orderMode = true
         )
+    }
+
+    private fun showWIPNoticeCard(shouldBeVisible: Boolean) =
+        with(binding.addonsWipCard) {
+            initView(
+                title = "View add-ons from your device!",
+                message = "We are working on making it easier for you to see product add-ons from your device! For now, you’ll be able to see the add-ons for your orders. You can create and edit these add-ons in your web dashbaord.",
+                onGiveFeedbackClick = ::onGiveFeedbackClicked,
+                onDismissClick = ::onDismissWIPCardClicked
+            )
+
+            visibility =
+                if (shouldBeVisible && shouldRequestFeedback) VISIBLE
+                else GONE
+        }
+
+    private fun onGiveFeedbackClicked() {
+        // should send track event
+
+        FeatureFeedbackSettings(CURRENT_WIP_NOTICE_FEATURE.name, GIVEN)
+            .let { FeedbackPrefs.setFeatureFeedbackSettings(TAG, it) }
+
+        NavGraphMainDirections
+            .actionGlobalFeedbackSurveyFragment(SurveyType.PRODUCT)
+            .apply { findNavController().navigateSafely(this) }
+    }
+
+    private fun onDismissWIPCardClicked() {
+        // should send track event
+
+        FeatureFeedbackSettings(
+            CURRENT_WIP_NOTICE_FEATURE.name,
+            UNANSWERED
+        ).registerItselfWith(TAG)
+
+        showWIPNoticeCard(false)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
@@ -63,7 +63,6 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentOrderedAddonBinding.bind(view)
-        supportActionBar?.setHomeAsUpIndicator(R.drawable.ic_gridicons_cross_24dp)
 
         setupObservers()
         setupViews()
@@ -83,6 +82,7 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
     }
 
     private fun setupViews() {
+        supportActionBar?.setHomeAsUpIndicator(R.drawable.ic_gridicons_cross_24dp)
         binding.addonsWipCard.initView(
             title = getString(R.string.ordered_add_ons_wip_title),
             message = getString(R.string.ordered_add_ons_wip_message),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
@@ -9,8 +9,10 @@ import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.LayoutManager
+import com.woocommerce.android.FeedbackPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentOrderedAddonBinding
+import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.model.ProductAddon
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.products.addons.AddonListAdapter
@@ -22,6 +24,7 @@ import javax.inject.Inject
 class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
     companion object {
         val TAG: String = OrderedAddonFragment::class.java.simpleName
+        val CURRENT_WIP_NOTICE_FEATURE = FeatureFeedbackSettings.Feature.PRODUCT_ADDONS
     }
 
     @Inject lateinit var currencyFormatter: CurrencyFormatter
@@ -33,10 +36,17 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
     private var _binding: FragmentOrderedAddonBinding? = null
     private val binding get() = _binding!!
     private var layoutManager: LayoutManager? = null
+
     private val supportActionBar
         get() = activity
             ?.let { it as? AppCompatActivity }
             ?.supportActionBar
+
+    private val shouldRequestFeedback
+        get() = FeedbackPrefs.getFeatureFeedbackSettings(TAG)
+                ?.takeIf { it.name == CURRENT_WIP_NOTICE_FEATURE.name }
+                ?.shouldRequestFeedback
+                ?: false
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/WooCommerce/src/main/res/layout/fragment_ordered_addon.xml
+++ b/WooCommerce/src/main/res/layout/fragment_ordered_addon.xml
@@ -7,6 +7,14 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">
+        <com.woocommerce.android.ui.products.FeatureWIPNoticeCard
+            android:id="@+id/addons_wip_card"
+            style="@style/Woo.Card.Expandable"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/minor_100"
+            android:visibility="gone"
+            tools:visibility="visible" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/addons_list"

--- a/WooCommerce/src/main/res/layout/order_detail_product_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_product_item.xml
@@ -76,6 +76,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/minor_100"
+        android:background="?attr/selectableItemBackground"
         android:drawableEnd="@drawable/ic_arrow_right"
         android:text="@string/orderdetail_product_lineitem_view_addons_action"
         android:textColor="@color/woo_black"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -367,6 +367,8 @@
     <string name="order_shipment_tracking_delete_error">Error deleting tracking</string>
     <string name="order_shipment_tracking_delete_success">Tracking deleted</string>
     <string name="ordered_add_ons_details_info_notice">If renaming an add-on in your web dashboard, please note that previous orders will no longer show that add-on within the app.</string>
+    <string name="ordered_add_ons_wip_title">View add-ons from your device!</string>
+    <string name="ordered_add_ons_wip_message">We are working on making it easier for you to see product add-ons from your device! For now, you’ll be able to see the add-ons for your orders. You can create and edit these add-ons in your web dashboard.</string>
     <!--
         Shipping label Refunds
     -->


### PR DESCRIPTION
Summary
==========
Fixes issue #4422 by creating the Beta banner for the Ordered Addons view with the ability to redirect the merchant to the Survey form and to dismiss the banner itself.

Screenshots
==========

## Figma Designs
![image](https://user-images.githubusercontent.com/5920403/130272949-153ff241-0f27-4f0f-9aa6-b4138255e7de.png)

## Result
| Ordered Addons with banner collapsed  | Ordered Addons with banner expanded |
| ------------- | ------------- |
| ![Screenshot_20210820_020207](https://user-images.githubusercontent.com/5920403/130272856-d235bf8b-bfb8-403d-b373-9a8aca7e8986.png) | ![Screenshot_20210820_020210](https://user-images.githubusercontent.com/5920403/130272862-ad294800-1ed7-4f92-9a82-d2bc77dd94b0.png) |

How to Test
==========
Prerequisites: Have your site with the add ons plugin installed, configured, and with at least one product with add-ons and at least one order of the configured product. ⚠️ Note that you should configure the Product directly from the Edit Product page of wp-admin, if you create Global add-ons only, they will not show up here yet.

1 - Launch the Woo app.
2 - Navigate to an order with a Product configured with Add-ons, verify if the `View Add-ons` Button is showing up for products that contain Add-ons inside the current Order, but doesn't show up for Products without Add-ons for that order or Products that don't have Add-ons configured at all.
3 - Click on `View Add-ons` and verify if the Ordered Addons view is displayed with all the expected data.
4 - Interact with the feature banner, verify if it's collapsing and expanding as expected and if each action is working as expected, including the Feedback Survey form presentation.


Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
