### PR TITLE
Issue/4553 check total

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityChecker.kt
@@ -14,6 +14,7 @@ class CardReaderPaymentCollectibilityChecker @Inject constructor(
             currency.equals("USD", ignoreCase = true) &&
                 (listOf(Order.Status.Pending, Order.Status.Processing, Order.Status.OnHold)).any { it == status } &&
                 !isOrderPaid &&
+                order.total.compareTo(BigDecimal.ZERO) == 1 &&
                 // TODO cardreader remove the following check when the backend issue is fixed
                 // https://github.com/Automattic/woocommerce-payments/issues/2390
                 BigDecimal.ZERO.compareTo(order.refundTotal) == 0 &&

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -49,6 +49,36 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
         }
 
     @Test
+    fun `when total amount less than zero, then hide collect button`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            val order = getOrder(total = BigDecimal(-2))
+
+            val isCollectable = checker.isCollectable(order)
+
+            assertThat(isCollectable).isFalse()
+        }
+
+    @Test
+    fun `when total amount equal to zero, then hide collect button`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            val order = getOrder(total = BigDecimal(0))
+
+            val isCollectable = checker.isCollectable(order)
+
+            assertThat(isCollectable).isFalse()
+        }
+
+    @Test
+    fun `when total amount greater than zero, then show collect button`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            val order = getOrder(total = BigDecimal(2))
+
+            val isCollectable = checker.isCollectable(order)
+
+            assertThat(isCollectable).isTrue()
+        }
+
+    @Test
     fun `when order has empty payment method, then it is not collectable`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             val order = getOrder(paymentMethod = "")
