### PR TITLE
hotfix/4671-product-imaage-upload-error-crash-fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
@@ -31,8 +31,11 @@ class MediaFileUploadHandler @Inject constructor(
         mediaUploadError: MediaStore.MediaError
     ) {
         val remoteProductId = mediaModel.postId
+        val errorMessage = mediaUploadError.message
+            ?: mediaUploadError.logMessage
+            ?: resourceProvider.getString(R.string.product_image_service_error_uploading)
         val newErrors = currentUploadErrors.get(remoteProductId, mutableListOf()) +
-            ProductImageUploadUiModel(mediaModel, mediaUploadError.type, mediaUploadError.message)
+            ProductImageUploadUiModel(mediaModel, mediaUploadError.type, errorMessage)
         currentUploadErrors.put(remoteProductId, newErrors)
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandlerTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.media
 
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.spy
 import com.woocommerce.android.R
@@ -12,6 +13,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.store.MediaStore
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
@@ -21,7 +23,10 @@ class MediaFileUploadHandlerTest : BaseUnitTest() {
         private const val REMOTE_SITE_ID = 1L
     }
 
-    private val resources: ResourceProvider = mock()
+    private val resources: ResourceProvider = mock {
+        on(it.getString(any())).thenAnswer { i -> i.arguments[0].toString() }
+        on(it.getString(any(), any())).thenAnswer { i -> i.arguments[0].toString() }
+    }
     private val testMediaModel = ProductTestUtils.generateProductMedia(REMOTE_PRODUCT_ID, REMOTE_SITE_ID)
     private val testMediaModelError = ProductTestUtils.generateMediaUploadErrorModel()
     private lateinit var mediaFileUploadHandler: MediaFileUploadHandler
@@ -36,6 +41,18 @@ class MediaFileUploadHandlerTest : BaseUnitTest() {
         assertThat(mediaFileUploadHandler.getMediaUploadErrorCount(testMediaModel.postId)).isEqualTo(0)
 
         mediaFileUploadHandler.handleMediaUploadFailure(testMediaModel, testMediaModelError)
+        assertThat(mediaFileUploadHandler.getMediaUploadErrorCount(testMediaModel.postId)).isEqualTo(1)
+        assertThat(mediaFileUploadHandler.getMediaUploadErrorMessage(testMediaModel.postId)).isEqualTo(
+            resources.getString(R.string.product_image_service_error_uploading_single)
+        )
+    }
+
+    @Test
+    fun `Handles empty error message in mediaModelError correctly`() {
+        val mediaErrorModel = MediaStore.MediaError(MediaStore.MediaErrorType.GENERIC_ERROR)
+        assertThat(mediaFileUploadHandler.getMediaUploadErrorCount(testMediaModel.postId)).isEqualTo(0)
+
+        mediaFileUploadHandler.handleMediaUploadFailure(testMediaModel, mediaErrorModel)
         assertThat(mediaFileUploadHandler.getMediaUploadErrorCount(testMediaModel.postId)).isEqualTo(1)
         assertThat(mediaFileUploadHandler.getMediaUploadErrorMessage(testMediaModel.postId)).isEqualTo(
             resources.getString(R.string.product_image_service_error_uploading_single)


### PR DESCRIPTION
Closes: #4671 

### Description
It looks like there can be scenarios in [MediaError where the message can be null](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/90bdce9186ee757fcbfe8bf039a1a48e1231bf02/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java#L225). But the Woo app is expecting a non null value. So the app is crashing. 

I wasn't able to reproduce the issue but did add a unit test with the exact same scenario which should cover this crash fix. 

Please note that this is targeting the `7.3` release branch and will be introduced as an hotfix directly to 7.3. cc @jkmassel! 

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.