### PR TITLE
Create Order detail address editing actions

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.OrderCustomerHelper
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.PhoneUtils
 import com.woocommerce.android.widgets.AppRatingDialog
 
@@ -129,6 +130,11 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         }
         if (shippingAddress.isEmpty() && billingInfo.isEmpty()) {
             hide()
+        }
+
+        if (FeatureFlag.ORDER_EDITING.isEnabled()) {
+            binding.customerInfoEditShippingAddr.visibility = VISIBLE
+            binding.customerInfoEditBillingAddr.visibility = VISIBLE
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -33,16 +33,11 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
     ) {
         val shippingAddress = bindShippingAddressInfo(order, isVirtualOrder)
 
-        bindCustomerNotes(order)
+        showCustomerNotes(order)
 
         val billingInfo = bindBillingAddressInfo(order)
         if (shippingAddress.isEmpty() && billingInfo.isEmpty()) {
             hide()
-        }
-
-        if (FeatureFlag.ORDER_EDITING.isEnabled()) {
-            binding.customerInfoEditShippingAddr.visibility = VISIBLE
-            binding.customerInfoEditBillingAddr.visibility = VISIBLE
         }
     }
 
@@ -65,6 +60,13 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
             binding.customerInfoViewMore.hide()
             binding.customerInfoMorePanel.hide()
             binding.customerInfoViewMore.setOnClickListener(null)
+        }
+
+        if (FeatureFlag.ORDER_EDITING.isEnabled()) {
+            binding.customerInfoBillingAddr.setTextIsSelectable(false)
+        } else {
+            binding.customerInfoBillingAddr.setTextIsSelectable(true)
+            binding.customerInfoBillingAddr.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0)
         }
         return billingInfo
     }
@@ -119,7 +121,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         }
     }
 
-    private fun bindCustomerNotes(order: Order) {
+    private fun showCustomerNotes(order: Order) {
         if (order.customerNote.isNotEmpty()) {
             binding.customerInfoCustomerNoteSection.show()
             binding.customerInfoCustomerNote.text = context.getString(
@@ -152,6 +154,13 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
                     true
                 } ?: false
             }
+        }
+
+        if (FeatureFlag.ORDER_EDITING.isEnabled()) {
+            binding.customerInfoShippingAddr.setTextIsSelectable(false)
+        } else {
+            binding.customerInfoShippingAddr.setTextIsSelectable(true)
+            binding.customerInfoShippingAddr.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0)
         }
         return shippingAddress
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -48,8 +48,8 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
                 binding.customerInfoDivider2.visibility = GONE
             }
 
-            bindBillingAddressPhoneInfo(order)
-            bindBillingAddressEmailInfo(order)
+            showBillingAddressPhoneInfo(order)
+            showBillingAddressEmailInfo(order)
             binding.customerInfoViewMore.setOnClickListener { onViewMoreCustomerInfoClick() }
         } else {
             binding.customerInfoViewMore.hide()
@@ -87,7 +87,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         }
     }
 
