### PR TITLE
hotfix/7.3-image-upload-crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
@@ -31,8 +31,11 @@ class MediaFileUploadHandler @Inject constructor(
         mediaUploadError: MediaStore.MediaError
     ) {
         val remoteProductId = mediaModel.postId
+        val errorMessage = mediaUploadError.message
+            ?: mediaUploadError.logMessage
+            ?: resourceProvider.getString(R.string.product_image_service_error_uploading)
         val newErrors = currentUploadErrors.get(remoteProductId, mutableListOf()) +
-            ProductImageUploadUiModel(mediaModel, mediaUploadError.type, mediaUploadError.message)
+            ProductImageUploadUiModel(mediaModel, mediaUploadError.type, errorMessage)
         currentUploadErrors.put(remoteProductId, newErrors)
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandlerTest.kt
@@ -11,7 +11,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.store.MediaStore
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
@@ -21,7 +23,10 @@ class MediaFileUploadHandlerTest : BaseUnitTest() {
         private const val REMOTE_SITE_ID = 1L
     }
 
-    private val resources: ResourceProvider = mock()
+    private val resources: ResourceProvider = mock {
+        on(it.getString(any())).thenAnswer { i -> i.arguments[0].toString() }
+        on(it.getString(any(), any())).thenAnswer { i -> i.arguments[0].toString() }
+    }
     private val testMediaModel = ProductTestUtils.generateProductMedia(REMOTE_PRODUCT_ID, REMOTE_SITE_ID)
     private val testMediaModelError = ProductTestUtils.generateMediaUploadErrorModel()
     private lateinit var mediaFileUploadHandler: MediaFileUploadHandler
@@ -36,6 +41,18 @@ class MediaFileUploadHandlerTest : BaseUnitTest() {
         assertThat(mediaFileUploadHandler.getMediaUploadErrorCount(testMediaModel.postId)).isEqualTo(0)
 
         mediaFileUploadHandler.handleMediaUploadFailure(testMediaModel, testMediaModelError)
+        assertThat(mediaFileUploadHandler.getMediaUploadErrorCount(testMediaModel.postId)).isEqualTo(1)
+        assertThat(mediaFileUploadHandler.getMediaUploadErrorMessage(testMediaModel.postId)).isEqualTo(
+            resources.getString(R.string.product_image_service_error_uploading_single)
+        )
+    }
+
+    @Test
+    fun `Handles empty error message in mediaModelError correctly`() {
+        val mediaErrorModel = MediaStore.MediaError(MediaStore.MediaErrorType.GENERIC_ERROR)
+        assertThat(mediaFileUploadHandler.getMediaUploadErrorCount(testMediaModel.postId)).isEqualTo(0)
+
+        mediaFileUploadHandler.handleMediaUploadFailure(testMediaModel, mediaErrorModel)
         assertThat(mediaFileUploadHandler.getMediaUploadErrorCount(testMediaModel.postId)).isEqualTo(1)
         assertThat(mediaFileUploadHandler.getMediaUploadErrorMessage(testMediaModel.postId)).isEqualTo(
             resources.getString(R.string.product_image_service_error_uploading_single)


### PR DESCRIPTION
This PR cherry picks the fix in #4672 and updates the same to the 7.4 release. 

### Description
It looks like there can be scenarios in [MediaError where the message can be null](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/90bdce9186ee757fcbfe8bf039a1a48e1231bf02/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java#L225). But the Woo app is expecting a non null value. So the app is crashing. 

I wasn't able to reproduce the issue but did add a unit test with the exact same scenario which should cover this crash fix. 

Please note that this is targeting the `7.4` release branch. cc @jkmassel