### PR TITLE
Fix runtime crash when using sample `google-services.json` file

### DIFF
--- a/WooCommerce/google-services.json-example
+++ b/WooCommerce/google-services.json-example
@@ -1,7 +1,7 @@
 {
   "project_info": {
     "project_number": "",
-    "project_id": ""
+    "project_id": "project_id"
   },
   "client": [
     {
@@ -27,7 +27,7 @@
       ],
       "api_key": [
         {
-          "current_key": ""
+          "current_key": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
         }
       ],
       "services": {
@@ -69,7 +69,7 @@
       ],
       "api_key": [
         {
-          "current_key": ""
+          "current_key": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
         }
       ],
       "services": {
@@ -111,7 +111,7 @@
       ],
       "api_key": [
         {
-          "current_key": ""
+          "current_key": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
         }
       ],
       "services": {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4694 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates fake values in `google-services.json-example` file to make it pass validation of Firebase SDK. For details of validation process please see `com.google.firebase.iid.FirebaseInstanceId#checkRequiredFirebaseOptions`.

As `iid` [is being replaced](https://github.com/firebase/firebase-android-sdk/issues/1679) by `firebase-installations`, it's necessary to re-check this change after updating to `firebase-messaging:22.x` in #4051 .

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
In order to not break your current Woo setup, please perform all operations on a separate, temporary repository.
1. Clone repository and checkout this branch `git clone git@github.com:woocommerce/woocommerce-android.git temp --branch issue/4694_fix_crash_with_example_google_services`
2. Go to the repository directory `cd temp`
2. Prepare repository for the first run: `cp gradle.properties-example gradle.properties`
3. Run `./gradlew installJalapenoDebug`
4. Observe logs. Assert `WARNING: You're using the example google-services.json file. Google login will fail.` is logged
5. Run the app. Assert there's no crash.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
