### PR TITLE
Issue/4887 edit customer order note

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -414,7 +414,8 @@ class MainActivity :
                 R.id.addOrderNoteFragment,
                 R.id.printShippingLabelInfoFragment,
                 R.id.shippingLabelFormatOptionsFragment,
-                R.id.printingInstructionsFragment -> {
+                R.id.printingInstructionsFragment,
+                R.id.editCustomerOrderNoteFragment-> {
                     true
                 }
                 R.id.productDetailFragment -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -415,7 +415,7 @@ class MainActivity :
                 R.id.printShippingLabelInfoFragment,
                 R.id.shippingLabelFormatOptionsFragment,
                 R.id.printingInstructionsFragment,
-                R.id.editCustomerOrderNoteFragment-> {
+                R.id.editCustomerOrderNoteFragment -> {
                     true
                 }
                 R.id.productDetailFragment -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/EditCustomerOrderNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/EditCustomerOrderNoteFragment.kt
@@ -1,0 +1,50 @@
+package com.woocommerce.android.ui.orders.details
+
+import android.os.Bundle
+import android.view.View
+import androidx.navigation.fragment.navArgs
+import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.databinding.FragmentEditCustomerOrderNoteBinding
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
+import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.util.ActivityUtils
+
+@AndroidEntryPoint
+class EditCustomerOrderNoteFragment : BaseFragment(R.layout.fragment_edit_customer_order_note), BackPressListener {
+    companion object {
+        const val TAG = "EditCustomerOrderNoteFragment"
+        const val KEY_EDIT_NOTE_RESULT = "key_edit_note_result"
+    }
+
+    private val navArgs: EditCustomerOrderNoteFragmentArgs by navArgs()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val binding = FragmentEditCustomerOrderNoteBinding.bind(view)
+
+        if (savedInstanceState == null) {
+            binding.customerOrderNoteEditor.setText(navArgs.customerOrderNote)
+            binding.customerOrderNoteEditor.requestFocus()
+            ActivityUtils.showKeyboard(binding.customerOrderNoteEditor)
+        }
+    }
+
+    override fun getFragmentTitle() = requireActivity().getString(R.string.orderdetail_customer_provided_note)
+
+    override fun onResume() {
+        super.onResume()
+        AnalyticsTracker.trackViewShown(this)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        activity?.let {
+            ActivityUtils.hideKeyboard(it)
+        }
+    }
+
+    override fun onRequestAllowBackPress() = true
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/EditCustomerOrderNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/EditCustomerOrderNoteFragment.kt
@@ -20,6 +20,12 @@ class EditCustomerOrderNoteFragment : BaseFragment(R.layout.fragment_edit_custom
 
     private val navArgs: EditCustomerOrderNoteFragmentArgs by navArgs()
 
+    /** TODO
+     * cross icon
+     * DONE button
+     * discard dialog
+     * make text selectable in order detail when feature flag not enabled
+     */
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -275,7 +275,8 @@ class OrderDetailFragment : BaseFragment(R.layout.fragment_order_detail), OrderP
         binding.orderDetailShippingMethodNotice.isVisible = order.multiShippingLinesAvailable
         binding.orderDetailCustomerInfo.updateCustomerInfo(
             order = order,
-            isVirtualOrder = viewModel.hasVirtualProductsOnly()
+            isVirtualOrder = viewModel.hasVirtualProductsOnly(),
+            isReadOnly = false
         )
         binding.orderDetailPaymentInfo.updatePaymentInfo(
             order = order,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditFragment.kt
@@ -1,16 +1,73 @@
 package com.woocommerce.android.ui.orders.details.editing
 
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import androidx.annotation.LayoutRes
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import org.wordpress.android.util.ActivityUtils
 
 abstract class BaseOrderEditFragment : BaseFragment, BackPressListener {
     constructor() : super()
     constructor(@LayoutRes layoutId: Int) : super(layoutId)
 
+    private var doneMenuItem: MenuItem? = null
+
+    /**
+     * This TextWatcher can be used to detect EditText changes in any descendant
+     */
+    protected val textWatcher = object : TextWatcher {
+        override fun afterTextChanged(s: Editable?) {
+            // noop
+        }
+
+        override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+            // noop
+        }
+
+        override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+            updateDoneMenuItem()
+        }
+    }
+
     abstract fun hasChanges(): Boolean
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setHasOptionsMenu(true)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        super.onCreateOptionsMenu(menu, inflater)
+        inflater.inflate(R.menu.menu_done, menu)
+        doneMenuItem = menu.findItem(R.id.menu_done)
+    }
+
+    override fun onPrepareOptionsMenu(menu: Menu) {
+        super.onPrepareOptionsMenu(menu)
+        updateDoneMenuItem()
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.menu_done -> {
+                ActivityUtils.hideKeyboard(activity)
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    private fun updateDoneMenuItem() {
+        doneMenuItem?.isVisible = hasChanges()
+    }
 
     override fun onRequestAllowBackPress(): Boolean {
         return if (hasChanges()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditFragment.kt
@@ -1,9 +1,31 @@
 package com.woocommerce.android.ui.orders.details.editing
 
 import androidx.annotation.LayoutRes
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 
-open class BaseOrderEditFragment : BaseFragment {
+abstract class BaseOrderEditFragment : BaseFragment, BackPressListener {
     constructor() : super()
     constructor(@LayoutRes layoutId: Int) : super(layoutId)
+
+    abstract fun hasChanges(): Boolean
+
+    override fun onRequestAllowBackPress(): Boolean {
+        return if (hasChanges()) {
+            confirmDisard()
+            false
+        } else {
+            true
+        }
+    }
+
+    private fun confirmDisard() {
+        MultiLiveEvent.Event.ShowDialog.buildDiscardDialogEvent(
+            positiveBtnAction = { _, _ ->
+                findNavController().navigateUp()
+            }
+        )
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditFragment.kt
@@ -26,6 +26,6 @@ abstract class BaseOrderEditFragment : BaseFragment, BackPressListener {
             positiveBtnAction = { _, _ ->
                 findNavController().navigateUp()
             }
-        )
+        ).showDialog()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditFragment.kt
@@ -14,14 +14,14 @@ abstract class BaseOrderEditFragment : BaseFragment, BackPressListener {
 
     override fun onRequestAllowBackPress(): Boolean {
         return if (hasChanges()) {
-            confirmDisard()
+            confirmDiscard()
             false
         } else {
             true
         }
     }
 
-    private fun confirmDisard() {
+    private fun confirmDiscard() {
         MultiLiveEvent.Event.ShowDialog.buildDiscardDialogEvent(
             positiveBtnAction = { _, _ ->
                 findNavController().navigateUp()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditFragment.kt
@@ -9,6 +9,7 @@ import android.view.MenuItem
 import androidx.annotation.LayoutRes
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -37,6 +38,15 @@ abstract class BaseOrderEditFragment : BaseFragment, BackPressListener {
         }
     }
 
+    /**
+     * These are the key and the result we use in navigateBackWithResult() when user taps Done
+     */
+    abstract val resultKey: String
+    abstract fun getResult(): Any
+
+    /**
+     * Descendants should return true if the user made any changes
+     */
     abstract fun hasChanges(): Boolean
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -59,6 +69,7 @@ abstract class BaseOrderEditFragment : BaseFragment, BackPressListener {
         return when (item.itemId) {
             R.id.menu_done -> {
                 ActivityUtils.hideKeyboard(activity)
+                navigateBackWithResult(resultKey, getResult())
                 true
             }
             else -> super.onOptionsItemSelected(item)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditFragment.kt
@@ -1,0 +1,9 @@
+package com.woocommerce.android.ui.orders.details.editing
+
+import androidx.annotation.LayoutRes
+import com.woocommerce.android.ui.base.BaseFragment
+
+open class BaseOrderEditFragment : BaseFragment {
+    constructor() : super()
+    constructor(@LayoutRes layoutId: Int) : super(layoutId)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/EditCustomerOrderNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/EditCustomerOrderNoteFragment.kt
@@ -24,9 +24,6 @@ class EditCustomerOrderNoteFragment :
     private val navArgs: EditCustomerOrderNoteFragmentArgs by navArgs()
     private var originalNote: String = ""
 
-    /** TODO
-     * DONE button
-     */
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -40,10 +37,13 @@ class EditCustomerOrderNoteFragment :
         } else {
             originalNote = savedInstanceState.getString(KEY_ORIGINAL_NOTE, "")
         }
+
+        binding.customerOrderNoteEditor.addTextChangedListener(textWatcher)
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
+        binding.customerOrderNoteEditor.removeTextChangedListener(textWatcher)
         _binding = null
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/EditCustomerOrderNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/EditCustomerOrderNoteFragment.kt
@@ -6,7 +6,6 @@ import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentEditCustomerOrderNoteBinding
-import com.woocommerce.android.databinding.FragmentOrderDetailBinding
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ActivityUtils
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/EditCustomerOrderNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/EditCustomerOrderNoteFragment.kt
@@ -18,6 +18,8 @@ class EditCustomerOrderNoteFragment :
         private const val KEY_ORIGINAL_NOTE = "key_original_note"
     }
 
+    override val resultKey = KEY_EDIT_NOTE_RESULT
+
     private var _binding: FragmentEditCustomerOrderNoteBinding? = null
     private val binding get() = _binding!!
 
@@ -67,6 +69,8 @@ class EditCustomerOrderNoteFragment :
     }
 
     override fun hasChanges() = originalNote != getCustomerNote()
+
+    override fun getResult() = getCustomerNote()
 
     private fun getCustomerNote() = binding.customerOrderNoteEditor.text.toString()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/EditCustomerOrderNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/EditCustomerOrderNoteFragment.kt
@@ -6,34 +6,51 @@ import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentEditCustomerOrderNoteBinding
-import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
+import com.woocommerce.android.databinding.FragmentOrderDetailBinding
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ActivityUtils
 
 @AndroidEntryPoint
 class EditCustomerOrderNoteFragment :
-    BaseOrderEditFragment(R.layout.fragment_edit_customer_order_note), BackPressListener {
+    BaseOrderEditFragment(R.layout.fragment_edit_customer_order_note) {
     companion object {
         const val TAG = "EditCustomerOrderNoteFragment"
         const val KEY_EDIT_NOTE_RESULT = "key_edit_note_result"
+        private const val KEY_ORIGINAL_NOTE = "key_original_note"
     }
 
+    private var _binding: FragmentEditCustomerOrderNoteBinding? = null
+    private val binding get() = _binding!!
+
     private val navArgs: EditCustomerOrderNoteFragmentArgs by navArgs()
+    private var originalNote: String = ""
 
     /** TODO
      * DONE button
-     * discard dialog
      */
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val binding = FragmentEditCustomerOrderNoteBinding.bind(view)
+        _binding = FragmentEditCustomerOrderNoteBinding.bind(view)
 
         if (savedInstanceState == null) {
+            originalNote = navArgs.customerOrderNote
             binding.customerOrderNoteEditor.setText(navArgs.customerOrderNote)
             binding.customerOrderNoteEditor.requestFocus()
             ActivityUtils.showKeyboard(binding.customerOrderNoteEditor)
+        } else {
+            originalNote = savedInstanceState.getString(KEY_ORIGINAL_NOTE, "")
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putString(KEY_ORIGINAL_NOTE, originalNote)
     }
 
     override fun getFragmentTitle() = requireActivity().getString(R.string.orderdetail_customer_provided_note)
@@ -50,5 +67,7 @@ class EditCustomerOrderNoteFragment :
         }
     }
 
-    override fun onRequestAllowBackPress() = true
+    override fun hasChanges() = originalNote != getCustomerNote()
+
+    private fun getCustomerNote() = binding.customerOrderNoteEditor.text.toString()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/EditCustomerOrderNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/EditCustomerOrderNoteFragment.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.orders.details
+package com.woocommerce.android.ui.orders.details.editing
 
 import android.os.Bundle
 import android.view.View
@@ -6,13 +6,13 @@ import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentEditCustomerOrderNoteBinding
-import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ActivityUtils
 
 @AndroidEntryPoint
-class EditCustomerOrderNoteFragment : BaseFragment(R.layout.fragment_edit_customer_order_note), BackPressListener {
+class EditCustomerOrderNoteFragment :
+    BaseOrderEditFragment(R.layout.fragment_edit_customer_order_note), BackPressListener {
     companion object {
         const val TAG = "EditCustomerOrderNoteFragment"
         const val KEY_EDIT_NOTE_RESULT = "key_edit_note_result"
@@ -21,10 +21,8 @@ class EditCustomerOrderNoteFragment : BaseFragment(R.layout.fragment_edit_custom
     private val navArgs: EditCustomerOrderNoteFragmentArgs by navArgs()
 
     /** TODO
-     * cross icon
      * DONE button
      * discard dialog
-     * make text selectable in order detail when feature flag not enabled
      */
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.widget.PopupMenu
 import androidx.core.view.isVisible
+import androidx.navigation.findNavController
 import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -14,9 +15,11 @@ import com.woocommerce.android.databinding.OrderDetailCustomerInfoBinding
 import com.woocommerce.android.extensions.collapse
 import com.woocommerce.android.extensions.expand
 import com.woocommerce.android.extensions.hide
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.OrderCustomerHelper
+import com.woocommerce.android.ui.orders.details.OrderDetailFragmentDirections
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.PhoneUtils
 import com.woocommerce.android.widgets.AppRatingDialog
@@ -65,7 +68,10 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
             if (FeatureFlag.ORDER_EDITING.isEnabled()) {
                 binding.customerInfoCustomerNote.setTextIsSelectable(false)
                 binding.customerInfoCustomerNoteSection.setOnClickListener {
-                    // TODO
+                    val action = OrderDetailFragmentDirections.actionOrderDetailFragmentToEditCustomerOrderNoteFragment(
+                        order.customerNote
+                    )
+                    findNavController().navigateSafely(action)
                 }
             } else {
                 binding.customerInfoCustomerNote.setTextIsSelectable(true)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -36,7 +36,35 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         isVirtualOrder: Boolean, // don't display shipping section for virtual products
         isReadOnly: Boolean
     ) {
-        // shipping address info
+        showCustomerNote(order, isReadOnly)
+        showShippingAddress(order, isVirtualOrder)
+        showBillingInfo(order)
+    }
+
+    private fun showCustomerNote(order: Order, isReadOnly: Boolean) {
+        if (order.customerNote.isNotEmpty()) {
+            binding.customerInfoCustomerNoteSection.show()
+            binding.customerInfoCustomerNote.text = context.getString(
+                R.string.orderdetail_customer_note,
+                order.customerNote
+            )
+            if (FeatureFlag.ORDER_EDITING.isEnabled() && !isReadOnly) {
+                binding.customerInfoCustomerNote.setTextIsSelectable(false)
+                binding.customerInfoCustomerNoteSection.setOnClickListener {
+                    val action = OrderDetailFragmentDirections.actionOrderDetailFragmentToEditCustomerOrderNoteFragment(
+                        order.customerNote
+                    )
+                    findNavController().navigateSafely(action)
+                }
+            } else {
+                binding.customerInfoCustomerNote.setTextIsSelectable(true)
+            }
+        } else {
+            binding.customerInfoCustomerNoteSection.hide()
+        }
+    }
+
+    private fun showShippingAddress(order: Order, isVirtualOrder: Boolean) {
         val shippingAddress = order.formatShippingInformationForDisplay()
         when {
             isVirtualOrder -> {
@@ -58,30 +86,10 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
                 } ?: false
             }
         }
+    }
 
-        // customer note
-        if (order.customerNote.isNotEmpty()) {
-            binding.customerInfoCustomerNoteSection.show()
-            binding.customerInfoCustomerNote.text = context.getString(
-                R.string.orderdetail_customer_note,
-                order.customerNote
-            )
-            if (FeatureFlag.ORDER_EDITING.isEnabled() && !isReadOnly) {
-                binding.customerInfoCustomerNote.setTextIsSelectable(false)
-                binding.customerInfoCustomerNoteSection.setOnClickListener {
-                    val action = OrderDetailFragmentDirections.actionOrderDetailFragmentToEditCustomerOrderNoteFragment(
-                        order.customerNote
-                    )
-                    findNavController().navigateSafely(action)
-                }
-            } else {
-                binding.customerInfoCustomerNote.setTextIsSelectable(true)
-            }
-        } else {
-            binding.customerInfoCustomerNoteSection.hide()
-        }
-
-        // billing info
+    @Suppress("LongMethod")
+    private fun showBillingInfo(order: Order) {
         val billingInfo = order.formatBillingInformationForDisplay()
         if (order.billingAddress.hasInfo()) {
             if (billingInfo.isNotEmpty()) {
@@ -143,6 +151,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
             binding.customerInfoMorePanel.hide()
             binding.customerInfoViewMore.setOnClickListener(null)
         }
+        val shippingAddress = order.formatShippingInformationForDisplay()
         if (shippingAddress.isEmpty() && billingInfo.isEmpty()) {
             hide()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -50,6 +50,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
             )
             if (FeatureFlag.ORDER_EDITING.isEnabled() && !isReadOnly) {
                 binding.customerInfoCustomerNote.setTextIsSelectable(false)
+                binding.customerInfoEditButton.show()
                 binding.customerInfoCustomerNoteSection.setOnClickListener {
                     val action = OrderDetailFragmentDirections.actionOrderDetailFragmentToEditCustomerOrderNoteFragment(
                         order.customerNote
@@ -58,6 +59,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
                 }
             } else {
                 binding.customerInfoCustomerNote.setTextIsSelectable(true)
+                binding.customerInfoEditButton.hide()
             }
         } else {
             binding.customerInfoCustomerNoteSection.hide()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.OrderCustomerHelper
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.PhoneUtils
 import com.woocommerce.android.widgets.AppRatingDialog
 
@@ -61,8 +62,13 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
                 R.string.orderdetail_customer_note,
                 order.customerNote
             )
-            binding.customerInfoCustomerNoteSection.setOnClickListener {
-                // TODO
+            if (FeatureFlag.ORDER_EDITING.isEnabled()) {
+                binding.customerInfoCustomerNote.setTextIsSelectable(false)
+                binding.customerInfoCustomerNoteSection.setOnClickListener {
+                    // TODO
+                }
+            } else {
+                binding.customerInfoCustomerNote.setTextIsSelectable(true)
             }
         } else {
             binding.customerInfoCustomerNoteSection.hide()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -50,7 +50,6 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
             )
             if (FeatureFlag.ORDER_EDITING.isEnabled() && !isReadOnly) {
                 binding.customerInfoCustomerNote.setTextIsSelectable(false)
-                binding.customerInfoEditButton.show()
                 binding.customerInfoCustomerNoteSection.setOnClickListener {
                     val action = OrderDetailFragmentDirections.actionOrderDetailFragmentToEditCustomerOrderNoteFragment(
                         order.customerNote
@@ -59,7 +58,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
                 }
             } else {
                 binding.customerInfoCustomerNote.setTextIsSelectable(true)
-                binding.customerInfoEditButton.hide()
+                binding.customerInfoCustomerNote.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0)
             }
         } else {
             binding.customerInfoCustomerNoteSection.hide()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -61,6 +61,9 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
                 R.string.orderdetail_customer_note,
                 order.customerNote
             )
+            binding.customerInfoCustomerNoteSection.setOnClickListener {
+                // TODO
+            }
         } else {
             binding.customerInfoCustomerNoteSection.hide()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -33,7 +33,8 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
 
     fun updateCustomerInfo(
         order: Order,
-        isVirtualOrder: Boolean // don't display shipping section for virtual products
+        isVirtualOrder: Boolean, // don't display shipping section for virtual products
+        isReadOnly: Boolean
     ) {
         // shipping address info
         val shippingAddress = order.formatShippingInformationForDisplay()
@@ -65,7 +66,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
                 R.string.orderdetail_customer_note,
                 order.customerNote
             )
-            if (FeatureFlag.ORDER_EDITING.isEnabled()) {
+            if (FeatureFlag.ORDER_EDITING.isEnabled() && !isReadOnly) {
                 binding.customerInfoCustomerNote.setTextIsSelectable(false)
                 binding.customerInfoCustomerNoteSection.setOnClickListener {
                     val action = OrderDetailFragmentDirections.actionOrderDetailFragmentToEditCustomerOrderNoteFragment(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillFragment.kt
@@ -141,7 +141,8 @@ class OrderFulfillFragment :
     private fun showOrderDetail(order: Order, binding: FragmentOrderFulfillBinding) {
         binding.orderDetailCustomerInfo.updateCustomerInfo(
             order = order,
-            isVirtualOrder = viewModel.hasVirtualProductsOnly()
+            isVirtualOrder = viewModel.hasVirtualProductsOnly(),
+            isReadOnly = true
         )
         binding.buttonMarkOrderCompete.setOnClickListener {
             viewModel.onMarkOrderCompleteButtonClicked()

--- a/WooCommerce/src/main/res/layout/fragment_edit_customer_order_note.xml
+++ b/WooCommerce/src/main/res/layout/fragment_edit_customer_order_note.xml
@@ -1,0 +1,20 @@
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/snack_root"
+    style="@style/Woo.Card"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context="com.woocommerce.android.ui.orders.notes.AddOrderNoteFragment">
+
+    <EditText
+        android:id="@+id/customerOrderNote_editor"
+        style="@style/Woo.EditText"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="top|start"
+        android:hint="@string/orderdetail_customer_note_hint"
+        android:importantForAutofill="no"
+        android:inputType="textAutoComplete|textMultiLine|textCapSentences"
+        tools:text="This is a customer order note." />
+</com.google.android.material.card.MaterialCardView>

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -29,9 +29,10 @@
             android:id="@+id/customerInfo_customerNoteSection"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/major_100"
+            android:background="?attr/selectableItemBackground"
             android:focusable="true"
             android:orientation="vertical"
-            android:layout_marginBottom="@dimen/major_100"
             tools:visibility="visible">
 
             <View

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -25,38 +25,59 @@
             android:text="@string/customer_information"/>
 
         <!-- Label: Customer note -->
-        <LinearLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/customerInfo_customerNoteSection"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/major_100"
             android:background="?attr/selectableItemBackground"
             android:focusable="true"
             android:orientation="vertical"
+            android:paddingBottom="@dimen/major_100"
             tools:visibility="visible">
 
             <View
+                android:id="@+id/customerInfo_noteDivider"
                 style="@style/Woo.Divider"
-                android:layout_marginStart="@dimen/major_100"/>
+                android:layout_marginStart="@dimen/major_100"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/customerInfo_customerNoteTitle"
                 style="@style/Woo.Card.Title"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/minor_50"
-                android:text="@string/orderdetail_customer_provided_note"/>
+                android:text="@string/orderdetail_customer_provided_note"
+                app:layout_constraintEnd_toStartOf="@id/customerInfo_editButton"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/customerInfo_noteDivider" />
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/customerInfo_customerNote"
                 style="@style/Woo.Card.Body"
-                android:drawableEnd="@drawable/ic_edit_pencil"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:textIsSelectable="true"
-                tools:text="This is a nice note from the customer"/>
+                app:layout_constraintEnd_toStartOf="@id/customerInfo_editButton"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/customerInfo_customerNoteTitle"
+                tools:text="This is a nice note from the customer" />
 
-        </LinearLayout>
+            <ImageView
+                android:id="@+id/customerInfo_editButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
+                android:contentDescription="@string/edit"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@drawable/ic_edit_pencil" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
         <!-- Label: Shipping -->
         <LinearLayout

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -49,7 +49,8 @@
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/customerInfo_customerNote"
                 style="@style/Woo.Card.Body"
-                android:layout_width="wrap_content"
+                android:drawableEnd="@drawable/ic_edit_pencil"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:textIsSelectable="true"
                 tools:text="This is a nice note from the customer"/>

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -71,9 +71,8 @@
                 android:layout_marginStart="@dimen/major_100"
                 android:layout_marginEnd="@dimen/major_100"
                 android:contentDescription="@string/edit"
-                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintTop_toTopOf="@id/customerInfo_customerNote"
                 app:srcCompat="@drawable/ic_edit_pencil" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -59,7 +59,6 @@
                 style="@style/Woo.Card.Body"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textIsSelectable="true"
                 app:layout_constraintEnd_toStartOf="@id/customerInfo_editButton"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/customerInfo_customerNoteTitle"

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -25,7 +25,7 @@
             android:text="@string/customer_information"/>
 
         <!-- Label: Customer note -->
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <LinearLayout
             android:id="@+id/customerInfo_customerNoteSection"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -38,10 +38,7 @@
             <View
                 android:id="@+id/customerInfo_noteDivider"
                 style="@style/Woo.Divider"
-                android:layout_marginStart="@dimen/major_100"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                android:layout_marginStart="@dimen/major_100" />
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/customerInfo_customerNoteTitle"
@@ -49,33 +46,18 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/minor_50"
-                android:text="@string/orderdetail_customer_provided_note"
-                app:layout_constraintEnd_toStartOf="@id/customerInfo_editButton"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/customerInfo_noteDivider" />
+                android:text="@string/orderdetail_customer_provided_note" />
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/customerInfo_customerNote"
                 style="@style/Woo.Card.Body"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:layout_constraintEnd_toStartOf="@id/customerInfo_editButton"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/customerInfo_customerNoteTitle"
-                tools:text="This is a nice note from the customer" />
+                android:drawableEnd="@drawable/ic_edit_pencil"
+                android:drawablePadding="@dimen/major_100"
+                tools:text="This is a nice note from the customer. Let's make it wrap to multiple lines." />
 
-            <ImageView
-                android:id="@+id/customerInfo_editButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:contentDescription="@string/edit"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@id/customerInfo_customerNote"
-                app:srcCompat="@drawable/ic_edit_pencil" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
+        </LinearLayout>
 
         <!-- Label: Shipping -->
         <LinearLayout

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -289,6 +289,13 @@
             app:exitAnim="@anim/activity_slide_out_to_left"
             app:popEnterAnim="@anim/activity_slide_in_from_left"
             app:popExitAnim="@anim/activity_slide_out_to_right" />
+        <action
+            android:id="@+id/action_orderDetailFragment_to_editCustomerOrderNoteFragment"
+            app:destination="@id/editCustomerOrderNoteFragment"
+            app:enterAnim="@anim/activity_slide_in_from_right"
+            app:exitAnim="@anim/activity_slide_out_to_left"
+            app:popEnterAnim="@anim/activity_slide_in_from_left"
+            app:popExitAnim="@anim/activity_slide_out_to_right" />
     </fragment>
     <dialog
         android:id="@+id/orderStatusSelectorDialog"
@@ -621,5 +628,14 @@
             android:name="addonsProductId"
             app:argType="long"
             app:nullable="false" />
+    </fragment>
+    <fragment
+        android:id="@+id/editCustomerOrderNoteFragment"
+        android:name="com.woocommerce.android.ui.orders.details.EditCustomerOrderNoteFragment"
+        android:label="EditCustomerOrderNoteFragment"
+        tools:layout="@layout/fragment_edit_customer_order_note">
+        <argument
+            android:name="customerOrderNote"
+            app:argType="string" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -631,7 +631,7 @@
     </fragment>
     <fragment
         android:id="@+id/editCustomerOrderNoteFragment"
-        android:name="com.woocommerce.android.ui.orders.details.EditCustomerOrderNoteFragment"
+        android:name="com.woocommerce.android.ui.orders.details.editing.EditCustomerOrderNoteFragment"
         android:label="EditCustomerOrderNoteFragment"
         tools:layout="@layout/fragment_edit_customer_order_note">
         <argument

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -305,6 +305,7 @@
     <string name="orderdetail_note_public">To customer</string>
     <string name="orderdetail_note_system">System</string>
     <string name="orderdetail_order_notes">Order notes</string>
+    <string name="orderdetail_customer_note_hint">Edit a customer order note</string>
     <string name="orderdetail_payment_cleared">Payment Cleared</string>
     <string name="orderdetail_show_billing">Show Billing</string>
     <string name="orderdetail_hide_billing">Hide Billing</string>


### PR DESCRIPTION
Closes #4891 and #4887 - This PR adds the basic UI framework for editing an order by enabling editing the customer order note. It would be good if both reviewers looked at this because decisions made in this PR will affect other order editing screens.

A few important things to note:

* Changes to the order note aren't retained - that will come in a separate PR once the FluxC part is ready
* There's no ViewModel yet - when that's added in a separate PR, some of the logic in `BaseOrderEditFragment` will be moved to it
* I'm using `navigateBackWithResult` to send the changes to the previous fragment (which are ignored), but will likely rely on the aforementioned ViewModel to save the changes
 
![note](https://user-images.githubusercontent.com/3903757/136096582-8d477ff6-97fc-41af-9b21-f8174a603b50.png)


