### PR TITLE
Product filter by category performance and UI improvements.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -854,10 +854,11 @@ class MainActivity :
         stockStatus: String?,
         productType: String?,
         productStatus: String?,
-        productCategory: String?
+        productCategory: String?,
+        productCategoryName: String?
     ) {
         val action = ProductListFragmentDirections.actionProductListFragmentToProductFilterListFragment(
-            stockStatus, productStatus, productType, productCategory
+            stockStatus, productStatus, productType, productCategory, productCategoryName
         )
         navController.navigateSafely(action)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
@@ -20,7 +20,15 @@ interface MainNavigationRouter {
         enableModeration: Boolean,
         tempStatus: String? = null
     )
-    fun showProductFilters(stockStatus: String?, productType: String?, productStatus: String?, productCategory: String?)
+
+    fun showProductFilters(
+        stockStatus: String?,
+        productType: String?,
+        productStatus: String?,
+        productCategory: String?,
+        productCategoryName: String?
+    )
+
     fun showFeedbackSurvey()
     fun showProductAddBottomSheet()
     fun showSettingsScreen()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -324,6 +324,10 @@ class ProductFilterListViewModel @Inject constructor(
             )
     }
 
+    fun onLoadMoreCategoriesRequested() {
+        TODO("Not yet implemented")
+    }
+
     @Parcelize
     data class ProductFilterListViewState(
         val screenTitle: String? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -319,6 +319,10 @@ class ProductFilterListViewModel @Inject constructor(
     }
 
     fun onLoadMoreRequested(selectedFilterItemPosition: Int) {
+        if (!networkStatus.isConnected()) {
+            return
+        }
+
         _filterListItems.value?.let {
             val filterItem = it[selectedFilterItemPosition]
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -343,10 +343,12 @@ class ProductFilterListViewModel @Inject constructor(
     fun onLoadMoreCategoriesRequested() {
         if (productCategoriesRepository.canLoadMoreProductCategories) {
             launch {
+                productFilterOptionListViewState = productFilterOptionListViewState.copy(isLoadingMore = true)
                 productCategories = productCategoriesRepository.fetchProductCategories(loadMore = true)
                 val categoryOptions = productCategoriesToOptionListItems()
                 _filterOptionListItems.value = categoryOptions
                 updateCategoryFilterListItem(categoryOptions)
+                productFilterOptionListViewState = productFilterOptionListViewState.copy(isLoadingMore = false)
             }
         }
     }
@@ -364,7 +366,8 @@ class ProductFilterListViewModel @Inject constructor(
     @Parcelize
     data class ProductFilterOptionListViewState(
         val screenTitle: String? = null,
-        val isSkeletonShown: Boolean? = null
+        val isSkeletonShown: Boolean? = null,
+        val isLoadingMore: Boolean? = null
     ) : Parcelable
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -342,7 +342,9 @@ class ProductFilterListViewModel @Inject constructor(
         if (productCategoriesRepository.canLoadMoreProductCategories) {
             launch {
                 productCategories = productCategoriesRepository.fetchProductCategories(loadMore = true)
-                updateCategoryFilterListItem(productCategoriesToOptionListItems())
+                val categoryOptions = productCategoriesToOptionListItems()
+                _filterOptionListItems.value = categoryOptions
+                updateCategoryFilterListItem(categoryOptions)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -122,10 +122,12 @@ class ProductFilterListViewModel @Inject constructor(
             val filterItem = filterListItem[selectedFilterListItemPosition]
             if (filterItem.filterItemKey == CATEGORY) {
                 launch {
+                    productFilterOptionListViewState = productFilterOptionListViewState.copy(isSkeletonShown = true)
                     loadCategoriesIfEmpty()
                     val categoryOptions = productCategoriesToOptionListItems()
                     _filterOptionListItems.value = categoryOptions
                     updateCategoryFilterListItem(categoryOptions)
+                    productFilterOptionListViewState = productFilterOptionListViewState.copy(isSkeletonShown = false)
                 }
             } else {
                 _filterOptionListItems.value = filterItem.filterOptionListItems
@@ -361,7 +363,8 @@ class ProductFilterListViewModel @Inject constructor(
 
     @Parcelize
     data class ProductFilterOptionListViewState(
-        val screenTitle: String? = null
+        val screenTitle: String? = null,
+        val isSkeletonShown: Boolean? = null
     ) : Parcelable
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -39,6 +39,7 @@ class ProductFilterListViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val KEY_PRODUCT_FILTER_OPTIONS = "key_product_filter_options"
+        private const val KEY_PRODUCT_FILTER_SELECTED_CATEGORY_NAME = "key_product_filter_selected_category_name"
     }
 
     private val arguments: ProductFilterListFragmentArgs by savedState.navArgs()
@@ -75,7 +76,7 @@ class ProductFilterListViewModel @Inject constructor(
         params
     }
 
-    private var selectedCategoryName: String? = arguments.selectedProductCategoryName
+    private var selectedCategoryName: String? = null
 
     fun getFilterString() = productFilterOptions.values.joinToString(", ")
 
@@ -97,7 +98,14 @@ class ProductFilterListViewModel @Inject constructor(
         }
     }
 
+    private fun initOrRestoreSelectedCategoryName() {
+        selectedCategoryName = savedState.get<String>(KEY_PRODUCT_FILTER_SELECTED_CATEGORY_NAME)
+        arguments.selectedProductCategoryName?. let { selectedCategoryName = it }
+        savedState[KEY_PRODUCT_FILTER_SELECTED_CATEGORY_NAME] = selectedCategoryName
+    }
+
     fun loadFilters() {
+        initOrRestoreSelectedCategoryName()
         _filterListItems.value = buildFilterListItemUiModel()
 
         val screenTitle = if (productFilterOptions.isNotEmpty()) {
@@ -181,6 +189,7 @@ class ProductFilterListViewModel @Inject constructor(
 
             if (filterItem.filterItemKey == CATEGORY) {
                 selectedCategoryName = selectedFilterItem.filterOptionItemName
+                savedState[KEY_PRODUCT_FILTER_SELECTED_CATEGORY_NAME] = selectedCategoryName
             }
 
             // update the filter options map - which is used to load the filter list screen
@@ -252,9 +261,6 @@ class ProductFilterListViewModel @Inject constructor(
             )
         )
         filterListItems.add(buildCategoryFilterListItemUiModel())
-
-        val a = filterListItems
-
         return filterListItems
     }
 
@@ -294,7 +300,7 @@ class ProductFilterListViewModel @Inject constructor(
             }
         }
 
-        val x = FilterListItemUiModel(
+        return FilterListItemUiModel(
             CATEGORY,
             resourceProvider.getString(string.product_category),
             addDefaultFilterOption(
@@ -302,7 +308,6 @@ class ProductFilterListViewModel @Inject constructor(
                 productFilterOptions[CATEGORY].isNullOrEmpty()
             )
         )
-        return x
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -131,13 +131,16 @@ class ProductFilterListViewModel @Inject constructor(
     }
 
     private fun productCategoriesToOptionListItems(): List<FilterListOptionItemUiModel> {
-        return productCategories.map { category ->
-            FilterListOptionItemUiModel(
-                category.name,
-                category.remoteCategoryId.toString(),
-                isSelected = productFilterOptions[CATEGORY] == category.remoteCategoryId.toString()
-            )
-        }
+        return addDefaultFilterOption(
+            productCategories.map { category ->
+                FilterListOptionItemUiModel(
+                    category.name,
+                    category.remoteCategoryId.toString(),
+                    isSelected = productFilterOptions[CATEGORY] == category.remoteCategoryId.toString()
+                )
+            }.toMutableList(),
+            productFilterOptions[CATEGORY].isNullOrEmpty()
+        )
     }
 
     fun onBackButtonClicked(): Boolean {
@@ -250,6 +253,8 @@ class ProductFilterListViewModel @Inject constructor(
         )
         filterListItems.add(buildCategoryFilterListItemUiModel())
 
+        val a = filterListItems
+
         return filterListItems
     }
 
@@ -289,7 +294,7 @@ class ProductFilterListViewModel @Inject constructor(
             }
         }
 
-        return FilterListItemUiModel(
+        val x = FilterListItemUiModel(
             CATEGORY,
             resourceProvider.getString(string.product_category),
             addDefaultFilterOption(
@@ -297,6 +302,7 @@ class ProductFilterListViewModel @Inject constructor(
                 productFilterOptions[CATEGORY].isNullOrEmpty()
             )
         )
+        return x
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -114,11 +114,9 @@ class ProductFilterListViewModel @Inject constructor(
             if (filterItem.filterItemKey == CATEGORY) {
                 launch {
                     loadCategoriesIfEmpty()
-
                     val categoryOptions = productCategoriesToOptionListItems()
-
-                    filterItem.filterOptionListItems = categoryOptions
                     _filterOptionListItems.value = categoryOptions
+                    updateCategoryFilterListItem(categoryOptions)
                 }
             } else {
                 _filterOptionListItems.value = filterItem.filterOptionListItems
@@ -327,9 +325,13 @@ class ProductFilterListViewModel @Inject constructor(
         if (productCategoriesRepository.canLoadMoreProductCategories) {
             launch {
                 productCategories = productCategoriesRepository.fetchProductCategories(loadMore = true)
-                _filterOptionListItems.value = productCategoriesToOptionListItems()
+                updateCategoryFilterListItem(productCategoriesToOptionListItems())
             }
         }
+    }
+
+    private fun updateCategoryFilterListItem(categoryOptions: List<FilterListOptionItemUiModel>) {
+        _filterListItems.value?.find { it.filterItemKey == CATEGORY }?.filterOptionListItems = categoryOptions
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -98,14 +98,13 @@ class ProductFilterListViewModel @Inject constructor(
         }
     }
 
-    private fun initOrRestoreSelectedCategoryName() {
-        selectedCategoryName = savedState.get<String>(KEY_PRODUCT_FILTER_SELECTED_CATEGORY_NAME)
-        arguments.selectedProductCategoryName?. let { selectedCategoryName = it }
-        savedState[KEY_PRODUCT_FILTER_SELECTED_CATEGORY_NAME] = selectedCategoryName
+    init {
+        arguments.selectedProductCategoryName?.let { selectedCategoryName = it }
     }
 
     fun loadFilters() {
-        initOrRestoreSelectedCategoryName()
+        savedState.get<String>(KEY_PRODUCT_FILTER_SELECTED_CATEGORY_NAME)?. let { selectedCategoryName = it }
+
         _filterListItems.value = buildFilterListItemUiModel()
 
         val screenTitle = if (productFilterOptions.isNotEmpty()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -71,7 +71,7 @@ class ProductFilterListViewModel @Inject constructor(
         arguments.selectedStockStatus?.let { params.put(STOCK_STATUS, it) }
         arguments.selectedProductType?.let { params.put(TYPE, it) }
         arguments.selectedProductStatus?.let { params.put(STATUS, it) }
-        arguments.selectedProductCategory?.let { params.put(CATEGORY, it) }
+        arguments.selectedProductCategoryId?.let { params.put(CATEGORY, it) }
         savedState[KEY_PRODUCT_FILTER_OPTIONS] = params
         params
     }
@@ -314,7 +314,7 @@ class ProductFilterListViewModel @Inject constructor(
             arguments.selectedProductStatus != getFilterByProductStatus() ||
                 arguments.selectedProductType != getFilterByProductType() ||
                 arguments.selectedStockStatus != getFilterByStockStatus() ||
-                arguments.selectedProductCategory != getFilterByProductCategory()
+                arguments.selectedProductCategoryId != getFilterByProductCategory()
             )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -59,7 +59,7 @@ class ProductFilterListViewModel @Inject constructor(
     private lateinit var productCategories: List<ProductCategory>
 
     /**
-     * Holds the filter properties (stock_status, status, type) already selected by the user in a [Map]
+     * Holds the filter properties (stock_status, status, type, category) already selected by the user in a [Map]
      * where the key is the [ProductFilterOption] and value is the slug associated with the property.
      *
      * If no filters are previously selected, the map is empty.
@@ -284,7 +284,7 @@ class ProductFilterListViewModel @Inject constructor(
     ) : Parcelable
 
     /**
-     * [filterItemKey] includes the [ProductFilterOption] which can be [STATUS], [TYPE] or [STOCK_STATUS]
+     * [filterItemKey] includes the [ProductFilterOption] which can be [STATUS], [TYPE], [CATEGORY], or [STOCK_STATUS]
      * [filterItemName] is the display name of the filter list item i.e Product Status, Stock Status
      * [filterOptionListItems] includes a list of [FilterListOptionItemUiModel]
      */
@@ -334,6 +334,7 @@ class ProductFilterListViewModel @Inject constructor(
      * Eg: for stock status, this would be instock, outofstock
      * for product type, this would be simple, grouped, variable
      * for product status, this would be pending, draft
+     * for category, this would be category ID
      */
     @Parcelize
     data class FilterListOptionItemUiModel(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -56,7 +56,7 @@ class ProductFilterListViewModel @Inject constructor(
         LiveDataDelegate(savedState, ProductFilterOptionListViewState())
     private var productFilterOptionListViewState by productFilterOptionListViewStateData
 
-    private val productCategories = mutableListOf<ProductCategory>()
+    private var productCategories: List<ProductCategory> = emptyList()
 
     /**
      * Holds the filter properties (stock_status, status, type, category) already selected by the user in a [Map]
@@ -87,12 +87,11 @@ class ProductFilterListViewModel @Inject constructor(
 
     private suspend fun loadCategoriesIfEmpty() {
         if (productCategories.isEmpty()) {
-            val result = if (networkStatus.isConnected()) {
+            productCategories = if (networkStatus.isConnected()) {
                 productCategoriesRepository.fetchProductCategories()
             } else {
                 productCategoriesRepository.getProductCategoriesList()
             }
-            productCategories.addAll(result)
         }
     }
 
@@ -325,7 +324,12 @@ class ProductFilterListViewModel @Inject constructor(
     }
 
     fun onLoadMoreCategoriesRequested() {
-        TODO("Not yet implemented")
+        if (productCategoriesRepository.canLoadMoreProductCategories) {
+            launch {
+                productCategories = productCategoriesRepository.fetchProductCategories(loadMore = true)
+                _filterOptionListItems.value = productCategoriesToOptionListItems()
+            }
+        }
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -75,6 +75,8 @@ class ProductFilterListViewModel @Inject constructor(
         params
     }
 
+    private var selectedCategoryName: String? = arguments.selectedProductCategoryName
+
     fun getFilterString() = productFilterOptions.values.joinToString(", ")
 
     private fun getFilterByStockStatus() = productFilterOptions[STOCK_STATUS]
@@ -174,6 +176,10 @@ class ProductFilterListViewModel @Inject constructor(
             }
             _filterOptionListItems.value = filterOptionItemList
 
+            if (filterItem.filterItemKey == CATEGORY) {
+                selectedCategoryName = selectedFilterItem.filterOptionItemName
+            }
+
             // update the filter options map - which is used to load the filter list screen
             // if the selected filter option item is the default filter item i.e. ANY,
             // then remove the filter from the map, since this means the filter for that option has been cleared,
@@ -191,7 +197,8 @@ class ProductFilterListViewModel @Inject constructor(
             productStatus = getFilterByProductStatus(),
             stockStatus = getFilterByStockStatus(),
             productType = getFilterByProductType(),
-            productCategory = getFilterByProductCategory()
+            productCategory = getFilterByProductCategory(),
+            productCategoryName = selectedCategoryName
         )
         triggerEvent(ExitWithResult(result))
     }
@@ -264,7 +271,7 @@ class ProductFilterListViewModel @Inject constructor(
             isComingFromProductListWithExistingFilterByCategory() -> {
                 listOf(
                     FilterListOptionItemUiModel(
-                        getFilterByProductCategory()!!, // TODO: We need to show category name here, instead of ID.
+                        selectedCategoryName!!,
                         getFilterByProductCategory()!!,
                         true
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -268,7 +268,8 @@ class ProductFilterListViewModel @Inject constructor(
         return (
             arguments.selectedProductStatus != getFilterByProductStatus() ||
                 arguments.selectedProductType != getFilterByProductType() ||
-                arguments.selectedStockStatus != getFilterByStockStatus()
+                arguments.selectedStockStatus != getFilterByStockStatus() ||
+                arguments.selectedProductCategory != getFilterByProductCategory()
             )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -340,15 +340,20 @@ class ProductFilterListViewModel @Inject constructor(
             )
     }
 
-    fun onLoadMoreCategoriesRequested() {
-        if (productCategoriesRepository.canLoadMoreProductCategories) {
-            launch {
-                productFilterOptionListViewState = productFilterOptionListViewState.copy(isLoadingMore = true)
-                productCategories = productCategoriesRepository.fetchProductCategories(loadMore = true)
-                val categoryOptions = productCategoriesToOptionListItems()
-                _filterOptionListItems.value = categoryOptions
-                updateCategoryFilterListItem(categoryOptions)
-                productFilterOptionListViewState = productFilterOptionListViewState.copy(isLoadingMore = false)
+    fun onLoadMoreRequested(selectedFilterItemPosition: Int) {
+        _filterListItems.value?.let {
+            val filterItem = it[selectedFilterItemPosition]
+
+            // Load more is only needed for Category filter item.
+            if (filterItem.filterItemKey == CATEGORY && productCategoriesRepository.canLoadMoreProductCategories) {
+                launch {
+                    productFilterOptionListViewState = productFilterOptionListViewState.copy(isLoadingMore = true)
+                    productCategories = productCategoriesRepository.fetchProductCategories(loadMore = true)
+                    val categoryOptions = productCategoriesToOptionListItems()
+                    _filterOptionListItems.value = categoryOptions
+                    updateCategoryFilterListItem(categoryOptions)
+                    productFilterOptionListViewState = productFilterOptionListViewState.copy(isLoadingMore = false)
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListAdapter.kt
@@ -3,30 +3,27 @@ package com.woocommerce.android.ui.products
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.view.isVisible
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.databinding.ProductFilterOptionListItemBinding
-import com.woocommerce.android.extensions.areSameAs
 import com.woocommerce.android.ui.products.ProductFilterListViewModel.FilterListOptionItemUiModel
 import com.woocommerce.android.ui.products.ProductFilterOptionListAdapter.ProductFilterOptionViewHolder
 
 class ProductFilterOptionListAdapter(
     private val clickListener: OnProductFilterOptionClickListener,
     private val loadMoreListener: OnLoadMoreListener
-) : RecyclerView.Adapter<ProductFilterOptionViewHolder>() {
-    var filterList = listOf<FilterListOptionItemUiModel>()
-        set(value) {
-            if (!isSameList(value)) {
-                field = value
-                notifyDataSetChanged()
-            }
-        }
-
+) : ListAdapter<FilterListOptionItemUiModel, ProductFilterOptionViewHolder>(FilterOptionDiffCallback) {
     init {
         setHasStableIds(true)
     }
 
     interface OnProductFilterOptionClickListener {
         fun onFilterOptionClick(selectedFilter: FilterListOptionItemUiModel)
+    }
+
+    fun updateData(uiModels: List<FilterListOptionItemUiModel>) {
+        submitList(uiModels)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProductFilterOptionViewHolder {
@@ -40,9 +37,9 @@ class ProductFilterOptionListAdapter(
     }
 
     override fun onBindViewHolder(holder: ProductFilterOptionViewHolder, position: Int) {
-        holder.bind(filterList[position])
+        holder.bind(getItem(position))
         holder.itemView.setOnClickListener {
-            clickListener.onFilterOptionClick(filterList[position])
+            clickListener.onFilterOptionClick(getItem(position))
         }
 
         if (position == itemCount - 1) {
@@ -52,16 +49,27 @@ class ProductFilterOptionListAdapter(
 
     override fun getItemId(position: Int) = position.toLong()
 
-    override fun getItemCount() = filterList.size
-
-    private fun isSameList(newList: List<FilterListOptionItemUiModel>) =
-        filterList.areSameAs(newList) { this.isSameFilterOption(it) }
-
     class ProductFilterOptionViewHolder(val viewBinding: ProductFilterOptionListItemBinding) :
         RecyclerView.ViewHolder(viewBinding.root) {
         fun bind(filter: FilterListOptionItemUiModel) {
             viewBinding.filterOptionItemName.text = filter.filterOptionItemName
             viewBinding.filterOptionItemTick.isVisible = filter.isSelected
+        }
+    }
+
+    object FilterOptionDiffCallback : DiffUtil.ItemCallback<FilterListOptionItemUiModel>() {
+        override fun areItemsTheSame(
+            oldItem: FilterListOptionItemUiModel,
+            newItem: FilterListOptionItemUiModel
+        ): Boolean {
+            return oldItem.filterOptionItemValue == newItem.filterOptionItemValue
+        }
+
+        override fun areContentsTheSame(
+            oldItem: FilterListOptionItemUiModel,
+            newItem: FilterListOptionItemUiModel
+        ): Boolean {
+            return oldItem == newItem
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListAdapter.kt
@@ -10,7 +10,8 @@ import com.woocommerce.android.ui.products.ProductFilterListViewModel.FilterList
 import com.woocommerce.android.ui.products.ProductFilterOptionListAdapter.ProductFilterOptionViewHolder
 
 class ProductFilterOptionListAdapter(
-    private val clickListener: OnProductFilterOptionClickListener
+    private val clickListener: OnProductFilterOptionClickListener,
+    private val loadMoreListener: OnLoadMoreListener
 ) : RecyclerView.Adapter<ProductFilterOptionViewHolder>() {
     var filterList = listOf<FilterListOptionItemUiModel>()
         set(value) {
@@ -42,6 +43,10 @@ class ProductFilterOptionListAdapter(
         holder.bind(filterList[position])
         holder.itemView.setOnClickListener {
             clickListener.onFilterOptionClick(filterList[position])
+        }
+
+        if (position == itemCount - 1) {
+            loadMoreListener.onRequestLoadMore()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.products
 
 import android.os.Bundle
 import android.view.View
+import androidx.core.view.isVisible
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.lifecycle.Observer
 import androidx.lifecycle.observe
@@ -12,7 +13,9 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.databinding.FragmentProductFilterOptionListBinding
+import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.products.ProductFilterListViewModel.FilterListOptionItemUiModel
@@ -74,7 +77,12 @@ class ProductFilterOptionListFragment :
     ) {
         viewModel.productFilterOptionListViewStateData.observe(viewLifecycleOwner) { old, new ->
             new.screenTitle.takeIfNotEqualTo(old?.screenTitle) { requireActivity().title = it }
-            new.isSkeletonShown?.takeIfNotEqualTo(old?.isSkeletonShown) { showSkeleton(it, binding) }
+            new.isSkeletonShown?.takeIfNotEqualTo(old?.isSkeletonShown) {
+                showSkeleton(it, binding)
+            }
+            new.isLoadingMore?.takeIfNotEqualTo(old?.isLoadingMore) {
+                showLoadMoreProgress(it, binding)
+            }
         }
 
         viewModel.filterOptionListItems.observe(
@@ -103,9 +111,15 @@ class ProductFilterOptionListFragment :
                 R.layout.skeleton_product_filter_options_categories_list,
                 delayed = true
             )
+            binding.filterOptionListBtnFrame.hide()
         } else {
             skeletonView.hide()
+            binding.filterOptionListBtnFrame.show()
         }
+    }
+
+    private fun showLoadMoreProgress(show: Boolean, binding: FragmentProductFilterOptionListBinding) {
+        binding.loadMoreProgress.isVisible = show
     }
 
     private fun showProductFilterList(productFilterOptionList: List<FilterListOptionItemUiModel>) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
@@ -90,7 +90,7 @@ class ProductFilterOptionListFragment :
     }
 
     private fun showProductFilterList(productFilterOptionList: List<FilterListOptionItemUiModel>) {
-        mProductFilterOptionListAdapter.filterList = productFilterOptionList
+        mProductFilterOptionListAdapter.updateData(productFilterOptionList)
     }
 
     override fun onFilterOptionClick(selectedFilter: FilterListOptionItemUiModel) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
@@ -24,6 +24,7 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class ProductFilterOptionListFragment :
     BaseFragment(R.layout.fragment_product_filter_option_list),
+    OnLoadMoreListener,
     OnProductFilterOptionClickListener {
     private val viewModel: ProductFilterListViewModel by hiltNavGraphViewModels(R.id.nav_graph_product_filters)
 
@@ -37,7 +38,7 @@ class ProductFilterOptionListFragment :
         val binding = FragmentProductFilterOptionListBinding.bind(view)
         setupObservers(viewModel)
 
-        mProductFilterOptionListAdapter = ProductFilterOptionListAdapter(this)
+        mProductFilterOptionListAdapter = ProductFilterOptionListAdapter(this, this)
         with(binding.filterOptionList) {
             addItemDecoration(
                 AlignedDividerDecoration(
@@ -94,5 +95,9 @@ class ProductFilterOptionListFragment :
 
     override fun onFilterOptionClick(selectedFilter: FilterListOptionItemUiModel) {
         viewModel.onFilterOptionItemSelected(arguments.selectedFilterItemPosition, selectedFilter)
+    }
+
+    override fun onRequestLoadMore() {
+        viewModel.onLoadMoreCategoriesRequested()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
@@ -131,7 +131,7 @@ class ProductFilterOptionListFragment :
     }
 
     override fun onRequestLoadMore() {
-        viewModel.onLoadMoreCategoriesRequested()
+        viewModel.onLoadMoreRequested(arguments.selectedFilterItemPosition)
     }
 
     override fun onDestroyView() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterResult.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterResult.kt
@@ -8,5 +8,6 @@ data class ProductFilterResult(
     val stockStatus: String?,
     val productType: String?,
     val productStatus: String?,
-    val productCategory: String?
+    val productCategory: String?,
+    val productCategoryName: String?
 ) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -292,7 +292,8 @@ class ProductListFragment :
                         event.stockStatusFilter,
                         event.productTypeFilter,
                         event.productStatusFilter,
-                        event.productCategoryFilter
+                        event.productCategoryFilter,
+                        event.selectedCategoryName
                     )
                     is ShowProductSortingBottomSheet -> showProductSortingBottomSheet()
                     else -> event.isHandled = false
@@ -315,7 +316,8 @@ class ProductListFragment :
                 stockStatus = result.stockStatus,
                 productStatus = result.productStatus,
                 productType = result.productType,
-                productCategory = result.productCategory
+                productCategory = result.productCategory,
+                productCategoryName = result.productCategoryName
             )
         }
     }
@@ -454,13 +456,15 @@ class ProductListFragment :
         stockStatus: String?,
         productType: String?,
         productStatus: String?,
-        productCategory: String?
+        productCategory: String?,
+        productCategoryName: String?
     ) {
         (activity as? MainNavigationRouter)?.showProductFilters(
             stockStatus,
             productType,
             productStatus,
-            productCategory
+            productCategory,
+            productCategoryName
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -60,6 +60,7 @@ class ProductListViewModel @Inject constructor(
         params
     }
 
+    private var selectedCategoryName: String? = null
     private var searchJob: Job? = null
     private var loadJob: Job? = null
 
@@ -102,7 +103,8 @@ class ProductListViewModel @Inject constructor(
         stockStatus: String?,
         productStatus: String?,
         productType: String?,
-        productCategory: String?
+        productCategory: String?,
+        productCategoryName: String?
     ) {
         if (areFiltersChanged(stockStatus, productStatus, productType, productCategory)) {
             productFilterOptions.clear()
@@ -110,6 +112,7 @@ class ProductListViewModel @Inject constructor(
             productStatus?.let { productFilterOptions[ProductFilterOption.STATUS] = it }
             productType?.let { productFilterOptions[ProductFilterOption.TYPE] = it }
             productCategory?.let { productFilterOptions[ProductFilterOption.CATEGORY] = it }
+            productCategoryName?. let { selectedCategoryName = it }
 
             viewState = viewState.copy(filterCount = productFilterOptions.size)
             refreshProducts()
@@ -135,7 +138,8 @@ class ProductListViewModel @Inject constructor(
                 productFilterOptions[ProductFilterOption.STOCK_STATUS],
                 productFilterOptions[ProductFilterOption.TYPE],
                 productFilterOptions[ProductFilterOption.STATUS],
-                productFilterOptions[ProductFilterOption.CATEGORY]
+                productFilterOptions[ProductFilterOption.CATEGORY],
+                selectedCategoryName
             )
         )
     }
@@ -430,7 +434,8 @@ class ProductListViewModel @Inject constructor(
             val stockStatusFilter: String?,
             val productTypeFilter: String?,
             val productStatusFilter: String?,
-            val productCategoryFilter: String?
+            val productCategoryFilter: String?,
+            val selectedCategoryName: String?
         ) : ProductListEvent()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -45,6 +45,7 @@ class ProductListViewModel @Inject constructor(
     companion object {
         private const val SEARCH_TYPING_DELAY_MS = 500L
         private const val KEY_PRODUCT_FILTER_OPTIONS = "key_product_filter_options"
+        private const val KEY_PRODUCT_FILTER_SELECTED_CATEGORY_NAME = "key_product_filter_selected_category_name"
     }
 
     private val _productList = MutableLiveData<List<Product>>()
@@ -70,6 +71,8 @@ class ProductListViewModel @Inject constructor(
             loadProducts()
         }
         viewState = viewState.copy(sortingTitleResource = getSortingTitle())
+
+        selectedCategoryName = savedState.get<String>(KEY_PRODUCT_FILTER_SELECTED_CATEGORY_NAME)
     }
 
     override fun onCleared() {
@@ -112,7 +115,10 @@ class ProductListViewModel @Inject constructor(
             productStatus?.let { productFilterOptions[ProductFilterOption.STATUS] = it }
             productType?.let { productFilterOptions[ProductFilterOption.TYPE] = it }
             productCategory?.let { productFilterOptions[ProductFilterOption.CATEGORY] = it }
-            productCategoryName?. let { selectedCategoryName = it }
+            productCategoryName?. let {
+                selectedCategoryName = it
+                savedState[KEY_PRODUCT_FILTER_SELECTED_CATEGORY_NAME] = it
+            }
 
             viewState = viewState.copy(filterCount = productFilterOptions.size)
             refreshProducts()

--- a/WooCommerce/src/main/res/layout/fragment_product_filter_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_filter_list.xml
@@ -9,22 +9,24 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/filterList"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
         android:background="?attr/colorSurface"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:itemCount="5"
+        app:layout_constraintBottom_toTopOf="@+id/bottomDivider"
+        tools:itemCount="4"
+        app:layout_constrainedHeight="true"
+        app:layout_constraintVertical_bias="0.0"
         tools:listitem="@layout/product_filter_list_item" />
 
     <View
         style="@style/Woo.Divider"
+        android:id="@+id/bottomDivider"
         android:layout_marginStart="@dimen/major_100"
         app:layout_constraintBottom_toTopOf="@+id/filterList_btnFrame"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/filterList"
-        app:layout_constraintVertical_bias="0.0" />
+        app:layout_constraintStart_toStartOf="parent" />
 
     <com.woocommerce.android.widgets.WCElevatedLinearLayout
         android:id="@+id/filterList_btnFrame"

--- a/WooCommerce/src/main/res/layout/fragment_product_filter_option_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_filter_option_list.xml
@@ -9,11 +9,14 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/filterOptionList"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
         android:background="?attr/colorSurface"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/bottomDivider"
+        app:layout_constrainedHeight="true"
+        app:layout_constraintVertical_bias="0.0"
         tools:itemCount="5"
         tools:listitem="@layout/product_filter_option_list_item" />
 
@@ -23,9 +26,7 @@
         android:layout_marginStart="@dimen/major_100"
         app:layout_constraintBottom_toTopOf="@+id/filterOptionList_btnFrame"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/filterOptionList"
-        app:layout_constraintVertical_bias="0.0" />
+        app:layout_constraintStart_toStartOf="parent" />
 
     <ProgressBar
         android:id="@+id/loadMoreProgress"
@@ -37,7 +38,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         tools:visibility="visible" />
-
 
     <com.woocommerce.android.widgets.WCElevatedLinearLayout
         android:id="@+id/filterOptionList_btnFrame"

--- a/WooCommerce/src/main/res/layout/fragment_product_filter_option_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_filter_option_list.xml
@@ -19,12 +19,25 @@
 
     <View
         style="@style/Woo.Divider"
+        android:id="@+id/bottomDivider"
         android:layout_marginStart="@dimen/major_100"
         app:layout_constraintBottom_toTopOf="@+id/filterOptionList_btnFrame"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/filterOptionList"
         app:layout_constraintVertical_bias="0.0" />
+
+    <ProgressBar
+        android:id="@+id/loadMoreProgress"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@+id/filterOptionList_btnFrame"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:visibility="visible" />
+
 
     <com.woocommerce.android.widgets.WCElevatedLinearLayout
         android:id="@+id/filterOptionList_btnFrame"

--- a/WooCommerce/src/main/res/layout/skeleton_product_filter_options_categories_list.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_product_filter_options_categories_list.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/color_surface"
+    android:orientation="vertical">
+
+    <include layout="@layout/skeleton_product_category_list_item"/>
+
+    <View style="@style/Woo.Divider" android:layout_marginStart="@dimen/major_100"/>
+
+    <include layout="@layout/skeleton_product_category_list_item"/>
+
+    <View style="@style/Woo.Divider" android:layout_marginStart="@dimen/major_100"/>
+
+    <include layout="@layout/skeleton_product_category_list_item"/>
+
+    <View style="@style/Woo.Divider" android:layout_marginStart="@dimen/major_100"/>
+
+    <include layout="@layout/skeleton_product_category_list_item"/>
+
+    <View style="@style/Woo.Divider" android:layout_marginStart="@dimen/major_100"/>
+
+    <include layout="@layout/skeleton_product_category_list_item"/>
+
+    <View style="@style/Woo.Divider" android:layout_marginStart="@dimen/major_100"/>
+
+    <include layout="@layout/skeleton_product_category_list_item"/>
+
+    <View style="@style/Woo.Divider" android:layout_marginStart="@dimen/major_100"/>
+
+    <include layout="@layout/skeleton_product_category_list_item"/>
+
+    <View style="@style/Woo.Divider" android:layout_marginStart="@dimen/major_100"/>
+
+    <include layout="@layout/skeleton_product_category_list_item"/>
+
+    <View style="@style/Woo.Divider" android:layout_marginStart="@dimen/major_100"/>
+
+    <include layout="@layout/skeleton_product_category_list_item"/>
+
+    <View style="@style/Woo.Divider" android:layout_marginStart="@dimen/major_100"/>
+
+    <include layout="@layout/skeleton_product_category_list_item"/>
+
+    <View style="@style/Woo.Divider" android:layout_marginStart="@dimen/major_100"/>
+
+    <include layout="@layout/skeleton_product_category_list_item"/>
+
+    <View style="@style/Woo.Divider" android:layout_marginStart="@dimen/major_100"/>
+
+    <include layout="@layout/skeleton_product_category_list_item"/>
+
+    <View style="@style/Woo.Divider" android:layout_marginStart="@dimen/major_100"/>
+
+    <include layout="@layout/skeleton_product_category_list_item"/>
+
+    <View style="@style/Woo.Divider" android:layout_marginStart="@dimen/major_100"/>
+
+    <include layout="@layout/skeleton_product_category_list_item"/>
+
+</LinearLayout>

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -52,7 +52,7 @@
                 app:argType="string"
                 app:nullable="true" />
             <argument
-                android:name="selectedProductCategory"
+                android:name="selectedProductCategoryId"
                 app:argType="string"
                 app:nullable="true" />
             <argument

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -55,6 +55,10 @@
                 android:name="selectedProductCategory"
                 app:argType="string"
                 app:nullable="true" />
+            <argument
+                android:name="selectedProductCategoryName"
+                app:argType="string"
+                app:nullable="true" />
         </action>
         <action
             android:id="@+id/action_productListFragment_to_productTypesBottomSheet"

--- a/WooCommerce/src/main/res/navigation/nav_graph_product_filters.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_product_filters.xml
@@ -21,7 +21,7 @@
             app:nullable="true"
             app:argType="string" />
         <argument
-            android:name="selectedProductCategory"
+            android:name="selectedProductCategoryId"
             app:nullable="true"
             app:argType="string" />
         <argument

--- a/WooCommerce/src/main/res/navigation/nav_graph_product_filters.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_product_filters.xml
@@ -24,6 +24,10 @@
             android:name="selectedProductCategory"
             app:nullable="true"
             app:argType="string" />
+        <argument
+            android:name="selectedProductCategoryName"
+            app:nullable="true"
+            app:argType="string" />
         <action
             android:id="@+id/action_productFilterListFragment_to_productFilterOptionListFragment"
             app:destination="@id/productFilterOptionListFragment"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductListViewModelTest.kt
@@ -215,7 +215,8 @@ class ProductListViewModelTest : BaseUnitTest() {
         val status = "simple"
         val type = "draft"
         val category = "hoodie"
-        viewModel.onFiltersChanged(stockStatus, status, type, category)
+        val categoryName = "Hoodie"
+        viewModel.onFiltersChanged(stockStatus, status, type, category, categoryName)
 
         val events = mutableListOf<Event>()
         viewModel.event.observeForever {
@@ -229,6 +230,7 @@ class ProductListViewModelTest : BaseUnitTest() {
         assertThat(event.productTypeFilter).isEqualTo(type)
         assertThat(event.stockStatusFilter).isEqualTo(stockStatus)
         assertThat(event.productCategoryFilter).isEqualTo(category)
+        assertThat(event.selectedCategoryName).isEqualTo(categoryName)
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

This is part of #4578
<!-- Id number of the GitHub issue this PR addresses. -->

### What this PR does

The amount of line changes is rather big, but a good amount of it is also just the skeleton XML and navigation setup. I've added various comments to hopefully help explain things, but please let me know if anything is unclear.

Here is the breakdown of all the added changes:

**1. Loading improvements to product filtering.**
Speaking generally, the product filtering flow goes like this:

```
 [Product List screen] -> [Filter Items screen] -> [Filter Item Options screen]
```

Previously, list of categories is loaded on Filter Items screen. With this PR, list of categories is loaded on Filter Item Options screen, instead. The PR makes Filter Items load faster, and adds a bit of caching after fetching list of categories.

**2. Load more categories.**
Previously, the category filter item option screen only loads 100 categories. With this PR, if the user scrolls down to the end and the site has more than 100 categories, then the app will load the next 100 categories, and so on.

This also includes a change in `ProductFilterOptionListAdapter` to inherit from `ListAdapter` instead of `RecyclerView.Adapter` for better diffing. They're mostly boilerplate code, though, and the only real change is the way it does load more call.

**3. Selected category name preservation.**
Due to how the existing code is set up, some code is also needed preserve selected category option name. Selected options preservation works like this: If a user already does a filtering, then wants to do another, then the previously selected filtering options are shown on the Filter Items screen. Here we want to preserve category name because it's the data we need to show.

 Quite a bit of parts in the PR has to do with this, especially with preserving and data passing for selected category name when moving between the three screens:
- From Filter Item Options to Filter Items, the selected data doesn't need to be passed as it's already stored in the shared  `ProductFilterListViewModel`
- From Filter Items to Products List, data are sent via `ExitWithResult` event.
- From Product List screen to Filter Items screen, the same data is sent via nav argument.
- There's also some `savedState` work to preserve category name in the event of process death, both on Products List and Filter Items screens. This follows existing code that already preserves the options.

**4. UI updates.**
Finally, this add a couple of UI changes:
- Skeleton loading on the options screen when loading categories
- Circular progress loading during load more categories action.

<hr />

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

**1. Loading improvements to product filtering.**
1. Go to Products List, tap Filter. 
2. Select "Category".
3. Assuming there's active internet connection, the app will show the loading skeleton and eventually show the list of categories. Make sure "Any" is shown at the top.
4. Select a category and go back to the Filter Item screen.
5. On Filter Item screen, tap "Category" again and make sure the list of categories now loads instantly instead of having to fetch and show skeleton again.
6. Select a category, complete the filtering, and check the result on the Products List screen.

**2. Load more categories.**
1. Use a test site with more than 100 categories. The simplest way might be via WP CLI command `wp term generate product_cat`, which will generate 100 example product categories. There is also [a plugin that can help](https://te.wordpress.org/plugins/bulk-woocommerce-category-creator/).
2. Go to Products List, tap Filter. 
2. Select "Category".
3. Assuming there's active internet connection, the app will show the loading skeleton and eventually show the list of categories.
4. Scroll to the end of the list, and make sure the circular progress bar is shown at the bottom as the app tries to load more categories.
5. Wait and make sure the next set of categories show up.
6. Pick a category from that next set, complete the filtering, and check the result on the Products List screen.

**3. Selected category name preservation.**
1. Go to Products List, tap Filter. 
2. Select "Category".
3. Assuming there's active internet connection, the app will show the loading skeleton and eventually show the list of categories. Make sure "Any" is shown at the top.
4. Select a category, remember its name.
5. Complete the filtering and check the result on the Products List screen.
6. Tap "Filter" again, this will open the Filter Items screen.
7. Make sure the selected category name is listed to the next of "Category" item.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
