### PR TITLE
Update post feedback screen background color

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_feedback_completed.xml
+++ b/WooCommerce/src/main/res/layout/fragment_feedback_completed.xml
@@ -9,6 +9,7 @@
         android:layout_height="wrap_content"
         android:gravity="center_horizontal|top"
         android:orientation="vertical"
+        android:background="@color/color_surface"
         android:padding="@dimen/major_200">
 
         <com.google.android.material.textview.MaterialTextView


### PR DESCRIPTION
Fixes #4582 

## Changes

The background color of the post feedback screen from grey to white

## Screenshots

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/130824204-10034f34-27c8-44a3-8fd9-8430d8ff7071.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/130824209-825e6b32-1abe-41d1-b434-58706c8cd96c.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/30724184/130824267-fe4e3149-c523-4cd4-9079-9e95f29c5176.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/130824276-12e2e19b-c9e1-44b0-afe3-791227e630d6.png" width="350"/> |

## Testing instructions

- open the app
- click on the settings icon
- click on Send Feedback tab
- provide some feedback and click on Finish Survey

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.