### PR TITLE
Make tabLayout visible in the appbar after coming back from a searched order screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -32,7 +32,6 @@ import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.StringUtils
-import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
@@ -162,9 +161,6 @@ class OrderListFragment :
 
         initializeViewModel()
         initializeTabs()
-
-        val filterOrSearchEnabled = isFilterEnabled || isSearching
-        showTabs(!filterOrSearchEnabled)
 
         if (isFilterEnabled) {
             viewModel.submitSearchOrFilter(statusFilter = orderStatusFilter)
@@ -612,14 +608,6 @@ class OrderListFragment :
      */
     private fun submitSearchQuery(query: String) {
         viewModel.submitSearchOrFilter(searchQuery = query)
-    }
-
-    private fun showTabs(show: Boolean) {
-        if (show && tabLayout.visibility != View.VISIBLE) {
-            WooAnimUtils.fadeIn(tabLayout)
-        } else if (!show && tabLayout.visibility != View.GONE) {
-            tabLayout.visibility = View.GONE
-        }
     }
 
     private fun refreshOrders() {


### PR DESCRIPTION
Fixes #4374

## Changes 

Updates the showTabs function to display the tabLayout in the appbar when coming back from a searched order screen

## Screenshots (gifs)

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/132672502-ed1b30cd-acec-44c5-aa88-30844aa34fcc.gif" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/132672545-dfb10975-e5eb-4f21-bfe4-c1c4a6bda655.gif" width="350"/> |

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/132674720-3b601909-3c19-48ee-aba9-0fa7ad6f31bd.gif" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/132674730-ee005112-4986-4df5-a703-aa672b3a8887.gif" width="350"/> 

## Testing Instructions

**1**
- Go to the Orders tab
- Tap the search icon (top right).
- Enter a search term that shows at least one result.
- Tap on any search result.
- Tap the back arrow.
- Tap the back arrow again.
- Check to see the sub-navigation for "Processing" and "All Orders" is still present.

**2** 

- Enable do not keep activities
- Go to the Orders tab
- Tap the search icon (top right)
- send the app to the background
- Open the app again
- tap the back arrow once
- Check to see the sub-navigation for "Processing" and "All Orders" is still present.

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
