### PR TITLE
Remove `multidex`

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -61,7 +61,6 @@ android {
         minSdkVersion 21
         targetSdkVersion 30
 
-        multiDexEnabled true
         vectorDrawables.useSupportLibrary = true
 
         testInstrumentationRunner 'com.woocommerce.android.WooCommerceTestRunner'
@@ -153,7 +152,6 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:2.0.4"
     implementation "androidx.recyclerview:recyclerview:1.1.0"
     implementation "androidx.recyclerview:recyclerview-selection:1.1.0"
-    implementation "androidx.multidex:multidex:2.0.1"
     implementation "androidx.appcompat:appcompat:$appCompatVersion"
     implementation "com.google.android.material:material:$materialVersion"
     implementation "androidx.cardview:cardview:1.0.0"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android
 
-import androidx.multidex.MultiDexApplication
+import android.app.Application
 import com.android.volley.VolleyLog
 import com.yarolegovich.wellsql.WellSql
 import dagger.Lazy
@@ -9,7 +9,7 @@ import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
 import javax.inject.Inject
 
-open class WooCommerce : MultiDexApplication(), HasAndroidInjector {
+open class WooCommerce : Application(), HasAndroidInjector {
     @Inject lateinit var androidInjector: DispatchingAndroidInjector<Any>
     // inject it lazily to avoid creating it before initializing WellSql
     @Inject lateinit var appInitializer: Lazy<AppInitializer>

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,6 @@ ext {
     mockitoKotlinVersion = '3.2.0'
     mockitoVersion = '3.8.0'
     constraintLayoutVersion = '1.2.0'
-    multidexVersion = '1.0.3'
     libaddressinputVersion = '0.0.2'
     eventBusVersion = '3.2.0'
     googlePlayCoreVersion = '1.10.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4804
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As we use `minSdkVersion >= 21` we can safely remove `multidex` which now is not needed ([source](https://developer.android.com/studio/build/multidex#mdex-on-l)).

I decided to remove it from `Woo` as a follow-up to similar PR from FluxC (https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2121) which caused an issue while I was testing some other, unrelated PR (p1631866900001900/1631863731.001300-slack-C02E6E4FFSN). So this PR doesn't change anything, but rather cleans up for future sake.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Build and run the app locally - just in case. Generally if CI tests will pass, it should mean that everything works fine.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->