### PR TITLE
Disable google pay on merchants phone

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.ACTION_OPEN_DOCUMENT"/>
+    <uses-permission android:name="android.permission.NFC" />
 
     <!-- Dangerous permissions, access must be requested at runtime -->
     <uses-permission android:name="android.permission.CAMERA" />

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialogFragment.kt
@@ -40,16 +40,6 @@ class CardReaderPaymentDialogFragment : DialogFragment(R.layout.card_reader_paym
 
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        disableDigitalWallets()
-    }
-
-    override fun onDetach() {
-        super.onDetach()
-        reEnableDigitalWallets()
-    }
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         dialog?.let {
             it.setCanceledOnTouchOutside(false)
@@ -159,6 +149,12 @@ class CardReaderPaymentDialogFragment : DialogFragment(R.layout.card_reader_paym
         printHtmlHelper.getAndClearPrintJobResult()?.let {
             viewModel.onPrintResult(it)
         }
+        disableDigitalWallets()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        reEnableDigitalWallets()
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialogFragment.kt
@@ -32,16 +32,13 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import android.nfc.NfcAdapter
 
-
 @AndroidEntryPoint
 class CardReaderPaymentDialogFragment : DialogFragment(R.layout.card_reader_payment_dialog) {
     val viewModel: CardReaderPaymentViewModel by viewModels()
 
-    @Inject
-    lateinit var printHtmlHelper: PrintHtmlHelper
+    @Inject lateinit var printHtmlHelper: PrintHtmlHelper
 
-    @Inject
-    lateinit var uiMessageResolver: UIMessageResolver
+    @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     override fun onAttach(context: Context) {
         super.onAttach(context)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialogFragment.kt
@@ -42,12 +42,12 @@ class CardReaderPaymentDialogFragment : DialogFragment(R.layout.card_reader_paym
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        disableGooglePay()
+        disableDigitalWallets()
     }
 
     override fun onDetach() {
         super.onDetach()
-        reEnableGooglePay()
+        reEnableDigitalWallets()
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -162,10 +162,10 @@ class CardReaderPaymentDialogFragment : DialogFragment(R.layout.card_reader_paym
     }
 
     /**
-     * Disables Google Pay in order to prevent the merchant from accidentally charging themselves instead of
-     * the customer.
+     * Disables digital wallets (eg. Google Pay) in order to prevent the merchant from accidentally charging themselves
+     * instead of the customer.
      */
-    private fun disableGooglePay() {
+    private fun disableDigitalWallets() {
         NfcAdapter.getDefaultAdapter(requireContext())
             ?.enableReaderMode(
                 requireActivity(),
@@ -175,7 +175,7 @@ class CardReaderPaymentDialogFragment : DialogFragment(R.layout.card_reader_paym
             )
     }
 
-    private fun reEnableGooglePay() {
+    private fun reEnableDigitalWallets() {
         NfcAdapter.getDefaultAdapter(requireContext())
             ?.disableReaderMode(requireActivity())
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentDialogFragment.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.orders.cardreader
 
 import android.app.Dialog
 import android.content.ContentResolver
-import android.content.Context
 import android.media.MediaPlayer
 import android.net.Uri
 import android.os.Bundle


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parent issue: #4553
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR disables Google Pay or any other "nfc virtual card" in order to prevent the merchant from accidentally charging themselves instead of the customer. 
I considered putting the logic into the VM, but decided against it - LiveData events are not handled when the fragment is not in the foreground and we want to make sure the app re-enables the feature as soon as the user leaves the payment flow. There are other solution but I don't think they are worth it. 

This solution is not foolproof, but I don't think we can create a foolproof solution - when the user puts the app into the background, they can still charge themselves using Google Pay -> the deactivation works only when WCAndroid is in the foreground.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Open an order which is eligible for in-person payments
2. Tap on collect payment button
3. Wait until the reader is ready to collect a payment
4. Touch the reader with your phone (the phone needs to have Google Pay or an alternative setup)
5. Notice that nothing happens

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
