### PR TITLE
Moved the dispatcher registration logic to the init block

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -146,9 +146,11 @@ class OrderDetailViewModel @Inject constructor(
         dispatcher.unregister(this)
     }
 
-    fun start() {
+    init {
         dispatcher.register(this)
+    }
 
+    fun start() {
         val orderInDb = orderDetailRepository.getOrder(navArgs.orderId)
         val needToFetch = orderInDb == null || checkIfFetchNeeded(orderInDb)
         launch {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4711 

### Description
This PR fixes the crash in the Order detail screen when coming back from the Issue Refund screen by moving the `dispatcher.register` logic to the `init` block.

### Testing instructions
- Open detail of a paid order
- Tap on “Issue refund” 
- Tap on back.
- Ensure the app no longer crashes.

Thank you @malinajirka for catching this crash before it went to release 🙇‍♀️ 

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.