### PR TITLE
Join order addons data with global addons

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductAddon.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductAddon.kt
@@ -124,17 +124,22 @@ fun WCProductAddonModel.toAppModel() =
         price = price ?: "",
         required = required.toBoolean(),
         adjustPrice = adjustPrice.toBoolean(),
-        titleFormat = TitleFormat.valueOf(titleFormat.toString()),
-        restrictionsType = Restrictions.valueOf(restrictionsType.toString()),
-        priceType = PriceType.valueOf(priceType.toString()),
-        type = Type.valueOf(type.toString()),
-        display = Display.valueOf(display.toString()),
+        titleFormat = TitleFormat.values()
+            .find { it.toString() == titleFormat?.toString() },
+        restrictionsType = Restrictions.values()
+            .find { it.toString() == restrictionsType?.toString() },
+        priceType = PriceType.values()
+            .find { it.toString() == priceType?.toString() },
+        type = Type.values().find { it.toString() == type?.toString() },
+        display = Display.values()
+            .find { it.toString() == display?.toString() },
         rawOptions = options?.map { it.toAppModel() } ?: emptyList()
     )
 
 fun WCProductAddonModel.ProductAddonOption.toAppModel() =
     ProductAddonOption(
-        priceType = PriceType.valueOf(priceType.toString()),
+        priceType = PriceType.values()
+            .find { it.toString() == priceType?.toString() },
         label = label ?: "",
         price = price ?: "",
         image = image ?: ""

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductAddon.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductAddon.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.model
 import android.os.Parcelable
 import com.woocommerce.android.model.ProductAddon.*
 import kotlinx.parcelize.Parcelize
+import org.wordpress.android.fluxc.model.addons.WCProductAddonModel
 import org.wordpress.android.fluxc.persistence.entity.AddonOptionEntity
 import org.wordpress.android.fluxc.persistence.entity.AddonWithOptions
 
@@ -111,3 +112,32 @@ fun AddonOptionEntity.toAppModel() =
         price = price ?: "",
         image = image ?: ""
     )
