### PR TITLE
Merge 7.4 release notes into develop

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,9 @@
 
 7.4
 -----
-
+- [*] Reviews Tab: Added a pending review label to unapproved reviews [https://github.com/woocommerce/woocommerce-android/pull/4644]
+- [*] Shipping Labels: Fixed a rare crash that occurred when adding a new package with decimal weight quantity [https://github.com/woocommerce/woocommerce-android/pull/4657]
+- [*] Shipping Labels: Updated error messages when validating origin and shipping addresses  [https://github.com/woocommerce/woocommerce-android/pull/4612]
 
 7.3
 -----

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -55,9 +55,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "7.4-rc-1"
+            versionName "7.4-rc-2"
         }
-        versionCode 239
+        versionCode 240
 
         minSdkVersion 21
         targetSdkVersion 30

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -57,7 +57,7 @@ android {
         } else {
             versionName "7.4-rc-2"
         }
-        versionCode 240
+        versionCode 241
 
         minSdkVersion 21
         targetSdkVersion 30

--- a/WooCommerce/metadata/PlayStoreStrings.pot
+++ b/WooCommerce/metadata/PlayStoreStrings.pot
@@ -11,18 +11,20 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_074"
+msgid ""
+"7.4:\n"
+"Product reviews requiring your approval have a new label to make it easier for you to distinguish them from already approved reviews.\n"
+"\n"
+"This update also includes several enhancements to the shipping label feature using the WooCommerce Shipping & Tax Extension. We value all of your feedback on this newer feature!\n"
+msgstr ""
+
 msgctxt "release_note_073"
 msgid ""
 "7.3:\n"
 "Merchants using the WooCommerce Shipping & Tax Extension will be happy to hear of two improvements we’ve made. You can create custom packages when creating a label. You can also create multiple shipping labels for a single order!\n"
 "\n"
 "This and many other tiny improvements were made to make your experience smoother. We hope you notice the love we put into our software.\n"
-msgstr ""
-
-msgctxt "release_note_072"
-msgid ""
-"7.2:\n"
-"We focused on making the product more stable and reliable for you this time. Several bugs were addressed and fixed, including one where the list of products would be empty sometimes when a product contained a value in total sales that was unexpected. Thanks for keeping up to date, and always let us know if you have feedback!\n"
 msgstr ""
 
 #. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,2 +1,3 @@
+Product reviews requiring your approval have a new label to make it easier for you to distinguish them from already approved reviews.
 
-
+This update also includes several enhancements to the shipping label feature using the WooCommerce Shipping & Tax Extension. We value all of your feedback on this newer feature!

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
@@ -31,8 +31,11 @@ class MediaFileUploadHandler @Inject constructor(
         mediaUploadError: MediaStore.MediaError
     ) {
         val remoteProductId = mediaModel.postId
+        val errorMessage = mediaUploadError.message
+            ?: mediaUploadError.logMessage
+            ?: resourceProvider.getString(R.string.product_image_service_error_uploading)
         val newErrors = currentUploadErrors.get(remoteProductId, mutableListOf()) +
-            ProductImageUploadUiModel(mediaModel, mediaUploadError.type, mediaUploadError.message)
+            ProductImageUploadUiModel(mediaModel, mediaUploadError.type, errorMessage)
         currentUploadErrors.put(remoteProductId, newErrors)
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandlerTest.kt
@@ -11,7 +11,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.store.MediaStore
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
@@ -21,7 +23,10 @@ class MediaFileUploadHandlerTest : BaseUnitTest() {
         private const val REMOTE_SITE_ID = 1L
     }
 
-    private val resources: ResourceProvider = mock()
+    private val resources: ResourceProvider = mock {
+        on(it.getString(any())).thenAnswer { i -> i.arguments[0].toString() }
+        on(it.getString(any(), any())).thenAnswer { i -> i.arguments[0].toString() }
+    }
     private val testMediaModel = ProductTestUtils.generateProductMedia(REMOTE_PRODUCT_ID, REMOTE_SITE_ID)
     private val testMediaModelError = ProductTestUtils.generateMediaUploadErrorModel()
     private lateinit var mediaFileUploadHandler: MediaFileUploadHandler
@@ -36,6 +41,18 @@ class MediaFileUploadHandlerTest : BaseUnitTest() {
         assertThat(mediaFileUploadHandler.getMediaUploadErrorCount(testMediaModel.postId)).isEqualTo(0)
 
         mediaFileUploadHandler.handleMediaUploadFailure(testMediaModel, testMediaModelError)
+        assertThat(mediaFileUploadHandler.getMediaUploadErrorCount(testMediaModel.postId)).isEqualTo(1)
+        assertThat(mediaFileUploadHandler.getMediaUploadErrorMessage(testMediaModel.postId)).isEqualTo(
+            resources.getString(R.string.product_image_service_error_uploading_single)
+        )
+    }
+
+    @Test
+    fun `Handles empty error message in mediaModelError correctly`() {
+        val mediaErrorModel = MediaStore.MediaError(MediaStore.MediaErrorType.GENERIC_ERROR)
+        assertThat(mediaFileUploadHandler.getMediaUploadErrorCount(testMediaModel.postId)).isEqualTo(0)
+
+        mediaFileUploadHandler.handleMediaUploadFailure(testMediaModel, mediaErrorModel)
         assertThat(mediaFileUploadHandler.getMediaUploadErrorCount(testMediaModel.postId)).isEqualTo(1)
         assertThat(mediaFileUploadHandler.getMediaUploadErrorMessage(testMediaModel.postId)).isEqualTo(
             resources.getString(R.string.product_image_service_error_uploading_single)


### PR DESCRIPTION
Merge 7.4 beta 2 and release notes into `develop`, including:
- Version number bumps
- The changes from 7.3.1 (which resulted in `7.4-rc-2`)