### PR TITLE
Add AddonRepository proper mocking at OrderDetailViewModelTest

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -42,6 +42,7 @@ import com.woocommerce.android.ui.orders.details.OrderDetailViewModel
 import com.woocommerce.android.ui.orders.details.OrderDetailViewModel.OrderInfo
 import com.woocommerce.android.ui.orders.details.OrderDetailViewModel.OrderStatusUpdateSource
 import com.woocommerce.android.ui.orders.details.OrderDetailViewModel.ViewState
+import com.woocommerce.android.ui.products.addons.AddonRepository
 import com.woocommerce.android.util.ContinuationWrapper
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -81,6 +82,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     private val preferences = mock<SharedPreferences> { whenever(it.edit()).thenReturn(editor) }
     private val selectedSite: SelectedSite = mock()
     private val repository: OrderDetailRepository = mock()
+    private val addonsRepository: AddonRepository = mock()
     private val cardReaderManager: CardReaderManager = mock()
     private val resources: ResourceProvider = mock {
         on { getString(any()) } doAnswer { invocationOnMock -> invocationOnMock.arguments[0].toString() }
@@ -137,7 +139,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                 networkStatus,
                 resources,
                 repository,
-                mock(),
+                addonsRepository,
                 selectedSite,
                 paymentCollectibilityChecker
             )
@@ -176,6 +178,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         doReturn(emptyList<ShippingLabel>()).whenever(repository).getOrderShippingLabels(any())
         doReturn(emptyList<ShippingLabel>()).whenever(repository).fetchOrderShippingLabels(any())
+        doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
 
         var orderData: ViewState? = null
         viewModel.viewStateData.observeForever { _, new -> orderData = new }
@@ -239,6 +242,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(order).whenever(repository).getOrder(any())
             doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
 
             // WHEN
             viewModel.start()
@@ -255,6 +259,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(order).whenever(repository).getOrder(any())
             doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
 
             // WHEN
             viewModel.start()
