### PR TITLE
"What's New" Screen: Create and show basic Feature Announcement dialog when the menu item is selected

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -35,6 +35,7 @@ import com.woocommerce.android.extensions.show
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
 import com.woocommerce.android.ui.sitepicker.SitePickerActivity
+import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementDialogFragment
 import com.woocommerce.android.util.*
 import com.woocommerce.android.util.FeatureFlag.CARD_READER
 import com.woocommerce.android.widgets.WCPromoTooltip
@@ -178,6 +179,11 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
 
         if (FeatureFlag.WHATS_NEW.isEnabled()) {
             binding.optionWhatsNew.show()
+            binding.optionWhatsNew.setOnClickListener {
+                FeatureAnnouncementDialogFragment().show(
+                    parentFragmentManager, FeatureAnnouncementDialogFragment.TAG
+                )
+            }
         }
 
         binding.optionLicenses.setOnClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -35,7 +35,6 @@ import com.woocommerce.android.extensions.show
 import com.woocommerce.android.support.HelpActivity
 import com.woocommerce.android.support.HelpActivity.Origin
 import com.woocommerce.android.ui.sitepicker.SitePickerActivity
-import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementDialogFragment
 import com.woocommerce.android.util.*
 import com.woocommerce.android.util.FeatureFlag.CARD_READER
 import com.woocommerce.android.widgets.WCPromoTooltip
