### PR TITLE
Fixes issue/4792-order-detail-duplicate-notes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -116,7 +116,9 @@ data class Order(
         val attributesDescription
             get() = attributesList.filter {
                 it.value.isNotEmpty() && it.key.isNotEmpty() && it.isNotInternalAttributeData
-            }.joinToString { it.value.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() } }
+            }.joinToString {
+                it.value.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
+            }
 
         @Parcelize
         data class Attribute(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -29,6 +29,7 @@ import java.util.Locale
 @Parcelize
 data class Order(
     val identifier: OrderIdentifier,
+    val localOrderId: Int,
     val remoteId: Long,
     val number: String,
     val localSiteId: Int,
@@ -115,7 +116,7 @@ data class Order(
         val attributesDescription
             get() = attributesList.filter {
                 it.value.isNotEmpty() && it.key.isNotEmpty() && it.isNotInternalAttributeData
-            }.joinToString { it.value.capitalize(Locale.getDefault()) }
+            }.joinToString { it.value.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() } }
 
         @Parcelize
         data class Attribute(
@@ -257,6 +258,7 @@ data class Order(
 fun WCOrderModel.toAppModel(): Order {
     return Order(
         identifier = OrderIdentifier(this),
+        localOrderId = this.id,
         remoteId = this.remoteOrderId,
         number = this.number,
         localSiteId = this.localSiteId,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.AppPrefs
-import com.woocommerce.android.R
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
@@ -323,7 +322,7 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     fun refreshShipmentTracking() {
-        _shipmentTrackings.value = orderDetailRepository.getOrderShipmentTrackings(orderIdSet.id)
+        _shipmentTrackings.value = orderDetailRepository.getOrderShipmentTrackings(order.localOrderId)
     }
 
     fun onShippingLabelRefunded() {
@@ -357,8 +356,8 @@ class OrderDetailViewModel @Inject constructor(
         )
 
         val snackbarMessage = when (updateSource) {
-            is OrderStatusUpdateSource.Dialog -> R.string.order_status_updated
-            is OrderStatusUpdateSource.FullFillScreen -> R.string.order_fulfill_completed
+            is OrderStatusUpdateSource.Dialog -> string.order_status_updated
+            is OrderStatusUpdateSource.FullFillScreen -> string.order_fulfill_completed
         }
 
         triggerEvent(
@@ -382,7 +381,7 @@ class OrderDetailViewModel @Inject constructor(
     fun onDeleteShipmentTrackingClicked(trackingNumber: String) {
         if (networkStatus.isConnected()) {
             orderDetailRepository.getOrderShipmentTrackingByTrackingNumber(
-                orderIdSet.id, trackingNumber
+                order.localOrderId, trackingNumber
             )?.let { deletedShipmentTracking ->
                 deletedOrderShipmentTrackingSet.add(trackingNumber)
 
@@ -421,7 +420,7 @@ class OrderDetailViewModel @Inject constructor(
     private fun deleteOrderShipmentTracking(shipmentTracking: OrderShipmentTracking) {
         launch {
             val deletedShipment = orderDetailRepository.deleteOrderShipmentTracking(
-                orderIdSet.id, orderIdSet.remoteOrderId, shipmentTracking.toDataModel()
+                order.localOrderId, orderIdSet.remoteOrderId, shipmentTracking.toDataModel()
             )
             if (deletedShipment) {
                 triggerEvent(ShowSnackbar(string.order_shipment_tracking_delete_success))
@@ -487,16 +486,16 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     private fun loadOrderNotes() {
-        _orderNotes.value = orderDetailRepository.getOrderNotes(orderIdSet.id)
+        _orderNotes.value = orderDetailRepository.getOrderNotes(order.localOrderId)
     }
 
     private fun fetchOrderNotes() {
         launch {
-            if (!orderDetailRepository.fetchOrderNotes(orderIdSet.id, orderIdSet.remoteOrderId)) {
+            if (!orderDetailRepository.fetchOrderNotes(order.localOrderId, orderIdSet.remoteOrderId)) {
                 triggerEvent(ShowSnackbar(string.order_error_fetch_notes_generic))
             }
             // fetch order notes from the local db and hide the skeleton view
-            _orderNotes.value = orderDetailRepository.getOrderNotes(orderIdSet.id)
+            _orderNotes.value = orderDetailRepository.getOrderNotes(order.localOrderId)
         }
     }
 
@@ -541,7 +540,7 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     private fun loadShipmentTracking(shippingLabels: ListInfo<ShippingLabel>): ListInfo<OrderShipmentTracking> {
-        val trackingList = orderDetailRepository.getOrderShipmentTrackings(orderIdSet.id)
+        val trackingList = orderDetailRepository.getOrderShipmentTrackings(order.localOrderId)
         return if (!appPrefs.isTrackingExtensionAvailable() || shippingLabels.isVisible || hasVirtualProductsOnly()) {
             ListInfo(isVisible = false)
         } else {
@@ -554,7 +553,7 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     private fun fetchShipmentTrackingAsync() = async {
-        val result = orderDetailRepository.fetchOrderShipmentTrackingList(orderIdSet.id, orderIdSet.remoteOrderId)
+        val result = orderDetailRepository.fetchOrderShipmentTrackingList(order.localOrderId, orderIdSet.remoteOrderId)
         appPrefs.setTrackingExtensionAvailable(result == SUCCESS)
     }
 


### PR DESCRIPTION
Closes: #4792 

### Description
When an order is opened from a notification, we don't have have `localOrderId` since the order is not yet stored in the local db. Instead we only have the `remoteOrderId` and the `localSiteId` from the notification payload. Since the `localOrderId` is 0 in this case, the order notes displayed are not only for this particular order but displays all the cached notes from the local db.

This PR adds logic to use the `localOrderId` from the current order, instead of expecting the `localOrderId` from the `navArgs` of the fragment. We use the `localOrderId` when fetching order notes, shipment trackings and adding/deleting shipment trackings.

### Testing instructions
- Click on a few orders from the order list. This ensures that there are some cached order notes and shipment trackings for the store in the local db.
- Initiate a new order notification from a test store.
- Open the order from the notification and notice that the order notes displayed are only for this order.
- Try adding/deleting shipment trackings/adding new notes to the order and verify that only those pertaining to this order is displayed correctly.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.