### PR TITLE
SSR: Display screen, show example data, add share and copy functionality

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -79,6 +79,11 @@
             android:theme="@style/Theme.Woo.DayNight"/>
 
         <activity
+            android:label="@string/support_system_status_report"
+            android:name=".support.SSRActivity"
+            android:theme="@style/Theme.Woo.DayNight"/>
+
+        <activity
             android:name=".support.HelpActivity"
             android:label="@string/support_help"
             android:theme="@style/Theme.Woo.DayNight" />

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -57,6 +57,7 @@ class HelpActivity : AppCompatActivity() {
         binding.myTicketsContainer.setOnClickListener { showZendeskTickets() }
         binding.faqContainer.setOnClickListener { showZendeskFaq() }
         binding.appLogContainer.setOnClickListener { showApplicationLog() }
+        binding.ssrContainer.setOnClickListener { showSSR() }
 
         with(binding.contactPaymentsContainer) {
             visibility = if (FeatureFlag.CARD_READER.isEnabled()) View.VISIBLE else View.GONE
@@ -169,6 +170,10 @@ class HelpActivity : AppCompatActivity() {
     private fun showApplicationLog() {
         AnalyticsTracker.track(Stat.SUPPORT_APPLICATION_LOG_VIEWED)
         startActivity(Intent(this, WooLogViewerActivity::class.java))
+    }
+
+    private fun showSSR() {
+        startActivity(Intent(this, SSRActivity::class.java))
     }
 
     enum class Origin(private val stringValue: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivity.kt
@@ -1,0 +1,122 @@
+package com.woocommerce.android.support
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.Menu
+import android.view.MenuItem
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
+import com.woocommerce.android.R
+import com.woocommerce.android.databinding.ActivitySsrBinding
+import com.woocommerce.android.extensions.takeIfNotEqualTo
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T
+import org.wordpress.android.util.ToastUtils
+import java.lang.IllegalStateException
+
+class SSRActivity : AppCompatActivity() {
+    companion object {
+        private const val ID_SHARE = 1
+        private const val ID_COPY_TO_CLIPBOARD = 2
+    }
+
+    private val viewModel: SSRActivityViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val binding = ActivitySsrBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        setSupportActionBar(binding.toolbar.toolbar as Toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        setupObservers(binding)
+    }
+
+    private fun setupObservers(binding: ActivitySsrBinding) {
+        viewModel.viewStateData.observe(this) { old, new ->
+            new.exampleString.takeIfNotEqualTo(old?.exampleString) {
+                binding.ssrContent.text = it
+            }
+        }
+        viewModel.event.observe(this) {
+            when (it) {
+                is ShareSSR -> shareSSR(it.ssrText)
+                is CopySSR -> copySSRToClipboard(it.ssrText)
+                else -> it.isHandled = false
+            }
+        }
+    }
+
+    private fun shareSSR(text: String) {
+        val intent = Intent(Intent.ACTION_SEND)
+        intent.type = "text/plain"
+        intent.putExtra(Intent.EXTRA_TEXT, text)
+        intent.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.app_name) + " " + title)
+        try {
+            startActivity(Intent.createChooser(intent, getString(R.string.share)))
+        } catch (e: android.content.ActivityNotFoundException) {
+            WooLog.e(T.UTILS, e)
+            ToastUtils.showToast(this, R.string.support_system_status_report_share_error)
+        }
+    }
+
+    private fun copySSRToClipboard(text: String) {
+        try {
+            val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+            clipboard.setPrimaryClip(
+                ClipData.newPlainText(
+                    getString(R.string.support_system_status_report_clipboard_label),
+                    text
+                )
+            )
+            ToastUtils.showToast(this, R.string.support_system_status_report_copied_to_clipboard)
+        } catch (e: IllegalStateException) {
+            WooLog.e(T.UTILS, e)
+            ToastUtils.showToast(this, R.string.support_system_status_report_error_copy_to_clipboard)
+        }
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        super.onCreateOptionsMenu(menu)
+
+        val mnuCopy = menu.add(
+            Menu.NONE,
+            ID_COPY_TO_CLIPBOARD, Menu.NONE, android.R.string.copy
+        )
+        mnuCopy.setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM)
+        mnuCopy.setIcon(R.drawable.ic_copy_white_24dp)
+
+        val mnuShare = menu.add(
+            Menu.NONE,
+            ID_SHARE, Menu.NONE, R.string.share
+        )
+        mnuShare.setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM)
+        mnuShare.setIcon(R.drawable.ic_share_white_24dp)
+
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            android.R.id.home -> {
+                finish()
+                true
+            }
+            ID_SHARE -> {
+                viewModel.onShareButtonTapped()
+                true
+            }
+            ID_COPY_TO_CLIPBOARD -> {
+                viewModel.onCopyButtonTapped()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivity.kt
@@ -15,9 +15,11 @@ import com.woocommerce.android.databinding.ActivitySsrBinding
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ToastUtils
 import java.lang.IllegalStateException
 
+@AndroidEntryPoint
 class SSRActivity : AppCompatActivity() {
     companion object {
         private const val ID_SHARE = 1

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivityViewModel.kt
@@ -1,0 +1,45 @@
+package com.woocommerce.android.support
+
+import android.os.Parcelable
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
+import com.woocommerce.android.viewmodel.LiveDataDelegate
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ResourceProvider
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.parcelize.Parcelize
+import javax.inject.Inject
+
+@HiltViewModel
+class SSRActivityViewModel @Inject constructor(
+    savedState: SavedStateHandle,
+    resourceProvider: ResourceProvider
+) : ScopedViewModel(savedState) {
+    val viewStateData = LiveDataDelegate(savedState, SSRViewState())
+    private var viewState by viewStateData
+
+    init {
+        val exampleStream = resourceProvider.openRawResource(R.raw.system_status)
+        val exampleAsString = exampleStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+        viewState = viewState.copy(
+            exampleString = exampleAsString
+        )
+    }
+
+    fun onShareButtonTapped() {
+        triggerEvent(ShareSSR(viewState.exampleString))
+    }
+
+    fun onCopyButtonTapped() {
+        triggerEvent(CopySSR(viewState.exampleString))
+    }
+
+    @Parcelize
+    data class SSRViewState(
+        val exampleString: String = ""
+    ) : Parcelable
+}
+
+data class CopySSR(val ssrText: String) : MultiLiveEvent.Event()
+data class ShareSSR(val ssrText: String) : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivityViewModel.kt
@@ -21,9 +21,8 @@ class SSRActivityViewModel @Inject constructor(
 
     init {
         val exampleStream = resourceProvider.openRawResource(R.raw.system_status)
-        val exampleAsString = exampleStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
         viewState = viewState.copy(
-            exampleString = exampleAsString
+            exampleString = exampleStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/ResourceProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/ResourceProvider.kt
@@ -3,8 +3,10 @@ package com.woocommerce.android.viewmodel
 import android.content.Context
 import androidx.annotation.ColorRes
 import androidx.annotation.DimenRes
+import androidx.annotation.RawRes
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
+import java.io.InputStream
 import javax.inject.Inject
 
 class ResourceProvider @Inject constructor(private val context: Context) {
@@ -23,5 +25,10 @@ class ResourceProvider @Inject constructor(private val context: Context) {
     fun getDimensionPixelSize(@DimenRes dimen: Int): Int {
         val resources = context.resources
         return resources.getDimensionPixelSize(dimen)
+    }
+
+    fun openRawResource(@RawRes rawId: Int): InputStream {
+        val resources = context.resources
+        return resources.openRawResource(rawId)
     }
 }

--- a/WooCommerce/src/main/res/layout/activity_help.xml
+++ b/WooCommerce/src/main/res/layout/activity_help.xml
@@ -78,6 +78,14 @@
                 android:layout_height="wrap_content"
                 app:optionTitle="@string/support_application_log"
                 app:optionValue="@string/support_application_log_detail"/>
+
+            <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+                android:id="@+id/ssrContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:optionTitle="@string/support_system_status_report"
+                app:optionValue="@string/support_system_status_report_detail"/>
+
         </LinearLayout>
     </ScrollView>
 

--- a/WooCommerce/src/main/res/layout/activity_ssr.xml
+++ b/WooCommerce/src/main/res/layout/activity_ssr.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@color/color_surface">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <include
+            layout="@layout/view_toolbar"
+            android:id="@+id/toolbar"/>
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/ssr_content"
+        style="@style/Woo.Card.Body"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:textIsSelectable="true"
+        tools:text="This is where SSR info is shown." />
+
+</LinearLayout>

--- a/WooCommerce/src/main/res/raw/system_status.json
+++ b/WooCommerce/src/main/res/raw/system_status.json
@@ -1,0 +1,144 @@
+{
+  "environment": {
+    "home_url": "http://example.com",
+    "site_url": "http://example.com",
+    "version": "3.0.0",
+    "log_directory": "/var/www/woocommerce/wp-content/uploads/wc-logs/",
+    "log_directory_writable": true,
+    "wp_version": "4.7.3",
+    "wp_multisite": false,
+    "wp_memory_limit": 134217728,
+    "wp_debug_mode": true,
+    "wp_cron": true,
+    "language": "en_US",
+    "server_info": "Apache/2.4.18 (Ubuntu)",
+    "php_version": "7.1.3-2+deb.sury.org~yakkety+1",
+    "php_post_max_size": 8388608,
+    "php_max_execution_time": 30,
+    "php_max_input_vars": 1000,
+    "curl_version": "7.50.1, OpenSSL/1.0.2g",
+    "suhosin_installed": false,
+    "max_upload_size": 2097152,
+    "mysql_version": "5.7.17",
+    "default_timezone": "UTC",
+    "fsockopen_or_curl_enabled": true,
+    "soapclient_enabled": true,
+    "domdocument_enabled": true,
+    "gzip_enabled": true,
+    "mbstring_enabled": true,
+    "remote_post_successful": true,
+    "remote_post_response": "200",
+    "remote_get_successful": true,
+    "remote_get_response": "200"
+  },
+  "database": {
+    "wc_database_version": "3.0.0",
+    "database_prefix": "wp_",
+    "maxmind_geoip_database": "/var/www/woocommerce/wp-content/uploads/GeoIP.dat",
+    "database_tables": {
+      "woocommerce_sessions": true,
+      "woocommerce_api_keys": true,
+      "woocommerce_attribute_taxonomies": true,
+      "woocommerce_downloadable_product_permissions": true,
+      "woocommerce_order_items": true,
+      "woocommerce_order_itemmeta": true,
+      "woocommerce_tax_rates": true,
+      "woocommerce_tax_rate_locations": true,
+      "woocommerce_shipping_zones": true,
+      "woocommerce_shipping_zone_locations": true,
+      "woocommerce_shipping_zone_methods": true,
+      "woocommerce_payment_tokens": true,
+      "woocommerce_payment_tokenmeta": true
+    }
+  },
+  "active_plugins": [
+    {
+      "plugin": "woocommerce/woocommerce.php",
+      "name": "WooCommerce",
+      "version": "3.0.0-rc.1",
+      "version_latest": "2.6.14",
+      "url": "https://woocommerce.com/",
+      "author_name": "Automattic",
+      "author_url": "https://woocommerce.com",
+      "network_activated": false
+    }
+  ],
+  "theme": {
+    "name": "Twenty Sixteen",
+    "version": "1.3",
+    "version_latest": "1.3",
+    "author_url": "https://wordpress.org/",
+    "is_child_theme": false,
+    "has_woocommerce_support": true,
+    "has_woocommerce_file": false,
+    "has_outdated_templates": false,
+    "overrides": [],
+    "parent_name": "",
+    "parent_version": "",
+    "parent_version_latest": "",
+    "parent_author_url": ""
+  },
+  "settings": {
+    "api_enabled": true,
+    "force_ssl": false,
+    "currency": "USD",
+    "currency_symbol": "&#36;",
+    "currency_position": "left",
+    "thousand_separator": ",",
+    "decimal_separator": ".",
+    "number_of_decimals": 2,
+    "geolocation_enabled": false,
+    "taxonomies": {
+      "external": "external",
+      "grouped": "grouped",
+      "simple": "simple",
+      "variable": "variable"
+    }
+  },
+  "security": {
+    "secure_connection": true,
+    "hide_errors": true
+  },
+  "pages": [
+    {
+      "page_name": "Shop base",
+      "page_id": "4",
+      "page_set": true,
+      "page_exists": true,
+      "page_visible": true,
+      "shortcode": "",
+      "shortcode_required": false,
+      "shortcode_present": false
+    },
+    {
+      "page_name": "Cart",
+      "page_id": "5",
+      "page_set": true,
+      "page_exists": true,
+      "page_visible": true,
+      "shortcode": "[woocommerce_cart]",
+      "shortcode_required": true,
+      "shortcode_present": true
+    },
+    {
+      "page_name": "Checkout",
+      "page_id": "6",
+      "page_set": true,
+      "page_exists": true,
+      "page_visible": true,
+      "shortcode": "[woocommerce_checkout]",
+      "shortcode_required": true,
+      "shortcode_present": true
+    },
+    {
+      "page_name": "My account",
+      "page_id": "7",
+      "page_set": true,
+      "page_exists": true,
+      "page_visible": true,
+      "shortcode": "[woocommerce_my_account]",
+      "shortcode_required": true,
+      "shortcode_present": true
+    }
+  ]
+}

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1322,7 +1322,11 @@
     <string name="support_application_log">Application log</string>
     <string name="support_application_log_detail">Advanced tool to review the app status</string>
     <string name="support_system_status_report">System status report</string>
+    <string name="support_system_status_report_clipboard_label">WooCommerce SSR</string>
     <string name="support_system_status_report_detail">Various system information about your site</string>
+    <string name="support_system_status_report_copied_to_clipboard">System status report copied to clipboard</string>
+    <string name="support_system_status_report_error_copy_to_clipboard">Error copying SSR to clipboard</string>
+    <string name="support_system_status_report_share_error">Unable to share System Status Report</string>
     <string name="help">Help</string>
     <string name="support_contact_email">Contact email</string>
     <string name="support_contact_email_not_set">Not set</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1321,6 +1321,8 @@
     <string name="support_contact_payments_detail">Reach our happiness engineers who can help answer payments related questions</string>
     <string name="support_application_log">Application log</string>
     <string name="support_application_log_detail">Advanced tool to review the app status</string>
+    <string name="support_system_status_report">System status report</string>
+    <string name="support_system_status_report_detail">Various system information about your site</string>
     <string name="help">Help</string>
     <string name="support_contact_email">Contact email</string>
     <string name="support_contact_email_not_set">Not set</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4782

### Description
This PR adds the following:
1. System Status Report menu item in Settings -> Help & support
2. The System Status Report screen itself, that will show example data
3. The copy and share text functionality on that screen

Considering that this is a quick project, most of this work is based on the existing "Application log" screen in Settings > Help & support, meaning it uses a regular Activity like "Application log" instead of fragment with navigation component. It does use a viewmodel with viewstate and event-based action, though.

### Testing instructions
1. Go to Settings -> Help & support
2. Select "System status report"
3. Ensure a JSON information is shown
4. Tap the copy icon. Ensure the "System status report copied to clipboard" Toast is shown.
5. Go to another app where you can paste text, then try to paste and ensure the pasted text is the same as the example content.
6. Go back to the Woo app, tap the Share icon. Try sharing or Copy action there and make sure the text is also correct.


### Screenshot

<img src="https://user-images.githubusercontent.com/266376/133753932-c643558f-b5a9-43e4-b588-6fc497812ac3.png" width="42%" />