-    private fun bindBillingAddressEmailInfo(order: Order) {
+    private fun showBillingAddressEmailInfo(order: Order) {
         // display email address info only if available, otherwise, hide the view
         if (order.billingAddress.email.isNotEmpty()) {
             binding.customerInfoEmailAddr.text = order.billingAddress.email
@@ -105,7 +105,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         }
     }
 
-    private fun bindBillingAddressPhoneInfo(order: Order) {
+    private fun showBillingAddressPhoneInfo(order: Order) {
         // display phone only if available, otherwise, hide the view
         if (order.billingAddress.phone.isNotEmpty()) {
             binding.customerInfoPhone.text = PhoneUtils.formatPhone(order.billingAddress.phone)

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -61,36 +61,43 @@
             android:id="@+id/customerInfo_shippingSection"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:focusable="true"
             android:layout_marginBottom="@dimen/major_100"
+            android:focusable="true"
             android:orientation="vertical">
-
-            <View
-                style="@style/Woo.Divider"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginEnd="@dimen/minor_00"/>
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/customerInfo_shippingLabel"
-                style="@style/Woo.Card.Title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/minor_50"
-                android:text="@string/orderdetail_shipping_details"/>
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal">
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/customerInfo_shippingAddr"
-                    style="@style/Woo.Card.Body"
-                    android:layout_width="wrap_content"
+                <LinearLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_weight="0.99"
-                    android:textIsSelectable="true"
-                    tools:text="John Vilanzo\n123 Sesame Pl\nWarner, FL\nUnited States" />
+                    android:orientation="vertical"
+                    android:layout_weight="0.99">
+
+                    <View
+                        style="@style/Woo.Divider"
+                        android:layout_marginEnd="@dimen/minor_00"
+                        android:layout_marginStart="@dimen/major_100" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/customerInfo_shippingLabel"
+                        style="@style/Woo.Card.Title"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/minor_50"
+                        android:text="@string/orderdetail_shipping_details" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/customerInfo_shippingAddr"
+                        style="@style/Woo.Card.Body"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textIsSelectable="true"
+                        tools:text="John Vilanzo\n123 Sesame Pl\nWarner, FL\nUnited States" />
+
+                </LinearLayout>
 
                 <ImageButton
                     android:id="@+id/customerInfo_editShippingAddr"

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -78,15 +78,35 @@
                 android:layout_marginBottom="@dimen/minor_50"
                 android:text="@string/orderdetail_shipping_details"/>
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/customerInfo_shippingAddr"
-                style="@style/Woo.Card.Body"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textIsSelectable="true"
-                android:drawableEnd="@drawable/ic_edit_pencil"
-                android:drawablePadding="@dimen/major_100"
-                tools:text="John Vilanzo\n123 Sesame Pl\nWarner, FL\nUnited States"/>
+                android:orientation="horizontal">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/customerInfo_shippingAddr"
+                    style="@style/Woo.Card.Body"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0.99"
+                    android:textIsSelectable="true"
+                    tools:text="John Vilanzo\n123 Sesame Pl\nWarner, FL\nUnited States" />
+
+                <ImageButton
+                    android:id="@+id/customerInfo_editShippingAddr"
+                    style="@style/Woo.Button.TextButton"
+                    android:layout_width="@dimen/image_major_50"
+                    android:layout_height="@dimen/image_major_50"
+                    android:layout_gravity="center_vertical"
+                    android:layout_weight="0.01"
+                    android:background="?attr/selectableItemBackground"
+                    android:contentDescription="@string/orderdetail_call_or_message_contentdesc"
+                    android:scaleType="center"
+                    android:src="@drawable/ic_edit_pencil" />
+
+            </LinearLayout>
+
+
 
             <!-- Label: Shipping method -->
             <LinearLayout

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -65,28 +65,36 @@
             android:focusable="true"
             android:orientation="vertical">
 
-            <View
-                style="@style/Woo.Divider"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginEnd="@dimen/minor_00"/>
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/customerInfo_shippingLabel"
-                style="@style/Woo.Card.Title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/minor_50"
-                android:text="@string/orderdetail_shipping_details"/>
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/customerInfo_shippingAddr"
-                style="@style/Woo.Card.Body"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:drawableEnd="@drawable/ic_edit_pencil"
-                android:drawablePadding="@dimen/major_100"
-                android:textIsSelectable="true"
-                tools:text="John Vilanzo\n123 Sesame Pl\nWarner, FL\nUnited States" />
+                android:background="?attr/selectableItemBackground"
+                android:orientation="vertical">
+
+                <View
+                    style="@style/Woo.Divider"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginEnd="@dimen/minor_00"/>
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/customerInfo_shippingLabel"
+                    style="@style/Woo.Card.Title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/minor_50"
+                    android:text="@string/orderdetail_shipping_details"/>
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/customerInfo_shippingAddr"
+                    style="@style/Woo.Card.Body"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:drawableEnd="@drawable/ic_edit_pencil"
+                    android:drawablePadding="@dimen/major_100"
+                    android:textIsSelectable="true"
+                    tools:text="John Vilanzo\n123 Sesame Pl\nWarner, FL\nUnited States" />
+
+            </LinearLayout>
 
             <!-- Label: Shipping method -->
             <LinearLayout
@@ -130,44 +138,55 @@
             android:visibility="gone"
             tools:visibility="visible">
 
-            <!-- Divider -->
-            <View
-                android:id="@+id/customerInfo_divider"
-                style="@style/Woo.Divider"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginEnd="@dimen/minor_00"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"/>
-
-            <!-- Label: Billing Details -->
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/customerInfo_billingLabel"
-                style="@style/Woo.Card.Title"
-                android:layout_width="0dp"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/customerInfo_billingAddressSection"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/orderdetail_billing_details"
-                app:layout_constraintTop_toBottomOf="@+id/customerInfo_divider"
-                app:layout_constrainedWidth="true"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="parent"/>
-
-            <!-- Billing Address -->
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/customerInfo_billingAddr"
-                style="@style/Woo.Card.Body"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/minor_50"
-                android:drawableEnd="@drawable/ic_edit_pencil"
-                android:drawablePadding="@dimen/major_100"
-                android:textAlignment="viewStart"
-                android:textIsSelectable="true"
-                app:layout_constraintEnd_toEndOf="parent"
+                android:background="?attr/selectableItemBackground"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/customerInfo_billingLabel"
-                tools:text="John Vilanzo\n123 Sesame Pl\nWarner, FL\nUnited States" />
+                app:layout_constraintTop_toTopOf="parent"
+                tools:visibility="visible">
+
+                <!-- Divider -->
+                <View
+                    android:id="@+id/customerInfo_divider"
+                    style="@style/Woo.Divider"
+                    android:layout_marginEnd="@dimen/minor_00"
+                    android:layout_marginStart="@dimen/major_100"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <!-- Label: Billing Details -->
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/customerInfo_billingLabel"
+                    style="@style/Woo.Card.Title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:text="@string/orderdetail_billing_details"
+                    app:layout_constrainedWidth="true"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/customerInfo_divider" />
+
+                <!-- Billing Address -->
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/customerInfo_billingAddr"
+                    style="@style/Woo.Card.Body"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/minor_50"
+                    android:drawableEnd="@drawable/ic_edit_pencil"
+                    android:drawablePadding="@dimen/major_100"
+                    android:textAlignment="viewStart"
+                    android:textIsSelectable="true"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/customerInfo_billingLabel"
+                    tools:text="John Vilanzo\n123 Sesame Pl\nWarner, FL\nUnited States" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
             <!-- Divider -->
             <View
@@ -178,7 +197,7 @@
                 android:layout_marginEnd="@dimen/minor_00"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/customerInfo_billingAddr"/>
+                app:layout_constraintTop_toBottomOf="@+id/customerInfo_billingAddressSection"/>
 
             <!-- Billing Phone -->
             <com.google.android.material.textview.MaterialTextView

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -189,12 +189,25 @@
                 android:textIsSelectable="true"
                 android:layout_marginTop="@dimen/minor_50"
                 android:textAlignment="viewStart"
-                android:drawableEnd="@drawable/ic_edit_pencil"
-                android:drawablePadding="@dimen/major_100"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/customerInfo_billingLabel"
                 tools:text="John Vilanzo\n123 Sesame Pl\nWarner, FL\nUnited States" />
+
+            <ImageButton
+                android:id="@+id/customerInfo_editBillingAddr"
+                style="@style/Woo.Button.TextButton"
+                android:layout_width="@dimen/image_major_50"
+                android:layout_height="@dimen/image_major_50"
+                android:layout_gravity="center_vertical"
+                android:layout_weight="0.01"
+                android:background="?attr/selectableItemBackground"
+                android:contentDescription="@string/orderdetail_edit_shipping_address_contentdesc"
+                android:scaleType="center"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/customerInfo_billingAddr"
+                app:layout_constraintBottom_toBottomOf="@id/customerInfo_billingAddr"
+                android:src="@drawable/ic_edit_pencil" />
 
             <!-- Divider -->
             <View

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -70,34 +70,27 @@
                 android:layout_marginEnd="@dimen/minor_00"
                 android:layout_marginStart="@dimen/major_100" />
 
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/customerInfo_shippingLabel"
+                style="@style/Woo.Card.Title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/minor_50"
+                android:text="@string/orderdetail_shipping_details" />
+
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal">
 
-                <LinearLayout
-                    android:layout_width="match_parent"
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/customerInfo_shippingAddr"
+                    style="@style/Woo.Card.Body"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:layout_weight="0.99">
-
-                    <com.google.android.material.textview.MaterialTextView
-                        android:id="@+id/customerInfo_shippingLabel"
-                        style="@style/Woo.Card.Title"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="@dimen/minor_50"
-                        android:text="@string/orderdetail_shipping_details" />
-
-                    <com.google.android.material.textview.MaterialTextView
-                        android:id="@+id/customerInfo_shippingAddr"
-                        style="@style/Woo.Card.Body"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:textIsSelectable="true"
-                        tools:text="John Vilanzo\n123 Sesame Pl\nWarner, FL\nUnited States" />
-
-                </LinearLayout>
+                    android:layout_weight="0.99"
+                    android:textIsSelectable="true"
+                    tools:text="John Vilanzo\n123 Sesame Pl\nWarner, FL\nUnited States" />
 
                 <ImageButton
                     android:id="@+id/customerInfo_editShippingAddr"

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -67,8 +67,8 @@
 
             <View
                 style="@style/Woo.Divider"
-                android:layout_marginEnd="@dimen/minor_00"
-                android:layout_marginStart="@dimen/major_100" />
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/minor_00"/>
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/customerInfo_shippingLabel"
@@ -76,36 +76,17 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/minor_50"
-                android:text="@string/orderdetail_shipping_details" />
+                android:text="@string/orderdetail_shipping_details"/>
 
-            <LinearLayout
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/customerInfo_shippingAddr"
+                style="@style/Woo.Card.Body"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal">
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/customerInfo_shippingAddr"
-                    style="@style/Woo.Card.Body"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="0.99"
-                    android:textIsSelectable="true"
-                    tools:text="John Vilanzo\n123 Sesame Pl\nWarner, FL\nUnited States" />
-
-                <ImageButton
-                    android:id="@+id/customerInfo_editShippingAddr"
-                    style="@style/Woo.Button.TextButton"
-                    android:layout_width="@dimen/image_major_50"
-                    android:layout_height="@dimen/image_major_50"
-                    android:layout_gravity="center_vertical"
-                    android:layout_weight="0.01"
-                    android:background="?attr/selectableItemBackground"
-                    android:contentDescription="@string/orderdetail_edit_shipping_address_contentdesc"
-                    android:scaleType="center"
-                    android:src="@drawable/ic_edit_pencil"
-                    android:visibility="gone" />
-
-            </LinearLayout>
+                android:drawableEnd="@drawable/ic_edit_pencil"
+                android:drawablePadding="@dimen/major_100"
+                android:textIsSelectable="true"
+                tools:text="John Vilanzo\n123 Sesame Pl\nWarner, FL\nUnited States" />
 
             <!-- Label: Shipping method -->
             <LinearLayout
@@ -178,29 +159,15 @@
                 style="@style/Woo.Card.Body"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:textIsSelectable="true"
                 android:layout_marginTop="@dimen/minor_50"
+                android:drawableEnd="@drawable/ic_edit_pencil"
+                android:drawablePadding="@dimen/major_100"
                 android:textAlignment="viewStart"
+                android:textIsSelectable="true"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/customerInfo_billingLabel"
                 tools:text="John Vilanzo\n123 Sesame Pl\nWarner, FL\nUnited States" />
-
-            <ImageButton
-                android:id="@+id/customerInfo_editBillingAddr"
-                style="@style/Woo.Button.TextButton"
-                android:layout_width="@dimen/image_major_50"
-                android:layout_height="@dimen/image_major_50"
-                android:layout_gravity="center_vertical"
-                android:layout_weight="0.01"
-                android:background="?attr/selectableItemBackground"
-                android:contentDescription="@string/orderdetail_edit_billing_address_contentdesc"
-                android:scaleType="center"
-                android:src="@drawable/ic_edit_pencil"
-                android:visibility="gone"
-                app:layout_constraintBottom_toBottomOf="@id/customerInfo_billingAddr"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@id/customerInfo_billingAddr" />
 
             <!-- Divider -->
             <View

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -102,7 +102,8 @@
                     android:background="?attr/selectableItemBackground"
                     android:contentDescription="@string/orderdetail_edit_shipping_address_contentdesc"
                     android:scaleType="center"
-                    android:src="@drawable/ic_edit_pencil" />
+                    android:src="@drawable/ic_edit_pencil"
+                    android:visibility="gone" />
 
             </LinearLayout>
 
@@ -195,10 +196,11 @@
                 android:background="?attr/selectableItemBackground"
                 android:contentDescription="@string/orderdetail_edit_shipping_address_contentdesc"
                 android:scaleType="center"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@id/customerInfo_billingAddr"
+                android:src="@drawable/ic_edit_pencil"
+                android:visibility="gone"
                 app:layout_constraintBottom_toBottomOf="@id/customerInfo_billingAddr"
-                android:src="@drawable/ic_edit_pencil" />
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/customerInfo_billingAddr" />
 
             <!-- Divider -->
             <View

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -107,7 +107,7 @@
                     android:layout_gravity="center_vertical"
                     android:layout_weight="0.01"
                     android:background="?attr/selectableItemBackground"
-                    android:contentDescription="@string/orderdetail_call_or_message_contentdesc"
+                    android:contentDescription="@string/orderdetail_edit_shipping_address_contentdesc"
                     android:scaleType="center"
                     android:src="@drawable/ic_edit_pencil" />
 

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -65,6 +65,11 @@
             android:focusable="true"
             android:orientation="vertical">
 
+            <View
+                style="@style/Woo.Divider"
+                android:layout_marginEnd="@dimen/minor_00"
+                android:layout_marginStart="@dimen/major_100" />
+
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -75,11 +80,6 @@
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
                     android:layout_weight="0.99">
-
-                    <View
-                        style="@style/Woo.Divider"
-                        android:layout_marginEnd="@dimen/minor_00"
-                        android:layout_marginStart="@dimen/major_100" />
 
                     <com.google.android.material.textview.MaterialTextView
                         android:id="@+id/customerInfo_shippingLabel"

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -106,8 +106,6 @@
 
             </LinearLayout>
 
-
-
             <!-- Label: Shipping method -->
             <LinearLayout
                 android:id="@+id/customerInfo_shippingMethodSection"

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -162,6 +162,8 @@
                 android:textIsSelectable="true"
                 android:layout_marginTop="@dimen/minor_50"
                 android:textAlignment="viewStart"
+                android:drawableEnd="@drawable/ic_edit_pencil"
+                android:drawablePadding="@dimen/major_100"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/customerInfo_billingLabel"

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -194,7 +194,7 @@
                 android:layout_gravity="center_vertical"
                 android:layout_weight="0.01"
                 android:background="?attr/selectableItemBackground"
-                android:contentDescription="@string/orderdetail_edit_shipping_address_contentdesc"
+                android:contentDescription="@string/orderdetail_edit_billing_address_contentdesc"
                 android:scaleType="center"
                 android:src="@drawable/ic_edit_pencil"
                 android:visibility="gone"

--- a/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_customer_info.xml
@@ -81,9 +81,11 @@
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/customerInfo_shippingAddr"
                 style="@style/Woo.Card.Body"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:textIsSelectable="true"
+                android:drawableEnd="@drawable/ic_edit_pencil"
+                android:drawablePadding="@dimen/major_100"
                 tools:text="John Vilanzo\n123 Sesame Pl\nWarner, FL\nUnited States"/>
 
             <!-- Label: Shipping method -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -305,8 +305,8 @@
     <string name="orderdetail_note_public">To customer</string>
     <string name="orderdetail_note_system">System</string>
     <string name="orderdetail_order_notes">Order notes</string>
-    <string name="orderdetail_edit_shipping_address_contentdesc">Edit the current shipping address</string>
-    <string name="orderdetail_edit_billing_address_contentdesc">Edit the current billing address</string>
+    <string name="orderdetail_edit_shipping_address_contentdesc">Edit shipping address</string>
+    <string name="orderdetail_edit_billing_address_contentdesc">Edit billing address</string>
     <string name="orderdetail_payment_cleared">Payment Cleared</string>
     <string name="orderdetail_show_billing">Show Billing</string>
     <string name="orderdetail_hide_billing">Hide Billing</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -305,6 +305,7 @@
     <string name="orderdetail_note_public">To customer</string>
     <string name="orderdetail_note_system">System</string>
     <string name="orderdetail_order_notes">Order notes</string>
+    <string name="orderdetail_edit_shipping_address_contentdesc">Edit the current shipping address</string>
     <string name="orderdetail_payment_cleared">Payment Cleared</string>
     <string name="orderdetail_show_billing">Show Billing</string>
     <string name="orderdetail_hide_billing">Hide Billing</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -305,8 +305,6 @@
     <string name="orderdetail_note_public">To customer</string>
     <string name="orderdetail_note_system">System</string>
     <string name="orderdetail_order_notes">Order notes</string>
-    <string name="orderdetail_edit_shipping_address_contentdesc">Edit shipping address</string>
-    <string name="orderdetail_edit_billing_address_contentdesc">Edit billing address</string>
     <string name="orderdetail_payment_cleared">Payment Cleared</string>
     <string name="orderdetail_show_billing">Show Billing</string>
     <string name="orderdetail_hide_billing">Hide Billing</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -306,6 +306,7 @@
     <string name="orderdetail_note_system">System</string>
     <string name="orderdetail_order_notes">Order notes</string>
     <string name="orderdetail_edit_shipping_address_contentdesc">Edit the current shipping address</string>
+    <string name="orderdetail_edit_billing_address_contentdesc">Edit the current billing address</string>
     <string name="orderdetail_payment_cleared">Payment Cleared</string>
     <string name="orderdetail_show_billing">Show Billing</string>
     <string name="orderdetail_hide_billing">Hide Billing</string>


### PR DESCRIPTION
Summary
==========
Fixes issue #4886 by creating two ImageButtons as edit actions for both shipping and billing addresses and set the visibility to be controlled by the Order Editing feature flag.

Screenshots
==========
| Before  | After |
| ------------- | ------------- |
| ![Screenshot_20211006_070216](https://user-images.githubusercontent.com/5920403/136183158-ae445e65-7774-478c-affa-2c05d3235940.png) | ![Screenshot_20211006_065534](https://user-images.githubusercontent.com/5920403/136183139-43def0c5-b609-4fa4-9495-da23c282494a.png) |

How to Test
==========
1. Create an Order containing at least the shipping AND billing addresses descriptions
2. Go to the Order Details of the selected Order
3. Verify if both pencil icons appear to Shipping and Billing

Update release notes:

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
