### PR TITLE
Remove team from Dependabot default reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
       interval: "daily"
     labels:
       - "bot: dependencies update"
-    reviewers:
-      - "woocommerce/android-developers"
     ignore:
       # The Android Gradle Plugin is a dependency we'd like to have in sync with other
       # in-house libraries due to compatibility with composite build.


### PR DESCRIPTION
This small PR updates Dependabot's config to remove default assignment of `woocommerce/android-developers` team to every PR. 

We agreed that we won't do this for other PRs so I think we don't want to have it for Dependabot too.