### PR TITLE
Initial commit for displaying specific error message when the total of the product is less than $0.50.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -487,7 +487,8 @@ class CardReaderPaymentViewModel
         NO_NETWORK(R.string.card_reader_payment_failed_no_network_state),
         SERVER_ERROR(R.string.card_reader_payment_failed_server_error_state),
         PAYMENT_DECLINED(R.string.card_reader_payment_failed_card_declined_state),
-        GENERIC_ERROR(R.string.card_reader_payment_failed_unexpected_error_state)
+        GENERIC_ERROR(R.string.card_reader_payment_failed_unexpected_error_state),
+        AMOUNT_TOO_SMALL(R.string.card_reader_payment_failed_amount_too_small),
     }
 
     private fun CardPaymentStatusErrorType.mapToUiError(): PaymentFlowError =
@@ -497,5 +498,6 @@ class CardReaderPaymentViewModel
             CardPaymentStatusErrorType.CARD_READ_TIMED_OUT,
             CardPaymentStatusErrorType.GENERIC_ERROR -> PaymentFlowError.GENERIC_ERROR
             CardPaymentStatusErrorType.SERVER_ERROR -> PaymentFlowError.SERVER_ERROR
+            CardPaymentStatusErrorType.AMOUNT_TOO_SMALL -> PaymentFlowError.AMOUNT_TOO_SMALL
         }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -429,7 +429,7 @@ class CardReaderPaymentViewModel
         data class FailedPaymentState(
             private val errorType: PaymentFlowError,
             override val amountWithCurrencyLabel: String?,
-            val primaryLabel: Int? = R.string.try_again,
+            private val primaryLabel: Int? = R.string.try_again,
             override val onPrimaryActionClicked: (() -> Unit)
         ) : ViewState(
             headerLabel = R.string.card_reader_payment_payment_failed_header,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -40,6 +40,7 @@ import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.PaymentData
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.payments.PaymentInfo
+import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
@@ -232,7 +233,21 @@ class CardReaderPaymentViewModel
         val onRetryClicked = error.paymentDataForRetry?.let {
             { retry(orderId, billingEmail, it, amountLabel) }
         } ?: { initPaymentFlow(isRetry = true) }
-        viewState.postValue(FailedPaymentState(error.type.mapToUiError(), amountLabel, onRetryClicked))
+        when (val errorType = error.type.mapToUiError()) {
+            PaymentFlowError.AMOUNT_TOO_SMALL -> {
+                val onBackPressed: () -> Unit = { onBackPressed() }
+                viewState.postValue(
+                    FailedPaymentState(
+                        errorType, amountLabel, R.string.card_reader_payment_payment_failed_ok, onBackPressed
+                    )
+                )
+            }
+            else -> {
+                viewState.postValue(
+                    FailedPaymentState(errorType, amountLabel, onPrimaryActionClicked = onRetryClicked)
+                )
+            }
+        }.exhaustive
     }
 
     private fun showPaymentSuccessfulState() {
@@ -414,12 +429,13 @@ class CardReaderPaymentViewModel
         data class FailedPaymentState(
             private val errorType: PaymentFlowError,
             override val amountWithCurrencyLabel: String?,
+            val primaryLabel: Int? = R.string.try_again,
             override val onPrimaryActionClicked: (() -> Unit)
         ) : ViewState(
             headerLabel = R.string.card_reader_payment_payment_failed_header,
             paymentStateLabel = errorType.message,
             paymentStateLabelTopMargin = R.dimen.major_100,
-            primaryActionLabel = R.string.try_again,
+            primaryActionLabel = primaryLabel,
             illustration = R.drawable.img_products_error
         )
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -760,6 +760,7 @@
     <string name="card_reader_payment_capturing_payment_header" translatable="false">@string/card_reader_collect_payment</string>
     <string name="card_reader_payment_completed_payment_header">Payment successful</string>
     <string name="card_reader_payment_payment_failed_header">Payment failed</string>
+    <string name="card_reader_payment_payment_failed_ok">OK</string>
 
     <string name="card_reader_payment_collect_payment_state">Reader is ready</string>
     <string name="card_reader_payment_processing_payment_state">Processing payment</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -769,6 +769,7 @@
     <string name="card_reader_payment_failed_card_declined_state">Card declined</string>
     <string name="card_reader_payment_failed_collecting_payment_timed_out_state">Card declined</string>
     <string name="card_reader_payment_failed_unexpected_error_state">Sorry, this payment couldn\’t be processed</string>
+    <string name="card_reader_payment_failed_amount_too_small">Amount must be at least $0.50 usd</string>
 
     <string name="card_reader_payment_retry_card_prompt">Retry with the same card</string>
     <string name="card_reader_payment_remove_card_prompt">Remove the card</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -400,6 +400,49 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `when payment fails because of AMOUNT_TOO_SMALL, then failed state has ok button`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(paymentFailedWithAmountTooSmall) }
