### PR TITLE
Recreate MainActivity when receiving a notification for a different store

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -695,11 +695,14 @@ class MainActivity :
 
             val localPushId = intent.getIntExtra(FIELD_PUSH_ID, 0)
             val notification = intent.getParcelableExtra<Notification>(FIELD_REMOTE_NOTIFICATION)
-            // Reset this flag now that it's being processed
-            intent.removeExtra(FIELD_REMOTE_NOTIFICATION)
-            intent.removeExtra(FIELD_PUSH_ID)
-
-            viewModel.handleIncomingNotification(localPushId, notification)
+            if (viewModel.handleIncomingNotification(localPushId, notification)) {
+                // Reset this flag now that it's being processed
+                intent.removeExtra(FIELD_REMOTE_NOTIFICATION)
+                intent.removeExtra(FIELD_PUSH_ID)
+            } else {
+                // Restore this flag to handle notification on next launch
+                intent.putExtra(FIELD_OPENED_FROM_PUSH, true)
+            }
         }
     }
     // endregion
@@ -727,6 +730,7 @@ class MainActivity :
                     is ViewReviewDetail -> {
                         showReviewDetail(event.uniqueId, launchedFromNotification = true, enableModeration = true)
                     }
+                    RecreateActivity -> restart()
                 }
             }
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -695,14 +695,11 @@ class MainActivity :
 
             val localPushId = intent.getIntExtra(FIELD_PUSH_ID, 0)
             val notification = intent.getParcelableExtra<Notification>(FIELD_REMOTE_NOTIFICATION)
-            if (viewModel.handleIncomingNotification(localPushId, notification)) {
-                // Reset this flag now that it's being processed
-                intent.removeExtra(FIELD_REMOTE_NOTIFICATION)
-                intent.removeExtra(FIELD_PUSH_ID)
-            } else {
-                // Restore this flag to handle notification on next launch
-                intent.putExtra(FIELD_OPENED_FROM_PUSH, true)
-            }
+            // Reset this flag now that it's being processed
+            intent.removeExtra(FIELD_REMOTE_NOTIFICATION)
+            intent.removeExtra(FIELD_PUSH_ID)
+
+            viewModel.handleIncomingNotification(localPushId, notification)
         }
     }
     // endregion
@@ -730,7 +727,13 @@ class MainActivity :
                     is ViewReviewDetail -> {
                         showReviewDetail(event.uniqueId, launchedFromNotification = true, enableModeration = true)
                     }
