### PR TITLE
Bump login lib - fix npe on site address fragment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext.kotlinVersion = '1.5.30'
     ext.navigationVersion = '2.3.5'
     ext.daggerVersion = '2.38.1'
-    ext.wordPressLoginVersion = '0.0.6'
+    ext.wordPressLoginVersion = '69-b16b455022f5f857671d55a7de05f665b9815d31'
     ext.detektVersion = '1.18.1'
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext.kotlinVersion = '1.5.30'
     ext.navigationVersion = '2.3.5'
     ext.daggerVersion = '2.38.1'
-    ext.wordPressLoginVersion = '69-b16b455022f5f857671d55a7de05f665b9815d31'
+    ext.wordPressLoginVersion = '0.0.7'
     ext.detektVersion = '1.18.1'
 
     repositories {


### PR DESCRIPTION
Closes #4942
Merge instructions: We'll probably want to release a new version of the login lib and replace the hashcode before we merge this PR (cc @anitaa1990 @jkmassel)

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes a NPE introduced in [this PR](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/67).

We were using java's nullable Boolean instead of non-nullable boolean. When we tried to store this value into a bundle, the app crashed with NPE as Bundle.putBoolean accepts boolean so when we pass a null Boolean the automatic cast results in NPE.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Clear app data
2. Enable Do not keep activities in developer settings
3. Click on the Login with site address.
4. Tap no the home button and bring the app back to foreground - notice it doesn't crash

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->

cc @jkmassel This PR merges changes from [this PR in the login lib](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/69) to the WCAndroid "release/7.7" branch. 
