### PR TITLE
Only show SSR menu if user is logged in and a site is selected.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/HelpActivity.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Stat
 import com.woocommerce.android.databinding.ActivityHelpBinding
+import com.woocommerce.android.extensions.show
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.FeatureFlag
@@ -57,7 +58,10 @@ class HelpActivity : AppCompatActivity() {
         binding.myTicketsContainer.setOnClickListener { showZendeskTickets() }
         binding.faqContainer.setOnClickListener { showZendeskFaq() }
         binding.appLogContainer.setOnClickListener { showApplicationLog() }
-        binding.ssrContainer.setOnClickListener { showSSR() }
+        if (userIsLoggedIn() && selectedSite.exists()) {
+            binding.ssrContainer.show()
+            binding.ssrContainer.setOnClickListener { showSSR() }
+        }
 
         with(binding.contactPaymentsContainer) {
             visibility = if (FeatureFlag.CARD_READER.isEnabled()) View.VISIBLE else View.GONE
@@ -100,6 +104,8 @@ class HelpActivity : AppCompatActivity() {
         }
         return super.onOptionsItemSelected(item)
     }
+
+    private fun userIsLoggedIn() = accountStore.hasAccessToken()
 
     private fun createNewZendeskTicket(ticketType: TicketType) {
         if (!AppPrefs.hasSupportEmail()) {

--- a/WooCommerce/src/main/res/layout/activity_help.xml
+++ b/WooCommerce/src/main/res/layout/activity_help.xml
@@ -84,7 +84,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 app:optionTitle="@string/support_system_status_report"
-                app:optionValue="@string/support_system_status_report_detail"/>
+                app:optionValue="@string/support_system_status_report_detail"
+                android:visibility="gone" />
 
         </LinearLayout>
     </ScrollView>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4943
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
The Help & Support section is available to merchants before they're logged in, for example by doing:

1. Log out
2. Click on the `Enter your store address` button
3. Click on the Help icon at the top right corner.

In that situation, if the "System Status Report" button is then selected, it crashes the app because no site is available to be used yet.

This PR adds a check to only show the button if user is logged in and a site is selected.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

**Logged out state:**

1. Log out
2. Click on the `Enter your store address` button
3. Click on the Help icon at the top right corner
4. The Help & Support section is shown, make sure "System status report" button is not listed there.

⚠️ **note**: there is currently [a different issue](https://github.com/woocommerce/woocommerce-android/issues/4942) that will cause a crash after doing step 3 above. If that issue is not fixed yet while this is being reviewed, a possible workaround is to go a step deeper in the login step (enter a site address, continue, then try the Help icon on the next screen).


**Logged in state:**
1. Log in properly and select a site,
2. Go to Settings > Help & support
3. Make sure "System status report" button is shown, and that it can be tapped and used normally as before.




