### PR TITLE
Issue/4765 handle required update failure

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectDialogFragment.kt
@@ -21,8 +21,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.google.android.material.snackbar.BaseTransientBottomBar
-import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.cardreader.CardReaderManager
@@ -105,7 +103,7 @@ class CardReaderConnectDialogFragment : DialogFragment(R.layout.card_reader_conn
     }
 
     private fun initObservers(binding: CardReaderConnectDialogBinding) {
-        observeEvents(binding)
+        observeEvents()
         observeState(binding)
         setupResultHandlers(viewModel)
     }
@@ -173,7 +171,7 @@ class CardReaderConnectDialogFragment : DialogFragment(R.layout.card_reader_conn
     }
 
     @Suppress("ComplexMethod")
-    private fun observeEvents(binding: CardReaderConnectDialogBinding) {
+    private fun observeEvents() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is CheckLocationPermissions -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectDialogFragment.kt
@@ -21,6 +21,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.snackbar.BaseTransientBottomBar
+import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.cardreader.CardReaderManager
@@ -51,6 +53,7 @@ import com.woocommerce.android.util.WooPermissionUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.widgets.AlignedDividerDecoration
 import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -102,7 +105,7 @@ class CardReaderConnectDialogFragment : DialogFragment(R.layout.card_reader_conn
     }
 
     private fun initObservers(binding: CardReaderConnectDialogBinding) {
-        observeEvents()
+        observeEvents(binding)
         observeState(binding)
         setupResultHandlers(viewModel)
     }
@@ -170,7 +173,7 @@ class CardReaderConnectDialogFragment : DialogFragment(R.layout.card_reader_conn
     }
 
     @Suppress("ComplexMethod")
-    private fun observeEvents() {
+    private fun observeEvents(binding: CardReaderConnectDialogBinding) {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is CheckLocationPermissions -> {
@@ -221,6 +224,8 @@ class CardReaderConnectDialogFragment : DialogFragment(R.layout.card_reader_conn
                 is ExitWithResult<*> -> {
                     navigateBackWithResult(KEY_CONNECT_TO_READER_RESULT, event.data as Boolean)
                 }
+                is CardReaderConnectViewModel.CardReaderConnectEvent.ShowToast ->
+                    ToastUtils.showToast(requireContext(), getString(event.message))
                 else -> event.isHandled = false
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -106,7 +106,10 @@ class CardReaderConnectViewModel @Inject constructor(
 
     fun onUpdateReaderResult(updateResult: CardReaderUpdateViewModel.UpdateResult) {
         when (updateResult) {
-            CardReaderUpdateViewModel.UpdateResult.FAILED -> exitFlow(connected = false)
+            CardReaderUpdateViewModel.UpdateResult.FAILED -> {
+                triggerEvent(CardReaderConnectEvent.ShowToast(R.string.card_reader_detail_connected_update_failed))
+                exitFlow(connected = false)
+            }
             CardReaderUpdateViewModel.UpdateResult.SUCCESS -> {
                 // noop
             }
@@ -392,6 +395,8 @@ class CardReaderConnectViewModel @Inject constructor(
         object ShowUpdateInProgress : CardReaderConnectEvent()
 
         object NavigateToOnboardingFlow : CardReaderConnectEvent()
+
+        data class ShowToast(@StringRes val message: Int) : CardReaderConnectEvent()
     }
 
     @Suppress("LongParameterList")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -851,6 +851,24 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given update reader result failed, when on update result called, then toast event emitted`() {
+        val result = CardReaderUpdateViewModel.UpdateResult.FAILED
+
+        val events = mutableListOf<Event>()
+        viewModel.event.observeForever {
+            events.add(it)
+        }
+
+        viewModel.onUpdateReaderResult(result)
+
+        assertThat(events[events.size - 2]).isEqualTo(
+            CardReaderConnectViewModel.CardReaderConnectEvent.ShowToast(
+                R.string.card_reader_detail_connected_update_failed
+            )
+        )
+    }
+
+    @Test
     fun `given update reader result success, when on update result called, then event is check location`() {
         val result = CardReaderUpdateViewModel.UpdateResult.SUCCESS
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4765 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
The PR adds toast which is shown when the required update fails

### Testing instructions
* Try to connect to a simulator and wait till "random" will throw "required"
* Click back -> cancel button on the "updating dialog"
* Notice toast

### Images/gif

https://user-images.githubusercontent.com/4923871/132836478-a129c4f3-741c-4193-b708-6d74439543f1.mp4


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
