### PR TITLE
Issue/disable update button on low battery

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailFragment.kt
@@ -87,7 +87,7 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
                 when (state) {
                     is ConnectedState -> {
                         with(binding.readerConnectedState) {
-                            UiHelpers.setTextOrHide(enforcedUpdateTv, state.enforceReaderUpdate)
+                            UiHelpers.setTextOrHide(enforcedUpdateTv, state.notice)
                             enforcedUpdateDivider.visibility = enforcedUpdateTv.visibility
                             UiHelpers.setTextOrHide(readerNameTv, state.readerName)
                             UiHelpers.setTextOrHide(readerBatteryTv, state.readerBattery)
@@ -98,6 +98,8 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
                             secondaryActionBtn.setOnClickListener {
                                 state.secondaryButtonState?.onActionClicked?.invoke()
                             }
+                            primaryActionBtn.isEnabled = state.primaryButtonState?.enabled == true
+                            secondaryActionBtn.isEnabled = state.secondaryButtonState?.enabled == true
                             binding.readerConnectedState.enforcedUpdateTv.setDrawableColor(
                                 color.warning_banner_foreground_color
                             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailFragment.kt
@@ -87,8 +87,8 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
                 when (state) {
                     is ConnectedState -> {
                         with(binding.readerConnectedState) {
-                            UiHelpers.setTextOrHide(enforcedUpdateTv, state.notice)
-                            enforcedUpdateDivider.visibility = enforcedUpdateTv.visibility
+                            UiHelpers.setTextOrHide(noticeTv, state.notice)
+                            enforcedUpdateDivider.visibility = noticeTv.visibility
                             UiHelpers.setTextOrHide(readerNameTv, state.readerName)
                             UiHelpers.setTextOrHide(readerBatteryTv, state.readerBattery)
                             UiHelpers.setTextOrHide(readerFirmwareVersionTv, state.readerFirmwareVersion)
@@ -100,7 +100,7 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
                             }
                             primaryActionBtn.isEnabled = state.primaryButtonState?.enabled == true
                             secondaryActionBtn.isEnabled = state.secondaryButtonState?.enabled == true
-                            binding.readerConnectedState.enforcedUpdateTv.setDrawableColor(
+                            binding.readerConnectedState.noticeTv.setDrawableColor(
                                 color.warning_banner_foreground_color
                             )
                             with(cardReaderDetailLearnMoreTv.root) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt
@@ -82,7 +82,7 @@ class CardReaderDetailViewModel @Inject constructor(
     private fun showConnectedState(readerStatus: Connected, updateAvailable: Boolean = false) {
         val lowBattery = readerStatus.cardReader.currentBatteryLevel ?: 1f <= LOW_BATTERY_LEVEL_THRESHOLD
         viewState.value = if (updateAvailable) {
-            triggerEvent(CardReaderUpdateScreen(startedByUser = false))
+            if (!lowBattery) triggerEvent(CardReaderUpdateScreen(startedByUser = false))
             ConnectedState(
                 notice = UiStringRes(
                     if (lowBattery) R.string.card_reader_detail_connected_update_software_low_battery

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_detail_connected_state.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_detail_connected_state.xml
@@ -8,7 +8,7 @@
     android:paddingBottom="@dimen/major_100">
 
     <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/enforced_update_tv"
+        android:id="@+id/notice_tv"
         style="@style/Woo.TextView.Body2"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -829,6 +829,7 @@
     <string name="card_reader_detail_connected_firmware_version">Firmware: %s</string>
     <string name="card_reader_detail_connected_update_software">Update reader\'s software</string>
     <string name="card_reader_detail_connected_enforced_update_software">Please update your reader software to keep accepting payments</string>
+    <string name="card_reader_detail_connected_update_software_low_battery">An update is available, but your reader battery is too low to update. Please charge your reader right away to continue accepting payments</string>
     <string name="card_reader_detail_connected_disconnect_reader">Disconnect reader</string>
     <string name="card_reader_detail_connected_reader_unknown">UNKNOWN CARD READER\'s NAME</string>
     <string name="card_reader_detail_connected_update_check_failed">Software version update check has failed</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
@@ -79,14 +79,16 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
             // THEN
             verifyConnectedState(
-                viewModel,
-                UiStringText(READER_NAME),
-                UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("65"))),
-                UiStringRes(
+                viewModel = viewModel,
+                readerName = UiStringText(READER_NAME),
+                batteryLevel = UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("65"))),
+                firmwareVersion = UiStringRes(
                     R.string.card_reader_detail_connected_firmware_version,
                     listOf(UiStringText(DUMMY_FIRMWARE_VERSION_SIMPLIFIED))
                 ),
-                updateAvailable = false
+                notice = null,
+                primaryButtonText = UiStringRes(R.string.card_reader_detail_connected_disconnect_reader),
+                secondaryButtonText = null
             )
         }
 
@@ -101,14 +103,17 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
             // THEN
             verifyConnectedState(
-                viewModel,
-                UiStringText(READER_NAME),
+                viewModel = viewModel,
+                readerName = UiStringText(READER_NAME),
+                batteryLevel =
                 UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("33"))),
-                UiStringRes(
+                firmwareVersion = UiStringRes(
                     R.string.card_reader_detail_connected_firmware_version,
                     listOf(UiStringText(DUMMY_FIRMWARE_VERSION_SIMPLIFIED))
                 ),
-                updateAvailable = false
+                notice = null,
+                primaryButtonText = UiStringRes(R.string.card_reader_detail_connected_disconnect_reader),
+                secondaryButtonText = null
             )
         }
 
@@ -124,14 +129,16 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
             // THEN
             verifyConnectedState(
-                viewModel,
-                UiStringRes(R.string.card_reader_detail_connected_reader_unknown),
-                null,
-                UiStringRes(
+                viewModel = viewModel,
+                readerName = UiStringRes(R.string.card_reader_detail_connected_reader_unknown),
+                batteryLevel = null,
+                firmwareVersion = UiStringRes(
                     R.string.card_reader_detail_connected_firmware_version,
                     listOf(UiStringText(DUMMY_FIRMWARE_VERSION_SIMPLIFIED))
                 ),
-                updateAvailable = false
+                notice = null,
+                primaryButtonText = UiStringRes(R.string.card_reader_detail_connected_disconnect_reader),
+                secondaryButtonText = null
             )
         }
 
@@ -199,14 +206,17 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
             // THEN
             verifyConnectedState(
-                viewModel,
-                UiStringText(READER_NAME),
+                viewModel = viewModel,
+                readerName = UiStringText(READER_NAME),
+                batteryLevel =
                 UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("65"))),
-                UiStringRes(
+                firmwareVersion = UiStringRes(
                     R.string.card_reader_detail_connected_firmware_version,
                     listOf(UiStringText(DUMMY_FIRMWARE_VERSION_SIMPLIFIED))
                 ),
-                updateAvailable = true
+                notice = UiStringRes(R.string.card_reader_detail_connected_enforced_update_software),
+                primaryButtonText = UiStringRes(R.string.card_reader_detail_connected_update_software),
+                secondaryButtonText = UiStringRes(R.string.card_reader_detail_connected_disconnect_reader)
             )
         }
 
@@ -221,14 +231,17 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
             // THEN
             verifyConnectedState(
-                viewModel,
-                UiStringText(READER_NAME),
+                viewModel = viewModel,
+                readerName = UiStringText(READER_NAME),
+                batteryLevel =
                 UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("65"))),
-                UiStringRes(
+                firmwareVersion = UiStringRes(
                     R.string.card_reader_detail_connected_firmware_version,
                     listOf(UiStringText(DUMMY_FIRMWARE_VERSION_SIMPLIFIED))
                 ),
-                updateAvailable = false
+                notice = null,
+                primaryButtonText = UiStringRes(R.string.card_reader_detail_connected_disconnect_reader),
+                secondaryButtonText = null
             )
             assertThat(viewModel.event.value)
                 .isEqualTo(Event.ShowSnackbar(R.string.card_reader_detail_connected_update_check_failed))
@@ -271,14 +284,17 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
             // THEN
             verifyConnectedState(
-                viewModel,
-                UiStringText(READER_NAME),
+                viewModel = viewModel,
+                readerName = UiStringText(READER_NAME),
+                batteryLevel =
                 UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("65"))),
-                UiStringRes(
+                firmwareVersion = UiStringRes(
                     R.string.card_reader_detail_connected_firmware_version,
                     listOf(UiStringText(DUMMY_FIRMWARE_VERSION_SIMPLIFIED))
                 ),
-                updateAvailable = false
+                notice = null,
+                primaryButtonText = UiStringRes(R.string.card_reader_detail_connected_disconnect_reader),
+                secondaryButtonText = null
             )
         }
     }
