### PR TITLE
Fixes issue/4785-fix-concurrentmodificationexception

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/push/NotificationMessageHandler.kt
@@ -238,7 +238,8 @@ class NotificationMessageHandler @Inject constructor(
 
     @Synchronized private fun hasNotifications() = ACTIVE_NOTIFICATIONS_MAP.isNotEmpty()
     @Synchronized private fun clearNotifications() = ACTIVE_NOTIFICATIONS_MAP.clear()
-    @Synchronized private fun removeNotificationByPushId(localPushId: Int) = ACTIVE_NOTIFICATIONS_MAP.remove(localPushId)
+    @Synchronized private fun removeNotificationByPushId(localPushId: Int) =
+        ACTIVE_NOTIFICATIONS_MAP.remove(localPushId)
 
     /**
      * Find the matching notification and send a track event for [PUSH_NOTIFICATION_TAPPED].


### PR DESCRIPTION
Fixes #4785

### Description
This PR fixes the `ConcurrentModificationException` crash that takes place when trying to dismiss notifications of a specific type from the notification tray.

I haven't been able to reproduce this issue but noticed that there were a bunch of `@Synchronized` methods in `NotificationHandler` that got removed during the refactor change. So fixed that in this PR as well. Also instead of using the `ACTIVE_NOTIFICATIONS_MAP`I added logic to use aa copy of that map when iterating. That being said, if there is anything else we can do to ensure that this does not happen again, I am all ears!

Given that this was introduced in the recent beta, it would be nice to fix this in beta before release next week.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.