### PR TITLE
Update save for later text

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -774,7 +774,7 @@
 
     <string name="card_reader_payment_print_receipt">Print receipt</string>
     <string name="card_reader_payment_send_receipt">Send receipt</string>
-    <string name="card_reader_payment_save_for_later">Save for later</string>
+    <string name="card_reader_payment_save_for_later">Save receipt and continue</string>
 
     <string name="card_reader_payment_description">Online payment for order %s for %s</string>
     <string name="card_reader_payment_receipt_email_subject">Your receipt from %s</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parent issue: #4553
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Updates text of "save for later" button on payment successful screen - some users didn't realize they can dismiss the dialog by clicking on "Save for later".

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Make sure you store is eligible for card present payments
2. Create an order and set the payment method to cash on delivery
3. Open the order in the app
4. Tap on Collect payment button
5. Complete the payment
6. Notice the last button on the payment successful screen says "Save receipt and continue"

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://user-images.githubusercontent.com/2261188/132230403-4a1482f6-e87f-4600-ab32-cc9c13adf5cd.png" width="250px"/>


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
