### PR TITLE
Issue/4749 Use of terminal application delegate

### DIFF
--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -53,6 +53,7 @@ internal class CardReaderManagerImpl(
     override fun initialize(app: Application) {
         if (!terminal.isInitialized()) {
             application = app
+            terminal.getLifecycleObserver().onCreate(app)
 
             app.registerComponentCallbacks(object : ComponentCallbacks2 {
                 override fun onConfigurationChanged(newConfig: Configuration) {}

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/wrappers/TerminalApplicationDelegateWrapper.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/wrappers/TerminalApplicationDelegateWrapper.kt
@@ -1,0 +1,12 @@
+package com.woocommerce.android.cardreader.internal.wrappers
+
+import android.app.Application
+import com.stripe.stripeterminal.TerminalApplicationDelegate
+
+class TerminalApplicationDelegateWrapper {
+    private val delegate = TerminalApplicationDelegate
+
+    fun onCreate(application: Application) = delegate.onCreate(application)
+
+    fun onTrimMemory(application: Application, level: Int) = delegate.onTrimMemory(application, level)
+}

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/wrappers/TerminalWrapper.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/wrappers/TerminalWrapper.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.cardreader.internal.wrappers
 
 import android.app.Application
 import com.stripe.stripeterminal.Terminal
-import com.stripe.stripeterminal.TerminalApplicationDelegate
 import com.stripe.stripeterminal.external.callable.BluetoothReaderListener
 import com.stripe.stripeterminal.external.callable.Callback
 import com.stripe.stripeterminal.external.callable.Cancelable

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/wrappers/TerminalWrapper.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/wrappers/TerminalWrapper.kt
@@ -27,7 +27,7 @@ import com.woocommerce.android.cardreader.connection.CardReaderImpl
  */
 internal class TerminalWrapper {
     fun isInitialized() = Terminal.isInitialized()
-    fun getLifecycleObserver() = TerminalApplicationDelegate
+    fun getLifecycleObserver() = TerminalApplicationDelegateWrapper()
     fun initTerminal(
         application: Application,
         logLevel: LogLevel,

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.cardreader.internal.connection.ConnectionManager
 import com.woocommerce.android.cardreader.internal.connection.TerminalListenerImpl
 import com.woocommerce.android.cardreader.internal.firmware.SoftwareUpdateManager
 import com.woocommerce.android.cardreader.internal.wrappers.LogWrapper
+import com.woocommerce.android.cardreader.internal.wrappers.TerminalApplicationDelegateWrapper
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
@@ -27,7 +28,10 @@ import org.mockito.kotlin.whenever
 @RunWith(MockitoJUnitRunner::class)
 class CardReaderManagerImplTest {
     private lateinit var cardReaderManager: CardReaderManagerImpl
-    private val terminalWrapper: TerminalWrapper = mock()
+    private val terminalApplicationDelegateWrapper: TerminalApplicationDelegateWrapper = mock()
+    private val terminalWrapper: TerminalWrapper = mock {
+        on { getLifecycleObserver() }.thenReturn(terminalApplicationDelegateWrapper)
+    }
     private val tokenProvider: TokenProvider = mock()
     private val application: Application = mock()
     private val logWrapper: LogWrapper = mock()
@@ -56,6 +60,13 @@ class CardReaderManagerImplTest {
         cardReaderManager.initialize(application)
 
         verify(application, atLeastOnce()).registerComponentCallbacks(any())
+    }
+
+    @Test
+    fun `given application delegate, when manager gets initialized, then delegate calls on create`() {
+        cardReaderManager.initialize(application)
+
+        verify(terminalApplicationDelegateWrapper).onCreate(application)
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4749 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
One of the changes introduced in the SDK v2 was:

```
Replaced TerminalLifecycleObserver with TerminalApplicationDelegate. Users now must invoke
TerminalApplicationDelegate.onCreate and TerminalApplicationDelegate.onTrimMemory from their
applications.
```

We would like to call `onCreate` of the delegate only when IPP is available for a user, so we won't risk other users with initializing the SDK. This approach might bring a risk with changes in the SDK, but we should be able to test it before the update

### Testing instructions
There are no user-facing changes.

Smoke test:
* Try to connect to a reader
* Try to collect money


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
