### PR TITLE
Show the create shipping label's button if the store is not part of in-person payment's beta program

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -574,9 +574,12 @@ class OrderDetailViewModel @Inject constructor(
             _shipmentTrackings.value = shipmentTracking.list
         }
 
+        val orderEligibleForInPersonPayments = viewState.orderInfo?.isPaymentCollectableWithCardReader == true &&
+            FeatureFlag.CARD_READER.isEnabled()
+
         val isOrderEligibleForSLCreation = isShippingPluginReady &&
             orderDetailRepository.isOrderEligibleForSLCreation(order.remoteId) &&
-            viewState.orderInfo?.isPaymentCollectableWithCardReader != true
+            !orderEligibleForInPersonPayments
 
         if (isOrderEligibleForSLCreation &&
             viewState.isCreateShippingLabelButtonVisible != true &&

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -74,6 +74,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     private val appPrefsWrapper: AppPrefs = mock {
         on(it.isTrackingExtensionAvailable()).thenAnswer { true }
     }
+    private val editor = mock<SharedPreferences.Editor> { whenever(it.putBoolean(any(), any())).thenReturn(mock()) }
+    private val preferences = mock<SharedPreferences> { whenever(it.edit()).thenReturn(editor) }
     private val selectedSite: SelectedSite = mock()
     private val repository: OrderDetailRepository = mock()
     private val cardReaderManager: CardReaderManager = mock()
@@ -139,8 +141,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             resources
         )
 
-        val editor = mock<SharedPreferences.Editor> { whenever(it.putBoolean(any(), any())).thenReturn(mock()) }
-        val preferences = mock<SharedPreferences> { whenever(it.edit()).thenReturn(editor) }
         mock<Context> {
             whenever(it.applicationContext).thenReturn(it)
             whenever(it.getSharedPreferences(any(), any())).thenReturn(preferences)
@@ -575,6 +575,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
             doReturn(Unit).whenever(repository).fetchSLCreationEligibility(order.remoteId)
             doReturn(true).whenever(repository).isOrderEligibleForSLCreation(order.remoteId)
+
+            doReturn(true).whenever(preferences).getBoolean("IS_CARD_PRESENT_ELIGIBLE", false)
 
             val shippingLabels = ArrayList<ShippingLabel>()
             viewModel.shippingLabels.observeForever {


### PR DESCRIPTION
### Description
@itsmeichigo found an issue with our logic when hiding the Shipping Label's create button if the order is eligible for in-person payments, if the order is eligible for the payments, but the store is not eligible for the beta program, we hide the button, which is not the correct behavior.
This PR fixes this by adding a check on `FeatureFlag.CARD_READER` value.

@jkmassel sorry for having this PR targeting 7.5 so late, it's a serious bug, and would be good to have it shipped with the next release. But if it's going to disturb the release process, let me know to move it to 7.6.

### Testing instructions
1. Make sure your store has wc_pay setup, but not enrolled in the in-person payment's beta.
2. Create an order with cash-on-delivery payment.
3. Open the app.
4. Confirm that you can see the "Create Shipping Label" button.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
