### PR TITLE
set tax status field to Taxable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductHelper.kt
@@ -5,7 +5,6 @@ import com.woocommerce.android.ui.products.ProductBackorderStatus.NotAvailable
 import com.woocommerce.android.ui.products.ProductStatus.DRAFT
 import com.woocommerce.android.ui.products.ProductStatus.PUBLISH
 import com.woocommerce.android.ui.products.ProductStockStatus.InStock
-import com.woocommerce.android.ui.products.ProductTaxStatus.None
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
 import com.woocommerce.android.ui.products.settings.ProductCatalogVisibility.VISIBLE
 import java.math.BigDecimal
@@ -79,7 +78,7 @@ object ProductHelper {
             saleEndDateGmt = null,
             saleStartDateGmt = null,
             isSoldIndividually = true,
-            taxStatus = None,
+            taxStatus = ProductTaxStatus.Taxable,
             isSaleScheduled = false,
             menuOrder = 0,
             categories = listOf(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
@@ -204,7 +204,7 @@ class ProductPricingFragment :
 
         pricingData.taxStatus?.let { status ->
             with(binding.productTaxStatus) {
-                setText(ProductTaxStatus.taxStatusToDisplayString(requireContext(), status))
+                setText(ProductTaxStatus.taxStatusToDisplayString(requireContext(), ProductTaxStatus.Taxable))
                 setClickListener {
                     productTaxStatusSelectorDialog = ProductItemSelectorDialog.newInstance(
                         this@ProductPricingFragment, RequestCodes.PRODUCT_TAX_STATUS,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductPricingFragment.kt
@@ -204,7 +204,7 @@ class ProductPricingFragment :
 
         pricingData.taxStatus?.let { status ->
             with(binding.productTaxStatus) {
-                setText(ProductTaxStatus.taxStatusToDisplayString(requireContext(), ProductTaxStatus.Taxable))
+                setText(ProductTaxStatus.taxStatusToDisplayString(requireContext(), status))
                 setClickListener {
                     productTaxStatusSelectorDialog = ProductItemSelectorDialog.newInstance(
                         this@ProductPricingFragment, RequestCodes.PRODUCT_TAX_STATUS,


### PR DESCRIPTION
Fixes #4360 

## Changes

Sets the  default tax status when creating a brand new product to "Taxable" as opposed to "None" to match the behaviour in the iOS app. 

## Sacreenshots (gifs) 

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/133176561-29f970cd-3963-4c8c-b387-7b5ffea97a78.gif" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/133176599-4f23ad6b-09b6-4522-b0b8-1e667715b7b9.gif" width="350"/> |

## Testing instructions

1. Navigate to Products.
2. Tap on the big plus button.
3. Navigate to Price Settings (“Add price” button)
4. Notice the Tax status default value set to Taxable

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
