### PR TITLE
Add a feature flag for Jetpack CP project

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -10,14 +10,18 @@ enum class FeatureFlag {
     ORDER_CREATION,
     ORDER_EDITING,
     CARD_READER,
-    WHATS_NEW;
+    WHATS_NEW,
+    JETPACK_CP;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
             DB_DOWNGRADE -> {
                 PackageUtils.isDebugBuild() || context != null && PackageUtils.isBetaBuild(context)
             }
-            ORDER_CREATION, ORDER_EDITING, WHATS_NEW -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
+            ORDER_CREATION,
+            ORDER_EDITING,
+            JETPACK_CP,
+            WHATS_NEW -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
             CARD_READER -> true // Keeping the flag for a few sprints so we can quickly disable the feature if needed
         }
     }


### PR DESCRIPTION
Closes: #4880

### Description
This just adds a new feature flag to be used during the development of Jetpack CP project.

Feel free to move to another milestone if this is not reviewed yet.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
