### PR TITLE
Fix activity restoration on ProductDetail screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -217,11 +217,18 @@ class ProductDetailViewModel @Inject constructor(
     }
 
     fun start() {
+        val isNotRestoringState = viewState.productDraft == null
+            if (isNotRestoringState) {
+                initializeViewState()
+            }
+        observeImageUploadEvents()
+    }
+
+    private fun initializeViewState() {
         when (isAddFlowEntryPoint) {
             true -> startAddNewProduct()
             else -> loadRemoteProduct(navArgs.remoteProductId)
         }
-        observeImageUploadEvents()
     }
 
     private fun startAddNewProduct() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -217,8 +217,8 @@ class ProductDetailViewModel @Inject constructor(
     }
 
     fun start() {
-        val isNotRestoringState = viewState.productDraft == null
-        if (isNotRestoringState) {
+        val isRestoredFromSavedState = viewState.productDraft != null
+        if (!isRestoredFromSavedState) {
             initializeViewState()
         }
         observeImageUploadEvents()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -218,9 +218,9 @@ class ProductDetailViewModel @Inject constructor(
 
     fun start() {
         val isNotRestoringState = viewState.productDraft == null
-            if (isNotRestoringState) {
-                initializeViewState()
-            }
+        if (isNotRestoringState) {
+            initializeViewState()
+        }
         observeImageUploadEvents()
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #3384 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When the user is creating a new product and the application gets killed and restored by the system (eg. "don't keep activites" is turned on), all the values entered by the user get lost. However, when editing an existing product the state restoration works as expected (props to @rossanafmenezes for noticing that as it significantly helped with the debugging).

Thanks for the pair programming session @rossanafmenezes ;)!


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable Do not keep activities in developer settings
1. Click on the Products tab.
2. Click on "+" floating action button
3. Add the product title or description or anything else
4. Click on the Home button.
5. Resume the app from the background.
6. Notice the changes made to the title/description are persisted
7. Repeat the testing steps for an existing product


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
