### PR TITLE
Fix is order paid condition

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -11,8 +11,6 @@ import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.model.Order.ShippingLine
 import com.woocommerce.android.model.Order.ShippingMethod
 import com.woocommerce.android.model.Order.Status
-import com.woocommerce.android.model.Order.Status.OnHold
-import com.woocommerce.android.model.Order.Status.Pending
 import com.woocommerce.android.ui.products.ProductHelper
 import com.woocommerce.android.util.AddressUtils
 import com.woocommerce.android.util.StringUtils
@@ -62,10 +60,7 @@ data class Order(
     val metaData: List<MetaData<String>>
 ) : Parcelable {
     @IgnoredOnParcel
-    val isOrderPaid = paymentMethodTitle.isEmpty() && datePaid == null
-
-    @IgnoredOnParcel
-    val isAwaitingPayment = status == Pending || status == OnHold || datePaid == null
+    val isOrderPaid = datePaid != null
 
     // Allow refunding only integer quantities
     @IgnoredOnParcel

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
@@ -26,7 +26,7 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
 ) : MaterialCardView(ctx, attrs, defStyleAttr) {
     private val binding = OrderDetailPaymentInfoBinding.inflate(LayoutInflater.from(ctx), this)
 
-    @Suppress("LongParameterList", "LongMethod")
+    @Suppress("LongParameterList")
     fun updatePaymentInfo(
         order: Order,
         isReceiptAvailable: Boolean,
@@ -73,7 +73,18 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
             }
         }
 
-        // Populate or hide discounts section
+        updateDiscountsSection(order, formatCurrencyForDisplay)
+        updateFeesSection(order, formatCurrencyForDisplay)
+        updateRefundSection(order, formatCurrencyForDisplay, onIssueRefundClickListener)
+        updateCollectPaymentSection(isPaymentCollectableWithCardReader, onCollectCardPresentPaymentClickListener)
+        updateSeeReceiptSection(isReceiptAvailable, onSeeReceiptClickListener)
+        updatePrintingInstructionSection(isPaymentCollectableWithCardReader, onPrintingInstructionsClickListener)
+    }
+
+    private fun updateDiscountsSection(
+        order: Order,
+        formatCurrencyForDisplay: (BigDecimal) -> String
+    ) {
         if (order.discountTotal isEqualTo BigDecimal.ZERO) {
             binding.paymentInfoDiscountSection.hide()
         } else {
@@ -87,16 +98,25 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
                 order.discountCodes
             )
         }
+    }
 
-        // Populate or hide the fees section
+    private fun updateFeesSection(
+        order: Order,
+        formatCurrencyForDisplay: (BigDecimal) -> String
+    ) {
         if (order.feesTotal isEqualTo BigDecimal.ZERO) {
             binding.paymentInfoFeesSection.hide()
         } else {
             binding.paymentInfoFeesSection.show()
             binding.paymentInfoFees.text = formatCurrencyForDisplay(order.feesTotal)
         }
+    }
 
-        // Populate or hide refund section
+    private fun updateRefundSection(
+        order: Order,
+        formatCurrencyForDisplay: (BigDecimal) -> String,
+        onIssueRefundClickListener: (view: View) -> Unit
+    ) {
         if (order.refundTotal > BigDecimal.ZERO) {
             binding.paymentInfoRefundSection.show()
             val newTotal = order.total - order.refundTotal
@@ -106,30 +126,46 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
         }
 
         binding.paymentInfoIssueRefundButton.setOnClickListener(onIssueRefundClickListener)
+    }
+
+    private fun updateCollectPaymentSection(
+        isPaymentCollectableWithCardReader: Boolean,
+        onCollectCardPresentPaymentClickListener: (view: View) -> Unit
+    ) {
         if (FeatureFlag.CARD_READER.isEnabled() && isPaymentCollectableWithCardReader) {
-            binding.paymentInfoCollectCardPresentPaymentButton.visibility = View.VISIBLE
+            binding.paymentInfoCollectCardPresentPaymentButton.visibility = VISIBLE
             binding.paymentInfoCollectCardPresentPaymentButton.setOnClickListener(
                 onCollectCardPresentPaymentClickListener
             )
         } else {
-            binding.paymentInfoCollectCardPresentPaymentButton.visibility = View.GONE
+            binding.paymentInfoCollectCardPresentPaymentButton.visibility = GONE
         }
+    }
 
