### PR TITLE
Issue/4732 Filter supported readers

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -18,6 +18,8 @@ import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents.F
 import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents.ReadersFound
 import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents.Started
 import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents.Succeeded
+import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
+import com.woocommerce.android.cardreader.connection.SpecificReader
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
@@ -204,7 +206,10 @@ class CardReaderConnectViewModel @Inject constructor(
 
     private suspend fun startScanning() {
         cardReaderManager
-            .discoverReaders(isSimulated = BuildConfig.USE_SIMULATED_READER)
+            .discoverReaders(
+                isSimulated = BuildConfig.USE_SIMULATED_READER,
+                cardReaderTypesToDiscover = CardReaderTypesToDiscover.SpecificReaders(SUPPORTED_READERS)
+            )
             .flowOn(dispatchers.io)
             .collect { discoveryEvent ->
                 handleScanEvent(discoveryEvent)
@@ -501,5 +506,9 @@ class CardReaderConnectViewModel @Inject constructor(
         ) : ListItemViewState() {
             val connectLabel: UiString = UiStringRes(R.string.card_reader_connect_connect_button)
         }
+    }
+
+    companion object {
+        private val SUPPORTED_READERS = listOf(SpecificReader.Chipper2X, SpecificReader.StripeM2)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -56,7 +56,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
             val vm = initVM(CardReaderOnboardingState.WcpaySetupNotCompleted, skipOnboarding = false)
 
             assertThat(vm.event.value)
-                .isInstanceOf(CardReaderConnectViewModel.CardReaderConnectEvent.NavigateToOnboardingFlow::class.java)
+                .isInstanceOf(NavigateToOnboardingFlow::class.java)
         }
 
     @Test
@@ -266,7 +266,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
             init()
 
-            verify(cardReaderManager).discoverReaders(anyBoolean())
+            verify(cardReaderManager).discoverReaders(anyBoolean(), any())
         }
 
     @Test
@@ -830,7 +830,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
     }
 
     private suspend fun init(scanState: ScanResult = READER_FOUND, connectingSucceeds: Boolean = true) {
-        whenever(cardReaderManager.discoverReaders(anyBoolean())).thenAnswer {
+        whenever(cardReaderManager.discoverReaders(anyBoolean(), any())).thenAnswer {
             flow {
                 when (scanState) {
                     SCANNING -> { // no-op

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import com.woocommerce.android.cardreader.connection.CardReader
 import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
+import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateAvailability
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus
 import com.woocommerce.android.cardreader.payments.PaymentInfo
@@ -20,7 +21,11 @@ interface CardReaderManager {
     val softwareUpdateAvailability: Flow<SoftwareUpdateAvailability>
 
     fun initialize(app: Application)
-    fun discoverReaders(isSimulated: Boolean): Flow<CardReaderDiscoveryEvents>
+    fun discoverReaders(
+        isSimulated: Boolean,
+        cardReaderTypesToDiscover: CardReaderTypesToDiscover,
+    ): Flow<CardReaderDiscoveryEvents>
+
     suspend fun connectToReader(cardReader: CardReader): Boolean
     suspend fun disconnectReader(): Boolean
 

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
@@ -42,7 +42,7 @@ object CardReaderManagerFactory {
             ConnectionManager(
                 terminal,
                 bluetoothReaderListener,
-                DiscoverReadersAction(terminal),
+                DiscoverReadersAction(terminal, logWrapper),
             ),
             SoftwareUpdateManager(
                 terminal,

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/CardReaderType.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/CardReaderType.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.cardreader.connection
+
+sealed class SpecificReader(val name: String) {
+    object Chipper2X : SpecificReader("CHIPPER_2X")
+    object StripeM2 : SpecificReader("STRIPE_M2")
+    object CotsDevice : SpecificReader("COTS_DEVICE")
+    object VerifoneP400 : SpecificReader("VERIFONE_P400")
+    object WisePade3 : SpecificReader("WISEPAD_3")
+    object WisePadeE : SpecificReader("WISEPOS_E")
+}
+
+sealed class CardReaderTypesToDiscover {
+    data class SpecificReaders(val readers: List<SpecificReader>) : CardReaderTypesToDiscover()
+    object UnspecifiedReaders : CardReaderTypesToDiscover()
+}

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.PaymentData
 import com.woocommerce.android.cardreader.connection.CardReader
 import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents
+import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
 import com.woocommerce.android.cardreader.internal.connection.ConnectionManager
 import com.woocommerce.android.cardreader.internal.connection.TerminalListenerImpl
 import com.woocommerce.android.cardreader.internal.firmware.SoftwareUpdateManager
@@ -73,9 +74,12 @@ internal class CardReaderManagerImpl(
         }
     }
 
-    override fun discoverReaders(isSimulated: Boolean): Flow<CardReaderDiscoveryEvents> {
+    override fun discoverReaders(
+        isSimulated: Boolean,
+        cardReaderTypesToDiscover: CardReaderTypesToDiscover,
+    ): Flow<CardReaderDiscoveryEvents> {
         if (!terminal.isInitialized()) throw IllegalStateException("Terminal not initialized")
-        return connectionManager.discoverReaders(isSimulated)
+        return connectionManager.discoverReaders(isSimulated, cardReaderTypesToDiscover)
     }
 
     override suspend fun connectToReader(cardReader: CardReader): Boolean {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
@@ -8,6 +8,7 @@ import com.stripe.stripeterminal.external.models.TerminalException
 import com.woocommerce.android.cardreader.connection.CardReader
 import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents
 import com.woocommerce.android.cardreader.connection.CardReaderImpl
+import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
@@ -23,7 +24,7 @@ internal class ConnectionManager(
     val softwareUpdateStatus = bluetoothReaderListener.updateStatusEvents
     val softwareUpdateAvailability = bluetoothReaderListener.updateAvailabilityEvents
 
-    fun discoverReaders(isSimulated: Boolean) =
+    fun discoverReaders(isSimulated: Boolean, cardReaderTypesToDiscover: CardReaderTypesToDiscover) =
         discoverReadersAction.discoverReaders(isSimulated).map { state ->
             when (state) {
                 is DiscoverReadersStatus.Started -> {
@@ -33,7 +34,17 @@ internal class ConnectionManager(
                     CardReaderDiscoveryEvents.Failed(state.exception.errorMessage)
                 }
                 is DiscoverReadersStatus.FoundReaders -> {
-                    CardReaderDiscoveryEvents.ReadersFound(state.readers.map { CardReaderImpl(it) })
+                    val filtering: (Reader) -> Boolean = when (cardReaderTypesToDiscover) {
+                        is CardReaderTypesToDiscover.SpecificReaders -> { reader ->
+                            cardReaderTypesToDiscover.readers.map { it.name }.contains(reader.deviceType.name)
+                        }
+                        CardReaderTypesToDiscover.UnspecifiedReaders -> { _ -> true }
+                    }
+                    CardReaderDiscoveryEvents.ReadersFound(
+                        state.readers
+                            .filter(filtering)
+                            .map { CardReaderImpl(it) }
+                    )
                 }
                 DiscoverReadersStatus.Success -> {
                     CardReaderDiscoveryEvents.Succeeded

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersAction.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersAction.kt
@@ -6,21 +6,29 @@ import com.stripe.stripeterminal.external.models.DiscoveryConfiguration
 import com.stripe.stripeterminal.external.models.DiscoveryMethod
 import com.stripe.stripeterminal.external.models.Reader
 import com.stripe.stripeterminal.external.models.TerminalException
+import com.woocommerce.android.cardreader.internal.LOG_TAG
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Failure
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.FoundReaders
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Started
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Success
+import com.woocommerce.android.cardreader.internal.wrappers.LogWrapper
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.channels.sendBlocking
+import kotlinx.coroutines.channels.onClosed
+import kotlinx.coroutines.channels.onFailure
+import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 
 private const val DISCOVERY_TIMEOUT_IN_SECONDS = 60
 
 @ExperimentalCoroutinesApi
-internal class DiscoverReadersAction(private val terminal: TerminalWrapper) {
+internal class DiscoverReadersAction(
+    private val terminal: TerminalWrapper,
+    private val logWrapper: LogWrapper,
+) {
     sealed class DiscoverReadersStatus {
         object Started : DiscoverReadersStatus()
         object Success : DiscoverReadersStatus()
@@ -30,7 +38,7 @@ internal class DiscoverReadersAction(private val terminal: TerminalWrapper) {
 
     fun discoverReaders(isSimulated: Boolean): Flow<DiscoverReadersStatus> {
         return callbackFlow {
-            this.sendBlocking(Started)
+            sendAndLog(Started)
             val config = DiscoveryConfiguration(
                 DISCOVERY_TIMEOUT_IN_SECONDS,
                 DiscoveryMethod.BLUETOOTH_SCAN,
@@ -43,18 +51,18 @@ internal class DiscoverReadersAction(private val terminal: TerminalWrapper) {
                     override fun onUpdateDiscoveredReaders(readers: List<Reader>) {
                         if (readers != foundReaders) {
                             foundReaders = readers
-                            this@callbackFlow.sendBlocking(FoundReaders(readers))
+                            this@callbackFlow.sendAndLog(FoundReaders(readers))
                         }
                     }
                 },
                 object : Callback {
                     override fun onFailure(e: TerminalException) {
-                        this@callbackFlow.sendBlocking(Failure(e))
+                        this@callbackFlow.sendAndLog(Failure(e))
                         this@callbackFlow.close()
                     }
 
                     override fun onSuccess() {
-                        this@callbackFlow.sendBlocking(Success)
+                        this@callbackFlow.sendAndLog(Success)
                         this@callbackFlow.close()
                     }
                 }
@@ -63,6 +71,12 @@ internal class DiscoverReadersAction(private val terminal: TerminalWrapper) {
                 cancelable.takeIf { !it.isCompleted }?.cancel(noopCallback)
             }
         }
+    }
+
+    private fun ProducerScope<DiscoverReadersStatus>.sendAndLog(status: DiscoverReadersStatus) {
+        trySendBlocking(status)
+            .onClosed { logWrapper.e(LOG_TAG, it?.message.orEmpty()) }
+            .onFailure { logWrapper.e(LOG_TAG, it?.message.orEmpty()) }
     }
 }
 

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.cardreader.internal
 
 import android.app.Application
+import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
+import com.woocommerce.android.cardreader.connection.SpecificReader
 import com.woocommerce.android.cardreader.internal.connection.ConnectionManager
 import com.woocommerce.android.cardreader.internal.connection.TerminalListenerImpl
 import com.woocommerce.android.cardreader.internal.firmware.SoftwareUpdateManager
@@ -32,6 +34,9 @@ class CardReaderManagerImplTest {
     private val connectionManager: ConnectionManager = mock()
     private val softwareUpdateManager: SoftwareUpdateManager = mock()
     private val terminalListener: TerminalListenerImpl = mock()
+
+    private val supportedReaders =
+        CardReaderTypesToDiscover.SpecificReaders(listOf(SpecificReader.Chipper2X, SpecificReader.StripeM2))
 
     @Before
     fun setUp() {
@@ -89,7 +94,7 @@ class CardReaderManagerImplTest {
     fun `given terminal not initialized, when reader discovery started, then exception is thrown`() {
         whenever(terminalWrapper.isInitialized()).thenReturn(false)
 
-        cardReaderManager.discoverReaders(true)
+        cardReaderManager.discoverReaders(true, supportedReaders)
     }
 
     @Test(expected = IllegalStateException::class)

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
@@ -48,7 +48,7 @@ class ConnectionManagerTest {
         whenever(discoverReadersAction.discoverReaders(anyBoolean()))
             .thenReturn(flow { emit(FoundReaders(discoveredReaders)) })
 
-        val result = connectionManager.discoverReaders(true).toList()
+        val result = connectionManager.discoverReaders(true, supportedReaders).toList()
 
         assertThat((result.first() as ReadersFound).list.first().id)
             .isEqualTo(dummyReaderId)
@@ -60,7 +60,7 @@ class ConnectionManagerTest {
         whenever(discoverReadersAction.discoverReaders(anyBoolean()))
             .thenReturn(flow { emit(Failure(terminalException)) })
 
-        val result = connectionManager.discoverReaders(true).single()
+        val result = connectionManager.discoverReaders(true, supportedReaders).single()
 
         assertThat(result).isInstanceOf(CardReaderDiscoveryEvents.Failed::class.java)
     }
@@ -70,7 +70,7 @@ class ConnectionManagerTest {
         whenever(discoverReadersAction.discoverReaders(anyBoolean()))
             .thenReturn(flow { emit(Success) })
 
-        val result = connectionManager.discoverReaders(true).single()
+        val result = connectionManager.discoverReaders(true, supportedReaders).single()
 
         assertThat(result).isInstanceOf(CardReaderDiscoveryEvents.Succeeded::class.java)
     }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
@@ -2,11 +2,14 @@ package com.woocommerce.android.cardreader.internal.connection
 
 import com.stripe.stripeterminal.external.callable.Callback
 import com.stripe.stripeterminal.external.callable.ReaderCallback
+import com.stripe.stripeterminal.external.models.DeviceType
 import com.stripe.stripeterminal.external.models.Reader
 import com.stripe.stripeterminal.external.models.TerminalException
 import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents
 import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents.ReadersFound
 import com.woocommerce.android.cardreader.connection.CardReaderImpl
+import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
+import com.woocommerce.android.cardreader.connection.SpecificReader
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Failure
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.FoundReaders
@@ -31,6 +34,9 @@ class ConnectionManagerTest {
     private val bluetoothReaderListener: BluetoothReaderListenerImpl = mock()
     private val discoverReadersAction: DiscoverReadersAction = mock()
 
+    private val supportedReaders =
+        CardReaderTypesToDiscover.SpecificReaders(listOf(SpecificReader.Chipper2X, SpecificReader.StripeM2))
+
     private lateinit var connectionManager: ConnectionManager
 
     @Before
@@ -42,8 +48,10 @@ class ConnectionManagerTest {
     fun `when readers discovered, then observers get notified`() = runBlockingTest {
         val dummyReaderId = "12345"
         val discoveredReaders = listOf(
-            mock<Reader>()
-                .apply { whenever(serialNumber).thenReturn(dummyReaderId) }
+            mock<Reader> {
+                on { serialNumber }.thenReturn(dummyReaderId)
+                on { deviceType }.thenReturn(DeviceType.STRIPE_M2)
+            }
         )
         whenever(discoverReadersAction.discoverReaders(anyBoolean()))
             .thenReturn(flow { emit(FoundReaders(discoveredReaders)) })
@@ -53,6 +61,91 @@ class ConnectionManagerTest {
         assertThat((result.first() as ReadersFound).list.first().id)
             .isEqualTo(dummyReaderId)
     }
+
+    @Test
+    fun `given found readers with specified, when readers discovered, then all readers returned`() =
+        runBlockingTest {
+            val dummyReaderId = "12345"
+            val discoveredReaders = listOf<Reader>(
+                mock {
+                    on { serialNumber }.thenReturn(dummyReaderId)
+                    on { deviceType }.thenReturn(DeviceType.CHIPPER_2X)
+                },
+                mock {
+                    on { serialNumber }.thenReturn(dummyReaderId)
+                    on { deviceType }.thenReturn(DeviceType.STRIPE_M2)
+                },
+                mock {
+                    on { serialNumber }.thenReturn(dummyReaderId)
+                    on { deviceType }.thenReturn(DeviceType.WISEPOS_E)
+                }
+            )
+            whenever(discoverReadersAction.discoverReaders(anyBoolean()))
+                .thenReturn(flow { emit(FoundReaders(discoveredReaders)) })
+
+            val result = connectionManager.discoverReaders(true, supportedReaders).toList()
+
+            assertThat((result.first() as ReadersFound).list[0].type).isEqualTo(SpecificReader.Chipper2X.name)
+            assertThat((result.first() as ReadersFound).list[1].type).isEqualTo(SpecificReader.StripeM2.name)
+        }
+
+    @Test
+    fun `given found readers with unspecified, when readers discovered, then required readers returned`() =
+        runBlockingTest {
+            val dummyReaderId = "12345"
+            val discoveredReaders = listOf<Reader>(
+                mock {
+                    on { serialNumber }.thenReturn(dummyReaderId)
+                    on { deviceType }.thenReturn(DeviceType.CHIPPER_2X)
+                },
+                mock {
+                    on { serialNumber }.thenReturn(dummyReaderId)
+                    on { deviceType }.thenReturn(DeviceType.STRIPE_M2)
+                },
+                mock {
+                    on { serialNumber }.thenReturn(dummyReaderId)
+                    on { deviceType }.thenReturn(DeviceType.WISEPOS_E)
+                }
+            )
+            whenever(discoverReadersAction.discoverReaders(anyBoolean()))
+                .thenReturn(flow { emit(FoundReaders(discoveredReaders)) })
+
+            val result = connectionManager.discoverReaders(
+                true,
+                CardReaderTypesToDiscover.UnspecifiedReaders
+            ).toList()
+
+            assertThat((result.first() as ReadersFound).list[0].type).isEqualTo(SpecificReader.Chipper2X.name)
+            assertThat((result.first() as ReadersFound).list[1].type).isEqualTo(SpecificReader.StripeM2.name)
+            assertThat((result.first() as ReadersFound).list[2].type).isEqualTo(SpecificReader.WisePadeE.name)
+        }
+
+    @Test
+    fun `given no readers found with specified, when readers discovered, then empty list returned`() =
+        runBlockingTest {
+            val discoveredReaders = listOf<Reader>()
+            whenever(discoverReadersAction.discoverReaders(anyBoolean()))
+                .thenReturn(flow { emit(FoundReaders(discoveredReaders)) })
+
+            val result = connectionManager.discoverReaders(true, supportedReaders).toList()
+
+            assertThat((result.first() as ReadersFound).list).isEmpty()
+        }
+
+    @Test
+    fun `given no readers found with unspecified, when readers discovered, then empty list returned`() =
+        runBlockingTest {
+            val discoveredReaders = listOf<Reader>()
+            whenever(discoverReadersAction.discoverReaders(anyBoolean()))
+                .thenReturn(flow { emit(FoundReaders(discoveredReaders)) })
+
+            val result = connectionManager.discoverReaders(
+                true,
+                CardReaderTypesToDiscover.UnspecifiedReaders
+            ).toList()
+
+            assertThat((result.first() as ReadersFound).list).isEmpty()
+        }
 
     @Test
     fun `when discovery fails, then observers get notified`() = runBlockingTest {

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
@@ -87,6 +87,7 @@ class ConnectionManagerTest {
 
             assertThat((result.first() as ReadersFound).list[0].type).isEqualTo(SpecificReader.Chipper2X.name)
             assertThat((result.first() as ReadersFound).list[1].type).isEqualTo(SpecificReader.StripeM2.name)
+            assertThat((result.first() as ReadersFound).list.size).isEqualTo(2)
         }
 
     @Test
@@ -118,6 +119,7 @@ class ConnectionManagerTest {
             assertThat((result.first() as ReadersFound).list[0].type).isEqualTo(SpecificReader.Chipper2X.name)
             assertThat((result.first() as ReadersFound).list[1].type).isEqualTo(SpecificReader.StripeM2.name)
             assertThat((result.first() as ReadersFound).list[2].type).isEqualTo(SpecificReader.WisePadeE.name)
+            assertThat((result.first() as ReadersFound).list.size).isEqualTo(3)
         }
 
     @Test

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersActionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersActionTest.kt
@@ -13,8 +13,8 @@ import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverRe
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.FoundReaders
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Started
 import com.woocommerce.android.cardreader.internal.connection.actions.DiscoverReadersAction.DiscoverReadersStatus.Success
+import com.woocommerce.android.cardreader.internal.wrappers.LogWrapper
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
-import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.filterNot
@@ -33,10 +33,11 @@ import org.mockito.junit.MockitoJUnitRunner
 class DiscoverReadersActionTest {
     private lateinit var action: DiscoverReadersAction
     private val terminal: TerminalWrapper = mock()
+    private val logWrapper: LogWrapper = mock()
 
     @Before
     fun setUp() {
-        action = DiscoverReadersAction(terminal)
+        action = DiscoverReadersAction(terminal, logWrapper)
     }
 
     @Test
@@ -195,18 +196,6 @@ class DiscoverReadersActionTest {
 
         assertThat(result.size).isEqualTo(3)
     }
-
-    @Test(expected = ClosedSendChannelException::class)
-    fun `given more events emitted, when terminal event already processed, then exception is thrown`() =
-        runBlockingTest {
-            whenever(terminal.discoverReaders(any(), any(), any())).thenAnswer {
-                onSuccess(it.arguments)
-                onUpdateDiscoveredReaders(args = it.arguments, readers = listOf())
-                mock<Cancelable>()
-            }
-
-            action.discoverReaders(false).toList()
-        }
 
     private fun onUpdateDiscoveredReaders(args: Array<Any>, readers: List<Reader>) {
         args.filterIsInstance<DiscoveryListener>().first().onUpdateDiscoveredReaders(readers)


### PR DESCRIPTION
Closes: #4732 


### Description
The SDK version 1 supported discovery based on reader type. It's not the case in SDK v.2, so this PR implements passing a list of supported readers to the module. The module does the filtering

### Testing instructions
* Run the app
* Start discovery process from the settings -> manage card readers
* Notice that only 2 readers are found Chipper2X and StripeM2 while WisePade3 is filtered out

### Images/gif
![image](https://user-images.githubusercontent.com/4923871/132319982-2b0b02b5-2bf5-4735-a75c-7277148319d8.png)
![image](https://user-images.githubusercontent.com/4923871/132320117-1c84d002-9d95-469c-b2dc-c74e2cfb66e3.png)


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
