### PR TITLE
Media Upload: check url before marking upload as successful

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
@@ -100,6 +100,7 @@ class MediaFilesRepository @Inject constructor(
                         event.media,
                         event.error.type,
                         event.error.message
+                            ?: resourceProvider.getString(R.string.product_image_service_error_uploading)
                     )
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
@@ -116,12 +116,12 @@ class MediaFilesRepository @Inject constructor(
                         T.MEDIA,
                         "MediaFilesRepository > error uploading media ${event.media?.id}, null url"
                     )
-                    // TODO use a better error message
+
                     uploadContinuation.continueWithException(
                         MediaUploadException(
                             event.media,
                             GENERIC_ERROR,
-                            resourceProvider.getString(R.string.product_image_service_error_media_null)
+                            resourceProvider.getString(R.string.product_image_service_error_uploading)
                         )
                     )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.media
 
 import android.content.Context
 import android.net.Uri
+import com.woocommerce.android.R
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.ContinuationWrapper
 import com.woocommerce.android.util.ContinuationWrapper.ContinuationResult.Cancellation
@@ -9,6 +10,7 @@ import com.woocommerce.android.util.ContinuationWrapper.ContinuationResult.Succe
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
+import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -16,6 +18,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.MediaActionBuilder
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.store.MediaStore
+import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded
 import org.wordpress.android.fluxc.store.MediaStore.UploadMediaPayload
 import java.io.File
@@ -26,7 +29,8 @@ class MediaFilesRepository @Inject constructor(
     private val context: Context,
     private val selectedSite: SelectedSite,
     private val mediaStore: MediaStore,
-    private val dispatchers: CoroutineDispatchers
+    private val dispatchers: CoroutineDispatchers,
+    private val resourceProvider: ResourceProvider
 ) {
     private var uploadContinuation = ContinuationWrapper<MediaModel>(T.MEDIA)
 
@@ -104,8 +108,23 @@ class MediaFilesRepository @Inject constructor(
                 uploadContinuation.cancel()
             }
             event.completed -> {
-                WooLog.i(T.MEDIA, "MediaFilesRepository > uploaded media ${event.media?.id}")
-                uploadContinuation.continueWith(event.media)
+                if (event.media?.url != null) {
+                    WooLog.i(T.MEDIA, "MediaFilesRepository > uploaded media ${event.media?.id}")
+                    uploadContinuation.continueWith(event.media)
+                } else {
+                    WooLog.w(
+                        T.MEDIA,
+                        "MediaFilesRepository > error uploading media ${event.media?.id}, null url"
+                    )
+                    // TODO use a better error message
+                    uploadContinuation.continueWithException(
+                        MediaUploadException(
+                            event.media,
+                            GENERIC_ERROR,
+                            resourceProvider.getString(R.string.product_image_service_error_media_null)
+                        )
+                    )
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -548,7 +548,7 @@ fun WCProductModel.toAppModel(): Product {
 fun MediaModel.toAppModel(): Product.Image {
     return Product.Image(
         id = this.mediaId,
-        name = this.fileName,
+        name = this.fileName.orEmpty(),
         source = this.url,
         dateCreated = DateTimeUtils.dateFromIso8601(this.uploadDate)
     )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4336 and #4827

### Description
I couldn't reproduce any of the issues, but it seems that having `event.completed == true` is not enough to say that the upload succeeded, as we may still get a null `url` or `fileName` (I tried checking FluxC to see in what circumstances this would occur, but I can't figure it out)

And there will be more cases of the first issue #4336, since it was affecting only downloadable files, but it will impact image uploads as well in 7.6, since they use MediaFileRepository now.

Those issues haven't been causing crashes for image uploads before, because they were failing silently, since `ProductImageServices` was [posting](https://github.com/woocommerce/woocommerce-android/blob/698cfbce899d317bedd334b080ce865e22d1a1e1/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesService.kt#L258) the events in a default `EventBus` instance, which means the exceptions were swallowed (`throwSubscriberException` is false by default), and the upload would fail silently, which is a bad user experience.

### Testing instructions
A small smoke test for image and downloadable file uploads should be enough.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
