### PR TITLE
Update in person payments dialog designs

### DIFF
--- a/WooCommerce/src/main/res/layout/card_reader_connect_dialog.xml
+++ b/WooCommerce/src/main/res/layout/card_reader_connect_dialog.xml
@@ -9,7 +9,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="@dimen/payments_dialog_width"
         android:layout_height="@dimen/payments_dialog_height"
-        android:background="?attr/colorSurface"
+        android:background="@color/color_surface_elevated"
         android:gravity="center_horizontal"
         android:orientation="vertical"
         android:paddingTop="@dimen/major_200"

--- a/WooCommerce/src/main/res/layout/card_reader_payment_dialog.xml
+++ b/WooCommerce/src/main/res/layout/card_reader_payment_dialog.xml
@@ -20,6 +20,7 @@
             android:layout_marginHorizontal="@dimen/major_125"
             android:layout_marginTop="0dp"
             android:gravity="center_horizontal"
+            android:textColor="@color/color_on_surface_high"
             app:layout_constraintBottom_toTopOf="@id/amount_label"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/WooCommerce/src/main/res/layout/card_reader_payment_dialog.xml
+++ b/WooCommerce/src/main/res/layout/card_reader_payment_dialog.xml
@@ -8,7 +8,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="@dimen/payments_dialog_width"
         android:layout_height="@dimen/payments_dialog_height"
-        android:background="?attr/colorSurface"
+        android:background="@color/color_surface_elevated"
         android:paddingTop="@dimen/major_150"
         android:paddingBottom="@dimen/major_150">
 

--- a/WooCommerce/src/main/res/layout/card_reader_tutorial_dialog.xml
+++ b/WooCommerce/src/main/res/layout/card_reader_tutorial_dialog.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:background="?attr/colorSurface"
+    android:background="@color/color_surface_elevated"
     tools:context=".ui.prefs.cardreader.tutorial.CardReaderTutorialDialogFragment">
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/WooCommerce/src/main/res/layout/card_reader_update_dialog.xml
+++ b/WooCommerce/src/main/res/layout/card_reader_update_dialog.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:background="?attr/colorSurface"
+    android:background="@color/color_surface_elevated"
     android:keepScreenOn="true"
     android:minWidth="@dimen/floating_dialog_min_width"
     android:paddingHorizontal="@dimen/major_150"

--- a/WooCommerce/src/main/res/layout/card_reader_welcome_dialog.xml
+++ b/WooCommerce/src/main/res/layout/card_reader_welcome_dialog.xml
@@ -9,7 +9,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="@dimen/payments_welcome_dialog_width"
         android:layout_height="@dimen/payments_welcome_dialog_height"
-        android:background="?attr/colorSurface"
+        android:background="@color/color_surface_elevated"
         android:gravity="center_horizontal"
         android:orientation="vertical"
         android:paddingTop="@dimen/major_200"

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_tutorial_viewpager_item.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_tutorial_viewpager_item.xml
@@ -13,6 +13,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="center"
+        android:textColor="@color/color_on_surface_high"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -9,6 +9,7 @@
     <color name="color_secondary">@color/woo_pink_30</color>
     <color name="color_secondary_variant">@color/woo_pink_50</color>
     <color name="color_surface">@color/woo_black_90</color>
+    <color name="color_surface_elevated">@color/woo_black_80</color>
     <color name="color_error">@color/woo_red_30</color>
     <color name="color_alert">@color/woo_yellow_30</color>
 

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -10,6 +10,7 @@
     <color name="color_secondary_variant">@color/woo_pink_70</color>
     <color name="color_surface">@color/woo_white</color>
     <color name="color_surface_variant">@color/woo_gray_40</color>
+    <color name="color_surface_elevated">@color/woo_white</color>
     <color name="color_error">@color/woo_red_50</color>
     <color name="color_alert">@color/woo_yellow_50</color>
 

--- a/WooCommerce/src/main/res/values/wc_colors_base.xml
+++ b/WooCommerce/src/main/res/values/wc_colors_base.xml
@@ -53,4 +53,5 @@
     <color name="woo_black_90_alpha_060">#99121212</color>
     <color name="woo_black_90_alpha_087">#DE121212</color>
     <color name="woo_black_900">#272727</color>
+    <color name="woo_black_80">#363636</color>
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Updates header text color and dialog dark mode background color on all in person payments related dialogs.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- make sure the background and header color of all in person payments dialogs looks ok in both light and dark mode - connection flow, update software flow, payment flow.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
https://cloudup.com/i7W63cL9jEg

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
