### PR TITLE
Issue/4835 feedback request crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -370,7 +370,7 @@ class MyStoreFragment :
     }
 
     private fun handleFeedbackRequestPositiveClick() {
-        context?.let {
+        if (isAdded) {
             // Hide the card and set last feedback date to now
             binding.storeFeedbackRequestCard.visibility = View.GONE
             FeedbackPrefs.lastFeedbackDate = Calendar.getInstance().time

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -370,36 +370,32 @@ class MyStoreFragment :
     }
 
     private fun handleFeedbackRequestPositiveClick() {
-        // set last feedback date to now
+        // set last feedback date to now and hide the card
         FeedbackPrefs.lastFeedbackDate = Calendar.getInstance().time
+        binding.storeFeedbackRequestCard.visibility = View.GONE
 
-        if (isAdded) {
-            // Hide the card
-            binding.storeFeedbackRequestCard.visibility = View.GONE
-
-            // Request a ReviewInfo object from the Google Reviews API. If this fails
-            // we just move on as there isn't anything we can do.
-            val manager = ReviewManagerFactory.create(requireContext())
-            val reviewRequest = manager.requestReviewFlow()
-            reviewRequest.addOnCompleteListener {
-                if (it.isSuccessful) {
-                    // Request to start the Review flow so the user can be prompted to submit
-                    // a play store review. The prompt will only appear if the user hasn't already
-                    // reached their quota for how often we can ask for a review.
-                    val reviewInfo = it.result
-                    val flow = manager.launchReviewFlow(requireActivity(), reviewInfo)
-                    flow.addOnFailureListener { ex ->
-                        WooLog.e(WooLog.T.DASHBOARD, "Error launching google review API flow.", ex)
-                    }
-                } else {
-                    // There was an error, just log and continue. Google doesn't really tell you what
-                    // type of scenario would cause an error.
-                    WooLog.e(
-                        WooLog.T.DASHBOARD,
-                        "Error fetching ReviewInfo object from Review API to start in-app review process",
-                        it.exception
-                    )
+        // Request a ReviewInfo object from the Google Reviews API. If this fails
+        // we just move on as there isn't anything we can do.
+        val manager = ReviewManagerFactory.create(requireContext())
+        val reviewRequest = manager.requestReviewFlow()
+        reviewRequest.addOnCompleteListener {
+            if (activity != null && it.isSuccessful) {
+                // Request to start the Review flow so the user can be prompted to submit
+                // a play store review. The prompt will only appear if the user hasn't already
+                // reached their quota for how often we can ask for a review.
+                val reviewInfo = it.result
+                val flow = manager.launchReviewFlow(requireActivity(), reviewInfo)
+                flow.addOnFailureListener { ex ->
+                    WooLog.e(WooLog.T.DASHBOARD, "Error launching google review API flow.", ex)
                 }
+            } else {
+                // There was an error, just log and continue. Google doesn't really tell you what
+                // type of scenario would cause an error.
+                WooLog.e(
+                    WooLog.T.DASHBOARD,
+                    "Error fetching ReviewInfo object from Review API to start in-app review process",
+                    it.exception
+                )
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -370,10 +370,12 @@ class MyStoreFragment :
     }
 
     private fun handleFeedbackRequestPositiveClick() {
+        // set last feedback date to now
+        FeedbackPrefs.lastFeedbackDate = Calendar.getInstance().time
+
         if (isAdded) {
-            // Hide the card and set last feedback date to now
+            // Hide the card
             binding.storeFeedbackRequestCard.visibility = View.GONE
-            FeedbackPrefs.lastFeedbackDate = Calendar.getInstance().time
 
             // Request a ReviewInfo object from the Google Reviews API. If this fails
             // we just move on as there isn't anything we can do.


### PR DESCRIPTION
Fixes #4835 - I wasn't able to reproduce the crash, but it's obvious from the crash report that `MyStoreFragment` was no longer attached when the user returning from giving positive feedback:

```
 MyStoreFragment{dd7eb77} (60b7915a-4a39-4edd-a59e-c0d5b6ab1f39) not attached to an activity.
    at androidx.fragment.app.Fragment.requireActivity(Fragment.java:928)
    at com.woocommerce.android.ui.mystore.MyStoreFragment$handleFeedbackRequestPositiveClick$$inlined$let$lambda$1.onComplete(MyStoreFragment.kt:388)
    at com.google.android.play.core.tasks.a.run
```

This PR resolves this by checking `isAdded` before proceeding.