@@ -295,14 +311,17 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
             // THEN
             verifyConnectedState(
-                viewModel,
-                UiStringText(READER_NAME),
+                viewModel = viewModel,
+                readerName = UiStringText(READER_NAME),
+                batteryLevel =
                 UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("65"))),
-                UiStringRes(
+                firmwareVersion = UiStringRes(
                     R.string.card_reader_detail_connected_firmware_version,
                     listOf(UiStringText(DUMMY_FIRMWARE_VERSION_SIMPLIFIED))
                 ),
-                updateAvailable = false
+                notice = null,
+                primaryButtonText = UiStringRes(R.string.card_reader_detail_connected_disconnect_reader),
+                secondaryButtonText = null
             )
         }
     }
@@ -321,14 +340,17 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
 
             // THEN
             verifyConnectedState(
-                viewModel,
-                UiStringText(READER_NAME),
+                viewModel = viewModel,
+                readerName = UiStringText(READER_NAME),
+                batteryLevel =
                 UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("65"))),
-                UiStringRes(
+                firmwareVersion = UiStringRes(
                     R.string.card_reader_detail_connected_firmware_version,
                     listOf(UiStringText(DUMMY_FIRMWARE_VERSION_SIMPLIFIED))
                 ),
-                updateAvailable = false
+                notice = null,
+                primaryButtonText = UiStringRes(R.string.card_reader_detail_connected_disconnect_reader),
+                secondaryButtonText = null
             )
             assertThat(events[0])
                 .isEqualTo(Event.ShowSnackbar(R.string.card_reader_detail_connected_update_success))