@@ -321,6 +326,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(testOrderShipmentTrackings).whenever(repository).getOrderShipmentTrackings(any())
             doReturn(emptyList<ShippingLabel>()).whenever(repository).getOrderShippingLabels(any())
             doReturn(emptyList<ShippingLabel>()).whenever(repository).fetchOrderShippingLabels(any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
 
             viewModel.start()
 
@@ -360,6 +366,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(testOrderShipmentTrackings).whenever(repository).getOrderShipmentTrackings(any())
             doReturn(emptyList<ShippingLabel>()).whenever(repository).getOrderShippingLabels(any())
             doReturn(emptyList<ShippingLabel>()).whenever(repository).fetchOrderShippingLabels(any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
 
             viewModel.start()
 
@@ -416,6 +423,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(testOrderShipmentTrackings).whenever(repository).getOrderShipmentTrackings(any())
 
             doReturn(orderShippingLabels).whenever(repository).getOrderShippingLabels(any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
 
             val shippingLabels = ArrayList<ShippingLabel>()
             viewModel.shippingLabels.observeForever {
@@ -449,6 +457,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(testOrderShipmentTrackings).whenever(repository).getOrderShipmentTrackings(any())
 
             doReturn(orderShippingLabels).whenever(repository).getOrderShippingLabels(any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
 
             doReturn(
                 WooPlugin(
@@ -495,6 +504,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(testOrderShipmentTrackings).whenever(repository).getOrderShipmentTrackings(any())
 
             doReturn(emptyList<ShippingLabel>()).whenever(repository).getOrderShippingLabels(any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
 
             doReturn(
                 WooPlugin(
@@ -542,6 +552,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(testOrderShipmentTrackings).whenever(repository).getOrderShipmentTrackings(any())
 
             doReturn(orderShippingLabels).whenever(repository).getOrderShippingLabels(any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
 
             var orderData: ViewState? = null
             viewModel.viewStateData.observeForever { _, new -> orderData = new }
@@ -574,6 +585,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(testOrderShipmentTrackings).whenever(repository).getOrderShipmentTrackings(any())
 
             doReturn(emptyList<ShippingLabel>()).whenever(repository).getOrderShippingLabels(any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
 
             doReturn(
                 WooPlugin(
@@ -642,6 +654,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     fun `Do not fetch order from api when not connected`() = coroutinesTestRule.testDispatcher.runBlockingTest {
         doReturn(null).whenever(repository).getOrder(any())
         doReturn(false).whenever(networkStatus).isConnected()
+        doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
 
         var snackbar: ShowSnackbar? = null
         viewModel.event.observeForever {
@@ -675,6 +688,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         doReturn(emptyList<ShippingLabel>()).whenever(repository).getOrderShippingLabels(any())
         doReturn(emptyList<ShippingLabel>()).whenever(repository).fetchOrderShippingLabels(any())
+        doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
 
         var snackbar: ShowUndoSnackbar? = null
         viewModel.event.observeForever {
@@ -726,6 +740,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         doReturn(emptyList<ShippingLabel>()).whenever(repository).getOrderShippingLabels(any())
         doReturn(emptyList<ShippingLabel>()).whenever(repository).fetchOrderShippingLabels(any())
+        doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
 
         var newOrder: Order? = null
         viewModel.viewStateData.observeForever { old, new ->
@@ -788,6 +803,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         doReturn(emptyList<ShippingLabel>()).whenever(repository).getOrderShippingLabels(any())
         doReturn(emptyList<ShippingLabel>()).whenever(repository).fetchOrderShippingLabels(any())
+        doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
 
         var orderShipmentTrackings = emptyList<OrderShipmentTracking>()
         viewModel.shipmentTrackings.observeForever {
@@ -816,6 +832,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         doReturn(emptyList<ShippingLabel>()).whenever(repository).fetchOrderShippingLabels(any())
         doReturn(emptyList<Refund>()).whenever(repository).fetchOrderRefunds(any())
         doReturn(emptyList<Product>()).whenever(repository).fetchProductsByRemoteIds(any())
+        doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
 
         var isCreateShippingLabelButtonVisible: Boolean? = null
         viewModel.viewStateData.observeForever { _, new ->
@@ -841,6 +858,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(emptyList<ShippingLabel>()).whenever(repository).fetchOrderShippingLabels(any())
             doReturn(emptyList<Refund>()).whenever(repository).fetchOrderRefunds(any())
             doReturn(emptyList<Product>()).whenever(repository).fetchProductsByRemoteIds(any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
 
             var isCreateShippingLabelButtonVisible: Boolean? = null
             viewModel.viewStateData.observeForever { _, new ->
@@ -859,6 +877,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
             doReturn(order).whenever(repository).getOrder(any())
             doReturn(order).whenever(repository).fetchOrder(any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
 
             doReturn(
                 WooPlugin(
@@ -904,6 +923,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(emptyList<ShippingLabel>()).whenever(repository).fetchOrderShippingLabels(any())
             doReturn(emptyList<Refund>()).whenever(repository).fetchOrderRefunds(any())
             doReturn(emptyList<Product>()).whenever(repository).fetchProductsByRemoteIds(any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
 
             var isCreateShippingLabelButtonVisible: Boolean? = null
             viewModel.viewStateData.observeForever { _, new ->
@@ -922,6 +942,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         viewModel.start()
         val orderAfterPayment = order.copy(status = Status.fromDataModel(CoreOrderStatus.COMPLETED)!!)
         doReturn(orderAfterPayment).whenever(repository).getOrder(any())
+        doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
 
         viewModel.onCardReaderPaymentCompleted()
 
@@ -933,6 +954,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
             doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
             var snackbar: ShowUndoSnackbar? = null
             viewModel.event.observeForever {
                 if (it is ShowUndoSnackbar) snackbar = it
@@ -954,6 +976,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
             doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
             var snackbar: ShowUndoSnackbar? = null
             viewModel.event.observeForever {
                 if (it is ShowUndoSnackbar) snackbar = it
@@ -975,6 +998,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
             doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
             var snackbar: ShowUndoSnackbar? = null
             viewModel.event.observeForever {
                 if (it is ShowUndoSnackbar) snackbar = it
@@ -991,6 +1015,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
             doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
             doReturn(ContinuationWrapper.ContinuationResult.Success(false)).whenever(repository)
                 .updateOrderStatus(any(), any())
             var snackbar: ShowSnackbar? = null
@@ -1009,6 +1034,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
             doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
             doReturn(ContinuationWrapper.ContinuationResult.Cancellation<Boolean>(CancellationException())).whenever(
                 repository
             ).updateOrderStatus(any(), any())
@@ -1028,6 +1054,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         coroutinesTestRule.testDispatcher.runBlockingTest {
             doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(true).whenever(repository).fetchOrderNotes(any(), any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
             doReturn(ContinuationWrapper.ContinuationResult.Success<Boolean>(true)).whenever(repository)
                 .updateOrderStatus(any(), any())
             var snackbar: ShowSnackbar? = null
@@ -1049,6 +1076,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(false).whenever(repository).fetchOrderNotes(any(), any())
             doReturn("testing url")
                 .whenever(appPrefsWrapper).getReceiptUrl(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
             viewModel.start()
 
             viewModel.onSeeReceiptClicked()
@@ -1063,6 +1091,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(order).whenever(repository).getOrder(any())
             doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(false).whenever(repository).fetchOrderNotes(any(), any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
             whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.Connecting))
             viewModel.start()
 
@@ -1080,6 +1109,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(order).whenever(repository).getOrder(any())
             doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(false).whenever(repository).fetchOrderNotes(any(), any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
             whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.Connected(mock())))
             viewModel.start()
 
@@ -1097,6 +1127,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(order).whenever(repository).getOrder(any())
             doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(false).whenever(repository).fetchOrderNotes(any(), any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
             whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.NotConnected))
             viewModel.start()
 
@@ -1114,6 +1145,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(order).whenever(repository).getOrder(any())
             doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(false).whenever(repository).fetchOrderNotes(any(), any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
             whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.NotConnected))
             whenever(appPrefsWrapper.isCardReaderOnboardingCompleted(anyInt(), anyLong(), anyLong())).thenReturn(false)
             viewModel.start()
@@ -1133,6 +1165,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(order).whenever(repository).getOrder(any())
             doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(false).whenever(repository).fetchOrderNotes(any(), any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
             whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.Connected(mock())))
             viewModel.start()
 
@@ -1150,6 +1183,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(order).whenever(repository).getOrder(any())
             doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(false).whenever(repository).fetchOrderNotes(any(), any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
             whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.Connecting))
             viewModel.start()
 
@@ -1167,6 +1201,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(order).whenever(repository).getOrder(any())
             doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(false).whenever(repository).fetchOrderNotes(any(), any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
             whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.NotConnected))
             viewModel.start()
 
@@ -1184,6 +1219,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(order).whenever(repository).getOrder(any())
             doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(false).whenever(repository).fetchOrderNotes(any(), any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
             viewModel.start()
 
             // When
@@ -1201,6 +1237,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(order).whenever(repository).getOrder(any())
             doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(false).whenever(repository).fetchOrderNotes(any(), any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
             viewModel.start()
 
             // When
@@ -1218,6 +1255,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(order).whenever(repository).getOrder(any())
             doReturn(order).whenever(repository).fetchOrder(any())
             doReturn(false).whenever(repository).fetchOrderNotes(any(), any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
             viewModel.start()
 
             // When


### PR DESCRIPTION
Summary
==========
Fixes the large list of exceptions happening for each test under OrderDetailViewModelTest class because of an incomplete mock of `AddonRepository` used by the OrderDetailViewModel. 

The solution was to mock correctly the AddonRepository behavior for each test that triggers the `checkAddonAvailability` method. I considered adding that mocking to the `setUp` method, but since it's a suspend function, and not all tests need to mock the repository, so I dropped the idea.

Thanks @malinajirka for catching this.

How to Test
==========
Just run `OrderDetailViewModelTest` class and make sure no Exception is shown.


Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
