### PR TITLE
"What's New" Screen": Feature Flag

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -31,14 +31,12 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SETTINGS_WE_ARE_H
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat.SETTING_CHANGE
 import com.woocommerce.android.databinding.FragmentSettingsMainBinding
 import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.extensions.show
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
 import com.woocommerce.android.ui.sitepicker.SitePickerActivity
-import com.woocommerce.android.util.AnalyticsUtils
-import com.woocommerce.android.util.AppThemeUtils
-import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.*
 import com.woocommerce.android.util.FeatureFlag.CARD_READER
-import com.woocommerce.android.util.ThemeOption
 import com.woocommerce.android.widgets.WCPromoTooltip
 import com.woocommerce.android.widgets.WCPromoTooltip.Feature
 import com.woocommerce.android.widgets.WooClickableSpan
@@ -176,6 +174,10 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         binding.optionAbout.setOnClickListener {
             AnalyticsTracker.track(SETTINGS_ABOUT_WOOCOMMERCE_LINK_TAPPED)
             findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_aboutFragment)
+        }
+
+        if (FeatureFlag.WHATS_NEW.isEnabled()) {
+            binding.optionWhatsNew.show()
         }
 
         binding.optionLicenses.setOnClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -11,14 +11,15 @@ enum class FeatureFlag {
     DB_DOWNGRADE,
     ORDER_CREATION,
     CARD_READER,
-    PRODUCT_ADD_ONS;
+    PRODUCT_ADD_ONS,
+    WHATS_NEW;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
             DB_DOWNGRADE -> {
                 PackageUtils.isDebugBuild() || context != null && PackageUtils.isBetaBuild(context)
             }
-            ORDER_CREATION -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
+            ORDER_CREATION, WHATS_NEW -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
             CARD_READER -> CardPresentEligibleFeatureChecker.isCardPresentEligible
             PRODUCT_ADD_ONS ->
                 (PackageUtils.isDebugBuild() || PackageUtils.isTesting()) &&

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -192,6 +192,14 @@
         app:optionTitle="@string/app_name" />
 
     <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+        android:id="@+id/option_whats_new"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:optionTitle="@string/settings_whats_new"
+        android:visibility="gone"
+        tools:visibility="visible"  />
+
+    <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
         android:id="@+id/option_licenses"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1271,6 +1271,7 @@
     <string name="settings_image_optimization_message">Resize and compress images for faster uploading</string>
     <string name="settings_about">About the app</string>
     <string name="settings_licenses">Open source licenses</string>
+    <string name="settings_whats_new">What\'s New in WooCommerce</string>
     <string name="settings_privacy_policy_header">Privacy Policy</string>
     <string name="settings_cookie_policy_header">Cookie Policy</string>
     <string name="settings_third_party_policy_header">Third Party Policy</string>


### PR DESCRIPTION
This is part of the "What's New" screen implementation work. #4698

## What This PR does
- Adds a new feature flag `WHATS_NEW`.
- Adds a "What's New in WooCommerce" menu in Settings area.

## To test
1. Run in a debug build,
2. Go to Settings, make sure **"What's New in WooCommerce"** is shown in the "About the app" section.
3. Run in a release build,
4. Go to Settings, make sure **"What's New in WooCommerce"** is not shown in the "About the app" section.