@@ -447,25 +469,17 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
         readerName: UiString,
         batteryLevel: UiString?,
         firmwareVersion: UiString,
-        updateAvailable: Boolean
+        notice: UiString?,
+        primaryButtonText: UiString,
+        secondaryButtonText: UiString?,
     ) {
         val state = viewModel.viewStateData.value as ConnectedState
         assertThat(state.readerName).isEqualTo(readerName)
         assertThat(state.readerBattery).isEqualTo(batteryLevel)
         assertThat(state.readerFirmwareVersion).isEqualTo(firmwareVersion)
-        if (updateAvailable) {
-            assertThat(state.enforceReaderUpdate)
-                .isEqualTo(UiStringRes(R.string.card_reader_detail_connected_enforced_update_software))
-            assertThat(state.primaryButtonState?.text)
-                .isEqualTo(UiStringRes(R.string.card_reader_detail_connected_update_software))
-            assertThat(state.secondaryButtonState?.text)
-                .isEqualTo(UiStringRes(R.string.card_reader_detail_connected_disconnect_reader))
-        } else {
-            assertThat(state.enforceReaderUpdate).isNull()
-            assertThat(state.primaryButtonState?.text)
-                .isEqualTo(UiStringRes(R.string.card_reader_detail_connected_disconnect_reader))
-            assertThat(state.secondaryButtonState?.text).isNull()
-        }
+        assertThat(state.notice).isEqualTo(notice)
+        assertThat(state.primaryButtonState?.text).isEqualTo(primaryButtonText)
+        assertThat(state.secondaryButtonState?.text).isEqualTo(secondaryButtonText)
     }
 
     private fun initConnectedState(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
@@ -88,7 +88,8 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
                 ),
                 notice = null,
                 primaryButtonText = UiStringRes(R.string.card_reader_detail_connected_disconnect_reader),
-                secondaryButtonText = null
+                secondaryButtonText = null,
+                primaryButtonEnabled = true
             )
         }
 
@@ -113,7 +114,8 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
                 ),
                 notice = null,
                 primaryButtonText = UiStringRes(R.string.card_reader_detail_connected_disconnect_reader),
-                secondaryButtonText = null
+                secondaryButtonText = null,
+                primaryButtonEnabled = true
             )
         }
 
@@ -138,7 +140,8 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
                 ),
                 notice = null,
                 primaryButtonText = UiStringRes(R.string.card_reader_detail_connected_disconnect_reader),
-                secondaryButtonText = null
+                secondaryButtonText = null,
+                primaryButtonEnabled = true
             )
         }
 
