### PR TITLE
Issue/4110 media adapter illegal state

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
@@ -136,26 +136,11 @@ class WPMediaGalleryView @JvmOverloads constructor(
         private val imageList = mutableListOf<Product.Image>()
 
         fun showImages(images: List<Product.Image>) {
-            if (isSameImageList(images)) {
-                return
-            }
             val diffUtil = WPMediaLibraryDiffUtil(imageList, images)
             val diffResult = DiffUtil.calculateDiff(diffUtil, true)
             imageList.clear()
             imageList.addAll(images)
             diffResult.dispatchUpdatesTo(this)
-        }
-
-        private fun isSameImageList(images: List<Product.Image>): Boolean {
-            if (images.size != imageList.size) {
-                return false
-            }
-            for (index in images.indices) {
-                if (images[index].id != imageList[index].id) {
-                    return false
-                }
-            }
-            return true
         }
 
         fun getImage(position: Int) = imageList[position]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
@@ -204,14 +204,7 @@ class WPMediaGalleryView @JvmOverloads constructor(
             return null
         }
 
-        private fun getImagePositionById(imageId: Long): Int {
-            for (position in 0 until imageList.count()) {
-                if (imageList[position].id == imageId) {
-                    return position
-                }
-            }
-            return -1
-        }
+        private fun getImagePositionById(imageId: Long) = imageList.indexOfFirst { it.id == imageId }
 
         fun getSelectedImages(): ArrayList<Product.Image> {
             val images = ArrayList<Product.Image>()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
@@ -291,8 +291,9 @@ class WPMediaGalleryView @JvmOverloads constructor(
             bundle.putParcelable(KEY_RECYCLER_STATE, WCSavedState(super.onSaveInstanceState(), recyclerState))
         }
 
-        // save the selected images
-        bundle.putParcelableArrayList(KEY_SELECTED_IMAGES, getSelectedImages())
+        if (getSelectedCount() > 0) {
+            bundle.putParcelableArrayList(KEY_SELECTED_IMAGES, getSelectedImages())
+        }
         bundle.putBoolean(KEY_MULTI_SELECT_ALLOWED, isMultiSelectionAllowed)
 
         return bundle
@@ -306,9 +307,7 @@ class WPMediaGalleryView @JvmOverloads constructor(
 
         // restore the selected images
         (state as? Bundle)?.getParcelableArrayList<Product.Image>(KEY_SELECTED_IMAGES)?.let { images ->
-            if (images.isNotEmpty()) {
-                setSelectedImages(images)
-            }
+            setSelectedImages(images)
         }
 
         // restore multi-selection

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
@@ -131,6 +131,7 @@ class WPMediaGalleryView @JvmOverloads constructor(
             areItemsTheSame(oldItemPosition, newItemPosition)
     }
 
+    @Suppress("TooManyFunctions")
     private inner class WPMediaLibraryGalleryAdapter : RecyclerView.Adapter<WPMediaViewHolder>() {
         private val imageList = mutableListOf<Product.Image>()
 
@@ -209,7 +210,6 @@ class WPMediaGalleryView @JvmOverloads constructor(
                     return position
                 }
             }
-
             return -1
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
@@ -203,6 +203,16 @@ class WPMediaGalleryView @JvmOverloads constructor(
             return null
         }
 
+        private fun getImagePositionById(imageId: Long): Int {
+            for (position in 0 until imageList.count()) {
+                if (imageList[position].id == imageId) {
+                    return position
+                }
+            }
+
+            return -1
+        }
+
         fun getSelectedImages(): ArrayList<Product.Image> {
             val images = ArrayList<Product.Image>()
             for (imageId in selectedIds) {
@@ -214,16 +224,39 @@ class WPMediaGalleryView @JvmOverloads constructor(
         }
 
         fun setSelectedImages(images: ArrayList<Product.Image>) {
-            selectedIds.clear()
+            val newSelectedIds = HashSet<Long>()
 
             if (isMultiSelectionAllowed) {
                 for (image in images) {
-                    selectedIds.add(image.id)
+                    newSelectedIds.add(image.id)
                 }
             } else if (images.isNotEmpty()) {
-                selectedIds.add(images.first().id)
+                newSelectedIds.add(images.first().id)
             }
-            notifyDataSetChanged()
+
+            setSelectedImageIds(newSelectedIds)
+        }
+
+        private fun setSelectedImageIds(imageIds: HashSet<Long>) {
+            val addedIds = imageIds.filter { !selectedIds.contains(it) }
+            val removedIds = selectedIds.filter { !imageIds.contains(it) }
+
+            selectedIds.clear()
+            selectedIds.addAll(imageIds)
+
+            addedIds.forEach {
+                val position = getImagePositionById(it)
+                if (position > -1) {
+                    notifyItemChanged(position)
+                }
+            }
+
+            removedIds.forEach {
+                val position = getImagePositionById(it)
+                if (position > -1) {
+                    notifyItemChanged(position)
+                }
+            }
         }
 
         private fun setItemSelectedByPosition(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
@@ -289,7 +289,9 @@ class WPMediaGalleryView @JvmOverloads constructor(
 
         // restore the selected images
         (state as? Bundle)?.getParcelableArrayList<Product.Image>(KEY_SELECTED_IMAGES)?.let { images ->
-            setSelectedImages(images)
+            if (images.isNotEmpty()) {
+                setSelectedImages(images)
+            }
         }
 
         // restore multi-selection

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
@@ -276,7 +276,7 @@ class WPMediaGalleryView @JvmOverloads constructor(
 
             // redraw after the scale animation completes
             val delayMs: Long = Duration.SHORT.toMillis(context)
-            Handler().postDelayed({ notifyDataSetChanged() }, delayMs)
+            Handler().postDelayed({ notifyItemChanged(position) }, delayMs)
 
             // let the fragment know the count has changed
             listener.onSelectionCountChanged()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/wpmediapicker/WPMediaGalleryView.kt
@@ -53,7 +53,7 @@ class WPMediaGalleryView @JvmOverloads constructor(
 
     var isMultiSelectionAllowed: Boolean = true
     private var imageSize = 0
-    private val selectedIds = ArrayList<Long>()
+    private val selectedIds = HashSet<Long>()
 
     private val adapter: WPMediaLibraryGalleryAdapter
     private val layoutInflater: LayoutInflater


### PR DESCRIPTION
Potentially fixes #4110 - This was another instance of the "Cannot call this method while RecyclerView is computing a layout or scrolling" exception, which can occur when updating a recycler multiple times or relying too heavily on `notifyDataSetChanged` for simple updates.

I wasn't able to reproduce the crash, but I did optimize `WPMediaGalleryView` to rely on `notifyItemChanged` rather `notifyDataSetChanged`, and I would think these changes would solve the crash.