@@ -180,9 +179,8 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         if (FeatureFlag.WHATS_NEW.isEnabled()) {
             binding.optionWhatsNew.show()
             binding.optionWhatsNew.setOnClickListener {
-                FeatureAnnouncementDialogFragment().show(
-                    parentFragmentManager, FeatureAnnouncementDialogFragment.TAG
-                )
+                findNavController()
+                    .navigateSafely(R.id.action_mainSettingsFragment_to_featureAnnouncementDialogFragment)
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/whatsnew/FeatureAnnouncementDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/whatsnew/FeatureAnnouncementDialogFragment.kt
@@ -1,0 +1,26 @@
+package com.woocommerce.android.ui.whatsnew
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import com.woocommerce.android.R
+import com.woocommerce.android.databinding.FeatureAnnouncementDialogFragmentBinding
+
+class FeatureAnnouncementDialogFragment : DialogFragment() {
+    companion object {
+        const val TAG: String = "FeatureAnnouncementDialog"
+    }
+
+    override fun getTheme(): Int {
+        return R.style.Woo_Dialog_Fullscreen
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        val view = inflater.inflate(R.layout.feature_announcement_dialog_fragment, container, false)
+        val binding = FeatureAnnouncementDialogFragmentBinding.bind(view)
+
+        return view
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/whatsnew/FeatureAnnouncementDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/whatsnew/FeatureAnnouncementDialogFragment.kt
@@ -21,6 +21,10 @@ class FeatureAnnouncementDialogFragment : DialogFragment() {
         val view = inflater.inflate(R.layout.feature_announcement_dialog_fragment, container, false)
         val binding = FeatureAnnouncementDialogFragmentBinding.bind(view)
 
+        binding.closeFeatureAnnouncementButton.setOnClickListener {
+            dismiss()
+        }
+
         return view
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/whatsnew/FeatureAnnouncementDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/whatsnew/FeatureAnnouncementDialogFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FeatureAnnouncementDialogFragmentBinding
 
@@ -22,7 +23,7 @@ class FeatureAnnouncementDialogFragment : DialogFragment() {
         val binding = FeatureAnnouncementDialogFragmentBinding.bind(view)
 
         binding.closeFeatureAnnouncementButton.setOnClickListener {
-            dismiss()
+            findNavController().popBackStack()
         }
 
         return view

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/whatsnew/FeatureAnnouncementDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/whatsnew/FeatureAnnouncementDialogFragment.kt
@@ -15,7 +15,7 @@ class FeatureAnnouncementDialogFragment : DialogFragment() {
     }
 
     override fun getTheme(): Int {
-        return R.style.Woo_Dialog_Fullscreen
+        return R.style.Theme_Woo
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/WooCommerce/src/main/res/layout/feature_announcement_dialog_fragment.xml
+++ b/WooCommerce/src/main/res/layout/feature_announcement_dialog_fragment.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:fillViewport="true"
+        android:paddingStart="@dimen/margin_dialog"
+        android:paddingEnd="@dimen/margin_dialog"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        app:layout_constraintBottom_toTopOf="@+id/close_feature_announcement_button_container"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/feature_announcement_dialog_label"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_dialog"
+                android:fontFamily="serif"
+                android:text="@string/settings_whats_new"
+                android:textAppearance="?attr/textAppearanceHeadline4"
+                android:textColor="?attr/colorOnSurface"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/feature_announcement_dialog_label">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/feature_announcement_version_label"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_extra_large"
+                    android:text="@string/settings_whats_new"
+                    android:textAppearance="?attr/textAppearanceSubtitle1" />
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/feature_list"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_extra_medium_large"
+                    tools:listitem="@layout/feature_announcement_list_item"
+                    tools:itemCount="5" />
+            </LinearLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.core.widget.NestedScrollView>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/close_feature_announcement_button_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:cardCornerRadius="0dp"
+        app:cardElevation="0dp"
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/close_feature_announcement_button"
+            style="@style/Woo.Button.Colored"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_extra_large"
+            android:layout_marginTop="@dimen/margin_large"
+            android:layout_marginEnd="@dimen/margin_extra_large"
+            android:layout_marginBottom="@dimen/margin_large"
+            android:text="@string/continue_button" />
+    </com.google.android.material.card.MaterialCardView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/feature_announcement_list_item.xml
+++ b/WooCommerce/src/main/res/layout/feature_announcement_list_item.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/margin_extra_medium_large"
+    android:orientation="horizontal">
+
+    <FrameLayout
+        android:id="@+id/feature_item_icon_container"
+        android:layout_width="@dimen/image_major_64"
+        android:layout_height="@dimen/image_major_64"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:layout_gravity="center"
+            android:id="@+id/feature_item_icon"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:contentDescription="@null"
+            tools:src="@drawable/ic_email" />
+
+    </FrameLayout>
+
+    <LinearLayout
+        android:id="@+id/feature_description_container"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin_extra_large"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="@+id/feature_item_icon_container"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/feature_item_icon_container"
+        app:layout_constraintTop_toTopOf="@+id/feature_item_icon_container">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/feature_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceSubtitle1"
+            tools:text="Amazing Feature" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/feature_subtitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceBody2"
+            tools:text="Great explanation of feature" />
+
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -51,6 +51,9 @@
             app:exitAnim="@anim/activity_slide_out_to_left"
             app:popEnterAnim="@anim/activity_slide_in_from_left"
             app:popExitAnim="@anim/activity_slide_out_to_right" />
+        <action
+            android:id="@+id/action_mainSettingsFragment_to_featureAnnouncementDialogFragment"
+            app:destination="@id/featureAnnouncementDialogFragment" />
     </fragment>
     <dialog
         android:id="@+id/cardReaderConnectFragment"
@@ -162,4 +165,8 @@
             android:name="surveyType"
             app:argType="com.woocommerce.android.ui.feedback.SurveyType" />
     </fragment>
+    <dialog
+        android:id="@+id/featureAnnouncementDialogFragment"
+        android:name="com.woocommerce.android.ui.whatsnew.FeatureAnnouncementDialogFragment"
+        android:label="FeatureAnnouncementDialogFragment" />
 </navigation>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -762,11 +762,4 @@ theme across the entire app. Overridden versions should be added to the styles.x
     <style name="Theme.Woo.BottomSheet" parent="Widget.Design.BottomSheet.Modal">
         <item name="android:background">@drawable/bottomsheet_rounded</item>
     </style>
-
-    <style name="Woo.Dialog.Fullscreen">
-        <item name="android:windowFullscreen">false</item>
-        <item name="android:windowIsFloating">false</item>
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
-    </style>
 </resources>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -762,4 +762,11 @@ theme across the entire app. Overridden versions should be added to the styles.x
     <style name="Theme.Woo.BottomSheet" parent="Widget.Design.BottomSheet.Modal">
         <item name="android:background">@drawable/bottomsheet_rounded</item>
     </style>
+
+    <style name="Woo.Dialog.Fullscreen">
+        <item name="android:windowFullscreen">false</item>
+        <item name="android:windowIsFloating">false</item>
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
 </resources>


### PR DESCRIPTION
This is step 2 for #4698.

## What this PR does

This is a small PR that adds the following:
- A basic dialog fragment class, plus its related layout files, and a generic styling to make the dialog appear full screen.
- The dialog to appear when the "What's New in WooCommerce" menu item in Settings is selected.
- The dialog to close when Continue button or back button is tapped.

## What is not included in the PR
These will be handled in future PRs and do not have to be tested/checked yet.
- Actual announcement content and correct design for the dialog.
- The content of the layout files are mostly copied from WordPress Android and will likely be replaced when the correct design is being worked on. 
- ~The "Continue" button on the dialog does not do anything yet.~ This is now added.

## To test
1. Run in a debug build,
2. Go to Settings, tap "What's New in WooCommerce"
3. Make sure the Dialog is shown properly, looking like below:

| Dark mode | Light mode |
| - | - |
|![image](https://user-images.githubusercontent.com/266376/132210938-19788a17-853b-4766-b14d-e03be1613f28.png) |![image](https://user-images.githubusercontent.com/266376/132210882-bbaab92a-71e0-4088-81a3-da6ef169a278.png)|

4. Tap "Continue" and make sure the dialog is closed, bringing you back to the Settings screen.
