### PR TITLE
Product Image Uploads: auto dismiss the error snackbar when needed

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaFileUploadHandler.kt
@@ -176,7 +176,7 @@ class MediaFileUploadHandler @Inject constructor(
     fun observeCurrentUploadErrors(remoteProductId: Long): Flow<List<ProductImageUploadData>> =
         uploadsStatus.map { list ->
             list.filter { it.remoteProductId == remoteProductId && it.uploadStatus is Failed }
-        }.filter { it.isNotEmpty() }
+        }
 
     fun observeCurrentUploads(remoteProductId: Long): Flow<List<String>> {
         return uploadsStatus

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListViewModel.kt
@@ -11,11 +11,11 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
-import kotlin.collections.map
 
 @HiltViewModel
 class MediaUploadErrorListViewModel @Inject constructor(
@@ -44,6 +44,7 @@ class MediaUploadErrorListViewModel @Inject constructor(
             mediaFileUploadHandler.clearImageErrors(navArgs.remoteId)
         } else {
             mediaFileUploadHandler.observeCurrentUploadErrors(navArgs.remoteId)
+                .filter { it.isNotEmpty() }
                 .onEach { errors ->
                     val currentErrors =
                         viewState.uploadErrorList + errors.map { ErrorUiModel(it.uploadStatus as Failed) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -75,7 +75,7 @@ class ProductDetailFragment :
     private var progressDialog: CustomProgressDialog? = null
     private var layoutManager: LayoutManager? = null
     private var updateMenuItem: MenuItem? = null
-    private var detailSnackbar: Snackbar? = null
+    private var imageUploadErrorsSnackbar: Snackbar? = null
 
     private val publishTitleId = R.string.product_add_tool_bar_menu_button_done
     private val saveTitleId = R.string.save
@@ -97,7 +97,7 @@ class ProductDetailFragment :
 
     override fun onDestroyView() {
         skeletonView.hide()
-        detailSnackbar?.dismiss()
+        imageUploadErrorsSnackbar?.dismiss()
         super.onDestroyView()
         _binding = null
     }
@@ -261,7 +261,7 @@ class ProductDetailFragment :
                         )
                     }
                     is ShowActionSnackbar -> displayProductImageUploadErrorSnackBar(event.message, event.action)
-                    is HideImageUploadErrorSnackbar -> detailSnackbar?.dismiss()
+                    is HideImageUploadErrorSnackbar -> imageUploadErrorsSnackbar?.dismiss()
                     else -> event.isHandled = false
                 }
             }
@@ -311,16 +311,16 @@ class ProductDetailFragment :
         message: String,
         actionListener: View.OnClickListener
     ) {
-        if (detailSnackbar == null) {
-            detailSnackbar = uiMessageResolver.getIndefiniteActionSnack(
+        if (imageUploadErrorsSnackbar == null) {
+            imageUploadErrorsSnackbar = uiMessageResolver.getIndefiniteActionSnack(
                 message = message,
                 actionText = getString(R.string.details),
                 actionListener = actionListener
             )
         } else {
-            detailSnackbar?.setText(message)
+            imageUploadErrorsSnackbar?.setText(message)
         }
-        detailSnackbar?.show()
+        imageUploadErrorsSnackbar?.show()
     }
 
     private fun startAddImageContainer() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -97,6 +97,7 @@ class ProductDetailFragment :
 
     override fun onDestroyView() {
         skeletonView.hide()
+        detailSnackbar?.dismiss()
         super.onDestroyView()
         _binding = null
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -23,17 +23,13 @@ import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.databinding.FragmentProductDetailBinding
-import com.woocommerce.android.extensions.fastStripHtml
-import com.woocommerce.android.extensions.handleResult
-import com.woocommerce.android.extensions.hide
-import com.woocommerce.android.extensions.navigateBackWithResult
-import com.woocommerce.android.extensions.show
-import com.woocommerce.android.extensions.takeIfNotEqualTo
+import com.woocommerce.android.extensions.*
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.Product.Image
 import com.woocommerce.android.ui.aztec.AztecEditorFragment
 import com.woocommerce.android.ui.aztec.AztecEditorFragment.Companion.ARG_AZTEC_EDITOR_TEXT
 import com.woocommerce.android.ui.dialog.WooDialog
+import com.woocommerce.android.ui.products.ProductDetailViewModel.HideImageUploadErrorSnackbar
 import com.woocommerce.android.ui.products.ProductDetailViewModel.RefreshMenu
 import com.woocommerce.android.ui.products.ProductInventoryViewModel.InventoryData
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductDetailBottomSheet
@@ -46,9 +42,7 @@ import com.woocommerce.android.ui.products.variations.VariationListFragment
 import com.woocommerce.android.ui.products.variations.VariationListViewModel.VariationListData
 import com.woocommerce.android.ui.wpmediapicker.WPMediaPickerFragment
 import com.woocommerce.android.util.ChromeCustomTabUtils
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowActionSnackbar
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.LaunchUrlInChromeTab
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*
 import com.woocommerce.android.widgets.CustomProgressDialog
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageInteractionListener
@@ -266,6 +260,7 @@ class ProductDetailFragment :
                         )
                     }
                     is ShowActionSnackbar -> displayProductImageUploadErrorSnackBar(event.message, event.action)
+                    is HideImageUploadErrorSnackbar -> detailSnackbar?.dismiss()
                     else -> event.isHandled = false
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1573,11 +1573,15 @@ class ProductDetailViewModel @Inject constructor(
                 .launchIn(this)
 
             mediaFileUploadHandler.observeCurrentUploadErrors(getRemoteProductId())
-                .onEach {
-                    val errorMsg = resources.getMediaUploadErrorMessage(it.size)
-                    triggerEvent(
-                        ShowActionSnackbar(errorMsg) { triggerEvent(ViewMediaUploadErrors(getRemoteProductId())) }
-                    )
+                .onEach { errorList ->
+                    if (errorList.isEmpty()) {
+                        triggerEvent(HideImageUploadErrorSnackbar)
+                    } else {
+                        val errorMsg = resources.getMediaUploadErrorMessage(errorList.size)
+                        triggerEvent(
+                            ShowActionSnackbar(errorMsg) { triggerEvent(ViewMediaUploadErrors(getRemoteProductId())) }
+                        )
+                    }
                 }
                 .launchIn(this)
         }
@@ -1992,6 +1996,8 @@ class ProductDetailViewModel @Inject constructor(
     }
 
     object RefreshMenu : Event()
+
+    object HideImageUploadErrorSnackbar: Event()
 
     /**
      * [productDraft] is used for the UI. Any updates to the fields in the UI would update this model.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1997,7 +1997,7 @@ class ProductDetailViewModel @Inject constructor(
 
     object RefreshMenu : Event()
 
-    object HideImageUploadErrorSnackbar: Event()
+    object HideImageUploadErrorSnackbar : Event()
 
     /**
      * [productDraft] is used for the UI. Any updates to the fields in the UI would update this model.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -66,7 +66,7 @@ class ProductImagesFragment :
 
     private var imageSourceDialog: AlertDialog? = null
     private var capturedPhotoUri: Uri? = null
-    private var detailSnackbar: Snackbar? = null
+    private var imageUploadErrorsSnackbar: Snackbar? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -87,7 +87,7 @@ class ProductImagesFragment :
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
-        detailSnackbar?.dismiss()
+        imageUploadErrorsSnackbar?.dismiss()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -222,16 +222,16 @@ class ProductImagesFragment :
         message: String,
         actionListener: View.OnClickListener
     ) {
-        if (detailSnackbar == null) {
-            detailSnackbar = uiMessageResolver.getIndefiniteActionSnack(
+        if (imageUploadErrorsSnackbar == null) {
+            imageUploadErrorsSnackbar = uiMessageResolver.getIndefiniteActionSnack(
                 message = message,
                 actionText = getString(R.string.details),
                 actionListener = actionListener
             )
         } else {
-            detailSnackbar?.setText(message)
+            imageUploadErrorsSnackbar?.setText(message)
         }
-        detailSnackbar?.show()
+        imageUploadErrorsSnackbar?.show()
     }
 
     private fun updateImages(images: List<Image>, uris: List<Uri>?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -24,7 +24,10 @@ import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.databinding.FragmentProductImagesBinding
-import com.woocommerce.android.extensions.*
+import com.woocommerce.android.extensions.handleResult
+import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.media.ProductImagesUtils
 import com.woocommerce.android.model.Product.Image
 import com.woocommerce.android.ui.products.ProductImagesViewModel.*
@@ -84,6 +87,7 @@ class ProductImagesFragment :
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+        detailSnackbar?.dismiss()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -197,6 +198,7 @@ class ProductImagesViewModel @Inject constructor(
             .launchIn(this)
 
         mediaFileUploadHandler.observeCurrentUploadErrors(remoteProductId)
+            .filter { it.isNotEmpty() }
             .onEach {
                 val errorMsg = resourceProvider.getMediaUploadErrorMessage(it.size)
                 triggerEvent(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
@@ -32,6 +32,7 @@ import com.woocommerce.android.ui.products.ProductPricingViewModel.PricingData
 import com.woocommerce.android.ui.products.ProductShippingViewModel.ShippingData
 import com.woocommerce.android.ui.products.adapters.ProductPropertyCardsAdapter
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
+import com.woocommerce.android.ui.products.variations.VariationDetailViewModel.HideImageUploadErrorSnackbar
 import com.woocommerce.android.ui.products.variations.attributes.edit.EditVariationAttributesFragment.Companion.KEY_VARIATION_ATTRIBUTES_RESULT
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*
 import com.woocommerce.android.widgets.CustomProgressDialog
@@ -85,6 +86,7 @@ class VariationDetailFragment :
 
     override fun onDestroyView() {
         skeletonView.hide()
+        detailSnackbar?.dismiss()
         super.onDestroyView()
         _binding = null
     }
@@ -243,6 +245,7 @@ class VariationDetailFragment :
                 when (event) {
                     is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                     is ShowActionSnackbar -> displayProductImageUploadErrorSnackBar(event.message, event.action)
+                    is HideImageUploadErrorSnackbar -> detailSnackbar?.dismiss()
                     is VariationNavigationTarget -> {
                         navigator.navigate(this, event)
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
@@ -67,7 +67,7 @@ class VariationDetailFragment :
     private val skeletonView = SkeletonView()
     private var progressDialog: CustomProgressDialog? = null
     private var layoutManager: LayoutManager? = null
-    private var detailSnackbar: Snackbar? = null
+    private var imageUploadErrorsSnackbar: Snackbar? = null
 
     private val viewModel: VariationDetailViewModel by viewModels()
 
@@ -86,7 +86,7 @@ class VariationDetailFragment :
 
     override fun onDestroyView() {
         skeletonView.hide()
-        detailSnackbar?.dismiss()
+        imageUploadErrorsSnackbar?.dismiss()
         super.onDestroyView()
         _binding = null
     }
@@ -245,7 +245,7 @@ class VariationDetailFragment :
                 when (event) {
                     is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                     is ShowActionSnackbar -> displayProductImageUploadErrorSnackBar(event.message, event.action)
-                    is HideImageUploadErrorSnackbar -> detailSnackbar?.dismiss()
+                    is HideImageUploadErrorSnackbar -> imageUploadErrorsSnackbar?.dismiss()
                     is VariationNavigationTarget -> {
                         navigator.navigate(this, event)
                     }
@@ -323,16 +323,16 @@ class VariationDetailFragment :
         message: String,
         actionListener: View.OnClickListener
     ) {
-        if (detailSnackbar == null) {
-            detailSnackbar = uiMessageResolver.getIndefiniteActionSnack(
+        if (imageUploadErrorsSnackbar == null) {
+            imageUploadErrorsSnackbar = uiMessageResolver.getIndefiniteActionSnack(
                 message = message,
                 actionText = getString(R.string.details),
                 actionListener = actionListener
             )
         } else {
-            detailSnackbar?.setText(message)
+            imageUploadErrorsSnackbar?.setText(message)
         }
-        detailSnackbar?.show()
+        imageUploadErrorsSnackbar?.show()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -32,12 +32,12 @@ import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.
 import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.ViewMediaUploadErrors
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.LiveDataDelegate
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -396,15 +396,20 @@ class VariationDetailViewModel @Inject constructor(
             .launchIn(this)
 
         mediaFileUploadHandler.observeCurrentUploadErrors(navArgs.remoteVariationId)
-            .filter { it.isNotEmpty() }
-            .onEach {
-                val errorMsg = resources.getMediaUploadErrorMessage(it.size)
-                triggerEvent(
-                    ShowActionSnackbar(errorMsg) { triggerEvent(ViewMediaUploadErrors(navArgs.remoteVariationId)) }
-                )
+            .onEach { errorList ->
+                if (errorList.isEmpty()) {
+                    triggerEvent(HideImageUploadErrorSnackbar)
+                } else {
+                    val errorMsg = resources.getMediaUploadErrorMessage(errorList.size)
+                    triggerEvent(
+                        ShowActionSnackbar(errorMsg) { triggerEvent(ViewMediaUploadErrors(navArgs.remoteVariationId)) }
+                    )
+                }
             }
             .launchIn(this)
     }
+
+    object HideImageUploadErrorSnackbar: Event()
 
     @Parcelize
     data class VariationViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -409,7 +409,7 @@ class VariationDetailViewModel @Inject constructor(
             .launchIn(this)
     }
 
-    object HideImageUploadErrorSnackbar: Event()
+    object HideImageUploadErrorSnackbar : Event()
 
     @Parcelize
     data class VariationViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -37,6 +37,7 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -395,6 +396,7 @@ class VariationDetailViewModel @Inject constructor(
             .launchIn(this)
 
         mediaFileUploadHandler.observeCurrentUploadErrors(navArgs.remoteVariationId)
+            .filter { it.isNotEmpty() }
             .onEach {
                 val errorMsg = resources.getMediaUploadErrorMessage(it.size)
                 triggerEvent(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModelTest.kt
@@ -1,27 +1,34 @@
 package com.woocommerce.android.ui.products.variations
 
 import androidx.lifecycle.SavedStateHandle
-import org.mockito.kotlin.any
-import org.mockito.kotlin.doAnswer
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.ProductVariation
+import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.media.MediaFileUploadHandler
+import com.woocommerce.android.ui.media.MediaFileUploadHandler.ProductImageUploadData
+import com.woocommerce.android.ui.media.MediaFileUploadHandler.UploadStatus
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.generateVariation
 import com.woocommerce.android.ui.products.models.SiteParameters
+import com.woocommerce.android.ui.products.variations.VariationDetailViewModel.HideImageUploadErrorSnackbar
 import com.woocommerce.android.ui.products.variations.VariationDetailViewModel.VariationViewState
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowActionSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.*
 import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.GENERIC_ERROR
 import java.time.LocalDateTime
 import java.time.ZoneOffset
-import java.util.Date
+import java.util.*
 
 @RunWith(RobolectricTestRunner::class)
 class VariationDetailViewModelTest : BaseUnitTest() {
@@ -52,14 +59,23 @@ class VariationDetailViewModelTest : BaseUnitTest() {
         on { getParameters(any(), any<SavedStateHandle>()) } doReturn (siteParams)
     }
     private val variationRepository: VariationDetailRepository = mock {
-        on { getVariation(any(), any()) } doReturn (TEST_VARIATION)
+        on { getVariation(any(), any()) } doReturn TEST_VARIATION
+        onBlocking { fetchVariation(any(), any()) } doReturn TEST_VARIATION
     }
 
     private val resourceProvider: ResourceProvider = mock {
         on { getString(any()) } doAnswer { answer -> answer.arguments[0].toString() }
     }
 
-    private val mediaFileUploadHandler: MediaFileUploadHandler = mock()
+    private val networkStatus: NetworkStatus = mock {
+        on { isConnected() } doReturn true
+    }
+
+    private val mediaFileUploadHandler: MediaFileUploadHandler = mock {
+        on { it.observeCurrentUploadErrors(any()) } doReturn emptyFlow()
+        on { it.observeCurrentUploads(any()) } doReturn flowOf(emptyList())
+        on { it.observeSuccessfulUploads(any()) } doReturn emptyFlow()
+    }
 
     private val savedState = VariationDetailFragmentArgs(
         TEST_VARIATION.remoteProductId,
@@ -72,7 +88,7 @@ class VariationDetailViewModelTest : BaseUnitTest() {
             savedState = savedState,
             variationRepository = variationRepository,
             productRepository = mock(),
-            networkStatus = mock(),
+            networkStatus = networkStatus,
             currencyFormatter = mock(),
             parameterRepository = parameterRepository,
             resources = resourceProvider,
@@ -108,6 +124,47 @@ class VariationDetailViewModelTest : BaseUnitTest() {
         sut.variationViewStateData.observeForever { _, _ -> }
 
         assertThat(viewState!!.uploadingImageUri).isNull()
+    }
+
+    @Test
+    fun `when there image upload errors, then show a snackbar`() = testBlocking {
+        val errorEvents = MutableSharedFlow<List<ProductImageUploadData>>()
+        doReturn(errorEvents).whenever(mediaFileUploadHandler)
+            .observeCurrentUploadErrors(TEST_VARIATION.remoteVariationId)
+        val errorMessage = "message"
+        doReturn(errorMessage).whenever(resourceProvider).getString(any())
+        doReturn(errorMessage).whenever(resourceProvider).getString(any(), anyVararg())
+
+        setup()
+        val errors = listOf(
+            ProductImageUploadData(
+                TEST_VARIATION.remoteVariationId,
+                "uri",
+                UploadStatus.Failed(
+                    MediaModel(),
+                    GENERIC_ERROR,
+                    "error"
+                )
+            )
+        )
+        errorEvents.emit(errors)
+
+        assertThat(sut.event.value).matches {
+            it is ShowActionSnackbar &&
+                it.message == errorMessage
+        }
+    }
+
+    @Test
+    fun `when image uploads gets cleared, then auto-dismiss the snackbar`() = testBlocking {
+        val errorEvents = MutableSharedFlow<List<ProductImageUploadData>>()
+        doReturn(errorEvents).whenever(mediaFileUploadHandler)
+            .observeCurrentUploadErrors(TEST_VARIATION.remoteVariationId)
+
+        setup()
+        errorEvents.emit(emptyList())
+
+        assertThat(sut.event.value).isEqualTo(HideImageUploadErrorSnackbar)
     }
 
     private val variation: ProductVariation?


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4769 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
When there are image upload errors, we display a persistent action SnackBar, to give the users a chance to check the error details, this SnackBar can be shown in multiple screens, but we were missing some scenarios where it should be dismissed automatically:
1. When navigating to a screen that can't handle its action.
2. When the error list has been cleared due to handling the action in another screen.

This PR adds handling for these two cases.

### Testing instructions
For all the test scenarios, please use `heic` images for example to simulate a failure, and please do the tests for both a product and a variation.

##### Auto dismiss when errors are cleared
1. Open product details.
2. Add some images to the product.
3. Stay on the gallery until all the uploads fail.
4. Click on "Details" button of the error SnackBar.
5. Go Back to the gallery, then to the product details.
6. Confirm that the Snackbar is not visible in the Product details screen.

##### Auto dismiss when navigating to another screen
1. Open product details.
2. Add some images to the product.
3. Go back to product details.
4. Wait until all the uploads fail.
5. When the error snackbar is displayed, go back to the product list.
6. Confirm that the snackbar is dismissed.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