+            }
+
+            viewModel.start()
+
+            assertEquals(
+                (viewModel.viewStateData.value as FailedPaymentState).primaryActionLabel,
+                R.string.card_reader_payment_payment_failed_ok
+            )
+        }
+
+    @Test
+    fun `when payment fails not because of AMOUNT_TOO_SMALL, then failed state has Try again button`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(paymentFailedWithServerError) }
+            }
+
+            viewModel.start()
+
+            assertEquals(
+                (viewModel.viewStateData.value as FailedPaymentState).primaryActionLabel,
+                R.string.try_again
+            )
+        }
+
+    @Test
+    fun `when payment fails because of AMOUNT_TOO_SMALL, then clicking on ok button triggers exit event`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(paymentFailedWithAmountTooSmall) }
+            }
+
+            viewModel.start()
+            (viewModel.viewStateData.value as FailedPaymentState).onPrimaryActionClicked.invoke()
+
+            assertThat(viewModel.event.value).isInstanceOf(Exit::class.java)
+        }
+
+    @Test
     fun `given user clicks on retry, when payment fails and retryData are null, then flow restarted from scratch`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -43,6 +43,7 @@ import org.mockito.kotlin.*
 import org.robolectric.RobolectricTestRunner
 import org.wordpress.android.fluxc.model.SiteModel
 import java.math.BigDecimal
+import kotlin.test.assertEquals
 
 private val DUMMY_TOTAL = BigDecimal(10.72)
 private const val DUMMY_CURRENCY_SYMBOL = "£"
@@ -68,6 +69,11 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
     private val paymentFailedWithEmptyDataForRetry = PaymentFailed(GENERIC_ERROR, null, "dummy msg")
     private val paymentFailedWithValidDataForRetry = PaymentFailed(GENERIC_ERROR, mock(), "dummy msg")
