### PR TITLE
Fix button not displayed for Orders containing Global Add-ons only

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -520,9 +520,8 @@ class OrderDetailViewModel @Inject constructor(
         }
     }
 
-    private fun containsAddons(product: Order.Item) =
-        addonsRepository
-            .getAddonsFrom(product.productId)
+    private suspend fun containsAddons(product: Order.Item) =
+        addonsRepository.getAddonsFrom(product.productId)
             ?.any { addon -> product.attributesList.any { it.addonName == addon.name } }
             ?: false
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -522,7 +522,7 @@ class OrderDetailViewModel @Inject constructor(
 
     private suspend fun containsAddons(product: Order.Item) =
         addonsRepository.getAddonsFrom(product.productId)
-            ?.any { addon -> product.attributesList.any { it.addonName == addon.name } }
+            ?.any { entity -> product.attributesList.any { it.addonName == entity.addon.name } }
             ?: false
 
     // the database might be missing certain products, so we need to fetch the ones we don't have

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/AddonRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/AddonRepository.kt
@@ -47,5 +47,6 @@ class AddonRepository @Inject constructor(
 
     private suspend fun List<Attribute>.joinWithAddonsFrom(productID: Long) =
         getAddonsFrom(productID)
+            ?.map { it.toAppModel() }
             ?.let { addons -> Pair(addons, this) }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/AddonRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/AddonRepository.kt
@@ -21,9 +21,11 @@ class AddonRepository @Inject constructor(
         addonsStore.fetchAllGlobalAddonsGroups(selectedSite.get())
             .isError.not()
 
-    fun getAddonsFrom(productID: Long) =
+    suspend fun getAddonsFrom(productID: Long) =
         productStore.getProductByRemoteId(selectedSite.get(), productID)
-            ?.addons
+            ?.let { addonsStore.observeAddonsForProduct(selectedSite.get().siteId, it) }
+            ?.firstOrNull()
+            ?.map { it.toAppModel() }
 
     suspend fun getOrderAddonsData(
         orderID: Long,
@@ -45,9 +47,6 @@ class AddonRepository @Inject constructor(
             ?.filter { it.isNotInternalAttributeData }
 
     private suspend fun List<Attribute>.joinWithAddonsFrom(productID: Long) =
-        productStore.getProductByRemoteId(selectedSite.get(), productID)
-            ?.let { addonsStore.observeAddonsForProduct(selectedSite.get().siteId, it) }
-            ?.firstOrNull()
-            ?.map { it.toAppModel() }
+        getAddonsFrom(productID)
             ?.let { addons -> Pair(addons, this) }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/AddonRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/AddonRepository.kt
@@ -25,7 +25,6 @@ class AddonRepository @Inject constructor(
         productStore.getProductByRemoteId(selectedSite.get(), productID)
             ?.let { addonsStore.observeAddonsForProduct(selectedSite.get().siteId, it) }
             ?.firstOrNull()
-            ?.map { it.toAppModel() }
 
     suspend fun getOrderAddonsData(
         orderID: Long,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonRepositoryTest.kt
@@ -123,7 +123,7 @@ class AddonRepositoryTest {
     fun `getAddonsFrom should return addons successfully`() = runBlockingTest {
         configureSuccessfulAddonResponse()
 
-        val expectedAddons = defaultWCProductModel.addons!!
+        val expectedAddons = defaultAddonWithOptionsList.map { it.toAppModel() }
 
         val actualAddons = repositoryUnderTest.getAddonsFrom(333)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonRepositoryTest.kt
@@ -123,7 +123,7 @@ class AddonRepositoryTest {
     fun `getAddonsFrom should return addons successfully`() = runBlockingTest {
         configureSuccessfulAddonResponse()
 
-        val expectedAddons = defaultAddonWithOptionsList.map { it.toAppModel() }
+        val expectedAddons = defaultAddonWithOptionsList
 
         val actualAddons = repositoryUnderTest.getAddonsFrom(333)
 


### PR DESCRIPTION
Summary
==========
Fixes issue #4704 by modifying how we verify Ordered Add-ons presence to each Product inside an Order. 

Currently, this Add-ons presence verification was taking into account Product-specific Add-ons only. The consequence happens when an Order Product containing ONLY Global Add-ons inside, the ending result was the `View Button` hidden since the Order Details view thinks there are no Add-ons to be displayed.

How to Test
==========
Prerequisites: Have your site with the add ons plugin installed, configured, and with at least one Global add-on configured and at least one order of a Product that contains Global Add-ons only.

1 - Launch the Woo app.
2 - Navigate to an order with a Product submitted with Global Add-ons only, verify if the View Add-ons Button is showing up for products that contain Add-ons inside the current Order.
3 - Click on View Add-ons and verify if the Ordered Addons view is displayed with all the expected data.


Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
