### PR TITLE
Hotfix: fix crash related to product images upload

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesNotificationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesNotificationHandler.kt
@@ -40,25 +40,24 @@ class ProductImagesNotificationHandler @Inject constructor(
     private val notificationManager =
         SystemServiceFactory.get(context, Context.NOTIFICATION_SERVICE) as NotificationManager
 
-    private lateinit var notificationBuilder: NotificationCompat.Builder
+    private val notificationBuilder: NotificationCompat.Builder
 
     init {
         createChannel()
-    }
-
-    fun attachToService(service: ProductImagesService) {
         notificationBuilder = NotificationCompat.Builder(
             context,
             CHANNEL_ID
-        ).also {
-            it.color = ContextCompat.getColor(context, R.color.woo_gray_40)
-            it.setSmallIcon(android.R.drawable.stat_sys_upload)
-            it.setOnlyAlertOnce(true)
-            it.setOngoing(true)
-            it.setProgress(0, 0, true)
-            it.setGroup(FOREGROUND_NOTIFICATION_ID.toString())
+        ).apply {
+            color = ContextCompat.getColor(context, R.color.woo_gray_40)
+            setSmallIcon(android.R.drawable.stat_sys_upload)
+            setOnlyAlertOnce(true)
+            setOngoing(true)
+            setProgress(0, 0, true)
+            setGroup(FOREGROUND_NOTIFICATION_ID.toString())
         }
+    }
 
+    fun attachToService(service: ProductImagesService) {
         val notification = notificationBuilder.build()
         service.startForeground(FOREGROUND_NOTIFICATION_ID, notification)
         notificationManager.notify(FOREGROUND_NOTIFICATION_ID, notification)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4916 

### Description
The cause of the crash is that `notificationBuilder` was initialized after the service creation, but since the service creation is async, sometimes we try to start image upload before it's done.
To fix this, I made `notificationBuilder` a regular val property, to make sure it's always initialized.

@jkmassel this is targeting the release branch, but IMO it doesn't warrant a release right now, it can wait for either another beta build, or the production release.

### Testing instructions
I couldn't reproduce the crash, it depends on the device's speed.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