@@ -216,7 +219,8 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
                 ),
                 notice = UiStringRes(R.string.card_reader_detail_connected_enforced_update_software),
                 primaryButtonText = UiStringRes(R.string.card_reader_detail_connected_update_software),
-                secondaryButtonText = UiStringRes(R.string.card_reader_detail_connected_disconnect_reader)
+                secondaryButtonText = UiStringRes(R.string.card_reader_detail_connected_disconnect_reader),
+                primaryButtonEnabled = true
             )
         }
 
@@ -241,7 +245,8 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
                 ),
                 notice = null,
                 primaryButtonText = UiStringRes(R.string.card_reader_detail_connected_disconnect_reader),
-                secondaryButtonText = null
+                secondaryButtonText = null,
+                primaryButtonEnabled = true
             )
             assertThat(viewModel.event.value)
                 .isEqualTo(Event.ShowSnackbar(R.string.card_reader_detail_connected_update_check_failed))
@@ -294,7 +299,8 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
                 ),
                 notice = null,
                 primaryButtonText = UiStringRes(R.string.card_reader_detail_connected_disconnect_reader),
-                secondaryButtonText = null
+                secondaryButtonText = null,
+                primaryButtonEnabled = true
             )
         }
     }
@@ -321,7 +327,8 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
                 ),
                 notice = null,
                 primaryButtonText = UiStringRes(R.string.card_reader_detail_connected_disconnect_reader),
-                secondaryButtonText = null
+                secondaryButtonText = null,
+                primaryButtonEnabled = true
             )
         }
     }
@@ -350,7 +357,8 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
                 ),
                 notice = null,
                 primaryButtonText = UiStringRes(R.string.card_reader_detail_connected_disconnect_reader),
-                secondaryButtonText = null
+                secondaryButtonText = null,
+                primaryButtonEnabled = true
             )
             assertThat(events[0])
                 .isEqualTo(Event.ShowSnackbar(R.string.card_reader_detail_connected_update_success))
@@ -442,6 +450,64 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
             verify(tracker).track(AnalyticsTracker.Stat.CARD_READER_DISCONNECT_TAPPED)
         }
 
+    @Test
+    fun `given battery level low, when update available, then update button disabled and notice shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            initConnectedState(
+                updateAvailable = SoftwareUpdateAvailability.UpdateAvailable,
+                batteryLevel = 0.1f
+            )
+
+            // WHEN
+            val viewModel = createViewModel()
+
+            // THEN
+            verifyConnectedState(
+                viewModel = viewModel,
+                readerName = UiStringText(READER_NAME),
+                batteryLevel =
+                UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("10"))),
+                firmwareVersion = UiStringRes(
+                    R.string.card_reader_detail_connected_firmware_version,
+                    listOf(UiStringText(DUMMY_FIRMWARE_VERSION_SIMPLIFIED))
+                ),
+                notice = UiStringRes(R.string.card_reader_detail_connected_update_software_low_battery),
+                primaryButtonText = UiStringRes(R.string.card_reader_detail_connected_update_software),
+                secondaryButtonText = UiStringRes(R.string.card_reader_detail_connected_disconnect_reader),
+                primaryButtonEnabled = false
+            )
+        }
+
+    @Test
+    fun `given battery level NOT low, when update available, then update button enabled and notice not shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            initConnectedState(
+                updateAvailable = SoftwareUpdateAvailability.UpdateAvailable,
+                batteryLevel = 1.0f
+            )
+
+            // WHEN
+            val viewModel = createViewModel()
+
+            // THEN
+            verifyConnectedState(
+                viewModel = viewModel,
+                readerName = UiStringText(READER_NAME),
+                batteryLevel =
+                UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("100"))),
+                firmwareVersion = UiStringRes(
+                    R.string.card_reader_detail_connected_firmware_version,
+                    listOf(UiStringText(DUMMY_FIRMWARE_VERSION_SIMPLIFIED))
+                ),
+                notice = UiStringRes(R.string.card_reader_detail_connected_enforced_update_software),
+                primaryButtonText = UiStringRes(R.string.card_reader_detail_connected_update_software),
+                secondaryButtonText = UiStringRes(R.string.card_reader_detail_connected_disconnect_reader),
+                primaryButtonEnabled = true
+            )
+        }
+
     private fun verifyNotConnectedState(viewModel: CardReaderDetailViewModel) {
         val state = viewModel.viewStateData.value as NotConnectedState
         assertThat(state.headerLabel)
@@ -472,6 +538,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
         notice: UiString?,
         primaryButtonText: UiString,
         secondaryButtonText: UiString?,
+        primaryButtonEnabled: Boolean,
     ) {
         val state = viewModel.viewStateData.value as ConnectedState
         assertThat(state.readerName).isEqualTo(readerName)
@@ -480,6 +547,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
         assertThat(state.notice).isEqualTo(notice)
         assertThat(state.primaryButtonState?.text).isEqualTo(primaryButtonText)
         assertThat(state.secondaryButtonState?.text).isEqualTo(secondaryButtonText)
+        assertThat(state.primaryButtonState?.enabled).isEqualTo(primaryButtonEnabled)
     }
 
     private fun initConnectedState(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
@@ -81,7 +81,8 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
             verifyConnectedState(
                 viewModel = viewModel,
                 readerName = UiStringText(READER_NAME),
-                batteryLevel = UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("65"))),
+                batteryLevel =
+                UiStringRes(R.string.card_reader_detail_connected_battery_percentage, listOf(UiStringText("65"))),
                 firmwareVersion = UiStringRes(
                     R.string.card_reader_detail_connected_firmware_version,
                     listOf(UiStringText(DUMMY_FIRMWARE_VERSION_SIMPLIFIED))
@@ -542,6 +543,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
             .isEqualTo(UiStringRes(R.string.card_reader_details_not_connected_connect_button_label))
     }
 