+
+fun WCProductAddonModel.toAppModel() =
+    ProductAddon(
+        name = name,
+        description = description,
+        descriptionEnabled = descriptionEnabled.toBoolean(),
+        max = max,
+        min = min,
+        position = position,
+        price = price ?: "",
+        required = required.toBoolean(),
+        adjustPrice = adjustPrice.toBoolean(),
+        titleFormat = TitleFormat.valueOf(titleFormat.toString()),
+        restrictionsType = Restrictions.valueOf(restrictionsType.toString()),
+        priceType = PriceType.valueOf(priceType.toString()),
+        type = Type.valueOf(type.toString()),
+        display = Display.valueOf(display.toString()),
+        rawOptions = options?.map { it.toAppModel() } ?: emptyList()
+    )
+
+fun WCProductAddonModel.ProductAddonOption.toAppModel() =
+    ProductAddonOption(
+        priceType = PriceType.valueOf(priceType.toString()),
+        label = label ?: "",
+        price = price ?: "",
+        image = image ?: ""
+    )
+
+private fun Int?.toBoolean() = this == 1

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductAddon.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductAddon.kt
@@ -2,12 +2,13 @@ package com.woocommerce.android.model
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
-import org.wordpress.android.fluxc.model.addons.WCProductAddonModel
-import org.wordpress.android.fluxc.model.addons.WCProductAddonModel.AddOnDisplay
-import org.wordpress.android.fluxc.model.addons.WCProductAddonModel.AddOnPriceType
-import org.wordpress.android.fluxc.model.addons.WCProductAddonModel.AddOnRestrictionsType
-import org.wordpress.android.fluxc.model.addons.WCProductAddonModel.AddOnTitleFormat
-import org.wordpress.android.fluxc.model.addons.WCProductAddonModel.AddOnType
+import org.wordpress.android.fluxc.persistence.entity.AddonEntity.Type
+import org.wordpress.android.fluxc.persistence.entity.AddonEntity.Restrictions
+import org.wordpress.android.fluxc.persistence.entity.AddonEntity.TitleFormat
+import org.wordpress.android.fluxc.persistence.entity.AddonEntity.PriceType
+import org.wordpress.android.fluxc.persistence.entity.AddonEntity.Display
+import org.wordpress.android.fluxc.persistence.entity.AddonOptionEntity
+import org.wordpress.android.fluxc.persistence.entity.AddonWithOptions
 
 @Parcelize
 data class ProductAddon(
@@ -18,12 +19,12 @@ data class ProductAddon(
     val max: Long,
     val min: Long,
     val position: Int,
-    val adjustPrice: Int,
-    val titleFormat: AddOnTitleFormat?,
-    val restrictionsType: AddOnRestrictionsType?,
-    val priceType: AddOnPriceType?,
-    val type: AddOnType?,
-    val display: AddOnDisplay?,
+    val adjustPrice: Boolean,
+    val titleFormat: TitleFormat?,
+    val restrictionsType: Restrictions?,
+    val priceType: PriceType?,
+    val type: Type?,
+    val display: Display?,
     private val price: String,
     private val rawOptions: List<ProductAddonOption>
 ) : Parcelable {
@@ -45,37 +46,35 @@ data class ProductAddon(
 
 @Parcelize
 data class ProductAddonOption(
-    val priceType: AddOnPriceType?,
+    val priceType: PriceType?,
     val label: String,
     val price: String,
     val image: String
 ) : Parcelable
 
-fun WCProductAddonModel.toAppModel() =
+fun AddonWithOptions.toAppModel() =
     ProductAddon(
-        name = name ?: "",
-        description = description ?: "",
-        descriptionEnabled = descriptionEnabled.toBoolean(),
-        max = max,
-        min = min,
-        position = position,
-        price = price ?: "",
-        adjustPrice = adjustPrice,
-        required = required.toBoolean(),
-        titleFormat = titleFormat,
-        restrictionsType = restrictionsType,
-        priceType = priceType,
-        type = type,
-        display = display,
-        rawOptions = options?.map { it.toAppModel() } ?: emptyList()
+        name = addon.name,
+        description = addon.description,
+        descriptionEnabled = addon.descriptionEnabled,
+        max = addon.max ?: 0,
+        min = addon.min ?: 0,
+        position = addon.position,
+        price = addon.price ?: "",
+        adjustPrice = addon.priceAdjusted ?: false,
+        required = addon.required,
+        titleFormat = addon.titleFormat,
+        restrictionsType = addon.restrictions,
+        priceType = addon.priceType,
+        type = addon.type,
+        display = addon.display,
+        rawOptions = options.map { it.toAppModel() }
     )
 
-fun WCProductAddonModel.ProductAddonOption.toAppModel() =
+fun AddonOptionEntity.toAppModel() =
     ProductAddonOption(
         priceType = priceType,
         label = label ?: "",
         price = price ?: "",
         image = image ?: ""
     )
-
-private fun Int?.toBoolean() = this == 1

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductAddon.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductAddon.kt
@@ -1,12 +1,8 @@
 package com.woocommerce.android.model
 
 import android.os.Parcelable
+import com.woocommerce.android.model.ProductAddon.*
 import kotlinx.parcelize.Parcelize
-import org.wordpress.android.fluxc.persistence.entity.AddonEntity.Type
-import org.wordpress.android.fluxc.persistence.entity.AddonEntity.Restrictions
-import org.wordpress.android.fluxc.persistence.entity.AddonEntity.TitleFormat
-import org.wordpress.android.fluxc.persistence.entity.AddonEntity.PriceType
-import org.wordpress.android.fluxc.persistence.entity.AddonEntity.Display
 import org.wordpress.android.fluxc.persistence.entity.AddonOptionEntity
 import org.wordpress.android.fluxc.persistence.entity.AddonWithOptions
 
@@ -42,6 +38,43 @@ data class ProductAddon(
 
     private val isNoPriceAvailableAtOptions
         get() = (rawOptions.size == 1) && rawOptions.single().price.isEmpty()
+
+    enum class Type {
+        MultipleChoice,
+        Checkbox,
+        CustomText,
+        CustomTextArea,
+        FileUpload,
+        CustomPrice,
+        InputMultiplier,
+        Heading
+    }
+
+    enum class Display {
+        Select,
+        RadioButton,
+        Images
+    }
+
+    enum class TitleFormat {
+        Label,
+        Heading,
+        Hide
+    }
+
+    enum class Restrictions {
+        AnyText,
+        OnlyLetters,
+        OnlyNumbers,
+        OnlyLettersNumbers,
+        Email
+    }
+
+    enum class PriceType {
+        FlatFee,
+        QuantityBased,
+        PercentageBased
+    }
 }
 
 @Parcelize
@@ -63,17 +96,17 @@ fun AddonWithOptions.toAppModel() =
         price = addon.price ?: "",
         adjustPrice = addon.priceAdjusted ?: false,
         required = addon.required,
-        titleFormat = addon.titleFormat,
-        restrictionsType = addon.restrictions,
-        priceType = addon.priceType,
-        type = addon.type,
-        display = addon.display,
+        titleFormat = TitleFormat.valueOf(addon.titleFormat.toString()),
+        restrictionsType = Restrictions.valueOf(addon.restrictions.toString()),
+        priceType = PriceType.valueOf(addon.priceType.toString()),
+        type = Type.valueOf(addon.type.toString()),
+        display = Display.valueOf(addon.display.toString()),
         rawOptions = options.map { it.toAppModel() }
     )
 
 fun AddonOptionEntity.toAppModel() =
     ProductAddonOption(
-        priceType = priceType,
+        priceType = PriceType.valueOf(priceType.toString()),
         label = label ?: "",
         price = price ?: "",
         image = image ?: ""

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/AddonRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/AddonRepository.kt
@@ -3,8 +3,10 @@ package com.woocommerce.android.ui.products.addons
 import com.woocommerce.android.model.Order.Item.Attribute
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.flow.firstOrNull
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
+import org.wordpress.android.fluxc.store.WCAddonsStore
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCProductStore
 import javax.inject.Inject
@@ -12,13 +14,17 @@ import javax.inject.Inject
 class AddonRepository @Inject constructor(
     private val orderStore: WCOrderStore,
     private val productStore: WCProductStore,
+    private val addonsStore: WCAddonsStore,
     private val selectedSite: SelectedSite
 ) {
+    suspend fun fetchGlobalAddons() =
+        addonsStore.fetchAllGlobalAddonsGroups(selectedSite.get())
+
     fun getAddonsFrom(productID: Long) =
         productStore.getProductByRemoteId(selectedSite.get(), productID)
             ?.addons
 
-    fun getOrderAddonsData(
+    suspend fun getOrderAddonsData(
         orderID: Long,
         orderItemID: Long,
         productID: Long
@@ -37,8 +43,10 @@ class AddonRepository @Inject constructor(
             ?.map { Attribute(it.key.orEmpty(), it.value.orEmpty()) }
             ?.filter { it.isNotInternalAttributeData }
 
-    private fun List<Attribute>.joinWithAddonsFrom(productID: Long) =
-        getAddonsFrom(productID)
+    private suspend fun List<Attribute>.joinWithAddonsFrom(productID: Long) =
+        productStore.getProductByRemoteId(selectedSite.get(), productID)
+            ?.let { addonsStore.observeAddonsForProduct(selectedSite.get().siteId, it) }
+            ?.firstOrNull()
             ?.map { it.toAppModel() }
             ?.let { addons -> Pair(addons, this) }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/AddonRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/AddonRepository.kt
@@ -17,8 +17,9 @@ class AddonRepository @Inject constructor(
     private val addonsStore: WCAddonsStore,
     private val selectedSite: SelectedSite
 ) {
-    suspend fun fetchGlobalAddons() =
+    suspend fun updateGlobalAddonsSuccessfully() =
         addonsStore.fetchAllGlobalAddonsGroups(selectedSite.get())
+            .isError.not()
 
     fun getAddonsFrom(productID: Long) =
         productStore.getProductByRemoteId(selectedSite.get(), productID)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
@@ -37,8 +37,7 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
         val CURRENT_WIP_NOTICE_FEATURE = FeatureFeedbackSettings.Feature.PRODUCT_ADDONS
     }
 
-    @Inject
-    lateinit var currencyFormatter: CurrencyFormatter
+    @Inject lateinit var currencyFormatter: CurrencyFormatter
 
     private val viewModel: OrderedAddonViewModel by viewModels()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
@@ -53,7 +53,7 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
         set(show) {
             field = show
             if (show) skeletonView.show(
-                viewActual = binding.addonsList,
+                viewActual = binding.contentContainer,
                 layoutId = R.layout.skeleton_ordered_addon_list,
                 delayed = true
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonFragment.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentOrderedAddonBinding
 import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.DISMISSED
 import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState.GIVEN
@@ -23,7 +24,9 @@ import com.woocommerce.android.model.ProductAddon
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.products.addons.AddonListAdapter
+import com.woocommerce.android.ui.products.addons.order.OrderedAddonViewModel.*
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.widgets.SkeletonView
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -34,7 +37,8 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
         val CURRENT_WIP_NOTICE_FEATURE = FeatureFeedbackSettings.Feature.PRODUCT_ADDONS
     }
 
-    @Inject lateinit var currencyFormatter: CurrencyFormatter
+    @Inject
+    lateinit var currencyFormatter: CurrencyFormatter
 
     private val viewModel: OrderedAddonViewModel by viewModels()
 
@@ -42,6 +46,19 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
 
     private var _binding: FragmentOrderedAddonBinding? = null
     private val binding get() = _binding!!
+
+    private val skeletonView = SkeletonView()
+
+    private var isLoadingSkeletonVisible: Boolean = false
+        set(show) {
+            field = show
+            if (show) skeletonView.show(
+                viewActual = binding.addonsList,
+                layoutId = R.layout.skeleton_ordered_addon_list,
+                delayed = true
+            )
+            else skeletonView.hide()
+        }
 
     private val supportActionBar
         get() = activity
@@ -80,6 +97,11 @@ class OrderedAddonFragment : BaseFragment(R.layout.fragment_ordered_addon) {
     private fun setupObservers() {
         viewModel.orderedAddonsData
             .observe(viewLifecycleOwner, Observer(::onOrderedAddonsReceived))
+        viewModel.viewStateLiveData.observe(viewLifecycleOwner, ::handleViewStateChanges)
+    }
+
+    private fun handleViewStateChanges(old: ViewState?, new: ViewState?) {
+        new?.isSkeletonShown?.takeIfNotEqualTo(old?.isSkeletonShown) { isLoadingSkeletonVisible = it }
     }
 
     private fun setupViews() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
@@ -43,8 +43,7 @@ class OrderedAddonViewModel @Inject constructor(
         orderItemID: Long,
         productID: Long
     ) = launch(dispatchers.computation) {
-        addonsRepository.fetchGlobalAddons()
-            .takeUnless { it.isError }
+            takeIf { addonsRepository.updateGlobalAddonsSuccessfully() }
             ?.let { addonsRepository.getOrderAddonsData(orderID, orderItemID, productID) }
             ?.let { mapAddonsFromOrderAttributes(it.first, it.second) }
             ?.let { dispatchResult(it) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
@@ -43,7 +43,9 @@ class OrderedAddonViewModel @Inject constructor(
         orderItemID: Long,
         productID: Long
     ) = launch(dispatchers.computation) {
-        addonsRepository.getOrderAddonsData(orderID, orderItemID, productID)
+         addonsRepository.fetchGlobalAddons()
+            .takeUnless { it.isError }
+            ?.let { addonsRepository.getOrderAddonsData(orderID, orderItemID, productID) }
             ?.let { mapAddonsFromOrderAttributes(it.first, it.second) }
             ?.let { dispatchResult(it) }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
@@ -54,7 +54,7 @@ class OrderedAddonViewModel @Inject constructor(
                 ?.let { addonsRepository.getOrderAddonsData(orderID, orderItemID, productID) }
                 ?.let { mapAddonsFromOrderAttributes(it.first, it.second) }
                 ?.let { dispatchResult(it) }
-                ?: viewState.copy(isSkeletonShown = false).let { viewState = it }
+                ?: dispatchFailure()
         }
     }
 
@@ -102,6 +102,12 @@ class OrderedAddonViewModel @Inject constructor(
         withContext(dispatchers.main) {
             viewState = viewState.copy(isSkeletonShown = false)
             _orderedAddons.value = result
+        }
+    }
+
+    private suspend fun dispatchFailure() {
+        withContext(dispatchers.main) {
+            viewState = viewState.copy(isSkeletonShown = false)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
@@ -43,7 +43,7 @@ class OrderedAddonViewModel @Inject constructor(
         orderItemID: Long,
         productID: Long
     ) = launch(dispatchers.computation) {
-         addonsRepository.fetchGlobalAddons()
+        addonsRepository.fetchGlobalAddons()
             .takeUnless { it.isError }
             ?.let { addonsRepository.getOrderAddonsData(orderID, orderItemID, productID) }
             ?.let { mapAddonsFromOrderAttributes(it.first, it.second) }

--- a/WooCommerce/src/main/res/layout/fragment_ordered_addon.xml
+++ b/WooCommerce/src/main/res/layout/fragment_ordered_addon.xml
@@ -16,26 +16,32 @@
             android:visibility="gone"
             tools:visibility="visible" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/addons_list"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            tools:itemCount="3"
-            tools:listitem="@layout/product_addon_card" />
-
-        <com.google.android.material.textview.MaterialTextView
-            style="@style/Woo.TextView.Caption"
+        <LinearLayout
+            android:id="@+id/content_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/minor_10"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/ordered_add_ons_details_info_notice"
-            android:drawableStart="@drawable/ic_info_outline_24dp"
-            android:drawablePadding="@dimen/minor_100"
-            android:gravity="center_vertical"
-            android:visibility="visible"
-            tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit." />
+            android:orientation="vertical">
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/addons_list"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                tools:itemCount="3"
+                tools:listitem="@layout/product_addon_card" />
+
+            <com.google.android.material.textview.MaterialTextView
+                style="@style/Woo.TextView.Caption"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/minor_10"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
+                android:text="@string/ordered_add_ons_details_info_notice"
+                android:drawableStart="@drawable/ic_info_outline_24dp"
+                android:drawablePadding="@dimen/minor_100"
+                android:gravity="center_vertical"
+                android:visibility="visible"
+                tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit." />
+        </LinearLayout>
     </LinearLayout>
 
 </androidx.core.widget.NestedScrollView>

--- a/WooCommerce/src/main/res/layout/skeleton_addon_card.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_addon_card.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/linearLayout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingBottom="@dimen/minor_100">
+
+    <View
+        android:layout_width="wrap_content"
+        android:layout_height="95dp"
+        android:background="@color/skeleton_color"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/skeleton_ordered_addon_list.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_ordered_addon_list.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/color_surface"
+    android:orientation="vertical">
+
+    <include layout="@layout/skeleton_variation_attributes_list_item"/>
+
+    <include layout="@layout/skeleton_variation_attributes_list_item"/>
+
+    <include layout="@layout/skeleton_variation_attributes_list_item"/>
+
+    <include layout="@layout/skeleton_variation_attributes_list_item"/>
+
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/skeleton_ordered_addon_list.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_ordered_addon_list.xml
@@ -6,12 +6,14 @@
     android:background="@color/color_surface"
     android:orientation="vertical">
 
-    <include layout="@layout/skeleton_variation_attributes_list_item"/>
+    <include layout="@layout/skeleton_addon_card"/>
 
-    <include layout="@layout/skeleton_variation_attributes_list_item"/>
+    <include layout="@layout/skeleton_addon_card"/>
 
-    <include layout="@layout/skeleton_variation_attributes_list_item"/>
+    <include layout="@layout/skeleton_addon_card"/>
 
-    <include layout="@layout/skeleton_variation_attributes_list_item"/>
+    <include layout="@layout/skeleton_addon_card"/>
+
+    <include layout="@layout/skeleton_addon_card"/>
 
 </LinearLayout>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/ProductAddonTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/ProductAddonTest.kt
@@ -1,9 +1,9 @@
 package com.woocommerce.android.model
 
+import com.woocommerce.android.model.ProductAddon.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.wordpress.android.fluxc.model.addons.WCProductAddonModel
 
 internal class ProductAddonTest {
     private lateinit var addonUnderTest: ProductAddon
@@ -11,7 +11,7 @@ internal class ProductAddonTest {
     private val addonPriceFake = "test-price"
     private val rawOptionsFake = listOf(
         ProductAddonOption(
-            priceType = WCProductAddonModel.AddOnPriceType.FlatFee,
+            priceType = PriceType.FlatFee,
             label = "test-option-label",
             price = "test-option-price",
             image = "test-option-image"
@@ -28,12 +28,12 @@ internal class ProductAddonTest {
             max = 0,
             min = 0,
             position = 0,
-            adjustPrice = 0,
-            titleFormat = WCProductAddonModel.AddOnTitleFormat.Label,
-            restrictionsType = WCProductAddonModel.AddOnRestrictionsType.OnlyLettersNumbers,
-            priceType = WCProductAddonModel.AddOnPriceType.FlatFee,
-            type = WCProductAddonModel.AddOnType.CustomPrice,
-            display = WCProductAddonModel.AddOnDisplay.RadioButton,
+            adjustPrice = false,
+            titleFormat = TitleFormat.Label,
+            restrictionsType = Restrictions.OnlyLettersNumbers,
+            priceType = PriceType.FlatFee,
+            type = Type.CustomPrice,
+            display = Display.RadioButton,
             price = addonPriceFake,
             rawOptions = rawOptionsFake
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.products.addons
 
+import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.addons.AddonTestFixtures.defaultAddonWithOptionsList
 import com.woocommerce.android.ui.products.addons.AddonTestFixtures.defaultOrderAttributes
@@ -95,6 +96,26 @@ class AddonRepositoryTest {
                     .getProductByRemoteId(siteModelMock, 333)
 
                 assertThat(orderAddons).isEqualTo(expectedAddons)
+            } ?: fail("non-null Pair with valid data was expected")
+    }
+
+    @Test
+    fun `fetchOrderAddonsData should map productAddons correctly`() = runBlockingTest {
+        configureSuccessfulOrderResponse()
+        configureSuccessfulAddonResponse()
+
+        val expectedAddons = defaultAddonWithOptionsList.map { it.toAppModel() }
+
+        repositoryUnderTest.getOrderAddonsData(123, 999, 333)
+            ?.let { (productAddons, _) ->
+
+                verify(productStoreMock, times(1))
+                    .getProductByRemoteId(siteModelMock, 333)
+
+                verify(addonStoreMock, times(1))
+                    .observeAddonsForProduct(321, defaultWCProductModel)
+
+                assertThat(productAddons).isEqualTo(expectedAddons)
             } ?: fail("non-null Pair with valid data was expected")
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonRepositoryTest.kt
@@ -1,9 +1,13 @@
 package com.woocommerce.android.ui.products.addons
 
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.products.addons.AddonTestFixtures.defaultAddonWithOptionsList
 import com.woocommerce.android.ui.products.addons.AddonTestFixtures.defaultOrderAttributes
 import com.woocommerce.android.ui.products.addons.AddonTestFixtures.defaultWCOrderItemList
 import com.woocommerce.android.ui.products.addons.AddonTestFixtures.defaultWCProductModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -15,15 +19,18 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
+import org.wordpress.android.fluxc.store.WCAddonsStore
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCProductStore
 import kotlin.test.fail
 
+@ExperimentalCoroutinesApi
 class AddonRepositoryTest {
     private lateinit var repositoryUnderTest: AddonRepository
 
     private lateinit var orderStoreMock: WCOrderStore
     private lateinit var productStoreMock: WCProductStore
+    private lateinit var addonStoreMock: WCAddonsStore
     private lateinit var selectedSiteMock: SelectedSite
     private lateinit var siteModelMock: SiteModel
 
@@ -35,24 +42,27 @@ class AddonRepositoryTest {
     fun setUp() {
         siteModelMock = mock {
             on { id }.doReturn(321)
+            on { siteId }.doReturn(321)
         }
-        orderStoreMock = mock()
-        productStoreMock = mock()
         selectedSiteMock = mock {
             on { get() }.doReturn(siteModelMock)
         }
+        orderStoreMock = mock()
+        productStoreMock = mock()
+        addonStoreMock = mock()
 
         repositoryUnderTest = AddonRepository(
             orderStoreMock,
             productStoreMock,
+            addonStoreMock,
             selectedSiteMock
         )
     }
 
     @Test
-    fun `fetchOrderAddonsData should return both order addons and product addons data`() {
+    fun `fetchOrderAddonsData should return both order addons and product addons data`() = runBlockingTest {
         configureSuccessfulOrderResponse()
-        configureSuccessfulProductResponse()
+        configureSuccessfulAddonResponse()
 
         repositoryUnderTest.getOrderAddonsData(123, 999, 333)
             ?.let { (productAddons, orderAddons) ->
@@ -69,9 +79,9 @@ class AddonRepositoryTest {
     }
 
     @Test
-    fun `fetchOrderAddonsData should map and filter orderAddons keys as List correctly`() {
+    fun `fetchOrderAddonsData should map and filter orderAddons keys as List correctly`() = runBlockingTest {
         configureSuccessfulOrderResponse()
-        configureSuccessfulProductResponse()
+        configureSuccessfulAddonResponse()
 
         val expectedAddons = defaultOrderAttributes
 
@@ -89,8 +99,8 @@ class AddonRepositoryTest {
     }
 
     @Test
-    fun `getAddonsFrom should return addons successfully`() {
-        configureSuccessfulProductResponse()
+    fun `getAddonsFrom should return addons successfully`() = runBlockingTest {
+        configureSuccessfulAddonResponse()
 
         val expectedAddons = defaultWCProductModel.addons!!
 
@@ -100,8 +110,8 @@ class AddonRepositoryTest {
     }
 
     @Test
-    fun `getAddonsFrom should return null when the requested with wrong ID`() {
-        configureSuccessfulProductResponse()
+    fun `getAddonsFrom should return null when the requested with wrong ID`() = runBlockingTest {
+        configureSuccessfulAddonResponse()
 
         val actualAddons = repositoryUnderTest.getAddonsFrom(999)
 
@@ -109,22 +119,22 @@ class AddonRepositoryTest {
     }
 
     @Test
-    fun `fetchOrderAddonsData should return null if product addon data fails`() {
+    fun `fetchOrderAddonsData should return null if product addon data fails`() = runBlockingTest {
         configureSuccessfulOrderResponse()
         val response = repositoryUnderTest.getOrderAddonsData(123, 999, 333)
         assertThat(response).isNull()
     }
 
     @Test
-    fun `fetchOrderAddonsData should return null if order addon data fails`() {
-        configureSuccessfulProductResponse()
+    fun `fetchOrderAddonsData should return null if order addon data fails`() = runBlockingTest {
+        configureSuccessfulAddonResponse()
         val response = repositoryUnderTest.getOrderAddonsData(123, 999, 333)
         assertThat(response).isNull()
     }
 
     @Test
-    fun `fetchOrderAddonsData should return null if order item ID is incorrect`() {
-        configureSuccessfulProductResponse()
+    fun `fetchOrderAddonsData should return null if order item ID is incorrect`() = runBlockingTest {
+        configureSuccessfulAddonResponse()
         val response = repositoryUnderTest.getOrderAddonsData(123, 0, 333)
         assertThat(response).isNull()
     }
@@ -141,11 +151,15 @@ class AddonRepositoryTest {
         }
     }
 
-    private fun configureSuccessfulProductResponse() {
+    private fun configureSuccessfulAddonResponse() {
         whenever(
             productStoreMock.getProductByRemoteId(
                 siteModelMock, remoteProductID
             )
         ).thenReturn(defaultWCProductModel)
+
+        whenever(
+            addonStoreMock.observeAddonsForProduct(localSiteID.toLong(), defaultWCProductModel)
+        ).thenReturn(MutableStateFlow(defaultAddonWithOptionsList))
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonTestFixtures.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonTestFixtures.kt
@@ -10,6 +10,11 @@ import com.woocommerce.android.util.UnitTestUtils.jsonFileAs
 import com.woocommerce.android.util.UnitTestUtils.jsonFileToString
 import org.wordpress.android.fluxc.model.WCOrderModel.LineItem
 import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.persistence.entity.AddonEntity
+import org.wordpress.android.fluxc.persistence.entity.AddonEntity.*
+import org.wordpress.android.fluxc.persistence.entity.AddonEntity.Type.*
+import org.wordpress.android.fluxc.persistence.entity.AddonOptionEntity
+import org.wordpress.android.fluxc.persistence.entity.AddonWithOptions
 
 object AddonTestFixtures {
     val defaultWCOrderItemList: List<LineItem> by lazy {
@@ -42,6 +47,44 @@ object AddonTestFixtures {
         defaultWCProductModel
             .toAppModel()
             .addons
+    }
+
+    val defaultAddonWithOptionsList by lazy {
+        listOf(
+            AddonWithOptions(
+                defaultAddonEntity.copy(
+                    name = "Topping",
+                    description = "Pizza topping",
+                    priceType = PriceType.FlatFee
+                ),
+                options = listOf(
+                    emptyAddonOptions.copy(
+                        label = "Peperoni",
+                        price = "3",
+                        image = "",
+                        priceType = PriceType.FlatFee
+                    ),
+                    emptyAddonOptions.copy(
+                        label = "Extra cheese",
+                        price = "4",
+                        image = "",
+                        priceType = PriceType.FlatFee
+                    ),
+                    emptyAddonOptions.copy(
+                        label = "Salami",
+                        price = "3",
+                        image = "",
+                        priceType = PriceType.FlatFee
+                    ),
+                    emptyAddonOptions.copy(
+                        label = "Ham",
+                        price = "3",
+                        image = "",
+                        priceType = PriceType.FlatFee
+                    )
+                )
+            )
+        )
     }
 
     val defaultOrderedAddonList by lazy {
@@ -153,6 +196,35 @@ object AddonTestFixtures {
             display = null,
             price = "",
             rawOptions = listOf()
+        )
+    }
+
+    val defaultAddonEntity by lazy {
+        AddonEntity(
+            name = "",
+            required = false,
+            description = "",
+            descriptionEnabled = true,
+            max = 0,
+            min = 0,
+            position = 0,
+            priceAdjusted = false,
+            titleFormat = TitleFormat.Label,
+            restrictions = Restrictions.AnyText,
+            priceType = PriceType.FlatFee,
+            type = Checkbox,
+            display = Display.Select,
+            price = ""
+        )
+    }
+
+    val emptyAddonOptions by lazy {
+        AddonOptionEntity(
+            label = "",
+            price = "",
+            image = "",
+            priceType = PriceType.FlatFee,
+            addonLocalId = 0
         )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonTestFixtures.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonTestFixtures.kt
@@ -2,14 +2,14 @@ package com.woocommerce.android.ui.products.addons
 
 import com.woocommerce.android.model.Order.Item.Attribute
 import com.woocommerce.android.model.ProductAddon
+import com.woocommerce.android.model.ProductAddon.PriceType.FlatFee
+import com.woocommerce.android.model.ProductAddon.PriceType.QuantityBased
 import com.woocommerce.android.model.ProductAddonOption
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.util.UnitTestUtils.jsonFileAs
 import com.woocommerce.android.util.UnitTestUtils.jsonFileToString
 import org.wordpress.android.fluxc.model.WCOrderModel.LineItem
 import org.wordpress.android.fluxc.model.WCProductModel
-import org.wordpress.android.fluxc.model.addons.WCProductAddonModel.AddOnPriceType.FlatFee
-import org.wordpress.android.fluxc.model.addons.WCProductAddonModel.AddOnPriceType.QuantityBased
 
 object AddonTestFixtures {
     val defaultWCOrderItemList: List<LineItem> by lazy {
@@ -145,7 +145,7 @@ object AddonTestFixtures {
             max = 0,
             min = 0,
             position = 0,
-            adjustPrice = 0,
+            adjustPrice = false,
             titleFormat = null,
             restrictionsType = null,
             priceType = null,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModelTest.kt
@@ -25,6 +25,9 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 
 @ExperimentalCoroutinesApi
@@ -69,6 +72,26 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
             viewModelUnderTest.start(321, 999, 123)
 
             assertThat(actualResult).isEqualTo(expectedResult)
+        }
+
+    @Test
+    fun `should return null if fetchGlobalAddons returns an error`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(addonRepositoryMock.getOrderAddonsData(321, 999, 123))
+                .thenReturn(Pair(defaultProductAddonList, defaultOrderAttributes))
+            whenever(addonRepositoryMock.fetchGlobalAddons()).thenReturn(
+                WooResult(WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.INVALID_RESPONSE))
+            )
+
+
+            var actualResult: List<ProductAddon>? = null
+            viewModelUnderTest.orderedAddonsData.observeForever {
+                actualResult = it
+            }
+
+            viewModelUnderTest.start(321, 999, 123)
+
+            assertThat(actualResult).isNull()
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModelTest.kt
@@ -3,6 +3,8 @@ package com.woocommerce.android.ui.products.addons.order
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.ProductAddon
+import com.woocommerce.android.model.ProductAddon.PriceType.FlatFee
+import com.woocommerce.android.model.ProductAddon.PriceType.QuantityBased
 import com.woocommerce.android.model.ProductAddonOption
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.addons.AddonRepository
@@ -23,8 +25,6 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
-import org.wordpress.android.fluxc.model.addons.WCProductAddonModel.AddOnPriceType.FlatFee
-import org.wordpress.android.fluxc.model.addons.WCProductAddonModel.AddOnPriceType.QuantityBased
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModelTest.kt
@@ -25,10 +25,6 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
-import org.wordpress.android.fluxc.network.BaseRequest
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
@@ -58,7 +54,7 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
     @Test
     fun `should trigger a successful parse to all data at once`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            whenever(addonRepositoryMock.fetchGlobalAddons()).thenReturn(WooResult(Unit))
+            whenever(addonRepositoryMock.updateGlobalAddonsSuccessfully()).thenReturn(true)
             whenever(addonRepositoryMock.getOrderAddonsData(321, 999, 123))
                 .thenReturn(Pair(defaultProductAddonList, defaultOrderAttributes))
 
@@ -79,9 +75,7 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(addonRepositoryMock.getOrderAddonsData(321, 999, 123))
                 .thenReturn(Pair(defaultProductAddonList, defaultOrderAttributes))
-            whenever(addonRepositoryMock.fetchGlobalAddons()).thenReturn(
-                WooResult(WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.INVALID_RESPONSE))
-            )
+            whenever(addonRepositoryMock.updateGlobalAddonsSuccessfully()).thenReturn(false)
 
             var actualResult: List<ProductAddon>? = null
             viewModelUnderTest.orderedAddonsData.observeForever {
@@ -108,7 +102,7 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
 
             whenever(addonRepositoryMock.getOrderAddonsData(321, 999, 123))
                 .doReturn(mockResponse)
-            whenever(addonRepositoryMock.fetchGlobalAddons()).thenReturn(WooResult(Unit))
+            whenever(addonRepositoryMock.updateGlobalAddonsSuccessfully()).thenReturn(true)
 
             val expectedResult = emptyProductAddon.copy(
                 name = "Delivery",
@@ -148,7 +142,7 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
                         )
                     )
                 )
-            whenever(addonRepositoryMock.fetchGlobalAddons()).thenReturn(WooResult(Unit))
+            whenever(addonRepositoryMock.updateGlobalAddonsSuccessfully()).thenReturn(true)
 
             val expectedResult = emptyProductAddon.copy(
                 name = "test-name",
@@ -192,7 +186,7 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
                         )
                     )
                 )
-            whenever(addonRepositoryMock.fetchGlobalAddons()).thenReturn(WooResult(Unit))
+            whenever(addonRepositoryMock.updateGlobalAddonsSuccessfully()).thenReturn(true)
 
             val expectedResult = listOf(
                 emptyProductAddon.copy(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModelTest.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android.ui.products.addons.order
 
-import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.ProductAddon
 import com.woocommerce.android.model.ProductAddon.PriceType.FlatFee
@@ -37,14 +37,19 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
         val storeParametersMock = mock<SiteParameters> {
             on { currencyCode }.doReturn("currency-code")
         }
-        val savedStateMock = mock<SavedStateHandle>()
+        val savedState = OrderedAddonFragmentArgs(
+            orderId = 321,
+            orderItemId = 999,
+            addonsProductId = 123
+        ).initSavedStateHandle()
+
         val parameterRepositoryMock = mock<ParameterRepository> {
-            on { getParameters("key_product_parameters", savedStateMock) }
+            on { getParameters("key_product_parameters", savedState) }
                 .doReturn(storeParametersMock)
         }
 
         viewModelUnderTest = OrderedAddonViewModel(
-            savedStateMock,
+            savedState,
             coroutinesTestRule.testDispatchers,
             addonRepositoryMock,
             parameterRepositoryMock

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModelTest.kt
@@ -25,6 +25,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
@@ -34,12 +35,12 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        val savedStateMock = mock<SavedStateHandle>()
-        val storeParametersMock = mock<SiteParameters>().apply {
-            whenever(currencyCode).doReturn("currency-code")
+        val storeParametersMock = mock<SiteParameters> {
+            on { currencyCode }.doReturn("currency-code")
         }
-        val parameterRepositoryMock = mock<ParameterRepository>().apply {
-            whenever(getParameters("key_product_parameters", savedStateMock))
+        val savedStateMock = mock<SavedStateHandle>()
+        val parameterRepositoryMock = mock<ParameterRepository> {
+            on { getParameters("key_product_parameters", savedStateMock) }
                 .doReturn(storeParametersMock)
         }
 
@@ -54,8 +55,9 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
     @Test
     fun `should trigger a successful parse to all data at once`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(addonRepositoryMock.fetchGlobalAddons()).thenReturn(WooResult(Unit))
             whenever(addonRepositoryMock.getOrderAddonsData(321, 999, 123))
-                .doReturn(Pair(defaultProductAddonList, defaultOrderAttributes))
+                .thenReturn(Pair(defaultProductAddonList, defaultOrderAttributes))
 
             val expectedResult = defaultOrderedAddonList
 
@@ -84,6 +86,7 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
 
             whenever(addonRepositoryMock.getOrderAddonsData(321, 999, 123))
                 .doReturn(mockResponse)
+            whenever(addonRepositoryMock.fetchGlobalAddons()).thenReturn(WooResult(Unit))
 
             val expectedResult = emptyProductAddon.copy(
                 name = "Delivery",
@@ -112,7 +115,7 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
     fun `should return Addon with single option when matching option is found`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(addonRepositoryMock.getOrderAddonsData(321, 999, 123))
-                .doReturn(
+                .thenReturn(
                     Pair(
                         listWithSingleAddonAndTwoValidOptions,
                         listOf(
@@ -123,6 +126,7 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
                         )
                     )
                 )
+            whenever(addonRepositoryMock.fetchGlobalAddons()).thenReturn(WooResult(Unit))
 
             val expectedResult = emptyProductAddon.copy(
                 name = "test-name",
@@ -166,6 +170,7 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
                         )
                     )
                 )
+            whenever(addonRepositoryMock.fetchGlobalAddons()).thenReturn(WooResult(Unit))
 
             val expectedResult = listOf(
                 emptyProductAddon.copy(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModelTest.kt
@@ -83,7 +83,6 @@ class OrderedAddonViewModelTest : BaseUnitTest() {
                 WooResult(WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.INVALID_RESPONSE))
             )
 
-
             var actualResult: List<ProductAddon>? = null
             viewModelUnderTest.orderedAddonsData.observeForever {
                 actualResult = it

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2102-47f5ab4f3a57b9c8e455db9379fed45f26338bde'
+    fluxCVersion = '2103-dfa147421da55dc1c6bcd9e903d78b1bab959860'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2103-dfa147421da55dc1c6bcd9e903d78b1bab959860'
+    fluxCVersion = 'develop-a300bc1eef0fe7ea7e23c9587269737d3d7c66c6'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'


### PR DESCRIPTION
Summary
==========
Fixes issue #4567 by making it possible to join Global Add-ons data within the Ordered Add-ons view. Since the Global Add-ons data isn't something available inside Order and Product models, we need to do a fetch operation that may lead to loading times, so this PR also introduces skeleton loading mechanics to the view.

Screenshots
==========
| Ordered Add-ons view loading skeleton  | Ordered Add-ons View containing Global Add-ons |
| ------------- | ------------- |
| ![Screenshot_20210829_182747](https://user-images.githubusercontent.com/5920403/131265930-383c9754-4472-46b3-a681-99a9b0cfa04a.png) | ![Screenshot_20210829_182733](https://user-images.githubusercontent.com/5920403/131265929-7c415714-a566-49d0-8be6-7754dc7fd00b.png) |

How to Test
==========
Prerequisites: Have your site with the add ons plugin installed, configured, and with at least one product with add-ons and at least one order of the configured product including Global Add-ons. 

⚠️ Note that you should configure both Product-specific and Global add-ons in your store in order to test this improvement properly.

1 - Launch the Woo app.
2 - Navigate to an order with a Product configured with Add-ons, verify if the `View Add-ons` Button is showing up for products that contain Add-ons inside the current Order, but doesn't show up for Products without Add-ons for that order or Products that don't have Add-ons configured at all.
3 - Click on `View Add-ons` and verify if the Ordered Addons view is displayed with all the expected data, including Global Add-ons data.


Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