@@ -203,6 +233,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
         }
 
     private fun getOrder(
+        total: BigDecimal = BigDecimal.ONE,
         currency: String = "USD",
         paymentStatus: Order.Status = Order.Status.Processing,
         paymentMethod: String = "cod",
@@ -211,6 +242,7 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
         datePaid: Date? = null
     ): Order {
         return generatedOrder.copy(
+            total = total,
             currency = currency,
             paymentMethod = paymentMethod,
             paymentMethodTitle = paymentMethodTitle,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -15,6 +16,7 @@ import org.junit.Test
 import java.math.BigDecimal
 import java.util.Date
 
+@ExperimentalCoroutinesApi
 class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
     private val repository: OrderDetailRepository = mock()
     private val checker: CardReaderPaymentCollectibilityChecker = CardReaderPaymentCollectibilityChecker(repository)
@@ -27,212 +29,164 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when order is paid then hide collect button`() =
+    fun `when order is paid, then hide collect button`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
             val order = getOrder(datePaid = Date())
 
-            // WHEN
             val isCollectable = checker.isCollectable(order)
 
-            // THEN
             assertThat(isCollectable).isFalse()
         }
 
     @Test
-    fun `when order not paid then show collect button`() =
+    fun `when order not paid, then show collect button`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
             val order = getOrder(datePaid = null)
 
-            // WHEN
             val isCollectable = checker.isCollectable(order)
 
-            // THEN
             assertThat(isCollectable).isTrue()
         }
 
     @Test
-    fun `when order has empty payment method then it is not collectable`() =
+    fun `when order has empty payment method, then it is not collectable`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
             val order = getOrder(paymentMethod = "")
 
-            // WHEN
             val isCollectable = checker.isCollectable(order)
 
-            // THEN
             assertThat(isCollectable).isTrue()
         }
 
     @Test
     fun `when order in USD then it is collectable`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
             val order = getOrder(currency = "USD")
 
-            // WHEN
             val isCollectable = checker.isCollectable(order)
 
-            // THEN
             assertThat(isCollectable).isTrue()
         }
 
     @Test
-    fun `when order has no subscriptions items then is collectable`() =
+    fun `when order has no subscriptions items, then is collectable`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
             val order = getOrder()
             doReturn(false).whenever(repository).hasSubscriptionProducts(any())
 
-            // WHEN
             val isCollectable = checker.isCollectable(order)
 
-            // THEN
             assertThat(isCollectable).isTrue()
         }
 
     @Test
-    fun `when order has subscriptions items then hide collect button`() =
+    fun `when order has subscriptions items, then hide collect button`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
             val order = getOrder()
             doReturn(true).whenever(repository).hasSubscriptionProducts(any())
 
-            // WHEN
             val isCollectable = checker.isCollectable(order)
 
-            // THEN
             assertThat(isCollectable).isFalse()
         }
 
     @Test
-    fun `when order has code payment method then is collectable`() =
+    fun `when order has code payment method, then is collectable`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
             val order = getOrder(paymentMethod = "cod")
 
-            // WHEN
             val isCollectable = checker.isCollectable(order)
 
-            // THEN
             assertThat(isCollectable).isTrue()
         }
 
     @Test
-    fun `when order has non code payment method then it is not collectable`() =
+    fun `when order has non code payment method, then it is not collectable`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
             val order = getOrder(paymentMethod = "stripe")
 
-            // WHEN
             val isCollectable = checker.isCollectable(order)
 
-            // THEN
             assertThat(isCollectable).isFalse()
         }
 
     @Test
-    fun `when order has processing status then is collectable`() =
+    fun `when order has processing status, then is collectable`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
             val order = getOrder(paymentStatus = Order.Status.Processing)
 
-            // WHEN
             val isCollectable = checker.isCollectable(order)
 
-            // THEN
             assertThat(isCollectable).isTrue()
         }
 
     @Test
-    fun `when order has on hold status then is collectable`() =
+    fun `when order has on hold status, then is collectable`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
             val order = getOrder(paymentStatus = Order.Status.OnHold)
 
-            // WHEN
             val isCollectable = checker.isCollectable(order)
 
-            // THEN
             assertThat(isCollectable).isTrue()
         }
 
     @Test
-    fun `when order has pending status then is collectable`() =
+    fun `when order has pending status, then is collectable`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
             val order = getOrder(paymentStatus = Order.Status.Pending)
 
-            // WHEN
             val isCollectable = checker.isCollectable(order)
 
-            // THEN
             assertThat(isCollectable).isTrue()
         }
 
     @Test
-    fun `when order has refunded status then is not collectable`() =
+    fun `when order has refunded status, then is not collectable`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
             val order = getOrder(paymentStatus = Order.Status.Refunded)
 
-            // WHEN
             val isCollectable = checker.isCollectable(order)
 
-            // THEN
             assertThat(isCollectable).isFalse()
         }
 
     @Test
-    fun `when order has custom status then is not collectable`() =
+    fun `when order has custom status, then is not collectable`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
             val order = getOrder(paymentStatus = Order.Status.Custom("custom"))
 
-            // WHEN
             val isCollectable = checker.isCollectable(order)
 
-            // THEN
             assertThat(isCollectable).isFalse()
         }
 
     @Test
-    fun `when order has failed status then is not collectable`() =
+    fun `when order has failed status, then is not collectable`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
             val order = getOrder(paymentStatus = Order.Status.Failed)
 
-            // WHEN
             val isCollectable = checker.isCollectable(order)
 
-            // THEN
             assertThat(isCollectable).isFalse()
         }
 
     @Test
-    fun `when order has completed status then hide collect button`() =
+    fun `when order has completed status, then hide collect button`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
             val order = getOrder(paymentStatus = Order.Status.Completed)
 
-            // WHEN
             val isCollectable = checker.isCollectable(order)
 
-            // THEN
             assertThat(isCollectable).isFalse()
         }
 
     @Test
-    fun `when order has cancelled status then hide collect button`() =
+    fun `when order has cancelled status, then hide collect button`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
             val order = getOrder(paymentStatus = Order.Status.Cancelled)
 
-            // WHEN
             val isCollectable = checker.isCollectable(order)
 
-            // THEN
             assertThat(isCollectable).isFalse()
         }
 
@@ -241,13 +195,10 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
     // https://github.com/Automattic/woocommerce-payments/issues/2390
     fun `when order has been refunded, then hide collect button `() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
             val order = getOrder(refundTotal = 99)
 
-            // WHEN
             val isCollectable = checker.isCollectable(order)
 
-            // THEN
             assertThat(isCollectable).isFalse()
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Can be merged into both 7.5 or 7.6.

Parent issue: #4553
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Hide Collect Payment button when `total` is lower or equal to 0.

The first commit adds `commas` into test names and removes `// Given // When // Then` comments to make the tests consistent with the rest of the codebase.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Open detail of an eligible order and verify that "collect payment" button is visible. Run the unit tests to verify it won't be shown when `amount <= 0`.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
