### PR TITLE
Issue/4848 Remove lint xml suppressing

### DIFF
--- a/WooCommerce/lint.xml
+++ b/WooCommerce/lint.xml
@@ -13,7 +13,6 @@
     <issue id="MissingTranslation" severity="ignore" />
     <issue id="ExtraTranslation" severity="ignore" />
     <issue id="PluralsCandidate" severity="ignore" /> <!-- GlotPress doesn't support plurals -->
-    <issue id="NewApi" severity="ignore" /> <!-- TODO remove when new gradle plugin will be merged. #4659 -->
 
     <issue id="InvalidPackage">
         <ignore regexp="java-common-1.13.jar" />


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4848
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
The PR removes the workaround which was needed due to usage of the old version of AGP with kotlin 1.5.*

### Testing instructions
Nothing to test here

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
