### PR TITLE
Handle add-on percentage price values

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/AddonsExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/AddonsExt.kt
@@ -12,7 +12,7 @@ fun Addon.HasAdjustablePrice.Price.Adjusted.handlePriceType(
     QuantityBased -> value
 }
 
-fun Addon.HasAdjustablePrice.Price.Adjusted.toFormattedPrice(
+private fun Addon.HasAdjustablePrice.Price.Adjusted.toFormattedPrice(
     formatCurrencyForDisplay: (BigDecimal) -> String
 ) = value.toBigDecimalOrNull()
     ?.let { formatCurrencyForDisplay(it) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/AddonsExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/AddonsExt.kt
@@ -1,7 +1,16 @@
 package com.woocommerce.android.ui.products.addons
 
 import org.wordpress.android.fluxc.domain.Addon
+import org.wordpress.android.fluxc.domain.Addon.HasAdjustablePrice.Price.Adjusted.PriceType.*
 import java.math.BigDecimal
+
+fun Addon.HasAdjustablePrice.Price.Adjusted.handlePriceType(
+    formatCurrencyForDisplay: (BigDecimal) -> String
+) = when (priceType) {
+    FlatFee -> this.toFormattedPrice(formatCurrencyForDisplay)
+    PercentageBased -> "$value%"
+    QuantityBased -> value
+}
 
 fun Addon.HasAdjustablePrice.Price.Adjusted.toFormattedPrice(
     formatCurrencyForDisplay: (BigDecimal) -> String

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/ProductAddonCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/ProductAddonCard.kt
@@ -70,7 +70,7 @@ class ProductAddonCard @JvmOverloads constructor(
             is Addon.HasAdjustablePrice.Price.Adjusted -> {
                 addonCustomPrice.apply {
                     visibility = View.VISIBLE
-                    text = price.toFormattedPrice(formatCurrencyForDisplay)
+                    text = price.handlePriceType(formatCurrencyForDisplay)
                 }
             }
             Addon.HasAdjustablePrice.Price.NotAdjusted -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/options/AddonOptionListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/options/AddonOptionListAdapter.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.ui.products.addons.options.AddonOptionListAdapter
 import com.woocommerce.android.ui.products.addons.toFormattedPrice
 import org.wordpress.android.fluxc.domain.Addon
 import org.wordpress.android.fluxc.domain.Addon.HasAdjustablePrice.Price.Adjusted.PriceType.FlatFee
+import org.wordpress.android.fluxc.domain.Addon.HasAdjustablePrice.Price.Adjusted.PriceType.PercentageBased
 import java.math.BigDecimal
 
 class AddonOptionListAdapter(
@@ -36,6 +37,7 @@ class AddonOptionListAdapter(
             binding.optionName.text = option.label
             binding.optionPrice.text = when(option.price.priceType) {
                 FlatFee -> option.price.toFormattedPrice(formatCurrencyForDisplay)
+                PercentageBased -> "%${option.price}"
                 else -> option.price.value
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/options/AddonOptionListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/options/AddonOptionListAdapter.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.databinding.ProductAddonOptionItemBinding
 import com.woocommerce.android.ui.products.addons.options.AddonOptionListAdapter.AddonOptionsViewHolder
 import com.woocommerce.android.ui.products.addons.toFormattedPrice
 import org.wordpress.android.fluxc.domain.Addon
+import org.wordpress.android.fluxc.domain.Addon.HasAdjustablePrice.Price.Adjusted.PriceType.FlatFee
 import java.math.BigDecimal
 
 class AddonOptionListAdapter(
@@ -33,7 +34,10 @@ class AddonOptionListAdapter(
     ) : RecyclerView.ViewHolder(binding.root) {
         fun bind(option: Addon.HasOptions.Option) {
             binding.optionName.text = option.label
-            binding.optionPrice.text = option.price.toFormattedPrice(formatCurrencyForDisplay)
+            binding.optionPrice.text = when(option.price.priceType) {
+                FlatFee -> option.price.toFormattedPrice(formatCurrencyForDisplay)
+                else -> option.price.value
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/options/AddonOptionListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/options/AddonOptionListAdapter.kt
@@ -5,10 +5,8 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.databinding.ProductAddonOptionItemBinding
 import com.woocommerce.android.ui.products.addons.options.AddonOptionListAdapter.AddonOptionsViewHolder
-import com.woocommerce.android.ui.products.addons.toFormattedPrice
+import com.woocommerce.android.ui.products.addons.handlePriceType
 import org.wordpress.android.fluxc.domain.Addon
-import org.wordpress.android.fluxc.domain.Addon.HasAdjustablePrice.Price.Adjusted.PriceType.FlatFee
-import org.wordpress.android.fluxc.domain.Addon.HasAdjustablePrice.Price.Adjusted.PriceType.PercentageBased
 import java.math.BigDecimal
 
 class AddonOptionListAdapter(
@@ -35,11 +33,7 @@ class AddonOptionListAdapter(
     ) : RecyclerView.ViewHolder(binding.root) {
         fun bind(option: Addon.HasOptions.Option) {
             binding.optionName.text = option.label
-            binding.optionPrice.text = when(option.price.priceType) {
-                FlatFee -> option.price.toFormattedPrice(formatCurrencyForDisplay)
-                PercentageBased -> "${option.price.value}%"
-                else -> option.price.value
-            }
+            binding.optionPrice.text = option.price.handlePriceType(formatCurrencyForDisplay)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/options/AddonOptionListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/options/AddonOptionListAdapter.kt
@@ -37,7 +37,7 @@ class AddonOptionListAdapter(
             binding.optionName.text = option.label
             binding.optionPrice.text = when(option.price.priceType) {
                 FlatFee -> option.price.toFormattedPrice(formatCurrencyForDisplay)
-                PercentageBased -> "%${option.price}"
+                PercentageBased -> "${option.price.value}%"
                 else -> option.price.value
             }
         }


### PR DESCRIPTION
Summary
==========
Fix issue #4653 by handling price types before displaying them inside any Add-on card, so if the price information is flagged as percentage-based, we shouldn't parse it to monetary format, but show the number with a percent symbol 

Screenshots
==========
| Before  | After |
| ------------- | ------------- |
| ![Screenshot_20210923_224344](https://user-images.githubusercontent.com/5920403/134605779-54c8ef99-9676-43eb-baed-74693e28816c.png) | ![Screenshot_20210923_224230](https://user-images.githubusercontent.com/5920403/134605752-1f8609c4-bd30-42af-a91f-ccfdc61bcde9.png) |

How to Test
==========
Prerequisites: Have your site with the add ons plugin installed, configured, and with at least one product with add-ons and at least one order of the configured product. 

1 - Launch the Woo app.
2 - Navigate to the app Product list and select a Product containing Add-ons configured with Percentage based prices 
3 - Click on `Product Add-ons` inside the Product Details view and verify if the Addons view is displayed with all the expected data and every percentage is displayed.


Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
