### PR TITLE
Stop clearing notifications when switching stores

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
@@ -110,7 +110,6 @@ class AppSettingsActivity :
         if (FeatureFlag.CARD_READER.isEnabled()) presenter.clearCardReaderData()
         siteChanged = true
         setResult(RESULT_CODE_SITE_CHANGED)
-        notificationMessageHandler.removeAllNotificationsFromSystemsBar()
 
         prefs.resetSitePreferences()
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4851 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR simply removes the method call of removing notifications when switching stores, since we support notifications for multiple stores now.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
