### PR TITLE
Update Shipping Labels

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -344,7 +344,7 @@
     <string name="orderdetail_shipping_label_wip_message">We are working on making it easier for you to print shipping labels directly from you device! For now, if you have created shipping labels for this order in your store admin with WooCommerce Shipping, you can print them in your Order Details here.</string>
     <string name="orderdetail_shipping_label_m3_wip_message">You can now create shipping labels for all physical orders directly from your device with the free WooCommerce Shipping plugin. Tap on "Create shipping label" to try our beta feature!</string>
     <string name="orderdetail_shipping_label_create_shipping_label">Create shipping label</string>
-    <string name="orderdetail_shipping_label_notice">Learn more about creating labels with your phone</string>
+    <string name="orderdetail_shipping_label_notice">Learn more about creating labels with your mobile device</string>
     <string name="receipt_preview_print_menu_item">Print</string>
     <string name="receipt_preview_send_menu_item">Send</string>
     <string name="order_mark_complete">Mark order complete</string>
@@ -395,7 +395,7 @@
     <string name="shipping_label_print_button">Print shipping label</string>
     <string name="shipping_label_print_multiple_button">Print shipping labels</string>
     <string name="shipping_label_paper_size_options_info">See label layout and paper size options</string>
-    <string name="shipping_label_print_info">Don\'t know how to print with your phone?</string>
+    <string name="shipping_label_print_info">Don\'t know how to print with your mobile device?</string>
     <string name="shipping_label_print_purchase_success">Shipping label purchased!</string>
     <string name="shipping_label_print_multiple_purchase_success">Shipping labels purchased!</string>
     <string name="shipping_label_print_save_for_later">Save for later</string>
@@ -439,7 +439,7 @@
     -->
     <string name="shipping_label_more_information_title">WooCommerce Shipping</string>
     <string name="shipping_label_more_information_heading">Save time and money by fulfilling with WooCommerce Shipping</string>
-    <string name="shipping_label_more_information_message">Cut the post office line by printing shipping labels at home with your phone at discounted rates!</string>
+    <string name="shipping_label_more_information_message">Cut the post office line by printing shipping labels at home with your mobile device at discounted rates!</string>
     <string name="shipping_label_more_information_link">Learn more</string>
     <string name="shipping_label_create_title">Create shipping label</string>
     <string name="shipping_label_create_packaging_details">Packaging details</string>


### PR DESCRIPTION
Fixes #4643 

## Changes

Updates the strings.xml file to reflect the term `mobile device` as opposed to `phone `when applicable for the shipping label screens

## Screenshots

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/131216032-76b82bb3-903c-467b-9ab2-a5f6e8013753.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/131216034-9c3ed677-6879-4a00-b853-88ef61801f22.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/30724184/131216056-f65c9cdf-3d65-4b34-b165-b7de285a0ba1.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/131216058-c8ae1cf5-9620-45fd-9ec7-098346a6f449.png" width="350"/> |

*Please note the third screen shows after you purchase a new label so I didn't go that far since it's not my account I'm using.
** Since this does not change any colours, it's just text I skipped the Dark Theme screenshots. Please let me know if I should add them.  

### Testing instructions

With the Option to print shipping labels active on your store
- Go to the products screen
- Select a product
- Screenshot one is right below the Print `Shipping label button`
- Screenshot two is after you click the info icon/text below the `Print Shipping label button`

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
