### PR TITLE
Issue/4764 handle cancelation and restart connection

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.connection.CardReader
 import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents.Failed
 import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents.ReadersFound
+import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
@@ -294,6 +295,52 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
             init()
 
             verify(cardReaderManager).discoverReaders(anyBoolean(), any())
+        }
+
+    @Test
+    fun `given installation started, when cardReaderManager gets initialized, then show update in progress emitted`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(cardReaderManager.softwareUpdateStatus).thenReturn(
+                flow {
+                    emit(SoftwareUpdateStatus.InstallationStarted)
+                }
+            )
+
+            init()
+
+            assertThat(viewModel.event.value).isEqualTo(
+                CardReaderConnectViewModel.CardReaderConnectEvent.ShowUpdateInProgress
+            )
+        }
+
+    @Test
+    fun `given installing update, when cardReaderManager gets initialized, then show update in progress emitted`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(cardReaderManager.softwareUpdateStatus).thenReturn(
+                flow {
+                    emit(SoftwareUpdateStatus.Installing(0.1f))
+                }
+            )
+
+            init()
+
+            assertThat(viewModel.event.value).isEqualTo(
+                CardReaderConnectViewModel.CardReaderConnectEvent.ShowUpdateInProgress
+            )
+        }
+
+    @Test
+    fun `given unknown update, when cardReaderManager gets initialized, then initializing manager`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(cardReaderManager.softwareUpdateStatus).thenReturn(
+                flow {
+                    emit(SoftwareUpdateStatus.Unknown)
+                }
+            )
+
+            init()
+
+            assertThat(viewModel.event.value).isInstanceOf(InitializeCardReaderManager::class.java)
         }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4764 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
The PR fixes the bug which happens if a user clicks "cancel" during connection flow right after actually connecting started

### Testing instructions
* Change `TerminalWrapper::77` to required
* Start connecting to a reader
* Right after a click on "connect" to a specific reader cancel the flow
* Try to connect to a reader again
* Notice that the update process is running and  displayed

### Images/gif


https://user-images.githubusercontent.com/4923871/133984367-155f9700-bda5-440d-b7db-6a6bd8f65947.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
