### PR TITLE
Design Changes - Dark mode top bar background color

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android.ui.products
 
-import android.graphics.Color
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.os.Parcelable
 import android.text.SpannableString
@@ -10,6 +10,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.annotation.StringRes
+import androidx.core.content.ContextCompat
 import androidx.core.view.forEach
 import androidx.core.view.isVisible
 import androidx.lifecycle.Observer
@@ -339,6 +340,7 @@ class ProductDetailFragment :
         super.onCreateOptionsMenu(menu, inflater)
     }
 
+    @SuppressLint("ResourceAsColor")
     override fun onPrepareOptionsMenu(menu: Menu) {
         super.onPrepareOptionsMenu(menu)
 
@@ -373,7 +375,7 @@ class ProductDetailFragment :
         with(menu.findItem(R.id.menu_trash_product)) {
             if (this == null) return@with
             val title = SpannableString(this.title)
-            title.setSpan(ForegroundColorSpan(Color.RED), 0, title.length, 0)
+            title.setSpan(ForegroundColorSpan(ContextCompat.getColor(requireContext(), R.color.woo_red_30)), 0, title.length, 0)
             this.title = title
             this.isVisible = viewModel.isTrashEnabled
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -375,7 +375,17 @@ class ProductDetailFragment :
         with(menu.findItem(R.id.menu_trash_product)) {
             if (this == null) return@with
             val title = SpannableString(this.title)
-            title.setSpan(ForegroundColorSpan(ContextCompat.getColor(requireContext(), R.color.woo_red_30)), 0, title.length, 0)
+            title.setSpan(
+                ForegroundColorSpan(
+                    ContextCompat.getColor(
+                        requireContext(),
+                        R.color.woo_red_30
+                    )
+                ),
+                0,
+                title.length,
+                0
+            )
             this.title = title
             this.isVisible = viewModel.isTrashEnabled
         }

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -13,6 +13,7 @@
     <color name="color_alert">@color/woo_yellow_30</color>
 
     <color name="color_surface_elevated_04">@color/woo_white_alpha_009</color>
+    <color name="color_surface_topbar">@color/woo_black_900</color>
 
     <color name="color_on_surface">@color/woo_white</color>
     <color name="color_on_surface_high">@color/woo_white_alpha_087</color>
@@ -109,7 +110,7 @@
     Empty state view
     -->
     <color name="empty_state_bg_color">@color/woo_black_90</color>
-  
+
     <!--
         Payment reader
     -->

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -39,7 +39,7 @@
     <!--
         App colors
     -->
-    <color name="color_status_bar">@color/color_topbar</color>
+    <color name="color_status_bar">@color/color_toolbar</color>
     <color name="default_window_background">@color/woo_black_90</color>
     <color name="divider_color">@color/woo_white_alpha_012</color>
     <color name="image_border_color">@color/woo_white_alpha_012</color>

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -13,7 +13,6 @@
     <color name="color_alert">@color/woo_yellow_30</color>
 
     <color name="color_surface_elevated_04">@color/woo_white_alpha_009</color>
-    <color name="color_surface_topbar">@color/woo_black_900</color>
 
     <color name="color_on_surface">@color/woo_white</color>
     <color name="color_on_surface_high">@color/woo_white_alpha_087</color>
@@ -40,13 +39,14 @@
     <!--
         App colors
     -->
-    <color name="color_status_bar">@color/color_surface</color>
+    <color name="color_status_bar">@color/color_topbar</color>
     <color name="default_window_background">@color/woo_black_90</color>
     <color name="divider_color">@color/woo_white_alpha_012</color>
     <color name="image_border_color">@color/woo_white_alpha_012</color>
     <color name="color_ripple_overlay">@color/woo_white_alpha_012</color>
     <color name="color_scrim_background">@color/woo_black_90_alpha_038</color>
     <color name="color_default_image_background">@color/woo_gray_40</color>
+    <color name="color_topbar">@color/woo_black_900</color>
 
     <!--
         Elevation colors

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -46,7 +46,7 @@
     <color name="color_ripple_overlay">@color/woo_white_alpha_012</color>
     <color name="color_scrim_background">@color/woo_black_90_alpha_038</color>
     <color name="color_default_image_background">@color/woo_gray_40</color>
-    <color name="color_topbar">@color/woo_black_900</color>
+    <color name="color_toolbar">@color/woo_black_900</color>
 
     <!--
         Elevation colors

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -14,7 +14,6 @@
     <color name="color_alert">@color/woo_yellow_50</color>
 
     <color name="color_surface_elevated_04">@color/woo_white</color>
-    <color name="color_surface_topbar">@color/woo_white</color>
 
     <color name="color_on_surface">@android:color/black</color>
     <color name="color_on_surface_high">@color/woo_black_90_alpha_087</color>
@@ -80,6 +79,7 @@
     <color name="color_ripple_overlay">@color/woo_black_90_alpha_012</color>
     <color name="image_border_color">@color/woo_black_90_alpha_012</color>
     <color name="splash_background">@color/woo_purple_60</color>
+    <color name="color_topbar">@color/woo_white</color>
 
     <!--
         Elevation colors

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -14,6 +14,7 @@
     <color name="color_alert">@color/woo_yellow_50</color>
 
     <color name="color_surface_elevated_04">@color/woo_white</color>
+    <color name="color_surface_topbar">@color/woo_white</color>
 
     <color name="color_on_surface">@android:color/black</color>
     <color name="color_on_surface_high">@color/woo_black_90_alpha_087</color>

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -79,7 +79,7 @@
     <color name="color_ripple_overlay">@color/woo_black_90_alpha_012</color>
     <color name="image_border_color">@color/woo_black_90_alpha_012</color>
     <color name="splash_background">@color/woo_purple_60</color>
-    <color name="color_topbar">@color/woo_white</color>
+    <color name="color_toolbar">@color/woo_white</color>
 
     <!--
         Elevation colors

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -17,7 +17,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="titleTextStyle">@style/TextAppearance.Woo.CollapsingToolbar.Collapsed</item>
         <item name="navigationIcon">@drawable/ic_back_24dp</item>
         <item name="android:theme">@style/Widget.Woo.Toolbar.Surface</item>
-        <item name="android:background">@color/color_topbar</item>
+        <item name="android:background">@color/color_toolbar</item>
     </style>
     <style name="Widget.Woo.Toolbar.Surface" parent="ThemeOverlay.MaterialComponents.Toolbar.Surface">
         <item name="actionMenuTextColor">@color/woo_pink_50</item>
@@ -34,7 +34,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
     </style>
     <style name="Woo.CollapsedToolbarLayout" parent="Widget.MaterialComponents.Toolbar.Surface">
         <item name="layout_scrollFlags">scroll|exitUntilCollapsed</item>
-        <item name="android:background">@color/color_topbar</item>
+        <item name="android:background">@color/color_toolbar</item>
         <item name="collapsedTitleTextAppearance">
             @style/TextAppearance.Woo.CollapsingToolbar.Collapsed
         </item>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -17,7 +17,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="titleTextStyle">@style/TextAppearance.Woo.CollapsingToolbar.Collapsed</item>
         <item name="navigationIcon">@drawable/ic_back_24dp</item>
         <item name="android:theme">@style/Widget.Woo.Toolbar.Surface</item>
-        <item name="android:background">@color/color_surface_topbar</item>
+        <item name="android:background">@color/color_topbar</item>
     </style>
     <style name="Widget.Woo.Toolbar.Surface" parent="ThemeOverlay.MaterialComponents.Toolbar.Surface">
         <item name="actionMenuTextColor">@color/woo_pink_50</item>
@@ -34,7 +34,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
     </style>
     <style name="Woo.CollapsedToolbarLayout" parent="Widget.MaterialComponents.Toolbar.Surface">
         <item name="layout_scrollFlags">scroll|exitUntilCollapsed</item>
-        <item name="android:background">@color/color_surface_topbar</item>
+        <item name="android:background">@color/color_topbar</item>
         <item name="collapsedTitleTextAppearance">
             @style/TextAppearance.Woo.CollapsingToolbar.Collapsed
         </item>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -17,6 +17,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="titleTextStyle">@style/TextAppearance.Woo.CollapsingToolbar.Collapsed</item>
         <item name="navigationIcon">@drawable/ic_back_24dp</item>
         <item name="android:theme">@style/Widget.Woo.Toolbar.Surface</item>
+        <item name="android:background">@color/color_surface_topbar</item>
     </style>
     <style name="Widget.Woo.Toolbar.Surface" parent="ThemeOverlay.MaterialComponents.Toolbar.Surface">
         <item name="actionMenuTextColor">@color/woo_pink_50</item>
@@ -33,6 +34,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
     </style>
     <style name="Woo.CollapsedToolbarLayout" parent="Widget.MaterialComponents.Toolbar.Surface">
         <item name="layout_scrollFlags">scroll|exitUntilCollapsed</item>
+        <item name="android:background">@color/color_surface_topbar</item>
         <item name="collapsedTitleTextAppearance">
             @style/TextAppearance.Woo.CollapsingToolbar.Collapsed
         </item>


### PR DESCRIPTION
Fixes #3704

## Changes

- Set the background color of the app bar/ Status bar / Collapsing bar on Dark mode to @color/woo_black_900 as per Figma
- Sets the Trash Product option Text color to woo_red_30

Notes on the other request for this issue:

- Products: Can we make sure the top right nav bar CTA (ie “Update”) of the product page is Pink 30? https://d.pr/i/vYpPmg

This was addressed [here](https://github.com/woocommerce/woocommerce-android/pull/4462) 

## Screenshots

Dark mode

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/135278969-9caa4069-776b-416d-9b39-86af1e4a53dd.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/135278907-ff009b5b-3778-44a5-88d4-075b317594f1.png" width="350"/> |
| <img src="https://user-images.githubusercontent.com/30724184/135279395-9a721729-ecbb-4311-8eec-bb80db756467.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/135279420-d313b7c2-403e-4fbb-b244-a8a8451f8562.png" width="350"/> |

Light Mode - no changes 

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/135279559-dbb10a7a-b70c-4176-b300-62f1569a5b26.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/135279578-421b5687-c3f0-4a1a-af63-c8fa2916fb10.png" width="350"/> |

Trash Product Menu Option

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/30724184/135284936-d7f0d24c-cb7d-439f-b85a-25e665229353.png" width="350"/> | <img src="https://user-images.githubusercontent.com/30724184/135284892-8e8cb9c6-cbe9-449b-a405-9872622bbc1b.png" width="350"/> |

## Testing Instructions

1 - Open the App
2 - Go to the top level screens
3 - On the orders screen select one of the orders

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
