### PR TITLE
Issue/4767 automattic optinal update start

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
@@ -84,7 +84,6 @@ class CardReaderDetailViewModel @Inject constructor(
 
     private fun showConnectedState(readerStatus: Connected, updateAvailable: Boolean = false) {
         viewState.value = if (updateAvailable) {
-            triggerEvent(NavigationTarget.CardReaderUpdateScreen)
             ConnectedState(
                 enforceReaderUpdate = UiStringRes(
                     R.string.card_reader_detail_connected_enforced_update_software

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
@@ -208,20 +208,6 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when view model init with connected state and update available should send card reader update screen event`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            // GIVEN
-            initConnectedState(updateAvailable = SoftwareUpdateAvailability.Available)
-
-            // WHEN
-            val viewModel = createViewModel()
-
-            assertThat(viewModel.event.value).isEqualTo(
-                CardReaderDetailViewModel.NavigationTarget.CardReaderUpdateScreen
-            )
-        }
-
-    @Test
     fun `when on update result with success should send snackbar event with success text`() {
         // GIVEN
         val viewModel = createViewModel()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4767 

### Description
The PR brings a change to reflect the new design - we don't want to open the "optional" update dialog automatically when it's available.

### Testing instructions
1. Open Settings -> In-App Payments -> Manager a reader
2.  Connect to a simulator. Make sure that optional update is available
3. Click back
4. Return to the details screen - notice that update dialog is not shown automatically 

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
