### PR TITLE
Refactoring: two different flows for UpdateAvailability and UpdateStatus

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModel.kt
@@ -10,11 +10,11 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_SOFTW
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.CARD_READER_SOFTWARE_UPDATE_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.cardreader.CardReaderManager
+import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus.Unknown
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus.Failed
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus.InstallationStarted
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus.Installing
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus.Success
-import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus.UpToDate
 import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
@@ -84,7 +84,7 @@ class CardReaderUpdateViewModel @Inject constructor(
                     is InstallationStarted -> updateProgress(viewState.value, 0)
                     is Installing -> updateProgress(viewState.value, convertProgressToPercentage(status.progress))
                     Success -> onUpdateSucceeded()
-                    UpToDate -> onUpdateUpToDate()
+                    Unknown -> onUpdateStatusUnknown()
                     else -> {
                     } // todo cardreader #4660
                 }.exhaustive
@@ -92,7 +92,7 @@ class CardReaderUpdateViewModel @Inject constructor(
         }
     }
 
-    private fun onUpdateUpToDate() {
+    private fun onUpdateStatusUnknown() {
         tracker.track(
             CARD_READER_SOFTWARE_UPDATE_FAILED,
             this@CardReaderUpdateViewModel.javaClass.simpleName,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModelTest.kt
@@ -12,8 +12,7 @@ import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus.
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus.InstallationStarted
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus.Installing
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus.Success
-import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus.UpToDate
-import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus.NotAvailable
+import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus.Unknown
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.ui.prefs.cardreader.update.CardReaderUpdateViewModel.UpdateResult
@@ -39,7 +38,7 @@ import org.robolectric.RobolectricTestRunner
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 class CardReaderUpdateViewModelTest : BaseUnitTest() {
-    private val softwareStatus = MutableStateFlow<SoftwareUpdateStatus>(NotAvailable)
+    private val softwareStatus = MutableStateFlow<SoftwareUpdateStatus>(Unknown)
     private val cardReaderManager: CardReaderManager = mock {
         on { softwareUpdateStatus }.thenReturn(softwareStatus)
     }
@@ -79,7 +78,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when click on primary btn explanation state with uptodate should emit updating state`() =
+    fun `when click on primary btn explanation state with unknown should emit updating state`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // GIVEN
             val viewModel = createViewModel()
@@ -143,7 +142,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
 
             // WHEN
             (viewModel.viewStateData.value as ExplanationState).primaryButton?.onActionClicked!!.invoke()
-            softwareStatus.value = UpToDate
+            softwareStatus.value = Unknown
 
             // THEN
             assertThat(viewModel.event.value).isInstanceOf(ExitWithResult::class.java)
@@ -184,7 +183,7 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // GIVEN
             val viewModel = createViewModel()
-            whenever(cardReaderManager.updateSoftware()).thenReturn(MutableStateFlow(UpToDate))
+            whenever(cardReaderManager.updateSoftware()).thenReturn(MutableStateFlow(Unknown))
 
             // WHEN
             (viewModel.viewStateData.value as ExplanationState).primaryButton?.onActionClicked!!.invoke()
@@ -222,15 +221,15 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when click on primary btn explanation state with up to date should track error event`() =
+    fun `when click on primary btn explanation state with unknown should track error event`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // GIVEN
             val viewModel = createViewModel()
-            whenever(cardReaderManager.updateSoftware()).thenReturn(MutableStateFlow(UpToDate))
+            whenever(cardReaderManager.updateSoftware()).thenReturn(MutableStateFlow(Unknown))
 
             // WHEN
             (viewModel.viewStateData.value as ExplanationState).primaryButton?.onActionClicked!!.invoke()
-            softwareStatus.value = UpToDate
+            softwareStatus.value = Unknown
 
             // THEN
             verify(tracker).track(eq(CARD_READER_SOFTWARE_UPDATE_FAILED), anyOrNull(), anyOrNull(), anyOrNull())

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/update/CardReaderUpdateViewModelTest.kt
@@ -211,10 +211,10 @@ class CardReaderUpdateViewModelTest : BaseUnitTest() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // GIVEN
             val viewModel = createViewModel()
+            whenever(cardReaderManager.updateSoftware()).thenReturn(MutableStateFlow(InstallationStarted))
 
             // WHEN
             (viewModel.viewStateData.value as ExplanationState).primaryButton?.onActionClicked!!.invoke()
-            softwareStatus.value = Failed("")
 
             // THEN
             verify(tracker).track(eq(CARD_READER_SOFTWARE_UPDATE_FAILED), anyOrNull(), anyOrNull(), anyOrNull())

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/event/CardReaderEvent.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/event/CardReaderEvent.kt
@@ -1,5 +1,0 @@
-package com.woocommerce.android.cardreader.connection.event
-
-sealed interface CardReaderEvent {
-    object Initialisation : CardReaderEvent
-}

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/event/SoftwareUpdateAvailability.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/event/SoftwareUpdateAvailability.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android.cardreader.connection.event
 
-sealed class SoftwareUpdateAvailability : CardReaderEvent {
+sealed class SoftwareUpdateAvailability {
     object Available : SoftwareUpdateAvailability()
     object NotAvailable : SoftwareUpdateAvailability()
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/event/SoftwareUpdateStatus.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/event/SoftwareUpdateStatus.kt
@@ -7,6 +7,5 @@ sealed class SoftwareUpdateStatus {
     data class Installing(val progress: Float) : SoftwareUpdateStatus(), SoftwareUpdateInProgress
     object Success : SoftwareUpdateStatus()
     data class Failed(val message: String?) : SoftwareUpdateStatus()
-    object UpToDate : SoftwareUpdateStatus()
-    object NotAvailable : SoftwareUpdateStatus()
+    object Unknown : SoftwareUpdateStatus()
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/event/SoftwareUpdateStatus.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/event/SoftwareUpdateStatus.kt
@@ -2,7 +2,7 @@ package com.woocommerce.android.cardreader.connection.event
 
 sealed interface SoftwareUpdateInProgress
 
-sealed class SoftwareUpdateStatus : CardReaderEvent {
+sealed class SoftwareUpdateStatus {
     object InstallationStarted : SoftwareUpdateStatus(), SoftwareUpdateInProgress
     data class Installing(val progress: Float) : SoftwareUpdateStatus(), SoftwareUpdateInProgress
     object Success : SoftwareUpdateStatus()

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/BluetoothReaderListenerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/BluetoothReaderListenerImpl.kt
@@ -26,11 +26,11 @@ internal class BluetoothReaderListenerImpl(
 
     override fun onFinishInstallingUpdate(update: ReaderSoftwareUpdate?, e: TerminalException?) {
         logWrapper.d(LOG_TAG, "onFinishInstallingUpdate: $update $e")
-        _updateStatusEvents.value = if (e == null) {
+        if (e == null) {
             _updateAvailabilityEvents.value = SoftwareUpdateAvailability.NotAvailable
-            SoftwareUpdateStatus.Success
+            _updateStatusEvents.value = SoftwareUpdateStatus.Success
         } else {
-            SoftwareUpdateStatus.Failed(e.message)
+            _updateStatusEvents.value = SoftwareUpdateStatus.Failed(e.message)
         }
     }
 

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/BluetoothReaderListenerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/BluetoothReaderListenerImpl.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.flow.asStateFlow
 internal class BluetoothReaderListenerImpl(
     private val logWrapper: LogWrapper,
 ) : BluetoothReaderListener {
-    private val _updateStatusEvents = MutableStateFlow<SoftwareUpdateStatus>(SoftwareUpdateStatus.NotAvailable)
+    private val _updateStatusEvents = MutableStateFlow<SoftwareUpdateStatus>(SoftwareUpdateStatus.Unknown)
     val updateStatusEvents = _updateStatusEvents.asStateFlow()
 
     private val _updateAvailabilityEvents =

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/BluetoothReaderListenerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/BluetoothReaderListenerImpl.kt
@@ -7,23 +7,27 @@ import com.stripe.stripeterminal.external.models.ReaderEvent
 import com.stripe.stripeterminal.external.models.ReaderInputOptions
 import com.stripe.stripeterminal.external.models.ReaderSoftwareUpdate
 import com.stripe.stripeterminal.external.models.TerminalException
-import com.woocommerce.android.cardreader.connection.event.CardReaderEvent
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateAvailability
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus
 import com.woocommerce.android.cardreader.internal.LOG_TAG
 import com.woocommerce.android.cardreader.internal.wrappers.LogWrapper
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 internal class BluetoothReaderListenerImpl(
     private val logWrapper: LogWrapper,
 ) : BluetoothReaderListener {
-    private val _events = MutableStateFlow<CardReaderEvent>(CardReaderEvent.Initialisation)
-    val events: StateFlow<CardReaderEvent> = _events
+    private val _updateStatusEvents = MutableStateFlow<SoftwareUpdateStatus>(SoftwareUpdateStatus.NotAvailable)
+    val updateStatusEvents = _updateStatusEvents.asStateFlow()
+
+    private val _updateAvailabilityEvents =
+        MutableStateFlow<SoftwareUpdateAvailability>(SoftwareUpdateAvailability.NotAvailable)
+    val updateAvailabilityEvents = _updateAvailabilityEvents.asStateFlow()
 
     override fun onFinishInstallingUpdate(update: ReaderSoftwareUpdate?, e: TerminalException?) {
         logWrapper.d(LOG_TAG, "onFinishInstallingUpdate: $update $e")
-        _events.value = if (e == null) {
+        _updateStatusEvents.value = if (e == null) {
+            _updateAvailabilityEvents.value = SoftwareUpdateAvailability.NotAvailable
             SoftwareUpdateStatus.Success
         } else {
             SoftwareUpdateStatus.Failed(e.message)
@@ -32,17 +36,17 @@ internal class BluetoothReaderListenerImpl(
 
     override fun onReportAvailableUpdate(update: ReaderSoftwareUpdate) {
         logWrapper.d(LOG_TAG, "onReportAvailableUpdate: $update")
-        _events.value = SoftwareUpdateAvailability.Available
+        _updateAvailabilityEvents.value = SoftwareUpdateAvailability.Available
     }
 
     override fun onReportReaderSoftwareUpdateProgress(progress: Float) {
         logWrapper.d(LOG_TAG, "onReportReaderSoftwareUpdateProgress: $progress")
-        _events.value = SoftwareUpdateStatus.Installing(progress)
+        _updateStatusEvents.value = SoftwareUpdateStatus.Installing(progress)
     }
 
     override fun onStartInstallingUpdate(update: ReaderSoftwareUpdate, cancelable: Cancelable?) {
         logWrapper.d(LOG_TAG, "onStartInstallingUpdate: $update $cancelable")
-        _events.value = SoftwareUpdateStatus.InstallationStarted
+        _updateStatusEvents.value = SoftwareUpdateStatus.InstallationStarted
     }
 
     override fun onReportLowBatteryWarning() {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
@@ -8,13 +8,9 @@ import com.stripe.stripeterminal.external.models.TerminalException
 import com.woocommerce.android.cardreader.connection.CardReader
 import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents
 import com.woocommerce.android.cardreader.connection.CardReaderImpl
-import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateAvailability
-import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.map
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
@@ -24,8 +20,8 @@ internal class ConnectionManager(
     private val bluetoothReaderListener: BluetoothReaderListenerImpl,
     private val discoverReadersAction: DiscoverReadersAction,
 ) {
-    val softwareUpdateStatus = bluetoothReaderListener.events.filterIsInstance<SoftwareUpdateStatus>()
-    val softwareUpdateAvailability: Flow<SoftwareUpdateAvailability> = bluetoothReaderListener.events.filterIsInstance()
+    val softwareUpdateStatus = bluetoothReaderListener.updateStatusEvents
+    val softwareUpdateAvailability = bluetoothReaderListener.updateAvailabilityEvents
 
     fun discoverReaders(isSimulated: Boolean) =
         discoverReadersAction.discoverReaders(isSimulated).map { state ->

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/firmware/SoftwareUpdateManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/firmware/SoftwareUpdateManager.kt
@@ -14,7 +14,6 @@ internal class SoftwareUpdateManager(
 ) {
     suspend fun updateSoftware() = flow {
         when (val updateStatus = checkUpdatesAction.checkUpdates()) {
-            CheckSoftwareUpdates.UpToDate -> emit(SoftwareUpdateStatus.UpToDate)
             is CheckSoftwareUpdates.Failed -> emit(SoftwareUpdateStatus.Failed(updateStatus.e.errorMessage))
             is CheckSoftwareUpdates.UpdateAvailable -> installUpdate()
         }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/BluetoothReaderListenerImplTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/BluetoothReaderListenerImplTest.kt
@@ -24,7 +24,7 @@ class BluetoothReaderListenerImplTest {
         listener.onFinishInstallingUpdate(mock(), exception)
 
         // THEN
-        assertThat(listener.events.value).isEqualTo(SoftwareUpdateStatus.Failed(expectedMessage))
+        assertThat(listener.updateStatusEvents.value).isEqualTo(SoftwareUpdateStatus.Failed(expectedMessage))
     }
 
     @Test
@@ -33,7 +33,16 @@ class BluetoothReaderListenerImplTest {
         listener.onFinishInstallingUpdate(mock(), null)
 
         // THEN
-        assertThat(listener.events.value).isEqualTo(SoftwareUpdateStatus.Success)
+        assertThat(listener.updateStatusEvents.value).isEqualTo(SoftwareUpdateStatus.Success)
+    }
+
+    @Test
+    fun `when finishes installing update without error, then update available emitted`() {
+        // WHEN
+        listener.onFinishInstallingUpdate(mock(), null)
+
+        // THEN
+        assertThat(listener.updateAvailabilityEvents.value).isEqualTo(SoftwareUpdateAvailability.NotAvailable)
     }
 
     @Test
@@ -42,11 +51,11 @@ class BluetoothReaderListenerImplTest {
         listener.onReportAvailableUpdate(mock())
 
         // THEN
-        assertThat(listener.events.value).isEqualTo(SoftwareUpdateAvailability.Available)
+        assertThat(listener.updateAvailabilityEvents.value).isEqualTo(SoftwareUpdateAvailability.Available)
     }
 
     @Test
-    fun `when on report reader update prgoress called, then installing emitted`() {
+    fun `when on report reader update progress called, then installing emitted`() {
         // GIVEN
         val progress = 0.3f
 
@@ -54,7 +63,7 @@ class BluetoothReaderListenerImplTest {
         listener.onReportReaderSoftwareUpdateProgress(progress)
 
         // THEN
-        assertThat(listener.events.value).isEqualTo(SoftwareUpdateStatus.Installing(progress))
+        assertThat(listener.updateStatusEvents.value).isEqualTo(SoftwareUpdateStatus.Installing(progress))
     }
 
     @Test
@@ -63,6 +72,6 @@ class BluetoothReaderListenerImplTest {
         listener.onStartInstallingUpdate(mock(), mock())
 
         // THEN
-        assertThat(listener.events.value).isEqualTo(SoftwareUpdateStatus.InstallationStarted)
+        assertThat(listener.updateStatusEvents.value).isEqualTo(SoftwareUpdateStatus.InstallationStarted)
     }
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/BluetoothReaderListenerImplTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/BluetoothReaderListenerImplTest.kt
@@ -37,7 +37,7 @@ class BluetoothReaderListenerImplTest {
     }
 
     @Test
-    fun `when finishes installing update without error, then update available emitted`() {
+    fun `when finishes installing update without error, then update not available emitted`() {
         // WHEN
         listener.onFinishInstallingUpdate(mock(), null)
 

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/firmware/SoftwareUpdateManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/firmware/SoftwareUpdateManagerTest.kt
@@ -38,15 +38,6 @@ class SoftwareUpdateManagerTest {
     }
 
     @Test
-    fun `when update not available, then UpToDate emitted`() = runBlockingTest {
-        whenever(checkUpdatesAction.checkUpdates()).thenReturn(CheckSoftwareUpdates.UpToDate)
-
-        val result = updateManager.updateSoftware().toList().last()
-
-        assertThat(result).isEqualTo(SoftwareUpdateStatus.UpToDate)
-    }
-
-    @Test
     fun `when check for updates fails, then CheckForUpdatesFailed emitted`() = runBlockingTest {
         val message = "error"
         val terminalException: TerminalException = mock {


### PR DESCRIPTION
Small refactoring to avoid having splitting one flow into two

### Description
As discussed offline, we want to try another approach here. Instead of having a hierarchy of sealed classes with filtering on type, this PR makes things more straightforward having 2 different flows per type

### Testing instructions
There are no user-facing changes


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
