### PR TITLE
Issue/4131 product tags adapter illegal state

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductTag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductTag.kt
@@ -28,13 +28,6 @@ data class ProductTag(
         selectedTags.remove(this)
         return selectedTags
     }
-
-    fun isSameTag(otherTag: ProductTag): Boolean {
-        return this.remoteTagId == otherTag.remoteTagId &&
-            this.name == otherTag.name &&
-            this.slug == otherTag.slug &&
-            this.description == otherTag.description
-    }
 }
 
 /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductTag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductTag.kt
@@ -28,6 +28,13 @@ data class ProductTag(
         selectedTags.remove(this)
         return selectedTags
     }
+
+    fun isSameTag(otherTag: ProductTag): Boolean {
+        return this.remoteTagId == otherTag.remoteTagId &&
+            this.name == otherTag.name &&
+            this.slug == otherTag.slug &&
+            this.description == otherTag.description
+    }
 }
 
 /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsAdapter.kt
@@ -7,6 +7,7 @@ import androidx.core.text.HtmlCompat
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.databinding.ProductTagListItemBinding
+import com.woocommerce.android.extensions.areSameAs
 import com.woocommerce.android.model.ProductTag
 import com.woocommerce.android.ui.products.OnLoadMoreListener
 import com.woocommerce.android.ui.products.tags.ProductTagsAdapter.ProductTagViewHolder
@@ -46,7 +47,14 @@ class ProductTagsAdapter(
         }
     }
 
+    private fun isSameList(newList: List<ProductTag>) =
+        this.productTags.areSameAs(newList) { this.isSameTag(it) }
+
     fun setProductTags(productsTags: List<ProductTag>) {
+        if (isSameList(productsTags)) {
+            return
+        }
+
         if (this.productTags.isEmpty()) {
             this.productTags.addAll(productsTags)
             notifyDataSetChanged()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsAdapter.kt
@@ -7,7 +7,6 @@ import androidx.core.text.HtmlCompat
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.databinding.ProductTagListItemBinding
-import com.woocommerce.android.extensions.areSameAs
 import com.woocommerce.android.model.ProductTag
 import com.woocommerce.android.ui.products.OnLoadMoreListener
 import com.woocommerce.android.ui.products.tags.ProductTagsAdapter.ProductTagViewHolder
@@ -47,11 +46,8 @@ class ProductTagsAdapter(
         }
     }
 
-    private fun isSameList(newList: List<ProductTag>) =
-        this.productTags.areSameAs(newList) { this == it }
-
     fun setProductTags(productsTags: List<ProductTag>) {
-        if (isSameList(productsTags)) {
+        if (productsTags == this.productTags) {
             return
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsAdapter.kt
@@ -74,8 +74,10 @@ class ProductTagsAdapter(
      * in the view model
      */
     fun setFilter(filter: String) {
-        currentFilter = filter
-        notifyDataSetChanged()
+        if (filter != currentFilter) {
+            currentFilter = filter
+            notifyDataSetChanged()
+        }
     }
 
     inner class ProductTagViewHolder(val viewBinding: ProductTagListItemBinding) :

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsAdapter.kt
@@ -48,7 +48,7 @@ class ProductTagsAdapter(
     }
 
     private fun isSameList(newList: List<ProductTag>) =
-        this.productTags.areSameAs(newList) { this.isSameTag(it) }
+        this.productTags.areSameAs(newList) { this == it }
 
     fun setProductTags(productsTags: List<ProductTag>) {
         if (isSameList(productsTags)) {


### PR DESCRIPTION
Possibly fixes #4131 - I wasn't able to reproduce the problem, but I did notice that `setProductTags()` on the product tag adapter was always being called twice in rapid succession, which could lead to the problem.

My hopeful fix is to only call `notifyDataChanged()` when the list of tags changes from the current list, or the filter changes from the current filter.