+    @Suppress("LongParameterList")
     private fun verifyConnectedState(
         viewModel: CardReaderDetailViewModel,
         readerName: UiString,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModelTest.kt
@@ -253,7 +253,7 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when view model init with connected state and update available should send card reader update screen event`() =
+    fun `when update available should send card reader update screen event`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // GIVEN
             initConnectedState(updateAvailable = SoftwareUpdateAvailability.UpdateAvailable)
@@ -262,6 +262,18 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
             val viewModel = createViewModel()
 
             assertThat(viewModel.event.value).isEqualTo(CardReaderUpdateScreen(startedByUser = false))
+        }
+
+    @Test
+    fun `when update available and low battery should NOT send card reader update screen event`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            initConnectedState(updateAvailable = SoftwareUpdateAvailability.UpdateAvailable, batteryLevel = 0.1f)
+
+            // WHEN
+            val viewModel = createViewModel()
+
+            assertThat(viewModel.event.value).isNull()
         }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR mirrors changes made [on iOS](https://github.com/woocommerce/woocommerce-ios/pull/5133). The update card reader software button is disabled and a notice is shown when the battery level is below 50%. The Stripe Terminal SDK throws a handled exception when the app attempts to update software with a low battery.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Either use a card reader with battery below 0.5f and update available or change [this](https://github.com/woocommerce/woocommerce-android/blob/455e89657870bb036bf2307d0777c2d9a5ba6c60/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt#L43) to 1.0f and [this](https://github.com/woocommerce/woocommerce-android/blob/455e89657870bb036bf2307d0777c2d9a5ba6c60/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt#L145) to `showConnectedState(readerStatus, updateAvailable = true)`
2. Open App settings
3. Tap on In Person Payments
4. Tap on Manage Card Reader
5. Tap on Connect Card Reader
6. Turn on the card reader and connect to it
7. Notice "Update" dialog is not shown, the update button is disabled and a notice is shown
------
1. Make sure you card reader is charged and update is available or change [this](https://github.com/woocommerce/woocommerce-android/blob/455e89657870bb036bf2307d0777c2d9a5ba6c60/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt#L43) to 0.0f and [this](https://github.com/woocommerce/woocommerce-android/blob/455e89657870bb036bf2307d0777c2d9a5ba6c60/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/detail/CardReaderDetailViewModel.kt#L145) to `showConnectedState(readerStatus, updateAvailable = true)`
2. Open App settings
3. Tap on In Person Payments
4. Tap on Manage Card Reader
5. Tap on Connect Card Reader
6. Turn on the card reader and connect to it
7. Notice "Update" dialog is shown, the update button is enabled and a notice is not shown

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->

cc @jkmassel This PR is targeting the release branch and contains changes in strings.xml. The feature is enabled only in the US so I think translating the string is not vital.