### PR TITLE
SSR: Add formatter to match core behavior

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -287,6 +287,7 @@ dependencies {
     // Use caution when updating these, as commons-text 1.9 caused the reviews tab to crash on API 21
     implementation "org.apache.commons:commons-lang3:3.9"
     implementation "org.apache.commons:commons-text:1.8"
+    implementation "commons-io:commons-io:2.11.0"
 
     implementation "com.tinder.statemachine:statemachine:$stateMachineVersion"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCSSRModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCSSRModelExt.kt
@@ -13,6 +13,7 @@ import java.util.*
 import org.apache.commons.io.FileUtils.byteCountToDisplaySize
 
 const val MISSING_VALUE = "Info not found"
+const val HEADING_SSR = "### System Status Report generated via the WooCommerce Android app ### \n"
 const val HEADING_WP_ENVIRONMENT = "WordPress Environment"
 const val HEADING_SERVER_ENVIRONMENT = "Server Environment"
 const val HEADING_DATABASE = "Database"
@@ -28,12 +29,14 @@ const val NO_CHECK = "–"
 const val PAGE_NOT_SET = "X Page not set"
 
 fun WCSSRModel.formatResult(): String {
-    var text = "### System Status Report generated via the WooCommerce Android app ### \n"
+    val sb = StringBuilder()
+
+    sb.append(HEADING_SSR)
 
     // Environment
     environment?.let { it ->
         try {
-            text += formatEnvironmentData(JSONObject(it))
+            sb.append(formatEnvironmentData(JSONObject(it)))
         } catch (e: JSONException) {
             WooLog.e(WooLog.T.UTILS, e)
         }
@@ -41,7 +44,7 @@ fun WCSSRModel.formatResult(): String {
 
     database?.let {
         try {
-            text += formatDatabaseData(JSONObject(it))
+            sb.append(formatDatabaseData(JSONObject(it)))
         } catch (e: JSONException) {
             WooLog.e(WooLog.T.UTILS, e)
         }
@@ -49,7 +52,7 @@ fun WCSSRModel.formatResult(): String {
 
     security?.let {
         try {
-            text += formatSecurityData(JSONObject(it))
+            sb.append(formatSecurityData(JSONObject(it)))
         } catch (e: JSONException) {
             WooLog.e(WooLog.T.UTILS, e)
         }
@@ -57,7 +60,7 @@ fun WCSSRModel.formatResult(): String {
 
     activePlugins?.let {
         try {
-            text += formatActivePluginsData(JSONArray(it))
+            sb.append(formatActivePluginsData(JSONArray(it)))
         } catch (e: JSONException) {
             WooLog.e(WooLog.T.UTILS, e)
         }
@@ -65,7 +68,7 @@ fun WCSSRModel.formatResult(): String {
 
     settings?.let {
         try {
-            text += formatSettingsData(JSONObject(it))
+            sb.append(formatSettingsData(JSONObject(it)))
         } catch (e: JSONException) {
             WooLog.e(WooLog.T.UTILS, e)
         }
@@ -73,7 +76,7 @@ fun WCSSRModel.formatResult(): String {
 
     pages?.let {
         try {
-            text += formatPagesData(JSONArray(it))
+            sb.append(formatPagesData(JSONArray(it)))
         } catch (e: JSONException) {
             WooLog.e(WooLog.T.UTILS, e)
         }
@@ -81,253 +84,257 @@ fun WCSSRModel.formatResult(): String {
 
     theme?.let {
         try {
-            text += formatThemeData(JSONObject(it))
+            sb.append(formatThemeData(JSONObject(it)))
         } catch (e: JSONException) {
             WooLog.e(WooLog.T.UTILS, e)
         }
     }
 
-    text += formatStatusReportInformationData()
-    return text
+    sb.append(formatStatusReportInformationData())
+    return sb.toString()
 }
 
 private fun formatEnvironmentData(data: JSONObject): String {
-    var text = formattedHeading(HEADING_WP_ENVIRONMENT)
-    text += "WordPress Address (URL): ${data.optString("home_url", MISSING_VALUE)}\n"
-    text += "Site Address (URL): ${data.optString("site_url", MISSING_VALUE)}\n"
-    text += "WC Version: ${data.optString("version", MISSING_VALUE)}\n"
-    text += "Log Directory Writable: ${checkIfTrue(data.optBoolean("log_directory_writable", false))}\n"
-    text += "WP Version: ${data.optString("wp_version", MISSING_VALUE)}\n"
-    text += "WP Multisite: ${checkIfTrue(data.optBoolean("wp_multisite", false))}\n"
+    val sb = StringBuilder()
+    sb.append(formattedHeading(HEADING_WP_ENVIRONMENT))
+        .append("WordPress Address (URL): ${data.optString("home_url", MISSING_VALUE)}\n")
+        .append("Site Address (URL): ${data.optString("site_url", MISSING_VALUE)}\n")
+        .append("WC Version: ${data.optString("version", MISSING_VALUE)}\n")
+        .append("Log Directory Writable: ${checkIfTrue(data.optBoolean("log_directory_writable", false))}\n")
+        .append("WP Version: ${data.optString("wp_version", MISSING_VALUE)}\n")
+        .append("WP Multisite: ${checkIfTrue(data.optBoolean("wp_multisite", false))}\n")
 
     val memoryLimit = data.optString("wp_memory_limit", MISSING_VALUE)
     if (memoryLimit != MISSING_VALUE) {
-        text += "WP Memory Limit: ${byteCountToDisplaySize(memoryLimit.toLong())}\n"
+        sb.append("WP Memory Limit: ${byteCountToDisplaySize(memoryLimit.toLong())}\n")
     }
-    text += "WP Debug Mode: ${checkIfTrue(data.optBoolean("wp_debug_mode", false))}\n"
-    text += "WP Cron: ${checkIfTrue(data.optBoolean("wp_cron", false))}\n"
-    text += "Language: ${data.optString("language", MISSING_VALUE)}\n"
-    text += "External object cache: ${checkIfTrue(data.optBoolean("external_object_cache", false))}\n"
 
-    text += formattedHeading(HEADING_SERVER_ENVIRONMENT)
-    text += "Server Info: ${data.optString("server_info", MISSING_VALUE)}\n"
-    text += "PHP Version: ${data.optString("php_version", MISSING_VALUE)}\n"
+    sb.append("WP Debug Mode: ${checkIfTrue(data.optBoolean("wp_debug_mode", false))}\n")
+        .append("WP Cron: ${checkIfTrue(data.optBoolean("wp_cron", false))}\n")
+        .append("Language: ${data.optString("language", MISSING_VALUE)}\n")
+        .append("External object cache: ${checkIfTrue(data.optBoolean("external_object_cache", false))}\n")
+
+        .append(formattedHeading(HEADING_SERVER_ENVIRONMENT))
+        .append("Server Info: ${data.optString("server_info", MISSING_VALUE)}\n")
+        .append("PHP Version: ${data.optString("php_version", MISSING_VALUE)}\n")
 
     val postMaxSize = data.optString("php_post_max_size", MISSING_VALUE)
     if (postMaxSize != MISSING_VALUE) {
-        text += "PHP Post Max Size: ${byteCountToDisplaySize(postMaxSize.toLong())}\n"
+        sb.append("PHP Post Max Size: ${byteCountToDisplaySize(postMaxSize.toLong())}\n")
     }
-    text += "PHP Time Limit: ${data.optString("php_max_execution_time", MISSING_VALUE)} s\n"
-    text += "PHP Max input Vars: ${data.optString("php_max_input_vars", MISSING_VALUE)}\n"
-    text += "cURL Version: ${data.optString("curl_version", MISSING_VALUE)}\n"
-    text += "Suhosin installed: ${checkIfTrue(data.optBoolean("suhosin_installed", false))}\n"
-    text += "MySQL Version: ${data.optString("mysql_version_string", MISSING_VALUE)}\n"
+
+    sb.append("PHP Time Limit: ${data.optString("php_max_execution_time", MISSING_VALUE)} s\n")
+        .append("PHP Max input Vars: ${data.optString("php_max_input_vars", MISSING_VALUE)}\n")
+        .append("cURL Version: ${data.optString("curl_version", MISSING_VALUE)}\n")
+        .append("Suhosin installed: ${checkIfTrue(data.optBoolean("suhosin_installed", false))}\n")
+        .append("MySQL Version: ${data.optString("mysql_version_string", MISSING_VALUE)}\n")
 
     val maxUploadSize = data.optString("max_upload_size", MISSING_VALUE)
     if (maxUploadSize != MISSING_VALUE) {
-        text += "PHP Post Max Size: ${byteCountToDisplaySize(maxUploadSize.toLong())}\n"
+        sb.append("PHP Post Max Size: ${byteCountToDisplaySize(maxUploadSize.toLong())}\n")
     }
-    text += "Default Timezone: ${data.optString("default_timezone", MISSING_VALUE)}\n"
-    text += "fsockopen/cURL: ${checkIfTrue(data.optBoolean("fsockopen_or_curl_enabled", false))}\n"
-    text += "SoapClient: ${checkIfTrue(data.optBoolean("soapclient_enabled", false))}\n"
-    text += "DOMDocument: ${checkIfTrue(data.optBoolean("domdocument_enabled", false))}\n"
-    text += "GZip: ${checkIfTrue(data.optBoolean("gzip_enabled", false))}\n"
-    text += "Multibye String: ${checkIfTrue(data.optBoolean("mbstring_enabled", false))}\n"
-    text += "Remote Post: ${checkIfTrue(data.optBoolean("remote_post_successful", false))}\n"
-    text += "Remote Get: ${checkIfTrue(data.optBoolean("remote_get_successful", false))}\n"
 
-    return text
+    sb.append("Default Timezone: ${data.optString("default_timezone", MISSING_VALUE)}\n")
+        .append("fsockopen/cURL: ${checkIfTrue(data.optBoolean("fsockopen_or_curl_enabled", false))}\n")
+        .append("SoapClient: ${checkIfTrue(data.optBoolean("soapclient_enabled", false))}\n")
+        .append("DOMDocument: ${checkIfTrue(data.optBoolean("domdocument_enabled", false))}\n")
+        .append("GZip: ${checkIfTrue(data.optBoolean("gzip_enabled", false))}\n")
+        .append("Multibye String: ${checkIfTrue(data.optBoolean("mbstring_enabled", false))}\n")
+        .append("Remote Post: ${checkIfTrue(data.optBoolean("remote_post_successful", false))}\n")
+        .append("Remote Get: ${checkIfTrue(data.optBoolean("remote_get_successful", false))}\n")
+
+    return sb.toString()
 }
 
 private fun formatDatabaseData(data: JSONObject): String {
-    var text = formattedHeading(HEADING_DATABASE)
-
-    text += "WC Database Version: ${data.optString("wc_database_version", MISSING_VALUE)}\n"
-    text += "WC Database Prefix: ${data.optString("wc_database_prefix", MISSING_VALUE)}\n"
+    val sb = StringBuilder()
+    sb.append(formattedHeading(HEADING_DATABASE))
+        .append("WC Database Version: ${data.optString("wc_database_version", MISSING_VALUE)}\n")
+        .append("WC Database Prefix: ${data.optString("wc_database_prefix", MISSING_VALUE)}\n")
 
     val sizeData = data.optJSONObject("database_size")
     sizeData?.let {
         val dataSize = it.optDouble("data", 0.0)
         val indexSize = it.optDouble("index", 0.0)
         val total = dataSize + indexSize
-        text += "Total Database Size: " + if (total != 0.0) {
-            total
-        } else {
-            MISSING_VALUE
-        } + "\n"
+        sb.append("Total Database Size: " + if (total != 0.0) { total } else { MISSING_VALUE } + "\n")
 
-        text += "Database Data Size: ${it.optString("data", MISSING_VALUE)}\n"
-        text += "Database Index Size: ${it.optString("index", MISSING_VALUE)}\n"
+            .append("Database Data Size: ${it.optString("data", MISSING_VALUE)}\n")
+            .append("Database Index Size: ${it.optString("index", MISSING_VALUE)}\n")
     }
 
     val tablesData = data.optJSONObject("database_tables")
     tablesData?.let { it ->
-        text += parseFormatTablesData(it, "woocommerce")
-        text += parseFormatTablesData(it, "other")
+        sb.append(parseFormatTablesData(it, "woocommerce"))
+            .append(parseFormatTablesData(it, "other"))
     }
 
-    return text
+    return sb.toString()
 }
 
 private fun formatSecurityData(data: JSONObject): String {
-    var text = formattedHeading(HEADING_SECURITY)
+    val sb = StringBuilder()
+    sb.append(formattedHeading(HEADING_SECURITY))
+        .append("Secure Connection (HTTPS): ${checkIfTrue(data.optBoolean("secure_connection", false))}\n")
+        .append("Hide errors from visitors: ${checkIfTrue(data.optBoolean("hide_errors", false))}\n")
 
-    text += "Secure Connection (HTTPS): ${checkIfTrue(data.optBoolean("secure_connection", false))}\n"
-    text += "Hide errors from visitors: ${checkIfTrue(data.optBoolean("hide_errors", false))}\n"
-
-    return text
+    return sb.toString()
 }
 
 private fun formatActivePluginsData(data: JSONArray): String {
-    var text = formattedHeading(HEADING_ACTIVE_PLUGINS)
+    val sb = StringBuilder()
+    sb.append(formattedHeading(HEADING_ACTIVE_PLUGINS))
+
     for (i in 0 until data.length()) {
         val plugin = data.optJSONObject(i)
         plugin?.let {
-            text += plugin.optString("name", MISSING_VALUE)
-            text += ": by " + plugin.optString("author_name", MISSING_VALUE)
+            sb.append(plugin.optString("name", MISSING_VALUE))
+                .append(": by " + plugin.optString("author_name", MISSING_VALUE))
 
             val currentVersion = plugin.optString("version", MISSING_VALUE)
             val latestVersion = plugin.optString("version_latest", MISSING_VALUE)
-            text += " - $currentVersion"
-            if (currentVersion != MISSING_VALUE &&
-                latestVersion != MISSING_VALUE &&
-                currentVersion != latestVersion
-            ) {
-                text += " (update to version $latestVersion available)"
+            sb.append(" - $currentVersion")
+            if (currentVersion != MISSING_VALUE && latestVersion != MISSING_VALUE && currentVersion != latestVersion) {
+                sb.append(" (update to version $latestVersion available)")
             }
-            text += "\n"
+            sb.append("\n")
         }
     }
-    return text
+    return sb.toString()
 }
 
 private fun formatSettingsData(data: JSONObject): String {
-    var text = formattedHeading(HEADING_SETTINGS)
-    text += "API Enabled: ${checkIfTrue(data.optBoolean("api_enabled", false))}\n"
-    text += "Force SSL: ${checkIfTrue(data.optBoolean("force_ssl", false))}\n"
+    val sb = StringBuilder()
+    sb.append(formattedHeading(HEADING_SETTINGS))
+        .append("API Enabled: ${checkIfTrue(data.optBoolean("api_enabled", false))}\n")
+        .append("Force SSL: ${checkIfTrue(data.optBoolean("force_ssl", false))}\n")
 
-    // Currency format: currency_name(currency_symbol)
-    // Correct value example: USD($)
-    // Missing value example: Info not found(Info not found)
-    text += "Currency: ${data.optString("currency", MISSING_VALUE)}"
-    text += "("
+        // Currency format: currency_name(currency_symbol)
+        // Correct value example: USD($)
+        // Missing value example: Info not found(Info not found)
+        .append("Currency: ${data.optString("currency", MISSING_VALUE)} (")
+
     val currencySymbolHTML = data.optString("currency_symbol", MISSING_VALUE)
-    text += if (currencySymbolHTML == MISSING_VALUE) {
-        MISSING_VALUE
-    } else {
-        text += StringUtils.fromHtml(currencySymbolHTML)
-    }
-    text += ")\n"
+    sb.append(
+        if (currencySymbolHTML == MISSING_VALUE) {
+            MISSING_VALUE
+        } else {
+            StringUtils.fromHtml(currencySymbolHTML)
+        }
+    )
+        .append(")\n")
 
-    text += "Currency Position: ${data.optString("currency_position", MISSING_VALUE)}\n"
-    text += "Thousand Separator: ${data.optString("thousand_separator", MISSING_VALUE)}\n"
-    text += "Decimal Separator: ${data.optString("decimal_separator", MISSING_VALUE)}\n"
-    text += "Number of Decimals: ${data.optString("number_of_decimals", MISSING_VALUE)}\n"
+        .append("Currency Position: ${data.optString("currency_position", MISSING_VALUE)}\n")
+        .append("Thousand Separator: ${data.optString("thousand_separator", MISSING_VALUE)}\n")
+        .append("Decimal Separator: ${data.optString("decimal_separator", MISSING_VALUE)}\n")
+        .append("Number of Decimals: ${data.optString("number_of_decimals", MISSING_VALUE)}\n")
 
     val productTypesTaxonomy = data.optJSONObject("taxonomies")
     productTypesTaxonomy?.let {
-        text += parseFormatTaxonomy(it, "Product Types") + "\n"
+        sb.append(parseFormatTaxonomy(it, "Product Types") + "\n")
     }
 
     val productVisibilityTaxonomy = data.optJSONObject("product_visibility_terms")
     productVisibilityTaxonomy?.let {
-        text += parseFormatTaxonomy(it, "Product Visibility") + "\n"
+        sb.append(parseFormatTaxonomy(it, "Product Visibility") + "\n")
     }
 
-    text += "Connected to WooCommerce.com: ${checkIfTrue(data.optBoolean("woocommerce_com_connected", false))}\n"
+    sb.append("Connected to WooCommerce.com: ${checkIfTrue(data.optBoolean("woocommerce_com_connected", false))}\n")
 
-    return text
+    return sb.toString()
 }
 
 private fun formatPagesData(data: JSONArray): String {
-    var text = formattedHeading(HEADING_PAGES)
+    val sb = StringBuilder()
+    sb.append(formattedHeading(HEADING_PAGES))
 
     for (i in 0 until data.length()) {
         val page = data.optJSONObject(i)
         page?.let {
-            text += "${it["page_name"]}: "
+            sb.append("${it["page_name"]}: ")
             val pageSet = it.optBoolean("page_set", false)
-            text += if (pageSet) {
-                " Page ID #${it["page_id"]}"
-            } else {
-                PAGE_NOT_SET
-            }
-            text += "\n"
+            sb.append(
+                if (pageSet) {
+                    " Page ID #${it["page_id"]}"
+                } else {
+                    PAGE_NOT_SET
+                }
+            )
+                .append("\n")
         }
     }
 
-    return text
+    return sb.toString()
 }
 
 private fun formatThemeData(data: JSONObject): String {
-    var text = formattedHeading(HEADING_THEME)
-    text += "Name: ${data.optString("name", MISSING_VALUE)}\n"
+    val sb = StringBuilder()
+    sb.append(formattedHeading(HEADING_THEME))
+        .append("Name: ${data.optString("name", MISSING_VALUE)}\n")
 
     val currentVersion = data.optString("version", MISSING_VALUE)
     val latestVersion = data.optString("version_latest", MISSING_VALUE)
-    text += "Version: $currentVersion"
-    if (currentVersion != MISSING_VALUE &&
-        latestVersion != MISSING_VALUE &&
-        currentVersion != latestVersion
-    ) {
-        text += " (update to version $latestVersion available)"
-    }
-    text += "\n"
 
-    text += "Author URL: ${data.optString("author_url", MISSING_VALUE)}\n"
+    sb.append("Version: $currentVersion")
+    if (currentVersion != MISSING_VALUE && latestVersion != MISSING_VALUE && currentVersion != latestVersion) {
+        sb.append(" (update to version $latestVersion available)")
+    }
+    sb.append("\n")
+
+        .append("Author URL: ${data.optString("author_url", MISSING_VALUE)}\n")
 
     val isChildTheme = data.optBoolean("is_child_theme", false)
     if (isChildTheme) {
-        text += "Child Theme: ${CHECK}\n"
-        text += "Parent Theme Name: ${data.optString("parent_name", MISSING_VALUE)}\n"
+        sb.append("Child Theme: ${CHECK}\n")
+            .append("Parent Theme Name: ${data.optString("parent_name", MISSING_VALUE)}\n")
 
         val parentCurrentVersion = data.optString("parent_version", MISSING_VALUE)
         val parentLatestVersion = data.optString("parent_version_latest", MISSING_VALUE)
-        text += "Parent Theme Version: $currentVersion"
+        sb.append("Parent Theme Version: $currentVersion")
         if (parentCurrentVersion != MISSING_VALUE &&
             parentLatestVersion != MISSING_VALUE &&
             parentCurrentVersion != parentLatestVersion
         ) {
-            text += " (update to version $latestVersion available)"
+            sb.append(" (update to version $latestVersion available)")
         }
-        text += "\n"
-
-        text += "Parent Theme Author URL: ${data.optString("parent_author_url", MISSING_VALUE)}\n"
+        sb.append("\n")
+            .append("Parent Theme Author URL: ${data.optString("parent_author_url", MISSING_VALUE)}\n")
     }
 
-    text += "WooCommerce support: ${checkIfTrue(data.optBoolean("has_woocommerce_support", false))}\n"
-    text += "WooCommerce files: ${checkIfTrue(data.optBoolean("has_woocommerce_file", false))}\n"
-    text += "Outdated templates: ${checkIfTrue(data.optBoolean("has_outdated_templates", false))}\n"
+    sb.append("WooCommerce support: ${checkIfTrue(data.optBoolean("has_woocommerce_support", false))}\n")
+        .append("WooCommerce files: ${checkIfTrue(data.optBoolean("has_woocommerce_file", false))}\n")
+        .append("Outdated templates: ${checkIfTrue(data.optBoolean("has_outdated_templates", false))}\n")
 
     val templates = data.optJSONArray("overrides")
-    templates?.let { text += formatTemplatesData(it) }
+    templates?.let { sb.append(formatTemplatesData(it)) }
 
-    return text
+    return sb.toString()
 }
 
 private fun formatTemplatesData(data: JSONArray): String {
-    var text = ""
+    val sb = StringBuilder()
     if (data.length() != 0) {
-        text += formattedHeading(HEADING_TEMPLATES)
-        text += "Overrides: "
+        sb.append(formattedHeading(HEADING_TEMPLATES))
+            .append("Overrides: ")
         for (i in 0 until data.length()) {
             val template = data.optJSONObject(i)
             template?.let { item ->
-                text += "${item.optString("file", MISSING_VALUE)}\n"
+                sb.append("${item.optString("file", MISSING_VALUE)}\n")
             }
         }
     }
-    return text
+    return sb.toString()
 }
 
 private fun formatStatusReportInformationData(): String {
-    var text = formattedHeading(HEADING_STATUS_REPORT_INFORMATION)
+    val sb = StringBuilder()
+    sb.append(formattedHeading(HEADING_STATUS_REPORT_INFORMATION))
 
     val today = Calendar.getInstance()
     val ssrCreationTime = SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z", Locale.getDefault()).format(today.time)
-    text += "Generated at: $ssrCreationTime"
+    sb.append("Generated at: $ssrCreationTime")
 
-    return text
+    return sb.toString()
 }
 
 private fun formattedHeading(text: String): String {
@@ -337,18 +344,18 @@ private fun formattedHeading(text: String): String {
 private fun checkIfTrue(check: Boolean) = if (check) CHECK else NO_CHECK
 
 private fun parseFormatTablesData(tables: JSONObject, tableType: String): String {
-    var result = ""
+    val sb = StringBuilder()
     val tablesByType = tables.optJSONObject(tableType)
 
     tablesByType?.let { it ->
         it.keys().forEach { key ->
             val tableData = it.optJSONObject(key)
             tableData?.let { data ->
-                result += "$key: " + parseFormatSingleTableData(data)
+                sb.append("$key: " + parseFormatSingleTableData(data))
             }
         }
     }
-    return result
+    return sb.toString()
 }
 
 // Example input: {"data":"0.05","index":"0.02","engine":"InnoDB"}
@@ -362,11 +369,12 @@ private fun parseFormatSingleTableData(table: JSONObject): String {
 }
 
 private fun parseFormatTaxonomy(taxonomies: JSONObject, taxonomyType: String): String {
-    var text = "Taxonomies: $taxonomyType: \n"
+    val sb = StringBuilder()
+    sb.append("Taxonomies: $taxonomyType: \n")
 
     taxonomies.keys().forEach { key ->
         val value = taxonomies.get(key)
-        text += "$key ($value)\n"
+        sb.append("$key ($value)\n")
     }
-    return text
+    return sb.toString()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCSSRModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCSSRModelExt.kt
@@ -24,7 +24,7 @@ const val HEADING_THEME = "Theme"
 const val HEADING_TEMPLATES = "Templates"
 const val HEADING_STATUS_REPORT_INFORMATION = "Status report information"
 const val CHECK = "✔"
-const val NO_CHECK = "false"
+const val NO_CHECK = "–"
 const val PAGE_NOT_SET = "X Page not set"
 
 fun WCSSRModel.formatResult(): String {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCSSRModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCSSRModelExt.kt
@@ -1,0 +1,372 @@
+@file:Suppress("TooManyFunctions", "ComplexMethod")
+
+package com.woocommerce.android.extensions
+
+import com.woocommerce.android.util.StringUtils
+import com.woocommerce.android.util.WooLog
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
+import org.wordpress.android.fluxc.model.WCSSRModel
+import java.text.SimpleDateFormat
+import java.util.*
+import org.apache.commons.io.FileUtils.byteCountToDisplaySize
+
+const val MISSING_VALUE = "Info not found"
+const val HEADING_WP_ENVIRONMENT = "WordPress Environment"
+const val HEADING_SERVER_ENVIRONMENT = "Server Environment"
+const val HEADING_DATABASE = "Database"
+const val HEADING_SECURITY = "Security"
+const val HEADING_ACTIVE_PLUGINS = "Active Plugins"
+const val HEADING_SETTINGS = "Settings"
+const val HEADING_PAGES = "WC Pages"
+const val HEADING_THEME = "Theme"
+const val HEADING_TEMPLATES = "Templates"
+const val HEADING_STATUS_REPORT_INFORMATION = "Status report information"
+const val CHECK = "✔"
+const val NO_CHECK = "false"
+const val PAGE_NOT_SET = "X Page not set"
+
+fun WCSSRModel.formatResult(): String {
+    var text = "### System Status Report generated via the WooCommerce Android app ### \n"
+
+    // Environment
+    environment?.let { it ->
+        try {
+            text += formatEnvironmentData(JSONObject(it))
+        } catch (e: JSONException) {
+            WooLog.e(WooLog.T.UTILS, e)
+        }
+    }
+
+    database?.let {
+        try {
+            text += formatDatabaseData(JSONObject(it))
+        } catch (e: JSONException) {
+            WooLog.e(WooLog.T.UTILS, e)
+        }
+    }
+
+    security?.let {
+        try {
+            text += formatSecurityData(JSONObject(it))
+        } catch (e: JSONException) {
+            WooLog.e(WooLog.T.UTILS, e)
+        }
+    }
+
+    activePlugins?.let {
+        try {
+            text += formatActivePluginsData(JSONArray(it))
+        } catch (e: JSONException) {
+            WooLog.e(WooLog.T.UTILS, e)
+        }
+    }
+
+    settings?.let {
+        try {
+            text += formatSettingsData(JSONObject(it))
+        } catch (e: JSONException) {
+            WooLog.e(WooLog.T.UTILS, e)
+        }
+    }
+
+    pages?.let {
+        try {
+            text += formatPagesData(JSONArray(it))
+        } catch (e: JSONException) {
+            WooLog.e(WooLog.T.UTILS, e)
+        }
+    }
+
+    theme?.let {
+        try {
+            text += formatThemeData(JSONObject(it))
+        } catch (e: JSONException) {
+            WooLog.e(WooLog.T.UTILS, e)
+        }
+    }
+
+    text += formatStatusReportInformationData()
+    return text
+}
+
+private fun formatEnvironmentData(data: JSONObject): String {
+    var text = formattedHeading(HEADING_WP_ENVIRONMENT)
+    text += "WordPress Address (URL): ${data.optString("home_url", MISSING_VALUE)}\n"
+    text += "Site Address (URL): ${data.optString("site_url", MISSING_VALUE)}\n"
+    text += "WC Version: ${data.optString("version", MISSING_VALUE)}\n"
+    text += "Log Directory Writable: ${checkIfTrue(data.optBoolean("log_directory_writable", false))}\n"
+    text += "WP Version: ${data.optString("wp_version", MISSING_VALUE)}\n"
+    text += "WP Multisite: ${checkIfTrue(data.optBoolean("wp_multisite", false))}\n"
+
+    val memoryLimit = data.optString("wp_memory_limit", MISSING_VALUE)
+    if (memoryLimit != MISSING_VALUE) {
+        text += "WP Memory Limit: ${byteCountToDisplaySize(memoryLimit.toLong())}\n"
+    }
+    text += "WP Debug Mode: ${checkIfTrue(data.optBoolean("wp_debug_mode", false))}\n"
+    text += "WP Cron: ${checkIfTrue(data.optBoolean("wp_cron", false))}\n"
+    text += "Language: ${data.optString("language", MISSING_VALUE)}\n"
+    text += "External object cache: ${checkIfTrue(data.optBoolean("external_object_cache", false))}\n"
+
+    text += formattedHeading(HEADING_SERVER_ENVIRONMENT)
+    text += "Server Info: ${data.optString("server_info", MISSING_VALUE)}\n"
+    text += "PHP Version: ${data.optString("php_version", MISSING_VALUE)}\n"
+
+    val postMaxSize = data.optString("php_post_max_size", MISSING_VALUE)
+    if (postMaxSize != MISSING_VALUE) {
+        text += "PHP Post Max Size: ${byteCountToDisplaySize(postMaxSize.toLong())}\n"
+    }
+    text += "PHP Time Limit: ${data.optString("php_max_execution_time", MISSING_VALUE)} s\n"
+    text += "PHP Max input Vars: ${data.optString("php_max_input_vars", MISSING_VALUE)}\n"
+    text += "cURL Version: ${data.optString("curl_version", MISSING_VALUE)}\n"
+    text += "Suhosin installed: ${checkIfTrue(data.optBoolean("suhosin_installed", false))}\n"
+    text += "MySQL Version: ${data.optString("mysql_version_string", MISSING_VALUE)}\n"
+
+    val maxUploadSize = data.optString("max_upload_size", MISSING_VALUE)
+    if (maxUploadSize != MISSING_VALUE) {
+        text += "PHP Post Max Size: ${byteCountToDisplaySize(maxUploadSize.toLong())}\n"
+    }
+    text += "Default Timezone: ${data.optString("default_timezone", MISSING_VALUE)}\n"
+    text += "fsockopen/cURL: ${checkIfTrue(data.optBoolean("fsockopen_or_curl_enabled", false))}\n"
+    text += "SoapClient: ${checkIfTrue(data.optBoolean("soapclient_enabled", false))}\n"
+    text += "DOMDocument: ${checkIfTrue(data.optBoolean("domdocument_enabled", false))}\n"
+    text += "GZip: ${checkIfTrue(data.optBoolean("gzip_enabled", false))}\n"
+    text += "Multibye String: ${checkIfTrue(data.optBoolean("mbstring_enabled", false))}\n"
+    text += "Remote Post: ${checkIfTrue(data.optBoolean("remote_post_successful", false))}\n"
+    text += "Remote Get: ${checkIfTrue(data.optBoolean("remote_get_successful", false))}\n"
+
+    return text
+}
+
+private fun formatDatabaseData(data: JSONObject): String {
+    var text = formattedHeading(HEADING_DATABASE)
+
+    text += "WC Database Version: ${data.optString("wc_database_version", MISSING_VALUE)}\n"
+    text += "WC Database Prefix: ${data.optString("wc_database_prefix", MISSING_VALUE)}\n"
+
+    val sizeData = data.optJSONObject("database_size")
+    sizeData?.let {
+        val dataSize = it.optDouble("data", 0.0)
+        val indexSize = it.optDouble("index", 0.0)
+        val total = dataSize + indexSize
+        text += "Total Database Size: " + if (total != 0.0) {
+            total
+        } else {
+            MISSING_VALUE
+        } + "\n"
+
+        text += "Database Data Size: ${it.optString("data", MISSING_VALUE)}\n"
+        text += "Database Index Size: ${it.optString("index", MISSING_VALUE)}\n"
+    }
+
+    val tablesData = data.optJSONObject("database_tables")
+    tablesData?.let { it ->
+        text += parseFormatTablesData(it, "woocommerce")
+        text += parseFormatTablesData(it, "other")
+    }
+
+    return text
+}
+
+private fun formatSecurityData(data: JSONObject): String {
+    var text = formattedHeading(HEADING_SECURITY)
+
+    text += "Secure Connection (HTTPS): ${checkIfTrue(data.optBoolean("secure_connection", false))}\n"
+    text += "Hide errors from visitors: ${checkIfTrue(data.optBoolean("hide_errors", false))}\n"
+
+    return text
+}
+
+private fun formatActivePluginsData(data: JSONArray): String {
+    var text = formattedHeading(HEADING_ACTIVE_PLUGINS)
+    for (i in 0 until data.length()) {
+        val plugin = data.optJSONObject(i)
+        plugin?.let {
+            text += plugin.optString("name", MISSING_VALUE)
+            text += ": by " + plugin.optString("author_name", MISSING_VALUE)
+
+            val currentVersion = plugin.optString("version", MISSING_VALUE)
+            val latestVersion = plugin.optString("version_latest", MISSING_VALUE)
+            text += " - $currentVersion"
+            if (currentVersion != MISSING_VALUE &&
+                latestVersion != MISSING_VALUE &&
+                currentVersion != latestVersion
+            ) {
+                text += " (update to version $latestVersion available)"
+            }
+            text += "\n"
+        }
+    }
+    return text
+}
+
+private fun formatSettingsData(data: JSONObject): String {
+    var text = formattedHeading(HEADING_SETTINGS)
+    text += "API Enabled: ${checkIfTrue(data.optBoolean("api_enabled", false))}\n"
+    text += "Force SSL: ${checkIfTrue(data.optBoolean("force_ssl", false))}\n"
+
+    // Currency format: currency_name(currency_symbol)
+    // Correct value example: USD($)
+    // Missing value example: Info not found(Info not found)
+    text += "Currency: ${data.optString("currency", MISSING_VALUE)}"
+    text += "("
+    val currencySymbolHTML = data.optString("currency_symbol", MISSING_VALUE)
+    text += if (currencySymbolHTML == MISSING_VALUE) {
+        MISSING_VALUE
+    } else {
+        text += StringUtils.fromHtml(currencySymbolHTML)
+    }
+    text += ")\n"
+
+    text += "Currency Position: ${data.optString("currency_position", MISSING_VALUE)}\n"
+    text += "Thousand Separator: ${data.optString("thousand_separator", MISSING_VALUE)}\n"
+    text += "Decimal Separator: ${data.optString("decimal_separator", MISSING_VALUE)}\n"
+    text += "Number of Decimals: ${data.optString("number_of_decimals", MISSING_VALUE)}\n"
+
+    val productTypesTaxonomy = data.optJSONObject("taxonomies")
+    productTypesTaxonomy?.let {
+        text += parseFormatTaxonomy(it, "Product Types") + "\n"
+    }
+
+    val productVisibilityTaxonomy = data.optJSONObject("product_visibility_terms")
+    productVisibilityTaxonomy?.let {
+        text += parseFormatTaxonomy(it, "Product Visibility") + "\n"
+    }
+
+    text += "Connected to WooCommerce.com: ${checkIfTrue(data.optBoolean("woocommerce_com_connected", false))}\n"
+
+    return text
+}
+
+private fun formatPagesData(data: JSONArray): String {
+    var text = formattedHeading(HEADING_PAGES)
+
+    for (i in 0 until data.length()) {
+        val page = data.optJSONObject(i)
+        page?.let {
+            text += "${it["page_name"]}: "
+            val pageSet = it.optBoolean("page_set", false)
+            text += if (pageSet) {
+                " Page ID #${it["page_id"]}"
+            } else {
+                PAGE_NOT_SET
+            }
+            text += "\n"
+        }
+    }
+
+    return text
+}
+
+private fun formatThemeData(data: JSONObject): String {
+    var text = formattedHeading(HEADING_THEME)
+    text += "Name: ${data.optString("name", MISSING_VALUE)}\n"
+
+    val currentVersion = data.optString("version", MISSING_VALUE)
+    val latestVersion = data.optString("version_latest", MISSING_VALUE)
+    text += "Version: $currentVersion"
+    if (currentVersion != MISSING_VALUE &&
+        latestVersion != MISSING_VALUE &&
+        currentVersion != latestVersion
+    ) {
+        text += " (update to version $latestVersion available)"
+    }
+    text += "\n"
+
+    text += "Author URL: ${data.optString("author_url", MISSING_VALUE)}\n"
+
+    val isChildTheme = data.optBoolean("is_child_theme", false)
+    if (isChildTheme) {
+        text += "Child Theme: ${CHECK}\n"
+        text += "Parent Theme Name: ${data.optString("parent_name", MISSING_VALUE)}\n"
+
+        val parentCurrentVersion = data.optString("parent_version", MISSING_VALUE)
+        val parentLatestVersion = data.optString("parent_version_latest", MISSING_VALUE)
+        text += "Parent Theme Version: $currentVersion"
+        if (parentCurrentVersion != MISSING_VALUE &&
+            parentLatestVersion != MISSING_VALUE &&
+            parentCurrentVersion != parentLatestVersion
+        ) {
+            text += " (update to version $latestVersion available)"
+        }
+        text += "\n"
+
+        text += "Parent Theme Author URL: ${data.optString("parent_author_url", MISSING_VALUE)}\n"
+    }
+
+    text += "WooCommerce support: ${checkIfTrue(data.optBoolean("has_woocommerce_support", false))}\n"
+    text += "WooCommerce files: ${checkIfTrue(data.optBoolean("has_woocommerce_file", false))}\n"
+    text += "Outdated templates: ${checkIfTrue(data.optBoolean("has_outdated_templates", false))}\n"
+
+    val templates = data.optJSONArray("overrides")
+    templates?.let { text += formatTemplatesData(it) }
+
+    return text
+}
+
+private fun formatTemplatesData(data: JSONArray): String {
+    var text = ""
+    if (data.length() != 0) {
+        text += formattedHeading(HEADING_TEMPLATES)
+        text += "Overrides: "
+        for (i in 0 until data.length()) {
+            val template = data.optJSONObject(i)
+            template?.let { item ->
+                text += "${item.optString("file", MISSING_VALUE)}\n"
+            }
+        }
+    }
+    return text
+}
+
+private fun formatStatusReportInformationData(): String {
+    var text = formattedHeading(HEADING_STATUS_REPORT_INFORMATION)
+
+    val today = Calendar.getInstance()
+    val ssrCreationTime = SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z", Locale.getDefault()).format(today.time)
+    text += "Generated at: $ssrCreationTime"
+
+    return text
+}
+
+private fun formattedHeading(text: String): String {
+    return "\n ### $text ### \n\n"
+}
+
+private fun checkIfTrue(check: Boolean) = if (check) CHECK else NO_CHECK
+
+private fun parseFormatTablesData(tables: JSONObject, tableType: String): String {
+    var result = ""
+    val tablesByType = tables.optJSONObject(tableType)
+
+    tablesByType?.let { it ->
+        it.keys().forEach { key ->
+            val tableData = it.optJSONObject(key)
+            tableData?.let { data ->
+                result += "$key: " + parseFormatSingleTableData(data)
+            }
+        }
+    }
+    return result
+}
+
+// Example input: {"data":"0.05","index":"0.02","engine":"InnoDB"}
+// Expected output: "Data: 0.05MB + Index: 0.02MB + Engine InnoDB"
+private fun parseFormatSingleTableData(table: JSONObject): String {
+    val data = table.optString("data", MISSING_VALUE)
+    val index = table.optString("index", MISSING_VALUE)
+    val engine = table.optString("engine", MISSING_VALUE)
+
+    return "Data: ${data}MB + Index: ${index}MB + Engine $engine\n"
+}
+
+private fun parseFormatTaxonomy(taxonomies: JSONObject, taxonomyType: String): String {
+    var text = "Taxonomies: $taxonomyType: \n"
+
+    taxonomies.keys().forEach { key ->
+        val value = taxonomies.get(key)
+        text += "$key ($value)\n"
+    }
+    return text
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivityViewModel.kt
@@ -3,12 +3,15 @@ package com.woocommerce.android.support
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.formatResult
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.parcelize.Parcelize
+import org.json.JSONObject
+import org.wordpress.android.fluxc.model.WCSSRModel
 import javax.inject.Inject
 
 @HiltViewModel
@@ -21,8 +24,20 @@ class SSRActivityViewModel @Inject constructor(
 
     init {
         val exampleStream = resourceProvider.openRawResource(R.raw.system_status)
+        val exampleJSON = JSONObject(exampleStream.bufferedReader(Charsets.UTF_8).use { it.readText() })
+        val exampleModel = WCSSRModel(
+            remoteSiteId = 1,
+            environment = exampleJSON["environment"].toString(),
+            database = exampleJSON["database"].toString(),
+            activePlugins = exampleJSON["active_plugins"].toString(),
+            theme = exampleJSON["theme"].toString(),
+            settings = exampleJSON["settings"].toString(),
+            security = exampleJSON["security"].toString(),
+            pages = exampleJSON["pages"].toString()
+        )
+
         viewState = viewState.copy(
-            exampleString = exampleStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+            exampleString = exampleModel.formatResult()
         )
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'develop-6087b5e9ed7e67b2b14e8e11a7680faed7d249ee'
+    fluxCVersion = 'develop-b266da9cb9fe0d12bf452c039f08b5157ed82009'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4820
⚠️  Please do not merge before #4803 is merged ⚠️ 

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds the following:

1. Converter from a raw JSON display to a more readable text format, similar to the result on wp-admin
2. The displayed example result is now formatted using the above

### Testing instructions
**Core:**
1. In wp-admin, go to wp-admin/admin.php?page=wc-status , then click "Get System Report"
2. Notice the formatting on the text that shows up there

**WordPress Android:**
1. Go to Settings -> Help & support
2. Select "System status report"
3. Do a quick check and ensure the formatting is similar to Core.
4. Note that some items might be displayed differently (especially true with the "Database" section, where the actual API format differs from the example in the app).

### Screenshot

<img src="https://user-images.githubusercontent.com/266376/133996314-807c33f5-b547-4c68-a6f5-ab9b117781c7.png" width="42%" />
