### PR TITLE
Jetpack CP: support signing in to Jetpack CP sites using WPCom credentials

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -276,6 +276,7 @@ dependencies {
     implementation "androidx.activity:activity-ktx:1.3.1"
     implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-process:$lifecycleVersion"
 
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -186,6 +186,7 @@ dependencies {
 
     implementation ("$gradle.ext.loginFlowBinaryPath:$wordPressLoginVersion") {
         exclude group: "org.wordpress", module: "utils"
+        exclude group: "org.wordpress", module: "fluxc"
     }
 
     implementation("com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:$aztecVersion") {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -74,7 +74,7 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
 
     @Inject lateinit var prefs: AppPrefs
 
-    @AppCoroutineScope @Inject lateinit var appCoroutineScope: CoroutineScope
+    @Inject @AppCoroutineScope lateinit var appCoroutineScope: CoroutineScope
 
     private var connectionReceiverRegistered = false
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -2,13 +2,17 @@ package com.woocommerce.android
 
 import android.app.Application
 import android.content.Context
+import android.content.Intent
 import android.content.IntentFilter
 import android.net.ConnectivityManager
+import androidx.lifecycle.Lifecycle.State.STARTED
+import androidx.lifecycle.ProcessLifecycleOwner
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
+import com.woocommerce.android.di.AppCoroutineScope
 import com.woocommerce.android.network.ConnectionChangeReceiver
 import com.woocommerce.android.push.FCMRegistrationIntentService
 import com.woocommerce.android.push.WooNotificationBuilder
@@ -17,30 +21,27 @@ import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.RateLimitedTask
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.common.UserEligibilityFetcher
-import com.woocommerce.android.util.AppThemeUtils
-import com.woocommerce.android.util.ApplicationLifecycleMonitor
+import com.woocommerce.android.ui.main.MainActivity
+import com.woocommerce.android.util.*
 import com.woocommerce.android.util.ApplicationLifecycleMonitor.ApplicationLifecycleListener
-import com.woocommerce.android.util.PackageUtils
-import com.woocommerce.android.util.REGEX_API_JETPACK_TUNNEL_METHOD
-import com.woocommerce.android.util.REGEX_API_NUMERIC_PARAM
-import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
+import com.woocommerce.android.util.WooLog.T.DASHBOARD
 import com.woocommerce.android.util.crashlogging.UploadEncryptedLogs
 import com.woocommerce.android.util.encryptedlogging.ObserveEncryptedLogsUploadResult
 import com.woocommerce.android.widgets.AppRatingDialog
 import dagger.android.DispatchingAndroidInjector
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
-import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.generated.WCCoreActionBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.OnJetpackTimeoutError
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.SiteStore
-import org.wordpress.android.fluxc.store.SiteStore.FetchSitesPayload
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.utils.ErrorUtils.OnUnexpectedError
 import javax.inject.Inject
@@ -73,6 +74,8 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
 
     @Inject lateinit var prefs: AppPrefs
 
+    @AppCoroutineScope @Inject lateinit var appCoroutineScope: CoroutineScope
+
     private var connectionReceiverRegistered = false
 
     private lateinit var application: Application
@@ -83,7 +86,9 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
     private val updateSelectedSite: RateLimitedTask = object : RateLimitedTask(SECONDS_BETWEEN_SITE_UPDATE) {
         override fun run(): Boolean {
             selectedSite.getIfExists()?.let {
-                dispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(it))
+                appCoroutineScope.launch {
+                    wooCommerceStore.fetchWooCommerceSite(it)
+                }
                 dispatcher.dispatch(WCCoreActionBuilder.newFetchSiteSettingsAction(it))
                 dispatcher.dispatch(WCCoreActionBuilder.newFetchProductSettingsAction(it))
             }
@@ -146,7 +151,16 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
         if (networkStatus.isConnected() && accountStore.hasAccessToken()) {
             dispatcher.dispatch(AccountActionBuilder.newFetchAccountAction())
             dispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction())
-            dispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(FetchSitesPayload()))
+            appCoroutineScope.launch {
+                wooCommerceStore.fetchWooCommerceSites()
+                if (!selectedSite.exists() && ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(STARTED)) {
+                    // The previously selected site is not connected anymore, take the user to the site picker
+                    WooLog.i(DASHBOARD, "Selected site no longer exists, showing site picker")
+                    val intent = Intent(application, MainActivity::class.java)
+                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                    application.startActivity(intent)
+                }
+            }
 
             // Update the user info for the currently logged in user
             if (selectedSite.exists()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
@@ -27,7 +27,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus.PROCESSING
 import org.wordpress.android.fluxc.store.*
 import org.wordpress.android.fluxc.store.AccountStore.*
-import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.*
 import javax.inject.Inject
 
@@ -147,16 +146,6 @@ class MainPresenter @Inject constructor(
                     }
                 }
             }
-        }
-    }
-
-    @Suppress("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onSiteChanged(event: OnSiteChanged) {
-        if (!selectedSite.exists()) {
-            // handle the possibility that the user has been removed from the active site
-            WooLog.i(WooLog.T.DASHBOARD, "Selected site no longer exists, showing site picker")
-            mainView?.showSitePickerScreen()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
@@ -14,20 +14,19 @@ import com.woocommerce.android.tools.ProductImageMap.RequestFetchProductEvent
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SelectedSite.SelectedSiteChangedEvent
 import com.woocommerce.android.util.WooLog
+import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.action.WCOrderAction.*
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
-import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus.PROCESSING
 import org.wordpress.android.fluxc.store.*
 import org.wordpress.android.fluxc.store.AccountStore.*
-import org.wordpress.android.fluxc.store.SiteStore.FetchSitesPayload
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.*
 import javax.inject.Inject
@@ -46,7 +45,6 @@ class MainPresenter @Inject constructor(
 
     private var isHandlingMagicLink: Boolean = false
     private var pendingUnfilledOrderCountCheck: Boolean = false
-    private var isFetchingSitesAfterDowngrade = false
 
     override fun takeView(view: MainContract.View) {
         mainView = view
@@ -93,9 +91,12 @@ class MainPresenter @Inject constructor(
     }
 
     override fun fetchSitesAfterDowngrade() {
-        isFetchingSitesAfterDowngrade = true
         mainView?.showProgressDialog(R.string.loading_stores)
-        dispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(FetchSitesPayload()))
+        coroutineScope.launch {
+            wooCommerceStore.fetchWooCommerceSites()
+            mainView?.hideProgressDialog()
+            mainView?.updateSelectedSite()
+        }
     }
 
     override fun isUserEligible() = appPrefs.isUserEligible()
@@ -135,7 +136,16 @@ class MainPresenter @Inject constructor(
                 dispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction())
             } else if (event.causeOfChange == AccountAction.FETCH_SETTINGS) {
                 // The user's account settings have also been fetched and stored - now we can fetch the user's sites
-                dispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(FetchSitesPayload()))
+                coroutineScope.launch {
+                    val result = wooCommerceStore.fetchWooCommerceSites()
+                    if (result.isError) {
+                        // TODO: Notify the user of the problem
+                    } else {
+                        // Magic link login is now complete - notify the activity to set the selected site and proceed with loading UI
+                        mainView?.updateSelectedSite()
+                        isHandlingMagicLink = false
+                    }
+                }
             }
         }
     }
