### PR TITLE
Amend filter list screen dividers

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -416,7 +416,8 @@ class MainActivity :
             showCrossIcon = false
         } else {
             binding.appBarLayout.elevation =
-                resources.getDimensionPixelSize(R.dimen.appbar_elevation_secondary).toFloat()
+                resources.getDimensionPixelSize(R.dimen.appbar_elevation).toFloat()
+
             showCrossIcon = when (destination.id) {
                 R.id.productFilterListFragment,
                 R.id.issueRefundFragment,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -415,7 +415,8 @@ class MainActivity :
             }
             showCrossIcon = false
         } else {
-            binding.appBarLayout.elevation = resources.getDimensionPixelSize(R.dimen.appbar_elevation_secondary).toFloat()
+            binding.appBarLayout.elevation =
+                resources.getDimensionPixelSize(R.dimen.appbar_elevation_secondary).toFloat()
             showCrossIcon = when (destination.id) {
                 R.id.productFilterListFragment,
                 R.id.issueRefundFragment,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -415,7 +415,7 @@ class MainActivity :
             }
             showCrossIcon = false
         } else {
-            binding.appBarLayout.elevation = resources.getDimensionPixelSize(R.dimen.appbar_elevation_filter).toFloat()
+            binding.appBarLayout.elevation = resources.getDimensionPixelSize(R.dimen.appbar_elevation_secondary).toFloat()
             showCrossIcon = when (destination.id) {
                 R.id.productFilterListFragment,
                 R.id.issueRefundFragment,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -415,7 +415,7 @@ class MainActivity :
             }
             showCrossIcon = false
         } else {
-            binding.appBarLayout.elevation = resources.getDimensionPixelSize(R.dimen.appbar_elevation).toFloat()
+            binding.appBarLayout.elevation = resources.getDimensionPixelSize(R.dimen.appbar_elevation_filter).toFloat()
             showCrossIcon = when (destination.id) {
                 R.id.productFilterListFragment,
                 R.id.issueRefundFragment,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
@@ -53,7 +53,7 @@ class ProductFilterListFragment :
         productFilterListAdapter = ProductFilterListAdapter(this)
         with(binding.filterList) {
             addItemDecoration(
-                AlignedDividerDecoration(
+                DividerItemDecoration(
                     requireActivity(),
                     DividerItemDecoration.VERTICAL
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
@@ -55,8 +55,7 @@ class ProductFilterListFragment :
             addItemDecoration(
                 AlignedDividerDecoration(
                     requireActivity(),
-                    DividerItemDecoration.VERTICAL,
-                    alignStartToStartOf = R.id.filterItemName
+                    DividerItemDecoration.VERTICAL
                 )
             )
             layoutManager = LinearLayoutManager(activity)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
@@ -24,7 +24,6 @@ import com.woocommerce.android.ui.products.ProductFilterListViewModel.FilterList
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
-import com.woocommerce.android.widgets.AlignedDividerDecoration
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
@@ -40,7 +40,7 @@ class ProductFilterOptionListFragment :
         mProductFilterOptionListAdapter = ProductFilterOptionListAdapter(this)
         with(binding.filterOptionList) {
             addItemDecoration(
-                AlignedDividerDecoration(
+                DividerItemDecoration(
                     requireActivity(),
                     DividerItemDecoration.VERTICAL
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
@@ -18,7 +18,6 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.products.ProductFilterListViewModel.FilterListOptionItemUiModel
 import com.woocommerce.android.ui.products.ProductFilterOptionListAdapter.OnProductFilterOptionClickListener
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
-import com.woocommerce.android.widgets.AlignedDividerDecoration
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
@@ -42,8 +42,7 @@ class ProductFilterOptionListFragment :
             addItemDecoration(
                 AlignedDividerDecoration(
                     requireActivity(),
-                    DividerItemDecoration.VERTICAL,
-                    alignStartToStartOf = R.id.filterOptionItem_name
+                    DividerItemDecoration.VERTICAL
                 )
             )
             layoutManager = LinearLayoutManager(activity)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListAdapter.kt
@@ -37,7 +37,7 @@ class ReviewListAdapter(
     private val removedRemoteIds = HashSet<Long>()
 
     interface OnReviewClickListener {
-        fun onReviewClick(review: ProductReview) { }
+        fun onReviewClick(review: ProductReview) {}
     }
 
     fun setReviews(reviews: List<ProductReview>) {
@@ -352,8 +352,12 @@ class ReviewListAdapter(
         override fun onBindItemViewHolder(holder: ViewHolder, position: Int) {
             val review = list[position]
             val itemHolder = holder as ItemViewHolder
-            itemHolder.bind(review, position, getContentItemsTotal(),
-                reviewStatus = ProductReviewStatus.fromString(review.status))
+            itemHolder.bind(
+                review,
+                position,
+                getContentItemsTotal(),
+                reviewStatus = ProductReviewStatus.fromString(review.status)
+            )
             itemHolder.itemView.setOnClickListener {
                 clickListener.onReviewClick(review)
             }
@@ -431,14 +435,15 @@ class ReviewListAdapter(
                 viewBinding.notifDivider.visibility = View.INVISIBLE
             }
         }
+
         private fun getPendingReviewLabel() =
             "<font color=$pendingLabelColor>${context.getString(R.string.pending_review_label)}</font>"
     }
-    }
+}
 
-    private class HeaderViewHolder(val viewBinding: OrderListHeaderBinding) :
-        RecyclerView.ViewHolder(viewBinding.root) {
-        fun bind(@StringRes headerId: Int) {
-            viewBinding.orderListHeader.text = viewBinding.root.context.getString(headerId)
-        }
+private class HeaderViewHolder(val viewBinding: OrderListHeaderBinding) :
+    RecyclerView.ViewHolder(viewBinding.root) {
+    fun bind(@StringRes headerId: Int) {
+        viewBinding.orderListHeader.text = viewBinding.root.context.getString(headerId)
     }
+}

--- a/WooCommerce/src/main/res/layout/fragment_product_filter_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_filter_list.xml
@@ -19,7 +19,6 @@
 
     <View
         style="@style/Woo.Divider"
-        android:layout_marginStart="@dimen/major_100"
         app:layout_constraintBottom_toTopOf="@+id/filterList_btnFrame"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/WooCommerce/src/main/res/layout/fragment_product_filter_option_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_filter_option_list.xml
@@ -19,7 +19,6 @@
 
     <View
         style="@style/Woo.Divider"
-        android:layout_marginStart="@dimen/major_100"
         app:layout_constraintBottom_toTopOf="@+id/filterOptionList_btnFrame"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/WooCommerce/src/main/res/values/dimens_base.xml
+++ b/WooCommerce/src/main/res/values/dimens_base.xml
@@ -111,7 +111,7 @@ so that's the baseline as defined in `major_100`.
     <dimen name="margin_app_title_aligned">72dp</dimen>
     <dimen name="min_tap_target">48dp</dimen>
     <dimen name="appbar_elevation">4dp</dimen>
-    <dimen name="appbar_elevation_filter">2dp</dimen>
+    <dimen name="appbar_elevation_secondary">2dp</dimen>
     <dimen name="alert_dialog_max_width">300dp</dimen>
     <dimen name="top_performer_min_height">224dp</dimen>
     <dimen name="expanded_toolbar_height">108dp</dimen>

--- a/WooCommerce/src/main/res/values/dimens_base.xml
+++ b/WooCommerce/src/main/res/values/dimens_base.xml
@@ -111,7 +111,6 @@ so that's the baseline as defined in `major_100`.
     <dimen name="margin_app_title_aligned">72dp</dimen>
     <dimen name="min_tap_target">48dp</dimen>
     <dimen name="appbar_elevation">4dp</dimen>
-    <dimen name="appbar_elevation_secondary">2dp</dimen>
     <dimen name="alert_dialog_max_width">300dp</dimen>
     <dimen name="top_performer_min_height">224dp</dimen>
     <dimen name="expanded_toolbar_height">108dp</dimen>

--- a/WooCommerce/src/main/res/values/dimens_base.xml
+++ b/WooCommerce/src/main/res/values/dimens_base.xml
@@ -111,6 +111,7 @@ so that's the baseline as defined in `major_100`.
     <dimen name="margin_app_title_aligned">72dp</dimen>
     <dimen name="min_tap_target">48dp</dimen>
     <dimen name="appbar_elevation">4dp</dimen>
+    <dimen name="appbar_elevation_filter">2dp</dimen>
     <dimen name="alert_dialog_max_width">300dp</dimen>
     <dimen name="top_performer_min_height">224dp</dimen>
     <dimen name="expanded_toolbar_height">108dp</dimen>


### PR DESCRIPTION
Fixes issue #3258

## Changes

- Removes the drop shadow from the appbar in the filters screens
- removes the margin for the dividers on the filter screens

## Screenshots

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/130511153-70d7026a-4a2b-4916-86f1-887c0a92302e.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/130511168-b7bc23ef-e847-4a80-8ced-d35b79853943.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/30724184/130511264-72689cd1-1075-420b-8e46-bb2d288725b8.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/130511276-7a517053-189a-470e-9f93-ff437f4ac591.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/30724184/130511389-6902318d-7ef3-4aab-a899-dc88a930b14b.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/130511397-56ded044-0b0c-473d-b3d9-d640a4f29db9.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/30724184/130512543-b425b384-2852-4418-879e-84af5079d978.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/130512562-cbbd0a3c-d22b-49b5-8a64-a9411d0a174f.png" width="350"/> |

## Testing Instructions

- Open the app
- Go to the Products screen
- Click on Filters and see the shadow has been removed from the appbar/ dividers are now full bleed
- Click on any of the filters and see the same result as mentioned above

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