+    private fun updateSeeReceiptSection(
+        isReceiptAvailable: Boolean,
+        onSeeReceiptClickListener: (view: View) -> Unit
+    ) {
         if (FeatureFlag.CARD_READER.isEnabled() && isReceiptAvailable) {
-            binding.paymentInfoSeeReceiptButton.visibility = View.VISIBLE
+            binding.paymentInfoSeeReceiptButton.visibility = VISIBLE
             binding.paymentInfoSeeReceiptButton.setOnClickListener(
                 onSeeReceiptClickListener
             )
         } else {
-            binding.paymentInfoSeeReceiptButton.visibility = View.GONE
+            binding.paymentInfoSeeReceiptButton.visibility = GONE
         }
+    }
 
+    private fun updatePrintingInstructionSection(
+        isPaymentCollectableWithCardReader: Boolean,
+        onPrintingInstructionsClickListener: (view: View) -> Unit
+    ) {
         if (FeatureFlag.CARD_READER.isEnabled() && isPaymentCollectableWithCardReader) {
             binding.paymentInfoPrintingInstructions.setOnClickListener(
                 onPrintingInstructionsClickListener
             )
         } else {
-            binding.paymentInfoPrintingInstructions.visibility = View.GONE
+            binding.paymentInfoPrintingInstructions.visibility = GONE
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
@@ -48,13 +48,13 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
             setHasFixedSize(true)
         }
 
-        if (order.isOrderPaid) {
+        if (order.paymentMethodTitle.isEmpty() && order.datePaid == null) {
             binding.paymentInfoPaymentMsg.hide()
             binding.paymentInfoPaidSection.hide()
         } else {
             binding.paymentInfoPaymentMsg.show()
 
-            if (order.isAwaitingPayment) {
+            if (order.status == Order.Status.Pending || order.status == Order.Status.OnHold || order.datePaid == null) {
                 binding.paymentInfoPaid.text = formatCurrencyForDisplay(BigDecimal.ZERO)
                 binding.paymentInfoPaymentMsg.text = context.getString(
                     R.string.orderdetail_payment_summary_onhold, order.paymentMethodTitle

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -30,7 +30,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
     fun `when order is paid then hide collect button`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // GIVEN
-            val order = getOrder(datePaid = null, paymentMethodTitle = "")
+            val order = getOrder(datePaid = Date())
 
             // WHEN
             val isCollectable = checker.isCollectable(order)
@@ -43,7 +43,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
     fun `when order not paid then show collect button`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // GIVEN
-            val order = getOrder(datePaid = Date())
+            val order = getOrder(datePaid = null)
 
             // WHEN
             val isCollectable = checker.isCollectable(order)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4690 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We tried to make the code easier to follow when we migrated from MVP to MVVM. We extracted complex conditions into fields/methods - eg. isOrderPaid, isAwaitingPayment. 
However, the condition for "isOrderPaid" is confusing since it is inverse - `true` when the order is not paid and `false` when the order is paid. This is quite confusing and the name doesn't correspond to the condition. 
We re-used `isOrderPaid` field in in-person payments and it bit us since we didn't expect the condition to be inversed. We decided to fix the condition and use `isOrderPaid` field only for in-person payments and revert extraction of the original condition on order detail screen.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Make sure your store is gated into the in-person payments and the onboarding is completed
1. Create an order in wpadmin and set payment method to "cash on delivery"
2. Open the order in the mobile app
3. Notice that "Collect Payment" button is visible

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
