### PR TITLE
Shipping Labels Add New Package: Improve number input validation to deal with "." entries.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateCustomPackageViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateCustomPackageViewModel.kt
@@ -156,7 +156,11 @@ class ShippingLabelCreateCustomPackageViewModel @Inject constructor(
     }
 
     private fun inputToFloat(input: String): Float {
-        return if (input.isBlank()) Float.NaN else input.trim('.').toFloat()
+        return when {
+            input.isBlank() -> Float.NaN
+            input == "." -> Float.NaN
+            else -> input.toFloat()
+        }
     }
 
     @Parcelize

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateCustomPackageViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateCustomPackageViewModelTest.kt
@@ -102,6 +102,38 @@ class ShippingLabelCreateCustomPackageViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given a dot length, width, height, or weight value, when value is entered, then display error message`() {
+        setup()
+        var state: ShippingLabelCreateCustomPackageViewState? = null
+        viewModel.viewStateData.observeForever { _, new -> state = new }
+        viewModel.onFieldTextChanged(".", InputName.LENGTH)
+        viewModel.onFieldTextChanged(".", InputName.WIDTH)
+        viewModel.onFieldTextChanged(".", InputName.HEIGHT)
+        viewModel.onFieldTextChanged(".", InputName.EMPTY_WEIGHT)
+
+        assertThat(state!!.lengthErrorMessage).isEqualTo(R.string.shipping_label_create_custom_package_field_empty_hint)
+        assertThat(state!!.widthErrorMessage).isEqualTo(R.string.shipping_label_create_custom_package_field_empty_hint)
+        assertThat(state!!.heightErrorMessage).isEqualTo(R.string.shipping_label_create_custom_package_field_empty_hint)
+        assertThat(state!!.weightErrorMessage).isEqualTo(R.string.shipping_label_create_custom_package_field_empty_hint)
+    }
+
+    @Test
+    fun `given a dot-something length,width,height,or weight value, when entered, then don't display error message`() {
+        setup()
+        var state: ShippingLabelCreateCustomPackageViewState? = null
+        viewModel.viewStateData.observeForever { _, new -> state = new }
+        viewModel.onFieldTextChanged(".5", InputName.LENGTH)
+        viewModel.onFieldTextChanged(".5", InputName.WIDTH)
+        viewModel.onFieldTextChanged(".5", InputName.HEIGHT)
+        viewModel.onFieldTextChanged(".5", InputName.EMPTY_WEIGHT)
+
+        assertThat(state!!.lengthErrorMessage).isEqualTo(null)
+        assertThat(state!!.widthErrorMessage).isEqualTo(null)
+        assertThat(state!!.heightErrorMessage).isEqualTo(null)
+        assertThat(state!!.weightErrorMessage).isEqualTo(null)
+    }
+
+    @Test
     fun `given zero package length, width, or height value, when value is entered, then display error message`() {
         setup()
         var state: ShippingLabelCreateCustomPackageViewState? = null


### PR DESCRIPTION
# What the PR does:
Fixes #4656 

1. In the Add new package screen, a singular `.` entry in the length/width/height/weight field will now show "This field is required" message instead of crashing the app.
2. a dot-something entry without a leading zero (like `.5`) will now be accepted as valid entry and be saved as such. This matches core behavior.


### Testing instructions

**Case 1**:

1. Create a label for any order, confirm addresses, and move on to package selection.
2. Tap "Package selected".
3. Go to "Add a new package" screen
4. Enter `.` to the length/width/height/weight field. 
5. Make sure that the app doesn't crash, and instead the field will say "This field is required".

**Case 2**:
1. Still on the "Add new package" screen, enter `.5` value to the length/width/height/weight field.
2. Fill in all remaining fields and tap "Done" to save the package.
3. Check in wp-admin (`wp-admin/admin.php?page=wc-settings&tab=shipping&section=woocommerce-services-settings`), and find the package you just created. Make sure that the "Dimensions" value do say "0.5 x 0.5 x 0.5".

- [x ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