-                    RecreateActivity -> restart()
+                    is RestartActivityForNotification -> {
+                        // Add flags for handling the push notification after restart
+                        intent.putExtra(FIELD_OPENED_FROM_PUSH, true)
+                        intent.putExtra(FIELD_REMOTE_NOTIFICATION, event.notification)
+                        intent.putExtra(FIELD_PUSH_ID, event.pushId)
+                        restart()
+                    }
                 }
             }
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -6,12 +6,7 @@ import com.woocommerce.android.push.NotificationMessageHandler
 import com.woocommerce.android.push.NotificationTestUtils
 import com.woocommerce.android.push.WooNotificationType
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.main.MainActivityViewModel.ViewOrderDetail
-import com.woocommerce.android.ui.main.MainActivityViewModel.ViewOrderList
-import com.woocommerce.android.ui.main.MainActivityViewModel.ViewReviewDetail
-import com.woocommerce.android.ui.main.MainActivityViewModel.ViewZendeskTickets
-import com.woocommerce.android.ui.main.MainActivityViewModel.ViewMyStoreStats
-import com.woocommerce.android.ui.main.MainActivityViewModel.ViewReviewList
+import com.woocommerce.android.ui.main.MainActivityViewModel.*
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -226,51 +221,31 @@ class MainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when order notifications for a second store is clicked then the order list screen for that store is opened`() {
+    fun `when order notifications for a second store is clicked then switch to the this store and restart activity`() {
         val orderNotification2 = testOrderNotification.copy(
             remoteSiteId = TEST_REMOTE_SITE_ID_2, uniqueId = TEST_NEW_ORDER_ID_2
         )
         val groupOrderPushId = orderNotification2.getGroupPushId()
-        var event: ViewOrderList? = null
-        viewModel.event.observeForever {
-            if (it is ViewOrderList) event = it
-        }
 
-        viewModel.handleIncomingNotification(groupOrderPushId, orderNotification2)
+        val isHandled = viewModel.handleIncomingNotification(groupOrderPushId, orderNotification2)
 
+        assertThat(viewModel.event.value).isEqualTo(RecreateActivity)
+        assertThat(isHandled).isFalse
         verify(selectedSite, atLeastOnce()).set(any())
-        verify(notificationMessageHandler, atLeastOnce()).markNotificationsOfTypeTapped(
-            eq(orderNotification2.channelType)
-        )
-        verify(notificationMessageHandler, atLeastOnce()).removeNotificationsOfTypeFromSystemsBar(
-            eq(orderNotification2.channelType),
-            eq(orderNotification2.remoteSiteId)
-        )
-        assertThat(event).isEqualTo(ViewOrderList)
     }
 
     @Test
-    fun `when review notifications for second store is clicked then the review list screen for that store is opened`() {
+    fun `when review notifications for second store is clicked then switch to the this store and restart activity`() {
         val reviewNotification2 = testReviewNotification.copy(
             remoteSiteId = TEST_REMOTE_SITE_ID_2, uniqueId = TEST_NEW_REVIEW_ID_2
         )
         val reviewPushId = reviewNotification2.getGroupPushId()
-        var event: ViewReviewList? = null
-        viewModel.event.observeForever {
-            if (it is ViewReviewList) event = it
-        }
 
-        viewModel.handleIncomingNotification(reviewPushId, reviewNotification2)
+        val isHandled = viewModel.handleIncomingNotification(reviewPushId, reviewNotification2)
 
+        assertThat(viewModel.event.value).isEqualTo(RecreateActivity)
+        assertThat(isHandled).isFalse
         verify(selectedSite, atLeastOnce()).set(any())
-        verify(notificationMessageHandler, atLeastOnce()).markNotificationsOfTypeTapped(
-            eq(reviewNotification2.channelType)
-        )
-        verify(notificationMessageHandler, atLeastOnce()).removeNotificationsOfTypeFromSystemsBar(
-            eq(reviewNotification2.channelType),
-            eq(reviewNotification2.remoteSiteId)
-        )
-        assertThat(event).isEqualTo(ViewReviewList)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -265,4 +265,14 @@ class MainActivityViewModelTest : BaseUnitTest() {
         )
         assertThat(event).isEqualTo(ViewMyStoreStats)
     }
+
+    @Test
+    fun `when notification of non existing store is clicked, then show default screen`() {
+        doReturn(null).whenever(siteStore).getSiteBySiteId(any())
+        val notification = testOrderNotification.copy(remoteSiteId = TEST_REMOTE_SITE_ID_2)
+
+        viewModel.handleIncomingNotification(1000, notification)
+
+        assertThat(viewModel.event.value).isEqualTo(ViewMyStoreStats)
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -227,11 +227,11 @@ class MainActivityViewModelTest : BaseUnitTest() {
         )
         val groupOrderPushId = orderNotification2.getGroupPushId()
 
-        val isHandled = viewModel.handleIncomingNotification(groupOrderPushId, orderNotification2)
+        viewModel.handleIncomingNotification(groupOrderPushId, orderNotification2)
 
-        assertThat(viewModel.event.value).isEqualTo(RecreateActivity)
-        assertThat(isHandled).isFalse
         verify(selectedSite, atLeastOnce()).set(any())
+        assertThat(viewModel.event.value)
+            .isEqualTo(RestartActivityForNotification(groupOrderPushId, orderNotification2))
     }
 
     @Test
@@ -241,11 +241,10 @@ class MainActivityViewModelTest : BaseUnitTest() {
         )
         val reviewPushId = reviewNotification2.getGroupPushId()
 
-        val isHandled = viewModel.handleIncomingNotification(reviewPushId, reviewNotification2)
+        viewModel.handleIncomingNotification(reviewPushId, reviewNotification2)
 
-        assertThat(viewModel.event.value).isEqualTo(RecreateActivity)
-        assertThat(isHandled).isFalse
         verify(selectedSite, atLeastOnce()).set(any())
+        assertThat(viewModel.event.value).isEqualTo(RestartActivityForNotification(reviewPushId, reviewNotification2))
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4846

### Description
When we receive a notification for a different store than the active one, we switch stores before navigating to the right screen, but since the top level fragments keep their state when navigating to other screens, those fragments may keep their previous content, and may keep hitting the old store.

This PR makes sure that MainActivity is recreated before navigating to the right screen.


### Testing instructions

You need multiple stores connected to your account, let's say Store 1 and Store 2

1. Keep the app open with Store 1 being current active store, stay on one of the tabs (e.g Products).
2. Create an order on Store 2.
3. Tap the notification of the new order -> navigates to order details.
4. Tap back, confirm that you see the orders list of Store 2.
5. Navigate to other tabs, and confirm that all have been switched to Store 2.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
