### PR TITLE
Issue/3173 Disable shipping for external products

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
@@ -64,7 +64,6 @@ class ProductDetailBottomSheetBuilder(
             }
             EXTERNAL -> {
                 listOfNotNull(
-                    product.getShipping(),
                     product.getCategories(),
                     product.getTags(),
                     product.getShortDescription(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.products
 
 import androidx.annotation.StringRes
-import com.woocommerce.android.R
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.model.Product
@@ -32,7 +31,7 @@ class ProductDetailBottomSheetBuilder(
         PRODUCT_TAGS(string.product_tags, string.bottom_sheet_tags_desc),
         SHORT_DESCRIPTION(string.product_short_description, string.bottom_sheet_short_description_desc),
         LINKED_PRODUCTS(string.product_detail_linked_products, string.bottom_sheet_linked_products_desc),
-        PRODUCT_DOWNLOADS(R.string.product_downloadable_files, string.bottom_sheet_downloadable_files_desc)
+        PRODUCT_DOWNLOADS(string.product_downloadable_files, string.bottom_sheet_downloadable_files_desc)
     }
 
     data class ProductDetailBottomSheetUiItem(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #3173
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Resolves bug when adding/editing products, shipping shouldn't be an option for External product types. However, when you go to "Add more details" on an External product, "Shipping" is an option there and you can enter shipping details for the product.

### Testing instructions
 1. Open the Products tab.
 2. Add or edit an external product.
 3. Tap "Add more details" at the bottom of the screen.
 4. Check how "Shipping" option is not displayed anymore

https://user-images.githubusercontent.com/2663464/135127898-dd1eaead-e72d-4796-94c7-e3ed4627d5f3.mp4

