### PR TITLE
Create Order Editing Feature flag

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -8,6 +8,7 @@ import android.content.Context
 enum class FeatureFlag {
     DB_DOWNGRADE,
     ORDER_CREATION,
+    ORDER_EDITING,
     CARD_READER,
     WHATS_NEW;
 
@@ -16,7 +17,7 @@ enum class FeatureFlag {
             DB_DOWNGRADE -> {
                 PackageUtils.isDebugBuild() || context != null && PackageUtils.isBetaBuild(context)
             }
-            ORDER_CREATION, WHATS_NEW -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
+            ORDER_CREATION, ORDER_EDITING, WHATS_NEW -> PackageUtils.isDebugBuild() || PackageUtils.isTesting()
             CARD_READER -> true // Keeping the flag for a few sprints so we can quickly disable the feature if needed
         }
     }


### PR DESCRIPTION
Summary
==========
Fixes issue #4845 by simply creating the ORDER_EDITING feature flag option inside `FeatureFlag` to support all related feature development.

How to Test
==========
Nothing to test since the Flag is not in use right now.

Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
