### PR TITLE
Remove tabs from order list and have a unique list with all orders by default

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -151,7 +151,7 @@ class OrderListFragment :
         } else if (isSearching) {
             searchHandler.postDelayed({ searchView?.setQuery(searchQuery, true) }, 100)
         } else {
-            viewModel.loadAllList()
+            viewModel.loadAllOrders()
         }
     }
 
@@ -230,7 +230,7 @@ class OrderListFragment :
 
     @Suppress("LongMethod")
     private fun initializeViewModel() {
-        viewModel.initializeListsForMainTabs()
+        viewModel.initializeOrderList()
 
         // populate views with any existing viewModel data
         viewModel.orderStatusOptions.value?.let { options ->
@@ -432,7 +432,7 @@ class OrderListFragment :
             clearSearchResults()
             searchMenuItem?.isVisible = true
         }
-        viewModel.loadAllList()
+        viewModel.loadAllOrders()
         onSearchViewActiveChanged(isActive = false)
         return true
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.list
 
 import android.os.Bundle
 import android.os.Handler
+import android.os.Looper
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
@@ -81,7 +82,7 @@ class OrderListFragment :
     private var orderListMenu: Menu? = null
     private var searchMenuItem: MenuItem? = null
     private var searchView: SearchView? = null
-    private val searchHandler = Handler()
+    private val searchHandler = Handler(Looper.getMainLooper())
 
     private var _binding: FragmentOrderListBinding? = null
     private val binding get() = _binding!!

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -11,7 +11,6 @@ import android.widget.EditText
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.SearchView.OnQueryTextListener
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
 import androidx.paging.PagedList
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.AppUrls
@@ -247,14 +246,14 @@ class OrderListFragment :
         // setup observers
         viewModel.isFetchingFirstPage.observe(
             viewLifecycleOwner,
-            Observer {
+            {
                 binding.orderRefreshLayout.isRefreshing = it == true
             }
         )
 
         viewModel.isLoadingMore.observe(
             viewLifecycleOwner,
-            Observer {
+            {
                 it?.let { isLoadingMore ->
                     binding.orderListView.setLoadingMoreIndicator(active = isLoadingMore)
                 }
@@ -263,7 +262,7 @@ class OrderListFragment :
 
         viewModel.orderStatusOptions.observe(
             viewLifecycleOwner,
-            Observer {
+            {
                 it?.let { options ->
                     // So the order status can be matched to the appropriate label
                     binding.orderListView.setOrderStatusOptions(options)
@@ -275,14 +274,14 @@ class OrderListFragment :
 
         viewModel.pagedListData.observe(
             viewLifecycleOwner,
-            Observer {
+            {
                 updatePagedListData(it)
             }
         )
 
         viewModel.event.observe(
             viewLifecycleOwner,
-            Observer { event ->
+            { event ->
                 when (event) {
                     is ShowErrorSnack -> {
                         uiMessageResolver.showSnack(event.messageRes)
@@ -295,7 +294,7 @@ class OrderListFragment :
 
         viewModel.emptyViewType.observe(
             viewLifecycleOwner,
-            Observer {
+            {
                 it?.let { emptyViewType ->
                     when (emptyViewType) {
                         EmptyViewType.SEARCH_RESULTS -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -13,7 +13,6 @@ import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.SearchView.OnQueryTextListener
 import androidx.fragment.app.viewModels
 import androidx.paging.PagedList
-import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -32,7 +31,6 @@ import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus.PROCESSING
 import org.wordpress.android.login.util.getColorFromAttribute
 import org.wordpress.android.util.DisplayUtils
 import javax.inject.Inject
@@ -53,8 +51,6 @@ class OrderListFragment :
         const val STATE_KEY_IS_FILTER_ENABLED = "is_filter_enabled"
 
         private const val SEARCH_TYPING_DELAY_MS = 500L
-        private const val TAB_INDEX_PROCESSING = 0
-        private const val TAB_INDEX_ALL = 1
     }
 
     @Inject internal lateinit var uiMessageResolver: UIMessageResolver
@@ -389,33 +385,6 @@ class OrderListFragment :
 
             updateActivityTitle()
             searchMenuItem?.isVisible = shouldShowSearchMenuItem()
-        }
-    }
-
-    /**
-     * Calculates the default tab position to display using the following logic:
-     * - If no orders for selected store -> "All Orders" tab
-     * - If no orders to process -> "All Orders" tab
-     * - The last tab the user viewed (saved in SharedPrefs)
-     * - Else the "Processing" tab (default)
-     *
-     * @return the index of the tab to be activated
-     */
-    private fun calculateStartupTabPosition(): Int {
-        val orderStatusOptions = getOrderStatusOptions()
-        return if (orderStatusFilter == PROCESSING.value) {
-            TAB_INDEX_PROCESSING
-        } else if (AppPrefs.hasSelectedOrderListTabPosition()) {
-            // If the user has already changed tabs once then select
-            // the last tab they had selected.
-            AppPrefs.getSelectedOrderListTabPosition()
-        } else if (orderStatusOptions.isEmpty() || orderStatusOptions[PROCESSING.value]?.statusCount == 0) {
-            // There are no "processing" orders to display, show all.
-            TAB_INDEX_ALL
-        } else {
-            // Default to the "processing" tab if there are orders to
-            // process.
-            TAB_INDEX_PROCESSING
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -1,19 +1,11 @@
 package com.woocommerce.android.ui.orders
 
 import androidx.lifecycle.SavedStateHandle
-import org.mockito.kotlin.any
-import org.mockito.kotlin.clearInvocations
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.reset
-import org.mockito.kotlin.times
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.NotificationReceivedEvent
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.RequestResult
 import com.woocommerce.android.push.NotificationChannelType
-import com.woocommerce.android.extensions.NotificationReceivedEvent
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.list.OrderListItemIdentifier
@@ -38,6 +30,14 @@ import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.clearInvocations
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
@@ -135,75 +135,37 @@ class OrderListViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `load orders for ALL tab activates list wrapper`() = coroutinesTestRule.testDispatcher.runBlockingTest {
+    fun `load all orders activates list wrapper`() = coroutinesTestRule.testDispatcher.runBlockingTest {
         doReturn(RequestResult.SUCCESS).whenever(repository).fetchOrderStatusOptionsFromApi()
         doReturn(orderStatusOptions).whenever(repository).getCachedOrderStatusOptions()
         doReturn(RequestResult.SUCCESS).whenever(repository).fetchPaymentGateways()
 
-        viewModel.initializeListsForMainTabs()
-        viewModel.loadAllList()
+        viewModel.initializeOrderList()
+        viewModel.loadAllOrders()
 
         assertNotNull(viewModel.allPagedListWrapper)
         assertNotNull(viewModel.activePagedListWrapper)
-        verify(viewModel.allPagedListWrapper, times(2))?.fetchFirstPage()
+        verify(viewModel.allPagedListWrapper, times(1))?.fetchFirstPage()
         verify(viewModel.allPagedListWrapper, times(1))?.invalidateData()
         assertEquals(viewModel.allPagedListWrapper, viewModel.activePagedListWrapper)
     }
 
     @Test
-    fun `load orders for ALL tab after initial run does not fetch first page`() =
+    fun `load all orders after initial run does not fetch first page`() =
         coroutinesTestRule.testDispatcher.runBlockingTest {
             doReturn(RequestResult.SUCCESS).whenever(repository).fetchOrderStatusOptionsFromApi()
             doReturn(orderStatusOptions).whenever(repository).getCachedOrderStatusOptions()
             doReturn(RequestResult.SUCCESS).whenever(repository).fetchPaymentGateways()
 
-            viewModel.initializeListsForMainTabs()
+            viewModel.initializeOrderList()
             clearInvocations(viewModel.allPagedListWrapper)
-            viewModel.loadAllList()
+            viewModel.loadAllOrders()
 
             assertNotNull(viewModel.allPagedListWrapper)
             assertNotNull(viewModel.activePagedListWrapper)
             verify(viewModel.allPagedListWrapper, times(0))?.fetchFirstPage()
             verify(viewModel.allPagedListWrapper, times(1))?.invalidateData()
             assertEquals(viewModel.allPagedListWrapper, viewModel.activePagedListWrapper)
-        }
-
-    @Test
-    fun `load orders for PROCESSING activates list wrapper and fetches first page`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            doReturn(RequestResult.SUCCESS).whenever(repository).fetchOrderStatusOptionsFromApi()
-            doReturn(orderStatusOptions).whenever(repository).getCachedOrderStatusOptions()
-            doReturn(RequestResult.SUCCESS).whenever(repository).fetchPaymentGateways()
-
-            viewModel.initializeListsForMainTabs()
-            clearInvocations(repository)
-            clearInvocations(viewModel.processingPagedListWrapper)
-            viewModel.loadProcessingList()
-
-            assertNotNull(viewModel.processingPagedListWrapper)
-            assertNotNull(viewModel.activePagedListWrapper)
-            verify(viewModel.processingPagedListWrapper, times(0))?.fetchFirstPage()
-            verify(viewModel.processingPagedListWrapper, times(1))?.invalidateData()
-            assertEquals(viewModel.processingPagedListWrapper, viewModel.activePagedListWrapper)
-        }
-
-    @Test
-    fun `load orders for PROCESSING tab after initial run does not fetch first page`() =
-        coroutinesTestRule.testDispatcher.runBlockingTest {
-            doReturn(RequestResult.SUCCESS).whenever(repository).fetchOrderStatusOptionsFromApi()
-            doReturn(orderStatusOptions).whenever(repository).getCachedOrderStatusOptions()
-            doReturn(RequestResult.SUCCESS).whenever(repository).fetchPaymentGateways()
-
-            viewModel.initializeListsForMainTabs()
-            viewModel.loadProcessingList()
-            clearInvocations(viewModel.processingPagedListWrapper)
-            viewModel.loadProcessingList()
-
-            assertNotNull(viewModel.processingPagedListWrapper)
-            assertNotNull(viewModel.activePagedListWrapper)
-            verify(viewModel.processingPagedListWrapper, times(0))?.fetchFirstPage()
-            verify(viewModel.processingPagedListWrapper, times(1))?.invalidateData()
-            assertEquals(viewModel.processingPagedListWrapper, viewModel.activePagedListWrapper)
         }
 
     /**
@@ -562,7 +524,7 @@ class OrderListViewModelTest : BaseUnitTest() {
             doReturn(RequestResult.SUCCESS).whenever(repository).fetchOrderStatusOptionsFromApi()
             doReturn(RequestResult.SUCCESS).whenever(repository).fetchPaymentGateways()
             viewModel.isSearching = true
-            viewModel.initializeListsForMainTabs()
+            viewModel.initializeOrderList()
 
             viewModel.submitSearchOrFilter(searchQuery = "Joe Doe")
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description

Part I of #4934

This PR is part of a bigger feature where to add filters to Order list screen. So the task is WIP and won't be merged to develop branch but to a feature branch where I'll be merging smaller tasks. 

In this PR the 2 tabs displaying ALL orders | PROCESSING orders have been removed. Now a single list with all the orders will be displayed by default. 

### Result

<img src="https://user-images.githubusercontent.com/2663464/136053526-fb262dd3-238b-40fa-90aa-06548aa60f4d.png" width="300">

