### PR TITLE
SSR: Fetch real data instead of example

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCSSRModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCSSRModelExt.kt
@@ -286,7 +286,9 @@ private fun formatThemeData(data: JSONObject): String {
     val latestVersion = data.optString("version_latest", MISSING_VALUE)
 
     sb.append("Version: $currentVersion")
-    if (currentVersion != MISSING_VALUE && latestVersion != MISSING_VALUE && currentVersion != latestVersion) {
+    if (currentVersion != MISSING_VALUE &&
+        (latestVersion != MISSING_VALUE && latestVersion != "0")  &&
+        currentVersion != latestVersion) {
         sb.append(" (update to version $latestVersion available)")
     }
     sb.append("\n")
@@ -302,7 +304,7 @@ private fun formatThemeData(data: JSONObject): String {
         val parentLatestVersion = data.optString("parent_version_latest", MISSING_VALUE)
         sb.append("Parent Theme Version: $currentVersion")
         if (parentCurrentVersion != MISSING_VALUE &&
-            parentLatestVersion != MISSING_VALUE &&
+            (parentLatestVersion != MISSING_VALUE && parentLatestVersion != "0") &&
             parentCurrentVersion != parentLatestVersion
         ) {
             sb.append(" (update to version $latestVersion available)")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCSSRModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCSSRModelExt.kt
@@ -11,6 +11,8 @@ import org.wordpress.android.fluxc.model.WCSSRModel
 import java.text.SimpleDateFormat
 import java.util.*
 import org.apache.commons.io.FileUtils.byteCountToDisplaySize
+import java.math.BigDecimal
+import java.math.RoundingMode
 
 const val MISSING_VALUE = "Info not found"
 const val HEADING_SSR = "### System Status Report generated via the WooCommerce Android app ### \n"
@@ -27,6 +29,7 @@ const val HEADING_STATUS_REPORT_INFORMATION = "Status report information"
 const val CHECK = "✔"
 const val NO_CHECK = "–"
 const val PAGE_NOT_SET = "X Page not set"
+const val DATABASE_SIZE_UNIT = "MB"
 
 fun WCSSRModel.formatResult(): String {
     val sb = StringBuilder()
@@ -150,17 +153,24 @@ private fun formatDatabaseData(data: JSONObject): String {
     val sb = StringBuilder()
     sb.append(formattedHeading(HEADING_DATABASE))
         .append("WC Database Version: ${data.optString("wc_database_version", MISSING_VALUE)}\n")
-        .append("WC Database Prefix: ${data.optString("wc_database_prefix", MISSING_VALUE)}\n")
+        .append("WC Database Prefix: ${data.optString("database_prefix", MISSING_VALUE)}\n")
 
     val sizeData = data.optJSONObject("database_size")
     sizeData?.let {
         val dataSize = it.optDouble("data", 0.0)
         val indexSize = it.optDouble("index", 0.0)
-        val total = dataSize + indexSize
-        sb.append("Total Database Size: " + if (total != 0.0) { total } else { MISSING_VALUE } + "\n")
 
-            .append("Database Data Size: ${it.optString("data", MISSING_VALUE)}\n")
-            .append("Database Index Size: ${it.optString("index", MISSING_VALUE)}\n")
+        val total = if (dataSize == 0.0 && indexSize == 0.0) {
+            MISSING_VALUE
+        } else {
+            roundDoubleDecimal(dataSize + indexSize)
+        }
+        val size = if (dataSize == 0.0) { MISSING_VALUE } else { roundDoubleDecimal(dataSize).toString() }
+        val index = if (indexSize == 0.0) { MISSING_VALUE } else { roundDoubleDecimal(indexSize).toString() }
+
+        sb.append("Total Database Size: $total $DATABASE_SIZE_UNIT\n")
+            .append("Database Data Size: $size $DATABASE_SIZE_UNIT\n")
+            .append("Database Index Size: $index $DATABASE_SIZE_UNIT\n")
     }
 
     val tablesData = data.optJSONObject("database_tables")
@@ -377,4 +387,8 @@ private fun parseFormatTaxonomy(taxonomies: JSONObject, taxonomyType: String): S
         sb.append("$key ($value)\n")
     }
     return sb.toString()
+}
+
+private fun roundDoubleDecimal(number: Double, scale: Int = 2, mode: RoundingMode = RoundingMode.UP): BigDecimal {
+    return number.toBigDecimal().setScale(scale, mode)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCSSRModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCSSRModelExt.kt
@@ -286,9 +286,11 @@ private fun formatThemeData(data: JSONObject): String {
     val latestVersion = data.optString("version_latest", MISSING_VALUE)
 
     sb.append("Version: $currentVersion")
-    if (currentVersion != MISSING_VALUE &&
-        (latestVersion != MISSING_VALUE && latestVersion != "0")  &&
-        currentVersion != latestVersion) {
+    val latestVersionExists = latestVersion != MISSING_VALUE && latestVersion != "0"
+    if (latestVersionExists &&
+        currentVersion != MISSING_VALUE &&
+        currentVersion != latestVersion
+    ) {
         sb.append(" (update to version $latestVersion available)")
     }
     sb.append("\n")
@@ -303,8 +305,9 @@ private fun formatThemeData(data: JSONObject): String {
         val parentCurrentVersion = data.optString("parent_version", MISSING_VALUE)
         val parentLatestVersion = data.optString("parent_version_latest", MISSING_VALUE)
         sb.append("Parent Theme Version: $currentVersion")
-        if (parentCurrentVersion != MISSING_VALUE &&
-            (parentLatestVersion != MISSING_VALUE && parentLatestVersion != "0") &&
+        val parentLatestVersionExists = parentLatestVersion != MISSING_VALUE && parentLatestVersion != "0"
+        if (parentLatestVersionExists &&
+            parentCurrentVersion != MISSING_VALUE &&
             parentCurrentVersion != parentLatestVersion
         ) {
             sb.append(" (update to version $latestVersion available)")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivity.kt
@@ -48,6 +48,16 @@ class SSRActivity : AppCompatActivity() {
             new.formattedSSR.takeIfNotEqualTo(old?.formattedSSR) {
                 binding.ssrContent.text = it
             }
+
+            new.isLoading.takeIfNotEqualTo(old?.isLoading) {
+                if (it) {
+                    binding.ssrLoading.show()
+                    binding.ssrContent.hide()
+                } else {
+                    binding.ssrLoading.hide()
+                    binding.ssrContent.show()
+                }
+            }
         }
         viewModel.event.observe(this) {
             when (it) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivity.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ToastUtils
 import java.lang.IllegalStateException
@@ -64,6 +65,7 @@ class SSRActivity : AppCompatActivity() {
                 is ShareSSR -> shareSSR(it.ssrText)
                 is CopySSR -> copySSRToClipboard(it.ssrText)
                 is ShowSnackbar -> ToastUtils.showToast(this, it.message)
+                is Exit -> finish()
                 else -> it.isHandled = false
             }
         }
@@ -120,10 +122,6 @@ class SSRActivity : AppCompatActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
-            android.R.id.home -> {
-                finish()
-                true
-            }
             ID_SHARE -> {
                 viewModel.onShareButtonTapped()
                 true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivity.kt
@@ -122,6 +122,10 @@ class SSRActivity : AppCompatActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
+            android.R.id.home -> {
+                finish()
+                true
+            }
             ID_SHARE -> {
                 viewModel.onShareButtonTapped()
                 true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivity.kt
@@ -12,9 +12,12 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.ActivitySsrBinding
+import com.woocommerce.android.extensions.hide
+import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ToastUtils
 import java.lang.IllegalStateException
@@ -42,7 +45,7 @@ class SSRActivity : AppCompatActivity() {
 
     private fun setupObservers(binding: ActivitySsrBinding) {
         viewModel.viewStateData.observe(this) { old, new ->
-            new.exampleString.takeIfNotEqualTo(old?.exampleString) {
+            new.formattedSSR.takeIfNotEqualTo(old?.formattedSSR) {
                 binding.ssrContent.text = it
             }
         }
@@ -50,6 +53,7 @@ class SSRActivity : AppCompatActivity() {
             when (it) {
                 is ShareSSR -> shareSSR(it.ssrText)
                 is CopySSR -> copySSRToClipboard(it.ssrText)
+                is ShowSnackbar -> ToastUtils.showToast(this, it.message)
                 else -> it.isHandled = false
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivityViewModel.kt
@@ -1,14 +1,18 @@
 package com.woocommerce.android.support
 
+import android.os.Handler
+import android.os.Looper
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.formatResult
+import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -22,26 +26,44 @@ class SSRActivityViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val dispatchers: CoroutineDispatchers,
     private val wooCommerceStore: WooCommerceStore,
-    private val selectedSite: SelectedSite
+    private val selectedSite: SelectedSite,
+    networkStatus: NetworkStatus
 ) : ScopedViewModel(savedState) {
+    companion object {
+        const val EXIT_DELAY = 1000L
+    }
+
     val viewStateData = LiveDataDelegate(savedState, SSRViewState())
     private var viewState by viewStateData
 
     init {
-        viewState = viewState.copy(isLoading = true)
-        launch(dispatchers.io) {
-            val result = wooCommerceStore.fetchSSR(selectedSite.get())
-            if (result.isError) {
-                triggerEvent(ShowSnackbar(R.string.support_system_status_report_fetch_error))
-                return@launch
-            }
+        if (networkStatus.isConnected()) {
+            viewState = viewState.copy(isLoading = true)
+            launch(dispatchers.io) {
+                val result = wooCommerceStore.fetchSSR(selectedSite.get())
 
-            result.model?.let {
-                withContext(dispatchers.main) {
-                    viewState = viewState.copy(formattedSSR = it.formatResult(), isLoading = false)
+                if (result.isError) {
+                    withContext(dispatchers.main) {
+                        triggerEvent(ShowSnackbar(R.string.support_system_status_report_fetch_error))
+                        pauseThenExit()
+                    }
+                    return@launch
+                }
+
+                result.model?.let {
+                    withContext(dispatchers.main) {
+                        viewState = viewState.copy(formattedSSR = it.formatResult(), isLoading = false)
+                    }
                 }
             }
+        } else {
+            triggerEvent(ShowSnackbar(R.string.offline_error))
+            pauseThenExit()
         }
+    }
+
+    private fun pauseThenExit() {
+        Handler(Looper.getMainLooper()).postDelayed({ triggerEvent(Exit) }, EXIT_DELAY)
     }
 
     fun onShareButtonTapped() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivityViewModel.kt
@@ -4,54 +4,56 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.formatResult
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent
-import com.woocommerce.android.viewmodel.ResourceProvider
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
-import org.json.JSONObject
-import org.wordpress.android.fluxc.model.WCSSRModel
+import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
 @HiltViewModel
 class SSRActivityViewModel @Inject constructor(
     savedState: SavedStateHandle,
-    resourceProvider: ResourceProvider
+    private val dispatchers: CoroutineDispatchers,
+    private val wooCommerceStore: WooCommerceStore,
+    private val selectedSite: SelectedSite
 ) : ScopedViewModel(savedState) {
     val viewStateData = LiveDataDelegate(savedState, SSRViewState())
     private var viewState by viewStateData
 
     init {
-        val exampleStream = resourceProvider.openRawResource(R.raw.system_status)
-        val exampleJSON = JSONObject(exampleStream.bufferedReader(Charsets.UTF_8).use { it.readText() })
-        val exampleModel = WCSSRModel(
-            remoteSiteId = 1,
-            environment = exampleJSON["environment"].toString(),
-            database = exampleJSON["database"].toString(),
-            activePlugins = exampleJSON["active_plugins"].toString(),
-            theme = exampleJSON["theme"].toString(),
-            settings = exampleJSON["settings"].toString(),
-            security = exampleJSON["security"].toString(),
-            pages = exampleJSON["pages"].toString()
-        )
+        launch(dispatchers.io) {
+            val result = wooCommerceStore.fetchSSR(selectedSite.get())
+            if (result.isError) {
+                triggerEvent(ShowSnackbar(R.string.support_system_status_report_fetch_error))
+                return@launch
+            }
 
-        viewState = viewState.copy(
-            exampleString = exampleModel.formatResult()
-        )
+            result.model?.let {
+                withContext(dispatchers.main) {
+                    viewState = viewState.copy(formattedSSR = it.formatResult())
+                }
+            }
+        }
     }
 
     fun onShareButtonTapped() {
-        triggerEvent(ShareSSR(viewState.exampleString))
+        triggerEvent(ShareSSR(viewState.formattedSSR))
     }
 
     fun onCopyButtonTapped() {
-        triggerEvent(CopySSR(viewState.exampleString))
+        triggerEvent(CopySSR(viewState.formattedSSR))
     }
 
     @Parcelize
     data class SSRViewState(
-        val exampleString: String = ""
+        val formattedSSR: String = ""
     ) : Parcelable
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/SSRActivityViewModel.kt
@@ -28,6 +28,7 @@ class SSRActivityViewModel @Inject constructor(
     private var viewState by viewStateData
 
     init {
+        viewState = viewState.copy(isLoading = true)
         launch(dispatchers.io) {
             val result = wooCommerceStore.fetchSSR(selectedSite.get())
             if (result.isError) {
@@ -37,7 +38,7 @@ class SSRActivityViewModel @Inject constructor(
 
             result.model?.let {
                 withContext(dispatchers.main) {
-                    viewState = viewState.copy(formattedSSR = it.formatResult())
+                    viewState = viewState.copy(formattedSSR = it.formatResult(), isLoading = false)
                 }
             }
         }
@@ -53,7 +54,8 @@ class SSRActivityViewModel @Inject constructor(
 
     @Parcelize
     data class SSRViewState(
-        val formattedSSR: String = ""
+        val formattedSSR: String = "",
+        val isLoading: Boolean = false
     ) : Parcelable
 }
 

--- a/WooCommerce/src/main/res/layout/activity_ssr.xml
+++ b/WooCommerce/src/main/res/layout/activity_ssr.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:background="@color/color_surface">
 
@@ -17,12 +17,26 @@
             android:id="@+id/toolbar"/>
     </com.google.android.material.appbar.AppBarLayout>
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/ssr_content"
-        style="@style/Woo.Card.Body"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:textIsSelectable="true"
-        tools:text="This is where SSR info is shown." />
+        android:layout_height="match_parent">
+
+        <ProgressBar
+            android:id="@+id/ssr_loading"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/ssr_content"
+            style="@style/Woo.Card.Body"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:textIsSelectable="true"
+            tools:text="This is where SSR info is shown." />
+</androidx.constraintlayout.widget.ConstraintLayout>
 
 </LinearLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1327,6 +1327,7 @@
     <string name="support_system_status_report_copied_to_clipboard">System status report copied to clipboard</string>
     <string name="support_system_status_report_error_copy_to_clipboard">Error copying SSR to clipboard</string>
     <string name="support_system_status_report_share_error">Unable to share System Status Report</string>
+    <string name="support_system_status_report_fetch_error">Error fetching SSR. Please check in WooCommerce -> Status in wp-admin.</string>
     <string name="help">Help</string>
     <string name="support_contact_email">Contact email</string>
     <string name="support_contact_email_not_set">Not set</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1327,7 +1327,7 @@
     <string name="support_system_status_report_copied_to_clipboard">System status report copied to clipboard</string>
     <string name="support_system_status_report_error_copy_to_clipboard">Error copying SSR to clipboard</string>
     <string name="support_system_status_report_share_error">Unable to share System Status Report</string>
-    <string name="support_system_status_report_fetch_error">Error fetching SSR. Please check in WooCommerce -> Status in wp-admin.</string>
+    <string name="support_system_status_report_fetch_error">Error fetching SSR. Please check WooCommerce -> Status in wp-admin.</string>
     <string name="help">Help</string>
     <string name="support_contact_email">Contact email</string>
     <string name="support_contact_email_not_set">Not set</string>


### PR DESCRIPTION
Closes: #4829 

## Description
This PR adds the following:

1. Fetching real data on the site, instead of using example data.
2. Loading indicator


## Testing instructions
**Core:**

1. In wp-admin, go to wp-admin/admin.php?page=wc-status , then click "Get System Report"
2. Notice the info shown there.

**WordPress Android:**

1. Go to Settings -> Help & support
2. Select "System status report"
3. Ensure loading animation is shown while it's still fetching data, and eventually SSR data is shown.
4. Check and compare the data shown on the app, to data shown on core. The majority of them should be the same. Please note that some information are missing on the app side, such as post type counts, inactive plugins, or action scheduler info. This is expected as these info are not available via API response.