### PR TITLE
Fixed incorrect continuation called when fetching product for a review

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailRepository.kt
@@ -186,7 +186,7 @@ class ReviewDetailRepository @Inject constructor(
     @Subscribe(threadMode = MAIN)
     fun onProductChanged(event: OnProductChanged) {
         if (event.causeOfChange == FETCH_SINGLE_PRODUCT && event.remoteProductId == remoteProductId) {
-            if (continuationReview.isWaiting) {
+            if (continuationProduct.isWaiting) {
                 if (event.isError) {
                     AnalyticsTracker.track(
                         Stat.REVIEW_PRODUCT_LOAD_FAILED,


### PR DESCRIPTION
Closes: #4794 

### Description
The review screen never loads and the pulsing placeholder image is shown indefinitely when tapping on a review push notification after the app has been completely closed or if you are viewing a review for the first time ever in a new install of the app. 

It looks like this was because when fetching product for a review, the continuation called was `continuationReview` instead of `continuationProduct`. This tiny PR fixes that.

### Testing instructions
- Uninstall any previous versions of the app and install and login.
- Do not open the Reviews screen.
- Force close the app.
- Receive a push notification for a new review.
- Tap on the review notification.
- Notice the review detail screen is displayed correctly. 

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.