### PR TITLE
Product Images Upload: remove temp files after the upload

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
@@ -74,16 +74,7 @@ class MediaFilesRepository @Inject constructor(
             throw NullPointerException("null media")
         }
 
-        val result = uploadContinuation.callAndWait {
-            WooLog.d(T.MEDIA, "MediaFilesRepository > Dispatching request to upload $localUri")
-            val payload = UploadMediaPayload(selectedSite.get(), mediaModel, true)
-            dispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload))
-        }
-
-        return when (result) {
-            is Cancellation -> throw result.exception
-            is Success -> result.value.url
-        }
+        return uploadMedia(mediaModel).url
     }
 
     @SuppressWarnings("unused")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesUtils.kt
@@ -47,15 +47,11 @@ object ProductImagesUtils {
         // optimize the image if the setting is enabled
         @Suppress("TooGenericExceptionCaught")
         if (AppPrefs.getImageOptimizationEnabled()) {
-            try {
-                getOptimizedImagePath(context, path)?.let {
-                    // Delete original file if it's in the cache directly
-                    if (path.contains(context.cacheDir.absolutePath)) File(path).delete()
-                    // Use the optimized image
-                    path = it
-                } ?: WooLog.w(T.MEDIA, "mediaModelFromLocalUri > failed to optimize image")
-            } catch (e: Exception) {
-                WooLog.e(T.MEDIA, "mediaModelFromLocalUri > failed to optimize image", e)
+            getOptimizedImagePath(context, path)?.let {
+                // Delete original file if it's in the cache directly
+                if (path.contains(context.cacheDir.absolutePath)) File(path).delete()
+                // Use the optimized image
+                path = it
             }
         }
 
@@ -181,12 +177,18 @@ object ProductImagesUtils {
         return null
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun getOptimizedImagePath(context: Context, path: String): String? {
-        getOptimizedImageUri(context, path)?.let { optUri ->
-            MediaUtils.getRealPathFromURI(context, optUri)?.let {
-                return it
-            }
+        try {
+            getOptimizedImageUri(context, path)?.let { optUri ->
+                MediaUtils.getRealPathFromURI(context, optUri)?.let {
+                    return it
+                }
+            } ?: WooLog.w(T.MEDIA, "mediaModelFromLocalUri > failed to optimize image")
+        } catch (e: Exception) {
+            WooLog.e(T.MEDIA, "mediaModelFromLocalUri > failed to optimize image", e)
         }
+
         return null
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesUtils.kt
@@ -19,8 +19,7 @@ import org.wordpress.android.util.UrlUtils
 import java.io.File
 import java.io.IOException
 import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
+import java.util.*
 
 object ProductImagesUtils {
     private const val OPTIMIZE_IMAGE_MAX_SIZE = 3000
@@ -50,6 +49,9 @@ object ProductImagesUtils {
         if (AppPrefs.getImageOptimizationEnabled()) {
             try {
                 getOptimizedImagePath(context, path)?.let {
+                    // Delete original file if it's in the cache directly
+                    if (path.contains(context.cacheDir.absolutePath)) File(path).delete()
+                    // Use the optimized image
                     path = it
                 } ?: WooLog.w(T.MEDIA, "mediaModelFromLocalUri > failed to optimize image")
             } catch (e: Exception) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4810 

### Description
Currently and since we don't request READ_EXTERNAL_STORAGE permission, when the user picks a file, we might copy it to the cache directory, prior to uploading it, which means we leave a lot of files in this directory until the user decides to clear the cache manually.
In this PR, once an upload finishes successfully, the temp file will be deleted.
I didn't do the same thing for upload failures, because we might want to support upload retry later, so we need the file cached.

### Testing instructions
1. Use an emulator or connect your device to ADB before starting.
2. Clear the cache of the app (to make checking new files easier).
3. Open Product details.
4. Add some images, and wait for the upload to complete.
5. Open the tab "Device File Explorer" in Android Studio.
6. Navigate to `/data/data/com.woocommerce.android.dev/cache` (replace `com.woocommerce.android.dev` with `com.woocommerce.android.prealpha` if you used the APK from the PR)
7. Confirm that no new files are in the cache directory.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
