### PR TITLE
Create Add-ons beta toggle

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/mystore/settings/BetaFeaturesScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/screenshots/mystore/settings/BetaFeaturesScreen.kt
@@ -5,13 +5,13 @@ import com.woocommerce.android.screenshots.util.Screen
 
 class BetaFeaturesScreen : Screen {
     companion object {
-        const val PRODUCT_EDITING_SWITCH = R.id.switchProductsUI
+        const val PRODUCT_ADDONS_SWITCH = R.id.switchAddonsToggle
     }
 
-    constructor() : super(PRODUCT_EDITING_SWITCH)
+    constructor() : super(PRODUCT_ADDONS_SWITCH)
 
-    fun enableProductEditing(): BetaFeaturesScreen {
-        flipSwitchOn(R.id.switchSetting_switch, PRODUCT_EDITING_SWITCH)
+    fun enableProductAddons(): BetaFeaturesScreen {
+        flipSwitchOn(R.id.switchSetting_switch, PRODUCT_ADDONS_SWITCH)
         return BetaFeaturesScreen()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -40,6 +40,7 @@ object AppPrefs {
         LOGIN_SITE_ADDRESS,
         DATABASE_DOWNGRADED,
         IS_PRODUCTS_FEATURE_ENABLED,
+        IS_PRODUCT_ADDONS_ENABLED,
         LOGIN_USER_BYPASSED_JETPACK_REQUIRED,
         SELECTED_ORDER_LIST_TAB_POSITION,
         IMAGE_OPTIMIZE_ENABLED,
@@ -119,6 +120,10 @@ object AppPrefs {
         } catch (ex: Throwable) {
             relativeInstallationDate
         }
+
+    var isProductAddonsEnabled: Boolean
+        get() = getBoolean(DeletablePrefKey.IS_PRODUCT_ADDONS_ENABLED, false)
+        set(value) = setBoolean(DeletablePrefKey.IS_PRODUCT_ADDONS_ENABLED, value)
 
     /**
      * This property informs a installation date relative to the moment the shared preferences data

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
@@ -130,11 +130,10 @@ class AppSettingsActivity :
         confirmLogout()
     }
 
-    override fun onProductsFeatureOptionChanged(enabled: Boolean) {
-        val isProductsFeatureEnabled = AppPrefs.isProductsFeatureEnabled()
-        if (isProductsFeatureEnabled != enabled) {
+    override fun onProductAddonsOptionChanged(enabled: Boolean) {
+        if (AppPrefs.isProductAddonsEnabled != enabled) {
             isBetaOptionChanged = true
-            AppPrefs.setIsProductsFeatureEnabled(enabled)
+            AppPrefs.isProductAddonsEnabled = enabled
             setResult(RESULT_CODE_BETA_OPTIONS_CHANGED)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
@@ -26,7 +26,7 @@ class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
         binding.switchAddonsToggle.isChecked = AppPrefs.isProductAddonsEnabled
         binding.switchAddonsToggle.setOnCheckedChangeListener { _, isChecked ->
             // trigger track event
-            settingsListener?.onProductsFeatureOptionChanged(isChecked)
+            settingsListener?.onProductAddonsOptionChanged(isChecked)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
@@ -6,39 +6,27 @@ import androidx.fragment.app.Fragment
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SETTINGS_BETA_FEATURES_PRODUCTS_TOGGLED
 import com.woocommerce.android.databinding.FragmentSettingsBetaBinding
 import com.woocommerce.android.ui.prefs.MainSettingsFragment.AppSettingsListener
-import com.woocommerce.android.util.AnalyticsUtils
 
 class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
     companion object {
         const val TAG = "beta-features"
     }
 
-    private lateinit var settingsListener: AppSettingsListener
+    private val settingsListener by lazy {
+        activity as? AppSettingsListener
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         val binding = FragmentSettingsBetaBinding.bind(view)
 
-        if (activity is AppSettingsListener) {
-            settingsListener = activity as AppSettingsListener
-        } else {
-            throw ClassCastException(context.toString() + " must implement AppSettingsListener")
-        }
-
-        binding.switchProductsUI.isChecked = AppPrefs.isProductsFeatureEnabled()
-        binding.switchProductsUI.setOnCheckedChangeListener { _, isChecked ->
-            AnalyticsTracker.track(
-                SETTINGS_BETA_FEATURES_PRODUCTS_TOGGLED,
-                mapOf(
-                    AnalyticsTracker.KEY_STATE to
-                        AnalyticsUtils.getToggleStateLabel(binding.switchProductsUI.isChecked)
-                )
-            )
-            settingsListener.onProductsFeatureOptionChanged(isChecked)
+        binding.switchAddonsToggle.isChecked = AppPrefs.isProductAddonsEnabled
+        binding.switchAddonsToggle.setOnCheckedChangeListener { _, isChecked ->
+            // trigger track event
+            settingsListener?.onProductsFeatureOptionChanged(isChecked)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
@@ -3,6 +3,8 @@ package com.woocommerce.android.ui.prefs
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
+import com.google.android.material.snackbar.BaseTransientBottomBar
+import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -27,6 +29,7 @@ class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
         binding.switchAddonsToggle.setOnCheckedChangeListener { _, isChecked ->
             // trigger track event
             settingsListener?.onProductAddonsOptionChanged(isChecked)
+                ?: binding.handleToggleChangeFailure(isChecked)
         }
     }
 
@@ -35,5 +38,14 @@ class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
         AnalyticsTracker.trackViewShown(this)
 
         activity?.setTitle(R.string.beta_features)
+    }
+
+    private fun FragmentSettingsBetaBinding.handleToggleChangeFailure(isChecked: Boolean) {
+        switchAddonsToggle.isChecked = !isChecked
+        Snackbar.make(
+            mainView,
+            R.string.settings_enable_beta_feature_failed_snackbar_text,
+            BaseTransientBottomBar.LENGTH_LONG
+        ).show()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -30,7 +30,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SETTINGS_SELECTED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SETTINGS_WE_ARE_HIRING_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SETTING_CHANGE
 import com.woocommerce.android.databinding.FragmentSettingsMainBinding
-import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -164,9 +164,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
 
         binding.optionBetaFeatures.optionValue = getString(R.string.settings_enable_product_adding_teaser_title)
 
-        // No beta features currently available
-        binding.optionBetaFeatures.hide()
-
         binding.optionPrivacy.setOnClickListener {
             AnalyticsTracker.track(SETTINGS_PRIVACY_SETTINGS_BUTTON_TAPPED)
             findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_privacySettingsFragment)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -63,7 +63,7 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
     interface AppSettingsListener {
         fun onRequestLogout()
         fun onSiteChanged()
-        fun onProductsFeatureOptionChanged(enabled: Boolean)
+        fun onProductAddonsOptionChanged(enabled: Boolean)
     }
 
     private lateinit var settingsListener: AppSettingsListener

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -161,7 +161,7 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
             findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_betaFeaturesFragment)
         }
 
-        binding.optionBetaFeatures.optionValue = getString(R.string.settings_enable_product_adding_teaser_title)
+        binding.optionBetaFeatures.optionValue = getString(R.string.settings_enable_product_addons_teaser_title)
 
         binding.optionPrivacy.setOnClickListener {
             AnalyticsTracker.track(SETTINGS_PRIVACY_SETTINGS_BUTTON_TAPPED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.util
 
 import android.content.Context
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.util.payment.CardPresentEligibleFeatureChecker
 
 /**
@@ -17,8 +18,11 @@ enum class FeatureFlag {
             DB_DOWNGRADE -> {
                 PackageUtils.isDebugBuild() || context != null && PackageUtils.isBetaBuild(context)
             }
-            ORDER_CREATION, PRODUCT_ADD_ONS -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
+            ORDER_CREATION -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
             CARD_READER -> CardPresentEligibleFeatureChecker.isCardPresentEligible
+            PRODUCT_ADD_ONS ->
+                (PackageUtils.isDebugBuild() || PackageUtils.isTesting())
+                    && AppPrefs.isProductAddonsEnabled
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -21,8 +21,8 @@ enum class FeatureFlag {
             ORDER_CREATION -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
             CARD_READER -> CardPresentEligibleFeatureChecker.isCardPresentEligible
             PRODUCT_ADD_ONS ->
-                (PackageUtils.isDebugBuild() || PackageUtils.isTesting())
-                    && AppPrefs.isProductAddonsEnabled
+                (PackageUtils.isDebugBuild() || PackageUtils.isTesting()) &&
+                    AppPrefs.isProductAddonsEnabled
         }
     }
 }

--- a/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -10,10 +9,21 @@
         android:id="@+id/switchProductsUI"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:toggleOptionDesc="@string/settings_enable_product_adding_teaser_message"
-        app:toggleOptionTitle="@string/settings_enable_product_adding_teaser_title"
-        app:layout_constraintStart_toStartOf="parent"
+        android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:toggleOptionDesc="@string/settings_enable_product_adding_teaser_message"
+        app:toggleOptionTitle="@string/settings_enable_product_adding_teaser_title" />
+
+    <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
+        android:id="@+id/switchAddonsToggle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:toggleOptionDesc="@string/settings_enable_product_addons_teaser_message"
+        app:toggleOptionTitle="@string/settings_enable_product_addons_teaser_title" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
@@ -6,17 +6,6 @@
     android:background="?attr/colorSurface">
 
     <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
-        android:id="@+id/switchProductsUI"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:toggleOptionDesc="@string/settings_enable_product_adding_teaser_message"
-        app:toggleOptionTitle="@string/settings_enable_product_adding_teaser_title" />
-
-    <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
         android:id="@+id/switchAddonsToggle"
         android:layout_width="0dp"
         android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/main_view"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/colorSurface">

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1239,6 +1239,8 @@
     <string name="settings_enable_v4_stats_title">Improved stats</string>
     <string name="settings_enable_product_adding_teaser_title">Creating products</string>
     <string name="settings_enable_product_adding_teaser_message">Test out the new simple, linked and grouped product creation as we get ready to launch</string>
+    <string name="settings_enable_product_addons_teaser_title">View Add-ons</string>
+    <string name="settings_enable_product_addons_teaser_message">Test out viewing Order Add-ons as we get ready to launch</string>
     <string name="settings_enable_product_teaser_title">Product editing</string>
     <string name="settings_enable_product_teaser_message">Test out the new product editing functionality as we get ready to launch</string>
     <string name="settings_send_stats_detail">Share information with our analytics tool about your use of services while logged in to your WordPress account</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1237,6 +1237,7 @@
     <string name="settings_confirm_logout">Are you sure you want to logout from the account %s?</string>
     <string name="settings_send_stats">Collect information</string>
     <string name="settings_enable_v4_stats_title">Improved stats</string>
+    <string name="settings_enable_beta_feature_failed_snackbar_text">Sorry, we couldn\'t change this feature setting right now</string>
     <string name="settings_enable_product_adding_teaser_title">Creating products</string>
     <string name="settings_enable_product_adding_teaser_message">Test out the new simple, linked and grouped product creation as we get ready to launch</string>
     <string name="settings_enable_product_addons_teaser_title">View Add-ons</string>


### PR DESCRIPTION
Summary
==========
Fixes issue #4686 by reactivating the Beta Toggle section at the App settings, but now with the option of controlling the activation of the Product Add-ons feature. Since we're still using the Feature Flag, the Beta toggle control is set inside the Feature Flag itself.

Screenshots
==========
| App Settings with Beta feature section  | Product Add-ons Beta toggle |
| ------------- | ------------- |
| ![Screenshot_20210831_001422](https://user-images.githubusercontent.com/5920403/131437288-ddc48169-5c1a-48f8-a213-ffb7faafd350.png) | ![Screenshot_20210831_001425](https://user-images.githubusercontent.com/5920403/131437310-8ec6682b-1f4b-4291-bbb0-cc2ab165890a.png) |

| Product Details with Toggle disabled  | Product Details with Toggle enabled |
| ------------- | ------------- |
| ![Screenshot_20210831_001443](https://user-images.githubusercontent.com/5920403/131437338-31fbcf44-e5d6-4e2e-a84f-0d1be1953b72.png) | ![Screenshot_20210831_001242](https://user-images.githubusercontent.com/5920403/131437232-1edde6b6-c530-46af-adc9-6a7967d14513.png) |

| Order Details with Toggle disabled  | Order Details with Toggle enabled |
| ------------- | ------------- |
| ![Screenshot_20210831_001454](https://user-images.githubusercontent.com/5920403/131437358-4f2aec25-440f-4285-b62f-0d0efbb2eae7.png) | ![Screenshot_20210831_001253](https://user-images.githubusercontent.com/5920403/131437254-881be40d-8053-426a-ae60-f4570033ae93.png) |

How to Test
==========
Prerequisites: Have your site with the add ons plugin installed, configured, and with at least one product with add-ons and at least one order of the configured product.

### With Beta Toggle activated
1 - Launch the Woo app.
2 - Go to App Settings, click at `Beta Features` and *ACTIVATE* the `View Add-ons` toggle
2 - Navigate to an order with a Product configured with Add-ons, verify if the `View Add-ons` Button is showing up for products that contain Add-ons inside the current Order, but doesn't show up for Products without Add-ons for that order or Products that don't have Add-ons configured at all.
3 - Navigate to a product with Add-ons configured, verify if the `Product Add-ons` button is visible, clickable and calls the Add-ons details view.

### With Beta Toggle deactivated
1 - Launch the Woo app.
2 - Go to App Settings, click at `Beta Features` and *DEACTIVATE* the `View Add-ons` toggle
2 - Navigate to an order with a Product configured with Add-ons, verify that no `View Add-ons` button is available for absolutely no Product within an Order.
3 - Navigate to a product with Add-ons configured, verify if the `Product Add-ons` button is *NOT* visible.



Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
