### PR TITLE
Issue/4806 convert fetch order notes into suspendable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -303,8 +303,6 @@ class OrderDetailRepository @Inject constructor(
         when (event.causeOfChange) {
             WCOrderAction.FETCH_SINGLE_ORDER ->
                 continuationFetchOrder.continueWith(event.isError.not())
-            WCOrderAction.FETCH_ORDER_NOTES ->
-                continuationFetchOrderNotes.continueWith(event.isError.not())
             WCOrderAction.FETCH_ORDER_SHIPMENT_TRACKINGS -> {
                 if (event.isError) {
                     val error = if (event.error.type == OrderErrorType.PLUGIN_NOT_ACTIVE) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.util.isSuccessful
 import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
@@ -52,7 +53,6 @@ class OrderDetailRepository @Inject constructor(
     private val wooCommerceStore: WooCommerceStore
 ) {
     private val continuationFetchOrder = ContinuationWrapper<Boolean>(ORDERS)
-    private val continuationFetchOrderNotes = ContinuationWrapper<Boolean>(ORDERS)
     private val continuationFetchOrderShipmentTrackingList = ContinuationWrapper<RequestResult>(ORDERS)
     private val continuationUpdateOrderStatus = ContinuationWrapper<Boolean>(ORDERS)
     private val continuationAddOrderNote = ContinuationWrapper<Boolean>(ORDERS)
@@ -84,14 +84,10 @@ class OrderDetailRepository @Inject constructor(
         localOrderId: Int,
         remoteOrderId: Long
     ): Boolean {
-        val result = continuationFetchOrderNotes.callAndWaitUntilTimeout(AppConstants.REQUEST_TIMEOUT) {
-            val payload = FetchOrderNotesPayload(localOrderId, remoteOrderId, selectedSite.get())
-            dispatcher.dispatch(WCOrderActionBuilder.newFetchOrderNotesAction(payload))
+        val result = withTimeoutOrNull(AppConstants.REQUEST_TIMEOUT) {
+            orderStore.fetchOrderNotes(localOrderId, remoteOrderId, selectedSite.get())
         }
-        return when (result) {
-            is Cancellation -> false
-            is Success -> result.value
-        }
+        return result?.isError == false
     }
 
     suspend fun fetchOrderShipmentTrackingList(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStorePresenterTest.kt
@@ -26,7 +26,6 @@ import org.junit.Test
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_HAS_ORDERS
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS
-import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDER_NOTES
 import org.wordpress.android.fluxc.action.WCOrderAction.UPDATE_ORDER_STATUS
 import org.wordpress.android.fluxc.action.WCStatsAction.FETCH_NEW_VISITOR_STATS
 import org.wordpress.android.fluxc.action.WCStatsAction.FETCH_REVENUE_STATS
@@ -149,15 +148,6 @@ class MyStorePresenterTest {
         // Simulate onOrderChanged event: UPDATE-ORDER-STATUS - My Store TAB should refresh
         presenter.onOrderChanged(OnOrderChanged(0).apply { causeOfChange = UPDATE_ORDER_STATUS })
         verify(myStoreView, times(0)).refreshMyStoreStats(forced = any())
-    }
-
-    @Test
-    fun `Handles FETCH-ORDER-NOTES order event correctly`() {
-        presenter.takeView(myStoreView)
-
-        // Simulate onOrderChanged event: FETCH-ORDER-NOTES - My Store TAB should ignore
-        presenter.onOrderChanged(OnOrderChanged(0).apply { causeOfChange = FETCH_ORDER_NOTES })
-        verify(myStoreView, times(0)).refreshMyStoreStats(forced = true)
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'develop-6087b5e9ed7e67b2b14e8e11a7680faed7d249ee'
+    fluxCVersion = '2122-9accb842e67c7bb7a2c180ae77a1502ed9375e4f'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2122-9accb842e67c7bb7a2c180ae77a1502ed9375e4f'
+    fluxCVersion = 'develop-53e2246be0347a8595eac8799d50a0a6757f5628'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'


### PR DESCRIPTION
**We'll need to update fluxc hash before we merge this PR.**

<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->
Parent issue https://github.com/woocommerce/woocommerce-android/issues/4806

"Do not merge" status - fluxc PR should be merged first and the hash updated

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

"FetchOrderNotes" action was refactored into a suspendable method - more info on FluxC PR https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2122

This PR is the second of 7/8 PRs - their goal is to transform OrderDetailRepository into a stateless singleton. The only state the repository holds are continuations which won't be necessary as soon as all the methods are using suspendable functions instead of event bus.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Open detail of a paid order
2. Add a note on the web
3. Issue a refund
3. Notice when the refund is done, the order gets updated and the newly notes is shown

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
