### PR TITLE
Issue/4878 Error handling for location fetching

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectDialogFragment.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.cardreader.CardReaderManager
@@ -224,6 +225,10 @@ class CardReaderConnectDialogFragment : DialogFragment(R.layout.card_reader_conn
                 }
                 is CardReaderConnectViewModel.CardReaderConnectEvent.ShowToast ->
                     ToastUtils.showToast(requireContext(), getString(event.message))
+                is CardReaderConnectViewModel.CardReaderConnectEvent.OpenWebView ->
+                    findNavController().navigate(
+                        NavGraphMainDirections.actionGlobalWPComWebViewFragment(urlToLoad = event.url)
+                    )
                 else -> event.isHandled = false
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -40,6 +40,7 @@ import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectView
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.ConnectingFailedState
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.ConnectingState
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.LocationDisabledError
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.MissingMerchantAddressError
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.MissingPermissionsError
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.MultipleReadersFoundState
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.ReaderFoundState
@@ -337,7 +338,14 @@ class CardReaderConnectViewModel @Inject constructor(
                         doConnectWithLocationId(cardReader, result.locationId)
                     }
                     is CardReaderLocationRepository.LocationIdFetchingResult.Error.MissingAddress -> {
-                        
+                        viewState.value = MissingMerchantAddressError(
+                            {
+                                triggerEvent(CardReaderConnectEvent.OpenWebView(result.url))
+                            },
+                            {
+                                onCancelClicked()
+                            }
+                        )
                     }
                     CardReaderLocationRepository.LocationIdFetchingResult.Error.Other -> {
                         // todo cardreader Tracking
@@ -441,6 +449,8 @@ class CardReaderConnectViewModel @Inject constructor(
         object NavigateToOnboardingFlow : CardReaderConnectEvent()
 
         data class ShowToast(@StringRes val message: Int) : CardReaderConnectEvent()
+
+        data class OpenWebView(val url: String) : CardReaderConnectEvent()
     }
 
     @Suppress("LongParameterList")
@@ -546,6 +556,17 @@ class CardReaderConnectViewModel @Inject constructor(
             headerLabel = UiStringRes(R.string.card_reader_connect_bluetooth_disabled_header),
             illustration = R.drawable.img_products_error,
             primaryActionLabel = R.string.card_reader_connect_open_bluetooth_settings,
+            secondaryActionLabel = R.string.cancel,
+            illustrationTopMargin = R.dimen.major_150
+        )
+
+        data class MissingMerchantAddressError(
+            override val onPrimaryActionClicked: () -> Unit,
+            override val onSecondaryActionClicked: () -> Unit
+        ) : ViewState(
+            headerLabel = UiStringRes(R.string.card_reader_connect_missing_address),
+            illustration = R.drawable.img_products_error,
+            primaryActionLabel = R.string.card_reader_connect_missing_address_button,
             secondaryActionLabel = R.string.cancel,
             illustrationTopMargin = R.dimen.major_150
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -348,7 +348,7 @@ class CardReaderConnectViewModel @Inject constructor(
                         )
                     }
                     CardReaderLocationRepository.LocationIdFetchingResult.Error.Other -> {
-                        // todo cardreader Tracking
+                        // todo cardreader Tracking?
                         onReaderConnectionFailed()
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModel.kt
@@ -337,11 +337,11 @@ class CardReaderConnectViewModel @Inject constructor(
         launch {
             val cardReaderLocationId = cardReader.locationId
             if (cardReaderLocationId != null) {
-                cardReaderManager.startConnectionToReader(cardReader, locationId)
+                cardReaderManager.startConnectionToReader(cardReader, cardReaderLocationId)
             } else {
                 when (val result = locationRepository.getDefaultLocationId()) {
                     is CardReaderLocationRepository.LocationIdFetchingResult.Success -> {
-                        cardReaderManager.startConnectionToReader(cardReader, locationId)
+                        cardReaderManager.startConnectionToReader(cardReader, result.locationId)
                     }
                     is CardReaderLocationRepository.LocationIdFetchingResult.Error.MissingAddress -> {
                         viewState.value = MissingMerchantAddressError(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderLocationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderLocationRepository.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.prefs.cardreader.connect
 
 import com.woocommerce.android.tools.SelectedSite
+import org.wordpress.android.fluxc.model.pay.WCTerminalStoreLocationErrorType
 import org.wordpress.android.fluxc.store.WCPayStore
 import javax.inject.Inject
 
@@ -8,14 +9,27 @@ class CardReaderLocationRepository @Inject constructor(
     private val wcPayStore: WCPayStore,
     private val selectedSite: SelectedSite
 ) {
-    suspend fun getDefaultLocationId(): String? {
-        val selectedSite = selectedSite.getIfExists() ?: return null
+    suspend fun getDefaultLocationId(): LocationIdFetchingResult {
+        val selectedSite = selectedSite.getIfExists() ?: return LocationIdFetchingResult.Error.Other
         val result = wcPayStore.getStoreLocationForSite(selectedSite)
         return if (result.isError) {
-            // TODO cardreader handle the error
-            null
+            when (val type = result.error?.type) {
+                is WCTerminalStoreLocationErrorType.MissingAddress -> {
+                    LocationIdFetchingResult.Error.MissingAddress(type.addressEditingUrl)
+                }
+                else -> LocationIdFetchingResult.Error.Other
+            }
         } else {
-            result.locationId!!
+            LocationIdFetchingResult.Success(result.locationId!!)
         }
+    }
+
+    sealed class LocationIdFetchingResult {
+        sealed class Error : LocationIdFetchingResult() {
+            data class MissingAddress(val url: String?) : Error()
+            object Other : Error()
+        }
+
+        data class Success(val locationId: String) : LocationIdFetchingResult()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderLocationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderLocationRepository.kt
@@ -26,7 +26,7 @@ class CardReaderLocationRepository @Inject constructor(
 
     sealed class LocationIdFetchingResult {
         sealed class Error : LocationIdFetchingResult() {
-            data class MissingAddress(val url: String?) : Error()
+            data class MissingAddress(val url: String) : Error()
             object Other : Error()
         }
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph_settings"
     app:startDestination="@id/mainSettingsFragment">
 
@@ -174,4 +175,19 @@
         android:id="@+id/featureAnnouncementDialogFragment"
         android:name="com.woocommerce.android.ui.whatsnew.FeatureAnnouncementDialogFragment"
         android:label="FeatureAnnouncementDialogFragment" />
+    <fragment
+        android:id="@+id/WPComWebViewFragment"
+        android:name="com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment"
+        android:label="WPComWebViewFragment"
+        tools:layout="@layout/fragment_wpcom_webview">
+        <argument
+            android:name="urlToLoad"
+            app:argType="string" />
+        <argument
+            android:name="urlToTriggerExit"
+            app:argType="string"
+            app:nullable="true"
+            android:defaultValue="@null"/>
+    </fragment>
+    <action android:id="@+id/action_global_WPComWebViewFragment" app:destination="@id/WPComWebViewFragment"/>
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -807,7 +807,7 @@
     <string name="card_reader_connect_connecting_hint" translatable="false">@string/please_wait</string>
     <string name="card_reader_connect_failed_header">We couldn\’t connect your reader</string>
     <string name="card_reader_connect_missing_address">Please provide your store address in order to proceed</string>
-    <string name="card_reader_connect_missing_address_button">Proceed</string>
+    <string name="card_reader_connect_missing_address_button">Enter address</string>
     <string name="card_reader_connect_scanning_failed_header">No reader connected</string>
     <string name="card_reader_connect_connecting_failed_hint">We couldn\'t connect to the reader.</string>
     <string name="card_reader_connect_missing_permissions_header">Missing required location permission</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -908,30 +908,6 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when app in missing address failed state, then correct labels and illustrations shown`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            init(scanState = READER_FOUND, connectingSucceeds = false)
-            val url = "https://wordpress.com"
-            whenever(locationRepository.getDefaultLocationId()).thenReturn(
-                CardReaderLocationRepository.LocationIdFetchingResult.Error.MissingAddress(url)
-            )
-
-            (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
-
-            assertThat(viewModel.viewStateData.value).isInstanceOf(MissingMerchantAddressError::class.java)
-            assertThat(viewModel.viewStateData.value!!.headerLabel)
-                .isEqualTo(UiStringRes(R.string.card_reader_connect_missing_address))
-            assertThat(viewModel.viewStateData.value!!.primaryActionLabel)
-                .isEqualTo(R.string.card_reader_connect_missing_address_button)
-            assertThat(viewModel.viewStateData.value!!.secondaryActionLabel)
-                .isEqualTo(R.string.cancel)
-            assertThat(viewModel.viewStateData.value!!.illustration)
-                .isEqualTo(R.drawable.img_products_error)
-            assertThat(viewModel.viewStateData.value!!.illustrationTopMargin)
-                .isEqualTo(R.dimen.major_150)
-        }
-
-    @Test
     fun `when app in missing location permissions state, then correct labels and illustrations shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             (viewModel.event.value as CheckLocationPermissions).onPermissionsCheckResult(false)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -519,7 +519,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
             (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
 
-            verify(cardReaderManager, never()).connectToReader(reader, locationId)
+            verify(cardReaderManager, never()).startConnectionToReader(reader, locationId)
             assertThat(viewModel.viewStateData.value).isInstanceOf(ConnectingFailedState::class.java)
         }
 
@@ -533,7 +533,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
             (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
 
-            verify(cardReaderManager, never()).connectToReader(reader, locationId)
+            verify(cardReaderManager, never()).startConnectionToReader(reader, locationId)
             assertThat(viewModel.viewStateData.value).isInstanceOf(MissingMerchantAddressError::class.java)
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectView
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ListItemViewState.ScanningInProgressListItem
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.BluetoothDisabledError
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.ConnectingFailedState
+import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.MissingMerchantAddressError
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.ConnectingState
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.LocationDisabledError
 import com.woocommerce.android.ui.prefs.cardreader.connect.CardReaderConnectViewModel.ViewState.MissingPermissionsError
@@ -58,6 +59,7 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
@@ -505,6 +507,34 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given location fetching fails, when user clicks on connect to reader button, then show error state`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            init()
+            whenever(locationRepository.getDefaultLocationId()).thenReturn(
+                CardReaderLocationRepository.LocationIdFetchingResult.Error.Other
+            )
+
+            (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
+
+            verify(cardReaderManager, never()).connectToReader(reader, locationId)
+            assertThat(viewModel.viewStateData.value).isInstanceOf(ConnectingFailedState::class.java)
+        }
+
+    @Test
+    fun `given location fetching fails address, when user clicks on connect button, then show address error state`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            init()
+            whenever(locationRepository.getDefaultLocationId()).thenReturn(
+                CardReaderLocationRepository.LocationIdFetchingResult.Error.MissingAddress("")
+            )
+
+            (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
+
+            verify(cardReaderManager, never()).connectToReader(reader, locationId)
+            assertThat(viewModel.viewStateData.value).isInstanceOf(MissingMerchantAddressError::class.java)
+        }
+
+    @Test
     fun `when user clicks on connect to reader button, then app starts connecting to reader`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             init()
@@ -851,6 +881,30 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `when app in missing address failed state, then correct labels and illustrations shown`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            init(scanState = READER_FOUND, connectingSucceeds = false)
+            val url = "https://wordpress.com"
+            whenever(locationRepository.getDefaultLocationId()).thenReturn(
+                CardReaderLocationRepository.LocationIdFetchingResult.Error.MissingAddress(url)
+            )
+
+            (viewModel.viewStateData.value as ReaderFoundState).onPrimaryActionClicked.invoke()
+
+            assertThat(viewModel.viewStateData.value).isInstanceOf(MissingMerchantAddressError::class.java)
+            assertThat(viewModel.viewStateData.value!!.headerLabel)
+                .isEqualTo(UiStringRes(R.string.card_reader_connect_missing_address))
+            assertThat(viewModel.viewStateData.value!!.primaryActionLabel)
+                .isEqualTo(R.string.card_reader_connect_missing_address_button)
+            assertThat(viewModel.viewStateData.value!!.secondaryActionLabel)
+                .isEqualTo(R.string.cancel)
+            assertThat(viewModel.viewStateData.value!!.illustration)
+                .isEqualTo(R.drawable.img_products_error)
+            assertThat(viewModel.viewStateData.value!!.illustrationTopMargin)
+                .isEqualTo(R.dimen.major_150)
+        }
+
+    @Test
     fun `when app in missing location permissions state, then correct labels and illustrations shown`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             (viewModel.event.value as CheckLocationPermissions).onPermissionsCheckResult(false)
@@ -997,7 +1051,9 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
                 }
             }
         }
-        whenever(locationRepository.getDefaultLocationId()).thenReturn(locationId)
+        whenever(locationRepository.getDefaultLocationId()).thenReturn(
+            CardReaderLocationRepository.LocationIdFetchingResult.Success(locationId)
+        )
         whenever(cardReaderManager.connectToReader(reader, locationId)).thenReturn(connectingSucceeds)
         whenever(cardReaderManager.connectToReader(reader2, locationId)).thenReturn(connectingSucceeds)
         (viewModel.event.value as CheckLocationPermissions).onPermissionsCheckResult(true)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderLocationRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/cardreader/connect/CardReaderLocationRepositoryTest.kt
@@ -9,6 +9,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.pay.WCTerminalStoreLocationError
+import org.wordpress.android.fluxc.model.pay.WCTerminalStoreLocationErrorType
 import org.wordpress.android.fluxc.model.pay.WCTerminalStoreLocationResult
 import org.wordpress.android.fluxc.store.WCPayStore
 
@@ -38,11 +39,11 @@ class CardReaderLocationRepositoryTest : BaseUnitTest() {
             val result = repository.getDefaultLocationId()
 
             // THEN
-            assertThat(result).isEqualTo(locationId)
+            assertThat(result).isEqualTo(CardReaderLocationRepository.LocationIdFetchingResult.Success(locationId))
         }
 
     @Test
-    fun `given store returns error, when get default location, then null returned`() =
+    fun `given store returns generic error, when get default location, then other error returned`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             // GIVEN
             whenever(wcPayStore.getStoreLocationForSite(any())).thenReturn(
@@ -55,6 +56,26 @@ class CardReaderLocationRepositoryTest : BaseUnitTest() {
             val result = repository.getDefaultLocationId()
 
             // THEN
-            assertThat(result).isNull()
+            assertThat(result).isEqualTo(CardReaderLocationRepository.LocationIdFetchingResult.Error.Other)
+        }
+
+    @Test
+    fun `given store returns missing address error, when get default location, then missing address error returned`() =
+        coroutinesTestRule.testDispatcher.runBlockingTest {
+            // GIVEN
+            val url = "https://wordpress.com"
+            whenever(wcPayStore.getStoreLocationForSite(any())).thenReturn(
+                WCTerminalStoreLocationResult(
+                    WCTerminalStoreLocationError(WCTerminalStoreLocationErrorType.MissingAddress(url)),
+                )
+            )
+
+            // WHEN
+            val result = repository.getDefaultLocationId()
+
+            // THEN
+            assertThat(result).isEqualTo(
+                CardReaderLocationRepository.LocationIdFetchingResult.Error.MissingAddress(url)
+            )
         }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4878 

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds handling of the errors for location fetching endpoint. When a merchant doesn't have an address set in WC Pay, then the backend returns a specific error. We show a screen with an explanation and a button that opens a web view on the settings page where a merchant can set an address.

Other errors were handled in a generic way - we should that we couldn't connect to a reader

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

** Missing address**
1. Remove WC pay address via wp-admin
2. Adjust `CardReaderConnectViewModel::connectToReader:332` to `val cardReaderLocationId = if (cardReader.locationId != null) null else cardReader.locationId` (this way we always featch a location id from the backend)
3. Try to connect to a reader
4. Notice specific dialog 
5. Notice that web view opens and you can change the address

**Generic error**
1. Do 2 from the previous list
2. Try to connect to a reader a disable internet
3. Notice error dialog

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
