### PR TITLE
Issue/4774 Sort and display filter categories in parent-child hierarchy

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -1,12 +1,10 @@
 package com.woocommerce.android.ui.products
 
-import android.content.DialogInterface
 import android.os.Parcelable
 import androidx.annotation.DimenRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
-import com.woocommerce.android.R
 import com.woocommerce.android.R.string
 import com.woocommerce.android.model.ProductCategory
 import com.woocommerce.android.model.sortCategories
@@ -16,9 +14,7 @@ import com.woocommerce.android.ui.products.ProductType.OTHER
 import com.woocommerce.android.ui.products.ProductType.VIRTUAL
 import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
 import com.woocommerce.android.viewmodel.LiveDataDelegate
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
@@ -27,10 +23,7 @@ import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
-import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption.STATUS
-import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption.STOCK_STATUS
-import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption.TYPE
-import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption.CATEGORY
+import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption.*
 import javax.inject.Inject
 
 @HiltViewModel

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -14,7 +14,8 @@ import com.woocommerce.android.ui.products.ProductType.OTHER
 import com.woocommerce.android.ui.products.ProductType.VIRTUAL
 import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
 import com.woocommerce.android.viewmodel.LiveDataDelegate
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
@@ -23,7 +24,10 @@ import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
-import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption.*
+import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption.CATEGORY
+import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption.STATUS
+import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption.STOCK_STATUS
+import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption.TYPE
 import javax.inject.Inject
 
 @HiltViewModel