+    private val paymentFailedWithNoNetwork = PaymentFailed(NO_NETWORK, mock(), "dummy msg")
+    private val paymentFailedWithPaymentDeclined = PaymentFailed(PAYMENT_DECLINED, mock(), "dummy msg")
+    private val paymentFailedWithCardReadTimeOut = PaymentFailed(GENERIC_ERROR, mock(), "dummy msg")
+    private val paymentFailedWithServerError = PaymentFailed(SERVER_ERROR, mock(), "dummy msg")
+    private val paymentFailedWithAmountTooSmall = PaymentFailed(AMOUNT_TOO_SMALL, mock(), "dummy msg")
 
     private val savedState: SavedStateHandle = CardReaderPaymentDialogFragmentArgs(
         ORDER_IDENTIFIER
@@ -301,6 +307,96 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             viewModel.start()
 
             verify(tracker).track(eq(AnalyticsTracker.Stat.CARD_PRESENT_COLLECT_PAYMENT_FAILED), any(), any(), any())
+        }
+
+    @Test
+    fun `when payment fails because of NO_NETWORK, then error is mapped correctly`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(paymentFailedWithNoNetwork) }
+            }
+
+            viewModel.start()
+
+            assertEquals(
+                (viewModel.viewStateData.value as FailedPaymentState).paymentStateLabel,
+                CardReaderPaymentViewModel.PaymentFlowError.NO_NETWORK.message
+            )
+        }
+
+    @Test
+    fun `when payment fails because of PAYMENT_DECLINED, then error is mapped correctly`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(paymentFailedWithPaymentDeclined) }
+            }
+
+            viewModel.start()
+
+            assertEquals(
+                (viewModel.viewStateData.value as FailedPaymentState).paymentStateLabel,
+                CardReaderPaymentViewModel.PaymentFlowError.PAYMENT_DECLINED.message
+            )
+        }
+
+    @Test
+    fun `when payment fails because of CARD_READ_TIME_OUT, then error is mapped correctly`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(paymentFailedWithCardReadTimeOut) }
+            }
+
+            viewModel.start()
+
+            assertEquals(
+                (viewModel.viewStateData.value as FailedPaymentState).paymentStateLabel,
+                CardReaderPaymentViewModel.PaymentFlowError.GENERIC_ERROR.message
+            )
+        }
+
+    @Test
+    fun `when payment fails because of GENERIC_ERROR, then error is mapped correctly`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(paymentFailedWithValidDataForRetry) }
+            }
+
+            viewModel.start()
+
+            assertEquals(
+                (viewModel.viewStateData.value as FailedPaymentState).paymentStateLabel,
+                CardReaderPaymentViewModel.PaymentFlowError.GENERIC_ERROR.message
+            )
+        }
+
+    @Test
+    fun `when payment fails because of SERVER_ERROR, then error is mapped correctly`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(paymentFailedWithServerError) }
+            }
+
+            viewModel.start()
+
+            assertEquals(
+                (viewModel.viewStateData.value as FailedPaymentState).paymentStateLabel,
+                CardReaderPaymentViewModel.PaymentFlowError.SERVER_ERROR.message
+            )
+        }
+
+    @Test
+    fun `when payment fails because of AMOUNT_TOO_SMALL, then error is mapped correctly`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(paymentFailedWithAmountTooSmall) }
+            }
+
+            viewModel.start()
+
+            assertEquals(
+                (viewModel.viewStateData.value as FailedPaymentState).paymentStateLabel,
+                CardReaderPaymentViewModel.PaymentFlowError.AMOUNT_TOO_SMALL.message
+            )
         }
 
     @Test

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/payments/CardPaymentStatus.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/payments/CardPaymentStatus.kt
@@ -20,7 +20,8 @@ sealed class CardPaymentStatus {
         NO_NETWORK,
         SERVER_ERROR,
         PAYMENT_DECLINED,
-        GENERIC_ERROR
+        GENERIC_ERROR,
+        AMOUNT_TOO_SMALL,
     }
 
     enum class AdditionalInfoType {

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentErrorMapperTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentErrorMapperTest.kt
@@ -6,11 +6,7 @@ import com.stripe.stripeterminal.model.external.PaymentIntent
 import com.stripe.stripeterminal.model.external.TerminalException
 import com.stripe.stripeterminal.model.external.TerminalException.TerminalErrorCode
 import com.stripe.stripeterminal.model.external.TerminalException.TerminalErrorCode.PAYMENT_DECLINED_BY_READER
-import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErrorType.CARD_READ_TIMED_OUT
-import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErrorType.GENERIC_ERROR
-import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErrorType.NO_NETWORK
-import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErrorType.PAYMENT_DECLINED
-import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErrorType.SERVER_ERROR
+import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErrorType.*
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -84,6 +80,30 @@ class PaymentErrorMapperTest {
     @Test
     fun `when other Terminal exception thrown, then GENERIC_ERROR type returned`() {
         whenever(terminalException.errorCode).thenReturn(mock())
+
+        val result = mapper.mapTerminalError(mock(), terminalException)
+
+        assertThat(result.type).isEqualTo(GENERIC_ERROR)
+    }
+
+    @Test
+    fun `when STRIPE_API_ERROR with amount_too_small code is thrown, then AMOUNT_TOO_SMALL type returned`() {
+        whenever(terminalException.errorCode).thenReturn(TerminalErrorCode.STRIPE_API_ERROR)
+        whenever(terminalException.apiError).thenReturn(mock())
+        whenever(terminalException.apiError?.code).thenReturn(
+            PaymentErrorMapper.StripeApiError.AMOUNT_TOO_SMALL.message
+        )
+
+        val result = mapper.mapTerminalError(mock(), terminalException)
+
+        assertThat(result.type).isEqualTo(AMOUNT_TOO_SMALL)
+    }
+
+    @Test
+    fun `when STRIPE_API_ERROR with code other than amount_too_small is thrown, then GENERIC_ERROR type returned`() {
+        whenever(terminalException.errorCode).thenReturn(TerminalErrorCode.STRIPE_API_ERROR)
+        whenever(terminalException.apiError).thenReturn(mock())
+        whenever(terminalException.apiError?.code).thenReturn("error")
 
         val result = mapper.mapTerminalError(mock(), terminalException)
 


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

Closes: #4707 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR shows a specific and helpful error message when the user tries to collect payment less than $0.50. See [this documentation](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts) from Stripe in order to know why the payment fails for the minimum amount for some currencies.

Please note that Stripe has changed how the `amount_too_small` code is propagated from the SDK to the client from V1 to V2. The implementation in this PR works only for Stripe's SDK V1. There will be a separate PR that handles this for SDK V2. 

If you are wondering what was the reason for working on this logic twice and instead implement only on SDK V2. The reason is that SDK V1 will be released first to users. We wanted to make sure to add this logic in the first release itself.
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions

1. Go to the `Orders` screen
2. Select any product which has a total of **less than** `$0.50`
3. Click on the `Collect Payment` button from the order detail screen.
4. Make sure the reason for failure is appropriate, helpful, and makes sense.
5. Make sure the Primary action button in case of the `amount_too_small` error has a text `OK` and clicking on that just dismiss the dialog
6. Make sure the Primary action button in case of any other error has the text "Try again" and clicking on that re-initiates collecting payment
6. Run the unit tests and ensure those pass.

<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/1331230/134337060-d1d40186-009f-496e-9454-17a862ec6165.mp4



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
