### PR TITLE
Bring back Android team to Dependabot default reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       interval: "daily"
     labels:
       - "bot: dependencies update"
+    reviewers:
+      - "woocommerce/android-developers"
     ignore:
       # The Android Gradle Plugin is a dependency we'd like to have in sync with other
       # in-house libraries due to compatibility with composite build.


### PR DESCRIPTION
Reverts woocommerce/woocommerce-android#4727

Discussion and reasoning: p1631870999369900-slack-C6H8C3G23