@@ -143,19 +153,7 @@ class MainPresenter @Inject constructor(
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onSiteChanged(event: OnSiteChanged) {
-        // if we were fetching sites due to a db downgrade, tell the main activity to update
-        if (isFetchingSitesAfterDowngrade) {
-            isFetchingSitesAfterDowngrade = false
-            mainView?.hideProgressDialog()
-            mainView?.updateSelectedSite()
-        } else if (event.isError) {
-            // TODO: Notify the user of the problem
-            isHandlingMagicLink = false
-        } else if (isHandlingMagicLink) {
-            // Magic link login is now complete - notify the activity to set the selected site and proceed with loading UI
-            mainView?.updateSelectedSite()
-            isHandlingMagicLink = false
-        } else if (!selectedSite.exists()) {
+        if (!selectedSite.exists()) {
             // handle the possibility that the user has been removed from the active site
             WooLog.i(WooLog.T.DASHBOARD, "Selected site no longer exists, showing site picker")
             mainView?.showSitePickerScreen()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -44,6 +44,7 @@ import com.woocommerce.android.ui.login.UnifiedLoginTracker.Step
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.sitepicker.SitePickerAdapter.OnSiteClickListener
 import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.widgets.CustomProgressDialog
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WooClickableSpan
@@ -295,11 +296,14 @@ class SitePickerActivity :
     }
 
     override fun showStoreList(wcSites: List<SiteModel>) {
+        val sites = wcSites.filter {
+            FeatureFlag.JETPACK_CP.isEnabled() || !it.isJetpackCPConnected
+        }
         hideProgressDialog()
         showUserInfo(centered = false)
 
         if (deferLoadingSitesIntoView) {
-            if (wcSites.isNotEmpty()) {
+            if (sites.isNotEmpty()) {
                 hasConnectedStores = true
 
                 // Make "show connected stores" visible to the user
@@ -348,7 +352,7 @@ class SitePickerActivity :
 
         binding.sitePickerRoot.visibility = View.VISIBLE
 
-        if (wcSites.isEmpty()) {
+        if (sites.isEmpty()) {
             showNoStoresView()
             return
         }
@@ -357,16 +361,16 @@ class SitePickerActivity :
         binding.siteListContainer.visibility = View.VISIBLE
 
         binding.siteListLabel.text = when {
-            wcSites.size == 1 -> getString(R.string.login_connected_store)
+            sites.size == 1 -> getString(R.string.login_connected_store)
             calledFromLogin -> getString(R.string.login_pick_store)
             else -> getString(R.string.site_picker_title)
         }
 
-        siteAdapter.siteList = wcSites
+        siteAdapter.siteList = sites
         siteAdapter.selectedSiteId = if (clickedSiteId > 0) {
             clickedSiteId
         } else {
-            selectedSite.getIfExists()?.siteId ?: wcSites[0].siteId
+            selectedSite.getIfExists()?.siteId ?: sites[0].siteId
         }
 
         with(binding.loginEpilogueButtonBar.buttonPrimary) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerActivity.kt
@@ -193,15 +193,7 @@ class SitePickerActivity :
                 loginSiteUrl = url
             }
 
-            // Signin M1: We still want the presenter to go out and fetch sites so we
-            // know whether or not to show the "view connected stores" button.
-            if (calledFromLogin) {
-                // Sites have already been fetched as part of the login process. Just load them
-                // from the db.
-                presenter.loadSites()
-            } else {
-                presenter.loadAndFetchSites()
-            }
+            presenter.loadAndFetchSites()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.sitepicker
 
-import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.ui.common.UserEligibilityFetcher
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
@@ -28,7 +27,6 @@ class SitePickerPresenter
     private val accountStore: AccountStore,
     private val siteStore: SiteStore,
     private val wooCommerceStore: WooCommerceStore,
-    private val appPrefs: AppPrefs,
     private val userEligibilityFetcher: UserEligibilityFetcher
 ) : SitePickerContract.Presenter {
     private var view: SitePickerContract.View? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
@@ -85,8 +85,15 @@ class SitePickerPresenter
     }
 
     override fun fetchUpdatedSiteFromAPI(site: SiteModel) {
-        view?.showSkeleton(true)
-        dispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(site))
+        coroutineScope.launch {
+            view?.showSkeleton(true)
+            val result = wooCommerceStore.fetchWooCommerceSite(site)
+            view?.showSkeleton(false)
+            if (result.isError) {
+                WooLog.e(T.LOGIN, "Site error [${result.error.type}] : ${result.error.message}")
+            }
+            loadSites()
+        }
     }
 
     override fun fetchUserRoleFromAPI(site: SiteModel) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerPresenter.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.sitepicker
 
 import com.woocommerce.android.ui.common.UserEligibilityFetcher
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import kotlinx.coroutines.Dispatchers
@@ -126,7 +127,9 @@ class SitePickerPresenter
     }
 
     override fun getSiteModelByUrl(url: String): SiteModel? =
-        SiteUtils.getSiteByMatchingUrl(siteStore, url)
+        SiteUtils.getSiteByMatchingUrl(siteStore, url)?.takeIf {
+            FeatureFlag.JETPACK_CP.isEnabled() || !it.isJetpackCPConnected
+        }
 
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2134-8fb74bab4381944885aad099423b08bf8177aa0b'
+    fluxCVersion = 'develop-acb1bbd3d65913a60c0cf6ba16de6dbc4537d3af'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '1.27.0'
+    fluxCVersion = '2134-8fb74bab4381944885aad099423b08bf8177aa0b'
     glideVersion = '4.12.0'
     testRunnerVersion = '1.0.1'
     espressoVersion = '3.3.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4856 

### Description
This PR includes changes from the FluxC's PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2134, and uses the new suspendable functions for fetching sites (check the other PR about those functions).

As we use a suspendable function now, I removed all the references to OnSiteChanged from the app.

### Testing instructions
#### Jetpack CP site connection
1. Create a new Jetpack CP site (you can use jurassic ninja for easier creation, then install WCPay and connect it to your WordPress.com account)
2. Make sure WooCommerce is installed in the site.
2. Open the app, and log in using your WordPress.com account.
3. Confirm that you can see the site in the site picker after login.

#### Non-regression tests
##### Non-WC site
1. You need a site without WooCommerce for this test.
2. Open the app, and use the URL for signing in.
3. When asked, log in using WordPress.com account.
4. In the site picker, confirm that you can see an error about WooCommerce's status.
5. Install/Activate WooCommerce on your site.
6. Click on Refresh.
7. Confirm that the login will continue successfully.

##### Site connected to a different account
1. Open the app, and use the site's URL for signing in.
2. When asked, use a different WordPress.com from the one connected to the site.
3. Confirm that you see an error about site not being connected.

##### Magiclink connection
Test and confirm magic link connection works as expected

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
