### PR TITLE
Fixes #4786-order-detail-notification-bug-fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -689,15 +689,13 @@ class MainActivity :
     private fun initFragment(savedInstanceState: Bundle?) {
         setupObservers()
         val openedFromPush = intent.getBooleanExtra(FIELD_OPENED_FROM_PUSH, false)
+        // Reset this flag now that it's being processed
+        intent.removeExtra(FIELD_OPENED_FROM_PUSH)
 
         if (savedInstanceState != null) {
             restoreSavedInstanceState(savedInstanceState)
         } else if (openedFromPush) {
             // Opened from a push notification
-            //
-            // Reset this flag now that it's being processed
-            intent.removeExtra(FIELD_OPENED_FROM_PUSH)
-
             menu?.close()
 
             val localPushId = intent.getIntExtra(FIELD_PUSH_ID, 0)


### PR DESCRIPTION
Fixes #4786 

### Description
I found a bug when testing notifications that when you switch stores after receiving a new order notification and clicking on it, you are redirected back to the same order from the previous store, even after switching stores. This PR adds a fix that resets the intent from the notification, once it is processed.

### Testing instructions
- Click on a new order notification in the app.
- Click on the back button from the order detail screen.
- Switch stores from the app settings screen.
- Click on the back button once the store is switched.
- Notice you are redirected back to the My Store tab of the new store and not the order detail of the previous store order.

cc @jkmassel this would require a new beta to be released once merged. Thank you! There are also a number of issues that are targeting this new beta though so I will ping you once all is merged!!

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.