### PR TITLE
Issue/4825 Fetching and usage of the location id

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -68,6 +68,7 @@ class CardReaderConnectViewModel @Inject constructor(
     private val tracker: AnalyticsTrackerWrapper,
     private val appPrefs: AppPrefs,
     private val onboardingChecker: CardReaderOnboardingChecker,
+    private val locationRepository: CardReaderLocationRepository,
 ) : ScopedViewModel(savedState) {
     private val arguments: CardReaderConnectDialogFragmentArgs by savedState.navArgs()
 
@@ -316,7 +317,11 @@ class CardReaderConnectViewModel @Inject constructor(
                     }
                 }
             }
-            val success = cardReaderManager.connectToReader(cardReader)
+
+            // TODO cardreader handle error cases
+//            val locationId = (cardReader.locationId ?: locationRepository.getDefaultLocationId())!!
+            val locationId = locationRepository.getDefaultLocationId()!!
+            val success = cardReaderManager.connectToReader(cardReader, locationId)
             if (success) {
                 tracker.track(AnalyticsTracker.Stat.CARD_READER_CONNECTION_SUCCESS)
                 onReaderConnected(cardReader)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -329,8 +329,7 @@ class CardReaderConnectViewModel @Inject constructor(
         viewState.value = ConnectingState(::onCancelClicked)
         launch {
             // TODO cardreader handle error cases
-//            val locationId = (cardReader.locationId ?: locationRepository.getDefaultLocationId())!!
-            val locationId = locationRepository.getDefaultLocationId()!!
+            val locationId = (cardReader.locationId ?: locationRepository.getDefaultLocationId())!!
             val success = cardReaderManager.connectToReader(cardReader, locationId)
             if (success) {
                 onReaderConnected(cardReader)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderLocationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderLocationRepository.kt
@@ -12,7 +12,7 @@ class CardReaderLocationRepository @Inject constructor(
         val selectedSite = selectedSite.getIfExists() ?: return null
         val result = wcPayStore.getStoreLocationForSite(selectedSite)
         return if (result.isError) {
-            // TODO cardreader
+            // TODO cardreader handle the error
             null
         } else {
             result.locationId!!

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderLocationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderLocationRepository.kt
@@ -1,0 +1,21 @@
+package com.woocommerce.android.ui.prefs.cardreader.connect
+
+import com.woocommerce.android.tools.SelectedSite
+import org.wordpress.android.fluxc.store.WCPayStore
+import javax.inject.Inject
+
+class CardReaderLocationRepository @Inject constructor(
+    private val wcPayStore: WCPayStore,
+    private val selectedSite: SelectedSite
+) {
+    suspend fun getDefaultLocationId(): String? {
+        val selectedSite = selectedSite.getIfExists() ?: return null
+        val result = wcPayStore.getStoreLocationForSite(selectedSite)
+        return if (result.isError) {
+            // TODO cardreader
+            null
+        } else {
+            result.locationId!!
+        }
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -76,6 +76,8 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
     private val onboardingChecker: CardReaderOnboardingChecker = mock()
     private val reader = mock<CardReader>().also { whenever(it.id).thenReturn("Dummy1") }
     private val reader2 = mock<CardReader>().also { whenever(it.id).thenReturn("Dummy2") }
+    private val locationRepository: CardReaderLocationRepository = mock()
+    private val locationId = "location_id"
 
     @Before
     fun setUp() = coroutinesTestRule.testDispatcher.runBlockingTest {
@@ -508,7 +510,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
             (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
 
-            verify(cardReaderManager).connectToReader(reader)
+            verify(cardReaderManager).connectToReader(reader, locationId)
         }
 
     @Test
@@ -519,7 +521,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
             val reader = (viewModel.viewStateData.value as MultipleReadersFoundState).listItems[1] as CardReaderListItem
             reader.onConnectClicked()
 
-            verify(cardReaderManager).connectToReader(argThat { this.id == reader.readerId })
+            verify(cardReaderManager).connectToReader(argThat { this.id == reader.readerId }, locationId)
         }
 
     @Test
@@ -965,6 +967,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
             tracker,
             appPrefs,
             onboardingChecker,
+            locationRepository
         )
     }
 
@@ -980,8 +983,8 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
                 }
             }
         }
-        whenever(cardReaderManager.connectToReader(reader)).thenReturn(connectingSucceeds)
-        whenever(cardReaderManager.connectToReader(reader2)).thenReturn(connectingSucceeds)
+        whenever(cardReaderManager.connectToReader(reader, locationId)).thenReturn(connectingSucceeds)
+        whenever(cardReaderManager.connectToReader(reader2, locationId)).thenReturn(connectingSucceeds)
         (viewModel.event.value as CheckLocationPermissions).onPermissionsCheckResult(true)
         (viewModel.event.value as CheckLocationEnabled).onLocationEnabledCheckResult(true)
         (viewModel.event.value as CheckBluetoothEnabled).onBluetoothCheckResult(true)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderLocationRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderLocationRepositoryTest.kt
@@ -1,0 +1,61 @@
+package com.woocommerce.android.ui.prefs.cardreader.connect
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.test.runBlockingTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.pay.WCTerminalStoreLocationError
+import org.wordpress.android.fluxc.model.pay.WCTerminalStoreLocationResult
+import org.wordpress.android.fluxc.store.WCPayStore
+
+class CardReaderLocationRepositoryTest : BaseUnitTest() {
+    private val wcPayStore: WCPayStore = mock()
+    private val selectedSite: SelectedSite = mock {
+        on { getIfExists() }.thenReturn(mock())
+    }
+
+    private val repository = CardReaderLocationRepository(wcPayStore, selectedSite)
+
+    @Test
+    fun `given store returns success, when get default location, then location returned`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val locationId = "locationId"
+            whenever(wcPayStore.getStoreLocationForSite(any())).thenReturn(
+                WCTerminalStoreLocationResult(
+                    locationId,
+                    null,
+                    null,
+                    null,
+                )
+            )
+
+            // WHEN
+            val result = repository.getDefaultLocationId()
+
+            // THEN
+            assertThat(result).isEqualTo(locationId)
+        }
+
+    @Test
+    fun `given store returns error, when get default location, then null returned`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            whenever(wcPayStore.getStoreLocationForSite(any())).thenReturn(
+                WCTerminalStoreLocationResult(
+                    WCTerminalStoreLocationError(),
+                )
+            )
+
+            // WHEN
+            val result = repository.getDefaultLocationId()
+
+            // THEN
+            assertThat(result).isNull()
+        }
+
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderLocationRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderLocationRepositoryTest.kt
@@ -57,5 +57,4 @@ class CardReaderLocationRepositoryTest : BaseUnitTest() {
             // THEN
             assertThat(result).isNull()
         }
-
 }

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'develop-6087b5e9ed7e67b2b14e8e11a7680faed7d249ee'
+    fluxCVersion = 'develop-b2d5b472ed41c5fa798e9a4116c56a9062c14d32'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
@@ -26,7 +26,7 @@ interface CardReaderManager {
         cardReaderTypesToDiscover: CardReaderTypesToDiscover,
     ): Flow<CardReaderDiscoveryEvents>
 
-    suspend fun connectToReader(cardReader: CardReader): Boolean
+    suspend fun connectToReader(cardReader: CardReader, locationId: String): Boolean
     suspend fun disconnectReader(): Boolean
 
     suspend fun collectPayment(paymentInfo: PaymentInfo): Flow<CardPaymentStatus>

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -83,9 +83,9 @@ internal class CardReaderManagerImpl(
         return connectionManager.discoverReaders(isSimulated, cardReaderTypesToDiscover)
     }
 
-    override suspend fun connectToReader(cardReader: CardReader): Boolean {
+    override suspend fun connectToReader(cardReader: CardReader, locationId: String): Boolean {
         if (!terminal.isInitialized()) throw IllegalStateException("Terminal not initialized")
-        return connectionManager.connectToReader(cardReader)
+        return connectionManager.connectToReader(cardReader, locationId)
     }
 
     override suspend fun disconnectReader(): Boolean {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
@@ -60,30 +60,31 @@ internal class ConnectionManager(
             }
         }
 
-    suspend fun connectToReader(cardReader: CardReader, locationId: String) = suspendCoroutine<Boolean> { continuation ->
-        (cardReader as CardReaderImpl).let {
-            updateReaderStatus(CardReaderStatus.Connecting)
-            val configuration = ConnectionConfiguration.BluetoothConnectionConfiguration(locationId)
-            val readerCallback = object : ReaderCallback {
-                override fun onSuccess(reader: Reader) {
-                    updateReaderStatus(CardReaderStatus.Connected(CardReaderImpl(reader)))
-                    continuation.resume(true)
+    suspend fun connectToReader(cardReader: CardReader, locationId: String) =
+        suspendCoroutine<Boolean> { continuation ->
+            (cardReader as CardReaderImpl).let {
+                updateReaderStatus(CardReaderStatus.Connecting)
+                val configuration = ConnectionConfiguration.BluetoothConnectionConfiguration(locationId)
+                val readerCallback = object : ReaderCallback {
+                    override fun onSuccess(reader: Reader) {
+                        updateReaderStatus(CardReaderStatus.Connected(CardReaderImpl(reader)))
+                        continuation.resume(true)
+                    }
+
+                    override fun onFailure(e: TerminalException) {
+                        updateReaderStatus(CardReaderStatus.NotConnected)
+                        continuation.resume(false)
+                    }
                 }
 
-                override fun onFailure(e: TerminalException) {
-                    updateReaderStatus(CardReaderStatus.NotConnected)
-                    continuation.resume(false)
-                }
+                terminal.connectToReader(
+                    cardReader.cardReader,
+                    configuration,
+                    readerCallback,
+                    bluetoothReaderListener,
+                )
             }
-
-            terminal.connectToReader(
-                cardReader.cardReader,
-                configuration,
-                readerCallback,
-                bluetoothReaderListener,
-            )
         }
-    }
 
     suspend fun disconnectReader() = suspendCoroutine<Boolean> { continuation ->
         terminal.disconnectReader(object : Callback {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
@@ -59,11 +59,8 @@ internal class ConnectionManager(
             }
         }
 
-    suspend fun connectToReader(cardReader: CardReader) = suspendCoroutine<Boolean> { continuation ->
+    suspend fun connectToReader(cardReader: CardReader, locationId: String) = suspendCoroutine<Boolean> { continuation ->
         (cardReader as CardReaderImpl).let {
-            val locationId = cardReader.locationId ?: throw IllegalStateException(
-                "Only attached to a location readers are supported at the moment"
-            )
             updateReaderStatus(CardReaderStatus.Connecting)
             val configuration = ConnectionConfiguration.BluetoothConnectionConfiguration(locationId)
             val readerCallback = object : ReaderCallback {

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
@@ -41,6 +41,8 @@ class CardReaderManagerImplTest {
     private val supportedReaders =
         CardReaderTypesToDiscover.SpecificReaders(listOf(SpecificReader.Chipper2X, SpecificReader.StripeM2))
 
+    private val locationId = "locationId"
+
     @Before
     fun setUp() {
         cardReaderManager = CardReaderManagerImpl(
@@ -112,7 +114,7 @@ class CardReaderManagerImplTest {
         runBlockingTest {
             whenever(terminalWrapper.isInitialized()).thenReturn(false)
 
-            cardReaderManager.connectToReader(mock())
+            cardReaderManager.connectToReader(mock(), locationId)
         }
 
     @Test

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
@@ -190,23 +190,10 @@ class ConnectionManagerTest {
         whenever(terminalWrapper.connectToReader(any(), any(), any(), any())).thenAnswer {
             (it.arguments[2] as ReaderCallback).onSuccess(cardReader.cardReader)
         }
-        val result = connectionManager.connectToReader(cardReader)
+        val result = connectionManager.connectToReader(cardReader, "location_id")
 
         assertThat(result).isTrue()
     }
-
-    @Test(expected = IllegalStateException::class)
-    fun `given reader without location id, when connectToReader, then IllegalStateException is thrown`() =
-        runBlockingTest {
-            val reader: Reader = mock()
-            val cardReader: CardReaderImpl = mock {
-                on { cardReader }.thenReturn(reader)
-            }
-            whenever(terminalWrapper.connectToReader(any(), any(), any(), any())).thenAnswer {
-                (it.arguments[2] as ReaderCallback).onSuccess(cardReader.cardReader)
-            }
-            connectionManager.connectToReader(cardReader)
-        }
 
     @Test
     fun `given reader with location id, when connectToReader fails, then false is returned`() = runBlockingTest {
@@ -219,7 +206,7 @@ class ConnectionManagerTest {
             (it.arguments[2] as ReaderCallback).onFailure(mock())
         }
 
-        val result = connectionManager.connectToReader(cardReader)
+        val result = connectionManager.connectToReader(cardReader, "location_id")
 
         assertThat(result).isFalse()
     }
@@ -236,7 +223,7 @@ class ConnectionManagerTest {
                 (it.arguments[2] as ReaderCallback).onFailure(mock())
             }
 
-            connectionManager.connectToReader(cardReader)
+            connectionManager.connectToReader(cardReader, "location_id")
 
             verify(terminalListenerImpl).updateReaderStatus(CardReaderStatus.Connecting)
         }
@@ -253,7 +240,7 @@ class ConnectionManagerTest {
                 (it.arguments[2] as ReaderCallback).onFailure(mock())
             }
 
-            connectionManager.connectToReader(cardReader)
+            connectionManager.connectToReader(cardReader, "location_id")
 
             verify(terminalListenerImpl).updateReaderStatus(CardReaderStatus.NotConnected)
         }
@@ -270,7 +257,7 @@ class ConnectionManagerTest {
                 (it.arguments[2] as ReaderCallback).onSuccess(cardReader.cardReader)
             }
 
-            connectionManager.connectToReader(cardReader)
+            connectionManager.connectToReader(cardReader, "location_id")
 
             val statusCaptor = argumentCaptor<CardReaderStatus>()
             verify(terminalListenerImpl, times(2)).updateReaderStatus(statusCaptor.capture())


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4825

### Description
The PR adds the happy flow for the fetching location id and passing it to a reader

THe endpoint used here is available only in WCPay version 3.0.0+

### Testing instructions
There are no visual changes, just try to connect to a real device and via debugger make sure that location id is fetched and passed to the reader

*Make sure that your store does have an address in WCPay otherwise it won't work (another ticket)*


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
