### PR TITLE
Initial commit for removing unused classes in cardreader module

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -35,7 +35,6 @@ import com.woocommerce.android.cardreader.payments.CardPaymentStatus.Initializin
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentCompleted
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentFailed
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.ProcessingPayment
-import com.woocommerce.android.cardreader.payments.CardPaymentStatus.ShowAdditionalInfo
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.WaitingForInput
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.payments.PaymentData

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModel.kt
@@ -34,7 +34,6 @@ import com.woocommerce.android.cardreader.CardPaymentStatus.InitializingPayment
 import com.woocommerce.android.cardreader.CardPaymentStatus.PaymentCompleted
 import com.woocommerce.android.cardreader.CardPaymentStatus.PaymentFailed
 import com.woocommerce.android.cardreader.CardPaymentStatus.ProcessingPayment
-import com.woocommerce.android.cardreader.CardPaymentStatus.ShowAdditionalInfo
 import com.woocommerce.android.cardreader.CardPaymentStatus.WaitingForInput
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.PaymentData
@@ -202,9 +201,6 @@ class CardReaderPaymentViewModel
             is PaymentCompleted -> {
                 tracker.track(AnalyticsTracker.Stat.CARD_PRESENT_COLLECT_PAYMENT_SUCCESS)
                 onPaymentCompleted(paymentStatus, orderId)
-            }
-            is ShowAdditionalInfo -> {
-                handleAdditionalInfo(paymentStatus.type)
             }
             WaitingForInput -> {
                 // noop

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -1129,68 +1129,23 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given collect payment shown, when multiple cards event received, then collect payment hint updated`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
-                flow {
-                    emit(CollectingPayment)
-                    emit(ShowAdditionalInfo(MULTIPLE_CONTACTLESS_CARDS_DETECTED))
-                }
-            }
-
-            viewModel.start()
-
-            assertThat((viewModel.viewStateData.value as CollectPaymentState).hintLabel)
-                .isEqualTo(R.string.card_reader_payment_multiple_contactless_cards_detected_prompt)
-        }
-
-    @Test
-    fun `given collect payment shown, when try another method event received, then collect payment hint updated`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
-                flow {
-                    emit(CollectingPayment)
-                    emit(ShowAdditionalInfo(TRY_ANOTHER_READ_METHOD))
-                }
-            }
-
-            viewModel.start()
-
-            assertThat((viewModel.viewStateData.value as CollectPaymentState).hintLabel)
-                .isEqualTo(R.string.card_reader_payment_try_another_read_method_prompt)
-        }
-
-    @Test
-    fun `given collect payment shown, when try another card event received, then collect payment hint updated`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
-                flow {
-                    emit(CollectingPayment)
-                    emit(ShowAdditionalInfo(TRY_ANOTHER_CARD))
-                }
-            }
-
-            viewModel.start()
-
-            assertThat((viewModel.viewStateData.value as CollectPaymentState).hintLabel)
-                .isEqualTo(R.string.card_reader_payment_try_another_card_prompt)
-        }
-
-    @Test
     fun `given collect payment NOT shown, when show additional info event received, then event ignored`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow {
                     emit(ProcessingPayment)
-                    emit(ShowAdditionalInfo(TRY_ANOTHER_CARD))
-                    emit(ShowAdditionalInfo(RETRY_CARD))
-                    emit(ShowAdditionalInfo(INSERT_CARD))
-                    emit(ShowAdditionalInfo(INSERT_OR_SWIPE_CARD))
-                    emit(ShowAdditionalInfo(SWIPE_CARD))
-                    emit(ShowAdditionalInfo(REMOVE_CARD))
-                    emit(ShowAdditionalInfo(MULTIPLE_CONTACTLESS_CARDS_DETECTED))
-                    emit(ShowAdditionalInfo(TRY_ANOTHER_READ_METHOD))
-                    emit(ShowAdditionalInfo(TRY_ANOTHER_CARD))
+                }
+            }
+            whenever(cardReaderManager.displayBluetoothCardReaderMessages).thenAnswer {
+                flow {
+                    emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(TRY_ANOTHER_CARD))
+                    emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(RETRY_CARD))
+                    emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(INSERT_CARD))
+                    emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(INSERT_OR_SWIPE_CARD))
+                    emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(SWIPE_CARD))
+                    emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(REMOVE_CARD))
+                    emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(MULTIPLE_CONTACTLESS_CARDS_DETECTED))
+                    emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(TRY_ANOTHER_READ_METHOD))
                 }
             }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/cardreader/CardReaderPaymentViewModelTest.kt
@@ -1185,6 +1185,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
                     emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(REMOVE_CARD))
                     emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(MULTIPLE_CONTACTLESS_CARDS_DETECTED))
                     emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(TRY_ANOTHER_READ_METHOD))
+                    emit(BluetoothCardReaderMessages.CardReaderDisplayMessage(CHECK_MOBILE_DEVICE))
                 }
             }
 

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
@@ -44,7 +44,6 @@ object CardReaderManagerFactory {
                 CancelPaymentAction(terminal),
                 PaymentUtils(),
                 PaymentErrorMapper(),
-                AdditionalInfoMapper(),
             ),
             ConnectionManager(
                 terminal,

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -13,8 +13,6 @@ import com.woocommerce.android.cardreader.payments.PaymentInfo
 import com.woocommerce.android.cardreader.internal.payments.actions.CancelPaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction.CollectPaymentStatus
-import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction.CollectPaymentStatus.DisplayMessageRequested
-import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction.CollectPaymentStatus.ReaderInputRequested
 import com.woocommerce.android.cardreader.internal.payments.actions.CreatePaymentAction
 import com.woocommerce.android.cardreader.internal.payments.actions.CreatePaymentAction.CreatePaymentStatus.Failure
 import com.woocommerce.android.cardreader.internal.payments.actions.CreatePaymentAction.CreatePaymentStatus.Success
@@ -36,7 +34,6 @@ internal class PaymentManager(
     private val cancelPaymentAction: CancelPaymentAction,
     private val paymentUtils: PaymentUtils,
     private val errorMapper: PaymentErrorMapper,
-    private val additionalInfoMapper: AdditionalInfoMapper,
 ) {
     suspend fun acceptPayment(paymentInfo: PaymentInfo): Flow<CardPaymentStatus> = flow {
         if (isInvalidState(paymentInfo)) return@flow
@@ -117,8 +114,6 @@ internal class PaymentManager(
         emit(CollectingPayment)
         collectPaymentAction.collectPayment(paymentIntent).collect {
             when (it) {
-                is DisplayMessageRequested -> emit(ShowAdditionalInfo(additionalInfoMapper.map(it.msg)))
-                is ReaderInputRequested -> emit(WaitingForInput)
                 is CollectPaymentStatus.Failure -> emit(errorMapper.mapTerminalError(paymentIntent, it.exception))
                 is CollectPaymentStatus.Success -> result = it.paymentIntent
             }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CollectPaymentAction.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CollectPaymentAction.kt
@@ -3,8 +3,6 @@ package com.woocommerce.android.cardreader.internal.payments.actions
 import com.stripe.stripeterminal.external.callable.Callback
 import com.stripe.stripeterminal.external.callable.PaymentIntentCallback
 import com.stripe.stripeterminal.external.models.PaymentIntent
-import com.stripe.stripeterminal.external.models.ReaderDisplayMessage
-import com.stripe.stripeterminal.external.models.ReaderInputOptions
 import com.stripe.stripeterminal.external.models.TerminalException
 import com.woocommerce.android.cardreader.internal.LOG_TAG
 import com.woocommerce.android.cardreader.internal.payments.actions.CollectPaymentAction.CollectPaymentStatus.Failure
@@ -18,8 +16,6 @@ import kotlinx.coroutines.flow.callbackFlow
 
 internal class CollectPaymentAction(private val terminal: TerminalWrapper, private val logWrapper: LogWrapper) {
     sealed class CollectPaymentStatus {
-        data class DisplayMessageRequested(val msg: ReaderDisplayMessage) : CollectPaymentStatus()
-        data class ReaderInputRequested(val options: ReaderInputOptions) : CollectPaymentStatus()
         data class Success(val paymentIntent: PaymentIntent) : CollectPaymentStatus()
         data class Failure(val exception: TerminalException) : CollectPaymentStatus()
     }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/payments/CardPaymentStatus.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/payments/CardPaymentStatus.kt
@@ -4,7 +4,6 @@ sealed class CardPaymentStatus {
     object InitializingPayment : CardPaymentStatus()
     object CollectingPayment : CardPaymentStatus()
     object WaitingForInput : CardPaymentStatus()
-    data class ShowAdditionalInfo(val type: AdditionalInfoType) : CardPaymentStatus()
     object ProcessingPayment : CardPaymentStatus()
     object CapturingPayment : CardPaymentStatus()
     data class PaymentCompleted(val receiptUrl: String) : CardPaymentStatus()

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
@@ -15,7 +15,6 @@ import com.stripe.stripeterminal.external.models.PaymentIntentStatus.REQUIRES_CA
 import com.stripe.stripeterminal.external.models.PaymentIntentStatus.REQUIRES_CONFIRMATION
 import com.stripe.stripeterminal.external.models.PaymentIntentStatus.REQUIRES_PAYMENT_METHOD
 import com.stripe.stripeterminal.external.models.TerminalException
-import com.woocommerce.android.cardreader.CardPaymentStatus.AdditionalInfoType.INSERT_CARD
 import com.woocommerce.android.cardreader.CardPaymentStatus.CapturingPayment
 import com.woocommerce.android.cardreader.CardPaymentStatus.CardPaymentStatusErrorType
 import com.woocommerce.android.cardreader.CardPaymentStatus.CollectingPayment
@@ -78,7 +77,6 @@ class PaymentManagerTest {
     private val cancelPaymentAction: CancelPaymentAction = mock()
     private val paymentErrorMapper: PaymentErrorMapper = mock()
     private val paymentUtils: PaymentUtils = mock()
-    private val additionalInfoMapper: AdditionalInfoMapper = mock()
 
     private val expectedSequence = listOf(
         InitializingPayment::class,
@@ -123,7 +121,6 @@ class PaymentManagerTest {
         whenever(paymentErrorMapper.mapError(anyOrNull(), anyOrNull()))
             .thenReturn(PaymentFailed(CardPaymentStatusErrorType.GENERIC_ERROR, null, ""))
         whenever(paymentUtils.isSupportedCurrency(any())).thenReturn(true)
-        whenever(additionalInfoMapper.map(any())).thenReturn(INSERT_CARD)
     }
 
     // BEGIN - Arguments validation and conversion

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
@@ -15,7 +15,6 @@ import com.stripe.stripeterminal.external.models.PaymentIntentStatus.REQUIRES_CA
 import com.stripe.stripeterminal.external.models.PaymentIntentStatus.REQUIRES_CONFIRMATION
 import com.stripe.stripeterminal.external.models.PaymentIntentStatus.REQUIRES_PAYMENT_METHOD
 import com.stripe.stripeterminal.external.models.TerminalException
-import com.woocommerce.android.cardreader.payments.CardPaymentStatus.AdditionalInfoType.INSERT_CARD
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CapturingPayment
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CollectingPayment
@@ -23,8 +22,6 @@ import com.woocommerce.android.cardreader.payments.CardPaymentStatus.Initializin
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentCompleted
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentFailed
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.ProcessingPayment
-import com.woocommerce.android.cardreader.payments.CardPaymentStatus.ShowAdditionalInfo
-import com.woocommerce.android.cardreader.payments.CardPaymentStatus.WaitingForInput
 import com.woocommerce.android.cardreader.CardReaderStore
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
 import com.woocommerce.android.cardreader.payments.PaymentInfo

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
@@ -23,8 +23,6 @@ import com.woocommerce.android.cardreader.CardPaymentStatus.InitializingPayment
 import com.woocommerce.android.cardreader.CardPaymentStatus.PaymentCompleted
 import com.woocommerce.android.cardreader.CardPaymentStatus.PaymentFailed
 import com.woocommerce.android.cardreader.CardPaymentStatus.ProcessingPayment
-import com.woocommerce.android.cardreader.CardPaymentStatus.ShowAdditionalInfo
-import com.woocommerce.android.cardreader.CardPaymentStatus.WaitingForInput
 import com.woocommerce.android.cardreader.CardReaderStore
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
 import com.woocommerce.android.cardreader.payments.PaymentInfo
@@ -101,7 +99,6 @@ class PaymentManagerTest {
             cancelPaymentAction,
             paymentUtils,
             paymentErrorMapper,
-            additionalInfoMapper
         )
         whenever(terminalWrapper.isInitialized()).thenReturn(true)
         whenever(createPaymentAction.createPaymentIntent(any()))
@@ -233,28 +230,6 @@ class PaymentManagerTest {
             .takeUntil(CollectingPayment::class).toList()
 
         assertThat(result.last()).isInstanceOf(CollectingPayment::class.java)
-    }
-
-    @Test
-    fun `when card reader awaiting input, then WaitingForInput emitted`() = runBlockingTest {
-        whenever(collectPaymentAction.collectPayment(anyOrNull()))
-            .thenReturn(flow { emit(CollectPaymentStatus.ReaderInputRequested(mock())) })
-
-        val result = manager
-            .acceptPayment(createPaymentInfo()).toList()
-
-        assertThat(result.last()).isInstanceOf(WaitingForInput::class.java)
-    }
-
-    @Test
-    fun `when card reader requests to display message, then ShowAdditionalInfo emitted`() = runBlockingTest {
-        whenever(collectPaymentAction.collectPayment(anyOrNull()))
-            .thenReturn(flow { emit(CollectPaymentStatus.DisplayMessageRequested(mock())) })
-
-        val result = manager
-            .acceptPayment(createPaymentInfo()).toList()
-
-        assertThat(result.last()).isInstanceOf(ShowAdditionalInfo::class.java)
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4860 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Remove unused DisplayMessageRequested and ReaderInputRequested classes from the card reader module.

### Okay. But, how do the messages get displayed now?
We have this logic in `BluetoothReaderListenerImpl` file inside `onRequestReaderDisplayMessage` and `onRequestReaderInput` method. [This](https://github.com/woocommerce/woocommerce-android/pull/4775) is the PR which implements the logic.

### I see the tests are removed. Are there any other tests that cover the same scenario?
Yes!  `BluetoothReaderListenerImplTest` and `CardReaderPaymentViewModelTest` has it covered 🙂 
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
Just verify that the payment flow works as expected.
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

<!-- Include before and after images or gifs when appropriate. -->

<br/>

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