@@ -184,7 +188,7 @@ class ProductFilterListViewModel @Inject constructor(
             triggerEvent(
                 ShowDialog.buildDiscardDialogEvent(
                     positiveBtnAction = { _, _ ->
-                        triggerEvent(Exit)
+                        triggerEvent(MultiLiveEvent.Event.Exit)
                     },
                     negativeButtonId = string.keep_changes
                 )
@@ -240,7 +244,7 @@ class ProductFilterListViewModel @Inject constructor(
             productCategory = getFilterByProductCategory(),
             productCategoryName = selectedCategoryName
         )
-        triggerEvent(ExitWithResult(result))
+        triggerEvent(MultiLiveEvent.Event.ExitWithResult(result))
     }
 
     private fun buildFilterListItemUiModel(): List<FilterListItemUiModel> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -14,7 +14,8 @@ import com.woocommerce.android.ui.products.ProductType.OTHER
 import com.woocommerce.android.ui.products.ProductType.VIRTUAL
 import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
 import com.woocommerce.android.viewmodel.LiveDataDelegate
-import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -188,7 +189,7 @@ class ProductFilterListViewModel @Inject constructor(
             triggerEvent(
                 ShowDialog.buildDiscardDialogEvent(
                     positiveBtnAction = { _, _ ->
-                        triggerEvent(MultiLiveEvent.Event.Exit)
+                        triggerEvent(Exit)
                     },
                     negativeButtonId = string.keep_changes
                 )
@@ -244,7 +245,7 @@ class ProductFilterListViewModel @Inject constructor(
             productCategory = getFilterByProductCategory(),
             productCategoryName = selectedCategoryName
         )
-        triggerEvent(MultiLiveEvent.Event.ExitWithResult(result))
+        triggerEvent(ExitWithResult(result))
     }
 
     private fun buildFilterListItemUiModel(): List<FilterListItemUiModel> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListAdapter.kt
@@ -1,7 +1,10 @@
 package com.woocommerce.android.ui.products
 
+import android.app.ActionBar
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.constraintlayout.widget.ConstraintLayout.*
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
@@ -52,7 +55,14 @@ class ProductFilterOptionListAdapter(
     class ProductFilterOptionViewHolder(val viewBinding: ProductFilterOptionListItemBinding) :
         RecyclerView.ViewHolder(viewBinding.root) {
         fun bind(filter: FilterListOptionItemUiModel) {
-            viewBinding.filterOptionItemName.text = filter.filterOptionItemName
+            viewBinding.filterOptionItemName.apply {
+                if (filter.margin != 0) {
+                    val newLayoutParams = layoutParams as LayoutParams
+                    newLayoutParams.marginStart = filter.margin
+                    layoutParams = newLayoutParams
+                }
+                text = filter.filterOptionItemName
+            }
             viewBinding.filterOptionItemTick.isVisible = filter.isSelected
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListAdapter.kt
@@ -1,10 +1,8 @@
 package com.woocommerce.android.ui.products
 
-import android.app.ActionBar
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.constraintlayout.widget.ConstraintLayout.*
+import androidx.constraintlayout.widget.ConstraintLayout.LayoutParams
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.products.ProductFilterListViewModel.FilterListOptionItemUiModel
 import com.woocommerce.android.ui.products.ProductFilterOptionListAdapter.OnProductFilterOptionClickListener
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
+import com.woocommerce.android.widgets.AlignedDividerDecoration
 import com.woocommerce.android.widgets.SkeletonView
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -46,9 +47,8 @@ class ProductFilterOptionListFragment :
         mProductFilterOptionListAdapter = ProductFilterOptionListAdapter(this, this)
         with(binding.filterOptionList) {
             addItemDecoration(
-                DividerItemDecoration(
-                    requireActivity(),
-                    DividerItemDecoration.VERTICAL
+                AlignedDividerDecoration(
+                    requireActivity(), DividerItemDecoration.VERTICAL, R.id.filterOptionItem_name, clipToMargin = false
                 )
             )
             layoutManager = LinearLayoutManager(activity)
@@ -68,6 +68,7 @@ class ProductFilterOptionListFragment :
             viewModel.onShowProductsClicked()
         }
     }
+
 
     private fun setupObservers(
         viewModel: ProductFilterListViewModel,
@@ -90,14 +91,17 @@ class ProductFilterOptionListFragment :
             }
         )
 
-        viewModel.event.observe(viewLifecycleOwner) { event ->
-            when (event) {
-                is ExitWithResult<*> -> {
-                    navigateBackWithResult(ProductListFragment.PRODUCT_FILTER_RESULT_KEY, event.data)
+        viewModel.event.observe(
+            viewLifecycleOwner,
+            Observer { event ->
+                when (event) {
+                    is ExitWithResult<*> -> {
+                        navigateBackWithResult(ProductListFragment.PRODUCT_FILTER_RESULT_KEY, event.data)
+                    }
+                    else -> event.isHandled = false
                 }
-                else -> event.isHandled = false
             }
-        }
+        )
 
         viewModel.loadFilterOptions(arguments.selectedFilterItemPosition)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
@@ -5,7 +5,6 @@ import android.view.View
 import androidx.core.view.isVisible
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.observe
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -68,7 +67,6 @@ class ProductFilterOptionListFragment :
             viewModel.onShowProductsClicked()
         }
     }
-
 
     private fun setupObservers(
         viewModel: ProductFilterListViewModel,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4774 

### Description
Display the category filters in the product list section in a parent-child hierarchy manner. 
Before:
<img src="https://user-images.githubusercontent.com/2663464/134477680-854eccc8-026e-4b5c-8f86-76fa784a64af.png" width="300">

After:
<img src="https://user-images.githubusercontent.com/2663464/134477698-83ca883a-2660-4cdc-9a95-b15fc8c04791.png" width="300">

These changes are based on how categories are displayed in the product details section. This means list dividers for category filters are now adjusted to the category text name instead of matching full width. These divider changes will also affect the rest of the filter lists (Stock status, Status, and Product type). See the demo video below for the final results. IMHO this ok visual change but it is true it is not fully consistent with the previous screen where the different filter types are displayed with full-width dividers. Should we involve design for this?

Alternatives here could be:

- Make dividers align with text for items in `ProductFilterListAdapter` too.
- Keep dividers always full-with even when displaying list items in a hierarchy (tested it and looks pretty weird)
- Implement a heterogeneous list and style/handle dividers per row and view type. IMHO this option is overkill. 

<img src="https://user-images.githubusercontent.com/2663464/134477984-eafe0ddd-a706-4225-b1d6-0f6ebd6107fa.png" width="300">

### Testing instructions
Just open products > filters > categories to check the results: 

https://user-images.githubusercontent.com/2663464/134481438-f1345cc5-0414-4a11-a257-be92ed1285a2.mp4



