### PR TITLE
Issue/4926 collapsing toolbar rtl

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -6,6 +6,8 @@ import android.content.Intent
 import android.content.res.Resources.Theme
 import android.net.Uri
 import android.os.Bundle
+import android.util.LayoutDirection
+import android.view.Gravity
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
@@ -16,6 +18,7 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.Toolbar
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
+import androidx.core.text.layoutDirection
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks
@@ -54,6 +57,7 @@ import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.login.LoginAnalyticsListener
 import org.wordpress.android.login.LoginMode
 import org.wordpress.android.util.NetworkUtils
+import java.util.*
 import javax.inject.Inject
 import kotlin.math.abs
 
@@ -177,6 +181,12 @@ class MainActivity :
         toolbar = binding.toolbar.toolbar
         setSupportActionBar(toolbar)
         toolbar.navigationIcon = null
+
+        // workaround for ensuring collapsing toolbar appears correct in RTL - note that Gravity.START doesn't work
+        if (Locale.getDefault().layoutDirection == LayoutDirection.RTL) {
+            binding.collapsingToolbar.collapsedTitleGravity = Gravity.RIGHT
+            binding.collapsingToolbar.expandedTitleGravity = Gravity.RIGHT
+        }
 
         presenter.takeView(this)
 

--- a/WooCommerce/src/main/res/layout/activity_main.xml
+++ b/WooCommerce/src/main/res/layout/activity_main.xml
@@ -35,6 +35,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:importantForAccessibility="yes"
+                    android:textAlignment="viewStart"
                     app:layout_collapseMode="parallax"
                     tools:text="Subtitle shop name"
                     tools:visibility="visible" />


### PR DESCRIPTION
Closes #4926 - This simple PR changes the collapsing toolbar so it appears correctly in RTL. I can't say I'm thrilled with the solution, but it's the only thing I could find that would work. If anyone has a better solution, I'm all ears!

![rtl](https://user-images.githubusercontent.com/3903757/135666604-bc79696d-48b2-41a3-921e-c8fbb8dd0379.png)

